### PR TITLE
perf(cpp): add graph-free clangd route queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,8 @@ clangd-workload-gate: core-build
 	@test -n "$(CLANGD_WORKLOAD_GATE_PROJECT_ROOT)" || { echo "Set CLANGD_WORKLOAD_GATE_PROJECT_ROOT=/path/to/repository" >&2; exit 1; }
 	PYTHONPATH="build/core:$$PYTHONPATH" python -m pytest -q \
 		test/ls_index/test_clangd_fact_query.py::test_symbol_results_errors_counts_and_relations_match_graph \
-		test/ls_index/test_clangd_fact_query.py::test_native_position_queries_match_legacy_without_materializing_graph
+		test/ls_index/test_clangd_fact_query.py::test_native_position_queries_match_legacy_without_materializing_graph \
+		test/ls_index/test_clangd_fact_query.py::test_native_route_view_matches_legacy_order_adjacency_and_results
 	PYTHONPATH="build/core:$$PYTHONPATH" python scripts/profiling/profile_clangd_workload_gate.py \
 		--idx-directory "$(CLANGD_WORKLOAD_GATE_INDEX_DIR)" \
 		--project-root "$(CLANGD_WORKLOAD_GATE_PROJECT_ROOT)" \

--- a/codenib/agent/lsp_graph.py
+++ b/codenib/agent/lsp_graph.py
@@ -292,6 +292,7 @@ def _compact_node(
     *,
     score: float = 1.0,
     use_selection_line: bool = False,
+    use_route_span: bool = False,
 ):
     info = graph.get_node_info_by_name(name) or {}
     file_path = info.get("file")
@@ -303,6 +304,8 @@ def _compact_node(
         else info.get("start_line")
     )
     end_line = start_line if use_selection_line else info.get("end_line")
+    if use_route_span and not use_selection_line:
+        start_line, end_line = _route_span(graph, name, info=info)
     if is_symbol_node(info.get("type")) and node_is_reference_only(info):
         file_path = None
         start_line = None
@@ -649,12 +652,26 @@ def _node_text(graph: Any, name: str) -> str:
 
 def _span_len(graph: Any, name: str) -> int:
     info = graph.get_node_info_by_name(name) or {}
+    start_value, end_value = _route_span(graph, name, info=info)
     try:
-        start = int(info.get("start_line") or 0)
-        end = int(info.get("end_line") or start)
+        start = int(start_value or 0)
+        end = int(end_value if end_value is not None else start)
     except (TypeError, ValueError):
         return 0
     return max(0, end - start + 1)
+
+
+def _route_span(
+    graph: Any, name: str, *, info: Optional[dict[str, Any]] = None
+) -> tuple[Any, Any]:
+    resolver = getattr(graph, "get_route_span", None)
+    if callable(resolver):
+        span = resolver(name)
+        if not isinstance(span, (tuple, list)) or len(span) != 2:
+            raise ValueError("route span resolver must return a two-item range")
+        return span[0], span[1]
+    node = info if info is not None else graph.get_node_info_by_name(name) or {}
+    return node.get("start_line"), node.get("end_line")
 
 
 def _role(graph: Any, name: str, *, query_terms: set[str]) -> str:
@@ -722,9 +739,20 @@ def _query_seed_candidates(
     if not query_terms:
         return []
 
+    prepared_query = getattr(graph, "prepared_route_seed_candidates", None)
+    if callable(prepared_query):
+        candidates = prepared_query(query_terms=query_terms, limit=limit)
+        return [dict(candidate) for candidate in candidates[:limit]]
+
     candidates: list[dict[str, Any]] = []
     scanned = 0
-    for name in getattr(graph, "name_to_vertex", {}) or {}:
+    route_names = getattr(graph, "iter_route_names", None)
+    names = (
+        route_names(_QUERY_SEED_SCAN_BUDGET)
+        if callable(route_names)
+        else (getattr(graph, "name_to_vertex", {}) or {})
+    )
+    for name in names:
         if scanned >= _QUERY_SEED_SCAN_BUDGET:
             break
         if scanned and time.monotonic() >= deadline:
@@ -806,6 +834,7 @@ def _route_node(graph: Any, candidate: dict[str, Any]) -> QueriedNode:
         name,
         relation,
         score=float(candidate.get("score") or 0.0),
+        use_route_span=True,
     )
 
 

--- a/codenib/agent/lsp_provider.py
+++ b/codenib/agent/lsp_provider.py
@@ -321,6 +321,17 @@ class StaticLSPProvider:
                 position_granularity="character",
                 position_encoding=self.position_encoding,
             )
+        if (
+            normalized == CAPABILITY_ROUTE
+            and getattr(self.graph, "supports_graph_routes", True) is False
+        ):
+            return _metadata(
+                normalized,
+                status="unavailable",
+                snapshot_id=self.snapshot_id,
+                backend=self.backend,
+                fallback_reason="fact_index_does_not_support_routes",
+            )
         if self.graph is None:
             return _metadata(
                 normalized,

--- a/codenib/ls_index/clangd_decode.py
+++ b/codenib/ls_index/clangd_decode.py
@@ -87,15 +87,15 @@ _NATIVE_QUERY_OFF = frozenset({"0", "false", "no", "off", "disabled"})
 _NATIVE_QUERY_AUTO = frozenset({"", "1", "true", "yes", "on", "auto"})
 _NATIVE_QUERY_REQUIRED = frozenset({"required", "strict"})
 _NATIVE_QUERY_PROMOTED = True
-_NATIVE_QUERY_ABI_VERSION = 2
-_NATIVE_QUERY_FORMAT = "clangd-riff-fact-query-v2"
-_NATIVE_QUERY_NORMALIZATION_PROFILE = "clangd-native-normalization-v2"
+_NATIVE_QUERY_ABI_VERSION = 3
+_NATIVE_QUERY_FORMAT = "clangd-riff-fact-query-v3"
+_NATIVE_QUERY_NORMALIZATION_PROFILE = "clangd-native-normalization-v3"
 _NATIVE_QUERY_SNAPSHOT_SCHEMA = "clangd-fact-query-snapshot-v1"
 _NATIVE_QUERY_CAPABILITIES = {
     "definition_by_symbol": True,
     "references_by_symbol": True,
     "position_queries": True,
-    "route_queries": False,
+    "route_queries": True,
 }
 
 
@@ -163,7 +163,7 @@ def _validate_native_query_contract(contract: Mapping[str, Any]) -> None:
         raise RuntimeError("compiled clangd supported position encodings mismatch")
     if contract.get("capabilities") != _NATIVE_QUERY_CAPABILITIES:
         raise RuntimeError(
-            "compiled clangd FactQueryIndex capabilities do not match v2"
+            "compiled clangd FactQueryIndex capabilities do not match v3"
         )
 
 
@@ -439,12 +439,181 @@ def parse_idx_file(filepath: str) -> dict:
 # ===================================================================
 
 
-class ClangdHybridQueryProvider:
-    """Serve symbol/position queries natively and lazily fall back for routes.
+class _NativeClangdRouteView:
+    """CodeGraph-shaped view over compact native adjacency and lazy spans."""
 
-    Exact supported occurrence queries stay graph-free. Unsupported or
-    ambiguous positions and every route request materialize the established
-    Python CodeGraph exactly once, including concurrent first fallbacks.
+    fact_query_index = True
+
+    def __init__(self, decoder: "ClangdGraphDecoder", query_index: Any):
+        self.decoder = decoder
+        self.index = query_index
+        self.supports_graph_routes = bool(
+            getattr(query_index, "supports_route_adjacency", False)
+        )
+        self._span_cache: dict[str, tuple[int | None, int | None]] = {}
+        self._span_lock = threading.Lock()
+
+    def __getattr__(self, name: str):
+        return getattr(self.index, name)
+
+    def get_route_span(self, name: str) -> tuple[int | None, int | None]:
+        cached = self._span_cache.get(name)
+        if cached is not None:
+            return cached
+        info = self.index.get_node_info_by_name(name) or {}
+        start = info.get("selection_line")
+        if start is None:
+            start = info.get("start_line")
+        file_path = info.get("file")
+        if start is None or not file_path:
+            return (info.get("start_line"), info.get("end_line"))
+        with self._span_lock:
+            cached = self._span_cache.get(name)
+            if cached is None:
+                started = time.perf_counter()
+                cached = self.decoder._find_range(str(file_path), int(start))
+                self.decoder.query_profile["native_route_range_enrichment"] = (
+                    float(
+                        self.decoder.query_profile.get(
+                            "native_route_range_enrichment", 0.0
+                        )
+                    )
+                    + time.perf_counter()
+                    - started
+                )
+                self._span_cache[name] = cached
+        return cached
+
+    def prepare_query_route(self, query: str, top_k: int):
+        return _PreparedNativeClangdRouteView(self, query=query, top_k=top_k)
+
+
+class _PreparedNativeClangdRouteView:
+    """Per-call bounded cache for deterministic query-seeded routing."""
+
+    fact_query_index = True
+    supports_graph_routes = True
+
+    def __init__(self, base: _NativeClangdRouteView, *, query: str, top_k: int) -> None:
+        from ..agent.lsp_graph import (
+            _QUERY_SEED_CANDIDATE_BUDGET,
+            _QUERY_SEED_MATCH_BUDGET,
+            _QUERY_SEED_MIN_OVERLAP,
+            _QUERY_SEED_SCAN_BUDGET,
+            _ROUTE_SEED_NODE_TYPES,
+            _candidate_score,
+            _include_neighbor,
+            _query_terms,
+            _role,
+            _route_neighbors,
+            _terms,
+        )
+
+        self.base = base
+        self.index = base.index
+        self._node_by_name: dict[str, Optional[dict[str, Any]]] = {}
+        self._node_by_id: dict[int, Optional[dict[str, Any]]] = {}
+        self._successors: dict[str, list[int]] = {}
+        self._predecessors: dict[str, list[int]] = {}
+        query_terms = _query_terms(query)
+        self._query_terms = frozenset(query_terms)
+        candidates = []
+        rows = self.index.route_scan_records(_QUERY_SEED_SCAN_BUDGET)
+        for name, node_type, display in rows:
+            if node_type and node_type not in _ROUTE_SEED_NODE_TYPES:
+                continue
+            overlap = _terms(f"{display} {name}") & query_terms
+            if len(overlap) < _QUERY_SEED_MIN_OVERLAP:
+                continue
+            self.get_route_span(name)
+            role = _role(self, name, query_terms=query_terms)
+            candidate = {
+                "name": name,
+                "role": role,
+                "source": "query_seed",
+                "seed": ", ".join(sorted(overlap)[:4]),
+                "direct_rank": len(candidates),
+            }
+            candidate["score"] = _candidate_score(
+                self, candidate, query_terms=query_terms
+            ) + 6.0 * len(overlap)
+            candidates.append(candidate)
+            if len(candidates) >= _QUERY_SEED_MATCH_BUDGET:
+                break
+
+        candidates.sort(
+            key=lambda item: (
+                -float(item.get("score") or 0.0),
+                str(
+                    (self.get_node_info_by_name(item["name"]) or {}).get("unified_name")
+                    or item["name"]
+                ),
+            )
+        )
+        self._candidates = candidates[: max(1, int(top_k or 12))]
+
+        # Warm exactly the bounded neighborhood that lsp_route may inspect so
+        # its deadline covers scoring rather than repeated Python/C++ crossings.
+        expanded = 0
+        for candidate in self._candidates:
+            if expanded >= _QUERY_SEED_CANDIDATE_BUDGET:
+                break
+            expanded += 1
+            for neighbor, _direction in _route_neighbors(self, candidate["name"]):
+                if expanded >= _QUERY_SEED_CANDIDATE_BUDGET:
+                    break
+                neighbor_role = _role(self, neighbor, query_terms=query_terms)
+                if not _include_neighbor(
+                    self,
+                    neighbor,
+                    role=neighbor_role,
+                    query_terms=query_terms,
+                ):
+                    continue
+                expanded += 1
+
+    def __getattr__(self, name: str):
+        return getattr(self.base, name)
+
+    def get_node_info_by_name(self, name: str):
+        if name not in self._node_by_name:
+            info = self.index.get_node_info_by_name(name)
+            self._node_by_name[name] = dict(info) if info is not None else None
+        return self._node_by_name[name]
+
+    def get_node_info_by_id(self, vertex_id: int):
+        if vertex_id not in self._node_by_id:
+            info = self.index.get_node_info_by_id(vertex_id)
+            cached = dict(info) if info is not None else None
+            self._node_by_id[vertex_id] = cached
+            if cached is not None and cached.get("name"):
+                self._node_by_name.setdefault(str(cached["name"]), cached)
+        return self._node_by_id[vertex_id]
+
+    def get_successors(self, name: str):
+        if name not in self._successors:
+            self._successors[name] = list(self.index.get_successors(name))
+        return self._successors[name]
+
+    def get_predecessors(self, name: str):
+        if name not in self._predecessors:
+            self._predecessors[name] = list(self.index.get_predecessors(name))
+        return self._predecessors[name]
+
+    def get_route_span(self, name: str):
+        return self.base.get_route_span(name)
+
+    def prepared_route_seed_candidates(self, *, query_terms, limit: int):
+        if frozenset(query_terms) != self._query_terms:
+            raise ValueError("prepared native route query terms changed")
+        return self._candidates[:limit]
+
+
+class ClangdHybridQueryProvider:
+    """Serve supported symbol, position, and route queries graph-free.
+
+    Unsupported or ambiguous positions and failed/incomplete route adjacency
+    materialize the established Python CodeGraph exactly once.
     """
 
     def __init__(self, decoder: "ClangdGraphDecoder", query_index: Any):
@@ -457,6 +626,16 @@ class ClangdHybridQueryProvider:
             query_index,
             snapshot_id=decoder.query_snapshot_id,
             backend=self.provider_backend,
+        )
+        self._route_view = _NativeClangdRouteView(decoder, query_index)
+        self._route_provider = (
+            StaticLSPProvider(
+                self._route_view,
+                snapshot_id=decoder.query_snapshot_id,
+                backend="native-clangd-route-adjacency-v1",
+            )
+            if self._route_view.supports_graph_routes
+            else None
         )
         self.occurrence_index = None
         self.position_query_index = None
@@ -550,10 +729,13 @@ class ClangdHybridQueryProvider:
         if str(capability) in {"route", "codenib/lspRoute"}:
             from dataclasses import replace
 
+            if self._route_provider is not None:
+                return self._route_provider.can_serve(capability)
             return replace(
                 decision,
+                status="ok",
                 backend="lazy-clangd-code-graph-v1",
-                fallback_reason="native_clangd_route_query_requires_complete_graph",
+                fallback_reason=None,
             )
         if str(capability) in {
             "definition",
@@ -622,11 +804,52 @@ class ClangdHybridQueryProvider:
         )
 
     def route(self, **arguments):
-        return self._graph_fallback(
-            "route",
-            "native_clangd_route_query_requires_complete_graph",
-            arguments,
-        )
+        if self._route_provider is None:
+            return self._graph_fallback(
+                "route",
+                "native_clangd_route_adjacency_unavailable",
+                arguments,
+            )
+        self.decoder._verify_native_snapshot("before native route")
+        try:
+            route_provider = self._route_provider
+            if not (arguments.get("symbols") or []) and arguments.get("query"):
+                from ..agent.lsp_provider import StaticLSPProvider
+
+                prepare_started = time.perf_counter()
+                prepared = self._route_view.prepare_query_route(
+                    query=str(arguments["query"]),
+                    top_k=int(arguments.get("top_k") or 12),
+                )
+                self.decoder.query_profile["native_route_query_preparation"] = (
+                    float(
+                        self.decoder.query_profile.get(
+                            "native_route_query_preparation", 0.0
+                        )
+                    )
+                    + time.perf_counter()
+                    - prepare_started
+                )
+                route_provider = StaticLSPProvider(
+                    prepared,
+                    snapshot_id=self.snapshot_id,
+                    backend="native-clangd-route-adjacency-v1",
+                )
+            result = route_provider.route(**arguments)
+            self.last_fallback_reason = None
+            return result
+        except MemoryError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Native clangd route adjacency failed; falling back to CodeGraph: %s",
+                exc,
+            )
+            return self._graph_fallback(
+                "route",
+                "native_clangd_route_adjacency_failed",
+                arguments,
+            )
 
     def position_samples(self, limit: int = 100):
         """Return deterministic exact positions without materializing CodeGraph."""
@@ -871,7 +1094,7 @@ class ClangdGraphDecoder:
         decode = getattr(codenib_core, "decode_clangd_fact_query_index", None)
         contract_reader = getattr(codenib_core, "clangd_fact_query_contract", None)
         if not callable(decode) or not callable(contract_reader):
-            raise RuntimeError("compiled core does not expose clangd FactQueryIndex v2")
+            raise RuntimeError("compiled core does not expose clangd FactQueryIndex v3")
         _validate_native_query_contract(contract_reader())
 
         started = time.perf_counter()
@@ -898,12 +1121,16 @@ class ClangdGraphDecoder:
             raise RuntimeError(
                 "native clangd query index does not guarantee graph-free use"
             )
+        if getattr(index, "supports_route_adjacency", None) is not True:
+            raise RuntimeError(
+                "native clangd query index does not provide complete route adjacency"
+            )
         expected_capabilities = {
             **_NATIVE_QUERY_CAPABILITIES,
             "position_queries": include_occurrences,
         }
         if getattr(index, "capabilities", None) != expected_capabilities:
-            raise RuntimeError("native clangd query index capabilities do not match v2")
+            raise RuntimeError("native clangd query index capabilities do not match v3")
         if getattr(index, "requires_anchored_references", None) is not False:
             raise RuntimeError(
                 "native clangd query index cannot preserve relation references"

--- a/core/README.md
+++ b/core/README.md
@@ -18,7 +18,7 @@ core decoder continue to use the serial Python path.
 - `fact_batch_buffer.{h,cpp}` — versioned flat semantic and graph-compatibility
   tables for the native/Python boundary.
 - `clangd_fact_query.{h,cpp}` — deterministic clangd RIFF shard decoding into
-  provider-neutral records for graph-free symbol queries.
+  provider-neutral records for graph-free symbol, position, and route queries.
 - `content_digest.{h,cpp}` — dependency-free streaming SHA-256 for native
   content receipts.
 - `graph_layers.{h,cpp}` — shared normalized edge-layer classification.
@@ -124,18 +124,19 @@ make fact-query-profile \
   FACT_QUERY_PROFILE_OUTPUT=/tmp/fact-query-report.json
 ```
 
-## Native clangd Symbol And Position Queries
+## Native clangd Symbol, Position, And Route Queries
 
 For C and C++ projects with an existing project-local clangd index,
 `decode_clangd_fact_query_index(...)` reads the direct `*.idx` children in
 stable filename order, decodes them into `DecodedRecords`, and builds the same
 `FactQueryIndex` without constructing `CodeGraph`, igraph, or Python record
 dictionaries. The initial symbol-only index covers definition and reference
-lookup by symbol. Each decode also exposes a content-bound snapshot over the query contract,
-normalized project root, exact supported RIFF versions, sorted shard names,
-and the exact bytes consumed by the decoder. clangd relation rows may be
-unanchored, so this provider explicitly opts into that record policy while
-still rejecting partial or invalid anchors.
+lookup by symbol plus complete compact route adjacency and the legacy vertex
+traversal order. Each decode also exposes a content-bound snapshot over the
+query contract, normalized project root, exact supported RIFF versions, sorted
+shard names, and the exact bytes consumed by the decoder. clangd relation rows
+may be unanchored, so this provider explicitly opts into that record policy
+while still rejecting partial or invalid anchors.
 
 Use `LSIndexer.process_query_index()` for the capability-specific index or
 `process_query_provider()` for hybrid behavior. The provider keeps successful
@@ -146,11 +147,19 @@ provider-neutral zero-based, half-open file ranges, role bits, and optional
 target/container vertex ids in C++, then builds per-file interval postings and
 per-target postings without Python record dictionaries. Unsupported,
 ambiguous, declaration-only, unanchored, or missing-source positions fall back
-with a stable reason. A route request still lazily constructs the complete
-compatible graph once. Existing `process_index()`, graph persistence,
+with a stable reason.
+
+The hybrid provider adapts the compact adjacency to the established route
+contract as `native-clangd-route-adjacency-v1`. Direct-symbol routes traverse
+the native postings; query-only routes use a deterministic bounded scan and
+candidate cache. Source spans are enriched lazily only for nodes touched by the
+route. A successful route never constructs `CodeGraph` or igraph. Incomplete
+adjacency, unavailable support, or any native route error falls back to one
+complete compatible graph and recomputes the whole request; a partial native
+route is never returned. Existing `process_index()`, graph persistence,
 incremental processing, and quality gates are unchanged.
 
-The clangd query ABI is `clangd-riff-fact-query-v2`. Position offsets are
+The clangd query ABI is `clangd-riff-fact-query-v3`. Position offsets are
 explicit and receipt-bound: UTF-16 is the default, while UTF-8 and UTF-32 are
 accepted at the provider boundary. Full and incremental background indexing
 use the same normalized clangd offset flag, so their rows cannot silently mix
@@ -170,17 +179,17 @@ make clangd-fact-query-profile \
 ```
 
 The first receipt hash shares the decoder's existing byte buffers. A second
-canonical read before publication detects mutation during decode, and the
-hybrid provider verifies the same receipt before and after lazy graph record
-collection. A mismatch fails the provider session rather than combining index
-generations; restart it to adopt new shards. Both receipt stages are included
-in the existing 20% profiling gate.
+canonical read before publication detects mutation during decode. The hybrid
+provider verifies the receipt before every native route and before and after
+lazy graph record collection. A mismatch fails the provider session rather
+than combining index generations; restart it to adopt new shards. Both receipt
+stages are included in the profiling gate.
 
-The mixed-workload gate additionally requires at least 20% position-first
-acceleration with zero graph materializations. Route-first and mixed workloads
-retain the 20% non-regression budget and exactly-once graph publication rule.
-This result makes no claim about clangd index generation time; native route
-lookup remains a separate promotion gate.
+The mixed-workload gate requires at least 20% acceleration for symbol-only,
+position-first, and route-first sessions, exact public-result parity, and zero
+native graph materializations in every workload. Mixed sessions retain the 20%
+non-regression budget. Concurrent native routes must also remain deterministic
+and graph-free. This result makes no claim about clangd index generation time.
 
 ## Use Through Python
 

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -97,12 +97,13 @@ py::dict position_query_to_dict(
   return result;
 }
 
-py::dict fact_query_capabilities(bool position_queries = false) {
+py::dict fact_query_capabilities(bool position_queries = false,
+                                 bool route_queries = false) {
   py::dict result;
   result["definition_by_symbol"] = true;
   result["references_by_symbol"] = true;
   result["position_queries"] = position_queries;
-  result["route_queries"] = false;
+  result["route_queries"] = route_queries;
   return result;
 }
 
@@ -491,7 +492,7 @@ py::dict clangd_fact_query_contract() {
   result["resource_limits"] = std::move(resource_limits);
   result["stable_filename_order"] = true;
   result["preserves_unanchored_relations"] = true;
-  result["capabilities"] = fact_query_capabilities(true);
+  result["capabilities"] = fact_query_capabilities(true, true);
   return result;
 }
 
@@ -539,10 +540,17 @@ PYBIND11_MODULE(codenib_core, m) {
       .def_property_readonly(
           "materializes_graph",
           [](const codenib::core::FactQueryIndex &) { return false; })
+      .def_property_readonly(
+          "supports_graph_routes",
+          [](const codenib::core::FactQueryIndex &) { return false; })
+      .def_property_readonly(
+          "supports_route_adjacency",
+          &codenib::core::FactQueryIndex::supports_route_adjacency)
       .def_property_readonly("capabilities",
                              [](const codenib::core::FactQueryIndex &index) {
                                return fact_query_capabilities(
-                                   index.supports_position_queries());
+                                   index.supports_position_queries(),
+                                   index.supports_route_adjacency());
                              })
       .def_property_readonly("project_root",
                              [](const codenib::core::FactQueryIndex &index) {
@@ -588,6 +596,22 @@ PYBIND11_MODULE(codenib_core, m) {
       .def("resolve_symbol_candidates",
            &codenib::core::FactQueryIndex::resolve_symbol_candidates,
            py::arg("symbol"), py::arg("limit") = 8)
+      .def("get_successors", &codenib::core::FactQueryIndex::get_successors,
+           py::arg("name"))
+      .def("get_predecessors", &codenib::core::FactQueryIndex::get_predecessors,
+           py::arg("name"))
+      .def("iter_route_names", &codenib::core::FactQueryIndex::route_names,
+           py::arg("limit") = 10000)
+      .def(
+          "route_scan_records",
+          [](const codenib::core::FactQueryIndex &index, std::size_t limit) {
+            py::list result;
+            for (const auto &row : index.route_scan_records(limit))
+              result.append(
+                  py::make_tuple(row.name, row.type, row.display_name));
+            return result;
+          },
+          py::arg("limit") = 10000)
       .def(
           "iter_incoming_references",
           [](const codenib::core::FactQueryIndex &index,

--- a/core/clangd_fact_query.cpp
+++ b/core/clangd_fact_query.cpp
@@ -859,6 +859,7 @@ build_query_records(const CollectedRecords &collected,
   upsert_structural(ROOT_NODE, "root");
   std::unordered_set<std::string> observed_files;
   std::unordered_set<std::string> observed_directories;
+  std::unordered_set<std::string> created_structural{ROOT_NODE};
   std::vector<std::pair<std::string, std::string>> structural_edge_names;
   std::unordered_map<std::string, CodeGraph::VertexId> vertex_by_symbol;
   vertex_by_symbol.reserve(collected.symbols.size());
@@ -888,8 +889,13 @@ build_query_records(const CollectedRecords &collected,
           auto parent = directory.parent_path().generic_string();
           if (parent.empty() || parent == ".")
             parent = ROOT_NODE;
+          // Match CodeGraph._add_edge during _ensure_file_hierarchy: an
+          // inner directory inserted before its parent does not gain a
+          // retroactive edge once that parent is created later.
+          if (created_structural.find(parent) != created_structural.end())
+            structural_edge_names.emplace_back(parent, name);
           ensure_placeholder(parent);
-          structural_edge_names.emplace_back(parent, name);
+          created_structural.insert(name);
         }
         directory = directory.parent_path();
       }
@@ -897,8 +903,10 @@ build_query_records(const CollectedRecords &collected,
       auto parent = std::filesystem::path(file).parent_path().generic_string();
       if (parent.empty() || parent == ".")
         parent = ROOT_NODE;
+      if (created_structural.find(parent) != created_structural.end())
+        structural_edge_names.emplace_back(parent, file);
       ensure_placeholder(parent);
-      structural_edge_names.emplace_back(parent, file);
+      created_structural.insert(file);
     }
 
     CodeGraph::VertexData vertex;
@@ -955,6 +963,10 @@ build_query_records(const CollectedRecords &collected,
           static_cast<CodeGraph::VertexId>(index));
     }
   }
+  records->route_vertex_order.reserve(records->vertices.size());
+  for (std::size_t index = 0; index < records->vertices.size(); ++index)
+    records->route_vertex_order.push_back(
+        static_cast<CodeGraph::VertexId>(index));
 
   if (include_occurrences) {
     std::size_t occurrence_capacity = collected.symbols.size() * 2;
@@ -1137,6 +1149,7 @@ build_query_records(const CollectedRecords &collected,
         CodeGraph::EdgeData{object->second, subject->second,
                             EDGE_TYPE_REFERENCE, std::nullopt, std::nullopt});
   }
+  records->route_adjacency_complete = true;
   return records;
 }
 

--- a/core/clangd_fact_query.h
+++ b/core/clangd_fact_query.h
@@ -16,10 +16,10 @@
 
 namespace codenib::core {
 
-inline constexpr std::uint32_t CLANGD_FACT_QUERY_ABI_VERSION = 2;
-inline constexpr char CLANGD_FACT_QUERY_FORMAT[] = "clangd-riff-fact-query-v2";
+inline constexpr std::uint32_t CLANGD_FACT_QUERY_ABI_VERSION = 3;
+inline constexpr char CLANGD_FACT_QUERY_FORMAT[] = "clangd-riff-fact-query-v3";
 inline constexpr char CLANGD_FACT_QUERY_NORMALIZATION_PROFILE[] =
-    "clangd-native-normalization-v2";
+    "clangd-native-normalization-v3";
 inline constexpr char CLANGD_FACT_QUERY_SNAPSHOT_SCHEMA[] =
     "clangd-fact-query-snapshot-v1";
 inline constexpr char CLANGD_DEFAULT_POSITION_ENCODING[] = "UTF16";

--- a/core/decoded_records.h
+++ b/core/decoded_records.h
@@ -50,6 +50,13 @@ struct DecodedRecords {
   // ordering without changing vertex ids or reference adjacency semantics.
   // Empty means natural vertex order.
   std::vector<CodeGraph::VertexId> query_resolution_order;
+  // Canonical traversal order for graph-free route queries. This remains
+  // separate from query resolution because providers may group display-name
+  // aliases differently from the legacy graph's vertex insertion order.
+  std::vector<CodeGraph::VertexId> route_vertex_order;
+  // True only when ``edges`` contains every route-visible structural,
+  // reference, and relation edge and route_vertex_order covers each vertex.
+  bool route_adjacency_complete{false};
   std::string project_root;
   std::string position_encoding{"UTF8"};
 };

--- a/core/fact_query_index.cpp
+++ b/core/fact_query_index.cpp
@@ -190,6 +190,29 @@ FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
     }
   }
 
+  std::vector<std::size_t> route_rank;
+  if (records_->route_adjacency_complete) {
+    if (records_->route_vertex_order.size() != records_->vertices.size())
+      throw std::invalid_argument(
+          "FactQueryIndex complete route order must cover every vertex");
+    route_rank.assign(records_->vertices.size(),
+                      std::numeric_limits<std::size_t>::max());
+    for (std::size_t rank = 0; rank < records_->route_vertex_order.size();
+         ++rank) {
+      const auto id = records_->route_vertex_order[rank];
+      if (id < 0 || static_cast<std::size_t>(id) >= records_->vertices.size())
+        throw std::out_of_range(
+            "FactQueryIndex route vertex id is out of range");
+      auto &slot = route_rank[static_cast<std::size_t>(id)];
+      if (slot != std::numeric_limits<std::size_t>::max())
+        throw std::invalid_argument(
+            "FactQueryIndex route order contains a duplicate vertex");
+      slot = rank;
+    }
+    outgoing_neighbors_.resize(records_->vertices.size());
+    incoming_neighbors_.resize(records_->vertices.size());
+  }
+
   incoming_reference_indexes_.reserve(definition_by_name_.size());
   std::vector<std::vector<std::size_t>> reference_indexes_by_source(
       records_->vertices.size());
@@ -199,6 +222,12 @@ FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
         static_cast<std::size_t>(edge.source) >= records_->vertices.size() ||
         static_cast<std::size_t>(edge.target) >= records_->vertices.size()) {
       throw std::out_of_range("FactQueryIndex edge endpoint is out of range");
+    }
+    if (records_->route_adjacency_complete) {
+      outgoing_neighbors_[static_cast<std::size_t>(edge.source)].push_back(
+          edge.target);
+      incoming_neighbors_[static_cast<std::size_t>(edge.target)].push_back(
+          edge.source);
     }
     if (edge.type != EDGE_TYPE_REFERENCE)
       continue;
@@ -225,6 +254,20 @@ FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
       const auto target = records_->edges[*posting].target;
       incoming_reference_indexes_[target].push_back(*posting);
     }
+  }
+
+  if (records_->route_adjacency_complete) {
+    auto compact_neighbors = [&](auto &groups) {
+      for (auto &neighbors : groups) {
+        std::sort(neighbors.begin(), neighbors.end(),
+                  [&](CodeGraph::VertexId left, CodeGraph::VertexId right) {
+                    return route_rank[static_cast<std::size_t>(left)] <
+                           route_rank[static_cast<std::size_t>(right)];
+                  });
+      }
+    };
+    compact_neighbors(outgoing_neighbors_);
+    compact_neighbors(incoming_neighbors_);
   }
 
   occurrence_indexes_by_file_.reserve(records_->occurrences.size() / 8 + 1);
@@ -291,6 +334,52 @@ FactQueryIndex::get_node_info_by_id(CodeGraph::VertexId id) const {
   if (id < 0 || static_cast<std::size_t>(id) >= records_->vertices.size())
     return std::nullopt;
   return records_->vertices[static_cast<std::size_t>(id)];
+}
+
+std::vector<CodeGraph::VertexId>
+FactQueryIndex::get_successors(const std::string &name) const {
+  const auto found = record_by_name_.find(name);
+  if (found == record_by_name_.end() || !records_->route_adjacency_complete)
+    return {};
+  return outgoing_neighbors_[static_cast<std::size_t>(found->second)];
+}
+
+std::vector<CodeGraph::VertexId>
+FactQueryIndex::get_predecessors(const std::string &name) const {
+  const auto found = record_by_name_.find(name);
+  if (found == record_by_name_.end() || !records_->route_adjacency_complete)
+    return {};
+  return incoming_neighbors_[static_cast<std::size_t>(found->second)];
+}
+
+std::vector<std::string> FactQueryIndex::route_names(std::size_t limit) const {
+  std::vector<std::string> names;
+  if (!records_->route_adjacency_complete || limit == 0)
+    return names;
+  names.reserve(std::min(limit, records_->route_vertex_order.size()));
+  for (const auto id : records_->route_vertex_order) {
+    names.push_back(records_->vertices[static_cast<std::size_t>(id)].name);
+    if (names.size() >= limit)
+      break;
+  }
+  return names;
+}
+
+std::vector<FactQueryIndex::RouteScanRecord>
+FactQueryIndex::route_scan_records(std::size_t limit) const {
+  std::vector<RouteScanRecord> rows;
+  if (!records_->route_adjacency_complete || limit == 0)
+    return rows;
+  rows.reserve(std::min(limit, records_->route_vertex_order.size()));
+  for (const auto id : records_->route_vertex_order) {
+    const auto &vertex = records_->vertices[static_cast<std::size_t>(id)];
+    rows.push_back(RouteScanRecord{
+        vertex.name, vertex.type,
+        vertex.unified_name.has_value() ? *vertex.unified_name : vertex.name});
+    if (rows.size() >= limit)
+      break;
+  }
+  return rows;
 }
 
 std::string FactQueryIndex::trim_symbol(std::string value) {

--- a/core/fact_query_index.h
+++ b/core/fact_query_index.h
@@ -24,8 +24,8 @@ inline constexpr char FACT_QUERY_INDEX_FORMAT[] = "fact-query-index-v1";
 
 // Graph-free read index for definition/reference subsets of the LSP-shaped
 // API. The index owns one immutable DecodedRecords allocation and stores only
-// integer postings. The generic v1 contract remains symbol-only; providers may
-// opt into occurrence postings, while route queries remain outside this type.
+// integer postings. Providers opt into occurrence postings and complete route
+// adjacency independently; an absent capability must fail closed.
 class FactQueryIndex {
 public:
   struct Reference {
@@ -61,6 +61,12 @@ public:
     std::vector<CodeGraph::VertexId> targets;
   };
 
+  struct RouteScanRecord {
+    std::string name;
+    std::string type;
+    std::string display_name;
+  };
+
   explicit FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
                           bool require_anchored_references = true,
                           std::string snapshot_id = {});
@@ -75,6 +81,13 @@ public:
                             std::size_t limit = 8) const;
   std::vector<Reference>
   incoming_references(const std::string &target_name) const;
+  std::vector<CodeGraph::VertexId>
+  get_successors(const std::string &name) const;
+  std::vector<CodeGraph::VertexId>
+  get_predecessors(const std::string &name) const;
+  std::vector<std::string> route_names(std::size_t limit = 10000) const;
+  std::vector<RouteScanRecord>
+  route_scan_records(std::size_t limit = 10000) const;
   PositionQueryResult definitions_at(const std::string &file_path, int line,
                                      int character,
                                      std::size_t limit = 8) const;
@@ -96,6 +109,9 @@ public:
   }
   bool supports_position_queries() const {
     return !records_->occurrences.empty();
+  }
+  bool supports_route_adjacency() const {
+    return records_->route_adjacency_complete;
   }
   bool requires_anchored_references() const {
     return require_anchored_references_;
@@ -134,6 +150,8 @@ private:
   std::vector<std::string> alias_order_;
   std::unordered_map<CodeGraph::VertexId, std::vector<std::size_t>>
       incoming_reference_indexes_;
+  std::vector<std::vector<CodeGraph::VertexId>> outgoing_neighbors_;
+  std::vector<std::vector<CodeGraph::VertexId>> incoming_neighbors_;
   std::unordered_map<std::string, FileOccurrencePostings>
       occurrence_indexes_by_file_;
   std::unordered_map<CodeGraph::VertexId, std::vector<std::size_t>>

--- a/core/tests/fact_query_index_test.cpp
+++ b/core/tests/fact_query_index_test.cpp
@@ -304,6 +304,55 @@ void assert_invalid_occurrences_fail_closed() {
   }
 }
 
+void assert_compact_route_adjacency() {
+  auto records = make_records();
+  records->route_vertex_order = {4, 0, 1, 2, 3, 5, 6};
+  records->route_adjacency_complete = true;
+  FactQueryIndex index(records);
+
+  assert(index.supports_route_adjacency());
+  assert((index.route_names() ==
+          std::vector<std::string>{"external-target", "canonical-target",
+                                   "canonical-caller", "canonical-run-one",
+                                   "canonical-run-two", "canonical-shared-one",
+                                   "canonical-shared-two"}));
+  assert((index.get_successors("canonical-caller") ==
+          std::vector<CodeGraph::VertexId>{4, 0, 0, 0}));
+  assert((index.get_predecessors("canonical-target") ==
+          std::vector<CodeGraph::VertexId>{1, 1, 1}));
+  assert(index.get_successors("missing").empty());
+
+  const auto scan = index.route_scan_records(2);
+  assert(scan.size() == 2);
+  assert(scan[0].name == "external-target");
+  assert(scan[0].display_name == "dependency.py:external()");
+  assert(scan[1].name == "canonical-target");
+
+  auto unavailable_records = make_records();
+  FactQueryIndex unavailable(unavailable_records);
+  assert(!unavailable.supports_route_adjacency());
+  assert(unavailable.route_names().empty());
+  assert(unavailable.get_successors("canonical-caller").empty());
+
+  auto incomplete = make_records();
+  incomplete->route_adjacency_complete = true;
+  incomplete->route_vertex_order = {0, 1};
+  try {
+    (void)FactQueryIndex(incomplete);
+    assert(false);
+  } catch (const std::invalid_argument &) {
+  }
+
+  auto duplicate = make_records();
+  duplicate->route_adjacency_complete = true;
+  duplicate->route_vertex_order = {0, 1, 2, 3, 4, 5, 5};
+  try {
+    (void)FactQueryIndex(duplicate);
+    assert(false);
+  } catch (const std::invalid_argument &) {
+  }
+}
+
 } // namespace
 
 int main() {
@@ -311,6 +360,7 @@ int main() {
   assert_invalid_records_fail_closed();
   assert_exact_occurrence_ranges_and_fallbacks();
   assert_invalid_occurrences_fail_closed();
+  assert_compact_route_adjacency();
   std::cout << "fact_query_index_test: OK\n";
   return 0;
 }

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -148,15 +148,16 @@ make fact-query-profile \
 Pass `--external-index-seconds` through `FACT_QUERY_PROFILE_EXTRA_ARGS` when a
 separate cold-start analysis should include unchanged SCIP generation time.
 
-## Native clangd Symbol And Position Queries
+## Native clangd Symbol, Position, And Route Queries
 
 The C/C++ query-specific path starts from an existing project-local clangd
 `.idx` directory. `decode_clangd_fact_query_index(...)` reads direct shards in
 stable filename order and decodes RIFF string, symbol, reference, and relation
 rows directly into provider-neutral `DecodedRecords`. `FactQueryIndex` then
 builds integer postings without a `CodeGraph`, igraph, or intermediate Python
-record dictionaries. The clangd-specific v2 contract advertises symbol and
-exact-position definition/reference support; route capability remains false.
+record dictionaries. The clangd-specific v3 contract adds complete compact
+successor/predecessor postings and a separate legacy vertex traversal order to
+the existing symbol and exact-position definition/reference support.
 
 Call `LSIndexer.process_query_index()` to obtain the capability-specific index,
 or `process_query_provider()` for a hybrid provider. Successful symbol queries
@@ -166,16 +167,32 @@ and optional target/container vertex ids. `FactQueryIndex` owns its per-file
 interval and per-target postings, so successful character-exact position
 queries stay graph-free. Unsupported, ambiguous, declaration-only, unanchored,
 and missing-source cases carry deterministic fallback reasons into the one
-complete compatible graph. A route request also materializes that graph once.
-The normal `process_index()` path, persistence format, incremental checks,
-range indexes, and graph quality behavior are unchanged.
+complete compatible graph.
+
+The raw `FactQueryIndex` reports `supports_graph_routes=false`: compact
+adjacency alone cannot supply source spans. `process_query_provider()` wraps it
+in a clangd-specific route view that lazily enriches only touched nodes through
+the C++ chunker and advertises `native-clangd-route-adjacency-v1`. Direct-symbol
+routes traverse the native postings. Query-only routes preserve the existing
+deterministic ranking while bounding the native scan to 10,000 rows, matching
+at most 256 seeds, and warming at most 512 candidates. Repeated edges are
+preserved because they affect igraph predecessor/successor parity.
+
+The decoder rejects a route index unless its traversal order covers every
+vertex exactly once and adjacency is complete. The provider verifies the
+content receipt before each route. If adjacency is unavailable or route
+preparation/execution fails, `auto` materializes one complete compatible graph
+and recomputes the whole request with a stable fallback reason. It never
+publishes a partial native result; `MemoryError` and snapshot changes fail
+closed. The normal `process_index()` path, persistence format, incremental
+checks, range indexes, and graph quality behavior are unchanged.
 
 UTF-16 is the default clangd position encoding. UTF-8 and UTF-32 are accepted
 explicitly, normalized at the provider boundary, and included in the content
 receipt. Full and incremental background commands use the same encoding flag.
-The symbol-only startup index deliberately contains no occurrence rows; this
-keeps route-first startup at the previously promoted cost, while position
-workloads pay for the native view only on first use.
+The symbol-only startup index deliberately contains no occurrence rows;
+position workloads pay for the native view only on first use. Route adjacency
+is part of that startup index and needs no second RIFF decode.
 
 `CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX=auto` is promoted by default after the
 persisted-artifact query-ready gate passed on both the generated C++ fixture
@@ -192,8 +209,7 @@ make clangd-fact-query-profile \
 ```
 
 This result measures an already generated `.idx` directory through identical
-definition/reference work. It does not claim faster clangd generation. Native
-route lookup remains an independent follow-up gate.
+definition/reference/route work. It does not claim faster clangd generation.
 
 ### MCP and agent runtime selection
 
@@ -207,10 +223,11 @@ checkouts, and disabled or unavailable native support use
 MCP definition, reference, and route tools and all three agent LSP skills use
 the common provider resolver. Definition/reference symbol requests remain on
 the startup postings path; supported exact positions use the lazy native
-occurrence view without igraph. Position fallbacks and routes share one
-snapshot-compatible complete graph. MCP result rows and `get_manifest` runtime
-metadata identify the backend, capabilities, fallback, encoding, and snapshot.
-The profiling report checks raw and MCP parity together with provider routing.
+occurrence view; supported routes use compact native adjacency. None constructs
+igraph. Position and route fallbacks share one snapshot-compatible complete
+graph. MCP result rows and `get_manifest` runtime metadata identify the
+backend, capabilities, fallback, encoding, and snapshot. The profiling report
+checks raw and MCP parity together with provider routing.
 
 ### Mixed workload and resource gate
 
@@ -229,13 +246,12 @@ make clangd-workload-gate \
   CLANGD_WORKLOAD_GATE_SUBJECT_ID=fmt-11.2.0
 ```
 
-The default gate requires at least 20% acceleration for symbol-only and
-position-first workloads, no more than 20% regression for graph-requiring
-workloads, native peak RSS no higher than 1.25x legacy or 4 GiB, no more than
-10% repeated-process peak spread, exact parity, and exactly one successful
-graph materialization when concurrent first route calls race. Symbol-only and
-position-first runs must materialize zero graphs; route-first and mixed runs
-must materialize exactly one. Graph-free route promotion remains #552.
+The v3 gate requires at least 20% acceleration for symbol-only, position-first,
+and route-first workloads, no more than 20% regression for mixed workloads,
+native peak RSS no higher than 1.25x legacy or 4 GiB, no more than 10% repeated
+process peak spread, and exact result/error parity. Every native workload must
+materialize zero graphs. Concurrent first routes must remain deterministic,
+use the native route backend, and materialize zero graphs.
 
 The maintained subject manifest pins fmt 11.2.0, GoogleTest 1.17.0, and
 protobuf 31.1 by full commit, covering template-, macro-, header-heavy, and
@@ -243,6 +259,25 @@ multi-target projects. Supplying `CLANGD_WORKLOAD_GATE_SUBJECT_ID` requires the
 checkout to be clean and at that exact revision. The Make target first executes
 the generated RIFF 18/19/20 parity matrix. clangd generation can be recorded as
 separate preparation time, but is explicitly excluded from query-ready gates.
+
+The 2026-08-11 promotion run used the clean manifest-pinned fmt 11.2.0
+revision `40626af88bd7df9a5fb80be7b25ac85b122d6c21`, 492 shards / 4,820,850
+bytes, 20 deterministic symbol and position requests, one deterministic
+query-only route, three measured process-isolated rounds after one warmup, and
+the default 20% thresholds:
+
+| Workload | Legacy | Native | Improvement | Native graphs |
+| --- | ---: | ---: | ---: | ---: |
+| symbol-only | 2.9039s | 0.1950s | 93.3% | 0 |
+| position-first | 3.0069s | 0.4308s | 85.7% | 0 |
+| route-first | 2.7913s | 0.7221s | 74.1% | 0 |
+| mixed | 2.8408s | 0.9655s | 66.0% | 0 |
+
+Exact public parity, snapshot, RIFF-version, RSS, and source-revision gates all
+passed. Three eight-worker concurrent route rounds used only
+`native-clangd-route-adjacency-v1` and materialized zero graphs. The decision
+is therefore to promote native route adjacency under `auto`, while retaining
+the complete graph as the atomic compatibility fallback.
 
 ### Content-bound snapshot receipt
 
@@ -258,11 +293,11 @@ LSP provider metadata.
 After record construction, the decoder re-reads the current canonical stream
 before publishing. This second pass is required to detect file-list or byte
 mutation during decode; both `hash_index` and `verify_snapshot` are included in
-native startup timing and reported by `make clangd-fact-query-profile`. Before
-the hybrid provider lazily parses the complete graph, it verifies the same
-receipt before and after Python record collection. A mismatch fails that
-provider session permanently instead of mixing generations. Restart the
-provider to adopt a new index. If the native candidate fails before it is
+native startup timing and reported by `make clangd-fact-query-profile`. The
+hybrid provider also verifies the same receipt before every native route and
+before and after Python record collection for a compatibility graph. A mismatch
+fails that provider session permanently instead of mixing generations. Restart
+the provider to adopt a new index. If the native candidate fails before it is
 published, `auto` may fall back to one graph from the current generation while
 `required` propagates the failure.
 

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -917,7 +917,47 @@ first-route runs passed; every concurrent run built exactly one graph. The
 receipt remained
 `clangd_fact_query:sha256:a88c9933461a2573a2c928eeeac8b734fcd5245d29f9d41e61d60f9c3d0b6693`.
 This is a query-ready result over existing shards, not a clangd-generation
-claim. Native route remains the independent #552 gate.
+claim. At that v2 milestone, native route remained the independent #552 gate.
+
+Native clangd route-query promotion status
+([#552](https://github.com/sysevol-ai/CodeNib/issues/552)): the query contract is
+now `clangd-riff-fact-query-v3`. Native normalization emits complete structural
+containment, reference/relation adjacency, and the legacy vertex traversal
+order. `FactQueryIndex` validates that the order covers every vertex exactly
+once, builds compact incoming/outgoing postings, and preserves repeated
+neighbors for exact igraph multi-edge parity. The raw index reports graph-route
+support unavailable because it lacks source spans; the clangd hybrid adapter
+adds lazy touched-node range enrichment and truthfully advertises
+`native-clangd-route-adjacency-v1`.
+
+Direct-symbol and query-only routes preserve legacy ordering, scoring, `top_k`,
+and result snapshots without constructing `CodeGraph`. Query-only preparation
+retains the established 10,000-row scan, 256-match, and 512-candidate bounds.
+The provider verifies the content receipt before every route. Incomplete
+adjacency or a native preparation/execution failure recomputes the entire route
+on one complete graph with a stable reason; no partial route is returned, and a
+snapshot mismatch fails closed.
+
+The versioned `clangd_mixed_workload_gate_v3` promotion run on 2026-08-11 used
+the clean manifest-pinned fmt 11.2.0 revision
+`40626af88bd7df9a5fb80be7b25ac85b122d6c21`, 492 shards / 4,820,850 bytes,
+20 deterministic query entries, one query-only route, and three isolated rounds
+after one warmup:
+
+| Workload | Legacy | Native | Improvement | Native graphs | Result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| symbol-only | 2.9039s | 0.1950s | 93.3% | 0 | pass |
+| position-first | 3.0069s | 0.4308s | 85.7% | 0 | pass |
+| route-first | 2.7913s | 0.7221s | 74.1% | 0 | pass |
+| mixed | 2.8408s | 0.9655s | 66.0% | 0 | pass |
+
+Exact public result/error parity, pre/post snapshot receipts, pinned revision,
+RSS, RIFF 18/19/20, and source-cleanliness gates passed. Three eight-thread
+concurrent native route rounds were deterministic and materialized zero graphs.
+The route-first improvement exceeds the 20% promotion threshold, so `auto`
+promotes compact native route adjacency and retains the full graph only as its
+atomic compatibility fallback. This remains a query-ready result over existing
+shards and does not claim faster clangd index generation.
 
 Native core CI enforcement status
 ([#547](https://github.com/sysevol-ai/CodeNib/issues/547)): the trusted

--- a/scripts/profiling/profile_clangd_workload_gate.py
+++ b/scripts/profiling/profile_clangd_workload_gate.py
@@ -49,6 +49,7 @@ from scripts.profiling.profile_fact_query_index import (  # noqa: E402
 WORKLOADS = ("symbol_only", "position_first", "route_first", "mixed")
 DEFAULT_SYMBOL_THRESHOLD = 0.20
 DEFAULT_POSITION_THRESHOLD = 0.20
+DEFAULT_ROUTE_THRESHOLD = 0.20
 DEFAULT_GRAPH_NON_REGRESSION_BUDGET = 0.20
 DEFAULT_PEAK_RSS_RATIO_BUDGET = 1.25
 DEFAULT_REPEAT_RSS_SPREAD_BUDGET = 0.10
@@ -155,6 +156,7 @@ def _run_mcp_workload(
     symbols: Sequence[str],
     positions: Sequence[Mapping[str, Any]],
     route_symbols: Sequence[str],
+    route_queries: Sequence[str],
 ) -> dict[str, Any]:
     from codenib.mcp.tools.lsp import (
         lsp_definition_impl,
@@ -236,6 +238,17 @@ def _run_mcp_workload(
                 include_neighbors=True,
             ),
         )
+        for route_query in route_queries:
+            record(
+                "route_by_query",
+                lsp_route_impl(
+                    context,
+                    symbols=[],
+                    query=route_query,
+                    top_k=100,
+                    include_neighbors=True,
+                ),
+            )
 
     if workload == "symbol_only":
         symbol_calls(symbols)
@@ -398,6 +411,7 @@ def _worker(config: Mapping[str, Any]) -> dict[str, Any]:
             symbols=config["symbols"],
             positions=config["positions"],
             route_symbols=config["route_symbols"],
+            route_queries=config["route_queries"],
         )
     workload_wall = time.perf_counter() - workload_started
     wall_seconds = time.perf_counter() - wall_started
@@ -658,6 +672,7 @@ def _workload_inputs(
     *,
     query_workload_size: int,
 ) -> dict[str, Any]:
+    from codenib.agent.lsp_graph import _terms
     from codenib.agent.lsp_provider import StaticLSPProvider
     from codenib.ls_index.clangd_decode import ClangdGraphDecoder
     from codenib.mcp.tools.lsp import lsp_definition_impl, lsp_references_impl
@@ -734,12 +749,24 @@ def _workload_inputs(
     route_symbols = symbols[: min(4, len(symbols))]
     if not route_symbols:
         raise ValueError("benchmark index has no route seed")
+    route_queries: list[str] = []
+    for symbol in route_symbols:
+        info = graph.get_node_info_by_name(symbol) or {}
+        display = str(info.get("unified_name") or symbol)
+        semantic_name = display.rsplit(":", 1)[-1]
+        terms = sorted(_terms(semantic_name))
+        if len(terms) >= 2:
+            route_queries.append(" ".join(terms[:4]))
+            break
+    if not route_queries:
+        raise ValueError("benchmark index has no query-only route seed")
     return {
         "symbols": symbols,
         "positions": positions,
         "position_candidate_count": len(candidate_positions),
         "position_encoding": native_provider.position_encoding,
         "route_symbols": route_symbols,
+        "route_queries": route_queries,
         "definition_symbol_count": len(all_symbols),
         "graph_vertex_count": graph.graph.vcount(),
         "graph_edge_count": graph.graph.ecount(),
@@ -853,6 +880,7 @@ def profile_clangd_workload_gate(
     query_workload_size: int = DEFAULT_QUERY_WORKLOAD_SIZE,
     symbol_threshold: float = DEFAULT_SYMBOL_THRESHOLD,
     position_threshold: float = DEFAULT_POSITION_THRESHOLD,
+    route_threshold: float = DEFAULT_ROUTE_THRESHOLD,
     graph_non_regression_budget: float = DEFAULT_GRAPH_NON_REGRESSION_BUDGET,
     peak_rss_ratio_budget: float = DEFAULT_PEAK_RSS_RATIO_BUDGET,
     repeat_rss_spread_budget: float = DEFAULT_REPEAT_RSS_SPREAD_BUDGET,
@@ -873,6 +901,8 @@ def profile_clangd_workload_gate(
         raise ValueError("symbol_threshold must be between 0 (inclusive) and 1")
     if not 0 <= position_threshold < 1:
         raise ValueError("position_threshold must be between 0 (inclusive) and 1")
+    if not 0 <= route_threshold < 1:
+        raise ValueError("route_threshold must be between 0 (inclusive) and 1")
     if graph_non_regression_budget < 0:
         raise ValueError("graph_non_regression_budget must be non-negative")
     if peak_rss_ratio_budget < 1:
@@ -939,6 +969,7 @@ def profile_clangd_workload_gate(
         "symbols": inputs["symbols"],
         "positions": inputs["positions"],
         "route_symbols": inputs["route_symbols"],
+        "route_queries": inputs["route_queries"],
         "position_encoding": inputs["position_encoding"],
         "concurrency_workers": concurrency_workers,
     }
@@ -1018,6 +1049,7 @@ def profile_clangd_workload_gate(
     rss_gates: dict[str, Any] = {}
     symbol_gate: dict[str, Any] | None = None
     position_gate: dict[str, Any] | None = None
+    route_gate: dict[str, Any] | None = None
     max_native_peak_rss_bytes = int(max_native_peak_rss_mb * 1024 * 1024)
 
     for workload in WORKLOADS:
@@ -1066,6 +1098,25 @@ def profile_clangd_workload_gate(
                 and position_gate["graph_free"]
                 and improvement >= position_threshold
             )
+        elif workload == "route_first":
+            improvement = _improvement(legacy_wall, native_wall)
+            graph_free = all(
+                run.get("graph_materialization_count") == 0
+                and run.get("graph_materialized") is False
+                and set(run.get("observed_backends") or ())
+                == {
+                    "native-clangd-fact-query-v1",
+                    "native-clangd-route-adjacency-v1",
+                }
+                and not run.get("observed_fallbacks")
+                for run in native_runs
+            )
+            route_gate = {
+                "threshold": route_threshold,
+                "improvement_fraction": improvement,
+                "graph_free": graph_free,
+                "passed": parity and graph_free and improvement >= route_threshold,
+            }
         else:
             regression = _regression(legacy_wall, native_wall)
             graph_gates[workload] = {
@@ -1074,12 +1125,11 @@ def profile_clangd_workload_gate(
                 "passed": parity and regression <= graph_non_regression_budget,
             }
 
-        graph_free_workload = workload in {"symbol_only", "position_first"}
-        expected_materializations = 0 if graph_free_workload else 1
+        expected_materializations = 0
         materialization_passed = all(
             run.get("graph_materialization_count") == expected_materializations
-            and run.get("graph_materialized") is (not graph_free_workload)
-            and (graph_free_workload or run.get("range_indexes_built") is True)
+            and run.get("graph_materialized") is False
+            and run.get("range_indexes_built") is False
             for run in native_runs
         )
         materialization_gates[workload] = {
@@ -1137,18 +1187,20 @@ def profile_clangd_workload_gate(
         raise RuntimeError("symbol-only gate was not evaluated")
     if position_gate is None:
         raise RuntimeError("position-first gate was not evaluated")
+    if route_gate is None:
+        raise RuntimeError("route-first gate was not evaluated")
     concurrency_thread_digests = {
         str(digest)
         for run in concurrency_runs
         for digest in run.get("thread_result_digests", [])
     }
     concurrency_passed = len(concurrency_thread_digests) == 1 and all(
-        run.get("graph_materialization_count") == 1
-        and run.get("graph_materialized") is True
-        and run.get("range_indexes_built") is True
+        run.get("graph_materialization_count") == 0
+        and run.get("graph_materialized") is False
+        and run.get("range_indexes_built") is False
         and run.get("thread_results_identical") is True
         and run.get("public_errors") == 0
-        and run.get("observed_backends") == ["lazy-clangd-code-graph-v1"]
+        and run.get("observed_backends") == ["native-clangd-route-adjacency-v1"]
         for run in concurrency_runs
     )
     concurrency = {
@@ -1176,6 +1228,7 @@ def profile_clangd_workload_gate(
         parity_passed
         and symbol_gate["passed"]
         and position_gate["passed"]
+        and route_gate["passed"]
         and graph_passed
         and materialization_passed
         and rss_passed
@@ -1186,7 +1239,7 @@ def profile_clangd_workload_gate(
 
     return {
         "schema_version": 1,
-        "benchmark": "clangd_mixed_workload_gate_v1",
+        "benchmark": "clangd_mixed_workload_gate_v3",
         "timer": {
             "wall": "time.perf_counter",
             "cpu": "time.process_time; scheduler-sensitive",
@@ -1223,6 +1276,7 @@ def profile_clangd_workload_gate(
             "query_workload_size": len(inputs["symbols"]),
             "position_query_workload_size": len(inputs["positions"]),
             "position_candidate_count": inputs["position_candidate_count"],
+            "query_only_route_count": len(inputs["route_queries"]),
             "alternating_arm_order": True,
             "warmup_arm_order": warmup_arm_order,
             "measured_arm_order": measured_arm_order,
@@ -1234,6 +1288,7 @@ def profile_clangd_workload_gate(
             "worker_timeout_seconds": worker_timeout_seconds,
             "symbol_threshold": symbol_threshold,
             "position_threshold": position_threshold,
+            "route_threshold": route_threshold,
             "position_encoding": inputs["position_encoding"],
             "graph_non_regression_budget": graph_non_regression_budget,
             "peak_rss_ratio_budget": peak_rss_ratio_budget,
@@ -1262,6 +1317,7 @@ def profile_clangd_workload_gate(
             "parity": {"passed": parity_passed},
             "symbol_only": symbol_gate,
             "position_first": position_gate,
+            "route_first": route_gate,
             "graph_non_regression": {
                 "passed": graph_passed,
                 "workloads": graph_gates,
@@ -1271,8 +1327,8 @@ def profile_clangd_workload_gate(
                 "workloads": materialization_gates,
             },
             "peak_rss": {"passed": rss_passed, "workloads": rss_gates},
-            "concurrent_first_materialization": {
-                "expected_count": 1,
+            "concurrent_graph_free_route": {
+                "expected_count": 0,
                 "passed": concurrency_passed,
             },
             "version_matrix": {"passed": version_gate},
@@ -1304,6 +1360,9 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--position-threshold", type=float, default=DEFAULT_POSITION_THRESHOLD
+    )
+    parser.add_argument(
+        "--route-threshold", type=float, default=DEFAULT_ROUTE_THRESHOLD
     )
     parser.add_argument(
         "--graph-non-regression-budget",
@@ -1357,6 +1416,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         query_workload_size=args.query_workload_size,
         symbol_threshold=args.symbol_threshold,
         position_threshold=args.position_threshold,
+        route_threshold=args.route_threshold,
         graph_non_regression_budget=args.graph_non_regression_budget,
         peak_rss_ratio_budget=args.peak_rss_ratio_budget,
         repeat_rss_spread_budget=args.repeat_rss_spread_budget,

--- a/test/ls_index/test_clangd_fact_query.py
+++ b/test/ls_index/test_clangd_fact_query.py
@@ -28,7 +28,8 @@ import codenib_core  # noqa: E402
 
 from codenib.agent.lsp_graph import lsp_definition  # noqa: E402
 from codenib.agent.lsp_graph import lsp_references
-from codenib.agent.lsp_provider import StaticLSPProvider  # noqa: E402
+from codenib.agent.lsp_provider import CAPABILITY_DEFINITION  # noqa: E402
+from codenib.agent.lsp_provider import CAPABILITY_ROUTE, StaticLSPProvider
 from codenib.compiler.manifest import RepoManifest  # noqa: E402
 from codenib.graph.code_graph import CodeGraph  # noqa: E402
 from codenib.graph.incremental import patcher_cpp as patcher_cpp_module  # noqa: E402
@@ -178,9 +179,9 @@ def _expected_snapshot_id(
 
     field("CodeNib clangd fact query snapshot")
     field("clangd-fact-query-snapshot-v1")
-    field("clangd-riff-fact-query-v2")
-    uint64(2)
-    field("clangd-native-normalization-v2")
+    field("clangd-riff-fact-query-v3")
+    uint64(3)
+    field("clangd-native-normalization-v3")
     field(project_root.absolute().as_posix())
     field(position_encoding)
     uint64(3)
@@ -393,9 +394,9 @@ def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
     index = payload["index"]
 
     assert contract == {
-        "abi_version": 2,
-        "format": "clangd-riff-fact-query-v2",
-        "normalization_profile": "clangd-native-normalization-v2",
+        "abi_version": 3,
+        "format": "clangd-riff-fact-query-v3",
+        "normalization_profile": "clangd-native-normalization-v3",
         "snapshot_schema": "clangd-fact-query-snapshot-v1",
         "snapshot_digest": "sha256",
         "supported_versions": [18, 19, 20],
@@ -421,7 +422,7 @@ def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
             "definition_by_symbol": True,
             "references_by_symbol": True,
             "position_queries": True,
-            "route_queries": False,
+            "route_queries": True,
         },
     }
     assert payload["graph_materialized"] is False
@@ -430,6 +431,9 @@ def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
     assert index.materializes_graph is False
     assert index.requires_anchored_references is False
     assert index.capabilities["position_queries"] is True
+    assert index.capabilities["route_queries"] is True
+    assert index.supports_route_adjacency is True
+    assert index.supports_graph_routes is False
     assert index.position_encoding == "UTF16"
     assert index.occurrence_count > 0
     assert not hasattr(index, "graph")
@@ -962,7 +966,7 @@ def test_selector_does_not_mask_memory_exhaustion_or_unknown_mode(
         ClangdGraphDecoder(str(idx_directory), str(root)).decode_query_index()
 
 
-def test_hybrid_uses_native_symbols_and_positions_then_one_route_graph(
+def test_hybrid_serves_symbols_positions_and_routes_without_graph(
     clangd_fixture, monkeypatch
 ) -> None:
     root, idx_directory = clangd_fixture
@@ -1010,10 +1014,124 @@ def test_hybrid_uses_native_symbols_and_positions_then_one_route_graph(
         "top_k": 10,
         "include_neighbors": True,
     }
-    assert [node.model_dump() for node in provider.route(**route_arguments)] == [
+    route_result = provider.route(**route_arguments)
+    assert [node.model_dump() for node in route_result] == [
         node.model_dump() for node in legacy.route(**route_arguments)
     ]
+    assert route_result.provider_metadata_dict()["backend"] == (
+        "native-clangd-route-adjacency-v1"
+    )
+    assert provider.graph_materialization_count == 0
+    assert decoder._graph_materialized is False
+
+
+def test_static_provider_marks_raw_fact_routes_unavailable(clangd_fixture) -> None:
+    root, idx_directory = clangd_fixture
+    index = codenib_core.decode_clangd_fact_query_index(
+        idx_directory=str(idx_directory), project_root=str(root)
+    )["index"]
+
+    provider = StaticLSPProvider(index)
+
+    assert provider.can_serve(CAPABILITY_DEFINITION).status == "ok"
+    route = provider.can_serve(CAPABILITY_ROUTE)
+    assert route.status == "unavailable"
+    assert route.fallback_reason == "fact_index_does_not_support_routes"
+    assert index.supports_route_adjacency is True
+
+
+def test_native_route_view_matches_legacy_order_adjacency_and_results(
+    clangd_fixture,
+) -> None:
+    root, idx_directory = clangd_fixture
+    graph = ClangdGraphDecoder(str(idx_directory), str(root)).materialize_code_graph()
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    native = decoder.decode_native_query_provider()
+    index = decoder.query_index
+
+    assert index.iter_route_names(10_000) == list(graph.name_to_vertex)
+    for name in graph.name_to_vertex:
+        legacy_successors = [
+            graph.get_node_info_by_id(vertex_id)["name"]
+            for vertex_id in graph.get_successors(name)
+        ]
+        native_successors = [
+            index.get_node_info_by_id(vertex_id)["name"]
+            for vertex_id in index.get_successors(name)
+        ]
+        legacy_predecessors = [
+            graph.get_node_info_by_id(vertex_id)["name"]
+            for vertex_id in graph.get_predecessors(name)
+        ]
+        native_predecessors = [
+            index.get_node_info_by_id(vertex_id)["name"]
+            for vertex_id in index.get_predecessors(name)
+        ]
+        assert native_successors == legacy_successors
+        assert native_predecessors == legacy_predecessors
+
+    legacy = StaticLSPProvider(graph)
+    cases = (
+        {
+            "symbols": ["1112131415161718"],
+            "query": "target caller",
+            "top_k": 10,
+            "include_neighbors": True,
+        },
+        {
+            "symbols": [],
+            "query": "demo target",
+            "top_k": 10,
+            "include_neighbors": True,
+        },
+        {
+            "symbols": ["target"],
+            "query": None,
+            "top_k": 10,
+            "include_neighbors": False,
+        },
+    )
+    for arguments in cases:
+        expected = [node.model_dump() for node in legacy.route(**arguments)]
+        observed = [node.model_dump() for node in native.route(**arguments)]
+        assert observed == expected
+    assert native.graph_materialization_count == 0
+    assert decoder._graph_materialized is False
+
+
+def test_native_query_route_failure_falls_back_without_partial_results(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+    legacy_graph = ClangdGraphDecoder(
+        str(idx_directory), str(root)
+    ).materialize_code_graph()
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    provider = decoder.decode_native_query_provider()
+
+    def fail_preparation(*, query: str, top_k: int):
+        raise RuntimeError(f"injected route failure: {query}/{top_k}")
+
+    monkeypatch.setattr(provider._route_view, "prepare_query_route", fail_preparation)
+    arguments = {
+        "symbols": [],
+        "query": "demo target",
+        "top_k": 10,
+        "include_neighbors": True,
+    }
+
+    observed = provider.route(**arguments)
+    expected = StaticLSPProvider(legacy_graph).route(**arguments)
+
+    assert [node.model_dump() for node in observed] == [
+        node.model_dump() for node in expected
+    ]
+    assert observed.provider_metadata_dict()["backend"] == ("lazy-clangd-code-graph-v1")
+    assert observed.provider_metadata_dict()["fallback_reason"] == (
+        "native_clangd_route_adjacency_failed"
+    )
     assert provider.graph_materialization_count == 1
+    assert decoder._graph_materialized is True
 
 
 def test_native_position_queries_match_legacy_without_materializing_graph(
@@ -1104,33 +1222,27 @@ def test_native_position_missing_source_falls_back_deterministically(
     assert decoder._graph_materialized is True
 
 
-def test_concurrent_first_graph_fallback_materializes_exactly_once(
+def test_concurrent_first_native_routes_remain_graph_free(
     clangd_fixture, monkeypatch
 ) -> None:
     import threading
-    import time
     from concurrent.futures import ThreadPoolExecutor
 
     root, idx_directory = clangd_fixture
     decoder = ClangdGraphDecoder(str(idx_directory), str(root))
     provider = decoder.decode_native_query_provider()
-    materialize = decoder.materialize_code_graph
+    build_graph = decoder._build_graph
     calls = 0
     calls_lock = threading.Lock()
     start = threading.Barrier(8)
 
-    def counted_materialize():
+    def counted_build_graph():
         nonlocal calls
-        # Widen the publication race: without the provider lock all callers
-        # enter graph construction before the first provider is visible.
-        time.sleep(0.02)
         with calls_lock:
             calls += 1
-        graph = materialize()
-        assert decoder._range_indexes_built is True
-        return graph
+        return build_graph()
 
-    monkeypatch.setattr(decoder, "materialize_code_graph", counted_materialize)
+    monkeypatch.setattr(decoder, "_build_graph", counted_build_graph)
     target = bytes.fromhex("1112131415161718").hex()
 
     def route_once(_index: int):
@@ -1149,26 +1261,19 @@ def test_concurrent_first_graph_fallback_materializes_exactly_once(
     with ThreadPoolExecutor(max_workers=8) as executor:
         results = list(executor.map(route_once, range(8)))
 
-    assert calls == 1
-    assert provider.graph_materialization_count == 1
-    assert decoder._graph_materialized is True
-    assert decoder._range_indexes_built is True
+    assert calls == 0
+    assert provider.graph_materialization_count == 0
+    assert decoder._graph_materialized is False
     assert all(result == results[0] for result in results)
-    assert results[0][1]["backend"] == "lazy-clangd-code-graph-v1"
-    assert results[0][1]["fallback_reason"] == (
-        "native_clangd_route_query_requires_complete_graph"
-    )
+    assert results[0][1]["backend"] == "native-clangd-route-adjacency-v1"
     position_after_route = provider.definition(
         file_path="src/main.cpp", line=1, character=22, top_k=100
     )
     assert position_after_route.provider_metadata_dict()["backend"] == (
-        "lazy-clangd-code-graph-v1"
+        "native-clangd-fact-query-v1"
     )
-    assert position_after_route.provider_metadata_dict()["fallback_reason"] == (
-        "native_position_legacy_graph_already_materialized"
-    )
-    assert provider.position_initialization_count == 0
-    assert provider.graph_materialization_count == 1
+    assert provider.position_initialization_count == 1
+    assert provider.graph_materialization_count == 0
 
 
 def test_concurrent_first_position_initializes_exactly_once(
@@ -1228,9 +1333,7 @@ def test_lazy_graph_fails_closed_when_snapshot_changes(
 
     _set_meta_version(idx_directory, 18, 19)
 
-    with pytest.raises(
-        RuntimeError, match="snapshot changed before legacy record collection"
-    ):
+    with pytest.raises(RuntimeError, match="snapshot changed before native route"):
         provider.route(symbols=["1112131415161718"], top_k=10)
     assert decoder._graph_materialized is False
     assert provider.snapshot_id == original_snapshot
@@ -1242,6 +1345,7 @@ def test_lazy_graph_detects_mutation_during_record_collection(
     root, idx_directory = clangd_fixture
     decoder = ClangdGraphDecoder(str(idx_directory), str(root))
     provider = decoder.decode_query_provider()
+    provider._route_provider = None
     collect = decoder._collect_all_idx
 
     def collect_then_mutate() -> None:
@@ -1300,7 +1404,7 @@ def test_ls_indexer_exposes_query_index_and_provider(
     assert provider.decoder._graph_materialized is False
 
 
-def test_real_mcp_boundary_keeps_supported_native_positions_graph_free(
+def test_real_mcp_boundary_keeps_supported_native_queries_graph_free(
     clangd_fixture, monkeypatch
 ) -> None:
     root, idx_directory = clangd_fixture
@@ -1358,11 +1462,9 @@ def test_real_mcp_boundary_keeps_supported_native_positions_graph_free(
         {key: value for key, value in row.items() if key != "lsp_provider"}
         for row in route
     ] == expected_route
-    assert route[0]["lsp_provider"]["backend"] == ("lazy-clangd-code-graph-v1")
-    assert route[0]["lsp_provider"]["fallback_reason"] == (
-        "native_clangd_route_query_requires_complete_graph"
-    )
-    assert provider.graph_materialization_count == 1
+    assert route[0]["lsp_provider"]["backend"] == ("native-clangd-route-adjacency-v1")
+    assert provider.graph_materialization_count == 0
+    assert decoder._graph_materialized is False
 
 
 def test_server_context_selects_native_and_portable_graph_fallback(
@@ -1410,6 +1512,7 @@ def test_process_isolated_workload_gate_reports_rss_parity_and_concurrency(
         query_workload_size=2,
         symbol_threshold=0.0,
         position_threshold=0.0,
+        route_threshold=0.0,
         graph_non_regression_budget=10.0,
         peak_rss_ratio_budget=10.0,
         repeat_rss_spread_budget=10.0,
@@ -1419,7 +1522,7 @@ def test_process_isolated_workload_gate_reports_rss_parity_and_concurrency(
     )
 
     assert report["schema_version"] == 1
-    assert report["benchmark"] == "clangd_mixed_workload_gate_v1"
+    assert report["benchmark"] == "clangd_mixed_workload_gate_v3"
     assert set(report["workloads"]) == {
         "symbol_only",
         "position_first",
@@ -1454,16 +1557,16 @@ def test_process_isolated_workload_gate_reports_rss_parity_and_concurrency(
     ] == [0]
     for workload in ("route_first", "mixed"):
         assert report["workloads"][workload]["native"]["observed_backends"] == [
-            "lazy-clangd-code-graph-v1",
             "native-clangd-fact-query-v1",
+            "native-clangd-route-adjacency-v1",
         ]
         assert report["gates"]["lazy_graph_materialization"]["workloads"][workload][
             "observed_native_counts"
-        ] == [1]
+        ] == [0]
     assert report["gates"]["lazy_graph_materialization"]["workloads"]["symbol_only"][
         "observed_native_counts"
     ] == [0]
-    assert report["concurrency"]["graph_materialization_counts"] == [1]
+    assert report["concurrency"]["graph_materialization_counts"] == [0]
     assert report["concurrency"]["passed"] is True
     assert report["configuration"]["process_isolated_arms"] is True
     assert report["configuration"]["alternating_arm_order"] is True
@@ -1471,6 +1574,8 @@ def test_process_isolated_workload_gate_reports_rss_parity_and_concurrency(
     assert report["configuration"]["position_encoding"] == "UTF16"
     assert report["gates"]["position_first"]["graph_free"] is True
     assert report["gates"]["position_first"]["passed"] is True
+    assert report["gates"]["route_first"]["graph_free"] is True
+    assert report["gates"]["route_first"]["passed"] is True
     assert report["repository_preparation"]["included_in_query_ready_gate"] is False
     assert report["content_receipt"]["before"] == report["content_receipt"]["after"]
     assert report["version_matrix"]["generated_fixture_versions"] == [18, 19, 20]


### PR DESCRIPTION
## Summary

Promote graph-free C/C++ route queries after exact parity and the 20% end-to-end gate passed. The native clangd FactQueryIndex now carries complete compact route adjacency and deterministic traversal order, while the hybrid provider preserves one atomic CodeGraph fallback for unsupported or failed native routes.

Closes #552

## Changes

- Bump the clangd query contract to v3 and build validated incoming/outgoing route postings without igraph.
- Adapt compact adjacency to the existing direct-symbol and query-only route contract with lazy touched-node span enrichment.
- Verify the snapshot before every native route and recompute the whole request on the complete graph after native failures; never expose partial route results.
- Report raw FactQueryIndex route capability as unavailable until the clangd span adapter is present.
- Extend the versioned mixed-workload gate with route acceleration, zero-materialization, query-only, concurrency, and backend-selection requirements.
- Add C++/Python/MCP parity, fallback, snapshot, and concurrency coverage and update the durable C++ roadmap.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- make core-test — 122 passed, 4 skipped plus all five C++ test executables.
- Focused route/provider/MCP tier — 59 passed.
- Default unit tier with two clean-base-reproduced environment failures deselected — 3968 passed, 8 skipped.
- pre-commit run on the changed file set — passed.
- Manifest-pinned fmt 11.2.0 v3 workload gate — passed on 492 shards: route-first 2.7913s to 0.7221s (74.1%), mixed 2.8408s to 0.9655s (66.0%), exact parity and zero native graph materializations in every workload and all concurrent route runs.
- The two excluded default-tier nodes fail identically at the merged dependency SHA: one FAISS is_trained expectation and one filesystem mode/umask expectation.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
