### PR TITLE
feat(mcp): route C++ queries through hybrid provider

### DIFF
--- a/codenib/agent/lsp_provider.py
+++ b/codenib/agent/lsp_provider.py
@@ -46,6 +46,7 @@ class LSPProviderMetadata:
     capability: str
     status: str
     lsp_method: str
+    backend: Optional[str] = None
     index_snapshot: Optional[str] = None
     fallback_reason: Optional[str] = None
     behavior_contract: str = _GRAPH_BEHAVIOR_CONTRACT
@@ -60,6 +61,8 @@ class LSPProviderMetadata:
             "behavior_contract": self.behavior_contract,
             "position_granularity": self.position_granularity,
         }
+        if self.backend is not None:
+            out["backend"] = self.backend
         if self.index_snapshot is not None:
             out["index_snapshot"] = self.index_snapshot
         if self.fallback_reason is not None:
@@ -94,12 +97,16 @@ class StaticLSPProvider:
         *,
         snapshot_id: Optional[str] = None,
         occurrence_index: Optional[SCIPOccurrenceIndex] = None,
+        backend: Optional[str] = None,
+        fallback_reason: Optional[str] = None,
     ) -> None:
         self.graph = graph
         self.occurrence_index = occurrence_index or getattr(
             graph, "lsp_occurrence_index", None
         )
         self.snapshot_id = snapshot_id or _graph_snapshot_id(graph)
+        self.backend = backend
+        self.fallback_reason = fallback_reason
 
     def can_serve(self, capability: str) -> LSPProviderMetadata:
         """Return a non-throwing fast-path decision for one capability."""
@@ -110,6 +117,7 @@ class StaticLSPProvider:
                 normalized,
                 status="unsupported",
                 snapshot_id=self.snapshot_id,
+                backend=self.backend,
                 fallback_reason="unsupported_capability",
             )
         if (
@@ -120,6 +128,8 @@ class StaticLSPProvider:
                 normalized,
                 status="ok",
                 snapshot_id=self.snapshot_id,
+                backend=self.backend,
+                fallback_reason=self.fallback_reason,
                 behavior_contract=_OCCURRENCE_BEHAVIOR_CONTRACT,
                 position_granularity="character",
             )
@@ -128,9 +138,16 @@ class StaticLSPProvider:
                 normalized,
                 status="unavailable",
                 snapshot_id=None,
+                backend=self.backend,
                 fallback_reason="symbol_graph_unavailable",
             )
-        return _metadata(normalized, status="ok", snapshot_id=self.snapshot_id)
+        return _metadata(
+            normalized,
+            status="ok",
+            snapshot_id=self.snapshot_id,
+            backend=self.backend,
+            fallback_reason=self.fallback_reason,
+        )
 
     def definition(
         self,
@@ -299,6 +316,8 @@ class StaticLSPProvider:
                 capability,
                 status="ok",
                 snapshot_id=self.snapshot_id,
+                backend=self.backend,
+                fallback_reason=self.fallback_reason,
                 behavior_contract=behavior_contract,
                 position_granularity=position_granularity,
             ),
@@ -308,13 +327,146 @@ class StaticLSPProvider:
 def resolve_lsp_provider(context: Any) -> Any:
     """Return an injected LSP provider or the default static graph provider."""
 
-    provider = getattr(context, "lsp_provider", None) if context is not None else None
+    provider = _context_attribute(context, "lsp_provider")
     if provider is not None:
         return provider
-    graph = getattr(context, "code_graph", None) if context is not None else None
+    graph = _context_attribute(context, "code_graph")
+    if graph is None:
+        graph = _context_attribute(context, "symbol_graph")
     if graph is None:
         raise RuntimeError("LSP provider and symbol graph are unavailable")
     return StaticLSPProvider(graph)
+
+
+def _context_attribute(context: Any, name: str) -> Any:
+    """Read a real context field without materializing MagicMock children."""
+
+    if context is None:
+        return None
+    attributes = getattr(context, "__dict__", {})
+    mock_children = (
+        attributes.get("_mock_children") if isinstance(attributes, Mapping) else None
+    )
+    if (
+        isinstance(mock_children, Mapping)
+        and name not in mock_children
+        and name not in attributes
+    ):
+        return None
+    return getattr(context, name, None)
+
+
+def select_checkout_lsp_provider(
+    *,
+    project_root: str,
+    languages: Iterable[str],
+    symbol_graph: Any = None,
+    allow_native: bool = True,
+    native_disabled_reason: str = "native_provider_not_authorized",
+) -> tuple[Any, dict[str, Any]]:
+    """Select an existing local clangd generation or an explicit graph fallback.
+
+    Selection never generates a clangd index. Mixed-language and portable
+    contexts retain the persisted graph so the native C++ slice cannot hide
+    other languages or become part of a portable artifact contract.
+    """
+
+    from ..languages import normalize_graph_language
+
+    normalized_languages = [
+        normalize_graph_language(str(language)) for language in languages
+    ]
+    canonical_languages = {
+        normalized for normalized in normalized_languages if normalized is not None
+    }
+    has_unknown_language = any(
+        normalized is None for normalized in normalized_languages
+    )
+    mode = "auto"
+    fallback_reason: Optional[str] = None
+    if not allow_native:
+        fallback_reason = native_disabled_reason or "native_provider_not_authorized"
+    elif canonical_languages != {"cpp"} or has_unknown_language:
+        fallback_reason = (
+            "mixed_language_requires_persisted_graph"
+            if "cpp" in canonical_languages
+            else "native_clangd_not_applicable"
+        )
+    else:
+        from ..ls_index.clangd_decode import (
+            native_clangd_query_mode,
+            native_clangd_query_promoted,
+        )
+
+        mode = native_clangd_query_mode()
+        if mode == "off":
+            fallback_reason = "native_clangd_provider_disabled"
+        elif mode == "auto" and not native_clangd_query_promoted():
+            fallback_reason = "native_clangd_provider_below_threshold"
+
+    if fallback_reason is None:
+        try:
+            from ..ls_router import LSIndexer
+
+            provider = LSIndexer(
+                project_root=project_root,
+                output_dir=project_root,
+                language="cpp",
+            ).process_query_provider(require_native=True)
+        except MemoryError:
+            raise
+        except Exception:
+            if mode == "required":
+                raise
+            fallback_reason = "native_clangd_provider_unavailable"
+        else:
+            backend = getattr(
+                provider,
+                "provider_backend",
+                "native-clangd-fact-query-v1",
+            )
+            return provider, {
+                "provider": getattr(provider, "provider", STATIC_LSP_PROVIDER),
+                "backend": backend,
+                "status": "ok",
+                "index_snapshot": getattr(provider, "snapshot_id", None),
+                "capabilities": {
+                    CAPABILITY_DEFINITION: True,
+                    CAPABILITY_REFERENCES: True,
+                    CAPABILITY_ROUTE: True,
+                },
+            }
+
+    if symbol_graph is not None:
+        provider = StaticLSPProvider(
+            symbol_graph,
+            backend="persisted-symbol-graph-v1",
+            fallback_reason=fallback_reason,
+        )
+        return provider, {
+            "provider": provider.provider,
+            "backend": provider.backend,
+            "status": "ok",
+            "index_snapshot": provider.snapshot_id,
+            "fallback_reason": fallback_reason,
+            "capabilities": {
+                CAPABILITY_DEFINITION: True,
+                CAPABILITY_REFERENCES: True,
+                CAPABILITY_ROUTE: True,
+            },
+        }
+
+    return None, {
+        "provider": STATIC_LSP_PROVIDER,
+        "backend": "unavailable",
+        "status": "unavailable",
+        "fallback_reason": fallback_reason or "symbol_graph_unavailable",
+        "capabilities": {
+            CAPABILITY_DEFINITION: False,
+            CAPABILITY_REFERENCES: False,
+            CAPABILITY_ROUTE: False,
+        },
+    }
 
 
 def normalize_native_lsp_nodes(
@@ -378,6 +530,7 @@ def _metadata(
     *,
     status: str,
     snapshot_id: Optional[str],
+    backend: Optional[str] = None,
     fallback_reason: Optional[str] = None,
     behavior_contract: str = _GRAPH_BEHAVIOR_CONTRACT,
     position_granularity: str = "line",
@@ -388,6 +541,7 @@ def _metadata(
         capability=normalized,
         status=status,
         lsp_method=_LSP_METHODS.get(normalized, normalized),
+        backend=backend,
         index_snapshot=snapshot_id,
         fallback_reason=fallback_reason,
         behavior_contract=behavior_contract,
@@ -479,6 +633,7 @@ __all__ = [
     "STATIC_LSP_PROVIDER",
     "StaticLSPProvider",
     "resolve_lsp_provider",
+    "select_checkout_lsp_provider",
     "fingerprint_lsp_result",
     "lsp_result_metadata",
     "normalize_native_lsp_nodes",

--- a/codenib/agent/skills/lsp_route/executor.py
+++ b/codenib/agent/skills/lsp_route/executor.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 def create_executor(context: "ExpandContext") -> Callable[..., List["QueriedNode"]]:
     """Return a semantic route-map implementation over the static graph."""
-    from ...lsp_provider import StaticLSPProvider
+    from ...lsp_provider import resolve_lsp_provider
 
     def execute(
         symbols: List[str],
@@ -22,9 +22,7 @@ def create_executor(context: "ExpandContext") -> Callable[..., List["QueriedNode
         include_neighbors: bool = True,
         **kwargs: Any,
     ) -> List["QueriedNode"]:
-        if context is None or context.code_graph is None:
-            raise RuntimeError("Symbol graph not available")
-        return StaticLSPProvider(context.code_graph).route(
+        return resolve_lsp_provider(context).route(
             symbols=list(symbols or []),
             query=query,
             top_k=int(top_k or 12),

--- a/codenib/compiler/skill_context.py
+++ b/codenib/compiler/skill_context.py
@@ -496,11 +496,19 @@ def build_skill_contexts(
                 exc,
             )
 
+    lsp_provider = None
+    if SkillType.EXPAND in skill_types or "symbol_graph" in loaded:
+        lsp_provider = _select_cpp_lsp_provider(
+            repo_path=repo_path,
+            languages=languages,
+            symbol_graph=loaded.get("symbol_graph"),
+        )
     return _package_contexts(
         loaded,
         skill_types=skill_types,
         default_top_k=default_top_k,
         default_level=default_level,
+        lsp_provider=lsp_provider,
     )
 
 
@@ -583,12 +591,41 @@ def load_contexts_from_manifest(
             manifest.indexes["symbol_graph"].path
         )
 
+    lsp_provider = None
+    if SkillType.EXPAND in skill_types or "symbol_graph" in loaded:
+        lsp_provider = _select_cpp_lsp_provider(
+            repo_path=manifest.repo_path,
+            languages=manifest.languages,
+            symbol_graph=loaded.get("symbol_graph"),
+        )
     return _package_contexts(
         loaded,
         skill_types=skill_types,
         default_top_k=default_top_k,
         default_level=default_level,
+        lsp_provider=lsp_provider,
     )
+
+
+def _select_cpp_lsp_provider(
+    *, repo_path: str, languages: Sequence[str], symbol_graph: Any
+) -> Any:
+    """Bind the native provider only for an unambiguous local C/C++ context."""
+
+    from ..languages import normalize_graph_language
+
+    normalized = [normalize_graph_language(language) for language in languages]
+    if not normalized or any(language != "cpp" for language in normalized):
+        return None
+
+    from ..agent.lsp_provider import select_checkout_lsp_provider
+
+    provider, _selection = select_checkout_lsp_provider(
+        project_root=repo_path,
+        languages=languages,
+        symbol_graph=symbol_graph,
+    )
+    return provider
 
 
 def _package_contexts(
@@ -597,6 +634,7 @@ def _package_contexts(
     skill_types: Set[SkillType],
     default_top_k: int,
     default_level: str,
+    lsp_provider: Any = None,
 ) -> Dict[str, Any]:
     """Wrap loaded index artifacts into the per-context-type dataclasses.
 
@@ -629,6 +667,9 @@ def _package_contexts(
     if SkillType.EXPAND in skill_types or "symbol_graph" in loaded:
         from ..ops.expand import ExpandContext
 
-        contexts["expand"] = ExpandContext(code_graph=loaded.get("symbol_graph"))
+        contexts["expand"] = ExpandContext(
+            code_graph=loaded.get("symbol_graph"),
+            lsp_provider=lsp_provider,
+        )
 
     return contexts

--- a/codenib/ls_index/clangd_decode.py
+++ b/codenib/ls_index/clangd_decode.py
@@ -429,7 +429,9 @@ class ClangdHybridQueryProvider:
         self.graph = query_index
         self.provider_backend = decoder.query_backend
         self._symbol_provider = StaticLSPProvider(
-            query_index, snapshot_id=decoder.query_snapshot_id
+            query_index,
+            snapshot_id=decoder.query_snapshot_id,
+            backend=self.provider_backend,
         )
         self._graph_provider = None
         self.graph_materialization_count = 0
@@ -437,41 +439,72 @@ class ClangdHybridQueryProvider:
         self.provider = self._symbol_provider.provider
         self.snapshot_id = self._symbol_provider.snapshot_id
 
-    def _full_graph_provider(self, reason: str):
+    def _full_graph_provider(self):
         from ..agent.lsp_provider import StaticLSPProvider
 
-        self.last_fallback_reason = reason
         if self._graph_provider is None:
             graph = self.decoder.materialize_code_graph()
             self._graph_provider = StaticLSPProvider(
-                graph, snapshot_id=self.snapshot_id
+                graph,
+                snapshot_id=self.snapshot_id,
+                backend="lazy-clangd-code-graph-v1",
             )
             self.graph_materialization_count += 1
         return self._graph_provider
 
+    def _graph_fallback(self, capability: str, reason: str, arguments: Mapping):
+        from dataclasses import replace
+
+        from ..agent.lsp_provider import LSPProviderNodes
+
+        self.last_fallback_reason = reason
+        result = getattr(self._full_graph_provider(), capability)(**arguments)
+        return LSPProviderNodes(
+            result,
+            metadata=replace(
+                result.lsp_provider_metadata,
+                fallback_reason=reason,
+            ),
+        )
+
     def can_serve(self, capability: str):
         # The hybrid can serve every established capability: native for symbol
         # definition/reference calls and the complete graph for everything else.
-        return self._symbol_provider.can_serve(capability)
+        decision = self._symbol_provider.can_serve(capability)
+        if str(capability) in {"route", "codenib/lspRoute"}:
+            from dataclasses import replace
+
+            return replace(
+                decision,
+                backend="lazy-clangd-code-graph-v1",
+                fallback_reason="native_clangd_route_query_requires_complete_graph",
+            )
+        return decision
 
     def definition(self, **arguments):
         if arguments.get("symbol"):
             return self._symbol_provider.definition(**arguments)
-        return self._full_graph_provider(
-            "native_clangd_position_query_requires_complete_graph"
-        ).definition(**arguments)
+        return self._graph_fallback(
+            "definition",
+            "native_clangd_position_query_requires_complete_graph",
+            arguments,
+        )
 
     def references(self, **arguments):
         if arguments.get("symbol"):
             return self._symbol_provider.references(**arguments)
-        return self._full_graph_provider(
-            "native_clangd_position_query_requires_complete_graph"
-        ).references(**arguments)
+        return self._graph_fallback(
+            "references",
+            "native_clangd_position_query_requires_complete_graph",
+            arguments,
+        )
 
     def route(self, **arguments):
-        return self._full_graph_provider(
-            "native_clangd_route_query_requires_complete_graph"
-        ).route(**arguments)
+        return self._graph_fallback(
+            "route",
+            "native_clangd_route_query_requires_complete_graph",
+            arguments,
+        )
 
 
 class ClangdGraphDecoder:
@@ -754,6 +787,23 @@ class ClangdGraphDecoder:
         if getattr(index, "fact_query_index", False):
             return ClangdHybridQueryProvider(self, index)
         return StaticLSPProvider(index)
+
+    def decode_native_query_provider(self):
+        """Return the native provider without silently building a legacy graph."""
+
+        if self.query_index is None:
+            total_started = time.perf_counter()
+            self.query_index, self.query_profile = self._decode_native_query_index()
+            self.query_backend = "native-clangd-fact-query-v1"
+            self.query_profile["fact_query_native"] = 1
+            self.query_profile["query_total"] = time.perf_counter() - total_started
+        if self.query_backend != "native-clangd-fact-query-v1" or not getattr(
+            self.query_index, "fact_query_index", False
+        ):
+            raise RuntimeError(
+                "clangd query decoder is already bound to a non-native backend"
+            )
+        return ClangdHybridQueryProvider(self, self.query_index)
 
     def save_graph(self, output_path: str):
         """Save the code graph to a file."""

--- a/codenib/ls_index/clangd_indexer.py
+++ b/codenib/ls_index/clangd_indexer.py
@@ -282,7 +282,7 @@ class ClangdIndexer:
             )
             return decoder.decode_query_index()
 
-    def process_query_provider(self):
+    def process_query_provider(self, *, require_native: bool = False):
         """Return native symbol queries with lazy complete-graph fallback."""
 
         self._select_existing_idx_directory()
@@ -295,6 +295,8 @@ class ClangdIndexer:
             idx_directory=str(self.idx_directory),
             project_root=str(self.project_root),
         )
+        if require_native:
+            return decoder.decode_native_query_provider()
         return decoder.decode_query_provider()
 
     def _select_existing_idx_directory(self) -> Optional[Path]:

--- a/codenib/ls_router.py
+++ b/codenib/ls_router.py
@@ -251,7 +251,7 @@ class LSIndexer:
             )
         return method()
 
-    def process_query_provider(self) -> Any:
+    def process_query_provider(self, *, require_native: bool = False) -> Any:
         """Build a backend-specific provider with compatible fallbacks."""
 
         method = getattr(self._delegate, "process_query_provider", None)
@@ -259,6 +259,8 @@ class LSIndexer:
             raise RuntimeError(
                 f"{self.language} indexer does not expose a query-provider path"
             )
+        if require_native:
+            return method(require_native=True)
         return method()
 
     def run_pipeline(

--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -75,9 +75,9 @@ also remain available. All forms accept
 | `search_regex` | `symbol_graph` | file / symbol | structural pattern matching |
 | `search_zoekt` | `zoekt` | file | fast substring/regex across raw repo contents |
 | `dependency_subgraph` | `symbol_graph` | call graph | structural dependency / impact analysis |
-| `lsp_definition` | `symbol_graph` | location | static graph analogue of go-to-definition |
-| `lsp_references` | `symbol_graph` | locations | static graph analogue of find-references |
-| `lsp_route` | `symbol_graph` | locations | compact route anchors for related symbols |
+| `lsp_definition` | runtime LSP provider or `symbol_graph` | location | static graph analogue of go-to-definition |
+| `lsp_references` | runtime LSP provider or `symbol_graph` | locations | static graph analogue of find-references |
+| `lsp_route` | runtime LSP provider or `symbol_graph` | locations | compact route anchors for related symbols |
 | `read_source` | verified checkout | source window | bounded source inspection after retrieval/navigation |
 | `get_manifest` | — | — | repo metadata: path, commit, languages, capabilities |
 
@@ -171,8 +171,16 @@ Returns `root`, `direction`, `nodes`, `edges`, `truncated`, and `note`.
 Each node's optional `line` is 1-based.
 
 ### `lsp_definition` / `lsp_references` / `lsp_route`
-Static LSP-shaped navigation over the loaded `symbol_graph`. These tools return
-compact locations only; clients should read source before finalizing.
+Static LSP-shaped navigation through the server's selected runtime provider.
+A source-verified local C/C++-only checkout can reuse an existing project-local
+clangd index for symbol definition and reference queries without generating a
+new index. Position and route calls lazily load the compatible complete graph
+once. Portable artifacts, mixed-language repositories, unverified checkouts,
+and disabled or unavailable native support use the persisted `symbol_graph`.
+Result rows expose provider backend, fallback, capability, and snapshot metadata
+when available; `get_manifest.runtime.lsp_provider` exposes the selection before
+the first result. These tools return compact locations only; clients should read
+source before finalizing.
 All three tools require `top_k` from 1 through 100. File paths are limited to
 4,096 characters, each symbol field or route entry to 1,024 characters, and a
 route query to 16,000 characters. `lsp_route` accepts at most 32 supplied symbol

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -122,10 +122,16 @@ class ServerContext:
     regex_index: Optional[RegexNodeIndex] = None
     zoekt: Optional[ZoektSearcher] = None
     vector: Optional[CodeVectorStore] = None
+    lsp_provider: Optional[Any] = field(default=None, repr=False)
+    lsp_provider_selection: Dict[str, Any] = field(default_factory=dict)
     errors: Dict[str, str] = field(default_factory=dict)
     artifact: Optional[Mapping[str, Any]] = None
     source_verified: bool = False
     source_error: Optional[str] = "source binding has not been verified"
+    _lsp_allow_native: bool = field(default=False, init=False, repr=False)
+    _lsp_native_disabled_reason: str = field(
+        default="local_source_not_verified", init=False, repr=False
+    )
     _view_lock: RLock = field(default_factory=RLock, init=False, repr=False)
 
     @classmethod
@@ -152,6 +158,14 @@ class ServerContext:
         ctx = cls(manifest=manifest, artifact=dict(artifact) if artifact else None)
 
         ctx.load_views(selected)
+        ctx.configure_lsp_provider(
+            allow_native=False,
+            native_disabled_reason=(
+                "portable_artifact_uses_persisted_graph"
+                if ctx.artifact is not None
+                else "local_source_not_verified"
+            ),
+        )
 
         cap_summary = {k: v for k, v in manifest.capabilities.items() if v}
         loaded = [
@@ -196,6 +210,11 @@ class ServerContext:
                 getattr(self, loader_name)()
                 if getattr(self, view, None) is not None:
                     self.errors.pop(view, None)
+            if "symbol_graph" in selected:
+                self.configure_lsp_provider(
+                    allow_native=self._lsp_allow_native,
+                    native_disabled_reason=self._lsp_native_disabled_reason,
+                )
             return {
                 view: self.errors.get(view, "view did not load")
                 for view in selected
@@ -206,12 +225,36 @@ class ServerContext:
         """Release runtime resources owned by this context."""
 
         with self._view_lock:
+            self.lsp_provider = None
             if self.zoekt is not None:
                 _stop_zoekt(self.zoekt)
                 self.zoekt = None
             if self.vector is not None:
                 _close_vector(self.vector)
                 self.vector = None
+
+    def configure_lsp_provider(
+        self,
+        *,
+        allow_native: bool,
+        native_disabled_reason: str = "native_provider_not_authorized",
+    ) -> Dict[str, Any]:
+        """Bind a runtime-only provider without mutating persisted artifacts."""
+
+        from ..agent.lsp_provider import select_checkout_lsp_provider
+
+        self._lsp_allow_native = allow_native
+        self._lsp_native_disabled_reason = native_disabled_reason
+        provider, selection = select_checkout_lsp_provider(
+            project_root=self.manifest.repo_path,
+            languages=self.manifest.languages,
+            symbol_graph=self.symbol_graph,
+            allow_native=allow_native,
+            native_disabled_reason=native_disabled_reason,
+        )
+        self.lsp_provider = provider
+        self.lsp_provider_selection = selection
+        return dict(selection)
 
     @classmethod
     def validate_views(

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -110,7 +110,7 @@ try:
             "search_bm25 for keyword lookups, search_regex for CodeGraph "
             "file/symbol pattern matching, and search_zoekt for fast trigram-based "
             "substring/regex search across raw file contents. Use "
-            "lsp_definition, lsp_references, and lsp_route for graph-backed "
+            "lsp_definition, lsp_references, and lsp_route for provider-backed "
             "LSP-shaped symbol navigation."
             " Use read_source to inspect a bounded source window after search or "
             "navigation returns a location."
@@ -305,9 +305,10 @@ async def dependency_subgraph(
 @mcp.tool(
     name="lsp_definition",
     description=(
-        "Return compact definition locations from CodeNib's static symbol "
-        "graph. Provide either symbol or file_path + 1-based line. Results are "
-        "locations only; call read_source before finalizing."
+        "Return compact definition locations from CodeNib's runtime LSP "
+        "provider or persisted symbol graph fallback. Provide either symbol "
+        "or file_path + 1-based line. Results are locations only; call "
+        "read_source before finalizing."
     ),
 )
 async def lsp_definition(
@@ -317,7 +318,7 @@ async def lsp_definition(
     symbol: _LspSymbol = "",
     top_k: _SearchTopK = 8,
 ) -> list[dict[str, Any]] | dict[str, str]:
-    """Graph-backed definition lookup over the static symbol graph."""
+    """Provider-backed definition lookup with persisted-graph fallback."""
     if _ctx is None:
         raise RuntimeError("Server not initialized")
     return await asyncio.to_thread(
@@ -334,9 +335,10 @@ async def lsp_definition(
 @mcp.tool(
     name="lsp_references",
     description=(
-        "Return compact definition/reference locations from CodeNib's static "
-        "symbol graph. Provide either symbol or file_path + 1-based line. "
-        "Results are locations only; call read_source before finalizing."
+        "Return compact definition/reference locations from CodeNib's runtime "
+        "LSP provider or persisted symbol graph fallback. Provide either "
+        "symbol or file_path + 1-based line. Results are locations only; call "
+        "read_source before finalizing."
     ),
 )
 async def lsp_references(
@@ -347,7 +349,7 @@ async def lsp_references(
     include_declaration: bool = True,
     top_k: _SearchTopK = 40,
 ) -> list[dict[str, Any]] | dict[str, str]:
-    """Graph-backed reference lookup over the static symbol graph."""
+    """Provider-backed reference lookup with persisted-graph fallback."""
     if _ctx is None:
         raise RuntimeError("Server not initialized")
     return await asyncio.to_thread(
@@ -365,10 +367,10 @@ async def lsp_references(
 @mcp.tool(
     name="lsp_route",
     description=(
-        "Return compact route anchors from CodeNib's static symbol graph for "
-        "symbol seeds, or use a query alone when no reliable symbol is known. "
-        "Use this for a route map across endpoint, bridge/factory, "
-        "provider/value, or type anchors. "
+        "Return compact route anchors from CodeNib's runtime LSP provider or "
+        "persisted symbol graph fallback for symbol seeds, or use a query "
+        "alone when no reliable symbol is known. Use this for a route map "
+        "across endpoint, bridge/factory, provider/value, or type anchors. "
         "Results are locations only; call read_source before finalizing."
     ),
 )
@@ -378,7 +380,7 @@ async def lsp_route(
     top_k: _SearchTopK = 12,
     include_neighbors: bool = True,
 ) -> list[dict[str, Any]] | dict[str, str]:
-    """Graph-backed route map over the static symbol graph."""
+    """Provider-backed route map with persisted-graph fallback."""
     if _ctx is None:
         raise RuntimeError("Server not initialized")
     return await asyncio.to_thread(
@@ -435,6 +437,7 @@ async def get_manifest() -> dict[str, Any]:
             "verified": _ctx.source_verified,
             "error": _ctx.source_error,
         },
+        "lsp_provider": dict(_ctx.lsp_provider_selection),
     }
     if _ctx.artifact is not None:
         result["artifact"] = dict(_ctx.artifact)
@@ -489,6 +492,13 @@ def server_status() -> str:
             lines.append("  ✓ symbol_graph: loaded")
         else:
             lines.append("  ✗ symbol_graph: not_loaded")
+
+        lsp_selection = ctx.lsp_provider_selection
+        lines.append(
+            "  lsp_provider: "
+            f"{lsp_selection.get('backend', 'unavailable')} "
+            f"({lsp_selection.get('status', 'unavailable')})"
+        )
 
         if ctx.zoekt is not None:
             lines.append(f"  ✓ zoekt: port={ctx.zoekt.port}")
@@ -625,6 +635,14 @@ def init_server(
                 _ctx.source_error = None
         if not _ctx.source_verified:
             logger.warning("Source reads disabled: %s", _ctx.source_error)
+    _ctx.configure_lsp_provider(
+        allow_native=_ctx.source_verified and _ctx.artifact is None,
+        native_disabled_reason=(
+            "portable_artifact_uses_persisted_graph"
+            if _ctx.artifact is not None
+            else "local_source_not_verified"
+        ),
+    )
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/codenib/mcp/tools/lsp.py
+++ b/codenib/mcp/tools/lsp.py
@@ -66,11 +66,27 @@ def _node_to_dict(node: Any) -> dict[str, Any]:
     return to_agent_repr(node)
 
 
-def _symbol_graph(ctx: Any) -> Any:
-    graph = getattr(ctx, "symbol_graph", None)
-    if graph is None:
+def _lsp_provider(ctx: Any) -> Any:
+    from ...agent.lsp_provider import resolve_lsp_provider
+
+    try:
+        return resolve_lsp_provider(ctx)
+    except RuntimeError:
         return None
-    return graph
+
+
+def _serialize_results(results: Any) -> list[dict[str, Any]]:
+    from ...agent.lsp_provider import lsp_result_metadata
+
+    metadata = lsp_result_metadata(results)
+    rows = [_node_to_dict(node) for node in results]
+    if metadata is not None and (
+        metadata.get("backend") is not None
+        or metadata.get("fallback_reason") is not None
+    ):
+        for row in rows:
+            row["lsp_provider"] = dict(metadata)
+    return rows
 
 
 def lsp_definition_impl(
@@ -81,7 +97,7 @@ def lsp_definition_impl(
     symbol: str = "",
     top_k: int = 8,
 ) -> list[dict[str, Any]] | dict[str, str]:
-    """Return graph-backed definition locations."""
+    """Return provider-backed definition locations."""
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     file_path = bounded_text(
         file_path,
@@ -102,25 +118,24 @@ def lsp_definition_impl(
             minimum=0,
             maximum=MAX_LSP_POSITION,
         )
-    graph = _symbol_graph(ctx)
-    if graph is None:
+    provider = _lsp_provider(ctx)
+    if provider is None:
         return {"error": "symbol_graph index not available"}
 
     from ...agent.boundary import from_agent_repr
-    from ...agent.lsp_provider import StaticLSPProvider
 
     graph_line = from_agent_repr(line)
     try:
-        results = StaticLSPProvider(graph).definition(
+        results = provider.definition(
             file_path=file_path or None,
             line=graph_line,
             character=character,
             symbol=symbol or None,
             top_k=top_k,
         )
-    except ValueError as exc:
+    except (RuntimeError, ValueError) as exc:
         return {"error": str(exc)}
-    return [_node_to_dict(node) for node in results]
+    return _serialize_results(results)
 
 
 def lsp_references_impl(
@@ -132,7 +147,7 @@ def lsp_references_impl(
     include_declaration: bool = True,
     top_k: int = 40,
 ) -> list[dict[str, Any]] | dict[str, str]:
-    """Return graph-backed reference locations."""
+    """Return provider-backed reference locations."""
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     file_path = bounded_text(
         file_path,
@@ -153,16 +168,15 @@ def lsp_references_impl(
             minimum=0,
             maximum=MAX_LSP_POSITION,
         )
-    graph = _symbol_graph(ctx)
-    if graph is None:
+    provider = _lsp_provider(ctx)
+    if provider is None:
         return {"error": "symbol_graph index not available"}
 
     from ...agent.boundary import from_agent_repr
-    from ...agent.lsp_provider import StaticLSPProvider
 
     graph_line = from_agent_repr(line)
     try:
-        results = StaticLSPProvider(graph).references(
+        results = provider.references(
             file_path=file_path or None,
             line=graph_line,
             character=character,
@@ -170,9 +184,9 @@ def lsp_references_impl(
             include_declaration=bool(include_declaration),
             top_k=top_k,
         )
-    except ValueError as exc:
+    except (RuntimeError, ValueError) as exc:
         return {"error": str(exc)}
-    return [_node_to_dict(node) for node in results]
+    return _serialize_results(results)
 
 
 def lsp_route_impl(
@@ -182,7 +196,7 @@ def lsp_route_impl(
     top_k: int = 12,
     include_neighbors: bool = True,
 ) -> list[dict[str, Any]] | dict[str, str]:
-    """Return graph-backed route anchors for one or more symbol seeds."""
+    """Return provider-backed route anchors for one or more symbol seeds."""
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     seeds = _coerce_symbols(symbols)
     requested_query = bounded_text(
@@ -193,16 +207,17 @@ def lsp_route_impl(
     normalized_query = requested_query.strip()
     if not seeds and not normalized_query:
         return []
-    graph = _symbol_graph(ctx)
-    if graph is None:
+    provider = _lsp_provider(ctx)
+    if provider is None:
         return {"error": "symbol_graph index not available"}
 
-    from ...agent.lsp_provider import StaticLSPProvider
-
-    results = StaticLSPProvider(graph).route(
-        symbols=seeds,
-        query=normalized_query or None,
-        top_k=top_k,
-        include_neighbors=bool(include_neighbors),
-    )
-    return [_node_to_dict(node) for node in results]
+    try:
+        results = provider.route(
+            symbols=seeds,
+            query=normalized_query or None,
+            top_k=top_k,
+            include_neighbors=bool(include_neighbors),
+        )
+    except (RuntimeError, ValueError) as exc:
+        return {"error": str(exc)}
+    return _serialize_results(results)

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -58,6 +58,19 @@ indexed search, and graph traversal. This checks that the provider boundary is
 language-agnostic; it is not evidence that the pinned Python-only LocAgent or
 OrcaLoca native implementations support those languages.
 
+### Shared LSP navigation provider
+
+The definition, reference, and route agent skills resolve the same provider
+injected into `ExpandContext`. For a source-verified C/C++-only build, symbol
+definition and reference requests can use the native clangd fact-query postings
+without materializing igraph; position and route requests lazily build and
+reuse the compatible complete graph. Mixed-language contexts select the
+persisted symbol graph; prebuilt contexts without a usable local native
+generation do the same, and portable artifacts always do so. Provider results
+retain backend,
+fallback, capability, and snapshot metadata so an agent trace can explain the
+route without changing the public location shape.
+
 ## Benchmark Compatibility
 
 These integrations evaluate CodeNib's native repository algorithms against

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -181,8 +181,25 @@ make clangd-fact-query-profile \
 
 This result measures an already generated `.idx` directory through identical
 definition/reference work. It does not claim faster clangd generation. Native
-position/route lookup and serving integration remain independent follow-up
-gates.
+position and route lookup remain independent follow-up gates.
+
+### MCP and agent runtime selection
+
+`ServerContext` and compiler skill contexts select one runtime-only LSP
+provider. A source-verified local C/C++-only checkout can reuse its existing
+clangd shards through `native-clangd-fact-query-v1`; selection does not generate
+an index. Portable artifacts, mixed-language repositories, unverified
+checkouts, and disabled or unavailable native support use
+`persisted-symbol-graph-v1` with a deterministic fallback reason.
+
+MCP definition, reference, and route tools and all three agent LSP skills use
+the common provider resolver. Definition and reference symbol requests remain
+on the native postings path without igraph. Position and route requests lazily
+materialize one snapshot-compatible complete graph and reuse it. MCP result
+rows and `get_manifest` runtime metadata identify the backend, capabilities,
+fallback, and snapshot. The profiling report's `mcp_consumer_decision` applies
+the acceleration gate to startup plus real MCP validation and serialization,
+in addition to checking raw-query parity.
 
 ### Content-bound snapshot receipt
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -120,9 +120,9 @@ Only tools whose backing views are fresh and available can return results.
 | `search_regex` | `symbol_graph` | file / symbol | Structural pattern matching |
 | `search_zoekt` | `zoekt` | file | Fast substring or regex search over files |
 | `dependency_subgraph` | `symbol_graph` | call graph | Caller impact, callee dependencies, or a one-hop neighborhood |
-| `lsp_definition` | `symbol_graph` | location | Static go-to-definition-shaped lookup |
-| `lsp_references` | `symbol_graph` | locations | Static find-references-shaped lookup |
-| `lsp_route` | `symbol_graph` | locations | Compact route anchors from symbol seeds or a bounded query fallback |
+| `lsp_definition` | runtime LSP provider or `symbol_graph` fallback | location | Static go-to-definition-shaped lookup |
+| `lsp_references` | runtime LSP provider or `symbol_graph` fallback | locations | Static find-references-shaped lookup |
+| `lsp_route` | runtime LSP provider or `symbol_graph` fallback | locations | Compact route anchors from symbol seeds or a bounded query fallback |
 | `read_source` | verified checkout | source window | Read an exact 1-based span after retrieval or navigation |
 | `get_manifest` | manifest | repository | Repository identity, languages, view states, and capabilities |
 
@@ -134,6 +134,16 @@ Call `lsp_route` with `symbols=[]` and a non-blank query when no reliable symbol
 is known. This best-effort fallback examines at most 10,000 graph nodes, retains
 at most 256 query matches and 512 expanded candidates, and stops after 100
 milliseconds.
+
+For a source-verified local C/C++-only checkout, the server can reuse an
+existing project-local clangd index for definition and reference symbol
+queries. This runtime selection never generates clangd data. Position and route
+queries lazily load the compatible complete graph once. Portable artifacts,
+mixed-language repositories, unverified checkouts, and disabled or unavailable
+native support remain on the persisted symbol graph. LSP result rows identify
+their backend, fallback reason, capabilities, and snapshot when provider
+metadata is available; `get_manifest.runtime.lsp_provider` reports the same
+selection even before a result is returned.
 
 `search_context` accepts `query`, `top_k` (1-100), `budget`
 (`fast`, `balanced`, or `thorough`), dense `level` (`l0` or `l2`), and

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -754,9 +754,9 @@ Reproduce the report with `make clangd-fact-query-profile`.
 This promotion does not include or accelerate clangd index generation. RIFF
 version/resource hardening (#546), zlib CI enforcement (#547), and
 content-bound generation receipts (#548) are independent production gates.
-Serving integration (#549), mixed/RSS/concurrency matrices (#550), native
-position (#553), native route (#552), and durable FactBatch storage (#551)
-remain separate review and promotion gates.
+Serving integration is tracked below. Mixed/RSS/concurrency matrices (#550),
+native position (#553), native route (#552), and durable FactBatch storage
+(#551) remain separate review and promotion gates.
 
 Native clangd RIFF compatibility and resource-safety status
 ([#546](https://github.com/sysevol-ai/CodeNib/issues/546)): the v1 reader now
@@ -810,6 +810,33 @@ receipt passes were included. The fused first-pass hash took 2.94 ms (12.6% of
 native startup); hashing plus publication verification took 7.09 ms. The
 maintained profiler now reports both stages and their fraction of startup, and
 the existing 20% acceleration decision includes their cost.
+
+Native clangd MCP consumer-routing status
+([#549](https://github.com/sysevol-ai/CodeNib/issues/549)):
+`ServerContext` now owns one runtime-only LSP provider selection. A
+source-verified, local, C/C++-only manifest may reuse its existing project-local
+clangd shards through the native fact-query provider; startup never generates
+or publishes a clangd index. Portable artifacts, mixed-language manifests,
+disabled or unavailable native support, and unverified checkouts select the
+persisted symbol graph with an explicit fallback reason. MCP definition,
+reference, and route calls and the three agent LSP skills all use the same
+provider resolver.
+
+Native definition and reference requests remain graph-free. The first position
+or route request materializes the snapshot-compatible complete graph exactly
+once and later graph-requiring calls reuse it. Result rows and `get_manifest`
+runtime metadata expose the selected backend, fallback reason, capabilities,
+and native snapshot identity. The maintained profiler now validates both raw
+query parity and MCP serialization/public-error parity and publishes a separate
+`mcp_consumer_decision` over startup plus consumer work.
+
+The 2026-08-10 consumer-boundary gate used 223 `cpp_simple` shards, five
+alternating measured rounds, and 100 deterministic symbol requests per round.
+Median complete-graph MCP consumer time was 178.269 ms versus 27.717 ms for the
+native provider, an 84.45% improvement with exact result parity. Symbol-only
+requests never imported or materialized igraph, and the first graph-requiring
+request materialized the compatible graph once. Native position and route
+indexes remain the independent #553 and #552 promotion gates.
 
 Native core CI enforcement status
 ([#547](https://github.com/sysevol-ai/CodeNib/issues/547)): the trusted

--- a/scripts/profiling/profile_clangd_fact_query_index.py
+++ b/scripts/profiling/profile_clangd_fact_query_index.py
@@ -7,9 +7,9 @@
 """Benchmark native clangd symbol queries against the complete CodeGraph.
 
 Both arms start from the same existing project-local .idx directory and run
-the same deterministic definition/reference workload. clangd index generation,
-position queries, routes, persistence, and serving integration are outside this
-baseline gate.
+the same deterministic definition/reference workload through both the raw query
+surface and the MCP consumer boundary. clangd index generation, native position
+and route indexes, and persistence are outside this gate.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ import hashlib
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Sequence
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -65,6 +66,34 @@ def _idx_digest(idx_directory: Path) -> tuple[str, int, int]:
 
 def _append_sample(samples: dict[str, list[float]], name: str, value: float) -> None:
     samples.setdefault(name, []).append(float(value))
+
+
+def _mcp_query_outcomes(provider: Any, symbols: Sequence[str]) -> list[Any]:
+    """Run MCP validation/serialization and normalize provider-only metadata."""
+
+    from codenib.mcp.tools.lsp import lsp_definition_impl, lsp_references_impl
+
+    context = SimpleNamespace(lsp_provider=provider, symbol_graph=None)
+    outcomes: list[Any] = []
+    for symbol in symbols:
+        for implementation in (lsp_definition_impl, lsp_references_impl):
+            result = implementation(context, symbol=symbol, top_k=100)
+            if isinstance(result, list):
+                result = [
+                    {key: value for key, value in row.items() if key != "lsp_provider"}
+                    for row in result
+                ]
+            outcomes.append(result)
+    return outcomes
+
+
+def _mcp_query_workload(provider: Any, symbols: Sequence[str]) -> int:
+    """Exercise provider resolution plus MCP validation and serialization."""
+
+    return sum(
+        len(result) if isinstance(result, list) else 1
+        for result in _mcp_query_outcomes(provider, symbols)
+    )
 
 
 def profile_clangd_fact_query_index(
@@ -132,6 +161,17 @@ def profile_clangd_fact_query_index(
     parity_symbols = _even_sample(all_symbols, parity_sample_limit)
     parity_seeds = _parity_seeds(baseline_graph, parity_symbols)
 
+    def measure_mcp_consumer(index: Any, *, backend: str) -> float:
+        from codenib.agent.lsp_provider import StaticLSPProvider
+
+        _, elapsed = _timed(
+            lambda: _mcp_query_workload(
+                StaticLSPProvider(index, backend=backend),
+                workload_symbols,
+            )
+        )
+        return elapsed
+
     def native_arm() -> tuple[Any, dict[str, float]]:
         payload, startup = _timed(
             lambda: codenib_core.decode_clangd_fact_query_index(
@@ -170,8 +210,16 @@ def profile_clangd_fact_query_index(
         }
 
     for _ in range(warmups):
-        _run_arm(legacy_arm)
-        _run_arm(native_arm)
+        (warm_graph, _timings), _total = _run_arm(legacy_arm)
+        measure_mcp_consumer(
+            warm_graph,
+            backend="persisted-symbol-graph-v1",
+        )
+        (warm_index, _timings), _total = _run_arm(native_arm)
+        measure_mcp_consumer(
+            warm_index,
+            backend="native-clangd-fact-query-v1",
+        )
 
     legacy_samples: dict[str, list[float]] = {}
     native_samples: dict[str, list[float]] = {}
@@ -182,13 +230,33 @@ def profile_clangd_fact_query_index(
         if iteration % 2 == 0:
             first_arm_by_iteration.append("legacy")
             (last_graph, legacy_timing), legacy_total = _run_arm(legacy_arm)
+            legacy_mcp = measure_mcp_consumer(
+                last_graph,
+                backend="persisted-symbol-graph-v1",
+            )
             (last_index, native_timing), native_total = _run_arm(native_arm)
+            native_mcp = measure_mcp_consumer(
+                last_index,
+                backend="native-clangd-fact-query-v1",
+            )
         else:
             first_arm_by_iteration.append("native")
             (last_index, native_timing), native_total = _run_arm(native_arm)
+            native_mcp = measure_mcp_consumer(
+                last_index,
+                backend="native-clangd-fact-query-v1",
+            )
             (last_graph, legacy_timing), legacy_total = _run_arm(legacy_arm)
+            legacy_mcp = measure_mcp_consumer(
+                last_graph,
+                backend="persisted-symbol-graph-v1",
+            )
         legacy_timing["total"] = legacy_total
         native_timing["total"] = native_total
+        legacy_timing["mcp_query_workload"] = legacy_mcp
+        native_timing["mcp_query_workload"] = native_mcp
+        legacy_timing["consumer_total"] = legacy_timing["startup"] + legacy_mcp
+        native_timing["consumer_total"] = native_timing["startup"] + native_mcp
         for name, value in legacy_timing.items():
             _append_sample(legacy_samples, name, value)
         for name, value in native_timing.items():
@@ -204,6 +272,24 @@ def profile_clangd_fact_query_index(
             expected_symbol_count=len(all_symbols),
             expected_reference_count=expected_references,
         )
+        from codenib.agent.lsp_provider import StaticLSPProvider
+
+        legacy_mcp_outcomes = _mcp_query_outcomes(
+            StaticLSPProvider(
+                last_graph,
+                backend="persisted-symbol-graph-v1",
+            ),
+            parity_seeds,
+        )
+        native_mcp_outcomes = _mcp_query_outcomes(
+            StaticLSPProvider(
+                last_index,
+                backend="native-clangd-fact-query-v1",
+            ),
+            parity_seeds,
+        )
+        if native_mcp_outcomes != legacy_mcp_outcomes:
+            raise AssertionError("MCP definition/reference outcomes differ")
     except AssertionError as exc:
         parity = False
         parity_error = str(exc)
@@ -231,6 +317,14 @@ def profile_clangd_fact_query_index(
         external_index_seconds=external_index_seconds,
         parity=parity,
         candidate_name="native-clangd-fact-query-index",
+    )
+    consumer_decision = acceleration_decision(
+        legacy_local_seconds=legacy_summary["consumer_total"]["median_seconds"],
+        candidate_local_seconds=native_summary["consumer_total"]["median_seconds"],
+        threshold=threshold,
+        external_index_seconds=external_index_seconds,
+        parity=parity,
+        candidate_name="native-clangd-mcp-provider",
     )
     hash_seconds = native_summary["native_stage_hash_index"]["median_seconds"]
     verify_seconds = native_summary["native_stage_verify_snapshot"]["median_seconds"]
@@ -264,6 +358,7 @@ def profile_clangd_fact_query_index(
             "cyclic_gc_disabled_during_timed_regions": True,
             "external_index_seconds": external_index_seconds,
             "clangd_fact_query_contract": contract,
+            "consumer_boundary": "codenib.mcp.tools.lsp:v1",
         },
         "capabilities": dict(contract["capabilities"]),
         "parity": {"passed": parity, "error": parity_error},
@@ -285,6 +380,7 @@ def profile_clangd_fact_query_index(
             ),
         },
         "decision": decision,
+        "mcp_consumer_decision": consumer_decision,
     }
 
 

--- a/test/agent/test_lsp_graph.py
+++ b/test/agent/test_lsp_graph.py
@@ -468,3 +468,21 @@ def test_lsp_route_skill_exposes_static_graph_tool_contract():
     assert results[0].content == "route endpoint: direct seed HandleRequest"
     assert lsp_result_metadata(results)["provider"] == STATIC_LSP_PROVIDER
     assert lsp_result_metadata(results)["capability"] == "route"
+
+
+def test_lsp_route_skill_uses_injected_provider_without_graph():
+    class Provider:
+        def route(self, **kwargs):
+            return [kwargs]
+
+    context = {"expand": ExpandContext(lsp_provider=Provider())}
+    meta = SkillLoader().load_skill("codenib/agent/skills/lsp_route", context)
+
+    assert meta.executor_fn(symbols=["demo"], query="find demo") == [
+        {
+            "symbols": ["demo"],
+            "query": "find demo",
+            "top_k": 12,
+            "include_neighbors": True,
+        }
+    ]

--- a/test/agent/test_lsp_provider.py
+++ b/test/agent/test_lsp_provider.py
@@ -7,13 +7,14 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from codenib.agent.lsp_provider import (
     STATIC_LSP_PROVIDER,
     LSPProviderNodes,
     StaticLSPProvider,
     normalize_native_lsp_nodes,
+    select_checkout_lsp_provider,
 )
 from codenib.agent.runner import AgentRunner
 from codenib.agent.skills.core import (
@@ -191,6 +192,104 @@ def test_static_lsp_provider_reports_fallback_reason_without_graph():
     assert decision.status == "unavailable"
     assert decision.fallback_reason == "symbol_graph_unavailable"
     assert decision.provider == STATIC_LSP_PROVIDER
+
+
+def test_persisted_provider_fallback_is_explicit_in_result_metadata():
+    provider, selection = select_checkout_lsp_provider(
+        project_root="/portable/repo",
+        languages=["cpp"],
+        symbol_graph=_range_graph(),
+        allow_native=False,
+        native_disabled_reason="portable_artifact_uses_persisted_graph",
+    )
+
+    result = provider.definition(symbol="load_config")
+    metadata = result.provider_metadata_dict()
+
+    assert selection["backend"] == "persisted-symbol-graph-v1"
+    assert selection["fallback_reason"] == ("portable_artifact_uses_persisted_graph")
+    assert metadata["backend"] == "persisted-symbol-graph-v1"
+    assert metadata["fallback_reason"] == ("portable_artifact_uses_persisted_graph")
+
+
+def test_mixed_language_checkout_does_not_hide_graph_symbols():
+    graph = _range_graph()
+    provider, selection = select_checkout_lsp_provider(
+        project_root="/mixed/repo",
+        languages=["cpp", "python"],
+        symbol_graph=graph,
+    )
+
+    assert provider.graph is graph
+    assert selection["backend"] == "persisted-symbol-graph-v1"
+    assert selection["fallback_reason"] == ("mixed_language_requires_persisted_graph")
+    assert selection["capabilities"] == {
+        "definition": True,
+        "references": True,
+        "route": True,
+    }
+
+
+def test_unknown_language_alongside_cpp_forces_graph_fallback():
+    graph = _range_graph()
+    provider, selection = select_checkout_lsp_provider(
+        project_root="/mixed/repo",
+        languages=["cpp", "unregistered-language"],
+        symbol_graph=graph,
+    )
+
+    assert provider.graph is graph
+    assert selection["backend"] == "persisted-symbol-graph-v1"
+    assert selection["fallback_reason"] == ("mixed_language_requires_persisted_graph")
+
+
+def test_runtime_native_off_switch_uses_persisted_provider(monkeypatch):
+    graph = _range_graph()
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "off")
+
+    with patch("codenib.ls_router.LSIndexer") as indexer:
+        provider, selection = select_checkout_lsp_provider(
+            project_root="/local/repo",
+            languages=["cpp"],
+            symbol_graph=graph,
+        )
+
+    indexer.assert_not_called()
+    assert provider.graph is graph
+    assert selection["backend"] == "persisted-symbol-graph-v1"
+    assert selection["fallback_reason"] == "native_clangd_provider_disabled"
+
+
+def test_native_checkout_selection_requires_native_query_provider():
+    native_provider = SimpleNamespace(
+        provider=STATIC_LSP_PROVIDER,
+        provider_backend="native-clangd-fact-query-v1",
+        snapshot_id="clangd_fact_query:sha256:test",
+    )
+
+    with patch("codenib.ls_router.LSIndexer") as indexer:
+        indexer.return_value.process_query_provider.return_value = native_provider
+        provider, selection = select_checkout_lsp_provider(
+            project_root="/local/repo",
+            languages=["cpp"],
+            symbol_graph=_range_graph(),
+        )
+
+    assert provider is native_provider
+    indexer.return_value.process_query_provider.assert_called_once_with(
+        require_native=True
+    )
+    assert selection == {
+        "provider": STATIC_LSP_PROVIDER,
+        "backend": "native-clangd-fact-query-v1",
+        "status": "ok",
+        "index_snapshot": "clangd_fact_query:sha256:test",
+        "capabilities": {
+            "definition": True,
+            "references": True,
+            "route": True,
+        },
+    }
 
 
 def test_runner_traces_static_lsp_provider_for_dynamic_tool_call():

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -250,6 +250,66 @@ def test_build_returns_expand_for_find_callers(registry, mocked_build, tmp_path)
     assert contexts["expand"].code_graph is not None
 
 
+def test_build_injects_native_provider_into_cpp_expand_context(
+    registry, mocked_build, tmp_path, monkeypatch
+):
+    from codenib.agent import lsp_provider
+
+    native_provider = object()
+    selections = []
+
+    def select_provider(**kwargs):
+        selections.append(kwargs)
+        return native_provider, {"backend": "native-clangd-fact-query-v1"}
+
+    monkeypatch.setattr(
+        lsp_provider,
+        "select_checkout_lsp_provider",
+        select_provider,
+    )
+
+    contexts = skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["find_callers"],
+        languages=("cpp",),
+        cache_dir=str(tmp_path / "cache"),
+        skill_registry=registry,
+    )
+
+    assert contexts["expand"].lsp_provider is native_provider
+    assert selections == [
+        {
+            "project_root": str(tmp_path),
+            "languages": ("cpp",),
+            "symbol_graph": contexts["expand"].code_graph,
+        }
+    ]
+
+
+def test_cpp_retrieve_context_does_not_start_lsp_provider(
+    registry, mocked_build, tmp_path, monkeypatch
+):
+    from codenib.agent import lsp_provider
+
+    selections = []
+    monkeypatch.setattr(
+        lsp_provider,
+        "select_checkout_lsp_provider",
+        lambda **kwargs: selections.append(kwargs),
+    )
+
+    contexts = skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["bm25_search"],
+        languages=("cpp",),
+        cache_dir=str(tmp_path / "cache"),
+        skill_registry=registry,
+    )
+
+    assert set(contexts) == {"retrieve"}
+    assert selections == []
+
+
 def test_build_returns_both_keys_for_mixed_skills(registry, mocked_build, tmp_path):
     contexts = skill_context.build_skill_contexts(
         repo_path=str(tmp_path),

--- a/test/ls_index/test_clangd_fact_query.py
+++ b/test/ls_index/test_clangd_fact_query.py
@@ -13,6 +13,7 @@ import os
 import struct
 import zlib
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable
 
 import pytest
@@ -27,6 +28,7 @@ import codenib_core  # noqa: E402
 
 from codenib.agent.lsp_graph import lsp_definition, lsp_references  # noqa: E402
 from codenib.agent.lsp_provider import StaticLSPProvider  # noqa: E402
+from codenib.compiler.manifest import RepoManifest  # noqa: E402
 from codenib.graph.code_graph import CodeGraph  # noqa: E402
 from codenib.ls_index import clangd_decode  # noqa: E402
 from codenib.ls_index.clangd_decode import ClangdGraphDecoder  # noqa: E402
@@ -35,6 +37,12 @@ from codenib.ls_index.clangd_decode import (
     _validate_native_query_contract,
 )
 from codenib.ls_router import LSIndexer  # noqa: E402
+from codenib.mcp.context import ServerContext  # noqa: E402
+from codenib.mcp.tools.lsp import (  # noqa: E402
+    lsp_definition_impl,
+    lsp_references_impl,
+    lsp_route_impl,
+)
 from codenib.types import EDGE_TYPE_REFERENCE, node_has_definition  # noqa: E402
 from scripts.profiling.profile_clangd_fact_query_index import (  # noqa: E402
     main as profile_main,
@@ -996,6 +1004,103 @@ def test_ls_indexer_exposes_query_index_and_provider(
     assert provider.decoder._graph_materialized is False
 
 
+def test_real_mcp_boundary_uses_native_symbols_then_one_lazy_graph(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+    monkeypatch.delenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", raising=False)
+    legacy_graph = ClangdGraphDecoder(
+        str(idx_directory), str(root)
+    ).materialize_code_graph()
+    legacy = SimpleNamespace(
+        lsp_provider=StaticLSPProvider(legacy_graph),
+        symbol_graph=legacy_graph,
+    )
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    provider = decoder.decode_native_query_provider()
+    context = SimpleNamespace(lsp_provider=provider, symbol_graph=None)
+    target = bytes.fromhex("1112131415161718").hex()
+
+    definitions = lsp_definition_impl(context, symbol=target, top_k=10)
+    references = lsp_references_impl(context, symbol=target, top_k=10)
+
+    assert decoder._graph_materialized is False
+    assert provider.graph_materialization_count == 0
+    assert definitions[0]["lsp_provider"]["backend"] == ("native-clangd-fact-query-v1")
+    assert definitions[0]["lsp_provider"]["index_snapshot"] == (provider.snapshot_id)
+    assert references[0]["lsp_provider"]["backend"] == ("native-clangd-fact-query-v1")
+
+    position_arguments = {
+        "file_path": "src/main.cpp",
+        "line": 2,
+        "character": 22,
+        "top_k": 10,
+    }
+    position = lsp_definition_impl(context, **position_arguments)
+    expected_position = lsp_definition_impl(legacy, **position_arguments)
+
+    assert [
+        {key: value for key, value in row.items() if key != "lsp_provider"}
+        for row in position
+    ] == expected_position
+    assert position[0]["lsp_provider"]["backend"] == ("lazy-clangd-code-graph-v1")
+    assert position[0]["lsp_provider"]["fallback_reason"] == (
+        "native_clangd_position_query_requires_complete_graph"
+    )
+    assert decoder._graph_materialized is True
+    assert provider.graph_materialization_count == 1
+
+    route_arguments = {
+        "symbols": [target],
+        "query": "target caller",
+        "top_k": 10,
+    }
+    route = lsp_route_impl(context, **route_arguments)
+    expected_route = lsp_route_impl(legacy, **route_arguments)
+
+    assert [
+        {key: value for key, value in row.items() if key != "lsp_provider"}
+        for row in route
+    ] == expected_route
+    assert route[0]["lsp_provider"]["backend"] == ("lazy-clangd-code-graph-v1")
+    assert route[0]["lsp_provider"]["fallback_reason"] == (
+        "native_clangd_route_query_requires_complete_graph"
+    )
+    assert provider.graph_materialization_count == 1
+
+
+def test_server_context_selects_native_and_portable_graph_fallback(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+    monkeypatch.delenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", raising=False)
+    graph = ClangdGraphDecoder(str(idx_directory), str(root)).materialize_code_graph()
+    context = ServerContext(
+        manifest=RepoManifest(repo_path=str(root), languages=["cpp"]),
+        symbol_graph=graph,
+    )
+
+    native = context.configure_lsp_provider(allow_native=True)
+
+    assert native["backend"] == "native-clangd-fact-query-v1"
+    assert native["index_snapshot"].startswith("clangd_fact_query:sha256:")
+    assert native["capabilities"] == {
+        "definition": True,
+        "references": True,
+        "route": True,
+    }
+    assert context.lsp_provider.decoder._graph_materialized is False
+
+    portable = context.configure_lsp_provider(
+        allow_native=False,
+        native_disabled_reason="portable_artifact_uses_persisted_graph",
+    )
+
+    assert portable["backend"] == "persisted-symbol-graph-v1"
+    assert portable["fallback_reason"] == "portable_artifact_uses_persisted_graph"
+    assert context.lsp_provider.graph is graph
+
+
 def test_profiler_records_parity_samples_order_and_contract(
     clangd_fixture,
 ) -> None:
@@ -1027,6 +1132,12 @@ def test_profiler_records_parity_samples_order_and_contract(
     )
     assert 0 <= report["snapshot_receipt"]["fraction_of_native_startup"] <= 1
     assert report["decision"]["parity"] is True
+    assert report["mcp_consumer_decision"]["parity"] is True
+    assert len(report["raw_samples"]["legacy_clangd_graph"]["consumer_total"]) == 2
+    assert (
+        len(report["raw_samples"]["native_clangd_fact_query_index"]["consumer_total"])
+        == 2
+    )
 
 
 def test_profiler_cli_writes_json(clangd_fixture, tmp_path: Path, capsys) -> None:

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -15,6 +15,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Literal
 from unittest.mock import MagicMock, patch
 
@@ -249,6 +250,44 @@ def test_lsp_definition_tool_no_symbol_graph():
     result = lsp_definition_impl(MagicMock(symbol_graph=None), symbol="load_config")
 
     assert result == {"error": "symbol_graph index not available"}
+
+
+def test_lsp_definition_uses_injected_provider_and_serializes_metadata():
+    from codenib.agent.lsp_provider import LSPProviderMetadata, LSPProviderNodes
+    from codenib.types import QueriedNode
+
+    class Provider:
+        def definition(self, **_kwargs):
+            return LSPProviderNodes(
+                [
+                    QueriedNode(
+                        node_name="demo",
+                        file="demo.cpp",
+                        start_line=4,
+                        end_line=4,
+                        content="definition of demo",
+                    )
+                ],
+                metadata=LSPProviderMetadata(
+                    provider="codenib_static_index",
+                    capability="definition",
+                    status="ok",
+                    lsp_method="textDocument/definition",
+                    backend="native-clangd-fact-query-v1",
+                    index_snapshot="clangd_fact_query:sha256:test",
+                ),
+            )
+
+    result = lsp_definition_impl(
+        SimpleNamespace(lsp_provider=Provider(), symbol_graph=None),
+        symbol="demo",
+    )
+
+    assert result[0]["start_line"] == 5
+    assert result[0]["lsp_provider"]["backend"] == ("native-clangd-fact-query-v1")
+    assert result[0]["lsp_provider"]["index_snapshot"] == (
+        "clangd_fact_query:sha256:test"
+    )
 
 
 def test_lsp_definition_tool_serializes_one_based_lines():

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -91,6 +91,31 @@ def test_load_selects_only_requested_views(
     assert calls == ["bm25"]
 
 
+def test_portable_context_never_attaches_project_local_native_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    graph = object()
+
+    def load_graph(self):
+        self.symbol_graph = graph
+
+    monkeypatch.setattr(ServerContext, "_load_symbol_graph", load_graph)
+    manifest = RepoManifest(repo_path=str(tmp_path), languages=["cpp"])
+    with patch("codenib.ls_router.LSIndexer") as indexer:
+        ctx = ServerContext.load(
+            manifest,
+            views={"symbol_graph"},
+            artifact={"verified": True},
+        )
+
+    indexer.assert_not_called()
+    assert ctx.lsp_provider.graph is graph
+    assert ctx.lsp_provider_selection["backend"] == "persisted-symbol-graph-v1"
+    assert ctx.lsp_provider_selection["fallback_reason"] == (
+        "portable_artifact_uses_persisted_graph"
+    )
+
+
 def test_load_views_adds_resources_idempotently(
     manifest_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -110,6 +135,36 @@ def test_load_views_adds_resources_idempotently(
 
     assert calls == ["bm25"]
     assert ctx.loaded_views == frozenset({"bm25"})
+
+
+def test_load_views_rebinds_lsp_provider_after_lazy_graph_load(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest = RepoManifest(repo_path=str(tmp_path), languages=["cpp"])
+    ctx = ServerContext.load(manifest, views=(), artifact={"verified": True})
+    graph = object()
+
+    def load_graph(self):
+        self.symbol_graph = graph
+
+    monkeypatch.setattr(ServerContext, "_load_symbol_graph", load_graph)
+
+    assert ctx.lsp_provider is None
+    assert ctx.lsp_provider_selection["status"] == "unavailable"
+    assert ctx.load_views({"symbol_graph"}) == {}
+    assert ctx.lsp_provider.graph is graph
+    assert ctx.lsp_provider_selection == {
+        "provider": "codenib_static_index",
+        "backend": "persisted-symbol-graph-v1",
+        "status": "ok",
+        "index_snapshot": "symbol_graph:unknown:0:0",
+        "fallback_reason": "portable_artifact_uses_persisted_graph",
+        "capabilities": {
+            "definition": True,
+            "references": True,
+            "route": True,
+        },
+    }
 
 
 def test_close_releases_live_runtime_resources(manifest_dir: Path) -> None:

--- a/test/mcp_server/test_server.py
+++ b/test/mcp_server/test_server.py
@@ -38,6 +38,11 @@ def _make_server_ctx(*, bm25_results=None, regex_results=None, zoekt_results=Non
     ctx.zoekt = MagicMock() if zoekt_results is not None else None
     ctx.errors = {}
     ctx.artifact = None
+    ctx.lsp_provider_selection = {
+        "provider": "codenib_static_index",
+        "backend": "persisted-symbol-graph-v1",
+        "status": "ok",
+    }
     if bm25_results is not None:
         ctx.bm25.search.return_value = bm25_results
     if regex_results is not None:
@@ -129,6 +134,7 @@ def test_get_manifest_tool() -> None:
 
     assert result["repo"]["path"] == "/repo"
     assert result["repo"]["commit"] == "abc123"
+    assert result["runtime"]["lsp_provider"]["backend"] == ("persisted-symbol-graph-v1")
 
 
 def test_search_bm25_raises_without_ctx() -> None:


### PR DESCRIPTION
## Summary
Route real C++ MCP and agent LSP symbol queries through the promoted native clangd FactQuery provider while keeping position/route compatibility and explicit persisted-graph fallback.

Closes #549.

## Changes
- Select a runtime-only native provider only for source-verified local C/C++ contexts with an existing clangd generation; never generate or package raw clangd indexes.
- Route MCP definition, references, route, and all three agent LSP skills through the shared provider resolver.
- Preserve portable, mixed-language, disabled, unavailable, and unknown-language contexts through deterministic persisted-graph fallback metadata.
- Keep native symbol calls graph-free and materialize one snapshot-compatible complete graph lazily for position or route calls.
- Extend the maintained profiler to measure MCP validation and serialization and document the 84.45% consumer-boundary improvement.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Focused MCP/agent/compiler/native suite: 167 passed.
- make core-test: 112 passed, 4 skipped, plus all five C++ executables.
- Affected subtrees: 869 passed, 7 skipped, with the documented unrelated umask baseline test deselected.
- Full unit tier: 3952 passed, 8 skipped, with the two previously audited unrelated FAISS/umask baseline tests deselected.
- pre-commit, mkdocs build --strict, and scripts/check_public_docs.py passed.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published