### PR TITLE
perf(cpp): add native clangd position queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,8 @@ clangd-workload-gate: core-build
 	@test -n "$(CLANGD_WORKLOAD_GATE_INDEX_DIR)" || { echo "Set CLANGD_WORKLOAD_GATE_INDEX_DIR=/path/to/.cache/clangd/index" >&2; exit 1; }
 	@test -n "$(CLANGD_WORKLOAD_GATE_PROJECT_ROOT)" || { echo "Set CLANGD_WORKLOAD_GATE_PROJECT_ROOT=/path/to/repository" >&2; exit 1; }
 	PYTHONPATH="build/core:$$PYTHONPATH" python -m pytest -q \
-		test/ls_index/test_clangd_fact_query.py::test_symbol_results_errors_counts_and_relations_match_graph
+		test/ls_index/test_clangd_fact_query.py::test_symbol_results_errors_counts_and_relations_match_graph \
+		test/ls_index/test_clangd_fact_query.py::test_native_position_queries_match_legacy_without_materializing_graph
 	PYTHONPATH="build/core:$$PYTHONPATH" python scripts/profiling/profile_clangd_workload_gate.py \
 		--idx-directory "$(CLANGD_WORKLOAD_GATE_INDEX_DIR)" \
 		--project-root "$(CLANGD_WORKLOAD_GATE_PROJECT_ROOT)" \

--- a/codenib/agent/lsp_provider.py
+++ b/codenib/agent/lsp_provider.py
@@ -12,10 +12,11 @@ required.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
-from ..scip_interface.lsp_occurrence_index import SCIPOccurrenceIndex
 from ..types import QueriedNode
 from .lsp_graph import lsp_definition, lsp_references, lsp_route
 from .route_context import fingerprint_lsp_route_nodes, summarize_lsp_route_nodes
@@ -36,6 +37,8 @@ _SUPPORTED_CAPABILITIES = frozenset(_LSP_METHODS)
 _GRAPH_BEHAVIOR_CONTRACT = "static_graph_lsp_v1"
 _GRAPH_POSITION_BEHAVIOR_CONTRACT = "static_symbol_graph_position_lsp_v1"
 _OCCURRENCE_BEHAVIOR_CONTRACT = "static_scip_occurrence_lsp_v1"
+_NATIVE_OCCURRENCE_BEHAVIOR_CONTRACT = "static_native_occurrence_lsp_v1"
+_POSITION_WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
 @dataclass(frozen=True)
@@ -51,6 +54,7 @@ class LSPProviderMetadata:
     fallback_reason: Optional[str] = None
     behavior_contract: str = _GRAPH_BEHAVIOR_CONTRACT
     position_granularity: str = "line"
+    position_encoding: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
         out = {
@@ -67,6 +71,8 @@ class LSPProviderMetadata:
             out["index_snapshot"] = self.index_snapshot
         if self.fallback_reason is not None:
             out["fallback_reason"] = self.fallback_reason
+        if self.position_encoding is not None:
+            out["position_encoding"] = self.position_encoding
         return out
 
 
@@ -86,6 +92,178 @@ class LSPProviderNodes(list):
         return self.lsp_provider_metadata.to_dict()
 
 
+class LSPPositionFallback(ValueError):
+    """Signal that an exact occurrence query must use the legacy provider."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = str(reason or "native_position_fallback")
+        super().__init__(self.reason)
+
+
+class NativeOccurrenceQueryAdapter:
+    """Occurrence adapter whose rows and interval postings remain in C++."""
+
+    behavior_contract = _NATIVE_OCCURRENCE_BEHAVIOR_CONTRACT
+    authoritative_empty = True
+
+    def __init__(self, query_index: Any) -> None:
+        self.query_index = query_index
+        self.position_encoding = str(
+            getattr(query_index, "position_encoding", None) or "UTF16"
+        )
+        self.occurrence_count = int(getattr(query_index, "occurrence_count", 0))
+        self.project_root = Path(str(getattr(query_index, "project_root", "") or ""))
+
+    def occurrence_at(self, file_path: str, line: int, character: int) -> Any:
+        if self.query_index.has_occurrence_at(file_path, line, character):
+            return {
+                "file_path": file_path,
+                "line": int(line),
+                "character": int(character),
+            }
+        return None
+
+    def definitions(
+        self,
+        *,
+        file_path: str,
+        line: int,
+        character: int,
+        top_k: int = 8,
+    ) -> list[Mapping[str, Any]]:
+        return self._locations(
+            self.query_index.position_definitions(
+                file_path=file_path,
+                line=line,
+                character=character,
+                top_k=top_k,
+            ),
+            file_path=file_path,
+            line=line,
+            character=character,
+        )
+
+    def references(
+        self,
+        *,
+        file_path: str,
+        line: int,
+        character: int,
+        include_declaration: bool = True,
+        top_k: int = 40,
+    ) -> list[Mapping[str, Any]]:
+        return self._locations(
+            self.query_index.position_references(
+                file_path=file_path,
+                line=line,
+                character=character,
+                include_declaration=include_declaration,
+                top_k=top_k,
+            ),
+            file_path=file_path,
+            line=line,
+            character=character,
+        )
+
+    def _locations(
+        self,
+        payload: Any,
+        *,
+        file_path: str,
+        line: int,
+        character: int,
+    ) -> list[Mapping[str, Any]]:
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("native occurrence query returned an invalid result")
+        if payload.get("served") is not True:
+            raise LSPPositionFallback(
+                str(payload.get("fallback_reason") or "native_position_fallback")
+            )
+        locations = payload.get("locations")
+        if not isinstance(locations, list) or not all(
+            isinstance(location, Mapping) for location in locations
+        ):
+            raise RuntimeError("native occurrence query returned invalid locations")
+        targets = payload.get("targets")
+        if not isinstance(targets, list) or not all(
+            isinstance(target, int) and not isinstance(target, bool)
+            for target in targets
+        ):
+            raise RuntimeError("native occurrence query returned invalid targets")
+        self._require_legacy_token_match(
+            file_path=file_path,
+            line=line,
+            character=character,
+            targets=targets,
+        )
+        return locations
+
+    def _require_legacy_token_match(
+        self,
+        *,
+        file_path: str,
+        line: int,
+        character: int,
+        targets: Sequence[int],
+    ) -> None:
+        token = self._source_token(file_path, line, character)
+        if token is None or not targets:
+            raise LSPPositionFallback("native_position_token_requires_legacy_graph")
+        for target in targets:
+            info = self.query_index.get_node_info_by_id(target)
+            if not isinstance(info, Mapping):
+                raise LSPPositionFallback("native_position_token_requires_legacy_graph")
+            anchors = {
+                self._bare_symbol(str(value))
+                for value in (info.get("name"), info.get("unified_name"))
+                if value
+            }
+            if token not in anchors:
+                raise LSPPositionFallback("native_position_token_requires_legacy_graph")
+
+    def _source_token(self, file_path: str, line: int, character: int) -> Optional[str]:
+        relative = Path(file_path)
+        if (
+            relative.is_absolute()
+            or relative != Path(*relative.parts)
+            or any(part in {"", ".", ".."} for part in relative.parts)
+        ):
+            return None
+        try:
+            root = self.project_root.resolve()
+            source = (root / relative).resolve()
+            source.relative_to(root)
+            source_line = source.read_text(
+                encoding="utf-8", errors="strict"
+            ).splitlines()[int(line)]
+            codepoint_character = self._codepoint_character(source_line, character)
+        except (OSError, IndexError, ValueError):
+            return None
+        for match in _POSITION_WORD_RE.finditer(source_line):
+            if match.start() <= codepoint_character < match.end():
+                return match.group(0)
+        return None
+
+    def _codepoint_character(self, source_line: str, character: int) -> int:
+        if character < 0:
+            raise ValueError("character must be non-negative")
+        if self.position_encoding == "UTF32":
+            if character > len(source_line):
+                raise ValueError("character exceeds source line")
+            return character
+        codec = "utf-8" if self.position_encoding == "UTF8" else "utf-16-le"
+        width = 1 if self.position_encoding == "UTF8" else 2
+        encoded = source_line.encode(codec)
+        offset = character * width
+        if offset > len(encoded):
+            raise ValueError("character exceeds source line")
+        return len(encoded[:offset].decode(codec))
+
+    @staticmethod
+    def _bare_symbol(symbol: str) -> str:
+        return symbol.split(":")[-1].split(".")[-1].split("#")[-1].rstrip("()")
+
+
 class StaticLSPProvider:
     """LSP-shaped provider backed by a loaded CodeNib symbol graph."""
 
@@ -96,7 +274,7 @@ class StaticLSPProvider:
         graph: Any,
         *,
         snapshot_id: Optional[str] = None,
-        occurrence_index: Optional[SCIPOccurrenceIndex] = None,
+        occurrence_index: Optional[Any] = None,
         backend: Optional[str] = None,
         fallback_reason: Optional[str] = None,
     ) -> None:
@@ -107,6 +285,15 @@ class StaticLSPProvider:
         self.snapshot_id = snapshot_id or _graph_snapshot_id(graph)
         self.backend = backend
         self.fallback_reason = fallback_reason
+        self.position_encoding = getattr(
+            self.occurrence_index, "position_encoding", None
+        )
+
+    def _occurrence_behavior_contract(self) -> str:
+        return str(
+            getattr(self.occurrence_index, "behavior_contract", None)
+            or _OCCURRENCE_BEHAVIOR_CONTRACT
+        )
 
     def can_serve(self, capability: str) -> LSPProviderMetadata:
         """Return a non-throwing fast-path decision for one capability."""
@@ -130,8 +317,9 @@ class StaticLSPProvider:
                 snapshot_id=self.snapshot_id,
                 backend=self.backend,
                 fallback_reason=self.fallback_reason,
-                behavior_contract=_OCCURRENCE_BEHAVIOR_CONTRACT,
+                behavior_contract=self._occurrence_behavior_contract(),
                 position_granularity="character",
+                position_encoding=self.position_encoding,
             )
         if self.graph is None:
             return _metadata(
@@ -175,14 +363,19 @@ class StaticLSPProvider:
                     character=character,
                     top_k=top_k,
                 )
+            except LSPPositionFallback:
+                raise
             except ValueError:
                 locations = []
-            if locations:
+            if locations or getattr(
+                self.occurrence_index, "authoritative_empty", False
+            ):
                 return self._wrap(
                     CAPABILITY_DEFINITION,
                     _nodes_from_locations(locations, capability=CAPABILITY_DEFINITION),
-                    behavior_contract=_OCCURRENCE_BEHAVIOR_CONTRACT,
+                    behavior_contract=self._occurrence_behavior_contract(),
                     position_granularity="character",
+                    position_encoding=self.position_encoding,
                 )
         nodes = lsp_definition(
             self.graph,
@@ -207,6 +400,7 @@ class StaticLSPProvider:
                 else _GRAPH_BEHAVIOR_CONTRACT
             ),
             position_granularity="character" if position_query else "line",
+            position_encoding="UTF32" if position_query else None,
         )
 
     def references(
@@ -237,14 +431,19 @@ class StaticLSPProvider:
                     include_declaration=include_declaration,
                     top_k=top_k,
                 )
+            except LSPPositionFallback:
+                raise
             except ValueError:
                 locations = []
-            if locations:
+            if locations or getattr(
+                self.occurrence_index, "authoritative_empty", False
+            ):
                 return self._wrap(
                     CAPABILITY_REFERENCES,
                     _nodes_from_locations(locations, capability=CAPABILITY_REFERENCES),
-                    behavior_contract=_OCCURRENCE_BEHAVIOR_CONTRACT,
+                    behavior_contract=self._occurrence_behavior_contract(),
                     position_granularity="character",
+                    position_encoding=self.position_encoding,
                 )
         nodes = lsp_references(
             self.graph,
@@ -270,6 +469,7 @@ class StaticLSPProvider:
                 else _GRAPH_BEHAVIOR_CONTRACT
             ),
             position_granularity="character" if position_query else "line",
+            position_encoding="UTF32" if position_query else None,
         )
 
     def route(
@@ -307,6 +507,7 @@ class StaticLSPProvider:
         *,
         behavior_contract: str = _GRAPH_BEHAVIOR_CONTRACT,
         position_granularity: str = "line",
+        position_encoding: Optional[str] = None,
     ) -> LSPProviderNodes:
         if capability in {CAPABILITY_DEFINITION, CAPABILITY_REFERENCES}:
             nodes = normalize_native_lsp_nodes(nodes, capability=capability)
@@ -320,6 +521,7 @@ class StaticLSPProvider:
                 fallback_reason=self.fallback_reason,
                 behavior_contract=behavior_contract,
                 position_granularity=position_granularity,
+                position_encoding=position_encoding,
             ),
         )
 
@@ -534,6 +736,7 @@ def _metadata(
     fallback_reason: Optional[str] = None,
     behavior_contract: str = _GRAPH_BEHAVIOR_CONTRACT,
     position_granularity: str = "line",
+    position_encoding: Optional[str] = None,
 ) -> LSPProviderMetadata:
     normalized = normalize_lsp_capability(capability)
     return LSPProviderMetadata(
@@ -546,6 +749,7 @@ def _metadata(
         fallback_reason=fallback_reason,
         behavior_contract=behavior_contract,
         position_granularity=position_granularity,
+        position_encoding=position_encoding,
     )
 
 
@@ -592,8 +796,8 @@ def _nodes_from_locations(
 ) -> list[QueriedNode]:
     nodes = []
     for location in locations:
-        file_path = str(location.file_path)
-        start_line = int(location.start_line)
+        file_path = str(_node_value(location, "file_path"))
+        start_line = int(_node_value(location, "start_line"))
         display_line = start_line + 1
         nodes.append(
             QueriedNode(
@@ -602,7 +806,7 @@ def _nodes_from_locations(
                 file=file_path,
                 node_id=f"{file_path}:{display_line}:{capability}",
                 start_line=start_line,
-                end_line=int(location.end_line),
+                end_line=int(_node_value(location, "end_line")),
                 score=1.0,
                 content=f"lsp {capability}",
             )
@@ -628,8 +832,10 @@ __all__ = [
     "CAPABILITY_REFERENCES",
     "CAPABILITY_ROUTE",
     "JSON_RPC_LSP_PROVIDER",
+    "LSPPositionFallback",
     "LSPProviderMetadata",
     "LSPProviderNodes",
+    "NativeOccurrenceQueryAdapter",
     "STATIC_LSP_PROVIDER",
     "StaticLSPProvider",
     "resolve_lsp_provider",

--- a/codenib/graph/incremental/patcher_cpp.py
+++ b/codenib/graph/incremental/patcher_cpp.py
@@ -19,6 +19,7 @@ import time
 from pathlib import Path
 
 from ...log_utils import get_logger
+from ...ls_index.clangd_contract import clangd_background_index_command
 from ...types import (
     EDGE_TYPE_CONTAIN,
     EDGE_TYPE_REFERENCE,
@@ -406,13 +407,7 @@ class PatcherCpp(PatcherBase):
             )
             pre_count = len(list(idx_dir.glob("*.idx")))
 
-        cmd = [
-            clangd,
-            "--background-index",
-            f"--compile-commands-dir={comp_db.parent}",
-            "--background-index-priority=normal",
-            "--log=error",
-        ]
+        cmd = list(clangd_background_index_command(clangd, comp_db.parent))
         process = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,

--- a/codenib/ls_index/clangd_contract.py
+++ b/codenib/ls_index/clangd_contract.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared clangd generation and source-position contract."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional, Sequence
+
+CLANGD_DEFAULT_POSITION_ENCODING = "UTF16"
+CLANGD_SUPPORTED_POSITION_ENCODINGS = frozenset({"UTF8", "UTF16", "UTF32"})
+CLANGD_POSITION_ENCODING_ENV = "CODENIB_CLANGD_POSITION_ENCODING"
+
+
+def normalize_clangd_position_encoding(value: str) -> str:
+    """Normalize an LSP position encoding to the native contract spelling."""
+
+    compact = "".join(
+        character for character in str(value).upper() if character.isalnum()
+    )
+    if compact not in CLANGD_SUPPORTED_POSITION_ENCODINGS:
+        supported = ", ".join(sorted(CLANGD_SUPPORTED_POSITION_ENCODINGS))
+        raise ValueError(
+            f"clangd position encoding must be one of {supported}; got {value!r}"
+        )
+    return compact
+
+
+def clangd_position_encoding_flag(position_encoding: str) -> str:
+    """Return clangd's CLI spelling for a normalized position encoding."""
+
+    normalized = normalize_clangd_position_encoding(position_encoding)
+    return f"--offset-encoding={normalized[:3].lower()}-{normalized[3:]}"
+
+
+def configured_clangd_position_encoding(value: Optional[str] = None) -> str:
+    """Return the shared generation/decode encoding, including its override."""
+
+    raw = (
+        os.environ.get(CLANGD_POSITION_ENCODING_ENV, CLANGD_DEFAULT_POSITION_ENCODING)
+        if value is None
+        else value
+    )
+    return normalize_clangd_position_encoding(str(raw))
+
+
+def clangd_background_index_command(
+    executable: str,
+    compile_commands_dir: str | Path,
+    *,
+    position_encoding: Optional[str] = None,
+) -> Sequence[str]:
+    """Build the common full/incremental background-index command."""
+
+    encoding = configured_clangd_position_encoding(position_encoding)
+    return [
+        executable,
+        "--background-index",
+        f"--compile-commands-dir={compile_commands_dir}",
+        "--background-index-priority=normal",
+        clangd_position_encoding_flag(encoding),
+        "--log=error",
+    ]

--- a/codenib/ls_index/clangd_decode.py
+++ b/codenib/ls_index/clangd_decode.py
@@ -31,7 +31,6 @@ import zlib
 from pathlib import Path
 from typing import Any, List, Mapping, Optional, Tuple
 
-from ..code_chunking import CppCodeChunker
 from ..graph.code_graph import CodeGraph
 from ..types import (
     EDGE_TYPE_CONTAIN,
@@ -42,6 +41,12 @@ from ..types import (
     NODE_TYPE_METHOD,
     NODE_TYPE_SYMBOL,
     ROOT_NODE,
+)
+from .clangd_contract import (
+    CLANGD_DEFAULT_POSITION_ENCODING,
+    CLANGD_POSITION_ENCODING_ENV,
+    CLANGD_SUPPORTED_POSITION_ENCODINGS,
+    configured_clangd_position_encoding,
 )
 
 logger = logging.getLogger(__name__)
@@ -77,18 +82,19 @@ RELATION_OVERRIDDEN_BY = 1
 ZERO_SYMBOL_ID = "0" * 16
 
 _NATIVE_QUERY_ENV = "CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX"
+_NATIVE_POSITION_ENCODING_ENV = CLANGD_POSITION_ENCODING_ENV
 _NATIVE_QUERY_OFF = frozenset({"0", "false", "no", "off", "disabled"})
 _NATIVE_QUERY_AUTO = frozenset({"", "1", "true", "yes", "on", "auto"})
 _NATIVE_QUERY_REQUIRED = frozenset({"required", "strict"})
 _NATIVE_QUERY_PROMOTED = True
-_NATIVE_QUERY_ABI_VERSION = 1
-_NATIVE_QUERY_FORMAT = "clangd-riff-fact-query-v1"
-_NATIVE_QUERY_NORMALIZATION_PROFILE = "clangd-native-normalization-v1"
+_NATIVE_QUERY_ABI_VERSION = 2
+_NATIVE_QUERY_FORMAT = "clangd-riff-fact-query-v2"
+_NATIVE_QUERY_NORMALIZATION_PROFILE = "clangd-native-normalization-v2"
 _NATIVE_QUERY_SNAPSHOT_SCHEMA = "clangd-fact-query-snapshot-v1"
 _NATIVE_QUERY_CAPABILITIES = {
     "definition_by_symbol": True,
     "references_by_symbol": True,
-    "position_queries": False,
+    "position_queries": True,
     "route_queries": False,
 }
 
@@ -114,6 +120,19 @@ def native_clangd_query_promoted() -> bool:
     return _NATIVE_QUERY_PROMOTED
 
 
+def native_clangd_position_encoding(value: Optional[str] = None) -> str:
+    """Return the explicit character-unit contract for clangd RIFF ranges."""
+
+    raw = os.environ.get(_NATIVE_POSITION_ENCODING_ENV) if value is None else value
+    try:
+        return configured_clangd_position_encoding(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{_NATIVE_POSITION_ENCODING_ENV} must be UTF8, UTF16, or UTF32; "
+            f"got {raw!r}"
+        ) from exc
+
+
 def _validate_native_query_contract(contract: Mapping[str, Any]) -> None:
     abi_version = contract.get("abi_version")
     if type(abi_version) is not int or abi_version != _NATIVE_QUERY_ABI_VERSION:
@@ -136,9 +155,15 @@ def _validate_native_query_contract(contract: Mapping[str, Any]) -> None:
         raise RuntimeError("compiled clangd reader does not guarantee stable order")
     if contract.get("preserves_unanchored_relations") is not True:
         raise RuntimeError("compiled clangd reader drops legacy relation rows")
+    if contract.get("default_position_encoding") != CLANGD_DEFAULT_POSITION_ENCODING:
+        raise RuntimeError("compiled clangd default position encoding mismatch")
+    if set(contract.get("supported_position_encodings") or ()) != set(
+        CLANGD_SUPPORTED_POSITION_ENCODINGS
+    ):
+        raise RuntimeError("compiled clangd supported position encodings mismatch")
     if contract.get("capabilities") != _NATIVE_QUERY_CAPABILITIES:
         raise RuntimeError(
-            "compiled clangd FactQueryIndex capabilities do not match v1"
+            "compiled clangd FactQueryIndex capabilities do not match v2"
         )
 
 
@@ -415,12 +440,11 @@ def parse_idx_file(filepath: str) -> dict:
 
 
 class ClangdHybridQueryProvider:
-    """Serve symbol queries natively and lazily fall back for full-graph work.
+    """Serve symbol/position queries natively and lazily fall back for routes.
 
-    The baseline native index advertises no position or route capability.
-    Those requests therefore materialize the established Python CodeGraph
-    exactly once, including when first requests arrive concurrently. Native
-    position, route, and persisted-fact capabilities remain separate gates.
+    Exact supported occurrence queries stay graph-free. Unsupported or
+    ambiguous positions and every route request materialize the established
+    Python CodeGraph exactly once, including concurrent first fallbacks.
     """
 
     def __init__(self, decoder: "ClangdGraphDecoder", query_index: Any):
@@ -434,19 +458,60 @@ class ClangdHybridQueryProvider:
             snapshot_id=decoder.query_snapshot_id,
             backend=self.provider_backend,
         )
+        self.occurrence_index = None
+        self.position_query_index = None
+        self._position_provider = None
         self._graph_provider = None
-        self._graph_provider_lock = threading.Lock()
+        # Position-view decoding and legacy graph construction both read the
+        # clangd snapshot. Serialize their first publication so a concurrent
+        # caller never observes a partially initialized provider.
+        self._materialization_lock = threading.Lock()
         self.graph_materialization_count = 0
         self.graph_materialization_seconds = 0.0
+        self.position_initialization_count = 0
+        self.position_initialization_seconds = 0.0
         self.last_fallback_reason = None
+        self.last_position_fallback_reason = None
         self.provider = self._symbol_provider.provider
         self.snapshot_id = self._symbol_provider.snapshot_id
+        self.position_encoding = decoder.position_encoding
+
+    def _native_position_provider(self):
+        from ..agent.lsp_provider import NativeOccurrenceQueryAdapter, StaticLSPProvider
+
+        if self._position_provider is None:
+            with self._materialization_lock:
+                if self._position_provider is None:
+                    # Once the complete graph owns position service, avoid a
+                    # second snapshot decode that can no longer remain native.
+                    if (
+                        self._graph_provider is not None
+                        or self.decoder._graph_materialized
+                    ):
+                        return None
+                    started = time.perf_counter()
+                    position_index = self.decoder.decode_native_position_query_index()
+                    occurrence_index = NativeOccurrenceQueryAdapter(position_index)
+                    position_provider = StaticLSPProvider(
+                        position_index,
+                        snapshot_id=self.snapshot_id,
+                        occurrence_index=occurrence_index,
+                        backend=self.provider_backend,
+                    )
+                    self.position_initialization_seconds += (
+                        time.perf_counter() - started
+                    )
+                    self.position_initialization_count += 1
+                    self.position_query_index = position_index
+                    self.occurrence_index = occurrence_index
+                    self._position_provider = position_provider
+        return self._position_provider
 
     def _full_graph_provider(self):
         from ..agent.lsp_provider import StaticLSPProvider
 
         if self._graph_provider is None:
-            with self._graph_provider_lock:
+            with self._materialization_lock:
                 if self._graph_provider is None:
                     started = time.perf_counter()
                     graph = self.decoder.materialize_code_graph()
@@ -490,11 +555,41 @@ class ClangdHybridQueryProvider:
                 backend="lazy-clangd-code-graph-v1",
                 fallback_reason="native_clangd_route_query_requires_complete_graph",
             )
+        if str(capability) in {
+            "definition",
+            "references",
+            "textDocument/definition",
+            "textDocument/references",
+        }:
+            from dataclasses import replace
+
+            return replace(
+                decision,
+                behavior_contract="static_native_occurrence_lsp_v1",
+                position_granularity="character",
+                position_encoding=self.position_encoding,
+            )
         return decision
 
     def definition(self, **arguments):
-        if arguments.get("symbol"):
+        if arguments.get("symbol") is not None:
             return self._symbol_provider.definition(**arguments)
+        if self._is_position_query(arguments):
+            from ..agent.lsp_provider import LSPPositionFallback
+
+            position_provider = self._native_position_provider()
+            if position_provider is None:
+                return self._position_fallback(
+                    "definition",
+                    "native_position_legacy_graph_already_materialized",
+                    arguments,
+                )
+            try:
+                result = position_provider.definition(**arguments)
+            except LSPPositionFallback as exc:
+                return self._position_fallback("definition", exc.reason, arguments)
+            self.last_position_fallback_reason = None
+            return result
         return self._graph_fallback(
             "definition",
             "native_clangd_position_query_requires_complete_graph",
@@ -502,8 +597,24 @@ class ClangdHybridQueryProvider:
         )
 
     def references(self, **arguments):
-        if arguments.get("symbol"):
+        if arguments.get("symbol") is not None:
             return self._symbol_provider.references(**arguments)
+        if self._is_position_query(arguments):
+            from ..agent.lsp_provider import LSPPositionFallback
+
+            position_provider = self._native_position_provider()
+            if position_provider is None:
+                return self._position_fallback(
+                    "references",
+                    "native_position_legacy_graph_already_materialized",
+                    arguments,
+                )
+            try:
+                result = position_provider.references(**arguments)
+            except LSPPositionFallback as exc:
+                return self._position_fallback("references", exc.reason, arguments)
+            self.last_position_fallback_reason = None
+            return result
         return self._graph_fallback(
             "references",
             "native_clangd_position_query_requires_complete_graph",
@@ -516,6 +627,78 @@ class ClangdHybridQueryProvider:
             "native_clangd_route_query_requires_complete_graph",
             arguments,
         )
+
+    def position_samples(self, limit: int = 100):
+        """Return deterministic exact positions without materializing CodeGraph."""
+
+        position_provider = self._native_position_provider()
+        if position_provider is None or self.position_query_index is None:
+            raise RuntimeError(
+                "native clangd position samples require an unmaterialized snapshot"
+            )
+        return self.position_query_index.position_samples(limit)
+
+    @staticmethod
+    def _is_position_query(arguments: Mapping[str, Any]) -> bool:
+        return (
+            arguments.get("file_path") is not None
+            and arguments.get("line") is not None
+            and arguments.get("character") is not None
+            and arguments.get("symbol") is None
+        )
+
+    def _position_fallback(
+        self, capability: str, reason: str, arguments: Mapping[str, Any]
+    ):
+        from dataclasses import replace
+
+        from ..agent.lsp_provider import LSPProviderNodes
+
+        self.last_position_fallback_reason = reason
+        graph_arguments = dict(arguments)
+        graph_arguments["character"] = self._graph_character(arguments)
+        result = getattr(self._full_graph_provider(), capability)(**graph_arguments)
+        return LSPProviderNodes(
+            result,
+            metadata=replace(
+                result.lsp_provider_metadata,
+                fallback_reason=reason,
+                position_encoding=self.position_encoding,
+            ),
+        )
+
+    def _graph_character(self, arguments: Mapping[str, Any]) -> int:
+        character = int(arguments["character"])
+        if self.position_encoding == "UTF32":
+            return character
+        try:
+            relative = Path(str(arguments["file_path"]))
+            if relative.is_absolute() or any(
+                part in {"", ".", ".."} for part in relative.parts
+            ):
+                return character
+            root = self.decoder.project_root.resolve()
+            source_path = (root / relative).resolve()
+            source_path.relative_to(root)
+            source_line = source_path.read_text(
+                encoding="utf-8", errors="strict"
+            ).splitlines()[int(arguments["line"])]
+        except (OSError, IndexError, ValueError):
+            return character
+        try:
+            if self.position_encoding == "UTF8":
+                encoded = source_line.encode("utf-8")
+                if character > len(encoded):
+                    return character
+                prefix = encoded[:character].decode("utf-8")
+            else:
+                encoded = source_line.encode("utf-16-le")
+                if character * 2 > len(encoded):
+                    return character
+                prefix = encoded[: character * 2].decode("utf-16-le")
+        except UnicodeError:
+            return character
+        return len(prefix)
 
 
 class ClangdGraphDecoder:
@@ -530,9 +713,15 @@ class ClangdGraphDecoder:
         graph = decoder.decode()
     """
 
-    def __init__(self, idx_directory: str, project_root: str):
+    def __init__(
+        self,
+        idx_directory: str,
+        project_root: str,
+        position_encoding: Optional[str] = None,
+    ):
         self.idx_directory = Path(idx_directory)
         self.project_root = Path(project_root).resolve()
+        self.position_encoding = native_clangd_position_encoding(position_encoding)
         self.code_graph = CodeGraph(str(self.project_root))
 
         # Accumulated data from all .idx files (Pass 1)
@@ -557,16 +746,19 @@ class ClangdGraphDecoder:
             Tuple[int, int, str, Optional[str], Optional[int]]
         ] = []
 
-        # Code chunker for range detection
-        self._chunker = CppCodeChunker()
+        # The chunker is needed only for full graph range enrichment. Native
+        # symbol/occurrence startup must not instantiate tree-sitter eagerly.
+        self._chunker = None
         self._chunks_cache = {}
         self._graph_materialized = False
         self._range_indexes_built = False
         self._records_collected = False
         self.query_index = None
+        self.position_query_index = None
         self.query_backend = "not-decoded"
         self.query_fallback_error = None
         self.query_profile: dict[str, Any] = {}
+        self.position_query_profile: dict[str, Any] = {}
         self.query_snapshot_id: Optional[str] = None
         self._native_snapshot_error: Optional[str] = None
 
@@ -624,6 +816,7 @@ class ClangdGraphDecoder:
         receipt = snapshot(
             idx_directory=str(self.idx_directory),
             project_root=str(self.project_root),
+            position_encoding=self.position_encoding,
         )
         if not isinstance(receipt, Mapping):
             raise RuntimeError(
@@ -662,7 +855,7 @@ class ClangdGraphDecoder:
             raise RuntimeError(self._native_snapshot_error)
         return receipt
 
-    def _decode_native_query_index(self):
+    def _decode_native_query_index(self, *, include_occurrences: bool = False):
         if self._records_collected or self._graph_materialized:
             raise RuntimeError(
                 "native clangd snapshot cannot bind records collected before "
@@ -678,13 +871,15 @@ class ClangdGraphDecoder:
         decode = getattr(codenib_core, "decode_clangd_fact_query_index", None)
         contract_reader = getattr(codenib_core, "clangd_fact_query_contract", None)
         if not callable(decode) or not callable(contract_reader):
-            raise RuntimeError("compiled core does not expose clangd FactQueryIndex v1")
+            raise RuntimeError("compiled core does not expose clangd FactQueryIndex v2")
         _validate_native_query_contract(contract_reader())
 
         started = time.perf_counter()
         payload = decode(
             idx_directory=str(self.idx_directory),
             project_root=str(self.project_root),
+            position_encoding=self.position_encoding,
+            include_occurrences=include_occurrences,
         )
         binding_seconds = time.perf_counter() - started
         if not isinstance(payload, Mapping):
@@ -693,6 +888,8 @@ class ClangdGraphDecoder:
             raise RuntimeError("native clangd query decoder returned unknown format")
         if payload.get("graph_materialized") is not False:
             raise RuntimeError("native clangd query decoder materialized a graph")
+        if payload.get("position_records_included") is not include_occurrences:
+            raise RuntimeError("native clangd query decoder changed occurrence scope")
 
         index = payload.get("index")
         if index is None or getattr(index, "fact_query_index", None) is not True:
@@ -701,12 +898,32 @@ class ClangdGraphDecoder:
             raise RuntimeError(
                 "native clangd query index does not guarantee graph-free use"
             )
-        if getattr(index, "capabilities", None) != _NATIVE_QUERY_CAPABILITIES:
-            raise RuntimeError("native clangd query index capabilities do not match v1")
+        expected_capabilities = {
+            **_NATIVE_QUERY_CAPABILITIES,
+            "position_queries": include_occurrences,
+        }
+        if getattr(index, "capabilities", None) != expected_capabilities:
+            raise RuntimeError("native clangd query index capabilities do not match v2")
         if getattr(index, "requires_anchored_references", None) is not False:
             raise RuntimeError(
                 "native clangd query index cannot preserve relation references"
             )
+        if include_occurrences:
+            required_position_api = (
+                "has_occurrence_at",
+                "position_definitions",
+                "position_references",
+                "position_samples",
+            )
+            if any(
+                not callable(getattr(index, name, None))
+                for name in required_position_api
+            ):
+                raise RuntimeError(
+                    "compiled core does not expose the native clangd occurrence API"
+                )
+        if getattr(index, "position_encoding", None) != self.position_encoding:
+            raise RuntimeError("native clangd index position encoding disagrees")
         snapshot_id = payload.get("snapshot_id")
         if not isinstance(snapshot_id, str) or not snapshot_id.startswith(
             "clangd_fact_query:sha256:"
@@ -727,6 +944,8 @@ class ClangdGraphDecoder:
             "record_count": int(getattr(index, "record_count", 0)),
             "definition_count": int(getattr(index, "symbol_count", 0)),
             "reference_count": int(getattr(index, "reference_count", 0)),
+            "occurrence_count": int(getattr(index, "occurrence_count", 0)),
+            "position_encoding": self.position_encoding,
             "snapshot_id": snapshot_id,
             "snapshot_file_count": int(payload.get("snapshot_file_count") or 0),
             "snapshot_index_bytes": int(payload.get("snapshot_index_bytes") or 0),
@@ -737,6 +956,7 @@ class ClangdGraphDecoder:
             "raw_reference_count",
             "definition_count",
             "reference_count",
+            "occurrence_count",
             "decoded_record_count",
             "index_bytes",
             "decompressed_string_bytes",
@@ -747,6 +967,8 @@ class ClangdGraphDecoder:
             profile[f"native_{name}"] = (
                 int(value) if name in count_fields else int(value) / 1_000_000_000
             )
+        if self.query_snapshot_id is not None and snapshot_id != self.query_snapshot_id:
+            raise RuntimeError("native clangd position snapshot disagrees with symbols")
         self.query_snapshot_id = snapshot_id
         return index, profile
 
@@ -793,7 +1015,7 @@ class ClangdGraphDecoder:
         return self.query_index
 
     def decode_query_provider(self):
-        """Return native symbol queries with lazy position/route fallback."""
+        """Return native symbol/position queries with lazy route fallback."""
 
         from ..agent.lsp_provider import StaticLSPProvider
 
@@ -801,6 +1023,27 @@ class ClangdGraphDecoder:
         if getattr(index, "fact_query_index", False):
             return ClangdHybridQueryProvider(self, index)
         return StaticLSPProvider(index)
+
+    def decode_native_position_query_index(self):
+        """Build the occurrence view lazily without constructing CodeGraph."""
+
+        if self.position_query_index is not None:
+            return self.position_query_index
+        if self.query_index is None:
+            self.decode_native_query_provider()
+        if self.query_backend != "native-clangd-fact-query-v1":
+            raise RuntimeError("native clangd position view requires native symbols")
+        (
+            self.position_query_index,
+            self.position_query_profile,
+        ) = self._decode_native_query_index(include_occurrences=True)
+        # Publish the capability-specific profile after the complete index is
+        # available. Route-first workers therefore retain the symbol-only
+        # startup profile, while position workloads report occurrence costs.
+        self.query_profile.update(self.position_query_profile)
+        self.query_profile["fact_query_native"] = 1
+        self.query_profile["position_fact_query_native"] = 1
+        return self.position_query_index
 
     def decode_native_query_provider(self):
         """Return the native provider without silently building a legacy graph."""
@@ -1041,6 +1284,10 @@ class ClangdGraphDecoder:
             return None
 
         try:
+            if self._chunker is None:
+                from ..code_chunking import CppCodeChunker
+
+                self._chunker = CppCodeChunker()
             chunks = self._chunker.chunk_file(str(full_path))
             self._chunks_cache[file_path] = chunks
             return chunks

--- a/codenib/ls_index/clangd_indexer.py
+++ b/codenib/ls_index/clangd_indexer.py
@@ -25,6 +25,7 @@ from ..graph.code_graph import CodeGraph
 from ..log_utils import get_logger
 from ..paths import CLANGD_INDEX_DIRNAME, temp_state_dir
 from ..profiler import Profiler
+from .clangd_contract import clangd_background_index_command
 from .index_quality import (
     IndexQualityPolicy,
     assess_index_quality,
@@ -128,13 +129,7 @@ class ClangdIndexer:
         """Build the full clangd background-index command."""
         clangd_cmd = getattr(self, "_clangd_path", "clangd")
         compile_commands_dir = str(comp_db.parent)
-        return [
-            clangd_cmd,
-            "--background-index",
-            f"--compile-commands-dir={compile_commands_dir}",
-            "--background-index-priority=normal",
-            "--log=error",
-        ]
+        return list(clangd_background_index_command(clangd_cmd, compile_commands_dir))
 
     def _get_decoder_class(self):
         """Return ClangdGraphDecoder."""

--- a/core/README.md
+++ b/core/README.md
@@ -124,14 +124,14 @@ make fact-query-profile \
   FACT_QUERY_PROFILE_OUTPUT=/tmp/fact-query-report.json
 ```
 
-## Native clangd Symbol Queries
+## Native clangd Symbol And Position Queries
 
 For C and C++ projects with an existing project-local clangd index,
 `decode_clangd_fact_query_index(...)` reads the direct `*.idx` children in
 stable filename order, decodes them into `DecodedRecords`, and builds the same
 `FactQueryIndex` without constructing `CodeGraph`, igraph, or Python record
-dictionaries. The v1 slice covers definition and reference lookup by symbol.
-Each decode also exposes a content-bound snapshot over the query contract,
+dictionaries. The initial symbol-only index covers definition and reference
+lookup by symbol. Each decode also exposes a content-bound snapshot over the query contract,
 normalized project root, exact supported RIFF versions, sorted shard names,
 and the exact bytes consumed by the decoder. clangd relation rows may be
 unanchored, so this provider explicitly opts into that record policy while
@@ -139,9 +139,22 @@ still rejecting partial or invalid anchors.
 
 Use `LSIndexer.process_query_index()` for the capability-specific index or
 `process_query_provider()` for hybrid behavior. The provider keeps successful
-symbol queries on the native index and lazily constructs the complete graph
-once when a position or route query is requested. Existing `process_index()`,
-graph persistence, incremental processing, and quality gates are unchanged.
+symbol queries on the native index. Its first exact position request lazily
+builds a second native occurrence view; a successful definition/reference
+position lookup never constructs `CodeGraph` or igraph. The view stores
+provider-neutral zero-based, half-open file ranges, role bits, and optional
+target/container vertex ids in C++, then builds per-file interval postings and
+per-target postings without Python record dictionaries. Unsupported,
+ambiguous, declaration-only, unanchored, or missing-source positions fall back
+with a stable reason. A route request still lazily constructs the complete
+compatible graph once. Existing `process_index()`, graph persistence,
+incremental processing, and quality gates are unchanged.
+
+The clangd query ABI is `clangd-riff-fact-query-v2`. Position offsets are
+explicit and receipt-bound: UTF-16 is the default, while UTF-8 and UTF-32 are
+accepted at the provider boundary. Full and incremental background indexing
+use the same normalized clangd offset flag, so their rows cannot silently mix
+coordinate systems.
 
 `CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX=auto` is the default and falls back to
 the compatible graph if native decoding fails. Set it to `off` to force the
@@ -163,9 +176,11 @@ collection. A mismatch fails the provider session rather than combining index
 generations; restart it to adopt new shards. Both receipt stages are included
 in the existing 20% profiling gate.
 
-This baseline makes no claim about clangd index generation time. Native
-position and route queries and serving integration remain separate promotion
-gates.
+The mixed-workload gate additionally requires at least 20% position-first
+acceleration with zero graph materializations. Route-first and mixed workloads
+retain the 20% non-regression budget and exactly-once graph publication rule.
+This result makes no claim about clangd index generation time; native route
+lookup remains a separate promotion gate.
 
 ## Use Through Python
 

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -63,11 +63,45 @@ py::dict vertex_to_dict(const CodeGraph::VertexData &v) {
   return d;
 }
 
-py::dict fact_query_capabilities() {
+py::dict
+location_to_dict(const codenib::core::FactQueryIndex::Location &location) {
+  py::dict row;
+  row["file_path"] = location.file_path;
+  row["start_line"] = location.start_line;
+  row["start_character"] = location.start_character;
+  row["end_line"] = location.end_line;
+  row["end_character"] = location.end_character;
+  row["roles"] = location.roles;
+  row["target_symbol"] = location.target_symbol.has_value()
+                             ? py::object(py::cast(*location.target_symbol))
+                             : py::object(py::none());
+  row["container_symbol"] =
+      location.container_symbol.has_value()
+          ? py::object(py::cast(*location.container_symbol))
+          : py::object(py::none());
+  return row;
+}
+
+py::dict position_query_to_dict(
+    const codenib::core::FactQueryIndex::PositionQueryResult &query) {
+  py::dict result;
+  result["served"] = query.served;
+  result["fallback_reason"] = query.fallback_reason.empty()
+                                  ? py::object(py::none())
+                                  : py::object(py::cast(query.fallback_reason));
+  py::list locations;
+  for (const auto &location : query.locations)
+    locations.append(location_to_dict(location));
+  result["locations"] = std::move(locations);
+  result["targets"] = query.targets;
+  return result;
+}
+
+py::dict fact_query_capabilities(bool position_queries = false) {
   py::dict result;
   result["definition_by_symbol"] = true;
   result["references_by_symbol"] = true;
-  result["position_queries"] = false;
+  result["position_queries"] = position_queries;
   result["route_queries"] = false;
   return result;
 }
@@ -253,6 +287,7 @@ py::dict clangd_decode_profile_to_dict(
   result["raw_reference_count"] = profile.raw_reference_count;
   result["definition_count"] = profile.definition_count;
   result["reference_count"] = profile.reference_count;
+  result["occurrence_count"] = profile.occurrence_count;
   result["decoded_record_count"] = profile.decoded_record_count;
   result["index_bytes"] = profile.index_bytes;
   result["decompressed_string_bytes"] = profile.decompressed_string_bytes;
@@ -380,7 +415,9 @@ py::dict fact_query_index_contract() {
 }
 
 py::dict decode_clangd_fact_query_index(const std::string &idx_directory,
-                                        const std::string &project_root) {
+                                        const std::string &project_root,
+                                        const std::string &position_encoding,
+                                        bool include_occurrences) {
   using clock = std::chrono::steady_clock;
   clock::time_point decode_started;
   clock::time_point decode_finished;
@@ -390,8 +427,9 @@ py::dict decode_clangd_fact_query_index(const std::string &idx_directory,
   {
     py::gil_scoped_release release;
     decode_started = clock::now();
-    decoded =
-        codenib::core::decode_clangd_query_records(idx_directory, project_root);
+    decoded = codenib::core::decode_clangd_query_records(
+        idx_directory, project_root, codenib::core::ClangdFactDecodeLimits{},
+        position_encoding, include_occurrences);
     decode_finished = clock::now();
     index = std::make_shared<codenib::core::FactQueryIndex>(
         decoded.records, false, decoded.receipt.snapshot_id);
@@ -409,6 +447,7 @@ py::dict decode_clangd_fact_query_index(const std::string &idx_directory,
   result["native_index_ns"] = elapsed_ns(decode_finished, index_finished);
   result["decode_profile_ns"] = clangd_decode_profile_to_dict(decoded.profile);
   result["graph_materialized"] = false;
+  result["position_records_included"] = include_occurrences;
   result["snapshot_id"] = decoded.receipt.snapshot_id;
   result["snapshot_file_count"] = decoded.receipt.file_count;
   result["snapshot_index_bytes"] = decoded.receipt.index_bytes;
@@ -445,20 +484,26 @@ py::dict clangd_fact_query_contract() {
   result["snapshot_schema"] = codenib::core::CLANGD_FACT_QUERY_SNAPSHOT_SCHEMA;
   result["snapshot_digest"] = "sha256";
   result["supported_versions"] = codenib::core::CLANGD_SUPPORTED_RIFF_VERSIONS;
+  result["default_position_encoding"] =
+      codenib::core::CLANGD_DEFAULT_POSITION_ENCODING;
+  result["supported_position_encodings"] =
+      codenib::core::CLANGD_SUPPORTED_POSITION_ENCODINGS;
   result["resource_limits"] = std::move(resource_limits);
   result["stable_filename_order"] = true;
   result["preserves_unanchored_relations"] = true;
-  result["capabilities"] = fact_query_capabilities();
+  result["capabilities"] = fact_query_capabilities(true);
   return result;
 }
 
 py::dict clangd_fact_query_snapshot(const std::string &idx_directory,
-                                    const std::string &project_root) {
+                                    const std::string &project_root,
+                                    const std::string &position_encoding) {
   codenib::core::ClangdIndexReceipt receipt;
   {
     py::gil_scoped_release release;
     receipt = codenib::core::compute_clangd_index_receipt(
-        idx_directory, project_root, codenib::core::ClangdFactDecodeLimits{});
+        idx_directory, project_root, codenib::core::ClangdFactDecodeLimits{},
+        position_encoding);
   }
   py::dict result;
   result["snapshot_id"] = receipt.snapshot_id;
@@ -495,8 +540,9 @@ PYBIND11_MODULE(codenib_core, m) {
           "materializes_graph",
           [](const codenib::core::FactQueryIndex &) { return false; })
       .def_property_readonly("capabilities",
-                             [](const codenib::core::FactQueryIndex &) {
-                               return fact_query_capabilities();
+                             [](const codenib::core::FactQueryIndex &index) {
+                               return fact_query_capabilities(
+                                   index.supports_position_queries());
                              })
       .def_property_readonly("project_root",
                              [](const codenib::core::FactQueryIndex &index) {
@@ -513,6 +559,10 @@ PYBIND11_MODULE(codenib_core, m) {
                              &codenib::core::FactQueryIndex::symbol_count)
       .def_property_readonly("reference_count",
                              &codenib::core::FactQueryIndex::reference_count)
+      .def_property_readonly("occurrence_count",
+                             &codenib::core::FactQueryIndex::occurrence_count)
+      .def_property_readonly("position_encoding",
+                             &codenib::core::FactQueryIndex::position_encoding)
       .def_property_readonly(
           "requires_anchored_references",
           &codenib::core::FactQueryIndex::requires_anchored_references)
@@ -549,7 +599,58 @@ PYBIND11_MODULE(codenib_core, m) {
             }
             return result;
           },
-          py::arg("target_name"));
+          py::arg("target_name"))
+      .def(
+          "position_definitions",
+          [](const codenib::core::FactQueryIndex &index,
+             const std::string &file_path, int line, int character,
+             std::size_t top_k) {
+            codenib::core::FactQueryIndex::PositionQueryResult query;
+            {
+              py::gil_scoped_release release;
+              query = index.definitions_at(file_path, line, character, top_k);
+            }
+            return position_query_to_dict(query);
+          },
+          py::arg("file_path"), py::arg("line"), py::arg("character"),
+          py::arg("top_k") = 8)
+      .def(
+          "position_references",
+          [](const codenib::core::FactQueryIndex &index,
+             const std::string &file_path, int line, int character,
+             bool include_declaration, std::size_t top_k) {
+            codenib::core::FactQueryIndex::PositionQueryResult query;
+            {
+              py::gil_scoped_release release;
+              query = index.references_at(file_path, line, character,
+                                          include_declaration, top_k);
+            }
+            return position_query_to_dict(query);
+          },
+          py::arg("file_path"), py::arg("line"), py::arg("character"),
+          py::arg("include_declaration") = true, py::arg("top_k") = 40)
+      .def(
+          "has_occurrence_at",
+          [](const codenib::core::FactQueryIndex &index,
+             const std::string &file_path, int line, int character) {
+            py::gil_scoped_release release;
+            return index.has_occurrence_at(file_path, line, character);
+          },
+          py::arg("file_path"), py::arg("line"), py::arg("character"))
+      .def(
+          "position_samples",
+          [](const codenib::core::FactQueryIndex &index, std::size_t limit) {
+            std::vector<codenib::core::FactQueryIndex::Location> samples;
+            {
+              py::gil_scoped_release release;
+              samples = index.position_samples(limit);
+            }
+            py::list result;
+            for (const auto &sample : samples)
+              result.append(location_to_dict(sample));
+            return result;
+          },
+          py::arg("limit") = 100);
 
   m.def("decode_scip", &decode_scip, py::arg("index_file"),
         py::arg("project_root") = std::optional<std::string>(std::nullopt),
@@ -619,13 +720,17 @@ route queries remain unavailable and no CodeGraph or igraph is materialized.
 
   m.def("decode_clangd_fact_query_index", &decode_clangd_fact_query_index,
         py::arg("idx_directory"), py::arg("project_root"),
+        py::arg("position_encoding") =
+            codenib::core::CLANGD_DEFAULT_POSITION_ENCODING,
+        py::arg("include_occurrences") = true,
         R"pbdoc(
-Decode an existing project-local clangd .idx directory into FactQueryIndex v1.
+Decode an existing project-local clangd .idx directory into FactQueryIndex v2.
 
 Direct .idx children are read in stable filename order into provider-neutral
-decoded records. The returned index supports symbol definitions and references
-without Python record dictionaries, CodeGraph, or igraph. Position and route
-queries remain outside this baseline capability.
+decoded records. With ``include_occurrences=True`` the returned index supports
+symbol and exact position definition/reference queries without Python record
+dictionaries, CodeGraph, or igraph. Route queries remain outside this
+capability.
 )pbdoc");
 
   m.def("clangd_fact_query_contract", &clangd_fact_query_contract,
@@ -633,6 +738,8 @@ queries remain outside this baseline capability.
 
   m.def("clangd_fact_query_snapshot", &clangd_fact_query_snapshot,
         py::arg("idx_directory"), py::arg("project_root"),
+        py::arg("position_encoding") =
+            codenib::core::CLANGD_DEFAULT_POSITION_ENCODING,
         R"pbdoc(Return the current content-bound clangd index receipt.)pbdoc");
 
   m.def("canonical_scip_decoder_languages",

--- a/core/clangd_fact_query.cpp
+++ b/core/clangd_fact_query.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -32,6 +33,7 @@ namespace {
 
 using Clock = std::chrono::steady_clock;
 
+constexpr std::uint8_t REF_KIND_DECLARATION = 0x1;
 constexpr std::uint8_t REF_KIND_DEFINITION = 0x2;
 constexpr std::uint8_t REF_KIND_REFERENCE = 0x4;
 constexpr std::uint8_t REF_KIND_SPELLED = 0x8;
@@ -54,6 +56,25 @@ bool is_supported_version(std::uint32_t version) {
   return std::find(CLANGD_SUPPORTED_RIFF_VERSIONS.begin(),
                    CLANGD_SUPPORTED_RIFF_VERSIONS.end(),
                    version) != CLANGD_SUPPORTED_RIFF_VERSIONS.end();
+}
+
+std::string normalize_position_encoding(std::string value) {
+  std::string compact;
+  compact.reserve(value.size());
+  for (const auto character : value) {
+    const auto byte = static_cast<unsigned char>(character);
+    if (std::isalnum(byte) != 0)
+      compact.push_back(static_cast<char>(std::toupper(byte)));
+  }
+  const auto supported =
+      std::find_if(CLANGD_SUPPORTED_POSITION_ENCODINGS.begin(),
+                   CLANGD_SUPPORTED_POSITION_ENCODINGS.end(),
+                   [&](const char *candidate) { return compact == candidate; });
+  if (supported == CLANGD_SUPPORTED_POSITION_ENCODINGS.end()) {
+    throw std::invalid_argument(
+        "clangd position encoding must be UTF8, UTF16, or UTF32");
+  }
+  return compact;
 }
 
 bool is_known_chunk(std::string_view id) {
@@ -684,13 +705,15 @@ void update_field(Sha256 &digest, std::string_view value) {
 class IndexReceiptBuilder {
 public:
   IndexReceiptBuilder(const std::filesystem::path &project_root,
-                      std::size_t file_count) {
+                      std::size_t file_count,
+                      const std::string &position_encoding) {
     update_field(digest_, "CodeNib clangd fact query snapshot");
     update_field(digest_, CLANGD_FACT_QUERY_SNAPSHOT_SCHEMA);
     update_field(digest_, CLANGD_FACT_QUERY_FORMAT);
     update_u64_le(digest_, CLANGD_FACT_QUERY_ABI_VERSION);
     update_field(digest_, CLANGD_FACT_QUERY_NORMALIZATION_PROFILE);
     update_field(digest_, project_root.generic_string());
+    update_field(digest_, position_encoding);
     update_u64_le(digest_, CLANGD_SUPPORTED_RIFF_VERSIONS.size());
     for (const auto version : CLANGD_SUPPORTED_RIFF_VERSIONS)
       update_u64_le(digest_, version);
@@ -717,8 +740,9 @@ private:
 
 ClangdIndexReceipt receipt_from_files(const std::vector<IndexFile> &files,
                                       const std::filesystem::path &project_root,
-                                      const ClangdFactDecodeLimits &limits) {
-  IndexReceiptBuilder builder(project_root, files.size());
+                                      const ClangdFactDecodeLimits &limits,
+                                      const std::string &position_encoding) {
+  IndexReceiptBuilder builder(project_root, files.size(), position_encoding);
   std::uint64_t read_bytes = 0;
   for (const auto &file : files) {
     const auto data = read_file(file.path, limits);
@@ -783,10 +807,29 @@ void replace_scope_separators(std::string &value) {
 
 std::shared_ptr<DecodedRecords>
 build_query_records(const CollectedRecords &collected,
-                    const std::filesystem::path &project_root) {
+                    const std::filesystem::path &project_root,
+                    const std::string &position_encoding,
+                    bool include_occurrences) {
   auto records = std::make_shared<DecodedRecords>();
   records->project_root = project_root.generic_string();
+  records->position_encoding = position_encoding;
   records->vertices.reserve(collected.symbols.size());
+
+  // clangd repeats the same file URI for every reference. Normalize each URI
+  // once instead of rebuilding filesystem paths for every occurrence row.
+  std::unordered_map<std::string, std::string> relative_files;
+  relative_files.reserve(128);
+  auto query_file = [&](const std::string &uri) {
+    const auto found = relative_files.find(uri);
+    if (found != relative_files.end())
+      return found->second;
+    auto file = relative_file(uri, project_root);
+    if (file.empty() || std::filesystem::path(file).is_absolute() ||
+        file.find("third_party/") != std::string::npos) {
+      file.clear();
+    }
+    return relative_files.emplace(uri, std::move(file)).first->second;
+  };
 
   std::unordered_map<std::string, CodeGraph::VertexId> record_indexes;
   record_indexes.reserve(collected.symbols.size());
@@ -830,9 +873,8 @@ build_query_records(const CollectedRecords &collected,
         symbol, ref_it == collected.refs.end() ? nullptr : &ref_it->second);
     if (!definition.has_value() || definition->file.empty())
       continue;
-    const std::string file = relative_file(definition->file, project_root);
-    if (std::filesystem::path(file).is_absolute() ||
-        file.find("third_party/") != std::string::npos) {
+    const std::string file = query_file(definition->file);
+    if (file.empty()) {
       continue;
     }
 
@@ -912,6 +954,93 @@ build_query_records(const CollectedRecords &collected,
       records->query_resolution_order.push_back(
           static_cast<CodeGraph::VertexId>(index));
     }
+  }
+
+  if (include_occurrences) {
+    std::size_t occurrence_capacity = collected.symbols.size() * 2;
+    for (const auto &[symbol, references] : collected.refs) {
+      (void)symbol;
+      occurrence_capacity += references.size();
+    }
+    records->occurrences.reserve(occurrence_capacity);
+    auto target_for = [&](const std::string &symbol_id)
+        -> std::optional<CodeGraph::VertexId> {
+      const auto found = vertex_by_symbol.find(symbol_id);
+      return found == vertex_by_symbol.end()
+                 ? std::nullopt
+                 : std::optional<CodeGraph::VertexId>(found->second);
+    };
+    auto add_occurrence = [&](const Location &location, std::uint32_t roles,
+                              std::optional<CodeGraph::VertexId> target,
+                              std::optional<CodeGraph::VertexId> container) {
+      if (location.file.empty())
+        return;
+      const auto file = query_file(location.file);
+      if (file.empty()) {
+        return;
+      }
+      records->occurrences.push_back(DecodedOccurrence{
+          file, location.start_line, location.start_col, location.end_line,
+          location.end_col, roles, target, container});
+    };
+    auto same_location = [](const Location &left, const Location &right) {
+      return left.file == right.file && left.start_line == right.start_line &&
+             left.start_col == right.start_col &&
+             left.end_line == right.end_line && left.end_col == right.end_col;
+    };
+
+    for (const auto &symbol : collected.symbols) {
+      const auto target = target_for(symbol.id);
+      const auto refs = collected.refs.find(symbol.id);
+      const auto primary = resolve_definition(
+          symbol, refs == collected.refs.end() ? nullptr : &refs->second);
+      if (symbol.definition.has_value()) {
+        auto roles = OCCURRENCE_ROLE_DEFINITION;
+        if (primary.has_value() && same_location(*symbol.definition, *primary))
+          roles |= OCCURRENCE_ROLE_PRIMARY_DEFINITION;
+        add_occurrence(*symbol.definition, roles, target, std::nullopt);
+      }
+      if (symbol.canonical_declaration.has_value()) {
+        add_occurrence(*symbol.canonical_declaration,
+                       OCCURRENCE_ROLE_DECLARATION, target, std::nullopt);
+      }
+    }
+
+    for (const auto &target_symbol : collected.ref_order) {
+      const auto target = target_for(target_symbol);
+      const auto symbol_index = collected.symbol_indexes.find(target_symbol);
+      std::optional<Location> primary;
+      if (symbol_index != collected.symbol_indexes.end()) {
+        const auto &symbol = collected.symbols[symbol_index->second];
+        const auto refs = collected.refs.find(target_symbol);
+        primary = resolve_definition(
+            symbol, refs == collected.refs.end() ? nullptr : &refs->second);
+      }
+      const auto ref_group = collected.refs.find(target_symbol);
+      if (ref_group == collected.refs.end())
+        continue;
+      for (const auto &reference : ref_group->second) {
+        std::uint32_t roles = 0;
+        if ((reference.kind & REF_KIND_DECLARATION) != 0)
+          roles |= OCCURRENCE_ROLE_DECLARATION;
+        if ((reference.kind & REF_KIND_DEFINITION) != 0)
+          roles |= OCCURRENCE_ROLE_DEFINITION;
+        if ((reference.kind & REF_KIND_REFERENCE) != 0)
+          roles |= OCCURRENCE_ROLE_REFERENCE;
+        if ((reference.kind & REF_KIND_SPELLED) != 0)
+          roles |= OCCURRENCE_ROLE_SPELLED;
+        if (primary.has_value() && same_location(reference.location, *primary))
+          roles |= OCCURRENCE_ROLE_PRIMARY_DEFINITION;
+        std::optional<CodeGraph::VertexId> container;
+        if (reference.container != std::string(8, '\0'))
+          container = target_for(reference.container);
+        add_occurrence(reference.location, roles, target, container);
+      }
+    }
+
+    // Collection follows stable .idx filename and record order. The native
+    // index sorts per-file postings and every public location result is
+    // deduplicated, so a second global string-heavy sort is unnecessary.
   }
 
   for (const auto &[source_name, target_name] : structural_edge_names) {
@@ -1013,12 +1142,14 @@ build_query_records(const CollectedRecords &collected,
 
 } // namespace
 
-ClangdQueryRecords
-decode_clangd_query_records(const std::string &idx_directory,
-                            const std::string &project_root,
-                            const ClangdFactDecodeLimits &limits) {
+ClangdQueryRecords decode_clangd_query_records(
+    const std::string &idx_directory, const std::string &project_root,
+    const ClangdFactDecodeLimits &limits, const std::string &position_encoding,
+    bool include_occurrences) {
   const auto total_started = Clock::now();
   ClangdFactDecodeProfile profile;
+  const auto normalized_encoding =
+      normalize_position_encoding(position_encoding);
 
   const auto discover_started = Clock::now();
   const auto files =
@@ -1031,7 +1162,7 @@ decode_clangd_query_records(const std::string &idx_directory,
 
   CollectedRecords collected;
   DecodeBudget budget(limits);
-  IndexReceiptBuilder receipt_builder(root, files.size());
+  IndexReceiptBuilder receipt_builder(root, files.size(), normalized_encoding);
   std::uint64_t read_bytes = 0;
   for (const auto &file : files) {
     const auto read_started = Clock::now();
@@ -1065,7 +1196,8 @@ decode_clangd_query_records(const std::string &idx_directory,
   }
 
   const auto build_started = Clock::now();
-  auto records = build_query_records(collected, root);
+  auto records = build_query_records(collected, root, normalized_encoding,
+                                     include_occurrences);
   profile.build_query_records_ns = elapsed_ns(build_started, Clock::now());
   profile.decoded_record_count = records->vertices.size();
   for (const auto &vertex : records->vertices) {
@@ -1076,14 +1208,15 @@ decode_clangd_query_records(const std::string &idx_directory,
     if (edge.type == EDGE_TYPE_REFERENCE)
       ++profile.reference_count;
   }
+  profile.occurrence_count = records->occurrences.size();
   profile.index_bytes = read_bytes;
   profile.decompressed_string_bytes = budget.string_table_bytes;
   profile.materialized_string_bytes = budget.materialized_string_bytes;
   profile.string_entry_count = budget.string_entries;
   auto receipt = receipt_builder.finish(files.size());
   const auto verify_started = Clock::now();
-  const auto verified =
-      compute_clangd_index_receipt(idx_directory, project_root, limits);
+  const auto verified = compute_clangd_index_receipt(
+      idx_directory, project_root, limits, normalized_encoding);
   profile.verify_snapshot_ns = elapsed_ns(verify_started, Clock::now());
   if (verified.snapshot_id != receipt.snapshot_id) {
     throw std::runtime_error(
@@ -1096,10 +1229,14 @@ decode_clangd_query_records(const std::string &idx_directory,
 ClangdIndexReceipt
 compute_clangd_index_receipt(const std::string &idx_directory,
                              const std::string &project_root,
-                             const ClangdFactDecodeLimits &limits) {
+                             const ClangdFactDecodeLimits &limits,
+                             const std::string &position_encoding) {
   const auto files =
       discover_index_files(normalized_absolute(idx_directory), limits);
-  return receipt_from_files(files, normalized_absolute(project_root), limits);
+  const auto normalized_encoding =
+      normalize_position_encoding(position_encoding);
+  return receipt_from_files(files, normalized_absolute(project_root), limits,
+                            normalized_encoding);
 }
 
 } // namespace codenib::core

--- a/core/clangd_fact_query.h
+++ b/core/clangd_fact_query.h
@@ -16,12 +16,15 @@
 
 namespace codenib::core {
 
-inline constexpr std::uint32_t CLANGD_FACT_QUERY_ABI_VERSION = 1;
-inline constexpr char CLANGD_FACT_QUERY_FORMAT[] = "clangd-riff-fact-query-v1";
+inline constexpr std::uint32_t CLANGD_FACT_QUERY_ABI_VERSION = 2;
+inline constexpr char CLANGD_FACT_QUERY_FORMAT[] = "clangd-riff-fact-query-v2";
 inline constexpr char CLANGD_FACT_QUERY_NORMALIZATION_PROFILE[] =
-    "clangd-native-normalization-v1";
+    "clangd-native-normalization-v2";
 inline constexpr char CLANGD_FACT_QUERY_SNAPSHOT_SCHEMA[] =
     "clangd-fact-query-snapshot-v1";
+inline constexpr char CLANGD_DEFAULT_POSITION_ENCODING[] = "UTF16";
+inline constexpr std::array<const char *, 3>
+    CLANGD_SUPPORTED_POSITION_ENCODINGS{{"UTF8", "UTF16", "UTF32"}};
 
 // clangd itself rejects non-current RIFF versions. CodeNib deliberately uses
 // an exact allowlist backed by checked fixtures and parity tests instead of
@@ -66,6 +69,7 @@ struct ClangdFactDecodeProfile {
   std::size_t raw_reference_count{0};
   std::size_t definition_count{0};
   std::size_t reference_count{0};
+  std::size_t occurrence_count{0};
   std::size_t decoded_record_count{0};
   std::uint64_t index_bytes{0};
   std::uint64_t decompressed_string_bytes{0};
@@ -90,12 +94,15 @@ struct ClangdQueryRecords {
 // the established ClangdGraphDecoder without publishing partial rows.
 ClangdQueryRecords decode_clangd_query_records(
     const std::string &idx_directory, const std::string &project_root,
-    const ClangdFactDecodeLimits &limits = ClangdFactDecodeLimits{});
+    const ClangdFactDecodeLimits &limits = ClangdFactDecodeLimits{},
+    const std::string &position_encoding = CLANGD_DEFAULT_POSITION_ENCODING,
+    bool include_occurrences = true);
 
 // Re-read the canonical filename/byte stream and return its content identity.
 // Lazy graph consumers compare this receipt with the one published by decode.
 ClangdIndexReceipt compute_clangd_index_receipt(
     const std::string &idx_directory, const std::string &project_root,
-    const ClangdFactDecodeLimits &limits = ClangdFactDecodeLimits{});
+    const ClangdFactDecodeLimits &limits = ClangdFactDecodeLimits{},
+    const std::string &position_encoding = CLANGD_DEFAULT_POSITION_ENCODING);
 
 } // namespace codenib::core

--- a/core/decoded_records.h
+++ b/core/decoded_records.h
@@ -8,10 +8,35 @@
 
 #include "code_graph.h"
 
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace codenib::core {
+
+// Provider-neutral occurrence roles. Adapters translate provider-specific
+// flags at the decode boundary so query consumers never need to understand
+// clangd RefKind, SCIP SymbolRole, or a live LSP wire format.
+inline constexpr std::uint32_t OCCURRENCE_ROLE_DECLARATION = 1U << 0;
+inline constexpr std::uint32_t OCCURRENCE_ROLE_DEFINITION = 1U << 1;
+inline constexpr std::uint32_t OCCURRENCE_ROLE_REFERENCE = 1U << 2;
+inline constexpr std::uint32_t OCCURRENCE_ROLE_SPELLED = 1U << 3;
+inline constexpr std::uint32_t OCCURRENCE_ROLE_PRIMARY_DEFINITION = 1U << 4;
+
+// Compact semantic occurrence row. Coordinates are zero-based and half-open
+// in ``DecodedRecords::position_encoding``. Integer symbol ids avoid repeated
+// strings and keep all postings on the native side of the Python boundary.
+struct DecodedOccurrence {
+  std::string file;
+  int start_line{0};
+  int start_character{0};
+  int end_line{0};
+  int end_character{0};
+  std::uint32_t roles{0};
+  std::optional<CodeGraph::VertexId> target_symbol;
+  std::optional<CodeGraph::VertexId> container_symbol;
+};
 
 // Provider-neutral semantic rows before an igraph instance or Python objects
 // are built. Vertex ids in ``edges`` index ``vertices``. Each adapter owns its
@@ -19,12 +44,14 @@ namespace codenib::core {
 struct DecodedRecords {
   std::vector<CodeGraph::VertexData> vertices;
   std::vector<CodeGraph::EdgeData> edges;
+  std::vector<DecodedOccurrence> occurrences;
   // Optional permutation used only while building user-facing symbol aliases.
   // Providers whose legacy lookup groups equal display names can preserve that
   // ordering without changing vertex ids or reference adjacency semantics.
   // Empty means natural vertex order.
   std::vector<CodeGraph::VertexId> query_resolution_order;
   std::string project_root;
+  std::string position_encoding{"UTF8"};
 };
 
 } // namespace codenib::core

--- a/core/fact_query_index.cpp
+++ b/core/fact_query_index.cpp
@@ -8,7 +8,10 @@
 
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
+#include <limits>
 #include <stdexcept>
+#include <tuple>
 #include <unordered_set>
 #include <utility>
 
@@ -32,6 +35,78 @@ bool has_suffix(const std::string &value, const std::string &suffix) {
   return value.size() >= suffix.size() &&
          value.compare(value.size() - suffix.size(), suffix.size(), suffix) ==
              0;
+}
+
+using Position = std::pair<int, int>;
+
+Position start_position(const DecodedOccurrence &occurrence) {
+  return {occurrence.start_line, occurrence.start_character};
+}
+
+Position end_position(const DecodedOccurrence &occurrence) {
+  return {occurrence.end_line, occurrence.end_character};
+}
+
+bool contains(const DecodedOccurrence &occurrence, Position position) {
+  return start_position(occurrence) <= position &&
+         position < end_position(occurrence);
+}
+
+auto span_key(const DecodedOccurrence &occurrence) {
+  return std::make_tuple(occurrence.end_line - occurrence.start_line,
+                         static_cast<long long>(occurrence.end_character) -
+                             static_cast<long long>(occurrence.start_character),
+                         occurrence.start_line, occurrence.start_character,
+                         occurrence.end_line, occurrence.end_character);
+}
+
+FactQueryIndex::Location location_from(const DecodedOccurrence &occurrence) {
+  return FactQueryIndex::Location{occurrence.file,
+                                  occurrence.start_line,
+                                  occurrence.start_character,
+                                  occurrence.end_line,
+                                  occurrence.end_character,
+                                  occurrence.roles,
+                                  occurrence.target_symbol,
+                                  occurrence.container_symbol};
+}
+
+bool location_less(const FactQueryIndex::Location &left,
+                   const FactQueryIndex::Location &right) {
+  return std::tie(left.file_path, left.start_line, left.start_character,
+                  left.end_line, left.end_character, left.target_symbol,
+                  left.container_symbol, left.roles) <
+         std::tie(right.file_path, right.start_line, right.start_character,
+                  right.end_line, right.end_character, right.target_symbol,
+                  right.container_symbol, right.roles);
+}
+
+bool same_location_identity(const FactQueryIndex::Location &left,
+                            const FactQueryIndex::Location &right) {
+  return left.file_path == right.file_path &&
+         left.start_line == right.start_line &&
+         left.start_character == right.start_character &&
+         left.end_line == right.end_line &&
+         left.end_character == right.end_character &&
+         left.target_symbol == right.target_symbol &&
+         left.container_symbol == right.container_symbol;
+}
+
+void sort_unique_locations(std::vector<FactQueryIndex::Location> &locations,
+                           std::size_t limit) {
+  std::sort(locations.begin(), locations.end(), location_less);
+  std::vector<FactQueryIndex::Location> compact;
+  compact.reserve(locations.size());
+  for (auto &location : locations) {
+    if (!compact.empty() && same_location_identity(compact.back(), location)) {
+      compact.back().roles |= location.roles;
+      continue;
+    }
+    compact.push_back(std::move(location));
+  }
+  locations = std::move(compact);
+  if (locations.size() > limit)
+    locations.resize(limit);
 }
 
 } // namespace
@@ -149,6 +224,52 @@ FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
          posting != source_postings.rend(); ++posting) {
       const auto target = records_->edges[*posting].target;
       incoming_reference_indexes_[target].push_back(*posting);
+    }
+  }
+
+  occurrence_indexes_by_file_.reserve(records_->occurrences.size() / 8 + 1);
+  occurrence_indexes_by_target_.reserve(definition_by_name_.size());
+  for (std::size_t index = 0; index < records_->occurrences.size(); ++index) {
+    const auto &occurrence = records_->occurrences[index];
+    if (occurrence.start_line < 0 || occurrence.start_character < 0 ||
+        occurrence.end_line < 0 || occurrence.end_character < 0 ||
+        end_position(occurrence) < start_position(occurrence)) {
+      throw std::invalid_argument("FactQueryIndex occurrence range is invalid");
+    }
+    for (const auto symbol :
+         {occurrence.target_symbol, occurrence.container_symbol}) {
+      if (symbol.has_value() &&
+          (*symbol < 0 ||
+           static_cast<std::size_t>(*symbol) >= records_->vertices.size())) {
+        throw std::out_of_range(
+            "FactQueryIndex occurrence symbol is out of range");
+      }
+    }
+    if (!occurrence.file.empty())
+      occurrence_indexes_by_file_[occurrence.file].indexes.push_back(index);
+    if (occurrence.target_symbol.has_value())
+      occurrence_indexes_by_target_[*occurrence.target_symbol].push_back(index);
+  }
+
+  for (auto &[file, postings] : occurrence_indexes_by_file_) {
+    (void)file;
+    std::sort(
+        postings.indexes.begin(), postings.indexes.end(),
+        [&](std::size_t left, std::size_t right) {
+          const auto &a = records_->occurrences[left];
+          const auto &b = records_->occurrences[right];
+          return std::make_tuple(a.start_line, a.start_character, a.end_line,
+                                 a.end_character, a.target_symbol.value_or(-1),
+                                 a.roles, left) <
+                 std::make_tuple(b.start_line, b.start_character, b.end_line,
+                                 b.end_character, b.target_symbol.value_or(-1),
+                                 b.roles, right);
+        });
+    postings.prefix_max_end.reserve(postings.indexes.size());
+    Position maximum{-1, -1};
+    for (const auto index : postings.indexes) {
+      maximum = std::max(maximum, end_position(records_->occurrences[index]));
+      postings.prefix_max_end.push_back(maximum);
     }
   }
 }
@@ -380,6 +501,285 @@ FactQueryIndex::incoming_references(const std::string &target_name) const {
     const auto &edge = records_->edges[index];
     result.push_back(
         Reference{edge.source, edge.anchor_file, edge.anchor_line});
+  }
+  return result;
+}
+
+bool FactQueryIndex::source_is_available(const std::string &file_path) const {
+  if (file_path.empty() || file_path.find('\\') != std::string::npos)
+    return false;
+  const std::filesystem::path relative(file_path);
+  if (relative.is_absolute() || relative.lexically_normal() != relative)
+    return false;
+  for (const auto &part : relative) {
+    if (part == "." || part == ".." || part.empty())
+      return false;
+  }
+  if (records_->project_root.empty())
+    return true;
+  std::error_code error;
+  const auto root = std::filesystem::weakly_canonical(
+      std::filesystem::path(records_->project_root), error);
+  if (error)
+    return false;
+  const auto source = std::filesystem::weakly_canonical(root / relative, error);
+  if (error)
+    return false;
+  auto root_part = root.begin();
+  auto source_part = source.begin();
+  for (; root_part != root.end(); ++root_part, ++source_part) {
+    if (source_part == source.end() || *source_part != *root_part)
+      return false;
+  }
+  return std::filesystem::is_regular_file(source, error) && !error;
+}
+
+std::vector<std::size_t>
+FactQueryIndex::occurrences_at(const std::string &file_path, int line,
+                               int character) const {
+  if (line < 0 || character < 0)
+    return {};
+  const auto found = occurrence_indexes_by_file_.find(file_path);
+  if (found == occurrence_indexes_by_file_.end())
+    return {};
+  const Position position{line, character};
+  const auto &postings = found->second;
+  auto upper = std::upper_bound(
+      postings.indexes.begin(), postings.indexes.end(), position,
+      [&](Position requested, std::size_t index) {
+        return requested < start_position(records_->occurrences[index]);
+      });
+
+  std::vector<std::size_t> matches;
+  auto cursor = static_cast<std::size_t>(upper - postings.indexes.begin());
+  while (cursor > 0) {
+    --cursor;
+    if (!(position < postings.prefix_max_end[cursor]))
+      break;
+    const auto index = postings.indexes[cursor];
+    if (contains(records_->occurrences[index], position))
+      matches.push_back(index);
+  }
+  if (matches.empty())
+    return matches;
+
+  const auto best = *std::min_element(
+      matches.begin(), matches.end(), [&](std::size_t left, std::size_t right) {
+        return span_key(records_->occurrences[left]) <
+               span_key(records_->occurrences[right]);
+      });
+  const auto &best_occurrence = records_->occurrences[best];
+  matches.erase(std::remove_if(matches.begin(), matches.end(),
+                               [&](std::size_t index) {
+                                 const auto &occurrence =
+                                     records_->occurrences[index];
+                                 return start_position(occurrence) !=
+                                            start_position(best_occurrence) ||
+                                        end_position(occurrence) !=
+                                            end_position(best_occurrence);
+                               }),
+                matches.end());
+  std::sort(matches.begin(), matches.end());
+  return matches;
+}
+
+FactQueryIndex::PositionQueryResult
+FactQueryIndex::targets_at(const std::string &file_path, int line,
+                           int character,
+                           std::vector<CodeGraph::VertexId> &targets) const {
+  if (line < 0 || character < 0)
+    return {false, "native_position_invalid_request", {}};
+  if (!source_is_available(file_path))
+    return {false, "native_position_source_unavailable", {}};
+  const auto matches = occurrences_at(file_path, line, character);
+  if (matches.empty())
+    return {false, "native_position_occurrence_not_found", {}};
+
+  const bool has_navigable =
+      std::any_of(matches.begin(), matches.end(), [&](std::size_t index) {
+        return (records_->occurrences[index].roles &
+                (OCCURRENCE_ROLE_DEFINITION | OCCURRENCE_ROLE_REFERENCE)) != 0;
+      });
+  if (!has_navigable)
+    return {false, "native_position_declaration_requires_legacy_graph", {}};
+  for (const auto index : matches) {
+    const auto &occurrence = records_->occurrences[index];
+    const bool navigable =
+        (occurrence.roles &
+         (OCCURRENCE_ROLE_DEFINITION | OCCURRENCE_ROLE_REFERENCE)) != 0;
+    if (!navigable)
+      continue;
+    if (!occurrence.target_symbol.has_value())
+      return {false, "native_position_target_unsupported", {}};
+    const auto target = *occurrence.target_symbol;
+    const auto &vertex = records_->vertices[static_cast<std::size_t>(target)];
+    if (!is_symbol_type(vertex.type) || !has_definition(vertex))
+      return {false, "native_position_definition_unavailable", {}};
+    if (std::find(targets.begin(), targets.end(), target) == targets.end())
+      targets.push_back(target);
+  }
+  const auto line_targets = reference_targets_on_line(file_path, line);
+  if (std::any_of(line_targets.begin(), line_targets.end(),
+                  [&](CodeGraph::VertexId target) {
+                    return std::find(targets.begin(), targets.end(), target) ==
+                           targets.end();
+                  })) {
+    return {false, "native_position_line_ambiguity_requires_legacy_graph", {}};
+  }
+  return {true, {}, {}, targets};
+}
+
+std::optional<FactQueryIndex::Location>
+FactQueryIndex::primary_definition(CodeGraph::VertexId target) const {
+  const auto found = occurrence_indexes_by_target_.find(target);
+  if (found == occurrence_indexes_by_target_.end())
+    return std::nullopt;
+  for (const auto index : found->second) {
+    const auto &occurrence = records_->occurrences[index];
+    if ((occurrence.roles & OCCURRENCE_ROLE_PRIMARY_DEFINITION) != 0)
+      return location_from(occurrence);
+  }
+  return std::nullopt;
+}
+
+std::vector<CodeGraph::VertexId>
+FactQueryIndex::reference_targets_on_line(const std::string &file_path,
+                                          int line) const {
+  const auto found = occurrence_indexes_by_file_.find(file_path);
+  if (found == occurrence_indexes_by_file_.end())
+    return {};
+  std::vector<CodeGraph::VertexId> targets;
+  for (const auto index : found->second.indexes) {
+    const auto &occurrence = records_->occurrences[index];
+    if (occurrence.start_line < line)
+      continue;
+    if (occurrence.start_line > line)
+      break;
+    if ((occurrence.roles & OCCURRENCE_ROLE_REFERENCE) == 0 ||
+        !occurrence.target_symbol.has_value() ||
+        !occurrence.container_symbol.has_value()) {
+      continue;
+    }
+    const auto target = *occurrence.target_symbol;
+    if (std::find(targets.begin(), targets.end(), target) == targets.end())
+      targets.push_back(target);
+  }
+  return targets;
+}
+
+FactQueryIndex::PositionQueryResult
+FactQueryIndex::definitions_at(const std::string &file_path, int line,
+                               int character, std::size_t limit) const {
+  std::vector<CodeGraph::VertexId> targets;
+  auto decision = targets_at(file_path, line, character, targets);
+  if (!decision.served)
+    return decision;
+  for (const auto target : targets) {
+    const auto definition = primary_definition(target);
+    if (!definition.has_value())
+      return {false, "native_position_definition_unavailable", {}};
+    decision.locations.push_back(*definition);
+  }
+  sort_unique_locations(decision.locations, std::max<std::size_t>(1, limit));
+  return decision;
+}
+
+FactQueryIndex::PositionQueryResult
+FactQueryIndex::references_at(const std::string &file_path, int line,
+                              int character, bool include_declaration,
+                              std::size_t limit) const {
+  std::vector<CodeGraph::VertexId> targets;
+  auto decision = targets_at(file_path, line, character, targets);
+  if (!decision.served)
+    return decision;
+  std::vector<CodeGraph::VertexId> resolved_targets;
+  for (const auto target : targets) {
+    const auto &vertex = records_->vertices[static_cast<std::size_t>(target)];
+    const auto &display =
+        vertex.unified_name.has_value() ? *vertex.unified_name : vertex.name;
+    const auto candidates = resolve_symbol_candidates(display);
+    if (candidates.size() == 1 && candidates.front() == vertex.name)
+      resolved_targets.push_back(target);
+  }
+  for (const auto target : resolved_targets) {
+    const auto incoming = incoming_reference_indexes_.find(target);
+    if (incoming != incoming_reference_indexes_.end() &&
+        std::any_of(incoming->second.begin(), incoming->second.end(),
+                    [&](std::size_t index) {
+                      const auto &edge = records_->edges[index];
+                      return !edge.anchor_file.has_value() ||
+                             !edge.anchor_line.has_value();
+                    })) {
+      return {false,
+              "native_position_unanchored_reference_requires_legacy_graph",
+              {}};
+    }
+    if (include_declaration) {
+      const auto definition = primary_definition(target);
+      if (!definition.has_value())
+        return {false, "native_position_definition_unavailable", {}};
+      decision.locations.push_back(*definition);
+    }
+    const auto found = occurrence_indexes_by_target_.find(target);
+    if (found == occurrence_indexes_by_target_.end())
+      continue;
+    for (const auto index : found->second) {
+      const auto &occurrence = records_->occurrences[index];
+      if ((occurrence.roles & OCCURRENCE_ROLE_REFERENCE) == 0 ||
+          !occurrence.container_symbol.has_value()) {
+        continue;
+      }
+      decision.locations.push_back(location_from(occurrence));
+    }
+  }
+  sort_unique_locations(decision.locations, std::max<std::size_t>(1, limit));
+  return decision;
+}
+
+bool FactQueryIndex::has_occurrence_at(const std::string &file_path, int line,
+                                       int character) const {
+  std::vector<CodeGraph::VertexId> targets;
+  return targets_at(file_path, line, character, targets).served;
+}
+
+std::vector<FactQueryIndex::Location>
+FactQueryIndex::position_samples(std::size_t limit) const {
+  if (limit == 0)
+    return {};
+  std::vector<Location> references;
+  std::vector<Location> definitions;
+  for (const auto &occurrence : records_->occurrences) {
+    if (!occurrence.target_symbol.has_value() ||
+        !source_is_available(occurrence.file) ||
+        !primary_definition(*occurrence.target_symbol).has_value()) {
+      continue;
+    }
+    if ((occurrence.roles & OCCURRENCE_ROLE_REFERENCE) != 0 &&
+        occurrence.container_symbol.has_value()) {
+      references.push_back(location_from(occurrence));
+    } else if ((occurrence.roles & OCCURRENCE_ROLE_PRIMARY_DEFINITION) != 0) {
+      definitions.push_back(location_from(occurrence));
+    }
+  }
+  sort_unique_locations(references, std::numeric_limits<std::size_t>::max());
+  sort_unique_locations(definitions, std::numeric_limits<std::size_t>::max());
+  std::vector<Location> result;
+  result.reserve(std::min(limit, references.size() + definitions.size()));
+  for (const auto *candidates : {&references, &definitions}) {
+    for (const auto &location : *candidates) {
+      if (!definitions_at(location.file_path, location.start_line,
+                          location.start_character, 1)
+               .served ||
+          !references_at(location.file_path, location.start_line,
+                         location.start_character, true, 1)
+               .served ||
+          std::find(result.begin(), result.end(), location) != result.end()) {
+        continue;
+      }
+      result.push_back(location);
+      if (result.size() >= limit)
+        return result;
+    }
   }
   return result;
 }

--- a/core/fact_query_index.h
+++ b/core/fact_query_index.h
@@ -14,6 +14,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace codenib::core {
@@ -21,16 +22,43 @@ namespace codenib::core {
 inline constexpr std::uint32_t FACT_QUERY_INDEX_ABI_VERSION = 1;
 inline constexpr char FACT_QUERY_INDEX_FORMAT[] = "fact-query-index-v1";
 
-// Graph-free read index for the symbol-based definition/reference subset of
-// the LSP-shaped API. The index owns one immutable DecodedRecords allocation
-// and stores only vertex ids and edge indexes as postings. Position and route
-// queries are deliberately outside the v1 capability contract.
+// Graph-free read index for definition/reference subsets of the LSP-shaped
+// API. The index owns one immutable DecodedRecords allocation and stores only
+// integer postings. The generic v1 contract remains symbol-only; providers may
+// opt into occurrence postings, while route queries remain outside this type.
 class FactQueryIndex {
 public:
   struct Reference {
     CodeGraph::VertexId source;
     std::optional<std::string> anchor_file;
     std::optional<int> anchor_line;
+  };
+
+  struct Location {
+    std::string file_path;
+    int start_line{0};
+    int start_character{0};
+    int end_line{0};
+    int end_character{0};
+    std::uint32_t roles{0};
+    std::optional<CodeGraph::VertexId> target_symbol;
+    std::optional<CodeGraph::VertexId> container_symbol;
+
+    bool operator==(const Location &other) const {
+      return file_path == other.file_path && start_line == other.start_line &&
+             start_character == other.start_character &&
+             end_line == other.end_line &&
+             end_character == other.end_character && roles == other.roles &&
+             target_symbol == other.target_symbol &&
+             container_symbol == other.container_symbol;
+    }
+  };
+
+  struct PositionQueryResult {
+    bool served{false};
+    std::string fallback_reason;
+    std::vector<Location> locations;
+    std::vector<CodeGraph::VertexId> targets;
   };
 
   explicit FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
@@ -47,24 +75,54 @@ public:
                             std::size_t limit = 8) const;
   std::vector<Reference>
   incoming_references(const std::string &target_name) const;
+  PositionQueryResult definitions_at(const std::string &file_path, int line,
+                                     int character,
+                                     std::size_t limit = 8) const;
+  PositionQueryResult references_at(const std::string &file_path, int line,
+                                    int character, bool include_declaration,
+                                    std::size_t limit = 40) const;
+  bool has_occurrence_at(const std::string &file_path, int line,
+                         int character) const;
+  std::vector<Location> position_samples(std::size_t limit = 100) const;
 
   const std::string &project_root() const { return records_->project_root; }
   std::size_t record_count() const { return records_->vertices.size(); }
   std::size_t edge_count() const { return records_->edges.size(); }
   std::size_t symbol_count() const { return definition_by_name_.size(); }
   std::size_t reference_count() const { return reference_count_; }
+  std::size_t occurrence_count() const { return records_->occurrences.size(); }
+  const std::string &position_encoding() const {
+    return records_->position_encoding;
+  }
+  bool supports_position_queries() const {
+    return !records_->occurrences.empty();
+  }
   bool requires_anchored_references() const {
     return require_anchored_references_;
   }
   const std::string &snapshot_id() const { return snapshot_id_; }
 
 private:
+  struct FileOccurrencePostings {
+    std::vector<std::size_t> indexes;
+    std::vector<std::pair<int, int>> prefix_max_end;
+  };
+
   static std::string trim_symbol(std::string value);
   static std::string bare_symbol(const std::string &value);
   static std::string graph_bare_symbol(const std::string &value);
   static std::string lowercase(std::string value);
   void append_candidate(std::vector<CodeGraph::VertexId> &output,
                         CodeGraph::VertexId id, std::size_t limit) const;
+  std::vector<std::size_t> occurrences_at(const std::string &file_path,
+                                          int line, int character) const;
+  PositionQueryResult
+  targets_at(const std::string &file_path, int line, int character,
+             std::vector<CodeGraph::VertexId> &targets) const;
+  std::optional<Location> primary_definition(CodeGraph::VertexId target) const;
+  std::vector<CodeGraph::VertexId>
+  reference_targets_on_line(const std::string &file_path, int line) const;
+  bool source_is_available(const std::string &file_path) const;
 
   std::shared_ptr<const DecodedRecords> records_;
   std::string snapshot_id_;
@@ -76,6 +134,10 @@ private:
   std::vector<std::string> alias_order_;
   std::unordered_map<CodeGraph::VertexId, std::vector<std::size_t>>
       incoming_reference_indexes_;
+  std::unordered_map<std::string, FileOccurrencePostings>
+      occurrence_indexes_by_file_;
+  std::unordered_map<CodeGraph::VertexId, std::vector<std::size_t>>
+      occurrence_indexes_by_target_;
   std::size_t reference_count_{0};
   bool require_anchored_references_{true};
 };

--- a/core/tests/fact_query_index_test.cpp
+++ b/core/tests/fact_query_index_test.cpp
@@ -4,6 +4,7 @@
 
 #include "fact_query_index.h"
 
+#include <algorithm>
 #include <cassert>
 #include <iostream>
 #include <memory>
@@ -13,6 +14,7 @@
 #include <vector>
 
 using codenib::core::CodeGraph;
+using codenib::core::DecodedOccurrence;
 using codenib::core::DecodedRecords;
 using codenib::core::FactQueryIndex;
 
@@ -60,6 +62,47 @@ std::shared_ptr<DecodedRecords> make_records() {
       {1, 0, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 10},
       {1, 4, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 11},
       {1, 0, codenib::core::EDGE_TYPE_CONTAIN, std::nullopt, std::nullopt},
+  };
+  return records;
+}
+
+DecodedOccurrence
+occurrence(int line, int start_character, int end_character,
+           std::uint32_t roles, std::optional<CodeGraph::VertexId> target,
+           std::optional<CodeGraph::VertexId> container = std::nullopt) {
+  return DecodedOccurrence{"src/main.py", line,  start_character, line,
+                           end_character, roles, target,          container};
+}
+
+std::shared_ptr<DecodedRecords> make_occurrence_records() {
+  auto records = make_records();
+  // An empty root makes this a provider-neutral range test without depending
+  // on a checkout path. Source availability is covered separately below.
+  records->project_root.clear();
+  records->position_encoding = "UTF16";
+  records->occurrences = {
+      occurrence(2, 4, 10,
+                 codenib::core::OCCURRENCE_ROLE_DEFINITION |
+                     codenib::core::OCCURRENCE_ROLE_PRIMARY_DEFINITION,
+                 0),
+      occurrence(5, 10, 16, codenib::core::OCCURRENCE_ROLE_REFERENCE, 0, 1),
+      occurrence(5, 10, 16,
+                 codenib::core::OCCURRENCE_ROLE_REFERENCE |
+                     codenib::core::OCCURRENCE_ROLE_SPELLED,
+                 0, 1),
+      occurrence(1, 4, 10, codenib::core::OCCURRENCE_ROLE_DECLARATION, 0),
+      occurrence(7, 0, 5, codenib::core::OCCURRENCE_ROLE_REFERENCE,
+                 std::nullopt, 1),
+      occurrence(12, 4, 8,
+                 codenib::core::OCCURRENCE_ROLE_DEFINITION |
+                     codenib::core::OCCURRENCE_ROLE_PRIMARY_DEFINITION,
+                 2),
+      occurrence(9, 0, 20, codenib::core::OCCURRENCE_ROLE_DEFINITION, 1, 1),
+      occurrence(9, 3, 8, codenib::core::OCCURRENCE_ROLE_REFERENCE, 0, 1),
+      occurrence(9, 3, 8, codenib::core::OCCURRENCE_ROLE_REFERENCE, 2, 1),
+      occurrence(10, 1, 4, codenib::core::OCCURRENCE_ROLE_REFERENCE, 0, 1),
+      occurrence(10, 8, 12, codenib::core::OCCURRENCE_ROLE_REFERENCE, 2, 1),
+      occurrence(11, 4, 19, codenib::core::OCCURRENCE_ROLE_REFERENCE, 4, 1),
   };
   return records;
 }
@@ -183,11 +226,91 @@ void assert_invalid_records_fail_closed() {
   }
 }
 
+void assert_exact_occurrence_ranges_and_fallbacks() {
+  FactQueryIndex index(make_occurrence_records(), true, "snapshot:test");
+  assert(index.snapshot_id() == "snapshot:test");
+  assert(index.position_encoding() == "UTF16");
+  assert(index.occurrence_count() == 12);
+  assert(index.supports_position_queries());
+
+  const auto at_start = index.definitions_at("src/main.py", 5, 10, 8);
+  assert(at_start.served);
+  assert(at_start.locations.size() == 1);
+  assert(at_start.locations[0].start_line == 2);
+  assert(index.definitions_at("src/main.py", 5, 15, 8).served);
+  const auto at_end = index.definitions_at("src/main.py", 5, 16, 8);
+  assert(!at_end.served);
+  assert(at_end.fallback_reason == "native_position_occurrence_not_found");
+
+  const auto with_definition =
+      index.references_at("src/main.py", 5, 10, true, 40);
+  assert(with_definition.served);
+  assert(with_definition.locations.size() == 4);
+  const auto merged_duplicate = std::find_if(
+      with_definition.locations.begin(), with_definition.locations.end(),
+      [](const FactQueryIndex::Location &location) {
+        return location.start_line == 5 && location.start_character == 10;
+      });
+  assert(merged_duplicate != with_definition.locations.end());
+  assert((merged_duplicate->roles & codenib::core::OCCURRENCE_ROLE_SPELLED) !=
+         0);
+  const auto without_definition =
+      index.references_at("src/main.py", 5, 10, false, 40);
+  assert(without_definition.served);
+  assert(without_definition.locations.size() == 3);
+
+  const auto overload = index.definitions_at("src/main.py", 9, 4, 8);
+  assert(overload.served);
+  assert(overload.locations.size() == 2);
+  const auto ambiguous = index.definitions_at("src/main.py", 10, 1, 8);
+  assert(!ambiguous.served);
+  assert(ambiguous.fallback_reason ==
+         "native_position_line_ambiguity_requires_legacy_graph");
+
+  const auto declaration = index.definitions_at("src/main.py", 1, 4, 8);
+  assert(!declaration.served);
+  assert(declaration.fallback_reason ==
+         "native_position_declaration_requires_legacy_graph");
+  const auto unsupported = index.definitions_at("src/main.py", 7, 1, 8);
+  assert(!unsupported.served);
+  assert(unsupported.fallback_reason == "native_position_target_unsupported");
+  const auto unavailable = index.definitions_at("../src/main.py", 5, 10, 8);
+  assert(!unavailable.served);
+  assert(unavailable.fallback_reason == "native_position_source_unavailable");
+
+  const auto samples = index.position_samples(100);
+  assert(!samples.empty());
+  for (const auto &sample : samples)
+    assert(sample.start_line != 1 && sample.start_line != 7);
+}
+
+void assert_invalid_occurrences_fail_closed() {
+  auto invalid_range = make_occurrence_records();
+  invalid_range->occurrences.push_back(
+      occurrence(13, 8, 4, codenib::core::OCCURRENCE_ROLE_REFERENCE, 0, 1));
+  try {
+    (void)FactQueryIndex(invalid_range);
+    assert(false);
+  } catch (const std::invalid_argument &) {
+  }
+
+  auto invalid_symbol = make_occurrence_records();
+  invalid_symbol->occurrences.push_back(
+      occurrence(13, 4, 8, codenib::core::OCCURRENCE_ROLE_REFERENCE, 99, 1));
+  try {
+    (void)FactQueryIndex(invalid_symbol);
+    assert(false);
+  } catch (const std::out_of_range &) {
+  }
+}
+
 } // namespace
 
 int main() {
   assert_symbol_resolution_and_postings();
   assert_invalid_records_fail_closed();
+  assert_exact_occurrence_ranges_and_fallbacks();
+  assert_invalid_occurrences_fail_closed();
   std::cout << "fact_query_index_test: OK\n";
   return 0;
 }

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -148,22 +148,34 @@ make fact-query-profile \
 Pass `--external-index-seconds` through `FACT_QUERY_PROFILE_EXTRA_ARGS` when a
 separate cold-start analysis should include unchanged SCIP generation time.
 
-## Native clangd Symbol Queries
+## Native clangd Symbol And Position Queries
 
 The C/C++ query-specific path starts from an existing project-local clangd
 `.idx` directory. `decode_clangd_fact_query_index(...)` reads direct shards in
 stable filename order and decodes RIFF string, symbol, reference, and relation
 rows directly into provider-neutral `DecodedRecords`. `FactQueryIndex` then
 builds integer postings without a `CodeGraph`, igraph, or intermediate Python
-record dictionaries. Its explicit contract advertises symbol definition and
-reference support while position and route capabilities remain false.
+record dictionaries. The clangd-specific v2 contract advertises symbol and
+exact-position definition/reference support; route capability remains false.
 
 Call `LSIndexer.process_query_index()` to obtain the capability-specific index,
 or `process_query_provider()` for a hybrid provider. Successful symbol queries
-stay graph-free. The first position or route request lazily materializes the
-complete compatible graph, and later unsupported requests reuse it. The normal
-`process_index()` path, persistence format, incremental checks, range indexes,
-and graph quality behavior are unchanged.
+stay on the startup index. The first position request lazily decodes a native
+occurrence view with provider-neutral zero-based, half-open ranges, role bits,
+and optional target/container vertex ids. `FactQueryIndex` owns its per-file
+interval and per-target postings, so successful character-exact position
+queries stay graph-free. Unsupported, ambiguous, declaration-only, unanchored,
+and missing-source cases carry deterministic fallback reasons into the one
+complete compatible graph. A route request also materializes that graph once.
+The normal `process_index()` path, persistence format, incremental checks,
+range indexes, and graph quality behavior are unchanged.
+
+UTF-16 is the default clangd position encoding. UTF-8 and UTF-32 are accepted
+explicitly, normalized at the provider boundary, and included in the content
+receipt. Full and incremental background commands use the same encoding flag.
+The symbol-only startup index deliberately contains no occurrence rows; this
+keeps route-first startup at the previously promoted cost, while position
+workloads pay for the native view only on first use.
 
 `CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX=auto` is promoted by default after the
 persisted-artifact query-ready gate passed on both the generated C++ fixture
@@ -181,7 +193,7 @@ make clangd-fact-query-profile \
 
 This result measures an already generated `.idx` directory through identical
 definition/reference work. It does not claim faster clangd generation. Native
-position and route lookup remain independent follow-up gates.
+route lookup remains an independent follow-up gate.
 
 ### MCP and agent runtime selection
 
@@ -193,13 +205,12 @@ checkouts, and disabled or unavailable native support use
 `persisted-symbol-graph-v1` with a deterministic fallback reason.
 
 MCP definition, reference, and route tools and all three agent LSP skills use
-the common provider resolver. Definition and reference symbol requests remain
-on the native postings path without igraph. Position and route requests lazily
-materialize one snapshot-compatible complete graph and reuse it. MCP result
-rows and `get_manifest` runtime metadata identify the backend, capabilities,
-fallback, and snapshot. The profiling report's `mcp_consumer_decision` applies
-the acceleration gate to startup plus real MCP validation and serialization,
-in addition to checking raw-query parity.
+the common provider resolver. Definition/reference symbol requests remain on
+the startup postings path; supported exact positions use the lazy native
+occurrence view without igraph. Position fallbacks and routes share one
+snapshot-compatible complete graph. MCP result rows and `get_manifest` runtime
+metadata identify the backend, capabilities, fallback, encoding, and snapshot.
+The profiling report checks raw and MCP parity together with provider routing.
 
 ### Mixed workload and resource gate
 
@@ -218,14 +229,13 @@ make clangd-workload-gate \
   CLANGD_WORKLOAD_GATE_SUBJECT_ID=fmt-11.2.0
 ```
 
-The default gate requires at least 20% symbol-only acceleration, no more than
-20% regression for graph-requiring workloads, native peak RSS no higher than
-1.25x legacy or 4 GiB, no more than 10% repeated-process peak spread, exact
-parity, and exactly one successful graph materialization when concurrent first
-route calls race. Symbol-only runs must materialize zero graphs; position,
-route, and mixed runs still intentionally materialize one complete graph in
-this milestone. Native position and graph-free route promotion remain #553 and
-#552 respectively.
+The default gate requires at least 20% acceleration for symbol-only and
+position-first workloads, no more than 20% regression for graph-requiring
+workloads, native peak RSS no higher than 1.25x legacy or 4 GiB, no more than
+10% repeated-process peak spread, exact parity, and exactly one successful
+graph materialization when concurrent first route calls race. Symbol-only and
+position-first runs must materialize zero graphs; route-first and mixed runs
+must materialize exactly one. Graph-free route promotion remains #552.
 
 The maintained subject manifest pins fmt 11.2.0, GoogleTest 1.17.0, and
 protobuf 31.1 by full commit, covering template-, macro-, header-heavy, and

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -754,9 +754,10 @@ Reproduce the report with `make clangd-fact-query-profile`.
 This promotion does not include or accelerate clangd index generation. RIFF
 version/resource hardening (#546), zlib CI enforcement (#547), and
 content-bound generation receipts (#548) are independent production gates.
-Serving integration is tracked below. Mixed/RSS/concurrency matrices (#550),
-native position (#553), native route (#552), and durable FactBatch storage
-(#551) remain separate review and promotion gates.
+Serving integration and the mixed/RSS/concurrency matrix are tracked below.
+Native position (#553) has its own promotion evidence below; native route
+(#552) and durable FactBatch storage (#551) remain separate review and
+promotion gates.
 
 Native clangd RIFF compatibility and resource-safety status
 ([#546](https://github.com/sysevol-ai/CodeNib/issues/546)): the v1 reader now
@@ -836,7 +837,8 @@ Median complete-graph MCP consumer time was 178.269 ms versus 27.717 ms for the
 native provider, an 84.45% improvement with exact result parity. Symbol-only
 requests never imported or materialized igraph, and the first graph-requiring
 request materialized the compatible graph once. Native position and route
-indexes remain the independent #553 and #552 promotion gates.
+indexes remained the independent #553 and #552 promotion gates at this stage;
+the position result is recorded below.
 
 Native clangd mixed-workload promotion status
 ([#550](https://github.com/sysevol-ai/CodeNib/issues/550)): first lazy graph
@@ -862,9 +864,9 @@ The subject manifest pins fmt 11.2.0, GoogleTest 1.17.0, and protobuf 31.1 at
 full commits, covering template-, macro-, header-heavy, and multi-target C++.
 Selecting a subject requires that exact clean revision. The same Make target
 first exercises generated RIFF 18/19/20 public parity fixtures. This milestone
-deliberately keeps position-first, route-first, and mixed native arms on one
-lazy complete graph; graph-free position and route changes remain isolated in
-#553 and #552.
+deliberately kept position-first, route-first, and mixed native arms on one
+lazy complete graph; the later graph-free position gate is recorded below and
+graph-free route remains isolated in #552.
 
 The recorded `cpp_simple` evidence used 223 shards and five measured rounds
 plus one warmup. Symbol-only improved from 177.96 ms to 37.28 ms (79.0%);
@@ -875,6 +877,47 @@ On the existing 51-shard fmt checkout, three isolated rounds improved
 symbol-only from 2.330 s to 0.137 s (94.1%); graph-workload regressions stayed
 within 2.3%, native peak stayed below 246 MiB and 1.14x legacy, and all three
 concurrent runs built once.
+
+Native clangd position-query promotion status
+([#553](https://github.com/sysevol-ai/CodeNib/issues/553)): the clangd query
+contract is now `clangd-riff-fact-query-v2`. It adds provider-neutral
+occurrence rows with zero-based half-open file ranges, role bits, and optional
+target/container vertex ids. `FactQueryIndex` builds native per-file interval
+postings and per-target postings without igraph or Python record dictionaries.
+UTF-16 is the default position encoding; UTF-8 and UTF-32 are normalized at the
+provider boundary, bound into the content receipt, and shared by full and
+incremental clangd background commands.
+
+The hybrid provider keeps its startup index symbol-only. Its first exact
+position request builds the native occurrence view under the same publication
+lock used for graph fallback, while route-first sessions retain the #550
+cold-start path. Successful definition/reference positions remain on
+`native-clangd-fact-query-v1` and materialize zero graphs. Invalid ranges,
+missing sources, declaration-only rows, unsupported targets, missing
+definitions, line ambiguity, unanchored references, and source-token mismatch
+carry stable reasons into the established graph fallback. A route or fallback
+still publishes one complete, range-indexed graph.
+
+The 2026-08-11 `fmt` gate used the clean pinned revision
+`b35de87ad91951c8269fe533dca6aebc3e0a25ba`, 51 shards / 2,392,564 bytes,
+20 deterministic exact positions, three measured isolated rounds after one
+warmup, and the unchanged 20% thresholds:
+
+| Workload | Legacy | Native | Change | Native graphs | Result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| symbol-only | 1.9313s | 0.1169s | +93.9% | 0 | pass |
+| position-first | 2.0626s | 0.2634s | +87.2% | 0 | pass |
+| route-first | 1.9109s | 2.0381s | 6.7% regression | 1 | pass |
+| mixed | 2.0475s | 2.3689s | 15.7% regression | 1 | pass |
+
+The median lazy native position initialization was 0.1388s for 121,434
+occurrence rows. Exact MCP result/public-error parity, snapshot receipts, RSS
+budgets, RIFF 18/19/20 fixtures, and all three eight-thread concurrent
+first-route runs passed; every concurrent run built exactly one graph. The
+receipt remained
+`clangd_fact_query:sha256:a88c9933461a2573a2c928eeeac8b734fcd5245d29f9d41e61d60f9c3d0b6693`.
+This is a query-ready result over existing shards, not a clangd-generation
+claim. Native route remains the independent #552 gate.
 
 Native core CI enforcement status
 ([#547](https://github.com/sysevol-ai/CodeNib/issues/547)): the trusted

--- a/scripts/profiling/profile_clangd_fact_query_index.py
+++ b/scripts/profiling/profile_clangd_fact_query_index.py
@@ -129,7 +129,7 @@ def profile_clangd_fact_query_index(
     if not hasattr(codenib_core, "decode_clangd_fact_query_index") or not hasattr(
         codenib_core, "clangd_fact_query_snapshot"
     ):
-        raise RuntimeError("compiled core does not expose clangd FactQueryIndex v1")
+        raise RuntimeError("compiled core does not expose clangd FactQueryIndex v2")
     contract = codenib_core.clangd_fact_query_contract()
     initial_receipt = dict(
         codenib_core.clangd_fact_query_snapshot(
@@ -175,11 +175,15 @@ def profile_clangd_fact_query_index(
     def native_arm() -> tuple[Any, dict[str, float]]:
         payload, startup = _timed(
             lambda: codenib_core.decode_clangd_fact_query_index(
-                idx_directory=str(idx_directory), project_root=str(project_root)
+                idx_directory=str(idx_directory),
+                project_root=str(project_root),
+                include_occurrences=False,
             )
         )
         if payload.get("graph_materialized") is not False:
             raise AssertionError("candidate payload reports graph materialization")
+        if payload.get("position_records_included") is not False:
+            raise AssertionError("symbol benchmark decoded occurrence rows")
         if payload.get("snapshot_id") != initial_receipt.get("snapshot_id"):
             raise RuntimeError("clangd index changed during native startup")
         index = payload["index"]
@@ -192,6 +196,7 @@ def profile_clangd_fact_query_index(
             "raw_reference_count",
             "definition_count",
             "reference_count",
+            "occurrence_count",
             "decoded_record_count",
             "index_bytes",
             "decompressed_string_bytes",
@@ -274,6 +279,10 @@ def profile_clangd_fact_query_index(
             seeds=parity_seeds,
             expected_symbol_count=len(all_symbols),
             expected_reference_count=expected_references,
+            expected_capabilities={
+                **contract["capabilities"],
+                "position_queries": False,
+            },
         )
         from codenib.agent.lsp_provider import StaticLSPProvider
 

--- a/scripts/profiling/profile_clangd_workload_gate.py
+++ b/scripts/profiling/profile_clangd_workload_gate.py
@@ -48,6 +48,7 @@ from scripts.profiling.profile_fact_query_index import (  # noqa: E402
 
 WORKLOADS = ("symbol_only", "position_first", "route_first", "mixed")
 DEFAULT_SYMBOL_THRESHOLD = 0.20
+DEFAULT_POSITION_THRESHOLD = 0.20
 DEFAULT_GRAPH_NON_REGRESSION_BUDGET = 0.20
 DEFAULT_PEAK_RSS_RATIO_BUDGET = 1.25
 DEFAULT_REPEAT_RSS_SPREAD_BUDGET = 0.10
@@ -338,16 +339,23 @@ def _worker(config: Mapping[str, Any]) -> dict[str, Any]:
     workload = str(config["workload"])
     idx_directory = Path(str(config["idx_directory"])).resolve()
     project_root = Path(str(config["project_root"])).resolve()
+    position_encoding = str(config["position_encoding"])
     receipt_before = dict(
         codenib_core.clangd_fact_query_snapshot(
-            idx_directory=str(idx_directory), project_root=str(project_root)
+            idx_directory=str(idx_directory),
+            project_root=str(project_root),
+            position_encoding=position_encoding,
         )
     )
     rss_start = _current_rss_bytes()
     peak_start = _peak_rss_bytes()
     cpu_started = time.process_time()
     wall_started = time.perf_counter()
-    decoder = ClangdGraphDecoder(str(idx_directory), str(project_root))
+    decoder = ClangdGraphDecoder(
+        str(idx_directory),
+        str(project_root),
+        position_encoding=position_encoding,
+    )
     stages: dict[str, float] = {}
 
     startup_started = time.perf_counter()
@@ -400,6 +408,7 @@ def _worker(config: Mapping[str, Any]) -> dict[str, Any]:
             "record_count",
             "definition_count",
             "reference_count",
+            "occurrence_count",
             "snapshot_file_count",
             "snapshot_index_bytes",
             "native_file_count",
@@ -407,12 +416,14 @@ def _worker(config: Mapping[str, Any]) -> dict[str, Any]:
             "native_raw_reference_count",
             "native_definition_count",
             "native_reference_count",
+            "native_occurrence_count",
             "native_decoded_record_count",
             "native_index_bytes",
             "native_decompressed_string_bytes",
             "native_materialized_string_bytes",
             "native_string_entry_count",
             "fact_query_native",
+            "position_fact_query_native",
         }
         index_counts = {
             name: int(decoder.query_profile[name])
@@ -430,12 +441,18 @@ def _worker(config: Mapping[str, Any]) -> dict[str, Any]:
             stages["lazy_materialize_graph"] = float(
                 provider.graph_materialization_seconds
             )
+        if getattr(provider, "position_initialization_seconds", 0.0):
+            stages["lazy_native_position_index"] = float(
+                provider.position_initialization_seconds
+            )
     else:
         index_counts = {}
 
     receipt_after = dict(
         codenib_core.clangd_fact_query_snapshot(
-            idx_directory=str(idx_directory), project_root=str(project_root)
+            idx_directory=str(idx_directory),
+            project_root=str(project_root),
+            position_encoding=position_encoding,
         )
     )
     peak_rss = _peak_rss_bytes()
@@ -643,7 +660,7 @@ def _workload_inputs(
 ) -> dict[str, Any]:
     from codenib.agent.lsp_provider import StaticLSPProvider
     from codenib.ls_index.clangd_decode import ClangdGraphDecoder
-    from codenib.mcp.tools.lsp import lsp_definition_impl
+    from codenib.mcp.tools.lsp import lsp_definition_impl, lsp_references_impl
 
     graph = ClangdGraphDecoder(
         str(idx_directory), str(project_root)
@@ -655,42 +672,73 @@ def _workload_inputs(
     legacy_context = SimpleNamespace(
         lsp_provider=StaticLSPProvider(graph), symbol_graph=graph
     )
-    candidate_symbols = _even_sample(all_symbols, max(100, query_workload_size * 20))
+    native_decoder = ClangdGraphDecoder(str(idx_directory), str(project_root))
+    native_provider = native_decoder.decode_native_query_provider()
+    native_context = SimpleNamespace(lsp_provider=native_provider, symbol_graph=None)
+    candidate_positions = native_provider.position_samples(
+        max(100, query_workload_size * 20)
+    )
     positions: list[dict[str, Any]] = []
-    seen_positions: set[tuple[str, int]] = set()
-    for symbol in candidate_symbols:
-        info = graph.get_node_info_by_name(symbol) or {}
-        file_path = info.get("file")
-        start_line = info.get("start_line")
+    seen_positions: set[tuple[str, int, int]] = set()
+    for sample in candidate_positions:
+        file_path = sample.get("file_path")
+        start_line = sample.get("start_line")
+        character = sample.get("start_character")
         if (
             not file_path
             or not isinstance(start_line, int)
             or isinstance(start_line, bool)
+            or not isinstance(character, int)
+            or isinstance(character, bool)
         ):
             continue
-        key = (str(file_path), start_line)
+        key = (str(file_path), start_line, character)
         if key in seen_positions:
             continue
-        # MCP input lines are 1-based. Character is intentionally omitted in
-        # this milestone: #550 measures the established full-graph position
-        # fallback; native character-granular occurrence lookup belongs to #553.
-        position = {"file_path": key[0], "line": start_line + 1}
-        result = lsp_definition_impl(legacy_context, **position, top_k=100)
-        if not isinstance(result, list) or not result:
+        # MCP input lines are one-based; clangd occurrence rows are zero-based.
+        position = {
+            "file_path": key[0],
+            "line": start_line + 1,
+            "character": character,
+        }
+        legacy_results = [
+            implementation(legacy_context, **position, top_k=100)
+            for implementation in (lsp_definition_impl, lsp_references_impl)
+        ]
+        native_results = [
+            implementation(native_context, **position, top_k=100)
+            for implementation in (lsp_definition_impl, lsp_references_impl)
+        ]
+        if any(not isinstance(result, list) for result in legacy_results):
+            continue
+        if any(not isinstance(result, list) for result in native_results):
+            continue
+        if [_canonical_tool_result(result) for result in native_results] != [
+            _canonical_tool_result(result) for result in legacy_results
+        ]:
+            continue
+        native_backends = {
+            str(metadata.get("backend"))
+            for result in native_results
+            for metadata in _provider_metadata(result)
+            if metadata.get("backend")
+        }
+        if native_backends != {"native-clangd-fact-query-v1"}:
             continue
         seen_positions.add(key)
         positions.append(position)
         if len(positions) >= query_workload_size:
             break
     if not positions:
-        raise ValueError("benchmark index has no usable graph position sample")
+        raise ValueError("benchmark index has no graph-free native position sample")
     route_symbols = symbols[: min(4, len(symbols))]
     if not route_symbols:
         raise ValueError("benchmark index has no route seed")
     return {
         "symbols": symbols,
         "positions": positions,
-        "position_candidate_count": len(candidate_symbols),
+        "position_candidate_count": len(candidate_positions),
+        "position_encoding": native_provider.position_encoding,
         "route_symbols": route_symbols,
         "definition_symbol_count": len(all_symbols),
         "graph_vertex_count": graph.graph.vcount(),
@@ -804,6 +852,7 @@ def profile_clangd_workload_gate(
     warmups: int = DEFAULT_WARMUPS,
     query_workload_size: int = DEFAULT_QUERY_WORKLOAD_SIZE,
     symbol_threshold: float = DEFAULT_SYMBOL_THRESHOLD,
+    position_threshold: float = DEFAULT_POSITION_THRESHOLD,
     graph_non_regression_budget: float = DEFAULT_GRAPH_NON_REGRESSION_BUDGET,
     peak_rss_ratio_budget: float = DEFAULT_PEAK_RSS_RATIO_BUDGET,
     repeat_rss_spread_budget: float = DEFAULT_REPEAT_RSS_SPREAD_BUDGET,
@@ -822,6 +871,8 @@ def profile_clangd_workload_gate(
         raise ValueError("query_workload_size must be positive")
     if not 0 <= symbol_threshold < 1:
         raise ValueError("symbol_threshold must be between 0 (inclusive) and 1")
+    if not 0 <= position_threshold < 1:
+        raise ValueError("position_threshold must be between 0 (inclusive) and 1")
     if graph_non_regression_budget < 0:
         raise ValueError("graph_non_regression_budget must be non-negative")
     if peak_rss_ratio_budget < 1:
@@ -870,7 +921,9 @@ def profile_clangd_workload_gate(
     idx_sha256, idx_bytes, idx_files = initial_idx_digest
     receipt = dict(
         codenib_core.clangd_fact_query_snapshot(
-            idx_directory=str(idx_directory), project_root=str(project_root)
+            idx_directory=str(idx_directory),
+            project_root=str(project_root),
+            position_encoding=inputs["position_encoding"],
         )
     )
     snapshot_id = str(receipt["snapshot_id"])
@@ -886,6 +939,7 @@ def profile_clangd_workload_gate(
         "symbols": inputs["symbols"],
         "positions": inputs["positions"],
         "route_symbols": inputs["route_symbols"],
+        "position_encoding": inputs["position_encoding"],
         "concurrency_workers": concurrency_workers,
     }
     workload_runs: dict[str, dict[str, list[dict[str, Any]]]] = {
@@ -943,7 +997,9 @@ def profile_clangd_workload_gate(
 
     final_receipt = dict(
         codenib_core.clangd_fact_query_snapshot(
-            idx_directory=str(idx_directory), project_root=str(project_root)
+            idx_directory=str(idx_directory),
+            project_root=str(project_root),
+            position_encoding=inputs["position_encoding"],
         )
     )
     final_idx_digest = _idx_digest(idx_directory)
@@ -961,6 +1017,7 @@ def profile_clangd_workload_gate(
     materialization_gates: dict[str, Any] = {}
     rss_gates: dict[str, Any] = {}
     symbol_gate: dict[str, Any] | None = None
+    position_gate: dict[str, Any] | None = None
     max_native_peak_rss_bytes = int(max_native_peak_rss_mb * 1024 * 1024)
 
     for workload in WORKLOADS:
@@ -992,6 +1049,23 @@ def profile_clangd_workload_gate(
                 "improvement_fraction": improvement,
                 "passed": parity and improvement >= symbol_threshold,
             }
+        elif workload == "position_first":
+            improvement = _improvement(legacy_wall, native_wall)
+            position_gate = {
+                "threshold": position_threshold,
+                "improvement_fraction": improvement,
+                "graph_free": all(
+                    run.get("graph_materialization_count") == 0
+                    and run.get("graph_materialized") is False
+                    and run.get("observed_backends") == ["native-clangd-fact-query-v1"]
+                    for run in native_runs
+                ),
+            }
+            position_gate["passed"] = (
+                parity
+                and position_gate["graph_free"]
+                and improvement >= position_threshold
+            )
         else:
             regression = _regression(legacy_wall, native_wall)
             graph_gates[workload] = {
@@ -1000,11 +1074,12 @@ def profile_clangd_workload_gate(
                 "passed": parity and regression <= graph_non_regression_budget,
             }
 
-        expected_materializations = 0 if workload == "symbol_only" else 1
+        graph_free_workload = workload in {"symbol_only", "position_first"}
+        expected_materializations = 0 if graph_free_workload else 1
         materialization_passed = all(
             run.get("graph_materialization_count") == expected_materializations
-            and run.get("graph_materialized") is (workload != "symbol_only")
-            and (workload == "symbol_only" or run.get("range_indexes_built") is True)
+            and run.get("graph_materialized") is (not graph_free_workload)
+            and (graph_free_workload or run.get("range_indexes_built") is True)
             for run in native_runs
         )
         materialization_gates[workload] = {
@@ -1060,6 +1135,8 @@ def profile_clangd_workload_gate(
 
     if symbol_gate is None:
         raise RuntimeError("symbol-only gate was not evaluated")
+    if position_gate is None:
+        raise RuntimeError("position-first gate was not evaluated")
     concurrency_thread_digests = {
         str(digest)
         for run in concurrency_runs
@@ -1098,6 +1175,7 @@ def profile_clangd_workload_gate(
     overall_passed = (
         parity_passed
         and symbol_gate["passed"]
+        and position_gate["passed"]
         and graph_passed
         and materialization_passed
         and rss_passed
@@ -1155,6 +1233,8 @@ def profile_clangd_workload_gate(
             "query_ready_excludes_process_launch_and_outer_receipt_checks": True,
             "worker_timeout_seconds": worker_timeout_seconds,
             "symbol_threshold": symbol_threshold,
+            "position_threshold": position_threshold,
+            "position_encoding": inputs["position_encoding"],
             "graph_non_regression_budget": graph_non_regression_budget,
             "peak_rss_ratio_budget": peak_rss_ratio_budget,
             "repeat_rss_spread_budget": repeat_rss_spread_budget,
@@ -1181,6 +1261,7 @@ def profile_clangd_workload_gate(
         "gates": {
             "parity": {"passed": parity_passed},
             "symbol_only": symbol_gate,
+            "position_first": position_gate,
             "graph_non_regression": {
                 "passed": graph_passed,
                 "workloads": graph_gates,
@@ -1220,6 +1301,9 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--symbol-threshold", type=float, default=DEFAULT_SYMBOL_THRESHOLD
+    )
+    parser.add_argument(
+        "--position-threshold", type=float, default=DEFAULT_POSITION_THRESHOLD
     )
     parser.add_argument(
         "--graph-non-regression-budget",
@@ -1272,6 +1356,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         warmups=args.warmups,
         query_workload_size=args.query_workload_size,
         symbol_threshold=args.symbol_threshold,
+        position_threshold=args.position_threshold,
         graph_non_regression_budget=args.graph_non_regression_budget,
         peak_rss_ratio_budget=args.peak_rss_ratio_budget,
         repeat_rss_spread_budget=args.repeat_rss_spread_budget,

--- a/scripts/profiling/profile_fact_query_index.py
+++ b/scripts/profiling/profile_fact_query_index.py
@@ -20,7 +20,7 @@ import json
 import sys
 import time
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _CORE_BUILD = _PROJECT_ROOT / "build/core"
@@ -129,6 +129,7 @@ def _assert_query_parity(
     seeds: Sequence[str],
     expected_symbol_count: int,
     expected_reference_count: int,
+    expected_capabilities: Mapping[str, bool] | None = None,
 ) -> None:
     from codenib.agent.lsp_graph import lsp_definition, lsp_references
 
@@ -136,14 +137,14 @@ def _assert_query_parity(
         index, "graph"
     ):
         raise AssertionError("candidate materialized a graph")
-    expected_capabilities = {
+    capabilities = expected_capabilities or {
         "definition_by_symbol": True,
         "references_by_symbol": True,
         "position_queries": False,
         "route_queries": False,
     }
-    if getattr(index, "capabilities", None) != expected_capabilities:
-        raise AssertionError("candidate capabilities differ from v1")
+    if getattr(index, "capabilities", None) != dict(capabilities):
+        raise AssertionError("candidate capabilities differ from expected contract")
     if index.symbol_count != expected_symbol_count:
         raise AssertionError(
             f"definition symbol count differs: {expected_symbol_count} != "

--- a/test/agent/test_lsp_provider.py
+++ b/test/agent/test_lsp_provider.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from codenib.agent.lsp_provider import (
     STATIC_LSP_PROVIDER,
+    LSPPositionFallback,
     LSPProviderNodes,
+    NativeOccurrenceQueryAdapter,
     StaticLSPProvider,
     normalize_native_lsp_nodes,
     select_checkout_lsp_provider,
@@ -150,6 +154,57 @@ def test_graph_position_backend_records_character_contract(tmp_path):
         "static_symbol_graph_position_lsp_v1"
     )
     assert definition.provider_metadata_dict()["position_granularity"] == "character"
+
+
+@pytest.mark.parametrize(
+    ("position_encoding", "character"),
+    [("UTF8", 5), ("UTF16", 3), ("UTF32", 2)],
+)
+def test_native_occurrence_adapter_normalizes_unicode_character_units(
+    tmp_path, position_encoding, character
+):
+    (tmp_path / "caller.cpp").write_text("😀 target();\n", encoding="utf-8")
+
+    class QueryIndex:
+        project_root = str(tmp_path)
+        occurrence_count = 1
+
+        def __init__(self):
+            self.position_encoding = position_encoding
+
+        @staticmethod
+        def position_definitions(**_arguments):
+            return {
+                "served": True,
+                "fallback_reason": None,
+                "locations": [
+                    {
+                        "file_path": "target.cpp",
+                        "start_line": 8,
+                        "start_character": 4,
+                        "end_line": 8,
+                        "end_character": 10,
+                    }
+                ],
+                "targets": [0],
+            }
+
+        @staticmethod
+        def get_node_info_by_id(_target):
+            return {"name": "canonical", "unified_name": "target.cpp:target()"}
+
+    adapter = NativeOccurrenceQueryAdapter(QueryIndex())
+
+    assert (
+        adapter.definitions(file_path="caller.cpp", line=0, character=character)[0][
+            "file_path"
+        ]
+        == "target.cpp"
+    )
+    with pytest.raises(
+        LSPPositionFallback, match="native_position_token_requires_legacy_graph"
+    ):
+        adapter.definitions(file_path="caller.cpp", line=0, character=0)
 
 
 def test_native_lsp_result_normalization_is_stable_and_deduplicated():

--- a/test/ls_index/test_clangd_fact_query.py
+++ b/test/ls_index/test_clangd_fact_query.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Baseline native clangd symbol-query parity, fallback, and benchmark tests."""
+"""Native clangd symbol/position parity, fallback, and benchmark tests."""
 
 from __future__ import annotations
 
@@ -26,11 +26,18 @@ if importlib.util.find_spec("codenib_core") is None:
 
 import codenib_core  # noqa: E402
 
-from codenib.agent.lsp_graph import lsp_definition, lsp_references  # noqa: E402
+from codenib.agent.lsp_graph import lsp_definition  # noqa: E402
+from codenib.agent.lsp_graph import lsp_references
 from codenib.agent.lsp_provider import StaticLSPProvider  # noqa: E402
 from codenib.compiler.manifest import RepoManifest  # noqa: E402
 from codenib.graph.code_graph import CodeGraph  # noqa: E402
+from codenib.graph.incremental import patcher_cpp as patcher_cpp_module  # noqa: E402
 from codenib.ls_index import clangd_decode  # noqa: E402
+from codenib.ls_index import clangd_indexer as clangd_indexer_module  # noqa: E402
+from codenib.ls_index.clangd_contract import (  # noqa: E402
+    clangd_background_index_command,
+    normalize_clangd_position_encoding,
+)
 from codenib.ls_index.clangd_decode import ClangdGraphDecoder  # noqa: E402
 from codenib.ls_index.clangd_decode import (
     ClangdHybridQueryProvider,
@@ -40,7 +47,8 @@ from codenib.ls_router import LSIndexer  # noqa: E402
 from codenib.mcp.context import ServerContext  # noqa: E402
 from codenib.mcp.tools.lsp import lsp_definition_impl  # noqa: E402
 from codenib.mcp.tools.lsp import lsp_references_impl, lsp_route_impl
-from codenib.types import EDGE_TYPE_REFERENCE, node_has_definition  # noqa: E402
+from codenib.types import EDGE_TYPE_REFERENCE  # noqa: E402
+from codenib.types import node_has_definition
 from scripts.profiling.profile_clangd_fact_query_index import (  # noqa: E402
     main as profile_main,
 )
@@ -155,7 +163,9 @@ def _set_meta_version(idx_directory: Path, before: int, after: int) -> None:
     path.write_bytes(data.replace(old, new, 1))
 
 
-def _expected_snapshot_id(idx_directory: Path, project_root: Path) -> str:
+def _expected_snapshot_id(
+    idx_directory: Path, project_root: Path, position_encoding: str = "UTF16"
+) -> str:
     digest = hashlib.sha256()
 
     def field(value: str) -> None:
@@ -168,10 +178,11 @@ def _expected_snapshot_id(idx_directory: Path, project_root: Path) -> str:
 
     field("CodeNib clangd fact query snapshot")
     field("clangd-fact-query-snapshot-v1")
-    field("clangd-riff-fact-query-v1")
-    uint64(1)
-    field("clangd-native-normalization-v1")
+    field("clangd-riff-fact-query-v2")
+    uint64(2)
+    field("clangd-native-normalization-v2")
     field(project_root.absolute().as_posix())
+    field(position_encoding)
     uint64(3)
     for version in (18, 19, 20):
         uint64(version)
@@ -194,7 +205,8 @@ def clangd_fixture(tmp_path: Path) -> tuple[Path, Path]:
         "int target() { return 1; }\n"
         "int caller() { return target(); }\n"
         "int target();\n"
-        "Thing value;\n",
+        "Thing value;\n"
+        "int clean() { return 0; }\n",
         encoding="utf-8",
     )
     idx_directory = root / ".cache" / "clangd" / "index"
@@ -207,6 +219,7 @@ def clangd_fixture(tmp_path: Path) -> tuple[Path, Path]:
     function_id = bytes.fromhex("4142434445464748")
     method_three_id = bytes.fromhex("5152535455565758")
     directory_collision_id = bytes.fromhex("6162636465666768")
+    clean_id = bytes.fromhex("7172737475767778")
     zero_id = b"\x00" * 8
     strings = [
         "",
@@ -217,6 +230,7 @@ def clangd_fixture(tmp_path: Path) -> tuple[Path, Path]:
         "Thing",
         "Thing::",
         "src",
+        "clean",
     ]
     raw_strings = b"\x00".join(value.encode("utf-8") for value in strings) + b"\x00"
     string_table = struct.pack("<I", len(raw_strings)) + zlib.compress(raw_strings)
@@ -281,6 +295,16 @@ def clangd_fixture(tmp_path: Path) -> tuple[Path, Path]:
                 scope_index=0,
                 file_index=1,
                 line=0,
+            ),
+            _symbol(
+                clean_id,
+                kind=12,
+                name_index=8,
+                scope_index=4,
+                file_index=1,
+                line=4,
+                column=4,
+                end_column=9,
             ),
         )
     )
@@ -369,12 +393,14 @@ def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
     index = payload["index"]
 
     assert contract == {
-        "abi_version": 1,
-        "format": "clangd-riff-fact-query-v1",
-        "normalization_profile": "clangd-native-normalization-v1",
+        "abi_version": 2,
+        "format": "clangd-riff-fact-query-v2",
+        "normalization_profile": "clangd-native-normalization-v2",
         "snapshot_schema": "clangd-fact-query-snapshot-v1",
         "snapshot_digest": "sha256",
         "supported_versions": [18, 19, 20],
+        "default_position_encoding": "UTF16",
+        "supported_position_encodings": ["UTF8", "UTF16", "UTF32"],
         "resource_limits": {
             "max_index_files": 200_000,
             "max_chunks_per_file": 128,
@@ -394,7 +420,7 @@ def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
         "capabilities": {
             "definition_by_symbol": True,
             "references_by_symbol": True,
-            "position_queries": False,
+            "position_queries": True,
             "route_queries": False,
         },
     }
@@ -403,7 +429,40 @@ def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
     assert index.fact_query_index is True
     assert index.materializes_graph is False
     assert index.requires_anchored_references is False
+    assert index.capabilities["position_queries"] is True
+    assert index.position_encoding == "UTF16"
+    assert index.occurrence_count > 0
     assert not hasattr(index, "graph")
+
+
+def test_full_and_incremental_generation_share_utf16_contract(
+    clangd_fixture, tmp_path: Path
+) -> None:
+    root, _idx_directory = clangd_fixture
+    indexer = clangd_indexer_module.ClangdIndexer(root, output_dir=tmp_path / "out")
+    indexer._clangd_path = "/opt/clangd"
+    comp_db = root / "build" / "compile_commands.json"
+
+    expected = [
+        "/opt/clangd",
+        "--background-index",
+        f"--compile-commands-dir={comp_db.parent}",
+        "--background-index-priority=normal",
+        "--offset-encoding=utf-16",
+        "--log=error",
+    ]
+    assert indexer._build_index_command(comp_db) == expected
+    assert list(clangd_background_index_command("/opt/clangd", comp_db.parent)) == (
+        expected
+    )
+    assert (
+        patcher_cpp_module.clangd_background_index_command
+        is clangd_background_index_command
+    )
+    assert normalize_clangd_position_encoding("utf-8") == "UTF8"
+    assert normalize_clangd_position_encoding("UTF_32") == "UTF32"
+    with pytest.raises(ValueError, match="must be one of"):
+        normalize_clangd_position_encoding("bytes")
 
 
 @pytest.mark.parametrize(
@@ -444,6 +503,38 @@ def test_native_snapshot_receipt_matches_canonical_recipe(clangd_fixture) -> Non
     }
     assert payload["decode_profile_ns"]["hash_index"] > 0
     assert payload["decode_profile_ns"]["verify_snapshot"] > 0
+
+
+def test_position_encoding_is_explicit_and_snapshot_bound(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+
+    default = codenib_core.decode_clangd_fact_query_index(
+        idx_directory=str(idx_directory), project_root=str(root)
+    )
+    utf8 = codenib_core.decode_clangd_fact_query_index(
+        idx_directory=str(idx_directory),
+        project_root=str(root),
+        position_encoding="utf-8",
+    )
+
+    assert default["index"].position_encoding == "UTF16"
+    assert utf8["index"].position_encoding == "UTF8"
+    assert default["snapshot_id"] != utf8["snapshot_id"]
+    assert utf8["snapshot_id"] == _expected_snapshot_id(idx_directory, root, "UTF8")
+
+    monkeypatch.setenv("CODENIB_CLANGD_POSITION_ENCODING", "utf-32")
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    assert decoder.position_encoding == "UTF32"
+    assert decoder.decode_native_query_provider().position_encoding == "UTF32"
+    assert list(clangd_background_index_command("clangd", root))[-2] == (
+        "--offset-encoding=utf-32"
+    )
+
+    monkeypatch.setenv("CODENIB_CLANGD_POSITION_ENCODING", "bytes")
+    with pytest.raises(ValueError, match="must be UTF8, UTF16, or UTF32"):
+        ClangdGraphDecoder(str(idx_directory), str(root))
 
 
 def test_native_snapshot_is_order_independent_and_content_bound(
@@ -513,7 +604,7 @@ def test_symbol_results_errors_counts_and_relations_match_graph(
 
     assert index.record_count == graph.graph.vcount()
     assert index.edge_count == graph.graph.ecount()
-    assert index.symbol_count == len(_definition_symbols(graph)) == 7
+    assert index.symbol_count == len(_definition_symbols(graph)) == 8
     assert index.reference_count == expected_references == 5
 
     for seed in _seeds(graph):
@@ -871,7 +962,7 @@ def test_selector_does_not_mask_memory_exhaustion_or_unknown_mode(
         ClangdGraphDecoder(str(idx_directory), str(root)).decode_query_index()
 
 
-def test_hybrid_uses_native_symbols_then_materializes_graph_once(
+def test_hybrid_uses_native_symbols_and_positions_then_one_route_graph(
     clangd_fixture, monkeypatch
 ) -> None:
     root, idx_directory = clangd_fixture
@@ -906,8 +997,12 @@ def test_hybrid_uses_native_symbols_then_materializes_graph_once(
     assert position_result.provider_metadata_dict()["index_snapshot"] == (
         provider.snapshot_id
     )
-    assert decoder._graph_materialized is True
-    assert provider.graph_materialization_count == 1
+    assert position_result.provider_metadata_dict()["behavior_contract"] == (
+        "static_native_occurrence_lsp_v1"
+    )
+    assert position_result.provider_metadata_dict()["position_encoding"] == "UTF16"
+    assert decoder._graph_materialized is False
+    assert provider.graph_materialization_count == 0
 
     route_arguments = {
         "symbols": [target],
@@ -919,6 +1014,94 @@ def test_hybrid_uses_native_symbols_then_materializes_graph_once(
         node.model_dump() for node in legacy.route(**route_arguments)
     ]
     assert provider.graph_materialization_count == 1
+
+
+def test_native_position_queries_match_legacy_without_materializing_graph(
+    clangd_fixture,
+) -> None:
+    root, idx_directory = clangd_fixture
+    graph = ClangdGraphDecoder(str(idx_directory), str(root)).materialize_code_graph()
+    legacy = StaticLSPProvider(graph)
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    native = decoder.decode_native_query_provider()
+    assert decoder.query_index.occurrence_count == 0
+    assert native.position_initialization_count == 0
+
+    queries = [
+        ("definition", {"file_path": "src/main.cpp", "line": 1, "character": 22}),
+        (
+            "references",
+            {
+                "file_path": "src/main.cpp",
+                "line": 4,
+                "character": 4,
+                "include_declaration": True,
+            },
+        ),
+        (
+            "references",
+            {
+                "file_path": "src/main.cpp",
+                "line": 4,
+                "character": 4,
+                "include_declaration": False,
+            },
+        ),
+        ("definition", {"file_path": "src/main.cpp", "line": 0, "character": 4}),
+    ]
+    for capability, arguments in queries:
+        expected = getattr(legacy, capability)(**arguments, top_k=100)
+        observed = getattr(native, capability)(**arguments, top_k=100)
+        assert [node.model_dump() for node in observed] == [
+            node.model_dump() for node in expected
+        ]
+        metadata = observed.provider_metadata_dict()
+        assert metadata["backend"] == "native-clangd-fact-query-v1", (
+            capability,
+            arguments,
+            native.last_position_fallback_reason,
+        )
+        assert metadata["behavior_contract"] == "static_native_occurrence_lsp_v1"
+        assert metadata["position_granularity"] == "character"
+        assert metadata["position_encoding"] == "UTF16"
+        assert decoder._graph_materialized is False
+
+    index = decoder.position_query_index
+    assert index is not None
+    assert index.has_occurrence_at("src/main.cpp", 1, 22) is True
+    assert index.has_occurrence_at("src/main.cpp", 1, 27) is True
+    assert index.has_occurrence_at("src/main.cpp", 1, 28) is False
+    declaration = index.position_definitions("src/main.cpp", 2, 4)
+    assert declaration["served"] is False
+    assert declaration["fallback_reason"] == (
+        "native_position_declaration_requires_legacy_graph"
+    )
+    assert native.position_initialization_count == 1
+    assert native.graph_materialization_count == 0
+
+
+def test_native_position_missing_source_falls_back_deterministically(
+    clangd_fixture,
+) -> None:
+    root, idx_directory = clangd_fixture
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    provider = decoder.decode_native_query_provider()
+    position_index = decoder.decode_native_position_query_index()
+    (root / "src" / "main.cpp").unlink()
+
+    decision = position_index.position_definitions("src/main.cpp", 1, 22)
+    assert decision == {
+        "served": False,
+        "fallback_reason": "native_position_source_unavailable",
+        "locations": [],
+        "targets": [],
+    }
+    with pytest.raises(ValueError, match="no indexed definition token"):
+        provider.definition(file_path="src/main.cpp", line=1, character=22, top_k=10)
+    assert provider.last_position_fallback_reason == (
+        "native_position_source_unavailable"
+    )
+    assert decoder._graph_materialized is True
 
 
 def test_concurrent_first_graph_fallback_materializes_exactly_once(
@@ -975,6 +1158,63 @@ def test_concurrent_first_graph_fallback_materializes_exactly_once(
     assert results[0][1]["fallback_reason"] == (
         "native_clangd_route_query_requires_complete_graph"
     )
+    position_after_route = provider.definition(
+        file_path="src/main.cpp", line=1, character=22, top_k=100
+    )
+    assert position_after_route.provider_metadata_dict()["backend"] == (
+        "lazy-clangd-code-graph-v1"
+    )
+    assert position_after_route.provider_metadata_dict()["fallback_reason"] == (
+        "native_position_legacy_graph_already_materialized"
+    )
+    assert provider.position_initialization_count == 0
+    assert provider.graph_materialization_count == 1
+
+
+def test_concurrent_first_position_initializes_exactly_once(
+    clangd_fixture, monkeypatch
+) -> None:
+    import threading
+    import time
+    from concurrent.futures import ThreadPoolExecutor
+
+    root, idx_directory = clangd_fixture
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    provider = decoder.decode_native_query_provider()
+    initialize = decoder.decode_native_position_query_index
+    calls = 0
+    calls_lock = threading.Lock()
+    start = threading.Barrier(8)
+
+    def counted_initialize():
+        nonlocal calls
+        time.sleep(0.02)
+        with calls_lock:
+            calls += 1
+        return initialize()
+
+    monkeypatch.setattr(
+        decoder, "decode_native_position_query_index", counted_initialize
+    )
+
+    def definition_once(_index: int):
+        start.wait()
+        result = provider.definition(
+            file_path="src/main.cpp", line=1, character=22, top_k=100
+        )
+        return (
+            [node.model_dump() for node in result],
+            result.provider_metadata_dict(),
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(definition_once, range(8)))
+
+    assert all(result == results[0] for result in results)
+    assert calls == 1
+    assert provider.position_initialization_count == 1
+    assert provider.graph_materialization_count == 0
+    assert decoder._graph_materialized is False
 
 
 def test_lazy_graph_fails_closed_when_snapshot_changes(
@@ -1060,7 +1300,7 @@ def test_ls_indexer_exposes_query_index_and_provider(
     assert provider.decoder._graph_materialized is False
 
 
-def test_real_mcp_boundary_uses_native_symbols_then_one_lazy_graph(
+def test_real_mcp_boundary_keeps_supported_native_positions_graph_free(
     clangd_fixture, monkeypatch
 ) -> None:
     root, idx_directory = clangd_fixture
@@ -1088,6 +1328,8 @@ def test_real_mcp_boundary_uses_native_symbols_then_one_lazy_graph(
 
     position_arguments = {
         "file_path": "src/main.cpp",
+        # MCP positions are one-based at this boundary; the provider receives
+        # the zero-based clangd occurrence on source line 1.
         "line": 2,
         "character": 22,
         "top_k": 10,
@@ -1099,12 +1341,10 @@ def test_real_mcp_boundary_uses_native_symbols_then_one_lazy_graph(
         {key: value for key, value in row.items() if key != "lsp_provider"}
         for row in position
     ] == expected_position
-    assert position[0]["lsp_provider"]["backend"] == ("lazy-clangd-code-graph-v1")
-    assert position[0]["lsp_provider"]["fallback_reason"] == (
-        "native_clangd_position_query_requires_complete_graph"
-    )
-    assert decoder._graph_materialized is True
-    assert provider.graph_materialization_count == 1
+    assert position[0]["lsp_provider"]["backend"] == ("native-clangd-fact-query-v1")
+    assert position[0]["lsp_provider"]["position_encoding"] == "UTF16"
+    assert decoder._graph_materialized is False
+    assert provider.graph_materialization_count == 0
 
     route_arguments = {
         "symbols": [target],
@@ -1169,6 +1409,7 @@ def test_process_isolated_workload_gate_reports_rss_parity_and_concurrency(
         warmups=0,
         query_workload_size=2,
         symbol_threshold=0.0,
+        position_threshold=0.0,
         graph_non_regression_budget=10.0,
         peak_rss_ratio_budget=10.0,
         repeat_rss_spread_budget=10.0,
@@ -1192,13 +1433,26 @@ def test_process_isolated_workload_gate_reports_rss_parity_and_concurrency(
         "native-clangd-fact-query-v1"
     ]
     native_counts = report["workloads"]["symbol_only"]["native"]["index_counts"][0]
-    assert native_counts["definition_count"] == 7
+    assert native_counts["definition_count"] == 8
+    assert native_counts["occurrence_count"] == 0
     assert native_counts["snapshot_file_count"] == 1
     native_stages = report["workloads"]["symbol_only"]["native"]["stages_seconds"]
     assert "native_decompressed_string_bytes" not in native_stages
     assert "native_materialized_string_bytes" not in native_stages
     assert "native_string_entry_count" not in native_stages
-    for workload in ("position_first", "route_first", "mixed"):
+    assert report["workloads"]["position_first"]["native"]["observed_backends"] == [
+        "native-clangd-fact-query-v1"
+    ]
+    position_counts = report["workloads"]["position_first"]["native"]["index_counts"][0]
+    assert position_counts["occurrence_count"] > 0
+    assert (
+        "lazy_native_position_index"
+        in report["workloads"]["position_first"]["native"]["stages_seconds"]
+    )
+    assert report["gates"]["lazy_graph_materialization"]["workloads"]["position_first"][
+        "observed_native_counts"
+    ] == [0]
+    for workload in ("route_first", "mixed"):
         assert report["workloads"][workload]["native"]["observed_backends"] == [
             "lazy-clangd-code-graph-v1",
             "native-clangd-fact-query-v1",
@@ -1213,7 +1467,10 @@ def test_process_isolated_workload_gate_reports_rss_parity_and_concurrency(
     assert report["concurrency"]["passed"] is True
     assert report["configuration"]["process_isolated_arms"] is True
     assert report["configuration"]["alternating_arm_order"] is True
-    assert report["configuration"]["position_query_workload_size"] == 2
+    assert 1 <= report["configuration"]["position_query_workload_size"] <= 2
+    assert report["configuration"]["position_encoding"] == "UTF16"
+    assert report["gates"]["position_first"]["graph_free"] is True
+    assert report["gates"]["position_first"]["passed"] is True
     assert report["repository_preparation"]["included_in_query_ready_gate"] is False
     assert report["content_receipt"]["before"] == report["content_receipt"]["after"]
     assert report["version_matrix"]["generated_fixture_versions"] == [18, 19, 20]


### PR DESCRIPTION
## Summary

Add the #553 native clangd occurrence view so exact definition/reference position requests remain graph-free while unsupported positions and routes retain deterministic lazy CodeGraph fallback.

Closes #553

## Changes

- Add provider-neutral zero-based half-open occurrence records and native interval/target postings.
- Bind clangd FactQuery v2 to explicit UTF-8, UTF-16, or UTF-32 coordinates and share the generation contract across full and incremental indexing.
- Keep symbol startup occurrence-free, initialize the native position view once on demand, and preserve exactly-once graph fallback.
- Extend MCP/provider metadata, parity tests, mixed-workload gates, core documentation, and the durable roadmap.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `make core-test`: 119 passed, 4 skipped, all native executables passed.
- Focused clangd/provider suite: 55 passed.
- Unit tier excluding two failures reproduced unchanged on origin/main: 3,963 passed, 8 skipped.
- Rebase policy/provider smoke: 36 passed.
- Pre-commit hooks: clang-format, black, isort, flake8, and namespace checks passed.
- Final fmt gate, three measured rounds after one warmup: symbol +93.9%, position +87.2%, route-first +6.7% regression, mixed +15.7% regression; parity, RSS, receipts, lazy counts, and concurrency passed.
- Draft Full CI 31490895719 on `d7f8fc22`: all seven jobs passed.
- Slow tier: 25 passed, 17 skipped; both maintained Vertex model parameters executed in `us-east5`.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
