### PR TITLE
fix(ci): restore slow Full CI environment

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Python version for conda"
     required: false
     default: "3.12"
+  project-extras:
+    description: "Comma-separated CodeNib extras installed with the editable package"
+    required: false
+    default: "test"
   install-rust:
     description: "Install Rust toolchain + rust-analyzer"
     required: false
@@ -96,16 +100,21 @@ runs:
       shell: bash -l {0}
       env:
         CODENIB_CI_PREINSTALL_CPU_TORCH: ${{ inputs.preinstall-cpu-torch }}
+        CODENIB_CI_PROJECT_EXTRAS: ${{ inputs.project-extras }}
         CODENIB_CI_TORCH_VERSION: ${{ inputs.torch-version }}
         CODENIB_CI_TORCH_INDEX_URL: ${{ inputs.torch-index-url }}
       run: |
         python -m pip install --upgrade pip
+        if [[ ! "$CODENIB_CI_PROJECT_EXTRAS" =~ ^[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*$ ]]; then
+          echo "::error::Invalid project-extras value: $CODENIB_CI_PROJECT_EXTRAS"
+          exit 2
+        fi
         if [[ "$CODENIB_CI_PREINSTALL_CPU_TORCH" == "true" ]]; then
           python -m pip install \
             --index-url "$CODENIB_CI_TORCH_INDEX_URL" \
             "torch==$CODENIB_CI_TORCH_VERSION"
         fi
-        pip install -e ".[test]"
+        pip install -e ".[${CODENIB_CI_PROJECT_EXTRAS}]"
 
     - name: Install Rust toolchain + rust-analyzer
       if: inputs.install-rust == 'true'

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -529,6 +529,7 @@ jobs:
       TMP: ${{ github.workspace }}/../.tmp
       TEMP: ${{ github.workspace }}/../.tmp
       VERTEXAI_PROJECT: ${{ vars.VERTEXAI_PROJECT }}
+      VERTEXAI_LOCATION: ${{ vars.VERTEXAI_LOCATION || 'us-east5' }}
     steps:
       - name: Prepare temp HOME
         run: |
@@ -565,6 +566,8 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-env
+        with:
+          project-extras: "test,vertex"
 
       - name: Setup GCP credentials
         env:

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -302,7 +302,9 @@ serial-chain failure blocks it. The job itself only runs when `preflight` set
 `run-slow=true` (see [Skip mechanisms](#skip-mechanisms)). This tier is
 intentionally not xdist-parallelized because embedding model loads can exhaust
 shared GPU memory when started by multiple workers. Sets up GCP credentials and
-`VERTEXAI_PROJECT`, then:
+`VERTEXAI_PROJECT`, selects `VERTEXAI_LOCATION` from the repository variable
+with `us-east5` as the maintained-model fallback, installs the `test,vertex`
+project extras, then:
 
 ```bash
 pytest -m "slow" --tb=short
@@ -318,6 +320,12 @@ use `make test-slow` explicitly for this tier. CI requires a non-empty, valid
 `GOOGLE_APPLICATION_CREDENTIALS_JSON` secret and exports its ADC path before
 running provider tests. Missing credentials fail the selected slow job, while
 an unconfigured local run skips provider-only cases before expensive fixtures.
+The generated agent embedding index is reused while its resolved model revision
+matches. A revision mismatch takes the builder's explicit `force_rebuild` path
+once, so a legacy self-hosted-runner cache cannot keep the slow tier red.
+Live agent routing remains intentionally non-deterministic: provider/index smoke
+tests validate any BM25 call that occurs without rejecting the always-on
+`read`/`grep`/`glob`/`bash` tools.
 
 The checked-in pull-request workflows route executable PR content only to
 ephemeral hosted runners. Drafts run hosted documentation, packaging, and
@@ -401,6 +409,10 @@ use the `./.github/actions/setup-env` composite action, which provisions:
 
 - **conda** env `codenib-test` (Python 3.12 by default) plus a separate
   `scip-env` from `codenib/scip_interface/scip-environment.yml`.
+- **Editable project extras** — `project-extras` defaults to `test`; jobs that
+  exercise an optional provider must opt in explicitly (`slow` uses
+  `test,vertex`). The action validates the comma-separated value before using
+  it in the pip requirement.
 - **CPU torch preinstall** — enabled by default through
   `preinstall-cpu-torch`, `torch-version`, and `torch-index-url`, so non-GPU
   jobs do not accidentally download CUDA wheels through transitive embedding

--- a/test/agent/test_agent_embedding_search.py
+++ b/test/agent/test_agent_embedding_search.py
@@ -49,47 +49,37 @@ class TestAgentEmbeddingSearch:
     def real_embedding_search(self, httpie_cli_repo):
         """Load embedding_search skill with real FAISS index over httpie/cli."""
         import codenib.agent.skills as pkg
-        from codenib.index.embedding import (
-            CodeVectorStore,
-            build_hierarchical_vector_store,
-        )
+        from codenib.index.embedding import build_hierarchical_vector_store
         from codenib.ops.retrieve import RetrieveContext
 
         repo_path = str(httpie_cli_repo)
-        l0 = Path(EMBEDDING_INDEX_PATH) / "l0"
-        l2 = Path(EMBEDDING_INDEX_PATH) / "l2"
-
-        if l0.exists() and l2.exists():
-            print(f"Loading existing index from {EMBEDDING_INDEX_PATH}")
-            vs = CodeVectorStore(
-                embedding_model="nomic-ai/CodeRankEmbed",
-                embedding_provider="huggingface",
-                dimension=768,
-                store_path=EMBEDDING_INDEX_PATH,
-                model_kwargs={"trust_remote_code": True},
-                encode_kwargs={
+        build_kwargs = {
+            "repo_path": repo_path,
+            "index_path": EMBEDDING_INDEX_PATH,
+            "languages": ["python"],
+            "embedding_model": "nomic-ai/CodeRankEmbed",
+            "embedding_provider": "huggingface",
+            "embedding_dimension": 768,
+            "embedding_kwargs": {
+                "model_kwargs": {"trust_remote_code": True},
+                "encode_kwargs": {
                     "batch_size": 8,
                     "normalize_embeddings": True,
                 },
+            },
+        }
+        try:
+            vs = build_hierarchical_vector_store(**build_kwargs)
+        except ValueError as exc:
+            if "Vector config embedding revision mismatch" not in str(exc):
+                raise
+            print(
+                "Cached embedding index has an incompatible model revision; "
+                f"rebuilding {EMBEDDING_INDEX_PATH}"
             )
-            vs.load(EMBEDDING_INDEX_PATH)
-        else:
-            print(f"Building new index at {EMBEDDING_INDEX_PATH}")
-            Path(EMBEDDING_INDEX_PATH).mkdir(parents=True, exist_ok=True)
             vs = build_hierarchical_vector_store(
-                repo_path=repo_path,
-                index_path=EMBEDDING_INDEX_PATH,
-                languages=["python"],
-                embedding_model="nomic-ai/CodeRankEmbed",
-                embedding_provider="huggingface",
-                embedding_dimension=768,
-                embedding_kwargs={
-                    "model_kwargs": {"trust_remote_code": True},
-                    "encode_kwargs": {
-                        "batch_size": 8,
-                        "normalize_embeddings": True,
-                    },
-                },
+                **build_kwargs,
+                force_rebuild=True,
             )
 
         ctx = RetrieveContext(vector_store=vs, default_level="l2")

--- a/test/agent/test_query_e2e.py
+++ b/test/agent/test_query_e2e.py
@@ -395,11 +395,10 @@ def test_query_with_real_vertex_model(
     # The agent actually ran a tool-call → observe → finalize loop.
     assert result.total_turns >= 1
     assert result.answer is not None
-    # The model may have skipped tool calls entirely (gemini can decide it
-    # already knows enough), so we don't *require* a tool call — but if it
-    # did make one, it must have succeeded against the real index.
-    for tc in result.tool_calls:
-        assert tc.skill_id == "bm25_search"
+    # The model may skip bm25 entirely or call an always-on default tool such
+    # as ``read`` first.  Only validate BM25 calls here: the test is a live
+    # provider/index smoke, not a deterministic routing assertion.
+    for tc in (tc for tc in result.tool_calls if tc.skill_id == "bm25_search"):
         assert tc.error is None, f"bm25_search execution failed: {tc.error}"
 
     # Token usage was tracked — sanity check that LiteLLMChat actually

--- a/test/test_ci_policy.py
+++ b/test/test_ci_policy.py
@@ -387,7 +387,14 @@ def test_default_make_target_excludes_external_and_billed_tiers() -> None:
 
 
 def test_slow_ci_requires_and_exports_explicit_vertex_credentials() -> None:
-    workflow = (ROOT / ".github/workflows/ci-full.yml").read_text(encoding="utf-8")
+    workflow_path = ROOT / ".github/workflows/ci-full.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    document = _workflow(str(workflow_path.relative_to(ROOT)))
+    setup_step = next(
+        step
+        for step in document["jobs"]["slow"]["steps"]
+        if step.get("name") == "Setup environment"
+    )
 
     assert "GOOGLE_APPLICATION_CREDENTIALS_JSON is required" in workflow
     assert 'python -m json.tool "$CREDENTIALS_PATH" >/dev/null' in workflow
@@ -395,6 +402,39 @@ def test_slow_ci_requires_and_exports_explicit_vertex_credentials() -> None:
         'echo "GOOGLE_APPLICATION_CREDENTIALS=$CREDENTIALS_PATH" >> "$GITHUB_ENV"'
         in workflow
     )
+    assert setup_step["with"]["project-extras"] == "test,vertex"
+    assert (
+        document["jobs"]["slow"]["env"]["VERTEXAI_LOCATION"]
+        == "${{ vars.VERTEXAI_LOCATION || 'us-east5' }}"
+    )
+
+
+def test_shared_ci_setup_validates_configurable_project_extras() -> None:
+    action = _workflow(".github/actions/setup-env/action.yml")
+    install_step = next(
+        step
+        for step in action["runs"]["steps"]
+        if step.get("name") == "Install dependencies"
+    )
+    install_run = str(install_step["run"])
+
+    assert action["inputs"]["project-extras"]["default"] == "test"
+    assert (
+        install_step["env"]["CODENIB_CI_PROJECT_EXTRAS"]
+        == "${{ inputs.project-extras }}"
+    )
+    assert "^[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*$" in install_run
+    assert 'pip install -e ".[${CODENIB_CI_PROJECT_EXTRAS}]"' in install_run
+
+
+def test_slow_embedding_cache_rebuild_is_narrowly_revision_scoped() -> None:
+    source = (ROOT / "test/agent/test_agent_embedding_search.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "except ValueError as exc:" in source
+    assert '"Vector config embedding revision mismatch" not in str(exc)' in source
+    assert "force_rebuild=True" in source
 
 
 def test_live_provider_tests_do_not_hide_runtime_failures() -> None:


### PR DESCRIPTION
## Summary

Restore the credentialed Full CI slow tier after reproducible main-branch failures from missing Vertex dependencies, stale embedding state, an implicit unsupported provider region, and an over-strict live-routing assertion.

Closes #577.

## Changes

- Add a validated `project-extras` input to the shared setup action, defaulting to `test`.
- Install `test,vertex` only in the Full CI slow job so `google.auth` and `vertexai` are present.
- Export a configurable Vertex location with `us-east5` as the maintained-model fallback.
- Rebuild the generated embedding test index only when its resolved model revision is incompatible, while reusing compatible caches.
- Validate BM25 calls in the live query smoke without rejecting exposed default tools such as `read`.
- Add CI contract coverage and document the slow-tier dependency, provider, and cache behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/test_ci_policy.py` — 21 passed
- embedding builder/artifact tests — 8 passed
- local unit tier excluding two independently reproduced main/environment failures — 3876 passed, 15 skipped
- pre-commit on all changed files — passed
- YAML parse, extras validation, and slow-test collection — passed
- Draft Full CI 31485881498 on `9f4c1da3` — all seven jobs passed
- slow tier — 25 passed, 17 skipped; both maintained models ran in `us-east5`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
