### PR TITLE
fix(artifacts): close portable query validation

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -63,6 +63,7 @@ class _TreeOwnership:
     entries: int
     byte_count: int
     metadata_bytes: int
+    inventory: tuple[tuple[str, str], ...]
 
 
 class _PreviousOutputIdentityLost(RuntimeError):
@@ -275,6 +276,7 @@ def _scan_owned_directory(
     root_device: int,
     mount_points: frozenset[str],
     budget: _OwnershipBudget,
+    inventory: list[tuple[str, str]],
     depth: int,
     required_root_file: bytes | None = None,
     allow_empty_root: bool = False,
@@ -352,6 +354,7 @@ def _scan_owned_directory(
                     root_device=root_device,
                     mount_points=mount_points,
                     budget=budget,
+                    inventory=inventory,
                     depth=depth + 1,
                 )
                 after = os.fstat(child_descriptor)
@@ -378,6 +381,7 @@ def _scan_owned_directory(
             _ownership_hash_field(entry_hasher, relative)
             entry_hasher.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
             entry_hasher.update(child_digest)
+            inventory.append((os.fsdecode(relative), "directory"))
         elif stat.S_ISREG(metadata.st_mode):
             size, digest = _hash_owned_regular_file(
                 descriptor,
@@ -393,6 +397,7 @@ def _scan_owned_directory(
             entry_hasher.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
             entry_hasher.update(size.to_bytes(8, "big"))
             entry_hasher.update(digest_bytes)
+            inventory.append((os.fsdecode(relative), "file"))
         else:
             raise RuntimeError(
                 f"directory ownership scan refuses special content: {child_path}"
@@ -458,6 +463,7 @@ def capture_directory_ownership(
             entries=0,
             byte_count=0,
             metadata_bytes=0,
+            inventory=(),
         )
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     flags |= getattr(os, "O_CLOEXEC", 0)
@@ -467,6 +473,7 @@ def capture_directory_ownership(
         if _ownership_binding_identity(opened) != _ownership_binding_identity(metadata):
             raise RuntimeError(f"directory ownership root changed: {path}")
         budget = _OwnershipBudget()
+        inventory: list[tuple[str, str]] = []
         digest = _scan_owned_directory(
             descriptor,
             path,
@@ -474,6 +481,7 @@ def capture_directory_ownership(
             root_device=opened.st_dev,
             mount_points=_linux_mount_points(),
             budget=budget,
+            inventory=inventory,
             depth=0,
             required_root_file=required_root_file_bytes,
             allow_empty_root=allow_empty_root,
@@ -494,7 +502,28 @@ def capture_directory_ownership(
         entries=budget.entries,
         byte_count=budget.byte_count,
         metadata_bytes=budget.metadata_bytes,
+        inventory=tuple(sorted(inventory)),
     )
+
+
+def directory_ownership_inventory(
+    ownership: _TreeOwnership,
+) -> tuple[tuple[str, str], ...]:
+    """Return the bounded no-follow inventory captured with an ownership token."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.inventory
+
+
+def directory_ownership_root_identity(
+    ownership: _TreeOwnership,
+) -> tuple[int, ...]:
+    """Return the no-follow root identity bound by an ownership token."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.root_identity
 
 
 def _require_tree_ownership(
@@ -1356,6 +1385,8 @@ def publish_staged_directory(
 
 __all__ = [
     "capture_directory_ownership",
+    "directory_ownership_inventory",
+    "directory_ownership_root_identity",
     "discard_owned_directory",
     "lexical_directory_path",
     "publish_staged_directory",

--- a/codenib/_contained_source.py
+++ b/codenib/_contained_source.py
@@ -1,0 +1,489 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Race-resistant reads of repository files, including contained symlinks."""
+
+from __future__ import annotations
+
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+_MAX_COMPONENTS = 256
+_MAX_SYMLINKS = 40
+_MAX_SYMLINK_TARGET_BYTES = 4_096
+_READ_CHUNK_BYTES = 1024 * 1024
+SECURE_CONTAINED_SYMLINKS = (
+    os.name == "posix"
+    and hasattr(os, "O_DIRECTORY")
+    and hasattr(os, "O_NOFOLLOW")
+    and os.open in getattr(os, "supports_dir_fd", ())
+    and os.stat in getattr(os, "supports_dir_fd", ())
+    and os.stat in getattr(os, "supports_follow_symlinks", ())
+    and os.readlink in getattr(os, "supports_dir_fd", ())
+)
+
+
+def _is_link_or_reparse(metadata: os.stat_result) -> bool:
+    return stat.S_ISLNK(metadata.st_mode) or bool(
+        getattr(metadata, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def _binding_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _version_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        *_binding_identity(metadata),
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+    )
+
+
+def _relative_parts(value: str) -> tuple[str, ...]:
+    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+        raise ValueError("source path must be a repository-relative POSIX path")
+    relative = PurePosixPath(value)
+    if (
+        relative.is_absolute()
+        or relative.as_posix() != value
+        or any(part in {"", ".", ".."} for part in relative.parts)
+        or len(relative.parts) > _MAX_COMPONENTS
+    ):
+        raise ValueError("source path must be a repository-relative POSIX path")
+    return relative.parts
+
+
+def _normalize_link_target(
+    prefix: tuple[str, ...],
+    target: str,
+) -> tuple[str, ...]:
+    if not target or "\x00" in target or os.path.isabs(target):
+        raise ValueError("source symlink target must be relative")
+    if len(os.fsencode(target)) > _MAX_SYMLINK_TARGET_BYTES:
+        raise ValueError("source symlink target exceeds its byte limit")
+    resolved = list(prefix)
+    for part in target.split("/"):
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if not resolved:
+                raise ValueError("source symlink resolves outside the repository")
+            resolved.pop()
+            continue
+        resolved.append(part)
+        if len(resolved) > _MAX_COMPONENTS:
+            raise ValueError("resolved source path exceeds its component limit")
+    if not resolved:
+        raise ValueError("source symlink does not resolve to a file")
+    return tuple(resolved)
+
+
+@dataclass(slots=True)
+class _PathObservation:
+    parent_descriptor: int
+    name: str
+    identity: tuple[int, ...]
+    link_target: str | None = None
+
+
+@dataclass(slots=True)
+class _BoundRepositoryFile:
+    descriptor: int
+    opened_identity: tuple[int, ...]
+    root: Path
+    root_descriptor: int
+    root_identity: tuple[int, ...]
+    observations: list[_PathObservation]
+
+    def read_bytes(self, *, max_bytes: int) -> bytes:
+        if (
+            isinstance(max_bytes, bool)
+            or not isinstance(max_bytes, int)
+            or max_bytes <= 0
+        ):
+            raise ValueError("source byte limit must be positive")
+        opened = os.fstat(self.descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or _version_identity(opened) != self.opened_identity
+            or opened.st_size < 0
+            or opened.st_size > max_bytes
+        ):
+            raise ValueError("source file is not a stable bounded regular file")
+        payload = bytearray()
+        remaining = opened.st_size
+        while remaining:
+            chunk = os.read(self.descriptor, min(remaining, _READ_CHUNK_BYTES))
+            if not chunk:
+                raise ValueError("source file was truncated while being read")
+            payload.extend(chunk)
+            remaining -= len(chunk)
+        if os.read(self.descriptor, 1):
+            raise ValueError("source file grew while being read")
+        self.verify()
+        return bytes(payload)
+
+    def verify(self) -> None:
+        if _version_identity(os.fstat(self.root_descriptor)) != self.root_identity:
+            raise ValueError("repository root changed during source resolution")
+        root_after = self.root.lstat()
+        if _binding_identity(root_after) != _binding_identity(
+            os.fstat(self.root_descriptor)
+        ):
+            raise ValueError("repository root changed during source resolution")
+        for observation in self.observations:
+            current = os.stat(
+                observation.name,
+                dir_fd=observation.parent_descriptor,
+                follow_symlinks=False,
+            )
+            if _version_identity(current) != observation.identity:
+                raise ValueError("source path changed during contained resolution")
+            if observation.link_target is not None:
+                if (
+                    not stat.S_ISLNK(current.st_mode)
+                    or os.readlink(
+                        observation.name,
+                        dir_fd=observation.parent_descriptor,
+                    )
+                    != observation.link_target
+                ):
+                    raise ValueError(
+                        "source symlink changed during contained resolution"
+                    )
+        if _version_identity(os.fstat(self.descriptor)) != self.opened_identity:
+            raise ValueError("source file changed while it was being read")
+
+    def close(self) -> None:
+        descriptors = [
+            self.descriptor,
+            self.root_descriptor,
+            *(item.parent_descriptor for item in self.observations),
+        ]
+        for descriptor in descriptors:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _directory_flags() -> int:
+    return (
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | os.O_NOFOLLOW
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+
+def _regular_flags() -> int:
+    return (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+
+
+def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
+    root_before = root.lstat()
+    if _is_link_or_reparse(root_before) or not stat.S_ISDIR(root_before.st_mode):
+        raise ValueError("repository root must be a real directory")
+    root_descriptor = os.open(root, _directory_flags())
+    current_descriptor = -1
+    source_descriptor = -1
+    observations: list[_PathObservation] = []
+    seen_links: set[tuple[int, int]] = set()
+    try:
+        root_opened = os.fstat(root_descriptor)
+        if _binding_identity(root_opened) != _binding_identity(root_before):
+            raise ValueError("repository root changed during source resolution")
+        current_descriptor = os.dup(root_descriptor)
+        pending = list(parts)
+        resolved_prefix: tuple[str, ...] = ()
+        symlink_count = 0
+        while pending:
+            name = pending.pop(0)
+            before = os.stat(name, dir_fd=current_descriptor, follow_symlinks=False)
+            if bool(
+                getattr(before, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+            ):
+                raise ValueError("source path contains a reparse point")
+            if stat.S_ISLNK(before.st_mode):
+                symlink_count += 1
+                if symlink_count > _MAX_SYMLINKS:
+                    raise ValueError("source symlink resolution exceeds its limit")
+                link_identity = (before.st_dev, before.st_ino)
+                if link_identity in seen_links:
+                    raise ValueError("source symlink resolution contains a loop")
+                seen_links.add(link_identity)
+                target = os.readlink(name, dir_fd=current_descriptor)
+                after = os.stat(
+                    name,
+                    dir_fd=current_descriptor,
+                    follow_symlinks=False,
+                )
+                if _version_identity(after) != _version_identity(before):
+                    raise ValueError(
+                        "source symlink changed during contained resolution"
+                    )
+                observations.append(
+                    _PathObservation(
+                        parent_descriptor=os.dup(current_descriptor),
+                        name=name,
+                        identity=_version_identity(before),
+                        link_target=target,
+                    )
+                )
+                target_parts = _normalize_link_target(resolved_prefix, target)
+                if len(target_parts) + len(pending) > _MAX_COMPONENTS:
+                    raise ValueError("resolved source path exceeds its component limit")
+                pending = [*target_parts, *pending]
+                resolved_prefix = ()
+                os.close(current_descriptor)
+                current_descriptor = os.dup(root_descriptor)
+                continue
+
+            observations.append(
+                _PathObservation(
+                    parent_descriptor=os.dup(current_descriptor),
+                    name=name,
+                    identity=_version_identity(before),
+                )
+            )
+            if pending:
+                if not stat.S_ISDIR(before.st_mode):
+                    raise ValueError("source path has a non-directory component")
+                child_descriptor = os.open(
+                    name,
+                    _directory_flags(),
+                    dir_fd=current_descriptor,
+                )
+                opened = os.fstat(child_descriptor)
+                if _binding_identity(opened) != _binding_identity(before):
+                    os.close(child_descriptor)
+                    raise ValueError("source directory changed while opening")
+                os.close(current_descriptor)
+                current_descriptor = child_descriptor
+                resolved_prefix = (*resolved_prefix, name)
+                continue
+
+            if not stat.S_ISREG(before.st_mode):
+                raise ValueError("source path is not a regular repository file")
+            source_descriptor = os.open(
+                name,
+                _regular_flags(),
+                dir_fd=current_descriptor,
+            )
+            opened = os.fstat(source_descriptor)
+            if _binding_identity(opened) != _binding_identity(before):
+                raise ValueError("source file changed while opening")
+            binding = _BoundRepositoryFile(
+                descriptor=source_descriptor,
+                opened_identity=_version_identity(opened),
+                root=root,
+                root_descriptor=root_descriptor,
+                root_identity=_version_identity(root_opened),
+                observations=observations,
+            )
+            source_descriptor = -1
+            root_descriptor = -1
+            try:
+                binding.verify()
+            except BaseException:
+                binding.close()
+                raise
+            return binding
+        raise ValueError("source path does not resolve to a file")
+    except OSError as exc:
+        raise ValueError("source path could not be resolved safely") from exc
+    finally:
+        if source_descriptor >= 0:
+            os.close(source_descriptor)
+        if current_descriptor >= 0:
+            os.close(current_descriptor)
+        if root_descriptor >= 0:
+            os.close(root_descriptor)
+        if root_descriptor >= 0 or source_descriptor >= 0:
+            for observation in observations:
+                try:
+                    os.close(observation.parent_descriptor)
+                except OSError:
+                    pass
+
+
+def _static_components(
+    root: Path,
+    parts: tuple[str, ...],
+) -> tuple[Path, tuple[tuple[int, ...], ...]]:
+    current = root
+    identities: list[tuple[int, ...]] = []
+    root_metadata = root.lstat()
+    if _is_link_or_reparse(root_metadata) or not stat.S_ISDIR(root_metadata.st_mode):
+        raise ValueError("repository root must be a real directory")
+    identities.append(_version_identity(root_metadata))
+    for index, part in enumerate(parts):
+        current /= part
+        metadata = current.lstat()
+        if _is_link_or_reparse(metadata):
+            raise ValueError(
+                "safe contained symlink resolution requires directory-fd support"
+            )
+        expected = stat.S_ISREG if index == len(parts) - 1 else stat.S_ISDIR
+        if not expected(metadata.st_mode):
+            raise ValueError("source path is not a regular repository file")
+        identities.append(_version_identity(metadata))
+    return current, tuple(identities)
+
+
+def _read_static(root: Path, parts: tuple[str, ...], *, max_bytes: int) -> bytes:
+    source, identities = _static_components(root, parts)
+    descriptor = -1
+    try:
+        descriptor = os.open(source, _regular_flags())
+        opened = os.fstat(descriptor)
+        if _version_identity(opened) != identities[-1] or opened.st_size > max_bytes:
+            raise ValueError("source file is not a stable bounded regular file")
+        payload = bytearray()
+        remaining = opened.st_size
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, _READ_CHUNK_BYTES))
+            if not chunk:
+                raise ValueError("source file was truncated while being read")
+            payload.extend(chunk)
+            remaining -= len(chunk)
+        if os.read(descriptor, 1):
+            raise ValueError("source file grew while being read")
+        _source, after_identities = _static_components(root, parts)
+        if after_identities != identities or _version_identity(
+            os.fstat(descriptor)
+        ) != (identities[-1]):
+            raise ValueError("source path changed while it was being read")
+        return bytes(payload)
+    except OSError as exc:
+        raise ValueError("source path could not be read safely") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def validate_repository_file(root: str | Path, relative: str) -> None:
+    """Require one stable regular source file resolving beneath *root*."""
+
+    repository = Path(root).expanduser().resolve()
+    parts = _relative_parts(relative)
+    if SECURE_CONTAINED_SYMLINKS:
+        binding = _open_secure(repository, parts)
+        try:
+            try:
+                binding.verify()
+            except OSError as exc:
+                raise ValueError("source path could not be resolved safely") from exc
+        finally:
+            binding.close()
+        return
+    _static_components(repository, parts)
+
+
+def read_repository_file(
+    root: str | Path,
+    relative: str,
+    *,
+    max_bytes: int,
+) -> bytes:
+    """Read a bounded source file through the contained-symlink contract."""
+
+    if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes <= 0:
+        raise ValueError("source byte limit must be positive")
+    repository = Path(root).expanduser().resolve()
+    parts = _relative_parts(relative)
+    if SECURE_CONTAINED_SYMLINKS:
+        binding = _open_secure(repository, parts)
+        try:
+            return binding.read_bytes(max_bytes=max_bytes)
+        except OSError as exc:
+            raise ValueError("source path could not be read safely") from exc
+        finally:
+            binding.close()
+    return _read_static(repository, parts, max_bytes=max_bytes)
+
+
+def update_repository_file_hash(
+    root: str | Path,
+    relative: str,
+    hasher: object,
+) -> None:
+    """Stream one stable contained source file into a hashlib-compatible hash."""
+
+    update = getattr(hasher, "update", None)
+    if not callable(update):
+        raise TypeError("hasher must provide an update method")
+    repository = Path(root).expanduser().resolve()
+    parts = _relative_parts(relative)
+    if not SECURE_CONTAINED_SYMLINKS:
+        source, identities = _static_components(repository, parts)
+        descriptor = -1
+        try:
+            descriptor = os.open(source, _regular_flags())
+            opened = os.fstat(descriptor)
+            if _version_identity(opened) != identities[-1]:
+                raise ValueError("source file changed while opening")
+            remaining = opened.st_size
+            while remaining:
+                block = os.read(descriptor, min(remaining, _READ_CHUNK_BYTES))
+                if not block:
+                    raise ValueError("source file was truncated while hashing")
+                update(block)
+                remaining -= len(block)
+            if os.read(descriptor, 1):
+                raise ValueError("source file grew while hashing")
+            _source, after_identities = _static_components(repository, parts)
+            if after_identities != identities:
+                raise ValueError("source path changed while hashing")
+            return
+        except OSError as exc:
+            raise ValueError("source path could not be hashed safely") from exc
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+
+    binding = _open_secure(repository, parts)
+    try:
+        opened = os.fstat(binding.descriptor)
+        remaining = opened.st_size
+        while remaining:
+            block = os.read(binding.descriptor, min(remaining, _READ_CHUNK_BYTES))
+            if not block:
+                raise ValueError("source file was truncated while hashing")
+            update(block)
+            remaining -= len(block)
+        if os.read(binding.descriptor, 1):
+            raise ValueError("source file grew while hashing")
+        binding.verify()
+    except OSError as exc:
+        raise ValueError("source path could not be hashed safely") from exc
+    finally:
+        binding.close()
+
+
+__all__ = [
+    "SECURE_CONTAINED_SYMLINKS",
+    "read_repository_file",
+    "update_repository_file_hash",
+    "validate_repository_file",
+]

--- a/codenib/_secret_fields.py
+++ b/codenib/_secret_fields.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-neutral credential-field and credential-value classification."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+_SECRET_FIELD_NAMES = frozenset(
+    {
+        "access_key",
+        "access_token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "bearer_token",
+        "client_secret",
+        "cookie",
+        "credential",
+        "credentials",
+        "headers",
+        "password",
+        "passwd",
+        "private_key",
+        "proxy_authorization",
+        "refresh_token",
+        "secret",
+        "secret_key",
+        "token",
+        "x_api_key",
+        "x_auth_token",
+    }
+)
+_NORMALIZED_SECRET_FIELD_NAMES = frozenset(
+    re.sub(r"[^a-z0-9]", "", name.casefold()) for name in _SECRET_FIELD_NAMES
+)
+_NORMALIZED_SECRET_FIELD_SUFFIXES = tuple(
+    re.sub(r"[^a-z0-9]", "", name.casefold())
+    for name in (
+        "api_key",
+        "access_key",
+        "access_token",
+        "auth_token",
+        "bearer_token",
+        "client_secret",
+        "credential",
+        "credentials",
+        "password",
+        "passwd",
+        "private_key",
+        "refresh_token",
+        "secret",
+        "secret_key",
+        "token",
+        "authorization",
+    )
+)
+_NORMALIZED_SECRET_HEADER_PREFIXES = tuple(
+    re.sub(r"[^a-z0-9]", "", name.casefold())
+    for name in ("proxy_authorization", "x_api_key", "x_auth_token")
+)
+
+
+class SecretFieldError(ValueError):
+    """A decoded value contains credential-shaped publication data."""
+
+
+def assert_no_secret_fields(value: Any, *, source: str = "value") -> None:
+    """Reject decoded credential keys, URL userinfo, and auth header values."""
+
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            normalized = re.sub(r"[^a-z0-9]", "", str(key).casefold())
+            if (
+                normalized in _NORMALIZED_SECRET_FIELD_NAMES
+                or normalized.endswith(_NORMALIZED_SECRET_FIELD_SUFFIXES)
+                or normalized.startswith(_NORMALIZED_SECRET_HEADER_PREFIXES)
+            ):
+                raise SecretFieldError(
+                    f"{source} contains a credential field or secret field: {key}"
+                )
+            assert_no_secret_fields(child, source=source)
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            assert_no_secret_fields(child, source=source)
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if "://" in stripped or stripped.startswith("//"):
+            try:
+                parsed = urlsplit(stripped)
+            except ValueError as exc:
+                raise SecretFieldError(f"{source} contains an invalid URL") from exc
+            if parsed.username is not None or parsed.password is not None:
+                raise SecretFieldError(f"{source} must not contain URL credentials")
+        normalized = stripped.casefold()
+        if normalized.startswith(("bearer ", "basic ")):
+            raise SecretFieldError(
+                f"{source} must not contain authorization credentials"
+            )
+
+
+__all__ = ["SecretFieldError", "assert_no_secret_fields"]

--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -19,7 +19,11 @@ from .github import (
     resolve_github_context_artifact,
 )
 from .mcp_config import MCP_CONFIG_HOSTS, render_artifact_mcp_config
-from .portable_views import SourceTrust, normalize_owned_query_view
+from .portable_views import (
+    SourceTrust,
+    normalize_owned_query_view,
+    validate_portable_query_view,
+)
 from .runtime import (
     ContextArtifactBinding,
     VerifiedContextArtifact,
@@ -42,6 +46,7 @@ __all__ = [
     "extract_context_artifact_archive",
     "fetch_github_context_artifact",
     "normalize_owned_query_view",
+    "validate_portable_query_view",
     "resolve_github_context_artifact",
     "render_artifact_mcp_config",
     "stage_context_artifact",

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -32,7 +32,7 @@ from ..index.embedding.artifact_integrity import (
     validate_vector_config_artifact,
 )
 from ..provider_routes import resolve_embedding_artifact_route
-from .portable_views import normalize_owned_query_view
+from .portable_views import normalize_owned_query_view, validate_portable_query_view
 from .security import assert_no_credential_fields, assert_publishable_tree, file_sha256
 
 CONTEXT_ARTIFACT_SCHEMA = "codenib.context-artifact.v1"
@@ -269,6 +269,7 @@ def stage_context_artifact(
         portable = manifest.to_dict()
         portable["repo"]["path"] = "source"
         portable_indexes: dict[str, Any] = {}
+        portable_validation: dict[str, tuple[str, dict[str, Any]]] = {}
         for view in selected:
             entry = manifest.indexes[view]
             assert_no_credential_fields(entry.config, source=f"view {view!r} config")
@@ -305,6 +306,15 @@ def stage_context_artifact(
             entry_data["path"] = relative
             for section in ("config", "metadata"):
                 entry_data[section].update(adjustments)
+            validate_portable_query_view(
+                stage.joinpath(*PurePosixPath(relative).parts),
+                repo_path=repo_path,
+                view_type=view,
+                view_config=entry_data["config"],
+                forbidden_paths=(manifest_root,),
+                environ=environment,
+            )
+            portable_validation[view] = (relative, dict(entry_data["config"]))
             portable_indexes[view] = entry_data
         portable["indexes"] = portable_indexes
         portable["capabilities"] = _portable_capabilities(
@@ -359,6 +369,15 @@ def stage_context_artifact(
         expected_metadata_bytes = _json_bytes(metadata)
 
         def validate_artifact(candidate: Path) -> None:
+            for view, (relative, config) in portable_validation.items():
+                validate_portable_query_view(
+                    candidate.joinpath(*PurePosixPath(relative).parts),
+                    repo_path=repo_path,
+                    view_type=view,
+                    view_config=config,
+                    forbidden_paths=(manifest_root,),
+                    environ=environment,
+                )
             assert_publishable_tree(
                 candidate,
                 forbidden_paths=(repo_path, manifest_root),

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import stat
+import sys
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Literal, Mapping
 
@@ -70,6 +71,28 @@ def _view_file_identity(metadata: os.stat_result) -> tuple[int, ...]:
     )
 
 
+def _view_binding_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    """Identify one directory entry without cache-sensitive timestamps."""
+
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _view_directory_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
 class _OwnedViewReader:
     """Read one captured view through a pinned no-follow root descriptor."""
 
@@ -83,6 +106,7 @@ class _OwnedViewReader:
         self._descriptor = -1
         self._cached_payloads: dict[PurePosixPath, bytearray] = {}
         self._authenticated_files: dict[PurePosixPath, tuple[int, os.stat_result]] = {}
+        self._replacement_targets: dict[PurePosixPath, tuple[int, os.stat_result]] = {}
         try:
             flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
             flags |= getattr(os, "O_CLOEXEC", 0)
@@ -108,6 +132,12 @@ class _OwnedViewReader:
             except OSError:
                 pass
         self._authenticated_files.clear()
+        for descriptor, _metadata in self._replacement_targets.values():
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        self._replacement_targets.clear()
         if self._descriptor >= 0:
             try:
                 os.close(self._descriptor)
@@ -145,9 +175,8 @@ class _OwnedViewReader:
             raise ValueError(f"portable view path is invalid: {value}")
         return relative
 
-    def _open_file(self, relative: PurePosixPath) -> tuple[int, os.stat_result]:
+    def _open_parent(self, relative: PurePosixPath) -> int:
         directory_descriptor = os.dup(self._descriptor)
-        source_descriptor = -1
         try:
             directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
             directory_flags |= getattr(os, "O_CLOEXEC", 0)
@@ -174,7 +203,20 @@ class _OwnedViewReader:
                     raise ValueError(f"portable view directory changed: {relative}")
                 os.close(directory_descriptor)
                 directory_descriptor = child
+            owned = directory_descriptor
+            directory_descriptor = -1
+            return owned
+        finally:
+            if directory_descriptor >= 0:
+                os.close(directory_descriptor)
 
+    @staticmethod
+    def _open_private_file(
+        directory_descriptor: int,
+        relative: PurePosixPath,
+    ) -> tuple[int, os.stat_result]:
+        source_descriptor = -1
+        try:
             name = relative.parts[-1]
             before = os.stat(
                 name,
@@ -202,6 +244,34 @@ class _OwnedViewReader:
             owned = source_descriptor
             source_descriptor = -1
             return owned, opened
+        finally:
+            if source_descriptor >= 0:
+                os.close(source_descriptor)
+
+    def _open_file(self, relative: PurePosixPath) -> tuple[int, os.stat_result]:
+        replacement_target = self._replacement_targets.get(relative)
+        directory_descriptor = -1
+        source_descriptor = -1
+        try:
+            directory_descriptor = (
+                os.dup(replacement_target[0])
+                if replacement_target is not None
+                else self._open_parent(relative)
+            )
+            source_descriptor, opened = self._open_private_file(
+                directory_descriptor,
+                relative,
+            )
+            if replacement_target is not None and _view_file_identity(
+                opened
+            ) != _view_file_identity(replacement_target[1]):
+                raise ValueError(
+                    f"portable view replacement target changed: {relative}"
+                )
+
+            owned = source_descriptor
+            source_descriptor = -1
+            return owned, opened
         except OSError as exc:
             raise ValueError(
                 f"portable view file is not safely readable: {relative}"
@@ -209,7 +279,258 @@ class _OwnedViewReader:
         finally:
             if source_descriptor >= 0:
                 os.close(source_descriptor)
-            os.close(directory_descriptor)
+            if directory_descriptor >= 0:
+                os.close(directory_descriptor)
+
+    def pin_replacement_target(self, path: Path) -> None:
+        """Pin a target's parent and identity before validating its contents."""
+
+        relative = self._relative(path.relative_to(self.root))
+        if relative in self._replacement_targets:
+            return
+        directory_descriptor = -1
+        source_descriptor = -1
+        try:
+            directory_descriptor = self._open_parent(relative)
+            source_descriptor, opened = self._open_private_file(
+                directory_descriptor,
+                relative,
+            )
+            self._replacement_targets[relative] = (directory_descriptor, opened)
+            directory_descriptor = -1
+        except OSError as exc:
+            raise ValueError(
+                f"portable view replacement target is not safely writable: {relative}"
+            ) from exc
+        finally:
+            if source_descriptor >= 0:
+                os.close(source_descriptor)
+            if directory_descriptor >= 0:
+                os.close(directory_descriptor)
+
+    def _verify_replacement_parent(
+        self,
+        relative: PurePosixPath,
+        pinned_descriptor: int,
+    ) -> None:
+        current_descriptor = -1
+        try:
+            current_descriptor = self._open_parent(relative)
+            if _view_directory_identity(
+                os.fstat(current_descriptor)
+            ) != _view_directory_identity(os.fstat(pinned_descriptor)):
+                raise RuntimeError(
+                    f"portable view replacement parent changed: {relative.parent}"
+                )
+        except OSError as exc:
+            raise RuntimeError(
+                f"portable view replacement parent changed: {relative.parent}"
+            ) from exc
+        finally:
+            if current_descriptor >= 0:
+                os.close(current_descriptor)
+
+    @staticmethod
+    def _write_all(descriptor: int, payload: bytes) -> None:
+        written = 0
+        while written < len(payload):
+            count = os.write(descriptor, payload[written:])
+            if count <= 0:
+                raise OSError("portable view temporary file write made no progress")
+            written += count
+
+    @staticmethod
+    def _remove_owned_temporary(
+        directory_descriptor: int,
+        name: str,
+        descriptor: int,
+    ) -> None:
+        try:
+            observed = os.stat(
+                name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            return
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or _view_binding_identity(observed) != _view_binding_identity(opened)
+        ):
+            raise RuntimeError(
+                "portable view canonicalization temporary file changed before cleanup"
+            )
+        os.unlink(name, dir_fd=directory_descriptor)
+        os.fsync(directory_descriptor)
+
+    def replace_bytes(self, path: Path, payload: bytes) -> None:
+        """Atomically replace a validated file through its pinned parent."""
+
+        relative = self._relative(path.relative_to(self.root))
+        replacement_target = self._replacement_targets.get(relative)
+        if replacement_target is None:
+            raise RuntimeError(
+                f"portable view replacement target is not pinned: {relative}"
+            )
+        directory_descriptor, expected = replacement_target
+        temporary_descriptor = -1
+        temporary_name: str | None = None
+        replaced = False
+        try:
+            self.verify_root()
+            self._verify_replacement_parent(relative, directory_descriptor)
+            current = os.stat(
+                relative.name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            if _view_file_identity(current) != _view_file_identity(expected):
+                raise RuntimeError(
+                    f"portable view replacement target changed: {relative}"
+                )
+
+            flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            for _attempt in range(128):
+                candidate = (
+                    f".codenib-canonical-{os.getpid()}-" f"{os.urandom(16).hex()}.tmp"
+                )
+                try:
+                    temporary_descriptor = os.open(
+                        candidate,
+                        flags,
+                        stat.S_IMODE(expected.st_mode),
+                        dir_fd=directory_descriptor,
+                    )
+                except FileExistsError:
+                    continue
+                temporary_name = candidate
+                break
+            if temporary_name is None:
+                raise RuntimeError(
+                    "portable view canonicalization could not reserve a temporary file"
+                )
+
+            created = os.fstat(temporary_descriptor)
+            observed_created = os.stat(
+                temporary_name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(created.st_mode)
+                or created.st_nlink != 1
+                or _view_binding_identity(observed_created)
+                != _view_binding_identity(created)
+            ):
+                raise RuntimeError(
+                    "portable view canonicalization temporary file is not private"
+                )
+            self._write_all(temporary_descriptor, payload)
+            os.fchmod(temporary_descriptor, stat.S_IMODE(expected.st_mode))
+            os.fsync(temporary_descriptor)
+            temporary_metadata = os.fstat(temporary_descriptor)
+            observed_temporary = os.stat(
+                temporary_name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(temporary_metadata.st_mode)
+                or temporary_metadata.st_nlink != 1
+                or _view_binding_identity(observed_temporary)
+                != _view_binding_identity(temporary_metadata)
+            ):
+                raise RuntimeError(
+                    "portable view canonicalization temporary file changed"
+                )
+
+            current = os.stat(
+                relative.name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            if _view_file_identity(current) != _view_file_identity(expected):
+                raise RuntimeError(
+                    f"portable view replacement target changed: {relative}"
+                )
+            os.replace(
+                temporary_name,
+                relative.name,
+                src_dir_fd=directory_descriptor,
+                dst_dir_fd=directory_descriptor,
+            )
+            replaced = True
+            installed = os.stat(
+                relative.name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            installed_descriptor = os.fstat(temporary_descriptor)
+            if _view_binding_identity(installed) != _view_binding_identity(
+                temporary_metadata
+            ) or _view_binding_identity(installed) != _view_binding_identity(
+                installed_descriptor
+            ):
+                raise RuntimeError(
+                    f"portable view canonical replacement changed: {relative}"
+                )
+            os.lseek(temporary_descriptor, 0, os.SEEK_SET)
+            installed_payload = self._read_exact(
+                temporary_descriptor,
+                installed_descriptor,
+                relative=relative,
+                max_bytes=len(payload),
+            )
+            installed_after_read = os.stat(
+                relative.name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            descriptor_after_read = os.fstat(temporary_descriptor)
+            if (
+                installed_payload != payload
+                or _view_file_identity(installed_after_read)
+                != _view_file_identity(installed_descriptor)
+                or _view_file_identity(descriptor_after_read)
+                != _view_file_identity(installed_descriptor)
+            ):
+                raise RuntimeError(
+                    f"portable view canonical replacement changed: {relative}"
+                )
+            os.fsync(directory_descriptor)
+            self._verify_replacement_parent(relative, directory_descriptor)
+        except (OSError, ValueError) as exc:
+            raise RuntimeError(
+                f"portable view could not canonicalize safely: {relative}"
+            ) from exc
+        finally:
+            cleanup_error: Exception | None = None
+            if (
+                temporary_name is not None
+                and temporary_descriptor >= 0
+                and not replaced
+            ):
+                try:
+                    self._remove_owned_temporary(
+                        directory_descriptor,
+                        temporary_name,
+                        temporary_descriptor,
+                    )
+                except Exception as exc:
+                    cleanup_error = exc
+            if temporary_descriptor >= 0:
+                try:
+                    os.close(temporary_descriptor)
+                except OSError as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+            if cleanup_error is not None and sys.exc_info()[1] is None:
+                raise RuntimeError(
+                    "portable view canonicalization temporary cleanup failed closed"
+                ) from cleanup_error
 
     @staticmethod
     def _read_exact(
@@ -1030,6 +1351,7 @@ def _faiss_contract(
 def _validate_level_semantics(
     path: Path,
     *,
+    present: bool,
     level: str,
     model: str,
     provider: str,
@@ -1041,8 +1363,14 @@ def _validate_level_semantics(
     canonicalize: bool = True,
     reader: _OwnedViewReader | None = None,
 ) -> None:
-    if not path.exists():
+    if not present:
         return
+    if canonicalize:
+        if reader is None:
+            raise RuntimeError(
+                "portable vector level canonicalization requires an owned reader"
+            )
+        reader.pin_replacement_target(path)
     config = _load_json_object(
         path,
         label=f"portable vector {level} config",
@@ -1092,7 +1420,8 @@ def _validate_level_semantics(
     if persisted_provider != provider:
         raise ValueError(f"portable vector {level} persistence provider does not match")
     if canonicalize:
-        path.write_bytes(_json_bytes(config))
+        assert reader is not None
+        reader.replace_bytes(path, _json_bytes(config))
 
 
 def _validate_vector_layout(
@@ -1250,8 +1579,10 @@ def _validate_vector_layout(
             raise ValueError(
                 f"portable vector active IVF index is untrained in {level}"
             )
+        level_config_path = level_path / f"config_{model_suffix}.json"
         _validate_level_semantics(
-            level_path / f"config_{model_suffix}.json",
+            level_config_path,
+            present=level_config_path in inventory_files,
             level=level,
             model=expected_model,
             provider=expected_provider,

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -6,27 +6,31 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
+import io
 import json
+import os
 import re
+import stat
 from pathlib import Path, PurePosixPath
-from typing import Any, Literal, Mapping
+from typing import Any, Iterable, Literal, Mapping
 
 from .. import compat_pickle
-from ..compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
+from .._atomic_directory import (
+    capture_directory_ownership,
+    directory_ownership_inventory,
+    directory_ownership_root_identity,
+)
+from .._contained_source import validate_repository_file
+from .._secret_fields import assert_no_secret_fields
 from ..index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
     VECTOR_VIEW_UPDATE_MARKER,
-    require_complete_vector_view,
-    validate_vector_config_artifact,
-    validate_vector_generation_artifacts,
-    vector_config_artifact_record,
-    vector_level_artifact_records,
 )
-from ..index.embedding.model_policy import (
-    resolve_embedding_load_policy_from_options,
-)
+from ..index.embedding.model_policy import resolve_embedding_load_policy_from_options
 from ..provider_routes import normalize_provider, resolve_embedding_artifact_route
+from .security import assert_publishable_json_value
 
 _VECTOR_LEVELS = ("l0", "l2")
 _REMOVABLE_MUTABLE_VECTOR_FILES = frozenset(
@@ -46,7 +50,368 @@ _MUTABLE_VECTOR_PREFIXES = (
 )
 _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
 _PICKLE_SUFFIXES = frozenset({".pkl", ".pickle"})
+_WINDOWS_REPARSE_POINT = 0x400
+_MAX_CONFIG_JSON_BYTES = 16 * 1024 * 1024
+_MAX_DOCUMENTS_JSON_BYTES = 256 * 1024 * 1024
+_JSON_READ_CHUNK_BYTES = 1024 * 1024
 SourceTrust = Literal["portable-inert", "trusted-local"]
+
+
+def _view_file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+class _OwnedViewReader:
+    """Read one captured view through a pinned no-follow root descriptor."""
+
+    def __init__(self, root: Path, ownership: object) -> None:
+        if not hasattr(os, "O_DIRECTORY") or not hasattr(os, "O_NOFOLLOW"):
+            raise RuntimeError(
+                "portable view validation requires no-follow directory descriptors"
+            )
+        self.root = root
+        self.ownership = ownership
+        self._descriptor = -1
+        self._cached_payloads: dict[PurePosixPath, bytearray] = {}
+        self._authenticated_files: dict[PurePosixPath, tuple[int, os.stat_result]] = {}
+        try:
+            flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            self._descriptor = os.open(root, flags)
+            opened = os.fstat(self._descriptor)
+            root_identity = (
+                opened.st_dev,
+                opened.st_ino,
+                stat.S_IFMT(opened.st_mode),
+                getattr(opened, "st_file_attributes", 0),
+            )
+            if root_identity != directory_ownership_root_identity(ownership):
+                raise RuntimeError("portable view root changed after capture")
+            self._root_identity = _view_file_identity(opened)
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        for descriptor, _metadata in self._authenticated_files.values():
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        self._authenticated_files.clear()
+        if self._descriptor >= 0:
+            try:
+                os.close(self._descriptor)
+            except OSError:
+                pass
+            self._descriptor = -1
+
+    def verify_root(self) -> None:
+        try:
+            current = os.fstat(self._descriptor)
+            path_current = self.root.lstat()
+        except OSError as exc:
+            raise RuntimeError("portable view root changed during validation") from exc
+        if _view_file_identity(current) != self._root_identity or (
+            current.st_dev,
+            current.st_ino,
+            stat.S_IFMT(current.st_mode),
+            getattr(current, "st_file_attributes", 0),
+        ) != (
+            path_current.st_dev,
+            path_current.st_ino,
+            stat.S_IFMT(path_current.st_mode),
+            getattr(path_current, "st_file_attributes", 0),
+        ):
+            raise RuntimeError("portable view root changed during validation")
+
+    @staticmethod
+    def _relative(value: Path) -> PurePosixPath:
+        relative = PurePosixPath(value.as_posix())
+        if (
+            relative.is_absolute()
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or len(relative.parts) > 256
+        ):
+            raise ValueError(f"portable view path is invalid: {value}")
+        return relative
+
+    def _open_file(self, relative: PurePosixPath) -> tuple[int, os.stat_result]:
+        directory_descriptor = os.dup(self._descriptor)
+        source_descriptor = -1
+        try:
+            directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            directory_flags |= getattr(os, "O_CLOEXEC", 0)
+            for part in relative.parts[:-1]:
+                before = os.stat(
+                    part,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if not stat.S_ISDIR(before.st_mode) or bool(
+                    getattr(before, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT
+                ):
+                    raise ValueError(
+                        f"portable view path is not a real directory: {relative}"
+                    )
+                child = os.open(part, directory_flags, dir_fd=directory_descriptor)
+                opened = os.fstat(child)
+                if (
+                    opened.st_dev != before.st_dev
+                    or opened.st_ino != before.st_ino
+                    or stat.S_IFMT(opened.st_mode) != stat.S_IFMT(before.st_mode)
+                ):
+                    os.close(child)
+                    raise ValueError(f"portable view directory changed: {relative}")
+                os.close(directory_descriptor)
+                directory_descriptor = child
+
+            name = relative.parts[-1]
+            before = os.stat(
+                name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or before.st_nlink != 1
+                or bool(
+                    getattr(before, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT
+                )
+            ):
+                raise ValueError(
+                    f"portable view path is not a private file: {relative}"
+                )
+            flags = os.O_RDONLY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+            source_descriptor = os.open(name, flags, dir_fd=directory_descriptor)
+            opened = os.fstat(source_descriptor)
+            if _view_file_identity(opened) != _view_file_identity(before):
+                raise ValueError(
+                    f"portable view file changed while opening: {relative}"
+                )
+            owned = source_descriptor
+            source_descriptor = -1
+            return owned, opened
+        except OSError as exc:
+            raise ValueError(
+                f"portable view file is not safely readable: {relative}"
+            ) from exc
+        finally:
+            if source_descriptor >= 0:
+                os.close(source_descriptor)
+            os.close(directory_descriptor)
+
+    @staticmethod
+    def _read_exact(
+        descriptor: int,
+        opened: os.stat_result,
+        *,
+        relative: PurePosixPath,
+        max_bytes: int | None,
+    ) -> bytearray:
+        if max_bytes is not None and opened.st_size > max_bytes:
+            raise ValueError(
+                f"portable view file exceeds its {max_bytes}-byte limit: {relative}"
+            )
+        payload = bytearray()
+        remaining = opened.st_size
+        while remaining:
+            block = os.read(descriptor, min(remaining, _JSON_READ_CHUNK_BYTES))
+            if not block:
+                raise ValueError(f"portable view file was truncated: {relative}")
+            payload.extend(block)
+            remaining -= len(block)
+        if os.read(descriptor, 1):
+            raise ValueError(f"portable view file grew while being read: {relative}")
+        if _view_file_identity(os.fstat(descriptor)) != _view_file_identity(opened):
+            raise ValueError(f"portable view file changed while being read: {relative}")
+        return payload
+
+    def read_bytes(self, path: Path, *, max_bytes: int) -> bytearray:
+        relative = self._relative(path.relative_to(self.root))
+        cached = self._cached_payloads.get(relative)
+        if cached is not None:
+            if len(cached) > max_bytes:
+                raise ValueError(
+                    f"portable view file exceeds its {max_bytes}-byte limit: {relative}"
+                )
+            return cached
+        descriptor, opened = self._open_file(relative)
+        try:
+            return self._read_exact(
+                descriptor,
+                opened,
+                relative=relative,
+                max_bytes=max_bytes,
+            )
+        except OSError as exc:
+            raise ValueError(f"portable view file is not readable: {relative}") from exc
+        finally:
+            os.close(descriptor)
+
+    def authenticate(
+        self,
+        path: Path,
+        expected: object,
+        *,
+        cache_bytes: bool,
+        max_bytes: int | None = None,
+        keep_descriptor: bool = False,
+    ) -> None:
+        relative = self._relative(path.relative_to(self.root))
+        if not isinstance(expected, Mapping):
+            raise ValueError(f"portable view fingerprint is invalid: {relative}")
+        expected_fields = {"size", "sha256"}
+        if "file" in expected:
+            expected_fields.add("file")
+        if set(expected) != expected_fields:
+            raise ValueError(f"portable view fingerprint is invalid: {relative}")
+        if "file" in expected and expected.get("file") != relative.name:
+            raise ValueError(
+                f"portable view fingerprint filename is invalid: {relative}"
+            )
+        size = expected.get("size")
+        digest = expected.get("sha256")
+        if (
+            not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+            or not isinstance(digest, str)
+            or not re.fullmatch(r"[0-9a-f]{64}", digest)
+        ):
+            raise ValueError(f"portable view fingerprint is invalid: {relative}")
+        descriptor, opened = self._open_file(relative)
+        try:
+            if opened.st_size != size or (
+                max_bytes is not None and opened.st_size > max_bytes
+            ):
+                raise ValueError(f"portable view fingerprint size mismatch: {relative}")
+            hasher = hashlib.sha256()
+            payload = bytearray() if cache_bytes else None
+            remaining = opened.st_size
+            while remaining:
+                block = os.read(descriptor, min(remaining, _JSON_READ_CHUNK_BYTES))
+                if not block:
+                    raise ValueError(f"portable view file was truncated: {relative}")
+                hasher.update(block)
+                if payload is not None:
+                    payload.extend(block)
+                remaining -= len(block)
+            if os.read(descriptor, 1):
+                raise ValueError(f"portable view file grew while hashing: {relative}")
+            if hasher.hexdigest() != digest or _view_file_identity(
+                os.fstat(descriptor)
+            ) != _view_file_identity(opened):
+                raise ValueError(f"portable view fingerprint mismatch: {relative}")
+            if payload is not None:
+                self._cached_payloads[relative] = payload
+            if keep_descriptor:
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                self._authenticated_files[relative] = (descriptor, opened)
+                descriptor = -1
+        except OSError as exc:
+            raise ValueError(f"portable view file is not readable: {relative}") from exc
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+
+    def pin_file(self, path: Path, *, max_bytes: int | None = None) -> None:
+        """Retain a stable file descriptor for a later parser."""
+
+        relative = self._relative(path.relative_to(self.root))
+        if relative in self._authenticated_files:
+            return
+        descriptor, opened = self._open_file(relative)
+        try:
+            if max_bytes is not None and opened.st_size > max_bytes:
+                raise ValueError(
+                    f"portable view file exceeds its {max_bytes}-byte limit: "
+                    f"{relative}"
+                )
+            self._authenticated_files[relative] = (descriptor, opened)
+            descriptor = -1
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+
+    def fingerprint(
+        self, path: Path, *, max_bytes: int | None = None
+    ) -> dict[str, Any]:
+        """Hash a stable regular file through the pinned view root."""
+
+        relative = self._relative(path.relative_to(self.root))
+        descriptor, opened = self._open_file(relative)
+        try:
+            if max_bytes is not None and opened.st_size > max_bytes:
+                raise ValueError(
+                    f"portable view file exceeds its {max_bytes}-byte limit: "
+                    f"{relative}"
+                )
+            hasher = hashlib.sha256()
+            remaining = opened.st_size
+            while remaining:
+                block = os.read(descriptor, min(remaining, _JSON_READ_CHUNK_BYTES))
+                if not block:
+                    raise ValueError(f"portable view file was truncated: {relative}")
+                hasher.update(block)
+                remaining -= len(block)
+            if os.read(descriptor, 1):
+                raise ValueError(f"portable view file grew while hashing: {relative}")
+            if _view_file_identity(os.fstat(descriptor)) != _view_file_identity(opened):
+                raise ValueError(
+                    f"portable view file changed while hashing: {relative}"
+                )
+            return {"size": opened.st_size, "sha256": hasher.hexdigest()}
+        except OSError as exc:
+            raise ValueError(f"portable view file is not readable: {relative}") from exc
+        finally:
+            os.close(descriptor)
+
+    def faiss_index(self, path: Path, faiss: Any) -> Any:
+        relative = self._relative(path.relative_to(self.root))
+        authenticated = self._authenticated_files.get(relative)
+        if authenticated is None:
+            raise ValueError(f"portable FAISS index is not authenticated: {relative}")
+        descriptor, opened = authenticated
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        remaining = opened.st_size
+
+        def read_bytes(requested: int) -> bytes:
+            nonlocal remaining
+            if requested <= 0 or remaining <= 0:
+                return b""
+            block = os.read(descriptor, min(requested, remaining, 8 * 1024 * 1024))
+            remaining -= len(block)
+            return block
+
+        reader = faiss.PyCallbackIOReader(read_bytes)
+        index = faiss.read_index(reader)
+        if _view_file_identity(os.fstat(descriptor)) != _view_file_identity(opened):
+            raise ValueError(f"portable FAISS index changed while parsing: {relative}")
+        return index
+
+
+def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_number(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
 
 
 def _json_bytes(value: Any) -> bytes:
@@ -63,17 +428,109 @@ def _json_bytes(value: Any) -> bytes:
     ).encode("utf-8")
 
 
-def _load_json(path: Path, *, label: str) -> Any:
-    if path.is_symlink() or not path.is_file():
-        raise ValueError(f"{label} is not a regular file: {path}")
+def _json_file_signature(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _read_bounded_json(path: Path, *, label: str, max_bytes: int) -> bytearray:
+    if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes <= 0:
+        raise ValueError(f"{label} byte limit must be positive")
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        before_path = path.lstat()
+        if (
+            stat.S_ISLNK(before_path.st_mode)
+            or not stat.S_ISREG(before_path.st_mode)
+            or before_path.st_nlink != 1
+            or bool(
+                getattr(before_path, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT
+            )
+        ):
+            raise ValueError(f"{label} is not a private regular file: {path}")
+        if before_path.st_size > max_bytes:
+            raise ValueError(f"{label} exceeds its {max_bytes}-byte limit: {path}")
+
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        descriptor = os.open(path, flags)
+        try:
+            opened = os.fstat(descriptor)
+            if not stat.S_ISREG(opened.st_mode) or _json_file_signature(
+                opened
+            ) != _json_file_signature(before_path):
+                raise ValueError(f"{label} changed while opening: {path}")
+            payload = bytearray()
+            while True:
+                chunk = os.read(descriptor, _JSON_READ_CHUNK_BYTES)
+                if not chunk:
+                    break
+                payload.extend(chunk)
+                if len(payload) > max_bytes:
+                    raise ValueError(
+                        f"{label} exceeds its {max_bytes}-byte limit: {path}"
+                    )
+            after_open = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+        after_path = path.lstat()
+        if _json_file_signature(after_open) != _json_file_signature(
+            opened
+        ) or _json_file_signature(after_path) != _json_file_signature(opened):
+            raise ValueError(f"{label} changed while reading: {path}")
+        return payload
+    except OSError as exc:
+        raise ValueError(f"{label} is not readable: {path}") from exc
+
+
+def _load_json(
+    path: Path,
+    *,
+    label: str,
+    max_bytes: int,
+    require_canonical: bool = False,
+    reader: _OwnedViewReader | None = None,
+) -> Any:
+    payload = (
+        _read_bounded_json(path, label=label, max_bytes=max_bytes)
+        if reader is None
+        else reader.read_bytes(path, max_bytes=max_bytes)
+    )
+    try:
+        value = json.loads(
+            payload,
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+        )
+    except ValueError as exc:
         raise ValueError(f"{label} is invalid JSON: {path}") from exc
+    if require_canonical and payload != _json_bytes(value):
+        raise ValueError(f"{label} is not canonical JSON: {path}")
+    return value
 
 
-def _load_json_object(path: Path, *, label: str) -> dict[str, Any]:
-    value = _load_json(path, label=label)
+def _load_json_object(
+    path: Path,
+    *,
+    label: str,
+    max_bytes: int = _MAX_CONFIG_JSON_BYTES,
+    require_canonical: bool = False,
+    reader: _OwnedViewReader | None = None,
+) -> dict[str, Any]:
+    value = _load_json(
+        path,
+        label=label,
+        max_bytes=max_bytes,
+        require_canonical=require_canonical,
+        reader=reader,
+    )
     if not isinstance(value, dict):
         raise ValueError(f"{label} must be a JSON object: {path}")
     return value
@@ -99,14 +556,6 @@ def _owned_view_root(root: Path, repo_path: Path) -> tuple[Path, Path]:
             "portable query view must not overlap the source repository: " f"{resolved}"
         )
 
-    for path in sorted(resolved.rglob("*")):
-        relative = path.relative_to(resolved)
-        if path.is_symlink():
-            raise ValueError(f"portable query view contains a symlink: {relative}")
-        if not path.is_dir() and not path.is_file():
-            raise ValueError(
-                f"portable query view contains a non-regular entry: {relative}"
-            )
     return resolved, repository
 
 
@@ -122,8 +571,8 @@ def _portable_source_path(value: object, repo_path: Path, *, source: str) -> str
     path = Path(raw).expanduser()
     if path.is_absolute():
         try:
-            path = path.resolve().relative_to(repo_path)
-        except (OSError, RuntimeError, ValueError) as exc:
+            path = path.relative_to(repo_path)
+        except ValueError as exc:
             raise ValueError(f"{source} points outside the repository: {raw}") from exc
         raw = path.as_posix()
     else:
@@ -146,17 +595,26 @@ def _portable_source_path(value: object, repo_path: Path, *, source: str) -> str
         or raw != normalized.as_posix()
     ):
         raise ValueError(f"{source} is not repository-relative: {raw}")
+    try:
+        validate_repository_file(repo_path, normalized.as_posix())
+    except ValueError as exc:
+        raise ValueError(
+            f"{source} is not a stable contained source file: {raw}"
+        ) from exc
     return normalized.as_posix()
 
 
 def _normalize_pickle_documents(
     path: Path,
     repo_path: Path,
+    *,
+    reader: _OwnedViewReader,
 ) -> list[dict[str, Any]]:
     """Load documents from an explicitly trusted, machine-local pickle."""
 
     try:
-        with path.open("rb") as handle:
+        payload = reader.read_bytes(path, max_bytes=_MAX_DOCUMENTS_JSON_BYTES)
+        with io.BytesIO(payload) as handle:
             documents = compat_pickle.load(handle)
     except Exception as exc:
         raise ValueError(
@@ -177,6 +635,10 @@ def _normalize_pickle_documents(
             raise ValueError(
                 f"portable vector document {index} has invalid metadata: {path.name}"
             )
+        assert_no_secret_fields(
+            metadata,
+            source=f"portable vector document {index} metadata",
+        )
         normalized_metadata = dict(metadata)
         normalized_metadata["file"] = _portable_source_path(
             metadata.get("file"),
@@ -194,16 +656,24 @@ def _normalize_pickle_documents(
     return payload
 
 
-def _pickle_paths(root: Path) -> list[Path]:
+def _owned_inventory_paths(root: Path, ownership: object, *, kind: str) -> set[Path]:
+    return {
+        root.joinpath(*PurePosixPath(relative).parts)
+        for relative, observed_kind in directory_ownership_inventory(ownership)
+        if observed_kind == kind
+    }
+
+
+def _pickle_paths(root: Path, ownership: object) -> list[Path]:
     return sorted(
         path
-        for path in root.rglob("*")
-        if path.is_file() and path.suffix.casefold() in _PICKLE_SUFFIXES
+        for path in _owned_inventory_paths(root, ownership, kind="file")
+        if path.suffix.casefold() in _PICKLE_SUFFIXES
     )
 
 
-def _reject_inert_pickles(root: Path) -> None:
-    pickles = _pickle_paths(root)
+def _reject_inert_pickles(root: Path, ownership: object) -> None:
+    pickles = _pickle_paths(root, ownership)
     if pickles:
         raise ValueError(
             "portable-inert query view must not contain pickle: "
@@ -214,8 +684,15 @@ def _reject_inert_pickles(root: Path) -> None:
 def _normalize_json_documents(
     path: Path,
     repo_path: Path,
+    *,
+    reader: _OwnedViewReader | None = None,
 ) -> list[dict[str, Any]]:
-    documents = _load_json(path, label="portable vector documents")
+    documents = _load_json(
+        path,
+        label="portable vector documents",
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        reader=reader,
+    )
     if not isinstance(documents, list):
         raise ValueError(f"portable vector documents must be a JSON list: {path}")
 
@@ -235,6 +712,10 @@ def _normalize_json_documents(
                 "portable vector document "
                 f"{index} has invalid content or metadata: {path.name}"
             )
+        assert_no_secret_fields(
+            metadata,
+            source=f"portable vector document {index} metadata",
+        )
         raw_file = metadata.get("file")
         if raw_file is not None and not isinstance(raw_file, str):
             raise ValueError(
@@ -255,6 +736,58 @@ def _normalize_json_documents(
     return payload
 
 
+def _normalize_bm25_documents(
+    path: Path,
+    repo_path: Path,
+    *,
+    reader: _OwnedViewReader,
+) -> None:
+    documents = _load_json(
+        path,
+        label="portable BM25 documents",
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        reader=reader,
+    )
+    if not isinstance(documents, list):
+        raise ValueError(f"portable BM25 documents must be a JSON list: {path}")
+
+    normalized: list[dict[str, Any]] = []
+    for index, document in enumerate(documents):
+        if not isinstance(document, dict) or set(document) != {
+            "page_content",
+            "metadata",
+        }:
+            raise ValueError(
+                f"portable BM25 document {index} has invalid shape: {path.name}"
+            )
+        page_content = document["page_content"]
+        metadata = document["metadata"]
+        if not isinstance(page_content, str) or not isinstance(metadata, dict):
+            raise ValueError(
+                f"portable BM25 document {index} has invalid content or metadata"
+            )
+        assert_no_secret_fields(
+            metadata,
+            source=f"portable BM25 document {index} metadata",
+        )
+        raw_file = metadata.get("file")
+        if raw_file is not None and not isinstance(raw_file, str):
+            raise ValueError(
+                f"portable BM25 document {index} has an invalid source path"
+            )
+        normalized_metadata = dict(metadata)
+        if raw_file is not None:
+            normalized_metadata["file"] = _portable_source_path(
+                raw_file,
+                repo_path,
+                source=f"BM25 document {index} file",
+            )
+        normalized.append(
+            {"page_content": page_content, "metadata": normalized_metadata}
+        )
+    path.write_bytes(_json_bytes(normalized))
+
+
 def _is_mutable_vector_state(path: Path) -> bool:
     name = path.name.lower()
     return (
@@ -267,6 +800,7 @@ def _is_mutable_vector_state(path: Path) -> bool:
 def _validate_vector_model_policy(
     root: Path,
     *,
+    ownership: object,
     model_suffix: str,
     source_trust: SourceTrust,
 ) -> None:
@@ -285,9 +819,10 @@ def _validate_vector_model_policy(
                 root / level / f"index_{model_suffix}.pkl",
             }
         )
+    inventory_files = _owned_inventory_paths(root, ownership, kind="file")
     unexpected_model_artifacts = sorted(
         path
-        for path in root.rglob("*")
+        for path in inventory_files
         if path.name.casefold().startswith(("config_", "documents_", "index_"))
         and path not in allowed_model_artifacts
     )
@@ -297,9 +832,9 @@ def _validate_vector_model_policy(
             f"{unexpected_model_artifacts[0].relative_to(root)}"
         )
 
-    pickles = _pickle_paths(root)
+    pickles = _pickle_paths(root, ownership)
     if source_trust == "portable-inert":
-        _reject_inert_pickles(root)
+        _reject_inert_pickles(root, ownership)
         return
 
     allowed_pickles = {
@@ -457,12 +992,20 @@ def _validate_vector_semantics(
     )
 
 
-def _faiss_contract(path: Path) -> tuple[int, int, str, str, bool]:
+def _faiss_contract(
+    path: Path,
+    *,
+    reader: _OwnedViewReader | None = None,
+) -> tuple[int, int, str, str, bool]:
     """Read the persisted index contract, importing FAISS on demand."""
 
     try:
         faiss = importlib.import_module("faiss")
-        index = faiss.read_index(str(path))
+        index = (
+            faiss.read_index(str(path))
+            if reader is None
+            else reader.faiss_index(path, faiss)
+        )
         dimension = int(index.d)
         total = int(index.ntotal)
         is_trained = bool(index.is_trained)
@@ -495,10 +1038,35 @@ def _validate_level_semantics(
     metric: object,
     index_type: str,
     count: int,
+    canonicalize: bool = True,
+    reader: _OwnedViewReader | None = None,
 ) -> None:
     if not path.exists():
         return
-    config = _load_json_object(path, label=f"portable vector {level} config")
+    config = _load_json_object(
+        path,
+        label=f"portable vector {level} config",
+        require_canonical=not canonicalize,
+        reader=reader,
+    )
+    assert_no_secret_fields(
+        config,
+        source=f"portable vector {level} config",
+    )
+    expected_fields = {
+        "embedding_model",
+        "embedding_provider",
+        "embedding_revision",
+        "dimension",
+        "index_type",
+        "index_metric",
+        "level",
+        "num_documents",
+    }
+    if set(config) != expected_fields:
+        raise ValueError(
+            f"portable vector {level} persistence config has an invalid shape"
+        )
     checks: tuple[tuple[str, object], ...] = (
         ("embedding_model", model),
         ("embedding_revision", revision),
@@ -523,12 +1091,15 @@ def _validate_level_semantics(
         ) from exc
     if persisted_provider != provider:
         raise ValueError(f"portable vector {level} persistence provider does not match")
+    if canonicalize:
+        path.write_bytes(_json_bytes(config))
 
 
 def _validate_vector_layout(
     root: Path,
     repo_path: Path,
     *,
+    ownership: object,
     model_suffix: str,
     config: Mapping[str, Any],
     expected_model: str,
@@ -538,6 +1109,8 @@ def _validate_vector_layout(
     expected_metric: str,
     expected_index_type: str,
     source_trust: SourceTrust,
+    canonicalize_level_configs: bool = True,
+    reader: _OwnedViewReader | None = None,
 ) -> tuple[
     str,
     dict[Path, list[dict[str, Any]]],
@@ -561,6 +1134,7 @@ def _validate_vector_layout(
 
     derived_counts: dict[str, int] = {}
     stale_paths: set[Path] = set()
+    inventory_files = _owned_inventory_paths(root, ownership, kind="file")
 
     for level in _VECTOR_LEVELS:
         count = config.get(f"{level}_documents") if not legacy_counts else None
@@ -573,7 +1147,7 @@ def _validate_vector_layout(
         level_path = root / level
         pickle_path = level_path / f"documents_{model_suffix}.pkl"
         json_path = level_path / f"documents_{model_suffix}.json"
-        present = [path for path in (pickle_path, json_path) if path.is_file()]
+        present = [path for path in (pickle_path, json_path) if path in inventory_files]
         expected_documents.update(present)
         index_path = level_path / f"index_{model_suffix}.faiss"
 
@@ -590,7 +1164,7 @@ def _validate_vector_layout(
                     level_path / f"index_{model_suffix}.pkl",
                     level_path / f"config_{model_suffix}.json",
                 )
-                if path.is_file()
+                if path in inventory_files
             )
             derived_counts[level] = 0
             continue
@@ -604,13 +1178,13 @@ def _validate_vector_layout(
             )
         if not present and count is None:
             if (
-                index_path.exists()
-                or (level_path / f"config_{model_suffix}.json").exists()
+                index_path in inventory_files
+                or (level_path / f"config_{model_suffix}.json") in inventory_files
             ):
                 raise ValueError(f"portable legacy vector {level} level is incomplete")
             derived_counts[level] = 0
             continue
-        if index_path.is_symlink() or not index_path.is_file():
+        if index_path not in inventory_files:
             raise ValueError(f"portable vector view is missing its index: {index_path}")
 
         path = present[0]
@@ -620,16 +1194,25 @@ def _validate_vector_layout(
                 raise ValueError(
                     "portable-inert vector view must not deserialize documents"
                 )
-            payload = _normalize_pickle_documents(path, repo_path)
+            if reader is None:
+                raise RuntimeError(
+                    "trusted-local vector normalization requires an owned reader"
+                )
+            payload = _normalize_pickle_documents(path, repo_path, reader=reader)
         else:
-            payload = _normalize_json_documents(path, repo_path)
+            payload = _normalize_json_documents(path, repo_path, reader=reader)
         if count is not None and len(payload) != count:
             raise ValueError(
                 f"portable vector {level} count differs from {path.name}: "
                 f"expected {count}, found {len(payload)}"
             )
         count = len(payload)
-        dimension, total, metric, index_type, is_trained = _faiss_contract(index_path)
+        if reader is not None:
+            reader.pin_file(index_path)
+        dimension, total, metric, index_type, is_trained = _faiss_contract(
+            index_path,
+            reader=reader,
+        )
         if dimension != expected_dimension:
             raise ValueError(
                 f"portable vector FAISS dimension mismatch in {level}: "
@@ -650,7 +1233,7 @@ def _validate_vector_layout(
                     level_path / f"index_{model_suffix}.pkl",
                     level_path / f"config_{model_suffix}.json",
                 )
-                if candidate.is_file()
+                if candidate in inventory_files
             )
             continue
         if metric != expected_metric:
@@ -677,6 +1260,8 @@ def _validate_vector_layout(
             metric=expected_metric,
             index_type=expected_index_type,
             count=count,
+            canonicalize=canonicalize_level_configs,
+            reader=reader,
         )
         formats.add(document_format)
         selected[path] = payload
@@ -688,8 +1273,9 @@ def _validate_vector_layout(
 
     candidates = {
         path
-        for path in root.rglob("documents_*")
+        for path in inventory_files
         if path.suffix.casefold() in {".json", ".pkl", ".pickle"}
+        and path.name.startswith("documents_")
     }
     unexpected_documents = sorted(candidates - expected_documents)
     if unexpected_documents:
@@ -703,16 +1289,20 @@ def _validate_vector_layout(
         path for path in stale_paths if path.suffix.casefold() in _PICKLE_SUFFIXES
     )
     allowed_pickles.update(
-        path for path in root.glob("l[02]/index_*.pkl") if path.is_file()
+        path
+        for path in inventory_files
+        if path.parent.name in _VECTOR_LEVELS
+        and path.name.startswith("index_")
+        and path.suffix.casefold() == ".pkl"
     )
     allowed_pickles.update(
         root / name
         for name in _REMOVABLE_MUTABLE_VECTOR_FILES
-        if name.endswith(".pkl") and (root / name).is_file()
+        if name.endswith(".pkl") and (root / name) in inventory_files
     )
     residual_pickles = sorted(
         path
-        for path in root.rglob("*")
+        for path in inventory_files
         if path.suffix.casefold() in _PICKLE_SUFFIXES and path not in allowed_pickles
     )
     if residual_pickles:
@@ -724,9 +1314,8 @@ def _validate_vector_layout(
     removable_mutable = {root / name for name in _REMOVABLE_MUTABLE_VECTOR_FILES}
     residual_mutable = sorted(
         path
-        for path in root.rglob("*")
-        if _is_mutable_vector_state(path)
-        and (path not in removable_mutable or not path.is_file())
+        for path in inventory_files
+        if _is_mutable_vector_state(path) and path not in removable_mutable
     )
     if residual_mutable:
         raise ValueError(
@@ -743,23 +1332,54 @@ def _refresh_vector_persistence_records(
     model_suffix: str,
 ) -> None:
     config_path = root / f"config_{model_suffix}.json"
-    config = _load_json_object(config_path, label="portable vector config")
-    level_artifacts: dict[str, dict[str, dict[str, Any]]] = {}
-    for level in _VECTOR_LEVELS:
-        count = config.get(f"{level}_documents")
-        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
-            raise ValueError(
-                f"portable vector config has invalid {level} count: {count!r}"
-            )
-        if count == 0:
-            continue
-        level_path = root / level
-        documents_path = level_path / f"documents_{model_suffix}.json"
-        level_artifacts[level] = vector_level_artifact_records(
-            level_path,
-            model_suffix,
-            documents_file=documents_path.name,
+    try:
+        ownership = capture_directory_ownership(root)
+        reader = _OwnedViewReader(root, ownership)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            "portable vector view could not be captured before refreshing records"
+        ) from exc
+    try:
+        config = _load_json_object(
+            config_path,
+            label="portable vector config",
+            reader=reader,
         )
+        assert_no_secret_fields(config, source="portable vector config")
+        level_artifacts: dict[str, dict[str, dict[str, Any]]] = {}
+        for level in _VECTOR_LEVELS:
+            count = config.get(f"{level}_documents")
+            if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+                raise ValueError(
+                    f"portable vector config has invalid {level} count: {count!r}"
+                )
+            if count == 0:
+                continue
+            level_path = root / level
+            documents_path = level_path / f"documents_{model_suffix}.json"
+            index_path = level_path / f"index_{model_suffix}.faiss"
+            index_record = reader.fingerprint(index_path)
+            index_record["file"] = index_path.name
+            documents_record = reader.fingerprint(
+                documents_path,
+                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+            )
+            documents_record["file"] = documents_path.name
+            level_artifacts[level] = {
+                "index": index_record,
+                "documents": documents_record,
+            }
+        reader.verify_root()
+        try:
+            recorded_tree = capture_directory_ownership(root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(
+                "portable vector view changed while refreshing records"
+            ) from exc
+        if recorded_tree != ownership:
+            raise RuntimeError("portable vector view changed while refreshing records")
+    finally:
+        reader.close()
     config["persistence_schema"] = VECTOR_PERSISTENCE_SCHEMA
     config["level_artifacts"] = level_artifacts
     config_path.write_bytes(_json_bytes(config))
@@ -795,29 +1415,91 @@ def _validate_view_document_count(
             )
 
 
-def _assert_normalized_vector_tree(root: Path) -> None:
-    for path in sorted(root.rglob("*")):
-        if path.suffix.casefold() in _PICKLE_SUFFIXES:
-            raise ValueError(
-                "portable vector normalization left a pickle behind: "
-                f"{path.relative_to(root)}"
-            )
-        if _is_mutable_vector_state(path):
-            raise ValueError(
-                "portable vector normalization left mutable state behind: "
-                f"{path.relative_to(root)}"
-            )
+def _assert_exact_view_tree(
+    *,
+    ownership: object,
+    allowed_files: set[PurePosixPath],
+    required_files: set[PurePosixPath],
+    label: str,
+) -> None:
+    allowed_directories = {
+        parent
+        for path in allowed_files
+        for parent in path.parents
+        if parent != PurePosixPath(".")
+    }
+    observed_files: set[PurePosixPath] = set()
+    for raw_relative, kind in directory_ownership_inventory(ownership):
+        relative = PurePosixPath(raw_relative)
+        if kind == "directory":
+            if relative not in allowed_directories:
+                raise ValueError(
+                    f"{label} contains an unexpected directory: {relative}"
+                )
+            continue
+        if relative not in allowed_files:
+            raise ValueError(f"{label} contains an unexpected file: {relative}")
+        observed_files.add(relative)
+
+    missing = sorted(required_files - observed_files, key=str)
+    if missing:
+        raise ValueError(f"{label} is missing a required file: {missing[0]}")
+
+
+def _assert_normalized_vector_tree(
+    *,
+    ownership: object,
+    model_suffix: str,
+    counts: Mapping[str, int],
+) -> None:
+    root_config = PurePosixPath(f"config_{model_suffix}.json")
+    allowed_files = {root_config}
+    required_files = {root_config}
+    for level in _VECTOR_LEVELS:
+        if counts[level] <= 0:
+            continue
+        level_path = PurePosixPath(level)
+        documents = level_path / f"documents_{model_suffix}.json"
+        index = level_path / f"index_{model_suffix}.faiss"
+        allowed_files.update(
+            {
+                level_path / f"config_{model_suffix}.json",
+                documents,
+                index,
+            }
+        )
+        required_files.update({documents, index})
+    _assert_exact_view_tree(
+        ownership=ownership,
+        allowed_files=allowed_files,
+        required_files=required_files,
+        label="portable vector view",
+    )
 
 
 def _normalize_vector_view(
     root: Path,
     repo_path: Path,
     *,
+    initial_tree: object,
+    reader: _OwnedViewReader,
     view_config: Mapping[str, Any],
     source_trust: SourceTrust,
 ) -> dict[str, Any]:
-    require_complete_vector_view(root)
-    interrupted = sorted(root.glob(".config_*.json.save-in-progress"))
+    assert_no_secret_fields(view_config, source="portable vector view config")
+    initial_files = _owned_inventory_paths(root, initial_tree, kind="file")
+    if root / VECTOR_VIEW_UPDATE_MARKER in initial_files:
+        raise ValueError(
+            "portable vector view has an incomplete update marker: "
+            f"{VECTOR_VIEW_UPDATE_MARKER}"
+        )
+    interrupted = sorted(
+        path
+        for path in initial_files
+        if path.parent == root
+        and path.name.startswith(".config_")
+        and path.name.endswith(".json.save-in-progress")
+    )
     if interrupted:
         raise ValueError(
             "portable vector view contains an interrupted save marker: "
@@ -828,21 +1510,35 @@ def _normalize_vector_view(
     model_suffix = route.model.replace("/", "__")
     _validate_vector_model_policy(
         root,
+        ownership=initial_tree,
         model_suffix=model_suffix,
         source_trust=source_trust,
     )
     expected_config = view_config.get("persistence_config_fingerprint")
-    if expected_config is not None:
-        validate_vector_config_artifact(
-            root,
-            model_suffix,
-            expected_config,
-        )
-    # Validate the committed source generation before replacing any trusted-local
-    # pickle or refreshing records. Otherwise normalization could bless torn files.
-    validate_vector_generation_artifacts(root, model_suffix)
     config_path = root / f"config_{model_suffix}.json"
-    config = _load_json_object(config_path, label="portable vector config")
+    if expected_config is not None:
+        config = _authenticate_vector_generation(
+            reader,
+            root,
+            model_suffix=model_suffix,
+            expected_config=expected_config,
+            require_canonical=False,
+        )
+    else:
+        config = _load_json_object(
+            config_path,
+            label="portable vector config",
+            reader=reader,
+        )
+        if config.get("persistence_schema") is not None:
+            config = _authenticate_vector_generation(
+                reader,
+                root,
+                model_suffix=model_suffix,
+                expected_config=None,
+                require_canonical=False,
+            )
+    assert_no_secret_fields(config, source="portable vector config")
     (
         semantic_suffix,
         expected_dimension,
@@ -856,6 +1552,7 @@ def _normalize_vector_view(
     document_format, documents, counts, stale_paths = _validate_vector_layout(
         root,
         repo_path,
+        ownership=initial_tree,
         model_suffix=model_suffix,
         config=config,
         expected_model=route.model,
@@ -865,8 +1562,11 @@ def _normalize_vector_view(
         expected_metric=expected_metric,
         expected_index_type=expected_index_type,
         source_trust=source_trust,
+        reader=reader,
     )
     _validate_view_document_count(view_config, counts)
+    reader.verify_root()
+    reader.close()
 
     for path, payload in documents.items():
         output = path.with_suffix(".json")
@@ -891,20 +1591,141 @@ def _normalize_vector_view(
     # mutable state was rejected before mutation.
     for name in _REMOVABLE_MUTABLE_VECTOR_FILES:
         (root / name).unlink(missing_ok=True)
-    for legacy in root.glob("l[02]/index_*.pkl"):
-        legacy.unlink()
+    for legacy in sorted(
+        path
+        for path in initial_files
+        if path.parent.parent == root
+        and path.parent.name in _VECTOR_LEVELS
+        and path.name.startswith("index_")
+        and path.suffix.casefold() == ".pkl"
+    ):
+        legacy.unlink(missing_ok=True)
 
     _refresh_vector_persistence_records(root, model_suffix=model_suffix)
-    _assert_normalized_vector_tree(root)
-    validate_vector_generation_artifacts(root, model_suffix)
+    try:
+        final_tree = capture_directory_ownership(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            "portable vector view could not be captured after normalization"
+        ) from exc
+    _assert_normalized_vector_tree(
+        ownership=final_tree,
+        model_suffix=model_suffix,
+        counts=counts,
+    )
+    try:
+        fingerprint_reader = _OwnedViewReader(root, final_tree)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            "portable vector view could not be opened after normalization"
+        ) from exc
+    try:
+        config_record = fingerprint_reader.fingerprint(
+            config_path,
+            max_bytes=_MAX_CONFIG_JSON_BYTES,
+        )
+        config_record["file"] = config_path.name
+        fingerprint_reader.verify_root()
+        try:
+            fingerprint_tree = capture_directory_ownership(root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(
+                "portable vector view changed while recording its fingerprint"
+            ) from exc
+        if fingerprint_tree != final_tree:
+            raise RuntimeError(
+                "portable vector view changed while recording its fingerprint"
+            )
+    finally:
+        fingerprint_reader.close()
     return {
         "artifact_scope": "query-serving",
         "portable_document_format": "codenib.vector-documents.v1",
-        "persistence_config_fingerprint": vector_config_artifact_record(
-            root,
-            model_suffix,
-        ),
+        "persistence_config_fingerprint": config_record,
     }
+
+
+def _normalize_bm25_view(
+    root: Path,
+    repo_path: Path,
+    *,
+    initial_tree: object,
+    reader: _OwnedViewReader,
+) -> dict[str, Any]:
+    _reject_inert_pickles(root, initial_tree)
+    documents_path = root / "documents.json"
+    _normalize_bm25_documents(documents_path, repo_path, reader=reader)
+    metadata_path = root / "bm25_metadata.json"
+    metadata = _load_json_object(
+        metadata_path,
+        label="portable BM25 metadata",
+        reader=reader,
+    )
+    assert_no_secret_fields(metadata, source="portable BM25 metadata")
+    if not set(metadata) <= {"project_root", "max_k", "language"}:
+        raise ValueError("portable BM25 metadata has an invalid shape")
+    max_k = metadata.get("max_k", 10)
+    if isinstance(max_k, bool) or not isinstance(max_k, int) or max_k <= 0:
+        raise ValueError("portable BM25 metadata max_k must be positive")
+    language = metadata.get("language", "english")
+    if (
+        not isinstance(language, str)
+        or not language.strip()
+        or "\x00" in language
+        or len(language) > 256
+    ):
+        raise ValueError("portable BM25 metadata language is invalid")
+    if metadata.get("project_root") is not None and not isinstance(
+        metadata.get("project_root"), str
+    ):
+        raise ValueError("portable BM25 metadata project_root is invalid")
+    metadata.update({"project_root": "source", "max_k": max_k, "language": language})
+    reader.verify_root()
+    reader.close()
+
+    metadata_path.write_bytes(_json_bytes(metadata))
+    expected_files = {
+        PurePosixPath("documents.json"),
+        PurePosixPath("bm25_metadata.json"),
+    }
+    try:
+        normalized_tree = capture_directory_ownership(root)
+        fingerprint_reader = _OwnedViewReader(root, normalized_tree)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            "portable BM25 view could not be captured after normalization"
+        ) from exc
+    try:
+        _assert_exact_view_tree(
+            ownership=normalized_tree,
+            allowed_files=expected_files,
+            required_files=expected_files,
+            label="portable BM25 view",
+        )
+        fingerprints = {
+            "documents.json": fingerprint_reader.fingerprint(
+                documents_path,
+                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+            ),
+            "bm25_metadata.json": fingerprint_reader.fingerprint(
+                metadata_path,
+                max_bytes=_MAX_CONFIG_JSON_BYTES,
+            ),
+        }
+        fingerprint_reader.verify_root()
+        try:
+            final_tree = capture_directory_ownership(root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(
+                "portable BM25 view changed while recording its fingerprints"
+            ) from exc
+        if final_tree != normalized_tree:
+            raise RuntimeError(
+                "portable BM25 view changed while recording its fingerprints"
+            )
+    finally:
+        fingerprint_reader.close()
+    return {"artifact_file_fingerprints": fingerprints}
 
 
 def normalize_owned_query_view(
@@ -928,27 +1749,435 @@ def normalize_owned_query_view(
     }:
         raise ValueError(f"invalid portable query view source trust: {source_trust!r}")
     normalized_root, repository = _owned_view_root(root, repo_path)
-    if view_type == "vector":
-        return _normalize_vector_view(
-            normalized_root,
-            repository,
-            view_config=view_config,
-            source_trust=source_trust,
-        )
-    if view_type != "bm25":
+    try:
+        initial_tree = capture_directory_ownership(normalized_root)
+        reader = _OwnedViewReader(normalized_root, initial_tree)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError("portable query view could not be captured safely") from exc
+    try:
+        if view_type == "vector":
+            return _normalize_vector_view(
+                normalized_root,
+                repository,
+                initial_tree=initial_tree,
+                reader=reader,
+                view_config=view_config,
+                source_trust=source_trust,
+            )
+        if view_type == "bm25":
+            return _normalize_bm25_view(
+                normalized_root,
+                repository,
+                initial_tree=initial_tree,
+                reader=reader,
+            )
         raise ValueError(
             f"view {view_type!r} is not yet supported by portable query views; "
             "select bm25 and/or vector"
         )
+    finally:
+        reader.close()
 
-    _reject_inert_pickles(normalized_root)
-    metadata_path = normalized_root / "bm25_metadata.json"
-    metadata = _load_json_object(metadata_path, label="portable BM25 metadata")
-    metadata["project_root"] = "source"
-    metadata_path.write_bytes(_json_bytes(metadata))
-    return {
-        "artifact_file_fingerprints": bm25_artifact_file_fingerprints(normalized_root)
+
+def _validate_normalized_document_sources(
+    path: Path,
+    repo_path: Path,
+    *,
+    view_type: str,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+    reader: _OwnedViewReader | None = None,
+) -> None:
+    documents = _load_json(
+        path,
+        label=f"portable {view_type} documents",
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        require_canonical=True,
+        reader=reader,
+    )
+    if not isinstance(documents, list):
+        raise ValueError(f"portable {view_type} documents must be a JSON list: {path}")
+    for index, document in enumerate(documents):
+        if not isinstance(document, dict) or set(document) != {
+            "page_content",
+            "metadata",
+        }:
+            raise ValueError(
+                f"portable {view_type} document {index} has an invalid shape"
+            )
+        if not isinstance(document["page_content"], str) or not isinstance(
+            document["metadata"], dict
+        ):
+            raise ValueError(
+                f"portable {view_type} document {index} has invalid content or metadata"
+            )
+        metadata = document["metadata"]
+        assert_no_secret_fields(
+            metadata,
+            source=f"portable {view_type} document {index} metadata",
+        )
+        assert_publishable_json_value(
+            metadata,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+            label=f"portable {view_type} document {index} metadata",
+        )
+        raw_file = metadata.get("file")
+        if raw_file is not None and not isinstance(raw_file, str):
+            raise ValueError(
+                f"portable {view_type} document {index} has an invalid source path"
+            )
+        if raw_file is not None:
+            normalized_file = _portable_source_path(
+                raw_file,
+                repo_path,
+                source=f"portable {view_type} document {index} file",
+            )
+            if raw_file != normalized_file:
+                raise ValueError(
+                    f"portable {view_type} document {index} file is not normalized"
+                )
+
+
+def _authenticate_vector_generation(
+    reader: _OwnedViewReader,
+    root: Path,
+    *,
+    model_suffix: str,
+    expected_config: object | None,
+    require_canonical: bool = True,
+) -> dict[str, Any]:
+    config_path = root / f"config_{model_suffix}.json"
+    if expected_config is not None:
+        try:
+            reader.authenticate(
+                config_path,
+                expected_config,
+                cache_bytes=True,
+                max_bytes=_MAX_CONFIG_JSON_BYTES,
+            )
+        except ValueError as exc:
+            raise ValueError(
+                "portable vector config does not match its manifest fingerprint"
+            ) from exc
+    config = _load_json_object(
+        config_path,
+        label="portable vector config",
+        require_canonical=require_canonical,
+        reader=reader,
+    )
+    if config.get("persistence_schema") != VECTOR_PERSISTENCE_SCHEMA:
+        raise ValueError("portable vector generation has an invalid persistence schema")
+    committed = config.get("level_artifacts")
+    if not isinstance(committed, Mapping) or not set(committed) <= set(_VECTOR_LEVELS):
+        raise ValueError("portable vector generation has invalid committed levels")
+    for level in _VECTOR_LEVELS:
+        count = config.get(f"{level}_documents")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError(f"portable vector generation has invalid {level} count")
+        records = committed.get(level)
+        if count == 0:
+            if records is not None:
+                raise ValueError(
+                    f"portable vector generation commits empty {level} artifacts"
+                )
+            continue
+        if not isinstance(records, Mapping) or set(records) != {
+            "index",
+            "documents",
+        }:
+            raise ValueError(
+                f"portable vector generation has invalid {level} artifacts"
+            )
+        index_name = f"index_{model_suffix}.faiss"
+        json_documents_name = f"documents_{model_suffix}.json"
+        allowed_documents_names = {json_documents_name}
+        if not require_canonical:
+            allowed_documents_names.add(f"documents_{model_suffix}.pkl")
+        index_record = records["index"]
+        documents_record = records["documents"]
+        if (
+            not isinstance(index_record, Mapping)
+            or index_record.get("file") != index_name
+        ):
+            raise ValueError(f"portable vector generation has invalid {level} index")
+        if (
+            not isinstance(documents_record, Mapping)
+            or documents_record.get("file") not in allowed_documents_names
+        ):
+            raise ValueError(
+                f"portable vector generation has invalid {level} documents"
+            )
+        try:
+            reader.authenticate(
+                root / level / str(documents_record["file"]),
+                documents_record,
+                cache_bytes=True,
+                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"committed documents vector artifact is invalid in {level}"
+            ) from exc
+        reader.authenticate(
+            root / level / index_name,
+            index_record,
+            cache_bytes=False,
+            keep_descriptor=True,
+        )
+    return config
+
+
+def _validate_portable_bm25_view(
+    root: Path,
+    repository: Path,
+    *,
+    view_config: Mapping[str, Any],
+    forbidden: tuple[Path, ...],
+    environment: Mapping[str, str],
+    initial_tree: object,
+    reader: _OwnedViewReader,
+) -> None:
+    assert_no_secret_fields(view_config, source="portable BM25 view config")
+    fingerprints = view_config.get("artifact_file_fingerprints")
+    if not isinstance(fingerprints, Mapping) or set(fingerprints) != {
+        "documents.json",
+        "bm25_metadata.json",
+    }:
+        raise ValueError(
+            "portable BM25 validation requires complete artifact file fingerprints"
+        )
+    expected_files = {
+        PurePosixPath("documents.json"),
+        PurePosixPath("bm25_metadata.json"),
     }
+    _assert_exact_view_tree(
+        ownership=initial_tree,
+        allowed_files=expected_files,
+        required_files=expected_files,
+        label="portable BM25 view",
+    )
+    reader.authenticate(
+        root / "documents.json",
+        fingerprints["documents.json"],
+        cache_bytes=True,
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+    )
+    reader.authenticate(
+        root / "bm25_metadata.json",
+        fingerprints["bm25_metadata.json"],
+        cache_bytes=True,
+        max_bytes=_MAX_CONFIG_JSON_BYTES,
+    )
+    metadata = _load_json_object(
+        root / "bm25_metadata.json",
+        label="portable BM25 metadata",
+        require_canonical=True,
+        reader=reader,
+    )
+    assert_no_secret_fields(metadata, source="portable BM25 metadata")
+    assert_publishable_json_value(
+        metadata,
+        forbidden_paths=forbidden,
+        environ=environment,
+        label="portable BM25 metadata",
+    )
+    if set(metadata) != {"project_root", "max_k", "language"}:
+        raise ValueError("portable BM25 metadata has an invalid normalized shape")
+    if metadata.get("project_root") != "source":
+        raise ValueError("portable BM25 metadata project_root is not normalized")
+    if (
+        isinstance(metadata.get("max_k"), bool)
+        or not isinstance(metadata.get("max_k"), int)
+        or metadata["max_k"] <= 0
+        or not isinstance(metadata.get("language"), str)
+        or not metadata["language"].strip()
+        or "\x00" in metadata["language"]
+        or len(metadata["language"]) > 256
+    ):
+        raise ValueError("portable BM25 metadata is invalid")
+    _validate_normalized_document_sources(
+        root / "documents.json",
+        repository,
+        view_type="BM25",
+        forbidden_paths=forbidden,
+        environ=environment,
+        reader=reader,
+    )
 
 
-__all__ = ["SourceTrust", "normalize_owned_query_view"]
+def _validate_portable_vector_view(
+    root: Path,
+    repository: Path,
+    *,
+    view_config: Mapping[str, Any],
+    forbidden: tuple[Path, ...],
+    environment: Mapping[str, str],
+    initial_tree: object,
+    reader: _OwnedViewReader,
+) -> None:
+    assert_no_secret_fields(view_config, source="portable vector view config")
+    route = resolve_embedding_artifact_route(view_config)
+    expected_suffix = route.model.replace("/", "__")
+    inventory_files = _owned_inventory_paths(root, initial_tree, kind="file")
+    root_configs = sorted(
+        path
+        for path in inventory_files
+        if path.parent == root
+        and path.name.startswith("config_")
+        and path.name.endswith(".json")
+    )
+    if len(root_configs) != 1:
+        raise ValueError("portable vector view must contain one root config")
+    config_path = root_configs[0]
+    model_suffix = config_path.name[len("config_") : -len(".json")]
+    if not model_suffix or model_suffix != expected_suffix:
+        raise ValueError("portable vector root config does not match its view model")
+    _validate_vector_model_policy(
+        root,
+        ownership=initial_tree,
+        model_suffix=model_suffix,
+        source_trust="portable-inert",
+    )
+    expected_config = view_config.get("persistence_config_fingerprint")
+    if expected_config is None:
+        raise ValueError("portable vector validation requires its config fingerprint")
+    config = _authenticate_vector_generation(
+        reader,
+        root,
+        model_suffix=model_suffix,
+        expected_config=expected_config,
+    )
+    assert_no_secret_fields(config, source="portable vector config")
+    assert_publishable_json_value(
+        config,
+        forbidden_paths=forbidden,
+        environ=environment,
+        label="portable vector config",
+    )
+    (
+        semantic_suffix,
+        expected_dimension,
+        expected_revision,
+        expected_metric,
+        expected_index_type,
+    ) = _validate_vector_semantics(config, view_config)
+    if semantic_suffix != model_suffix:
+        raise ValueError("portable vector config embedding model does not match")
+    document_format, _documents, counts, stale_paths = _validate_vector_layout(
+        root,
+        repository,
+        ownership=initial_tree,
+        model_suffix=model_suffix,
+        config=config,
+        expected_model=route.model,
+        expected_provider=route.provider,
+        expected_revision=expected_revision,
+        expected_dimension=expected_dimension,
+        expected_metric=expected_metric,
+        expected_index_type=expected_index_type,
+        source_trust="portable-inert",
+        canonicalize_level_configs=False,
+        reader=reader,
+    )
+    if document_format != "json" or stale_paths:
+        raise ValueError("portable vector view is not in its normalized final form")
+    _validate_view_document_count(view_config, counts)
+    _assert_normalized_vector_tree(
+        ownership=initial_tree,
+        model_suffix=model_suffix,
+        counts=counts,
+    )
+    for level in _VECTOR_LEVELS:
+        if counts[level] <= 0:
+            continue
+        level_root = root / level
+        level_config = level_root / f"config_{model_suffix}.json"
+        if level_config in inventory_files:
+            assert_publishable_json_value(
+                _load_json_object(
+                    level_config,
+                    label=f"portable vector {level} config",
+                    require_canonical=True,
+                    reader=reader,
+                ),
+                forbidden_paths=forbidden,
+                environ=environment,
+                label=f"portable vector {level} config",
+            )
+        _validate_normalized_document_sources(
+            level_root / f"documents_{model_suffix}.json",
+            repository,
+            view_type=f"vector {level}",
+            forbidden_paths=forbidden,
+            environ=environment,
+            reader=reader,
+        )
+
+
+def validate_portable_query_view(
+    root: Path,
+    *,
+    repo_path: Path,
+    view_type: str,
+    view_config: Mapping[str, Any] | None = None,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    """Revalidate a normalized query view without mutating its bytes."""
+
+    normalized_root, repository = _owned_view_root(root, repo_path)
+    if view_type not in {"bm25", "vector"}:
+        raise ValueError(f"unsupported portable query view: {view_type!r}")
+    if not isinstance(view_config, Mapping):
+        raise ValueError(f"portable {view_type} validation requires its view config")
+    try:
+        initial_tree = capture_directory_ownership(normalized_root)
+        reader = _OwnedViewReader(normalized_root, initial_tree)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            f"portable {view_type} view could not be captured safely"
+        ) from exc
+    environment = os.environ if environ is None else environ
+    forbidden = (repository, *tuple(forbidden_paths))
+    try:
+        if view_type == "bm25":
+            _validate_portable_bm25_view(
+                normalized_root,
+                repository,
+                view_config=view_config,
+                forbidden=forbidden,
+                environment=environment,
+                initial_tree=initial_tree,
+                reader=reader,
+            )
+        else:
+            _validate_portable_vector_view(
+                normalized_root,
+                repository,
+                view_config=view_config,
+                forbidden=forbidden,
+                environment=environment,
+                initial_tree=initial_tree,
+                reader=reader,
+            )
+        reader.verify_root()
+        try:
+            final_tree = capture_directory_ownership(normalized_root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(
+                f"portable {view_type} view changed during semantic validation"
+            ) from exc
+        if final_tree != initial_tree:
+            raise RuntimeError(
+                f"portable {view_type} view changed during semantic validation"
+            )
+    finally:
+        reader.close()
+
+
+__all__ = [
+    "SourceTrust",
+    "normalize_owned_query_view",
+    "validate_portable_query_view",
+]

--- a/codenib/artifacts/runtime.py
+++ b/codenib/artifacts/runtime.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
 
+from .._contained_source import validate_repository_file
 from ..compiler.checkout_identity import checkout_commit
 from ..compiler.manifest import MANIFEST_FILENAME, MANIFEST_VERSION, RepoManifest
 from ..compiler.snapshot_store import normalize_repo
@@ -30,6 +31,7 @@ _REPOSITORY_RE = re.compile(r"^[a-z0-9_.-]+(?:/[a-z0-9_.-]+)*$")
 _DEFAULT_MAX_FILES = 100_000
 _DEFAULT_MAX_BYTES = 64 * 1024 * 1024 * 1024
 _MAX_METADATA_BYTES = 16 * 1024 * 1024
+_MAX_DOCUMENTS_BYTES = 256 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -276,7 +278,7 @@ def _validate_view_payloads(
         metadata = _load_json_object(
             root / metadata_relative,
             label="portable BM25 metadata",
-            max_bytes=inventory[metadata_relative][0],
+            max_bytes=_MAX_METADATA_BYTES,
         )
         if metadata.get("project_root") != "source":
             raise ValueError("portable BM25 project root must be 'source'")
@@ -284,7 +286,7 @@ def _validate_view_payloads(
             _document_source_paths(
                 root / documents_relative,
                 label="portable BM25 documents",
-                max_bytes=inventory[documents_relative][0],
+                max_bytes=_MAX_DOCUMENTS_BYTES,
             )
         )
 
@@ -311,7 +313,7 @@ def _validate_view_payloads(
                 _document_source_paths(
                     root.joinpath(*path.parts),
                     label=f"portable vector documents {relative}",
-                    max_bytes=inventory[relative][0],
+                    max_bytes=_MAX_DOCUMENTS_BYTES,
                 )
             )
     return tuple(sorted(source_paths))
@@ -572,15 +574,13 @@ def bind_context_artifact(
             "repository file count does not match the context artifact manifest"
         )
     for relative in artifact.source_paths:
-        candidate = repo.joinpath(*PurePosixPath(relative).parts)
-        resolved_source = candidate.resolve()
-        if not resolved_source.is_file() or (
-            resolved_source != repo and repo not in resolved_source.parents
-        ):
+        try:
+            validate_repository_file(repo, relative)
+        except ValueError as exc:
             raise ValueError(
-                "context artifact source path does not resolve to a file inside "
+                "context artifact source path is not a stable file inside "
                 f"the repository checkout: {relative}"
-            )
+            ) from exc
 
     manifest_data = artifact.manifest.to_dict()
     manifest_data["repo"]["path"] = str(repo)

--- a/codenib/artifacts/security.py
+++ b/codenib/artifacts/security.py
@@ -11,6 +11,8 @@ import json
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+from .._secret_fields import assert_no_secret_fields
+
 _SENSITIVE_ENV_NAMES = {
     "ANTHROPIC_API_KEY",
     "AWS_SECRET_ACCESS_KEY",
@@ -26,33 +28,42 @@ _SENSITIVE_ENV_NAMES = {
 }
 _SENSITIVE_ENV_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET")
 _SCAN_CHUNK_BYTES = 1024 * 1024
-_CREDENTIAL_FIELDS = {
-    "access_token",
-    "api_key",
-    "apikey",
-    "authorization",
-    "bearer_token",
-    "client_secret",
-    "headers",
-    "password",
-    "private_key",
-    "secret_key",
-    "token",
-}
 
 
 def assert_no_credential_fields(value: Any, *, source: str) -> None:
     """Reject credential-shaped keys in metadata intended for publication."""
 
-    if isinstance(value, Mapping):
-        for key, item in value.items():
-            name = str(key).strip().lower().replace("-", "_")
-            if name in _CREDENTIAL_FIELDS:
-                raise ValueError(f"{source} contains a credential field: {key}")
-            assert_no_credential_fields(item, source=source)
-    elif isinstance(value, (list, tuple)):
-        for item in value:
-            assert_no_credential_fields(item, source=source)
+    assert_no_secret_fields(value, source=source)
+
+
+def assert_publishable_json_value(
+    value: Any,
+    *,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+    label: str,
+) -> None:
+    """Scan decoded JSON semantics without depending on their source encoding."""
+
+    assert_no_credential_fields(value, source=label)
+    payload = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    forbidden_values: list[str] = []
+    for path in forbidden_paths:
+        resolved = path.expanduser().resolve()
+        forbidden_values.extend((str(resolved), resolved.as_posix()))
+    if any(
+        pattern and pattern in payload
+        for pattern in _serialized_patterns(forbidden_values)
+    ):
+        raise ValueError(f"{label} contains an absolute build-machine path")
+    if any(pattern and pattern in payload for pattern in _secret_values(environ)):
+        raise ValueError(f"{label} contains a configured credential")
 
 
 def _serialized_patterns(values: Iterable[str]) -> tuple[bytes, ...]:
@@ -168,6 +179,7 @@ def assert_publishable_tree(
 
 __all__ = [
     "assert_no_credential_fields",
+    "assert_publishable_json_value",
     "assert_publishable_tree",
     "file_sha256",
 ]

--- a/codenib/compiler/artifact_fingerprints.py
+++ b/codenib/compiler/artifact_fingerprints.py
@@ -15,6 +15,8 @@ from typing import Any, Mapping
 
 _BM25_ARTIFACT_PATHS = (Path("documents.json"), Path("bm25_metadata.json"))
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_READ_BYTES = 1024 * 1024
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 
 
 def regular_file_fingerprint(path: str | Path) -> dict[str, Any]:
@@ -54,6 +56,63 @@ def regular_file_fingerprint(path: str | Path) -> dict[str, Any]:
     return {"size": size, "sha256": digest.hexdigest()}
 
 
+def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _file_fingerprint(path: Path) -> dict[str, Any]:
+    descriptor = -1
+    try:
+        before = path.lstat()
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or bool(
+                getattr(before, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+            )
+        ):
+            raise ValueError(f"invalid BM25 artifact file: {path}")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or _file_identity(opened) != _file_identity(
+            before
+        ):
+            raise ValueError(f"BM25 artifact file changed while opening: {path}")
+        digest = hashlib.sha256()
+        remaining = opened.st_size
+        while remaining:
+            block = os.read(descriptor, min(remaining, _READ_BYTES))
+            if not block:
+                raise ValueError(f"BM25 artifact file was truncated: {path}")
+            digest.update(block)
+            remaining -= len(block)
+        if os.read(descriptor, 1):
+            raise ValueError(f"BM25 artifact file grew while hashing: {path}")
+        after_open = os.fstat(descriptor)
+        after_path = path.lstat()
+        if _file_identity(after_open) != _file_identity(opened) or _file_identity(
+            after_path
+        ) != _file_identity(opened):
+            raise ValueError(f"BM25 artifact file changed while hashing: {path}")
+        return {"size": opened.st_size, "sha256": digest.hexdigest()}
+    except OSError as exc:
+        raise ValueError(f"invalid BM25 artifact file: {path}") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
 def bm25_artifact_file_fingerprints(
     root: str | Path,
 ) -> dict[str, dict[str, Any]]:
@@ -63,9 +122,7 @@ def bm25_artifact_file_fingerprints(
     fingerprints: dict[str, dict[str, Any]] = {}
     for relative in _BM25_ARTIFACT_PATHS:
         path = artifact_root / relative
-        if path.is_symlink() or not path.is_file():
-            raise ValueError(f"invalid BM25 artifact file: {path}")
-        fingerprints[relative.as_posix()] = regular_file_fingerprint(path)
+        fingerprints[relative.as_posix()] = _file_fingerprint(path)
     return fingerprints
 
 

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -9,25 +9,137 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import stat
 from pathlib import Path
 from typing import Any, Mapping
 
 VECTOR_PERSISTENCE_SCHEMA = 1
 VECTOR_VIEW_UPDATE_MARKER = ".vector-view.update-in-progress"
 _DIGEST_BYTES = 1024 * 1024
+_MAX_CONFIG_BYTES = 16 * 1024 * 1024
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _UPDATE_MARKER_PAYLOAD = b'{"schema":"codenib.vector-view-update.v1"}\n'
 
 
+def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _open_stable_regular(path: Path) -> tuple[int, os.stat_result]:
+    descriptor = -1
+    try:
+        before = path.lstat()
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or bool(
+                getattr(before, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+            )
+        ):
+            raise ValueError(f"invalid vector artifact file: {path}")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or _file_identity(opened) != _file_identity(
+            before
+        ):
+            raise ValueError(f"vector artifact changed while opening: {path}")
+        return descriptor, opened
+    except ValueError:
+        if descriptor >= 0:
+            os.close(descriptor)
+        raise
+    except OSError as exc:
+        if descriptor >= 0:
+            os.close(descriptor)
+        raise ValueError(f"invalid vector artifact file: {path}") from exc
+
+
+def _read_exact(descriptor: int, size: int, path: Path) -> bytearray:
+    payload = bytearray()
+    remaining = size
+    while remaining:
+        block = os.read(descriptor, min(remaining, _DIGEST_BYTES))
+        if not block:
+            raise ValueError(f"vector artifact was truncated: {path}")
+        payload.extend(block)
+        remaining -= len(block)
+    if os.read(descriptor, 1):
+        raise ValueError(f"vector artifact grew while reading: {path}")
+    return payload
+
+
+def _verify_open_file(
+    descriptor: int,
+    opened: os.stat_result,
+    path: Path,
+) -> None:
+    try:
+        after_open = os.fstat(descriptor)
+        after_path = path.lstat()
+    except OSError as exc:
+        raise ValueError(f"vector artifact changed while reading: {path}") from exc
+    if _file_identity(after_open) != _file_identity(opened) or _file_identity(
+        after_path
+    ) != _file_identity(opened):
+        raise ValueError(f"vector artifact changed while reading: {path}")
+
+
 def _file_record(path: Path) -> dict[str, Any]:
-    if path.is_symlink() or not path.is_file():
-        raise ValueError(f"invalid vector artifact file: {path}")
-    digest = hashlib.sha256()
-    size = 0
-    with path.open("rb") as handle:
-        while block := handle.read(_DIGEST_BYTES):
+    descriptor, opened = _open_stable_regular(path)
+    try:
+        digest = hashlib.sha256()
+        remaining = opened.st_size
+        while remaining:
+            block = os.read(descriptor, min(remaining, _DIGEST_BYTES))
+            if not block:
+                raise ValueError(f"vector artifact was truncated: {path}")
             digest.update(block)
-            size += len(block)
-    return {"file": path.name, "size": size, "sha256": digest.hexdigest()}
+            remaining -= len(block)
+        if os.read(descriptor, 1):
+            raise ValueError(f"vector artifact grew while hashing: {path}")
+        _verify_open_file(descriptor, opened, path)
+        return {
+            "file": path.name,
+            "size": opened.st_size,
+            "sha256": digest.hexdigest(),
+        }
+    except OSError as exc:
+        raise ValueError(f"vector artifact could not be read: {path}") from exc
+    finally:
+        os.close(descriptor)
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    descriptor, opened = _open_stable_regular(path)
+    try:
+        if opened.st_size > _MAX_CONFIG_BYTES:
+            raise ValueError(f"vector generation config exceeds its byte limit: {path}")
+        payload = _read_exact(descriptor, opened.st_size, path)
+        _verify_open_file(descriptor, opened, path)
+        try:
+            config = json.loads(payload)
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise ValueError(
+                f"vector generation config is invalid JSON: {path}"
+            ) from exc
+    except OSError as exc:
+        raise ValueError(f"vector generation config could not be read: {path}") from exc
+    finally:
+        os.close(descriptor)
+    if not isinstance(config, dict):
+        raise ValueError(f"vector generation config must be an object: {path}")
+    return config
 
 
 def vector_level_artifact_records(
@@ -180,12 +292,7 @@ def validate_vector_generation_artifacts(
     """Validate every file committed by one modern top-level vector config."""
 
     config_path = Path(root) / f"config_{model_suffix}.json"
-    if config_path.is_symlink() or not config_path.is_file():
-        raise ValueError(f"invalid vector generation config: {config_path}")
-    with config_path.open(encoding="utf-8") as handle:
-        config = json.load(handle)
-    if not isinstance(config, dict):
-        raise ValueError(f"vector generation config must be an object: {config_path}")
+    config = _load_config(config_path)
 
     persistence_schema = config.get("persistence_schema")
     committed_levels = config.get("level_artifacts")

--- a/codenib/index/sparse_idx/bm25_index.py
+++ b/codenib/index/sparse_idx/bm25_index.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 from rank_bm25 import BM25Okapi
 
+from ..._contained_source import read_repository_file
 from ...code_chunker import CodeChunk
 from ...log_utils import get_logger
 from ...types import NODE_TYPE_DIRECTORY, NODE_TYPE_FILE, NodeInfo, is_symbol_node
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+_MAX_RUNTIME_SOURCE_BYTES = 64 * 1024 * 1024
 _SECURE_SOURCE_DIRECTORY_FDS = (
     os.name == "posix"
     and hasattr(os, "O_DIRECTORY")
@@ -325,10 +327,19 @@ def _read_source_text(project_root: object, file_path: object) -> Optional[str]:
         return None
     root, _source_path, parts = contained
     if _SECURE_SOURCE_DIRECTORY_FDS:
-        descriptor = _open_regular_file_beneath(root, parts)
-        if descriptor is None:
+        try:
+            payload = read_repository_file(
+                root,
+                "/".join(parts),
+                max_bytes=_MAX_RUNTIME_SOURCE_BYTES,
+            )
+        except ValueError:
             return None
-        return _read_open_descriptor(descriptor)
+        return (
+            payload.decode("utf-8", errors="replace")
+            .replace("\r\n", "\n")
+            .replace("\r", "\n")
+        )
     return _read_static_contained_source(root, parts)
 
 

--- a/codenib/mcp/tools/source.py
+++ b/codenib/mcp/tools/source.py
@@ -39,11 +39,6 @@ def _repository_relative_source(ctx: ServerContext, value: str) -> str:
         raise ValueError("file_path must be a repository-relative POSIX path.")
 
     root = Path(ctx.manifest.repo_path).expanduser().resolve()
-    candidate = root
-    for part in path.parts:
-        candidate = candidate / part
-        if candidate.is_symlink():
-            raise ValueError("file_path must not traverse a symbolic link.")
     relative = safe_repo_relative_path(str(root), path_text)
     if relative != path_text:
         raise ValueError("file_path must resolve inside the repository checkout.")

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from ._contained_source import update_repository_file_hash
 from .repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     repository_path_is_visible,
@@ -73,11 +74,8 @@ def fingerprint_repository(
     file_count = 0
 
     for path in walk_repository_files(root_path, exclude_roots=exclude_roots):
-        relative = (
-            path.relative_to(root_path)
-            .as_posix()
-            .encode("utf-8", errors="surrogateescape")
-        )
+        relative_text = path.relative_to(root_path).as_posix()
+        relative = relative_text.encode("utf-8", errors="surrogateescape")
         try:
             mode = path.lstat().st_mode
         except OSError as exc:
@@ -87,7 +85,9 @@ def fingerprint_repository(
 
         if stat.S_ISLNK(mode):
             try:
-                target = os.readlink(path).encode("utf-8", errors="surrogateescape")
+                before_link = path.lstat()
+                raw_target = os.readlink(path)
+                target = raw_target.encode("utf-8", errors="surrogateescape")
             except OSError as exc:
                 raise RepositoryChangedError(
                     f"repository link changed while it was being inspected: {path}"
@@ -97,16 +97,28 @@ def fingerprint_repository(
             hasher.update(b"\0")
             hasher.update(target)
             hasher.update(b"\0")
-            if path.is_file():
-                hasher.update(b"C\0")
-                try:
-                    _update_file(hasher, path)
-                except OSError as exc:
-                    raise RepositoryChangedError(
-                        "repository link target could not be read consistently: "
-                        f"{path}"
-                    ) from exc
-                hasher.update(b"\0")
+            hasher.update(b"C\0")
+            try:
+                update_repository_file_hash(root_path, relative_text, hasher)
+                after_link = path.lstat()
+                after_target = os.readlink(path)
+            except (OSError, ValueError) as exc:
+                raise RepositoryChangedError(
+                    "repository link target could not be read consistently: " f"{path}"
+                ) from exc
+            if (
+                before_link.st_dev != after_link.st_dev
+                or before_link.st_ino != after_link.st_ino
+                or before_link.st_mode != after_link.st_mode
+                or before_link.st_size != after_link.st_size
+                or before_link.st_mtime_ns != after_link.st_mtime_ns
+                or before_link.st_ctime_ns != after_link.st_ctime_ns
+                or raw_target != after_target
+            ):
+                raise RepositoryChangedError(
+                    f"repository link changed while it was being read: {path}"
+                )
+            hasher.update(b"\0")
             file_count += 1
             continue
 

--- a/codenib/storage/models.py
+++ b/codenib/storage/models.py
@@ -15,9 +15,7 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, Mapping
 
-from .._secret_fields import (
-    SecretFieldError,
-)
+from .._secret_fields import SecretFieldError
 from .._secret_fields import assert_no_secret_fields as _assert_no_secret_fields
 
 _DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)

--- a/codenib/storage/models.py
+++ b/codenib/storage/models.py
@@ -15,28 +15,14 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, Mapping
 
+from .._secret_fields import (
+    SecretFieldError,
+)
+from .._secret_fields import assert_no_secret_fields as _assert_no_secret_fields
+
 _DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
 _CATALOG_INT64_MAX = 9_223_372_036_854_775_807
 INDEX_JOB_REQUEST_CONTRACT = "codenib.index-job-request.v1"
-_SECRET_FIELD_NAMES = frozenset(
-    {
-        "access_key",
-        "access_token",
-        "api_key",
-        "apikey",
-        "authorization",
-        "client_secret",
-        "cookie",
-        "credential",
-        "credentials",
-        "password",
-        "passwd",
-        "private_key",
-        "refresh_token",
-        "secret",
-        "token",
-    }
-)
 
 
 class StorageError(RuntimeError):
@@ -190,18 +176,21 @@ def _canonical_json_object(value: str, field: str) -> tuple[str, dict[str, Any]]
     return canonical_json(parsed), parsed
 
 
+def assert_no_secret_fields(value: Any, *, source: str = "value") -> None:
+    """Apply the shared credential policy with a storage validation error.
+
+    The classifier lives outside storage so artifacts do not depend on the
+    catalog layer; this wrapper preserves the public storage exception contract.
+    """
+
+    try:
+        _assert_no_secret_fields(value, source=source)
+    except SecretFieldError as exc:
+        raise StorageValidationError(str(exc)) from exc
+
+
 def _reject_secret_fields(value: Any, *, path: str = "request") -> None:
-    if isinstance(value, Mapping):
-        for key, child in value.items():
-            normalized = key.lower().replace("-", "_")
-            if normalized in _SECRET_FIELD_NAMES:
-                raise StorageValidationError(
-                    f"index job request must not contain secret field: {path}.{key}"
-                )
-            _reject_secret_fields(child, path=f"{path}.{key}")
-    elif isinstance(value, list):
-        for index, child in enumerate(value):
-            _reject_secret_fields(child, path=f"{path}[{index}]")
+    assert_no_secret_fields(value, source="index job request")
 
 
 class IndexJobStatus(str, Enum):
@@ -1013,6 +1002,7 @@ __all__ = [
     "StorageValidationError",
     "ViewGeneration",
     "ViewProfile",
+    "assert_no_secret_fields",
     "canonical_json",
     "content_id",
     "normalize_digest",

--- a/codenib/web/repository_files.py
+++ b/codenib/web/repository_files.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import os
 import re
-import stat
 import subprocess
 from functools import lru_cache
 from typing import Optional
+
+from .._contained_source import read_repository_file
 
 _COMMIT_RE = re.compile(r"[0-9a-fA-F]{7,64}\Z")
 _MAX_SOURCE_BYTES = 8 * 1024 * 1024
@@ -212,24 +213,12 @@ def live_source_slice(
     relative = safe_repo_relative_path(repo_dir, file_path)
     if relative is None:
         return None
-    candidate = os.path.realpath(os.path.join(repo_dir, relative))
-    descriptor = -1
     try:
-        descriptor = os.open(
-            candidate,
-            os.O_RDONLY | getattr(os, "O_NONBLOCK", 0),
+        content = read_repository_file(
+            repo_dir,
+            relative,
+            max_bytes=_MAX_SOURCE_BYTES,
         )
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-            return None
-        handle = os.fdopen(descriptor, "rb")
-        descriptor = -1
-        with handle:
-            content = handle.read(_MAX_SOURCE_BYTES + 1)
-    except OSError:
-        return None
-    finally:
-        if descriptor >= 0:
-            os.close(descriptor)
-    if len(content) > _MAX_SOURCE_BYTES:
+    except ValueError:
         return None
     return _source_slice(relative, content, start, end)

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -218,6 +218,28 @@ path, component, and depth limits.  This avoids relying on directory timestamps,
 which are not reliable on every supported filesystem.  Existing non-empty trees
 fail closed on platforms without safe directory-fd traversal; a first publish
 may proceed only with caller validation and an ownership-checked empty sentinel.
+Portable BM25 and vector normalization now exposes a read-only validation
+boundary for storage publishers.  Retained JSON must be bounded,
+duplicate-safe canonical JSON; decoded metadata and configuration pass the
+shared credential and build-path policy.  BM25 validation binds normalized
+document paths and artifact fingerprints, while vector validation binds the
+provider/model/revision/dimension/metric contract, persistence fingerprints,
+level inventories, document counts, and FAISS type/training semantics inside a
+bounded full-tree ownership sandwich.  Validation holds a no-follow root
+descriptor, authenticates JSON and indexes through descriptor-relative stable
+opens, and gives FAISS a callback over the already authenticated index
+descriptor rather than reopening an attacker-replaceable path.  The M1 JSON
+format has a fixed 16 MiB configuration limit and 256 MiB documents-file limit;
+larger repositories require a future streaming or sharded format rather than a
+manifest-controlled memory override.  Repository-relative source aliases may
+use bounded relative symlinks only when resolution remains inside the pinned
+checkout; absolute, outside, looping, raced, and reparse-point paths fail
+closed in staging, binding, BM25 reads, and MCP reads.  The shared credential
+classifier lives outside both artifacts and storage so the artifact layer does
+not depend on the catalog implementation.  These gates close the current
+portable context publication surface; they are a prerequisite for, but do not
+complete, the remaining legacy manifest import/export adapter or a future
+streaming payload revision.
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -641,7 +641,15 @@ def test_context_artifact_rejects_source_drift(tmp_path: Path) -> None:
 
 def test_context_artifact_rejects_configured_secret_in_view(tmp_path: Path) -> None:
     repo, manifest_path, view_path = _fixture_manifest(tmp_path)
-    (view_path / "leak.bin").write_bytes(b"runtime-secret-value")
+    documents_path = view_path / "documents.json"
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    documents[0]["metadata"]["note"] = "runtime-secret-value"
+    documents_path.write_text(json.dumps(documents), encoding="utf-8")
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["bm25"].config["artifact_file_fingerprints"] = (
+        bm25_artifact_file_fingerprints(view_path)
+    )
+    manifest.save(manifest_path)
 
     with pytest.raises(ValueError, match="configured credential"):
         stage_context_artifact(
@@ -656,15 +664,54 @@ def test_context_artifact_stream_scan_finds_boundary_spanning_secret(
     tmp_path: Path,
 ) -> None:
     repo, manifest_path, view_path = _fixture_manifest(tmp_path)
-    secret = b"boundary-spanning-secret"
-    (view_path / "large.bin").write_bytes(b"x" * (1024 * 1024 - 5) + secret)
+    secret = "boundary-spanning-secret"
+    documents = [
+        {
+            "page_content": "value",
+            "metadata": {"file": "sample.py", "note": secret},
+        }
+    ]
+    probe = (
+        json.dumps(
+            documents,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    )
+    secret_offset = probe.index(secret)
+    documents[0]["metadata"]["note"] = "x" * (1024 * 1024 - 5 - secret_offset) + secret
+    documents_payload = (
+        json.dumps(
+            documents,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    )
+    assert documents_payload.index(secret) == 1024 * 1024 - 5
+    (view_path / "documents.json").write_text(
+        documents_payload,
+        encoding="utf-8",
+    )
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["bm25"].config["artifact_file_fingerprints"] = (
+        bm25_artifact_file_fingerprints(view_path)
+    )
+    manifest.save(manifest_path)
 
     with pytest.raises(ValueError, match="configured credential"):
         stage_context_artifact(
             repo,
             manifest_path,
             tmp_path / "publish" / "context",
-            environ={"CODENIB_ACTION_EMBEDDING_KEY": secret.decode()},
+            environ={"CODENIB_ACTION_EMBEDDING_KEY": secret},
         )
 
 

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from codenib.artifacts import normalize_owned_query_view
+from codenib.artifacts import normalize_owned_query_view, validate_portable_query_view
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
@@ -45,12 +45,46 @@ def _tree(root: Path) -> dict[str, bytes]:
     }
 
 
+def _canonical_json_bytes(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
 def _repository(root: Path) -> tuple[Path, Path]:
     repo = root / "repo"
     repo.mkdir(parents=True)
     source = repo / "sample.py"
     source.write_text("VALUE = 1\n", encoding="utf-8")
     return repo, source
+
+
+def _bm25_view(
+    root: Path,
+    *,
+    documents: list[dict[str, object]] | None = None,
+    metadata: dict[str, object] | None = None,
+) -> tuple[Path, Path]:
+    repo, _source = _repository(root)
+    bm25 = root / "state" / "bm25"
+    bm25.mkdir(parents=True)
+    (bm25 / "documents.json").write_text(
+        json.dumps(documents or []),
+        encoding="utf-8",
+    )
+    (bm25 / "bm25_metadata.json").write_text(
+        json.dumps(metadata or {}),
+        encoding="utf-8",
+    )
+    return repo, bm25
 
 
 def _write_faiss(
@@ -300,6 +334,443 @@ def test_normalize_bm25_rewrites_project_root_and_refreshes_fingerprints(
     }
 
 
+def test_normalize_bm25_rejects_unicode_escaped_secret_metadata(
+    tmp_path: Path,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    (bm25 / "documents.json").write_text(
+        '[{"page_content":"safe","metadata":{"x\\u002dapi\\u002dkey":"value"}}]',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="secret field"):
+        normalize_owned_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+        )
+
+
+def test_normalize_bm25_does_not_scan_semantic_page_content(tmp_path: Path) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "example Authorization: Bearer documentation-token",
+                "metadata": {"file": "sample.py"},
+            }
+        ],
+    )
+
+    normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+
+
+@pytest.mark.parametrize("extra", ["extra.json", "nested/extra.txt"])
+def test_normalize_bm25_rejects_every_extra_entry(
+    tmp_path: Path,
+    extra: str,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    path = bm25 / extra
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unexpected (file|directory)"):
+        normalize_owned_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+        )
+
+
+def test_normalize_bm25_rejects_source_symlink_component(tmp_path: Path) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "outside",
+                "metadata": {"file": "linked/outside.py"},
+            }
+        ],
+    )
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "outside.py").write_text("OUTSIDE = 1\n", encoding="utf-8")
+    (repo / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="stable contained source"):
+        normalize_owned_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+        )
+
+
+def test_portable_view_validator_detects_source_symlink_swap(tmp_path: Path) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "sample.py"},
+            }
+        ],
+    )
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    outside = tmp_path / "outside.py"
+    outside.write_text("OUTSIDE = 1\n", encoding="utf-8")
+    (repo / "sample.py").unlink()
+    (repo / "sample.py").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="stable contained source"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config=adjustments,
+        )
+
+
+@pytest.mark.parametrize("leak", ["path", "secret"])
+def test_portable_bm25_validator_rejects_decoded_metadata_without_mutation(
+    tmp_path: Path,
+    leak: str,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "sample.py"},
+            }
+        ],
+    )
+    normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    documents_path = bm25 / "documents.json"
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    secret = "decoded-runtime-secret"
+    documents[0]["metadata"]["innocent_note"] = str(repo) if leak == "path" else secret
+    documents_path.write_bytes(_canonical_json_bytes(documents))
+    view_config = {"artifact_file_fingerprints": bm25_artifact_file_fingerprints(bm25)}
+    before = _tree(bm25)
+
+    with pytest.raises(ValueError, match="build-machine path|configured credential"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config=view_config,
+            environ={"MODELS_TOKEN": secret},
+        )
+
+    assert _tree(bm25) == before
+
+
+def test_portable_bm25_accepts_contained_relative_source_symlink(
+    tmp_path: Path,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "alias.py"},
+            }
+        ],
+    )
+    (repo / "alias.py").symlink_to("sample.py")
+
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    validate_portable_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config=adjustments,
+    )
+
+
+def test_portable_bm25_rejects_contained_source_symlink_swap_and_restore(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "alias.py"},
+            }
+        ],
+    )
+    alias = repo / "alias.py"
+    alias.symlink_to("sample.py")
+    outside = tmp_path / "outside.py"
+    outside.write_text("SECRET = 1\n", encoding="utf-8")
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    import codenib._contained_source as contained_source_module
+
+    real_verify = contained_source_module._BoundRepositoryFile.verify
+    calls = 0
+
+    def swap_then_restore(binding) -> None:
+        nonlocal calls
+        calls += 1
+        if calls != 2:
+            return real_verify(binding)
+        alias.unlink()
+        alias.symlink_to("../outside.py")
+        try:
+            return real_verify(binding)
+        finally:
+            alias.unlink()
+            alias.symlink_to("sample.py")
+
+    monkeypatch.setattr(
+        contained_source_module._BoundRepositoryFile,
+        "verify",
+        swap_then_restore,
+    )
+
+    with pytest.raises(ValueError, match="stable contained source"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config=adjustments,
+        )
+
+    assert calls == 2
+
+
+def test_portable_bm25_requires_complete_file_fingerprints(tmp_path: Path) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+
+    for view_config in (None, {}, {"artifact_file_fingerprints": {}}):
+        with pytest.raises(ValueError, match="view config|complete artifact"):
+            validate_portable_query_view(
+                bm25,
+                repo_path=repo,
+                view_type="bm25",
+                view_config=view_config,
+            )
+
+
+def test_portable_bm25_rejects_documents_replaced_after_authentication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "sample.py"},
+            }
+        ],
+    )
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_authenticate = portable_views_module._OwnedViewReader.authenticate
+    replaced = False
+
+    def replace_after_authentication(reader, path, expected, **kwargs):
+        nonlocal replaced
+        result = real_authenticate(reader, path, expected, **kwargs)
+        if Path(path).name == "documents.json" and not replaced:
+            replaced = True
+            Path(path).write_bytes(_canonical_json_bytes([]))
+        return result
+
+    monkeypatch.setattr(
+        portable_views_module._OwnedViewReader,
+        "authenticate",
+        replace_after_authentication,
+    )
+
+    with pytest.raises(RuntimeError, match="changed during semantic validation"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config=adjustments,
+        )
+
+    assert replaced
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX")
+@pytest.mark.timeout(2)
+def test_portable_bm25_rejects_fifo_swapped_after_capture_without_blocking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_capture = portable_views_module.capture_directory_ownership
+    documents = bm25 / "documents.json"
+    original = documents.read_bytes()
+    swapped = False
+
+    def capture_then_swap(path, **kwargs):
+        nonlocal swapped
+        token = real_capture(path, **kwargs)
+        if Path(path) == bm25 and not swapped:
+            swapped = True
+            documents.unlink()
+            os.mkfifo(documents)
+        return token
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "capture_directory_ownership",
+        capture_then_swap,
+    )
+    try:
+        with pytest.raises(ValueError, match="private file|safely readable"):
+            validate_portable_query_view(
+                bm25,
+                repo_path=repo,
+                view_type="bm25",
+                view_config=adjustments,
+            )
+    finally:
+        if documents.exists():
+            documents.unlink()
+        documents.write_bytes(original)
+
+
+def test_portable_validator_does_not_use_path_rglob(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+
+    def forbidden_rglob(*_args, **_kwargs):
+        raise AssertionError("portable validation must use its bounded fd inventory")
+
+    monkeypatch.setattr(Path, "rglob", forbidden_rglob)
+    validate_portable_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config=adjustments,
+    )
+
+
+def test_portable_documents_contract_has_a_fixed_nonconfigurable_cap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    monkeypatch.setattr(
+        "codenib.artifacts.portable_views._MAX_DOCUMENTS_JSON_BYTES",
+        1,
+    )
+
+    with pytest.raises(ValueError, match="size mismatch"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={**adjustments, "max_documents_bytes": 10**12},
+        )
+
+
+def test_normalize_json_disappearance_is_reported_as_value_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    documents = bm25 / "documents.json"
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_capture = portable_views_module.capture_directory_ownership
+    disappeared = False
+
+    def capture_then_disappear(path, **kwargs):
+        nonlocal disappeared
+        token = real_capture(path, **kwargs)
+        if Path(path) == bm25 and not disappeared:
+            disappeared = True
+            documents.unlink()
+        return token
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "capture_directory_ownership",
+        capture_then_disappear,
+    )
+
+    with pytest.raises(ValueError, match="safely readable"):
+        normalize_owned_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+        )
+
+    assert disappeared
+
+
 def test_normalize_vector_converts_trusted_pickle_and_strips_build_state(
     tmp_path: Path,
 ) -> None:
@@ -364,6 +835,418 @@ def test_normalize_committed_json_vector_is_idempotent(tmp_path: Path) -> None:
 
     assert _tree(vector) == first_tree
     assert second_adjustments == first_adjustments
+
+
+def test_portable_vector_validator_rejects_noncanonical_json_without_mutation(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    documents_path = vector / "l2" / f"documents_{_MODEL_SUFFIX}.json"
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    documents_path.write_text(json.dumps(documents), encoding="utf-8")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["level_artifacts"]["l2"] = vector_level_artifact_records(
+        vector / "l2",
+        _MODEL_SUFFIX,
+        documents_file=documents_path.name,
+    )
+    config_path.write_bytes(_canonical_json_bytes(config))
+    view_config = {
+        **_VECTOR_CONFIG,
+        **adjustments,
+        "persistence_config_fingerprint": vector_config_artifact_record(
+            vector,
+            _MODEL_SUFFIX,
+        ),
+    }
+    before = _tree(vector)
+    before_modes = {
+        path.relative_to(vector).as_posix(): path.stat().st_mode
+        for path in vector.rglob("*")
+    }
+
+    with pytest.raises(ValueError, match="not canonical JSON"):
+        validate_portable_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+    assert _tree(vector) == before
+    assert {
+        path.relative_to(vector).as_posix(): path.stat().st_mode
+        for path in vector.rglob("*")
+    } == before_modes
+
+
+def test_portable_vector_validator_rechecks_faiss_semantics_after_records(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    level = vector / "l2"
+    _write_faiss(level / f"index_{_MODEL_SUFFIX}.faiss", dimension=8)
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["level_artifacts"]["l2"] = vector_level_artifact_records(
+        level,
+        _MODEL_SUFFIX,
+        documents_file=f"documents_{_MODEL_SUFFIX}.json",
+    )
+    config_path.write_bytes(_canonical_json_bytes(config))
+    view_config = {
+        **_VECTOR_CONFIG,
+        **adjustments,
+        "persistence_config_fingerprint": vector_config_artifact_record(
+            vector,
+            _MODEL_SUFFIX,
+        ),
+    }
+
+    with pytest.raises(ValueError, match="FAISS dimension mismatch"):
+        validate_portable_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+@pytest.mark.parametrize("artifact", ["config", "documents", "faiss"])
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX")
+@pytest.mark.timeout(2)
+def test_portable_vector_rejects_fifo_swapped_after_capture_without_blocking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    artifact: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    view_config = {**_VECTOR_CONFIG, **adjustments}
+    targets = {
+        "config": vector / f"config_{_MODEL_SUFFIX}.json",
+        "documents": vector / "l2" / f"documents_{_MODEL_SUFFIX}.json",
+        "faiss": vector / "l2" / f"index_{_MODEL_SUFFIX}.faiss",
+    }
+    target = targets[artifact]
+    original = target.read_bytes()
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_capture = portable_views_module.capture_directory_ownership
+    swapped = False
+
+    def capture_then_swap(path, **kwargs):
+        nonlocal swapped
+        token = real_capture(path, **kwargs)
+        if Path(path) == vector and not swapped:
+            swapped = True
+            target.unlink()
+            os.mkfifo(target)
+        return token
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "capture_directory_ownership",
+        capture_then_swap,
+    )
+    try:
+        with pytest.raises(
+            ValueError,
+            match=(
+                "private file|safely readable|manifest fingerprint|"
+                "committed documents"
+            ),
+        ):
+            validate_portable_query_view(
+                vector,
+                repo_path=repo,
+                view_type="vector",
+                view_config=view_config,
+            )
+    finally:
+        if target.exists():
+            target.unlink()
+        target.write_bytes(original)
+
+
+def test_portable_vector_parses_faiss_from_authenticated_callback_reader(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    faiss = importlib.import_module("faiss")
+    real_read_index = faiss.read_index
+    sources: list[object] = []
+
+    def tracking_read_index(source, *args, **kwargs):
+        sources.append(source)
+        return real_read_index(source, *args, **kwargs)
+
+    monkeypatch.setattr(faiss, "read_index", tracking_read_index)
+    validate_portable_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config={**_VECTOR_CONFIG, **adjustments},
+    )
+
+    assert len(sources) == 1
+    assert not isinstance(sources[0], (str, Path))
+
+
+def test_portable_vector_rejects_external_symlink_swap_and_restore(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    target = vector / "l2" / f"documents_{_MODEL_SUFFIX}.json"
+    saved = target.with_name("saved-documents.json")
+    outside = tmp_path / "outside.json"
+    outside.write_text('[{"secret": "outside"}]', encoding="utf-8")
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_open = portable_views_module._OwnedViewReader._open_file
+    swapped = False
+
+    def swap_then_restore(reader, relative):
+        nonlocal swapped
+        if relative.name != target.name or swapped:
+            return real_open(reader, relative)
+        swapped = True
+        target.rename(saved)
+        target.symlink_to(outside)
+        try:
+            return real_open(reader, relative)
+        finally:
+            target.unlink()
+            saved.rename(target)
+
+    monkeypatch.setattr(
+        portable_views_module._OwnedViewReader,
+        "_open_file",
+        swap_then_restore,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="private file|safely readable|committed documents",
+    ):
+        validate_portable_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config={**_VECTOR_CONFIG, **adjustments},
+        )
+
+    assert swapped
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs")
+def test_portable_validator_closes_anchored_descriptors(tmp_path: Path) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    for _ in range(20):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config=adjustments,
+        )
+
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
+
+
+@pytest.mark.parametrize("mutation", ["faiss-dimension", "unicode-secret"])
+def test_portable_vector_validator_rejects_late_synchronized_tree_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    view_config = {**_VECTOR_CONFIG, **adjustments}
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_validate = portable_views_module._validate_normalized_document_sources
+    validation_calls = 0
+    secret = "晚到的凭据秘密值-12345678"
+
+    def mutate_after_document_validation(path, repo_path, **kwargs):
+        nonlocal validation_calls
+        result = real_validate(path, repo_path, **kwargs)
+        validation_calls += 1
+        if validation_calls == 1:
+            level = vector / "l2"
+            documents_path = level / f"documents_{_MODEL_SUFFIX}.json"
+            if mutation == "faiss-dimension":
+                _write_faiss(
+                    level / f"index_{_MODEL_SUFFIX}.faiss",
+                    dimension=8,
+                )
+            else:
+                documents = json.loads(documents_path.read_text(encoding="utf-8"))
+                documents[0]["metadata"]["innocent_note"] = secret
+                documents_path.write_bytes(_canonical_json_bytes(documents))
+            config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+            config["level_artifacts"]["l2"] = vector_level_artifact_records(
+                level,
+                _MODEL_SUFFIX,
+                documents_file=documents_path.name,
+            )
+            config_path.write_bytes(_canonical_json_bytes(config))
+        return result
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "_validate_normalized_document_sources",
+        mutate_after_document_validation,
+    )
+    with pytest.raises(RuntimeError, match="changed during semantic validation"):
+        validate_portable_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+            environ={"MODELS_TOKEN": secret},
+        )
+
+    assert validation_calls == 1
+
+
+@pytest.mark.parametrize("extra", ["extra.json", "l2/nested/extra.json"])
+def test_normalize_vector_rejects_every_extra_entry(
+    tmp_path: Path,
+    extra: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    path = vector / extra
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unexpected (file|directory)"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_vector_rejects_root_config_url_credentials(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["endpoint"] = "//user:password@example.test/api"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="URL credentials"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_vector_rejects_level_config_authorization_header(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    level_config = vector / "l2" / f"config_{_MODEL_SUFFIX}.json"
+    level_config.write_text(
+        json.dumps(
+            {
+                "embedding_model": "test/model",
+                "embedding_provider": "huggingface",
+                "embedding_revision": None,
+                "dimension": 4,
+                "index_type": "flat",
+                "index_metric": "ip",
+                "level": "l2",
+                "num_documents": 1,
+                "Proxy-Authorization": "Basic dXNlcjpwYXNz",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="secret field"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_vector_rejects_document_metadata_secret(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    documents_path = vector / "l2" / f"documents_{_MODEL_SUFFIX}.json"
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    documents[0]["metadata"]["github_token"] = "value"
+    documents_path.write_text(json.dumps(documents), encoding="utf-8")
+    _refresh_level_record(vector)
+
+    with pytest.raises(ValueError, match="secret field"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
 
 
 def test_normalize_portable_json_is_idempotent_in_a_different_checkout(
@@ -1167,6 +2050,7 @@ def test_normalize_rejects_level_config_semantic_drift(tmp_path: Path) -> None:
             {
                 "embedding_model": "test/model",
                 "embedding_provider": "huggingface",
+                "embedding_revision": None,
                 "dimension": 4,
                 "index_type": "flat",
                 "index_metric": "l2",

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -10,7 +10,7 @@ import os
 import pickle
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 
 import pytest
@@ -2068,6 +2068,175 @@ def test_normalize_rejects_level_config_semantic_drift(tmp_path: Path) -> None:
             view_type="vector",
             view_config=_VECTOR_CONFIG,
         )
+
+
+def test_normalize_uses_initial_inventory_for_level_config_presence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    level_config = vector / "l2" / f"config_{_MODEL_SUFFIX}.json"
+    level_config.write_text(
+        json.dumps(
+            {
+                "embedding_model": "test/model",
+                "embedding_provider": "huggingface",
+                "embedding_revision": None,
+                "dimension": 4,
+                "index_type": "flat",
+                "index_metric": "l2",
+                "level": "l2",
+                "num_documents": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    real_exists = Path.exists
+
+    def temporarily_hidden(path: Path) -> bool:
+        if path == level_config:
+            return False
+        return real_exists(path)
+
+    monkeypatch.setattr(Path, "exists", temporarily_hidden)
+
+    with pytest.raises(ValueError, match="l2 persistence index_metric"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX directory descriptors")
+def test_normalize_level_config_symlink_race_cannot_write_external_victim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    level_config = vector / "l2" / f"config_{_MODEL_SUFFIX}.json"
+    level_payload = {
+        "embedding_model": "test/model",
+        "embedding_provider": "huggingface",
+        "embedding_revision": None,
+        "dimension": 4,
+        "index_type": "flat",
+        "index_metric": "ip",
+        "level": "l2",
+        "num_documents": 1,
+    }
+    level_config.write_text(json.dumps(level_payload), encoding="utf-8")
+    victim = tmp_path / "external-victim.json"
+    victim_payload = b"external victim must remain unchanged\n"
+    victim.write_bytes(victim_payload)
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_write_all = portable_views_module._OwnedViewReader._write_all
+    raced = False
+
+    def write_then_swap(descriptor: int, payload: bytes) -> None:
+        nonlocal raced
+        real_write_all(descriptor, payload)
+        if not raced:
+            raced = True
+            level_config.unlink()
+            level_config.symlink_to(victim)
+
+    monkeypatch.setattr(
+        portable_views_module._OwnedViewReader,
+        "_write_all",
+        staticmethod(write_then_swap),
+    )
+
+    with pytest.raises(RuntimeError, match="replacement target changed"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+    assert raced
+    assert victim.read_bytes() == victim_payload
+    assert level_config.is_symlink()
+    assert not list(level_config.parent.glob(".codenib-canonical-*.tmp"))
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX directory descriptors")
+def test_normalize_rejects_same_inode_mutation_after_canonical_readback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    level_config = vector / "l2" / f"config_{_MODEL_SUFFIX}.json"
+    level_config.write_text(
+        json.dumps(
+            {
+                "embedding_model": "test/model",
+                "embedding_provider": "huggingface",
+                "embedding_revision": None,
+                "dimension": 4,
+                "index_type": "flat",
+                "index_metric": "ip",
+                "level": "l2",
+                "num_documents": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_read_exact = portable_views_module._OwnedViewReader._read_exact
+    injected = False
+    target_reads = 0
+
+    def read_then_mutate(
+        descriptor: int,
+        opened: os.stat_result,
+        *,
+        relative: PurePosixPath,
+        max_bytes: int | None,
+    ) -> bytearray:
+        nonlocal injected, target_reads
+        payload = real_read_exact(
+            descriptor,
+            opened,
+            relative=relative,
+            max_bytes=max_bytes,
+        )
+        if relative == PurePosixPath("l2", level_config.name):
+            target_reads += 1
+        if target_reads == 2 and not injected:
+            injected = True
+            mutated = bytes(payload).replace(
+                b'"index_metric": "ip"', b'"index_metric": "l2"'
+            )
+            assert len(mutated) == len(payload)
+            assert mutated != bytes(payload)
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            portable_views_module._OwnedViewReader._write_all(descriptor, mutated)
+            os.fsync(descriptor)
+        return payload
+
+    monkeypatch.setattr(
+        portable_views_module._OwnedViewReader,
+        "_read_exact",
+        staticmethod(read_then_mutate),
+    )
+
+    with pytest.raises(RuntimeError, match="canonical replacement changed"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+    assert injected
 
 
 def test_normalize_rejects_persisted_route_identity_drift(tmp_path: Path) -> None:

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -39,7 +39,8 @@ from codenib.compiler.index_builders import VectorIndexBuilder
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
-from codenib.source_fingerprint import fingerprint_repository
+from codenib.mcp.tools.source import read_source_impl
+from codenib.source_fingerprint import RepositoryChangedError, fingerprint_repository
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -55,20 +56,26 @@ def _bm25_artifact(
     tmp_path: Path,
     *,
     source_symlink: bool = False,
+    internal_source_symlink: bool = False,
 ) -> tuple[Path, Path, str]:
     repo = tmp_path / "repo"
     repo.mkdir()
     source = repo / "sample.py"
+    if source_symlink and internal_source_symlink:
+        raise ValueError("source symlink fixture modes are mutually exclusive")
     if source_symlink:
         outside = tmp_path / "outside.py"
         outside.write_text("SECRET = 'outside checkout'\n", encoding="utf-8")
         source.symlink_to(outside)
+    elif internal_source_symlink:
+        (repo / "real.py").write_text("VALUE = 1\n", encoding="utf-8")
+        source.symlink_to("real.py")
     else:
         source.write_text("VALUE = 1\n", encoding="utf-8")
     _git(repo, "init", "--quiet")
     _git(repo, "config", "user.name", "CodeNib Test")
     _git(repo, "config", "user.email", "codenib@example.invalid")
-    _git(repo, "add", "sample.py")
+    _git(repo, "add", ".")
     _git(repo, "commit", "--quiet", "-m", "fixture")
     commit = _git(repo, "rev-parse", "HEAD")
 
@@ -299,6 +306,34 @@ def test_verify_and_bind_artifact_before_loading_bm25(tmp_path: Path) -> None:
     assert "VALUE = 1" in (results[0].content or "")
 
 
+def test_stage_bind_query_and_mcp_accept_contained_source_symlink(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(
+        tmp_path,
+        internal_source_symlink=True,
+    )
+    binding = bind_context_artifact(
+        artifact,
+        repo,
+        expected_repository="example/project",
+        expected_commit=commit,
+    )
+    context = ServerContext.load(
+        binding.manifest,
+        views=["bm25"],
+        artifact={"repository": "example/project"},
+    )
+    context.source_verified = True
+    context.source_error = None
+
+    assert context.bm25 is not None
+    results = context.bm25.search("value", return_code_content=True)
+    assert "VALUE = 1" in (results[0].content or "")
+    source = read_source_impl(context, "sample.py", 1, 1)
+    assert source["content"] == "VALUE = 1\n"
+
+
 def test_bind_and_query_portable_semantic_artifact_without_pickle(
     tmp_path: Path,
 ) -> None:
@@ -421,11 +456,12 @@ def test_verify_rejects_unsafe_bm25_source_contract(tmp_path: Path) -> None:
         verify_context_artifact(artifact)
 
 
-def test_bind_rejects_source_symlink_outside_checkout(tmp_path: Path) -> None:
-    repo, artifact, _commit = _bm25_artifact(tmp_path, source_symlink=True)
-
-    with pytest.raises(ValueError, match="inside the repository checkout"):
-        bind_context_artifact(artifact, repo)
+def test_stage_rejects_source_symlink_outside_checkout(tmp_path: Path) -> None:
+    with pytest.raises(
+        (ValueError, RepositoryChangedError),
+        match="stable contained source|resolves outside|could not be read consistently",
+    ):
+        _bm25_artifact(tmp_path, source_symlink=True)
 
 
 def test_bind_rejects_checkout_commit_drift(tmp_path: Path) -> None:

--- a/test/index/sparse_idx/test_bm25_safe_source.py
+++ b/test/index/sparse_idx/test_bm25_safe_source.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+import codenib._contained_source as contained_source_module
 from codenib.code_chunking.base import CodeChunk
 from codenib.index.sparse_idx import bm25_index as bm25_module
 from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
@@ -221,7 +222,7 @@ def test_source_on_a_different_windows_drive_is_rejected(tmp_path: Path) -> None
     )
 
 
-def test_final_source_symlink_is_rejected(tmp_path: Path) -> None:
+def test_absolute_final_source_symlink_is_rejected(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     target = repo / "real.py"
@@ -231,6 +232,124 @@ def test_final_source_symlink_is_rejected(tmp_path: Path) -> None:
     indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
 
     assert _content(indexer) is None
+
+
+def test_relative_final_source_symlink_inside_root_is_accepted(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "real.py").write_text("contained alias target\n", encoding="utf-8")
+    _symlink_or_skip(repo / "source.py", Path("real.py"))
+
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) == "contained alias target\n"
+
+
+def test_relative_intermediate_symlink_with_parent_inside_root_is_accepted(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    real = repo / "real" / "source.py"
+    real.parent.mkdir(parents=True)
+    real.write_text("inside_call()\n", encoding="utf-8")
+    links = repo / "links"
+    links.mkdir()
+    _symlink_or_skip(links / "pkg", Path("../real"), directory=True)
+    indexer = _indexer(repo, "links/pkg/source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) == "inside_call()\n"
+    occurrences = indexer.search_identifier_occurrences(
+        "inside_call",
+        wrap_with_ln=False,
+    )
+    assert [item.content for item in occurrences] == ["inside_call()\n"]
+
+
+@pytest.mark.parametrize("target", ["../outside.py", "missing.py"])
+def test_relative_final_source_symlink_outside_or_broken_is_rejected(
+    tmp_path: Path,
+    target: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside.py").write_text("outside secret\n", encoding="utf-8")
+    _symlink_or_skip(repo / "source.py", Path(target))
+
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+
+
+def test_source_symlink_loop_is_rejected(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _symlink_or_skip(repo / "source.py", Path("other.py"))
+    _symlink_or_skip(repo / "other.py", Path("source.py"))
+
+    assert _content(_indexer(repo, "source.py", node_type=NODE_TYPE_FILE)) is None
+
+
+def test_source_symlink_hop_limit_is_enforced(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "real.py").write_text("safe\n", encoding="utf-8")
+    for index in range(41):
+        target = f"link-{index + 1}.py" if index < 40 else "real.py"
+        _symlink_or_skip(repo / f"link-{index}.py", Path(target))
+
+    assert _content(_indexer(repo, "link-0.py", node_type=NODE_TYPE_FILE)) is None
+
+
+def test_source_symlink_reversible_swap_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "real.py").write_text("safe\n", encoding="utf-8")
+    outside = tmp_path / "outside.py"
+    outside.write_text("outside secret\n", encoding="utf-8")
+    link = repo / "source.py"
+    _symlink_or_skip(link, Path("real.py"))
+    real_verify = contained_source_module._BoundRepositoryFile.verify
+    calls = 0
+
+    def swap_then_restore(binding) -> None:
+        nonlocal calls
+        calls += 1
+        if calls != 2:
+            return real_verify(binding)
+        link.unlink()
+        link.symlink_to(Path("../outside.py"))
+        try:
+            return real_verify(binding)
+        finally:
+            link.unlink()
+            link.symlink_to(Path("real.py"))
+
+    monkeypatch.setattr(
+        contained_source_module._BoundRepositoryFile,
+        "verify",
+        swap_then_restore,
+    )
+
+    assert _content(_indexer(repo, "source.py", node_type=NODE_TYPE_FILE)) is None
+    assert calls == 2
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs")
+def test_contained_symlink_reads_do_not_leak_descriptors(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "real.py").write_text("safe\n", encoding="utf-8")
+    _symlink_or_skip(repo / "source.py", Path("real.py"))
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    for _ in range(20):
+        assert _content(indexer) == "safe\n"
+
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
 
 
 def test_intermediate_source_symlink_is_rejected(tmp_path: Path) -> None:

--- a/test/mcp_server/test_source_tool.py
+++ b/test/mcp_server/test_source_tool.py
@@ -68,16 +68,46 @@ def test_read_source_rejects_noncanonical_paths(
         read_source_impl(_context(tmp_path), file_path)
 
 
-def test_read_source_rejects_symlinks_and_nonregular_files(tmp_path: Path) -> None:
+def test_read_source_rejects_absolute_symlinks_and_nonregular_files(
+    tmp_path: Path,
+) -> None:
     source = tmp_path / "source.py"
     source.write_text("value = 1\n", encoding="utf-8")
     (tmp_path / "link.py").symlink_to(source)
     (tmp_path / "folder").mkdir()
 
-    with pytest.raises(ValueError, match="symbolic link"):
+    with pytest.raises(ValueError, match="readable regular"):
         read_source_impl(_context(tmp_path), "link.py")
     with pytest.raises(ValueError, match="readable regular"):
         read_source_impl(_context(tmp_path), "folder")
+
+
+def test_read_source_accepts_relative_symlink_contained_in_repository(
+    tmp_path: Path,
+) -> None:
+    real = tmp_path / "real" / "source.py"
+    real.parent.mkdir()
+    real.write_text("contained = True\n", encoding="utf-8")
+    (tmp_path / "alias.py").symlink_to("real/source.py")
+
+    result = read_source_impl(_context(tmp_path), "alias.py", 1, 1)
+
+    assert result["content"] == "contained = True\n"
+
+
+def test_read_source_accepts_contained_intermediate_symlink_with_parent(
+    tmp_path: Path,
+) -> None:
+    real = tmp_path / "real" / "source.py"
+    real.parent.mkdir()
+    real.write_text("contained = True\n", encoding="utf-8")
+    links = tmp_path / "links"
+    links.mkdir()
+    (links / "package").symlink_to("../real", target_is_directory=True)
+
+    result = read_source_impl(_context(tmp_path), "links/package/source.py", 1, 1)
+
+    assert result["content"] == "contained = True\n"
 
 
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="POSIX FIFO required")

--- a/test/storage/test_models.py
+++ b/test/storage/test_models.py
@@ -18,8 +18,61 @@ from codenib.storage.models import (
     StorageValidationError,
     ViewGeneration,
     ViewProfile,
+    assert_no_secret_fields,
     canonical_json,
 )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "access_key",
+        "cookie",
+        "credential",
+        "refresh_token",
+        "secret",
+        "Refresh-Token",
+        "accessKey",
+        "headers",
+        "Proxy-Authorization",
+        "proxy_authorization_options",
+        "X-API-Key",
+        "x-api-key-secondary",
+        "X-Auth-Token",
+        "aws_secret_access_key",
+        "github_token",
+        "auth_token",
+        "my_client_secret",
+    ],
+)
+def test_shared_secret_classifier_rejects_normalized_field_names(field: str) -> None:
+    with pytest.raises(StorageValidationError, match="secret field"):
+        assert_no_secret_fields({"nested": [{field: "value"}]}, source="profile")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://user:password@example.test/api",
+        "//user:password@example.test/api",
+        "Bearer token-value",
+        "Basic dXNlcjpwYXNz",
+    ],
+)
+def test_shared_secret_classifier_rejects_credential_values(value: str) -> None:
+    with pytest.raises(StorageValidationError, match="credentials"):
+        assert_no_secret_fields({"endpoint": value}, source="profile")
+
+
+def test_shared_secret_classifier_does_not_reject_noncredential_token_words() -> None:
+    assert_no_secret_fields(
+        {
+            "authorization_url": "https://example.test/oauth/authorize",
+            "token_count": 10,
+            "tokenizer": "cl100k_base",
+        },
+        source="profile",
+    )
 
 
 def _object(suffix: str) -> ObjectRecord:

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -14,6 +14,7 @@ import pytest
 import codenib._atomic_directory as atomic_module
 from codenib._atomic_directory import (
     capture_directory_ownership,
+    directory_ownership_inventory,
     publish_staged_directory,
 )
 
@@ -369,6 +370,24 @@ def test_directory_ownership_is_independent_of_entry_order(tmp_path: Path) -> No
         second_token.entries,
         second_token.byte_count,
         second_token.metadata_bytes,
+    )
+
+
+def test_directory_ownership_inventory_comes_from_the_bounded_scan(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (root / "one.txt").write_text("one", encoding="utf-8")
+    (nested / "two.txt").write_text("two", encoding="utf-8")
+
+    ownership = capture_directory_ownership(root)
+
+    assert directory_ownership_inventory(ownership) == (
+        ("nested", "directory"),
+        ("nested/two.txt", "file"),
+        ("one.txt", "file"),
     )
 
 

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -6,7 +6,11 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
+import codenib._contained_source as contained_source_module
 from codenib.source_fingerprint import (
+    RepositoryChangedError,
     fingerprint_repository,
     repository_source_is_dirty,
 )
@@ -56,10 +60,10 @@ def test_fingerprint_ignores_git_worktree_pointer_file(tmp_path):
 def test_fingerprint_includes_symlink_target_and_content(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
-    target = tmp_path / "target.py"
+    target = repo / "target.py"
     target.write_text("VALUE = 1\n")
     link = repo / "current.py"
-    link.symlink_to(target)
+    link.symlink_to("target.py")
     initial = fingerprint_repository(repo)
 
     target.write_text("VALUE = 2\n")
@@ -67,8 +71,55 @@ def test_fingerprint_includes_symlink_target_and_content(tmp_path):
     assert changed_content.value != initial.value
 
     link.unlink()
-    link.symlink_to(tmp_path / "other.py")
+    (repo / "other.py").write_text("VALUE = 3\n")
+    link.symlink_to("other.py")
     assert fingerprint_repository(repo).value != changed_content.value
+
+
+def test_fingerprint_rejects_source_symlink_outside_repository(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside.py").write_text("SECRET = 1\n")
+    (repo / "current.py").symlink_to("../outside.py")
+
+    with pytest.raises(RepositoryChangedError, match="could not be read consistently"):
+        fingerprint_repository(repo)
+
+
+def test_fingerprint_rejects_reversible_source_symlink_swap(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "target.py").write_text("VALUE = 1\n")
+    (tmp_path / "outside.py").write_text("SECRET = 1\n")
+    link = repo / "current.py"
+    link.symlink_to("target.py")
+    real_verify = contained_source_module._BoundRepositoryFile.verify
+    calls = 0
+
+    def swap_then_restore(binding) -> None:
+        nonlocal calls
+        calls += 1
+        if calls != 2:
+            return real_verify(binding)
+        link.unlink()
+        link.symlink_to("../outside.py")
+        try:
+            return real_verify(binding)
+        finally:
+            link.unlink()
+            link.symlink_to("target.py")
+
+    monkeypatch.setattr(
+        contained_source_module._BoundRepositoryFile,
+        "verify",
+        swap_then_restore,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="could not be read consistently"):
+        fingerprint_repository(repo)
 
 
 def test_dirty_check_ignores_generated_dirs_but_detects_source_changes(tmp_path):


### PR DESCRIPTION
## Summary
Harden portable BM25 and vector query artifacts so validation, source reads, and published metadata remain bound to canonical repository content rather than ambient paths.

## Changes
- add bounded, no-follow portable view validation and contained repository source reads
- enforce canonical source fingerprints, artifact identities, secret-field rejection, and storage model limits
- keep BM25 source reads fail-closed when a live checkout is not content-authenticated
- update the hybrid storage roadmap and add regression coverage across artifact, MCP, storage, and source lifecycle paths

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- 289 passed, 1 skipped across the changed artifact, BM25, MCP, storage, atomic-directory, and source-fingerprint suites
- Black, isort, flake8, py_compile, and git diff --check passed for all changed Python files

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published