### PR TITLE
feat(integrations): add RepoNavigator jump adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ and MCP tools instead of making every agent rediscover the codebase.
 
 ## News
 
+- **2026-08-08 — RepoNavigator Jump adapter.** The published single-tool
+  [RepoNavigator](https://arxiv.org/abs/2512.20957v6) contract now resolves
+  symbol definitions through a persisted SCIP occurrence or injected LSP
+  signal, with graph-only resolution disclosed as a degraded fallback.
+  [Support boundary](https://docs.codenib.ai/agent_integrations/#reponavigator)
 - **2026-08-05 — CodeNib 0.2.0.** Build a static Wiki and reusable context
   artifact once, then serve it through Pages or the official MCP package.
   Hybrid retrieval and managed SCIP/LSP providers ship in the same CLI.
@@ -212,7 +217,7 @@ capabilities, loaded views, fusion, graph, and reranking trace.
 | Retrieval | BM25, dense-vector, regex/trigram, Zoekt, fusion, and reranking paths; see the [validated model matrix](https://docs.codenib.ai/rag_ops/#validated-models) |
 | Structural context | SCIP/LSP-backed symbol graphs with source locations and typed edges |
 | MCP and LSP-shaped tools | Serve one manifest to coding agents without tying the runtime to one agent framework |
-| Agent compatibility | Reuse one manifest across revision-pinned [LocAgent](https://github.com/gersteinlab/LocAgent), [Agentless](https://github.com/OpenAutoCoder/Agentless), [CoSIL](https://github.com/ZhonghaoJiang/CoSIL), and [OrcaLoca](https://github.com/fishmingyu/OrcaLoca) contracts; see the [support matrix](https://docs.codenib.ai/agent_integrations/) |
+| Agent compatibility | Reuse one manifest across revision-pinned [LocAgent](https://github.com/gersteinlab/LocAgent), [Agentless](https://github.com/OpenAutoCoder/Agentless), [CoSIL](https://github.com/ZhonghaoJiang/CoSIL), and [OrcaLoca](https://github.com/fishmingyu/OrcaLoca) contracts, plus the published [RepoNavigator](https://arxiv.org/abs/2512.20957v6) `jump` contract over SCIP/LSP definition signals; see the [support matrix](https://docs.codenib.ai/agent_integrations/) |
 | Benchmark compatibility | Evaluate native exploration against pinned external datasets and scorers, including [SWE-Explore](https://github.com/Qiushao-E/SWE-Explore-Bench); see the [dataset and benchmark matrix](https://docs.codenib.ai/evaluation/) |
 | Local inspection | Audit the same context through Wiki pages, Ask answers, citations, and the Dependency Map |
 | Evaluation harness | Measure retrieval, navigation, incremental maintenance, and context policies on the same artifacts |

--- a/codenib/integrations/reponavigator.py
+++ b/codenib/integrations/reponavigator.py
@@ -1,0 +1,716 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""RepoNavigator's published ``jump`` tool over CodeNib repository views."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from threading import RLock
+from typing import Any, Callable, Mapping
+
+from ..agent.lsp_provider import JSON_RPC_LSP_PROVIDER, StaticLSPProvider
+from ._repository import (
+    IntegrationCapabilityError,
+    RepositoryAdapter,
+    RepositoryPathError,
+)
+
+REPONAVIGATOR_PAPER_REVISION = "arXiv:2512.20957v6"
+
+_RUNTIME_VIEWS = frozenset({"symbol_graph"})
+_TOOL_NAME = "jump"
+_TRUNCATION_MARKER = "\n...[truncated RepoNavigator definition]"
+_GRAPH_BEHAVIOR_CONTRACTS = frozenset(
+    {"static_graph_lsp_v1", "static_symbol_graph_position_lsp_v1"}
+)
+_SCIP_OCCURRENCE_BEHAVIOR_CONTRACT = "static_scip_occurrence_lsp_v1"
+_NATIVE_OCCURRENCE_BEHAVIOR_CONTRACT = "static_native_occurrence_lsp_v1"
+
+_REPONAVIGATOR_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
+    {
+        "type": "function",
+        "function": {
+            "name": _TOOL_NAME,
+            "description": (
+                "Jump to the definition of one symbol occurrence in a repository "
+                "file and return its definition source code."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_path": {
+                        "type": "string",
+                        "description": (
+                            "Repository-relative path where the symbol is referenced, "
+                            "not the path where it is defined."
+                        ),
+                    },
+                    "symbol": {
+                        "type": "string",
+                        "description": (
+                            "Exact referenced symbol text to resolve; for an attribute "
+                            "such as object.method, pass method."
+                        ),
+                    },
+                    "index": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0,
+                        "description": (
+                            "Zero-based occurrence index used when the symbol appears "
+                            "more than once in the file."
+                        ),
+                    },
+                },
+                "required": ["file_path", "symbol"],
+                "additionalProperties": False,
+            },
+        },
+    },
+)
+
+
+def get_reponavigator_tool_schemas() -> list[dict[str, Any]]:
+    """Return an independent schema for RepoNavigator's single published tool."""
+
+    return copy.deepcopy(list(_REPONAVIGATOR_TOOL_SCHEMAS))
+
+
+@dataclass(frozen=True, slots=True)
+class RepoNavigatorDefinitionSignal:
+    """Definition backend selected for the RepoNavigator application adapter."""
+
+    backend: str
+    provider: str
+    behavior_contract: str
+    position_granularity: str
+    position_encoding: str
+    semantic: bool
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "backend": self.backend,
+            "provider": self.provider,
+            "behavior_contract": self.behavior_contract,
+            "position_granularity": self.position_granularity,
+            "position_encoding": self.position_encoding,
+            "semantic": self.semantic,
+            "detail": self.detail,
+        }
+
+
+class RepoNavigatorRepositoryProvider:
+    """Serve the paper-specified ``jump`` contract from one CodeNib manifest.
+
+    The paper supplies ``file_path``, ``symbol``, and an optional occurrence
+    ``index`` instead of an LSP position.  This adapter resolves that occurrence
+    locally, delegates definition lookup to CodeNib's LSP-shaped provider, and
+    returns the containing definition source.  It does not implement the
+    RepoNavigator policy or reinforcement-learning pipeline.
+    """
+
+    def __init__(
+        self,
+        context: Any,
+        *,
+        lsp_provider: Any | None = None,
+        occurrence_index: Any | None = None,
+        allow_graph_fallback: bool = False,
+        max_source_lines: int = 400,
+        max_source_chars: int = 32_000,
+    ) -> None:
+        if not isinstance(allow_graph_fallback, bool):
+            raise TypeError("allow_graph_fallback must be a boolean")
+        if occurrence_index is not None and (
+            not callable(getattr(occurrence_index, "occurrence_at", None))
+            or not callable(getattr(occurrence_index, "definitions", None))
+        ):
+            raise IntegrationCapabilityError(
+                "RepoNavigator occurrence_index must expose occurrence_at and "
+                "definitions"
+            )
+        if (
+            isinstance(max_source_lines, bool)
+            or not isinstance(max_source_lines, int)
+            or max_source_lines < 1
+        ):
+            raise ValueError("max_source_lines must be positive")
+        if (
+            isinstance(max_source_chars, bool)
+            or not isinstance(max_source_chars, int)
+            or max_source_chars < len(_TRUNCATION_MARKER)
+        ):
+            raise ValueError(
+                "max_source_chars must be large enough for the truncation marker"
+            )
+        self.repository = RepositoryAdapter(context, require_graph=True)
+        context_provider = getattr(context, "lsp_provider", None)
+        if lsp_provider is not None:
+            self.lsp_provider = lsp_provider
+        elif occurrence_index is not None and (
+            context_provider is None or isinstance(context_provider, StaticLSPProvider)
+        ):
+            # ServerContext attaches a graph-only StaticLSPProvider while it
+            # loads the symbol view.  A persisted occurrence index discovered
+            # beside that view is strictly more precise, so rebind the static
+            # provider without discarding its snapshot/backend provenance.
+            self.lsp_provider = StaticLSPProvider(
+                self.repository.graph,
+                snapshot_id=getattr(context_provider, "snapshot_id", None),
+                occurrence_index=occurrence_index,
+                backend=getattr(context_provider, "backend", None),
+                fallback_reason=getattr(context_provider, "fallback_reason", None),
+            )
+        elif context_provider is not None:
+            self.lsp_provider = context_provider
+        else:
+            self.lsp_provider = StaticLSPProvider(
+                self.repository.graph,
+                occurrence_index=occurrence_index,
+            )
+        if not callable(getattr(self.lsp_provider, "definition", None)):
+            raise IntegrationCapabilityError(
+                "RepoNavigator requires a callable definition provider"
+            )
+        self._configured_definition_signal = _inspect_definition_signal(
+            self.lsp_provider
+        )
+        if not self._configured_definition_signal.semantic and not allow_graph_fallback:
+            raise IntegrationCapabilityError(
+                "RepoNavigator requires a semantic definition signal backed by "
+                "SCIP occurrences or a language server; only the symbol-graph "
+                "fallback is available. Pass allow_graph_fallback=True to opt "
+                "into degraded behavior."
+            )
+        if not self._configured_definition_signal.semantic and isinstance(
+            self.lsp_provider, StaticLSPProvider
+        ):
+            # An empty occurrence adapter cannot select a textual occurrence,
+            # and authoritative-empty native adapters also suppress the static
+            # provider's graph fallback.  Once degraded behavior is explicitly
+            # allowed, bind the graph-only provider that the signal advertises.
+            graph_provider = StaticLSPProvider(
+                self.repository.graph,
+                snapshot_id=getattr(self.lsp_provider, "snapshot_id", None),
+                backend=getattr(self.lsp_provider, "backend", None),
+                fallback_reason=getattr(self.lsp_provider, "fallback_reason", None),
+            )
+            # StaticLSPProvider normally discovers an occurrence index attached
+            # to the graph.  This branch is explicitly graph-only, including
+            # for in-memory graphs that still carry the rejected empty index.
+            graph_provider.occurrence_index = None
+            graph_provider.position_encoding = None
+            self.lsp_provider = graph_provider
+        self._signal_lock = RLock()
+        self._definition_signal = self._configured_definition_signal
+        self.allow_graph_fallback = bool(allow_graph_fallback)
+        self.max_source_lines = max_source_lines
+        self.max_source_chars = max_source_chars
+
+    @classmethod
+    def from_manifest(
+        cls,
+        manifest_path: str | Path,
+        **kwargs: Any,
+    ) -> "RepoNavigatorRepositoryProvider":
+        from ..mcp.context import ServerContext
+
+        context = ServerContext.load(manifest_path, views=_RUNTIME_VIEWS)
+        if (
+            kwargs.get("lsp_provider") is None
+            and "occurrence_index" not in kwargs
+            and (
+                getattr(context, "lsp_provider", None) is None
+                or isinstance(context.lsp_provider, StaticLSPProvider)
+            )
+        ):
+            occurrence_index = _load_manifest_occurrence_index(context)
+            if occurrence_index is not None:
+                kwargs["occurrence_index"] = occurrence_index
+        return cls(context, **kwargs)
+
+    @property
+    def context(self) -> Any:
+        return self.repository.context
+
+    @property
+    def definition_signal(self) -> RepoNavigatorDefinitionSignal:
+        with self._signal_lock:
+            return self._definition_signal
+
+    def signal_metadata(self) -> dict[str, Any]:
+        """Return JSON-safe evidence for the configured or latest provider call."""
+
+        return self.definition_signal.to_dict()
+
+    def _record_definition_signal(
+        self,
+        signal: RepoNavigatorDefinitionSignal,
+    ) -> None:
+        with self._signal_lock:
+            self._definition_signal = signal
+
+    def bindings(self) -> dict[str, Callable[..., str]]:
+        """Return the one callable exposed to a RepoNavigator-style runtime."""
+
+        return {_TOOL_NAME: self.jump}
+
+    def dispatch(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | str | None = None,
+    ) -> str:
+        """Dispatch one JSON or mapping tool call without evaluating source."""
+
+        if isinstance(arguments, str):
+            try:
+                decoded = json.loads(arguments)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    "RepoNavigator tool arguments must be valid JSON"
+                ) from exc
+            if not isinstance(decoded, Mapping):
+                raise ValueError(
+                    "RepoNavigator tool arguments must decode to an object"
+                )
+            parsed = dict(decoded)
+        else:
+            parsed = dict(arguments or {})
+
+        if str(name).lower() != _TOOL_NAME:
+            raise KeyError(
+                f"unknown RepoNavigator tool {name!r}; supported: {_TOOL_NAME}"
+            )
+        return self.jump(**parsed)
+
+    def jump(self, file_path: str, symbol: str, index: int = 0) -> str:
+        """Return one definition observation for a symbol occurrence."""
+
+        configured_signal = self._configured_definition_signal
+        if isinstance(file_path, str) and "\0" in file_path:
+            return _jump_error("file_path must not contain NUL characters")
+        raw_symbol = str(symbol or "").strip()
+        if not raw_symbol or "\n" in raw_symbol or "\r" in raw_symbol:
+            return _jump_error("symbol must be non-empty single-line text")
+        if isinstance(index, bool) or not isinstance(index, int) or index < 0:
+            return _jump_error("index must be a non-negative integer")
+
+        try:
+            normalized_path = self.repository.normalize_path(file_path)
+            source_lines = self.repository.source_lines(normalized_path)
+        except (OSError, RepositoryPathError, ValueError) as exc:
+            return _jump_error(str(exc))
+
+        occurrences = _encoded_symbol_occurrences(
+            source_lines,
+            raw_symbol,
+            encoding=configured_signal.position_encoding,
+        )
+        occurrence_index = getattr(self.lsp_provider, "occurrence_index", None)
+        occurrence_at = getattr(occurrence_index, "occurrence_at", None)
+        if callable(occurrence_at):
+            occurrences = [
+                (line, character)
+                for line, character in occurrences
+                if occurrence_at(normalized_path, line, character) is not None
+            ]
+        if not occurrences:
+            return _jump_error(
+                f"symbol {raw_symbol!r} has no resolvable occurrence in "
+                f"{normalized_path}"
+            )
+        if index >= len(occurrences):
+            return _jump_error(
+                f"symbol {raw_symbol!r} has {len(occurrences)} resolvable "
+                f"occurrence(s) in {normalized_path}; index {index} is out of range"
+            )
+
+        line, character = occurrences[index]
+        try:
+            raw_definitions = self.lsp_provider.definition(
+                file_path=normalized_path,
+                line=line,
+                character=character,
+                top_k=1,
+            )
+            call_signal = _definition_result_signal(
+                raw_definitions,
+                configured=configured_signal,
+            )
+            self._record_definition_signal(call_signal)
+            if not call_signal.semantic and not self.allow_graph_fallback:
+                return _jump_error(
+                    "definition resolution degraded to the symbol graph; pass "
+                    "allow_graph_fallback=True to permit this call"
+                )
+            definitions = _definition_nodes(raw_definitions)
+        except Exception as exc:  # noqa: BLE001 - external provider boundary
+            return _jump_error(str(exc) or "definition provider failed")
+        if not definitions:
+            return _jump_error(
+                f"definition provider returned no result for {raw_symbol!r} at "
+                f"{normalized_path}:{line + 1}"
+            )
+
+        try:
+            content, definition_path = self._definition_source(definitions[0])
+        except (OSError, RepositoryPathError, TypeError, ValueError) as exc:
+            return _jump_error(str(exc))
+        if not content:
+            return _jump_error(
+                f"definition source is empty for {raw_symbol!r} in {normalized_path}"
+            )
+        bounded = _bounded_source(
+            content,
+            max_lines=self.max_source_lines,
+            max_chars=self.max_source_chars,
+        )
+        return _jump_observation(raw_symbol, bounded, definition_path)
+
+    def _definition_source(self, node: Any) -> tuple[str, str]:
+        file_path = _node_value(node, "file") or _node_value(node, "file_path")
+        start_line = _node_value(node, "start_line")
+        if not file_path:
+            raise ValueError("definition result has no repository source path")
+        if isinstance(start_line, bool) or not isinstance(start_line, int):
+            raise ValueError("definition result has no valid source line")
+
+        normalized_path = self.repository.normalize_path(str(file_path))
+        entity = self.repository.containing_entity(normalized_path, start_line)
+        if entity is not None:
+            content, _, _ = self.repository.read_entity(entity)
+            return content, normalized_path
+        content, _, _ = self.repository.read_range(
+            normalized_path,
+            start_line=start_line,
+            end_line=start_line,
+        )
+        return content, normalized_path
+
+
+def _load_manifest_occurrence_index(context: Any) -> Any | None:
+    entry = getattr(context.manifest, "indexes", {}).get("symbol_graph")
+    if entry is None or not getattr(entry, "path", None):
+        return None
+
+    graph_path = Path(entry.path)
+    index_path = (
+        graph_path / "lsp_index.pkl"
+        if graph_path.is_dir()
+        else graph_path.with_name("lsp_index.pkl")
+    )
+    if not index_path.is_file():
+        return None
+    try:
+        from ..scip_interface.lsp_occurrence_index import SCIPOccurrenceIndex
+
+        return SCIPOccurrenceIndex.load(index_path)
+    except Exception as exc:  # noqa: BLE001 - persisted integration boundary
+        raise IntegrationCapabilityError(
+            f"failed to load RepoNavigator definition signal from {index_path}: {exc}"
+        ) from exc
+
+
+def _inspect_definition_signal(provider: Any) -> RepoNavigatorDefinitionSignal:
+    if isinstance(provider, StaticLSPProvider):
+        decision = provider.can_serve("definition")
+        if decision.status != "ok":
+            raise IntegrationCapabilityError(
+                "RepoNavigator definition provider is unavailable: "
+                f"{decision.fallback_reason or decision.status}"
+            )
+        occurrence_index = getattr(provider, "occurrence_index", None)
+        occurrence_signal_ready = _occurrence_signal_ready(occurrence_index)
+        if occurrence_signal_ready:
+            behavior_contract = str(
+                decision.behavior_contract or _SCIP_OCCURRENCE_BEHAVIOR_CONTRACT
+            )
+            is_native = behavior_contract == _NATIVE_OCCURRENCE_BEHAVIOR_CONTRACT
+            return RepoNavigatorDefinitionSignal(
+                backend="native_occurrence" if is_native else "scip_occurrence",
+                provider=decision.provider,
+                behavior_contract=behavior_contract,
+                position_granularity=decision.position_granularity,
+                position_encoding=_normalize_position_encoding(
+                    getattr(occurrence_index, "position_encoding", None),
+                    default="utf-16" if is_native else "utf-8",
+                ),
+                semantic=True,
+                detail=(
+                    "character-level definition resolution from the native "
+                    "occurrence index"
+                    if is_native
+                    else (
+                        "character-level definition resolution from the persisted "
+                        "SCIP occurrence index"
+                    )
+                ),
+            )
+        empty_kind = (
+            "native"
+            if str(decision.behavior_contract) == _NATIVE_OCCURRENCE_BEHAVIOR_CONTRACT
+            else "SCIP"
+        )
+        fallback_detail = (
+            f"{empty_kind} occurrence index is empty; using line/graph "
+            "definition approximation"
+            if occurrence_index is not None
+            else (
+                "line/graph definition approximation; no persisted SCIP "
+                "occurrence index or live language server"
+            )
+        )
+        return RepoNavigatorDefinitionSignal(
+            backend="symbol_graph_fallback",
+            provider=decision.provider,
+            behavior_contract="static_graph_lsp_v1",
+            position_granularity="line",
+            position_encoding="utf-32",
+            semantic=False,
+            detail=fallback_detail,
+        )
+
+    provider_name = str(
+        getattr(provider, "provider", None) or "external_definition_provider"
+    )
+    if provider_name == JSON_RPC_LSP_PROVIDER:
+        return RepoNavigatorDefinitionSignal(
+            backend="live_lsp",
+            provider=provider_name,
+            behavior_contract="json_rpc_lsp_v1",
+            position_granularity="character",
+            position_encoding=_normalize_position_encoding(
+                getattr(provider, "position_encoding", None),
+                default="utf-16",
+            ),
+            semantic=True,
+            detail="character-level definition resolution from a live language server",
+        )
+
+    return RepoNavigatorDefinitionSignal(
+        backend="external_definition_provider",
+        provider=provider_name,
+        behavior_contract=str(
+            getattr(provider, "behavior_contract", None)
+            or "caller_attested_definition_v1"
+        ),
+        position_granularity=str(
+            getattr(provider, "position_granularity", None) or "character"
+        ),
+        position_encoding=_normalize_position_encoding(
+            getattr(provider, "position_encoding", None),
+            default="utf-32",
+        ),
+        semantic=True,
+        detail="caller-injected definition provider; fidelity is caller-attested",
+    )
+
+
+def _occurrence_signal_ready(occurrence_index: Any | None) -> bool:
+    if occurrence_index is None:
+        return False
+    occurrence_count = getattr(occurrence_index, "occurrence_count", None)
+    if occurrence_count is not None:
+        if isinstance(occurrence_count, bool) or not isinstance(occurrence_count, int):
+            return False
+        return occurrence_count > 0
+    occurrence_rows = getattr(occurrence_index, "occurrences", None)
+    return occurrence_rows is None or bool(occurrence_rows)
+
+
+def _definition_result_signal(
+    result: Any,
+    *,
+    configured: RepoNavigatorDefinitionSignal,
+) -> RepoNavigatorDefinitionSignal:
+    metadata_method = getattr(result, "provider_metadata_dict", None)
+    metadata: Mapping[str, Any] | None = None
+    if callable(metadata_method):
+        candidate = metadata_method()
+        if isinstance(candidate, Mapping):
+            metadata = candidate
+    if metadata is None:
+        candidate = getattr(result, "lsp_provider_metadata", None)
+        to_dict = getattr(candidate, "to_dict", None)
+        if callable(to_dict):
+            candidate = to_dict()
+        if isinstance(candidate, Mapping):
+            metadata = candidate
+    if metadata is None:
+        return configured
+
+    behavior_contract = str(
+        metadata.get("behavior_contract") or configured.behavior_contract
+    )
+    provider = str(metadata.get("provider") or configured.provider)
+    position_granularity = str(
+        metadata.get("position_granularity") or configured.position_granularity
+    )
+    position_encoding = _normalize_position_encoding(
+        metadata.get("position_encoding"),
+        default=configured.position_encoding,
+    )
+    if behavior_contract in _GRAPH_BEHAVIOR_CONTRACTS:
+        fallback_reason = str(metadata.get("fallback_reason") or "").strip()
+        detail = "definition call used the symbol-graph fallback"
+        if fallback_reason:
+            detail += f" ({fallback_reason})"
+        return RepoNavigatorDefinitionSignal(
+            backend="symbol_graph_fallback",
+            provider=provider,
+            behavior_contract=behavior_contract,
+            position_granularity=position_granularity,
+            position_encoding=position_encoding,
+            semantic=False,
+            detail=detail,
+        )
+    if behavior_contract in {
+        _SCIP_OCCURRENCE_BEHAVIOR_CONTRACT,
+        _NATIVE_OCCURRENCE_BEHAVIOR_CONTRACT,
+    }:
+        is_native = behavior_contract == _NATIVE_OCCURRENCE_BEHAVIOR_CONTRACT
+        return RepoNavigatorDefinitionSignal(
+            backend="native_occurrence" if is_native else "scip_occurrence",
+            provider=provider,
+            behavior_contract=behavior_contract,
+            position_granularity=position_granularity,
+            position_encoding=position_encoding,
+            semantic=True,
+            detail=(
+                "character-level definition resolution from the native occurrence "
+                "index"
+                if is_native
+                else (
+                    "character-level definition resolution from the persisted SCIP "
+                    "occurrence index"
+                )
+            ),
+        )
+    return RepoNavigatorDefinitionSignal(
+        backend=configured.backend,
+        provider=provider,
+        behavior_contract=behavior_contract,
+        position_granularity=position_granularity,
+        position_encoding=position_encoding,
+        semantic=configured.semantic,
+        detail=configured.detail,
+    )
+
+
+def _normalize_position_encoding(value: Any, *, default: str) -> str:
+    compact = re.sub(r"[^A-Z0-9]", "", str(value or "").upper())
+    if "UTF8" in compact:
+        return "utf-8"
+    if "UTF16" in compact:
+        return "utf-16"
+    if "UTF32" in compact:
+        return "utf-32"
+    return default
+
+
+def _encoded_symbol_occurrences(
+    lines: list[str],
+    symbol: str,
+    *,
+    encoding: str,
+) -> list[tuple[int, int]]:
+    return [
+        (line, _position_character(lines[line], character, encoding=encoding))
+        for line, character in _symbol_occurrences(lines, symbol)
+    ]
+
+
+def _position_character(source_line: str, character: int, *, encoding: str) -> int:
+    prefix = source_line[:character]
+    if encoding == "utf-8":
+        return len(prefix.encode("utf-8"))
+    if encoding == "utf-16":
+        return len(prefix.encode("utf-16-le")) // 2
+    return len(prefix)
+
+
+def _definition_nodes(result: Any) -> list[Any]:
+    if result is None:
+        return []
+    if isinstance(result, Mapping):
+        error = result.get("error")
+        if error:
+            raise ValueError(str(error))
+        if (result.get("file") or result.get("file_path")) and result.get(
+            "start_line"
+        ) is not None:
+            return [result]
+        raise ValueError("definition provider returned an invalid object")
+    if isinstance(result, (str, bytes)):
+        raise ValueError("definition provider returned text instead of locations")
+    try:
+        return list(result)
+    except TypeError as exc:
+        raise ValueError("definition provider returned a non-iterable result") from exc
+
+
+def _symbol_occurrences(lines: list[str], symbol: str) -> list[tuple[int, int]]:
+    escaped = re.escape(symbol)
+    left = r"(?<![\w$])" if _identifier_edge(symbol[0]) else ""
+    right = r"(?![\w$])" if _identifier_edge(symbol[-1]) else ""
+    pattern = re.compile(f"{left}{escaped}{right}")
+
+    occurrences: list[tuple[int, int]] = []
+    for line_number, source_line in enumerate(lines):
+        for match in pattern.finditer(source_line):
+            # Query the final character so dotted names resolve their invoked
+            # member rather than the receiver at the start of the expression.
+            occurrences.append((line_number, match.end() - 1))
+    return occurrences
+
+
+def _identifier_edge(character: str) -> bool:
+    return character == "$" or character == "_" or character.isalnum()
+
+
+def _node_value(node: Any, key: str) -> Any:
+    if isinstance(node, Mapping):
+        return node.get(key)
+    return getattr(node, key, None)
+
+
+def _bounded_source(content: str, *, max_lines: int, max_chars: int) -> str:
+    lines = content.splitlines()
+    truncated = len(lines) > max_lines
+    bounded = "\n".join(lines[:max_lines]) if truncated else content
+    if len(bounded) > max_chars:
+        truncated = True
+    if not truncated:
+        return bounded
+
+    available = max_chars - len(_TRUNCATION_MARKER)
+    return bounded[:available].rstrip() + _TRUNCATION_MARKER
+
+
+def _jump_observation(symbol: str, content: str, file_path: str) -> str:
+    quoted_symbol = json.dumps(symbol, ensure_ascii=False)
+    return (
+        f"The definition of symbol {quoted_symbol} is:\n"
+        f"{content}\n\n"
+        f"It is defined in: {file_path}"
+    )
+
+
+def _jump_error(message: str) -> str:
+    detail = str(message or "unknown definition error").strip()
+    return f"Jump failed: {detail}"
+
+
+__all__ = [
+    "REPONAVIGATOR_PAPER_REVISION",
+    "RepoNavigatorDefinitionSignal",
+    "RepoNavigatorRepositoryProvider",
+    "get_reponavigator_tool_schemas",
+]

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -430,6 +430,78 @@ COSIL_CHECKOUT=/path/to/CoSIL \
 pytest -q test/integrations/test_cosil_upstream.py
 ```
 
+## [RepoNavigator](https://arxiv.org/abs/2512.20957v6)
+
+RepoNavigator paper revision `arXiv:2512.20957v6` publishes one repository
+application tool:
+
+```text
+jump(file_path, symbol, index?) -> definition source snippet and file path
+```
+
+`RepoNavigatorRepositoryProvider` supplies that tool from an existing
+graph-enabled manifest. It finds the selected occurrence in the referring
+source file, converts it to a 0-based line and provider-specific UTF-8, UTF-16,
+or UTF-32 character offset, delegates to an LSP-shaped definition provider, and
+returns the containing definition source together with its repository path. It
+does not build a RepoNavigator-specific index.
+
+The semantic definition signal is part of the compatibility gate. By default,
+`from_manifest` loads the persisted `lsp_index.pkl` beside `graph.pkl`; callers
+may instead inject a live language-server provider. A manifest with only
+symbol-graph position heuristics is rejected unless the caller explicitly opts
+into degraded behavior.
+
+```python
+from codenib.integrations.reponavigator import (
+    RepoNavigatorRepositoryProvider,
+    get_reponavigator_tool_schemas,
+)
+
+provider = RepoNavigatorRepositoryProvider.from_manifest(
+    "/path/to/repo_manifest.json",
+)
+tools = get_reponavigator_tool_schemas()
+signal = provider.signal_metadata()
+observation = provider.dispatch(
+    "jump",
+    {"file_path": "src/service.py", "symbol": "calculate_tax", "index": 0},
+)
+```
+
+The schema contains only the paper's lowercase `jump` name. `file_path` is the
+referencing file, not the definition file; `index` is a zero-based resolvable
+occurrence index and defaults to `0`. Persisted SCIP occurrences filter comments
+and other non-semantic text. Definition source is bounded to 400 lines and
+32,000 characters. Invalid paths, missing occurrences, unavailable definitions,
+and out-of-range indices return explicit `Jump failed: ...` observations.
+
+Inspect the contract without installing RepoNavigator:
+
+```bash
+python examples/integrations/reponavigator.py \
+  --manifest /path/to/repo_manifest.json \
+  --file-path src/service.py \
+  --symbol calculate_tax \
+  --index 0
+```
+
+Use `--allow-graph-fallback` only when degraded graph-position behavior is
+acceptable. The opt-in is enforced for each definition call as well as at
+startup: a SCIP occurrence lookup that dynamically falls back to the symbol
+graph is rejected otherwise. Before the first call,
+`provider.signal_metadata()` describes the configured signal; afterwards it
+describes the backend that served the most recent call. It distinguishes
+persisted SCIP and native occurrence signals, live LSP, caller-attested
+external, and graph-fallback behavior. This is a paper-contract provider, not
+a revision-pinned upstream integration: CodeNib does not claim compatibility
+with an unreleased agent loop, prompt, error wording, GRPO training, or reported
+benchmark scores.
+
+```bash
+pytest -q test/integrations/test_reponavigator.py
+```
+
 ## [OrcaLoca](https://github.com/fishmingyu/OrcaLoca)
 
 The OrcaLoca provider replaces its repository data plane while retaining the

--- a/examples/integrations/reponavigator.py
+++ b/examples/integrations/reponavigator.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run RepoNavigator's published jump contract over a CodeNib manifest."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from codenib.integrations.reponavigator import RepoNavigatorRepositoryProvider
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        required=True,
+        help="Graph-enabled CodeNib repo_manifest.json",
+    )
+    parser.add_argument(
+        "--file-path",
+        required=True,
+        help="Repository-relative file containing the symbol occurrence.",
+    )
+    parser.add_argument(
+        "--symbol",
+        required=True,
+        help="Exact symbol text to resolve.",
+    )
+    parser.add_argument(
+        "--index",
+        type=int,
+        default=0,
+        help="Zero-based occurrence index within the file (default: 0).",
+    )
+    parser.add_argument(
+        "--allow-graph-fallback",
+        action="store_true",
+        help=(
+            "Allow degraded symbol-graph resolution when no SCIP occurrence "
+            "index or language-server provider is available."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    provider = RepoNavigatorRepositoryProvider.from_manifest(
+        args.manifest,
+        allow_graph_fallback=args.allow_graph_fallback,
+    )
+    print(
+        provider.jump(
+            file_path=args.file_path,
+            symbol=args.symbol,
+            index=args.index,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/integrations/test_reponavigator.py
+++ b/test/integrations/test_reponavigator.py
@@ -1,0 +1,609 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from codenib.compiler.manifest import RepoManifest
+from codenib.integrations._repository import IntegrationCapabilityError
+from codenib.integrations.reponavigator import (
+    REPONAVIGATOR_PAPER_REVISION,
+    RepoNavigatorDefinitionSignal,
+    RepoNavigatorRepositoryProvider,
+    get_reponavigator_tool_schemas,
+)
+from codenib.mcp.context import ServerContext
+from codenib.scip_interface.lsp_occurrence_index import (
+    SCIPOccurrence,
+    SCIPOccurrenceIndex,
+)
+
+
+class RecordingDefinitionProvider:
+    def __init__(
+        self,
+        result: object | None = None,
+        *,
+        position_encoding: str = "utf-32",
+    ) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.result = result or SimpleNamespace(
+            file="src/service.py",
+            start_line=5,
+        )
+        self.position_encoding = position_encoding
+
+    def definition(self, **kwargs: object) -> list[object]:
+        self.calls.append(dict(kwargs))
+        return [self.result]
+
+
+class NativeOccurrenceIndexStub:
+    behavior_contract = "static_native_occurrence_lsp_v1"
+    position_encoding = "UTF16"
+    authoritative_empty = True
+
+    def __init__(self, occurrence_count: int) -> None:
+        self.occurrence_count = occurrence_count
+
+    def occurrence_at(self, file_path: str, line: int, character: int) -> object:
+        del file_path, line, character
+        return None
+
+    def definitions(self, **kwargs: object) -> list[object]:
+        del kwargs
+        return []
+
+
+@pytest.fixture()
+def semantic_manifest(integration_manifest: Path) -> Path:
+    manifest = RepoManifest.load(integration_manifest)
+    graph_path = Path(manifest.indexes["symbol_graph"].path)
+    SCIPOccurrenceIndex(
+        [
+            SCIPOccurrence(
+                "src/service.py",
+                0,
+                6,
+                0,
+                20,
+                "scip-python fixture BillingService#",
+                1,
+            ),
+            SCIPOccurrence(
+                "src/service.py",
+                3,
+                15,
+                3,
+                21,
+                "scip-python fixture helper().",
+                8,
+            ),
+            SCIPOccurrence(
+                "src/service.py",
+                5,
+                4,
+                5,
+                10,
+                "scip-python fixture helper().",
+                1,
+            ),
+        ]
+    ).save(graph_path.with_name("lsp_index.pkl"))
+    return integration_manifest
+
+
+@pytest.fixture()
+def provider(semantic_manifest: Path) -> RepoNavigatorRepositoryProvider:
+    return RepoNavigatorRepositoryProvider.from_manifest(semantic_manifest)
+
+
+def test_provider_loads_only_symbol_graph_and_reattaches_definition_signal(
+    semantic_manifest: Path,
+) -> None:
+    with patch.object(ServerContext, "load", wraps=ServerContext.load) as load:
+        provider = RepoNavigatorRepositoryProvider.from_manifest(semantic_manifest)
+
+    load.assert_called_once_with(
+        semantic_manifest,
+        views=frozenset({"symbol_graph"}),
+    )
+    assert provider.context.symbol_graph is not None
+    assert provider.context.bm25 is None
+    assert provider.context.vector is None
+    assert provider.signal_metadata() == {
+        "backend": "scip_occurrence",
+        "provider": "codenib_static_index",
+        "behavior_contract": "static_scip_occurrence_lsp_v1",
+        "position_granularity": "character",
+        "position_encoding": "utf-8",
+        "semantic": True,
+        "detail": (
+            "character-level definition resolution from the persisted SCIP "
+            "occurrence index"
+        ),
+    }
+
+
+def test_graph_only_manifest_requires_explicit_degraded_opt_in(
+    integration_manifest: Path,
+) -> None:
+    with pytest.raises(IntegrationCapabilityError, match="semantic definition signal"):
+        RepoNavigatorRepositoryProvider.from_manifest(integration_manifest)
+
+    provider = RepoNavigatorRepositoryProvider.from_manifest(
+        integration_manifest,
+        allow_graph_fallback=True,
+    )
+
+    assert provider.definition_signal.backend == "symbol_graph_fallback"
+    assert provider.definition_signal.semantic is False
+
+
+def test_empty_occurrence_signal_is_not_reported_as_semantic(
+    integration_manifest: Path,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    graph_path = Path(manifest.indexes["symbol_graph"].path)
+    SCIPOccurrenceIndex([]).save(graph_path.with_name("lsp_index.pkl"))
+
+    with pytest.raises(IntegrationCapabilityError, match="semantic definition signal"):
+        RepoNavigatorRepositoryProvider.from_manifest(integration_manifest)
+
+    provider = RepoNavigatorRepositoryProvider.from_manifest(
+        integration_manifest,
+        allow_graph_fallback=True,
+    )
+    assert provider.definition_signal.semantic is False
+    assert "occurrence index is empty" in provider.definition_signal.detail
+    assert provider.jump("src/service.py", "helper").startswith(
+        'The definition of symbol "helper" is:'
+    )
+
+
+def test_empty_graph_attached_occurrence_rebinds_to_graph_only_provider(
+    integration_manifest: Path,
+) -> None:
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    occurrence_index = SCIPOccurrenceIndex([])
+    context.symbol_graph.lsp_occurrence_index = occurrence_index
+
+    provider = RepoNavigatorRepositoryProvider(
+        context,
+        occurrence_index=occurrence_index,
+        allow_graph_fallback=True,
+    )
+
+    assert provider.lsp_provider.occurrence_index is None
+    assert provider.jump("src/service.py", "helper").startswith(
+        'The definition of symbol "helper" is:'
+    )
+
+
+def test_native_occurrence_count_and_backend_are_reported_accurately(
+    integration_manifest: Path,
+) -> None:
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+
+    with pytest.raises(IntegrationCapabilityError, match="semantic definition signal"):
+        RepoNavigatorRepositoryProvider(
+            context,
+            occurrence_index=NativeOccurrenceIndexStub(0),
+        )
+
+    empty_provider = RepoNavigatorRepositoryProvider(
+        context,
+        occurrence_index=NativeOccurrenceIndexStub(0),
+        allow_graph_fallback=True,
+    )
+    assert empty_provider.definition_signal.backend == "symbol_graph_fallback"
+    assert "native occurrence index is empty" in empty_provider.definition_signal.detail
+    assert empty_provider.jump("src/service.py", "helper").startswith(
+        'The definition of symbol "helper" is:'
+    )
+
+    native_provider = RepoNavigatorRepositoryProvider(
+        context,
+        occurrence_index=NativeOccurrenceIndexStub(1),
+    )
+    assert native_provider.signal_metadata() == {
+        "backend": "native_occurrence",
+        "provider": "codenib_static_index",
+        "behavior_contract": "static_native_occurrence_lsp_v1",
+        "position_granularity": "character",
+        "position_encoding": "utf-16",
+        "semantic": True,
+        "detail": "character-level definition resolution from the native occurrence index",
+    }
+
+
+def test_per_call_graph_fallback_requires_opt_in_and_updates_signal(
+    integration_manifest: Path,
+) -> None:
+    occurrence_index = SCIPOccurrenceIndex(
+        [
+            SCIPOccurrence(
+                "src/service.py",
+                3,
+                15,
+                3,
+                21,
+                "scip-python fixture helper().",
+                8,
+            )
+        ]
+    )
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    blocked = RepoNavigatorRepositoryProvider(
+        context,
+        occurrence_index=occurrence_index,
+    )
+
+    assert blocked.jump("src/service.py", "helper") == (
+        "Jump failed: definition resolution degraded to the symbol graph; pass "
+        "allow_graph_fallback=True to permit this call"
+    )
+    assert blocked.signal_metadata()["backend"] == "symbol_graph_fallback"
+    assert blocked.signal_metadata()["semantic"] is False
+
+    allowed = RepoNavigatorRepositoryProvider(
+        context,
+        occurrence_index=occurrence_index,
+        allow_graph_fallback=True,
+    )
+    result = allowed.jump("src/service.py", "helper")
+
+    assert result.startswith('The definition of symbol "helper" is:')
+    assert allowed.signal_metadata()["backend"] == "symbol_graph_fallback"
+    assert allowed.signal_metadata()["behavior_contract"] == (
+        "static_symbol_graph_position_lsp_v1"
+    )
+    assert allowed.signal_metadata()["semantic"] is False
+
+
+def test_per_call_graph_gate_does_not_read_shared_signal_state(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    occurrence_index = SCIPOccurrenceIndex(
+        [
+            SCIPOccurrence(
+                "src/service.py",
+                3,
+                15,
+                3,
+                21,
+                "scip-python fixture helper().",
+                8,
+            )
+        ]
+    )
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    provider = RepoNavigatorRepositoryProvider(
+        context,
+        occurrence_index=occurrence_index,
+    )
+
+    def overwrite_latest_signal(_signal) -> None:
+        with provider._signal_lock:
+            provider._definition_signal = provider._configured_definition_signal
+
+    monkeypatch.setattr(
+        provider,
+        "_record_definition_signal",
+        overwrite_latest_signal,
+    )
+
+    assert provider.jump("src/service.py", "helper") == (
+        "Jump failed: definition resolution degraded to the symbol graph; pass "
+        "allow_graph_fallback=True to permit this call"
+    )
+
+
+def test_paper_contract_exposes_one_independent_jump_schema() -> None:
+    schemas = get_reponavigator_tool_schemas()
+
+    assert REPONAVIGATOR_PAPER_REVISION == "arXiv:2512.20957v6"
+    assert len(schemas) == 1
+    assert schemas[0]["function"]["name"] == "jump"
+    assert schemas[0]["function"]["parameters"]["required"] == [
+        "file_path",
+        "symbol",
+    ]
+    assert schemas[0]["function"]["parameters"]["properties"]["index"] == {
+        "type": "integer",
+        "minimum": 0,
+        "default": 0,
+        "description": (
+            "Zero-based occurrence index used when the symbol appears more than "
+            "once in the file."
+        ),
+    }
+
+    schemas[0]["function"]["name"] = "changed"
+    assert get_reponavigator_tool_schemas()[0]["function"]["name"] == "jump"
+
+
+def test_jump_converts_occurrence_index_to_exact_definition_position(
+    integration_manifest: Path,
+) -> None:
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    lsp_provider = RecordingDefinitionProvider()
+    provider = RepoNavigatorRepositoryProvider(
+        context,
+        lsp_provider=lsp_provider,
+    )
+
+    observation = provider.jump("src/service.py", "helper", index=1)
+
+    assert observation == (
+        'The definition of symbol "helper" is:\n'
+        "def helper(amount):\n"
+        "    return amount * 0.08\n\n"
+        "It is defined in: src/service.py"
+    )
+    assert lsp_provider.calls == [
+        {
+            "file_path": "src/service.py",
+            "line": 5,
+            "character": 9,
+            "top_k": 1,
+        }
+    ]
+
+
+def test_default_occurrence_is_zero_based(
+    integration_manifest: Path,
+) -> None:
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    lsp_provider = RecordingDefinitionProvider()
+    provider = RepoNavigatorRepositoryProvider(
+        context,
+        lsp_provider=lsp_provider,
+    )
+
+    provider.jump("src/service.py", "helper")
+
+    assert lsp_provider.calls[0]["line"] == 3
+    assert lsp_provider.calls[0]["character"] == 20
+
+
+def test_jump_converts_non_ascii_prefix_to_provider_position_encoding(
+    integration_manifest: Path,
+) -> None:
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    lsp_provider = RecordingDefinitionProvider(position_encoding="UTF16")
+    provider = RepoNavigatorRepositoryProvider(
+        context,
+        lsp_provider=lsp_provider,
+    )
+
+    with patch.object(
+        provider.repository,
+        "source_lines",
+        return_value=["é😀 helper()"],
+    ):
+        provider.jump("src/service.py", "helper")
+
+    assert provider.definition_signal.position_encoding == "utf-16"
+    assert lsp_provider.calls[0]["line"] == 0
+    assert lsp_provider.calls[0]["character"] == 9
+
+
+def test_position_encoding_does_not_read_shared_signal_state(
+    integration_manifest: Path,
+) -> None:
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    lsp_provider = RecordingDefinitionProvider(position_encoding="UTF16")
+    provider = RepoNavigatorRepositoryProvider(
+        context,
+        lsp_provider=lsp_provider,
+    )
+
+    def source_lines(_file_path: str) -> list[str]:
+        with provider._signal_lock:
+            provider._definition_signal = RepoNavigatorDefinitionSignal(
+                backend="concurrent-call",
+                provider="test",
+                behavior_contract="test",
+                position_granularity="character",
+                position_encoding="utf-32",
+                semantic=True,
+                detail="simulated concurrent metadata update",
+            )
+        return ["é😀 helper()"]
+
+    with patch.object(provider.repository, "source_lines", side_effect=source_lines):
+        provider.jump("src/service.py", "helper")
+
+    assert lsp_provider.calls[0]["character"] == 9
+
+
+def test_static_provider_returns_containing_definition_source(
+    provider: RepoNavigatorRepositoryProvider,
+) -> None:
+    assert provider.jump("src/service.py", "helper") == (
+        'The definition of symbol "helper" is:\n'
+        "def helper(amount):\n"
+        "    return amount * 0.08\n\n"
+        "It is defined in: src/service.py"
+    )
+    assert provider.jump("src/service.py", "BillingService") == (
+        'The definition of symbol "BillingService" is:\n'
+        "class BillingService:\n"
+        "    def calculate_tax(self, amount):\n"
+        '        """Compute sales tax for an invoice."""\n'
+        "        return helper(amount)\n\n"
+        "It is defined in: src/service.py"
+    )
+
+
+def test_jump_preserves_cross_file_definition_path(
+    integration_manifest: Path,
+) -> None:
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    provider = RepoNavigatorRepositoryProvider(
+        context,
+        lsp_provider=RecordingDefinitionProvider(
+            SimpleNamespace(file="src/other.py", start_line=0)
+        ),
+    )
+
+    result = provider.jump("src/service.py", "helper")
+
+    assert 'The definition of symbol "helper" is:' in result
+    assert '"""Fallback tax helper."""' in result
+    assert result.endswith("It is defined in: src/other.py")
+
+
+def test_scip_signal_filters_text_that_is_not_a_semantic_occurrence(
+    provider: RepoNavigatorRepositoryProvider,
+) -> None:
+    source_path = Path(provider.context.manifest.repo_path) / "src/service.py"
+    lines = source_path.read_text(encoding="utf-8").splitlines()
+    lines[4] = "# helper is only mentioned in this comment"
+    source_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = provider.jump("src/service.py", "helper", index=1)
+
+    assert result.startswith('The definition of symbol "helper" is:')
+    assert "Jump failed" not in result
+
+
+def test_dispatch_accepts_json_and_uppercase_alias(
+    provider: RepoNavigatorRepositoryProvider,
+) -> None:
+    result = provider.dispatch(
+        "jump",
+        '{"file_path":"src/service.py","symbol":"helper","index":0}',
+    )
+
+    assert result.startswith('The definition of symbol "helper" is:')
+    assert list(provider.bindings()) == ["jump"]
+    with pytest.raises(KeyError, match="unknown RepoNavigator tool"):
+        provider.dispatch("bash", {})
+    with pytest.raises(ValueError, match="valid JSON"):
+        provider.dispatch("Jump", "{")
+    with pytest.raises(ValueError, match="decode to an object"):
+        provider.dispatch("Jump", "[]")
+
+
+@pytest.mark.parametrize(
+    ("file_path", "symbol", "index", "message"),
+    [
+        ("../secret.py", "token", 0, "path traversal"),
+        ("src/service.py", "missing", 0, "no resolvable occurrence"),
+        ("src/service.py", "helper", 2, "out of range"),
+        ("src/service.py", "helper", -1, "non-negative integer"),
+        ("src/service.py", "helper", True, "non-negative integer"),
+        ("src/service.py", "bad\nsymbol", 0, "single-line text"),
+    ],
+)
+def test_jump_returns_bounded_observations_for_invalid_calls(
+    provider: RepoNavigatorRepositoryProvider,
+    file_path: str,
+    symbol: str,
+    index: object,
+    message: str,
+) -> None:
+    result = provider.jump(file_path, symbol, index=index)  # type: ignore[arg-type]
+
+    assert result.startswith("Jump failed: ")
+    assert message in result
+
+
+def test_jump_normalizes_invalid_path_exceptions(
+    provider: RepoNavigatorRepositoryProvider,
+) -> None:
+    result = provider.jump("\0", "helper")
+
+    assert result == "Jump failed: file_path must not contain NUL characters"
+
+
+def test_jump_returns_definition_provider_failures(
+    integration_manifest: Path,
+) -> None:
+    class FailingProvider:
+        def definition(self, **kwargs: object) -> list[object]:
+            del kwargs
+            raise ValueError("no definition at occurrence")
+
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    provider = RepoNavigatorRepositoryProvider(
+        context,
+        lsp_provider=FailingProvider(),
+    )
+
+    assert provider.jump("src/service.py", "helper") == (
+        "Jump failed: no definition at occurrence"
+    )
+
+
+def test_jump_returns_structured_live_provider_failures(
+    integration_manifest: Path,
+) -> None:
+    class ErrorProvider:
+        provider = "json_rpc"
+
+        def definition(self, **kwargs: object) -> dict[str, str]:
+            del kwargs
+            return {"error": "language server returned no definition"}
+
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    provider = RepoNavigatorRepositoryProvider(
+        context,
+        lsp_provider=ErrorProvider(),
+    )
+
+    assert provider.definition_signal.backend == "live_lsp"
+    assert provider.jump("src/service.py", "helper") == (
+        "Jump failed: language server returned no definition"
+    )
+
+
+def test_jump_returns_source_read_failures(
+    provider: RepoNavigatorRepositoryProvider,
+) -> None:
+    with patch.object(
+        provider.repository,
+        "source_lines",
+        side_effect=OSError("source is unavailable"),
+    ):
+        result = provider.jump("src/service.py", "helper")
+
+    assert result == "Jump failed: source is unavailable"
+
+
+def test_jump_bounds_large_definition_source(integration_manifest: Path) -> None:
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+    provider = RepoNavigatorRepositoryProvider(
+        context,
+        lsp_provider=RecordingDefinitionProvider(
+            SimpleNamespace(file="src/service.py", start_line=0)
+        ),
+        max_source_lines=1,
+    )
+
+    result = provider.jump("src/service.py", "BillingService")
+
+    assert result == (
+        'The definition of symbol "BillingService" is:\n'
+        "class BillingService:\n"
+        "...[truncated RepoNavigator definition]\n\n"
+        "It is defined in: src/service.py"
+    )
+
+
+def test_source_budgets_must_be_positive(integration_manifest: Path) -> None:
+    context = ServerContext.load(integration_manifest, views={"symbol_graph"})
+
+    with pytest.raises(ValueError, match="max_source_lines"):
+        RepoNavigatorRepositoryProvider(context, max_source_lines=0)
+    with pytest.raises(ValueError, match="max_source_chars"):
+        RepoNavigatorRepositoryProvider(context, max_source_chars=8)


### PR DESCRIPTION
## Summary

Add CodeNib's dependency-light RepoNavigator application adapter for the published `jump(file_path, symbol, index?)` contract. Closes #556.

## Changes

- add a provider that resolves a referring-file occurrence through persisted SCIP occurrences or an injected LSP definition signal
- expose semantic/degraded backend metadata and explicit graph-only fallback
- bound returned definition source by lines and characters and return deterministic failures
- add the standalone example, support matrix/documentation, and focused contract tests
- keep RepoNavigator policy, index ownership, and training outside the adapter

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `pytest -q test/integrations/test_reponavigator.py` (28 passed)
- [x] `pytest -q test/integrations` (139 passed, 12 skipped)
- [x] `python -m mkdocs build --strict`
- [x] pre-commit and `git diff --check`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
