### PR TITLE
fix(storage): harden captured artifact authority

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -10,9 +10,9 @@ import hashlib
 import os
 import stat
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Literal
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _EXPECTED_DESTINATION_UNSET = object()
@@ -57,13 +57,29 @@ class _OwnershipBudget:
 
 
 @dataclass(frozen=True, slots=True)
+class TreeFileRecord:
+    """Canonical content record captured before an owned file is consumed."""
+
+    path: str
+    mode: int
+    size: int
+    sha256: str
+
+
+DirectoryEntryPolicy = Callable[[str, Literal["directory", "file"], int, int], None]
+
+
+@dataclass(frozen=True, slots=True)
 class _TreeOwnership:
     root_identity: tuple[int, ...]
+    root_version_identity: tuple[int, ...]
     digest: str
     entries: int
     byte_count: int
     metadata_bytes: int
     inventory: tuple[tuple[str, str], ...]
+    file_records: tuple[TreeFileRecord, ...]
+    entry_identities: tuple[tuple[str, str, tuple[int, ...]], ...]
 
 
 class _PreviousOutputIdentityLost(RuntimeError):
@@ -223,7 +239,9 @@ def _hash_owned_regular_file(
     *,
     root_device: int,
     budget: _OwnershipBudget,
-) -> tuple[int, str]:
+    relative: str,
+    entry_policy: DirectoryEntryPolicy | None,
+) -> tuple[int, str, tuple[int, ...]]:
     flags = os.O_RDONLY | os.O_NOFOLLOW
     flags |= getattr(os, "O_CLOEXEC", 0)
     flags |= getattr(os, "O_NONBLOCK", 0)
@@ -238,6 +256,8 @@ def _hash_owned_regular_file(
         ):
             raise RuntimeError(f"directory ownership file changed: {path}")
         size = opened.st_size
+        if entry_policy is not None:
+            entry_policy(relative, "file", stat.S_IMODE(opened.st_mode), size)
         if size < 0 or budget.byte_count + size > _MAX_OWNERSHIP_BYTES:
             raise RuntimeError("directory ownership scan exceeds its byte limit")
         digest = hashlib.sha256()
@@ -265,7 +285,7 @@ def _hash_owned_regular_file(
     finally:
         os.close(descriptor)
     budget.byte_count += size
-    return size, digest.hexdigest()
+    return size, digest.hexdigest(), _ownership_version_identity(after)
 
 
 def _scan_owned_directory(
@@ -277,6 +297,9 @@ def _scan_owned_directory(
     mount_points: frozenset[str],
     budget: _OwnershipBudget,
     inventory: list[tuple[str, str]],
+    file_records: list[TreeFileRecord],
+    entry_identities: list[tuple[str, str, tuple[int, ...]]],
+    entry_policy: DirectoryEntryPolicy | None,
     depth: int,
     required_root_file: bytes | None = None,
     allow_empty_root: bool = False,
@@ -338,6 +361,13 @@ def _scan_owned_directory(
 
         entry_hasher = hashlib.sha256()
         if stat.S_ISDIR(metadata.st_mode):
+            if entry_policy is not None:
+                entry_policy(
+                    os.fsdecode(relative),
+                    "directory",
+                    stat.S_IMODE(metadata.st_mode),
+                    0,
+                )
             child_descriptor = os.open(name, flags, dir_fd=descriptor)
             try:
                 opened = os.fstat(child_descriptor)
@@ -355,6 +385,9 @@ def _scan_owned_directory(
                     mount_points=mount_points,
                     budget=budget,
                     inventory=inventory,
+                    file_records=file_records,
+                    entry_identities=entry_identities,
+                    entry_policy=entry_policy,
                     depth=depth + 1,
                 )
                 after = os.fstat(child_descriptor)
@@ -382,14 +415,23 @@ def _scan_owned_directory(
             entry_hasher.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
             entry_hasher.update(child_digest)
             inventory.append((os.fsdecode(relative), "directory"))
+            entry_identities.append(
+                (
+                    os.fsdecode(relative),
+                    "directory",
+                    _ownership_version_identity(after),
+                )
+            )
         elif stat.S_ISREG(metadata.st_mode):
-            size, digest = _hash_owned_regular_file(
+            size, digest, file_identity = _hash_owned_regular_file(
                 descriptor,
                 name,
                 child_path,
                 metadata,
                 root_device=root_device,
                 budget=budget,
+                relative=os.fsdecode(relative),
+                entry_policy=entry_policy,
             )
             digest_bytes = bytes.fromhex(digest)
             entry_hasher.update(b"F")
@@ -398,6 +440,15 @@ def _scan_owned_directory(
             entry_hasher.update(size.to_bytes(8, "big"))
             entry_hasher.update(digest_bytes)
             inventory.append((os.fsdecode(relative), "file"))
+            file_records.append(
+                TreeFileRecord(
+                    path=os.fsdecode(relative),
+                    mode=stat.S_IMODE(metadata.st_mode),
+                    size=size,
+                    sha256=digest,
+                )
+            )
+            entry_identities.append((os.fsdecode(relative), "file", file_identity))
         else:
             raise RuntimeError(
                 f"directory ownership scan refuses special content: {child_path}"
@@ -417,6 +468,7 @@ def capture_directory_ownership(
     *,
     required_root_file: str | None = None,
     allow_empty_root: bool = False,
+    entry_policy: DirectoryEntryPolicy | None = None,
 ) -> _TreeOwnership:
     """Return a bounded content token for one stable, real directory tree."""
 
@@ -459,11 +511,14 @@ def capture_directory_ownership(
         digest.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
         return _TreeOwnership(
             root_identity=_directory_inode_identity(metadata),
+            root_version_identity=_ownership_version_identity(metadata),
             digest=digest.hexdigest(),
             entries=0,
             byte_count=0,
             metadata_bytes=0,
             inventory=(),
+            file_records=(),
+            entry_identities=(),
         )
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     flags |= getattr(os, "O_CLOEXEC", 0)
@@ -474,6 +529,8 @@ def capture_directory_ownership(
             raise RuntimeError(f"directory ownership root changed: {path}")
         budget = _OwnershipBudget()
         inventory: list[tuple[str, str]] = []
+        file_records: list[TreeFileRecord] = []
+        entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
         digest = _scan_owned_directory(
             descriptor,
             path,
@@ -482,6 +539,9 @@ def capture_directory_ownership(
             mount_points=_linux_mount_points(),
             budget=budget,
             inventory=inventory,
+            file_records=file_records,
+            entry_identities=entry_identities,
+            entry_policy=entry_policy,
             depth=0,
             required_root_file=required_root_file_bytes,
             allow_empty_root=allow_empty_root,
@@ -498,11 +558,14 @@ def capture_directory_ownership(
         raise RuntimeError(f"directory ownership root changed: {path}")
     return _TreeOwnership(
         root_identity=_directory_inode_identity(opened),
+        root_version_identity=_ownership_version_identity(opened),
         digest=digest.hex(),
         entries=budget.entries,
         byte_count=budget.byte_count,
         metadata_bytes=budget.metadata_bytes,
         inventory=tuple(sorted(inventory)),
+        file_records=tuple(sorted(file_records, key=lambda record: record.path)),
+        entry_identities=tuple(sorted(entry_identities)),
     )
 
 
@@ -516,6 +579,36 @@ def directory_ownership_inventory(
     return ownership.inventory
 
 
+def directory_ownership_file_records(
+    ownership: _TreeOwnership,
+) -> tuple[TreeFileRecord, ...]:
+    """Return canonical per-file records bound by an ownership token."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.file_records
+
+
+def directory_ownership_entry_identities(
+    ownership: _TreeOwnership,
+) -> tuple[tuple[str, str, tuple[int, ...]], ...]:
+    """Return private filesystem identities captured for every tree entry."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.entry_identities
+
+
+def directory_ownership_root_version_identity(
+    ownership: _TreeOwnership,
+) -> tuple[int, ...]:
+    """Return the captured root version identity used by pinned readers."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.root_version_identity
+
+
 def directory_ownership_root_identity(
     ownership: _TreeOwnership,
 ) -> tuple[int, ...]:
@@ -526,17 +619,38 @@ def directory_ownership_root_identity(
     return ownership.root_identity
 
 
+def directory_ownership_digest(ownership: _TreeOwnership) -> str:
+    """Return the canonical complete-tree digest bound by a token."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.digest
+
+
 def _require_tree_ownership(
     path: Path,
     expected: _TreeOwnership,
     *,
     label: str,
+    allow_root_rename: bool = False,
 ) -> None:
+    allow_root_rename = allow_root_rename or label in {
+        "moved destination",
+        "previous destination",
+        "published staged directory",
+    }
     try:
         observed = capture_directory_ownership(path)
     except (OSError, ValueError, RuntimeError) as exc:
         raise RuntimeError(f"{label} changed during directory publication") from exc
-    if observed != expected:
+    if observed != expected and not (
+        allow_root_rename
+        and replace(
+            observed,
+            root_version_identity=expected.root_version_identity,
+        )
+        == expected
+    ):
         raise RuntimeError(f"{label} changed during directory publication")
 
 
@@ -1384,9 +1498,15 @@ def publish_staged_directory(
 
 
 __all__ = [
+    "DirectoryEntryPolicy",
+    "TreeFileRecord",
     "capture_directory_ownership",
+    "directory_ownership_digest",
+    "directory_ownership_entry_identities",
+    "directory_ownership_file_records",
     "directory_ownership_inventory",
     "directory_ownership_root_identity",
+    "directory_ownership_root_version_identity",
     "discard_owned_directory",
     "lexical_directory_path",
     "publish_staged_directory",

--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -929,6 +929,151 @@ class _WindowsResourceOwner:
         return None
 
 
+class _WindowsLexicalAuthorityOwner:
+    """Retain a component-pinned Windows authority across handoff failures."""
+
+    __slots__ = ("_resource",)
+
+    def __init__(self) -> None:
+        self._resource: object | None = None
+
+    def own(self, resource: object) -> None:
+        current = self._resource
+        if current is not None and current is not resource:
+            current_handles = getattr(current, "handles", None)
+            replacement_handles = getattr(resource, "handles", None)
+            if current_handles is not replacement_handles:
+                raise RuntimeError("Windows lexical authority ownership changed")
+        self._resource = resource
+
+    @property
+    def authority(self) -> _windows_fs.WindowsDirectoryAuthority:
+        resource = self._resource
+        if not isinstance(resource, _windows_fs.WindowsDirectoryAuthority):
+            raise RuntimeError("Windows lexical authority was not acquired")
+        return resource
+
+    @property
+    def closed(self) -> bool:
+        resource = self._resource
+        if resource is None:
+            return True
+        handles = getattr(resource, "handles", None)
+        if isinstance(handles, list):
+            return not handles
+        return bool(resource.closed)  # type: ignore[attr-defined]
+
+    def close(self) -> None:
+        resource = self._resource
+        if resource is None:
+            return
+        handles = getattr(resource, "handles", None)
+        api = getattr(resource, "api", None)
+        if not isinstance(handles, list) or api is None:
+            resource.close()  # type: ignore[attr-defined]
+            return
+        if not handles:
+            if isinstance(resource, _windows_fs.WindowsDirectoryAuthority):
+                resource.closed = True
+            return
+
+        stored_identities: dict[int, tuple[int, ...]] = {}
+        if isinstance(resource, _windows_fs.WindowsDirectoryAuthority):
+            full_identities = {resource.handles[0]: resource.anchor_identity}
+            full_identities.update(
+                {
+                    observation.child_handle: observation.child_identity
+                    for observation in resource.observations
+                }
+            )
+            for handle, identity in full_identities.items():
+                file_id = identity[1]
+                if not isinstance(file_id, bytes):
+                    raise RuntimeError("Windows lexical FILE_ID is invalid")
+                stored_identities[handle] = (
+                    int(identity[0]),
+                    1,
+                    int.from_bytes(file_id, "big"),
+                    stat.S_IFMT(int(identity[2])),
+                )
+
+        primary_error: BaseException | None = None
+        for handle in reversed(tuple(handles)):
+            expected = stored_identities.get(handle)
+            if expected is None:
+                cleanup_identities = getattr(resource, "expected_identities", {})
+                cleanup_identity = cleanup_identities.get(handle)
+                try:
+                    observed = api.metadata(handle)
+                except KeyError:
+                    while handle in handles:
+                        handles.remove(handle)
+                    cleanup_identities.pop(handle, None)
+                    continue
+                except OSError as probe_error:
+                    if _windows_handle_is_invalid_error(probe_error):
+                        while handle in handles:
+                            handles.remove(handle)
+                        cleanup_identities.pop(handle, None)
+                        continue
+                    primary_error = _retain_first_error(
+                        primary_error,
+                        "additional Windows lexical HANDLE probe failed",
+                        probe_error,
+                    )
+                    continue
+                except BaseException as probe_error:  # noqa: B036
+                    primary_error = _retain_first_error(
+                        primary_error,
+                        "additional Windows lexical HANDLE probe failed",
+                        probe_error,
+                    )
+                    continue
+                if (
+                    cleanup_identity is not None
+                    and (
+                        observed.st_dev,
+                        observed.file_id_128,
+                    )
+                    != cleanup_identity
+                ):
+                    primary_error = _retain_first_error(
+                        primary_error,
+                        "additional Windows lexical HANDLE ownership changed",
+                        RuntimeError("Windows lexical HANDLE ownership changed"),
+                    )
+                    continue
+                expected = _resource_owner_identity(observed)
+            record = _WindowsHandleRecord(handle, expected)
+            temporary_owner = _WindowsResourceOwner(api)
+            close_error = temporary_owner._close_record(record)
+            if not record.handle:
+                while handle in handles:
+                    handles.remove(handle)
+                cleanup_identities = getattr(resource, "expected_identities", {})
+                cleanup_identities.pop(handle, None)
+            if close_error is not None:
+                primary_error = _retain_first_error(
+                    primary_error,
+                    "additional Windows lexical HANDLE cleanup failed",
+                    close_error,
+                )
+        if isinstance(resource, _windows_fs.WindowsDirectoryAuthority):
+            resource.closed = not handles
+        if primary_error is not None:
+            raise primary_error
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close()
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "Windows lexical authority cleanup also failed",
+                close_error,
+            )
+
+
 class _PublicationAuthorityOwner:
     """Pre-existing slot for cancellation-safe authority handoff."""
 
@@ -1925,14 +2070,14 @@ def _windows_find_child(
     name: str,
 ) -> _WindowsDirectoryEntry | None:
     folded = name.casefold()
-    matches = [
-        entry
-        for entry in api.enumerate_directory(parent_handle)
-        if entry.name.casefold() == folded
-    ]
-    if len(matches) > 1:
-        raise RuntimeError("Windows directory contains ambiguous child names")
-    return matches[0] if matches else None
+    match: _WindowsDirectoryEntry | None = None
+    for entry in api.iter_directory(parent_handle):
+        if entry.name.casefold() != folded:
+            continue
+        if match is not None:
+            raise RuntimeError("Windows directory contains ambiguous child names")
+        match = entry
+    return match
 
 
 def _windows_open_child_by_id(
@@ -2180,7 +2325,7 @@ def _scan_windows_owned_directory(
     if not stat.S_ISDIR(before.st_mode) or before.st_dev != root_device:
         raise RuntimeError(f"directory ownership root changed: {path}")
     entries: list[tuple[bytes, _WindowsDirectoryEntry]] = []
-    for entry in api.enumerate_directory(handle):
+    for entry in api.iter_directory(handle):
         _simple_child_name(entry.name, label="directory ownership component")
         try:
             raw_name = entry.name.encode("utf-8", errors="strict")
@@ -2366,17 +2511,56 @@ def _open_windows_publication_authority(
 ) -> _PublicationAuthority:
     api = _windows_kernel_api()
     resources = _WindowsResourceOwner(api)
+    lexical_owner = _WindowsLexicalAuthorityOwner()
+    lexical_authority: _windows_fs.WindowsDirectoryAuthority | None = None
     authority: _PublicationAuthority | None = None
-    try:
-        parent_handle = resources.acquire(
-            lambda: (
-                api.create_directory_handle(path)
-                if parent_resource is None
-                else api.duplicate_handle(parent_resource)
+
+    def close_resources() -> None:
+        primary_error: BaseException | None = None
+        try:
+            resources.close_all()
+        except BaseException as close_error:  # noqa: B036 - visit both owners
+            primary_error = close_error
+        try:
+            lexical_owner.close()
+        except BaseException as close_error:  # noqa: B036 - retain first
+            primary_error = _retain_first_error(
+                primary_error,
+                "Windows lexical authority cleanup also failed",
+                close_error,
             )
-        )
+        if primary_error is not None:
+            raise primary_error
+
+    def close_resources_after_error(primary_error: BaseException) -> None:
+        try:
+            close_resources()
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "Windows publication authority cleanup also failed",
+                close_error,
+            )
+
+    def resources_closed() -> bool:
+        return resources.closed and lexical_owner.closed
+
+    try:
+        if parent_resource is None:
+            _windows_fs.open_lexical_directory_authority(
+                path,
+                api=api,
+                cleanup_slot=lexical_owner,
+            )
+            lexical_authority = lexical_owner.authority
+            parent_handle = lexical_authority.handle
+        else:
+            parent_handle = resources.acquire(
+                lambda: api.duplicate_handle(parent_resource)
+            )
         opened = api.metadata(parent_handle)
-        resources.bind_identity(parent_handle, opened)
+        if parent_resource is not None:
+            resources.bind_identity(parent_handle, opened)
         if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
             raise ValueError("publication parent must be a real directory")
         identity = _directory_inode_identity(opened)
@@ -2386,9 +2570,10 @@ def _open_windows_publication_authority(
             expected_parent_identity
         ):
             raise RuntimeError("publication parent identity does not match authority")
-        path_handle = resources.acquire(lambda: api.create_directory_handle(path))
-        if _directory_inode_identity(api.metadata(path_handle)) != identity:
-            raise RuntimeError("publication parent path changed")
+        if lexical_authority is None:
+            path_handle = resources.acquire(lambda: api.create_directory_handle(path))
+            if _directory_inode_identity(api.metadata(path_handle)) != identity:
+                raise RuntimeError("publication parent path changed")
         owned_parent_handle = parent_handle
 
         def open_child(
@@ -2549,6 +2734,9 @@ def _open_windows_publication_authority(
         def verify_callback() -> None:
             if _directory_inode_identity(api.metadata(owned_parent_handle)) != identity:
                 raise RuntimeError("publication parent authority changed")
+            if lexical_authority is not None:
+                lexical_authority.verify_binding()
+                return
             rebound_handle = resources.acquire(
                 lambda: api.create_directory_handle(path)
             )
@@ -2576,12 +2764,12 @@ def _open_windows_publication_authority(
             identity=identity,
             backend_tag="windows-file-id",
             resource=owned_parent_handle,
-            close_callback=lambda _resource: resources.close_all(),
+            close_callback=lambda _resource: close_resources(),
             metadata_callback=metadata_callback,
             reader_callback=reader_callback,
             rename_callback=rename_callback,
             verify_callback=verify_callback,
-            close_complete_callback=lambda: resources.closed,
+            close_complete_callback=resources_closed,
         )
         if authority_owner is not None:
             authority_owner.install(authority)
@@ -2594,7 +2782,7 @@ def _open_windows_publication_authority(
         ):
             authority_owner.close_after_error(primary_error)
         else:
-            resources.close_all_after_error(primary_error)
+            close_resources_after_error(primary_error)
         raise
 
 

--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -6,13 +6,35 @@
 
 from __future__ import annotations
 
+import ctypes
+import errno
 import hashlib
 import os
+import secrets
 import stat
-import tempfile
+import sys
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
-from pathlib import Path
-from typing import Callable, Literal
+from pathlib import Path, PurePosixPath
+from typing import Callable, ContextManager, Iterator, Literal, Protocol, TypeVar
+
+from . import _windows_fs_authority as _windows_fs
+
+_WINDOWS_DELETE = _windows_fs.DELETE
+_WINDOWS_FILE_ATTRIBUTE_DIRECTORY = _windows_fs.FILE_ATTRIBUTE_DIRECTORY
+_WINDOWS_FILE_ATTRIBUTE_READONLY = _windows_fs.FILE_ATTRIBUTE_READONLY
+_WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT = _windows_fs.FILE_ATTRIBUTE_REPARSE_POINT
+_WINDOWS_FILE_LIST_DIRECTORY = _windows_fs.FILE_LIST_DIRECTORY
+_WINDOWS_FILE_READ_ATTRIBUTES = _windows_fs.FILE_READ_ATTRIBUTES
+_WINDOWS_FILE_READ_DATA = _windows_fs.FILE_READ_DATA
+_WINDOWS_SYNCHRONIZE = _windows_fs.SYNCHRONIZE
+_WindowsDirectoryEntry = _windows_fs.WindowsDirectoryEntry
+_WindowsHandleMetadata = _windows_fs.WindowsHandleMetadata
+_WindowsKernelApi = _windows_fs.WindowsKernelApi
+_windows_extended_path = _windows_fs.windows_extended_path
+_windows_mode_from_attributes = _windows_fs.windows_mode_from_attributes
+_shared_windows_kernel_api = _windows_fs.windows_kernel_api
+_shared_windows_require_publication_api = _windows_fs.windows_require_publication_api
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _EXPECTED_DESTINATION_UNSET = object()
@@ -24,15 +46,16 @@ _MAX_OWNERSHIP_METADATA_BYTES = 16 << 20
 _MAX_OWNERSHIP_PATH_BYTES = 4_096
 _MAX_OWNERSHIP_COMPONENT_BYTES = 255
 _OWNERSHIP_COPY_BYTES = 1 << 20
-_SAFE_REMOVAL_DIRECTORY_FDS = (
-    hasattr(os, "O_DIRECTORY")
-    and hasattr(os, "O_NOFOLLOW")
-    and os.open in os.supports_dir_fd
-    and os.stat in os.supports_dir_fd
-    and os.stat in os.supports_follow_symlinks
-    and os.scandir in os.supports_fd
-    and os.unlink in os.supports_dir_fd
-    and os.rmdir in os.supports_dir_fd
+_MAX_PUBLICATION_SNAPSHOT_BYTES = 64 << 20
+_MAX_PUBLICATION_STREAM_READ_BYTES = 8 << 20
+_RENAME_NOREPLACE = 1
+_RENAME_EXCL = 0x4
+_MAX_ORPHAN_NAME_ATTEMPTS = 128
+_DURABLE_PUBLICATION_FSYNC_BACKENDS = frozenset({"linux-renameat2"})
+_WINDOWS_RESERVED_BASENAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{number}" for number in range(1, 10)}
+    | {f"LPT{number}" for number in range(1, 10)}
 )
 _SAFE_OWNERSHIP_DIRECTORY_FDS = (
     hasattr(os, "O_DIRECTORY")
@@ -43,10 +66,7 @@ _SAFE_OWNERSHIP_DIRECTORY_FDS = (
     and os.scandir in os.supports_fd
 )
 
-
-@dataclass(slots=True)
-class _RemovalState:
-    destructive_started: bool = False
+_T = TypeVar("_T")
 
 
 @dataclass(slots=True)
@@ -82,17 +102,1629 @@ class _TreeOwnership:
     entry_identities: tuple[tuple[str, str, tuple[int, ...]], ...]
 
 
+@dataclass(frozen=True, slots=True)
+class _ExpectedPublicationFile:
+    record: TreeFileRecord
+    file_identity: tuple[int, ...]
+    directory_identities: tuple[tuple[str, tuple[int, ...]], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationFileSnapshot:
+    """Immutable bytes and their authenticated canonical file record."""
+
+    record: TreeFileRecord
+    _payload: bytes
+
+    def read_bytes(self) -> bytes:
+        return self._payload
+
+    def iter_bytes(self, *, chunk_size: int = _OWNERSHIP_COPY_BYTES) -> Iterator[bytes]:
+        if isinstance(chunk_size, bool) or not isinstance(chunk_size, int):
+            raise TypeError("publication snapshot chunk size must be an integer")
+        if chunk_size <= 0 or chunk_size > _OWNERSHIP_COPY_BYTES:
+            raise ValueError("publication snapshot chunk size is out of bounds")
+        for offset in range(0, len(self._payload), chunk_size):
+            yield self._payload[offset : offset + chunk_size]
+
+
+class PublicationAuthenticatedFile:
+    """One bounded file stream whose handle is verified when its context exits."""
+
+    __slots__ = (
+        "path",
+        "mode",
+        "size",
+        "_remaining",
+        "_read_callback",
+        "_verify_callback",
+        "_digest",
+        "_record",
+        "_closed",
+    )
+
+    def __init__(
+        self,
+        *,
+        path: str,
+        mode: int,
+        size: int,
+        read_callback: Callable[[int], bytes],
+        verify_callback: Callable[[], None],
+    ) -> None:
+        self.path = path
+        self.mode = mode
+        self.size = size
+        self._remaining = size
+        self._read_callback = read_callback
+        self._verify_callback = verify_callback
+        self._digest = hashlib.sha256()
+        self._record: TreeFileRecord | None = None
+        self._closed = False
+
+    @property
+    def record(self) -> TreeFileRecord:
+        if self._record is None:
+            raise RuntimeError(
+                "publication file record is available after context verification"
+            )
+        return self._record
+
+    def read(self, size: int = -1) -> bytes:
+        if self._closed:
+            raise ValueError("publication authenticated file is closed")
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError("publication authenticated read size must be an integer")
+        if size < 0:
+            if self._remaining > _MAX_PUBLICATION_STREAM_READ_BYTES:
+                raise ValueError(
+                    "unbounded publication reads are disabled for large files"
+                )
+            requested = self._remaining
+        else:
+            if size > _MAX_PUBLICATION_STREAM_READ_BYTES:
+                raise ValueError("publication read size exceeds its per-call limit")
+            requested = min(size, self._remaining)
+        if requested == 0:
+            return b""
+        block = self._read_callback(requested)
+        if not isinstance(block, bytes) or len(block) > requested:
+            raise RuntimeError("publication file backend returned invalid bytes")
+        if not block:
+            raise RuntimeError("publication authenticated file was truncated")
+        self._remaining -= len(block)
+        self._digest.update(block)
+        return block
+
+    def iter_bytes(
+        self,
+        *,
+        chunk_size: int = _OWNERSHIP_COPY_BYTES,
+    ) -> Iterator[bytes]:
+        if isinstance(chunk_size, bool) or not isinstance(chunk_size, int):
+            raise TypeError("publication stream chunk size must be an integer")
+        if chunk_size <= 0 or chunk_size > _MAX_PUBLICATION_STREAM_READ_BYTES:
+            raise ValueError("publication stream chunk size is out of bounds")
+        while self._remaining:
+            yield self.read(min(chunk_size, self._remaining))
+
+    def _finalize(self) -> None:
+        if self._closed:
+            return
+        try:
+            while self._remaining:
+                self.read(min(_OWNERSHIP_COPY_BYTES, self._remaining))
+            extra = self._read_callback(1)
+            self._verify_callback()
+            if extra:
+                raise RuntimeError("publication authenticated file grew while read")
+            self._record = TreeFileRecord(
+                path=self.path,
+                mode=self.mode,
+                size=self.size,
+                sha256=self._digest.hexdigest(),
+            )
+        finally:
+            self._closed = True
+
+
+class PublicationDirectoryReader:
+    """A child tree that is usable only during an authority-owned callback."""
+
+    __slots__ = (
+        "_diagnostic_path",
+        "root_identity",
+        "_capture",
+        "_open_file",
+        "_expected_ownership",
+        "_records_by_path",
+        "_entries_by_path",
+        "_authentication_failed",
+        "_active",
+    )
+
+    def __init__(
+        self,
+        display_path: Path,
+        root_identity: tuple[int, ...],
+        capture: Callable[
+            [str | None, bool, DirectoryEntryPolicy | None], _TreeOwnership
+        ],
+        open_file: Callable[
+            [PurePosixPath, int, _ExpectedPublicationFile],
+            ContextManager[PublicationAuthenticatedFile],
+        ],
+        expected_ownership: _TreeOwnership | None,
+    ) -> None:
+        self._diagnostic_path = display_path
+        self.root_identity = root_identity
+        self._capture = capture
+        self._open_file = open_file
+        self._expected_ownership = expected_ownership
+        self._records_by_path = (
+            {}
+            if expected_ownership is None
+            else {record.path: record for record in expected_ownership.file_records}
+        )
+        self._entries_by_path = (
+            {}
+            if expected_ownership is None
+            else {
+                path: (kind, identity)
+                for path, kind, identity in expected_ownership.entry_identities
+            }
+        )
+        self._authentication_failed = False
+        self._active = True
+        if (
+            expected_ownership is not None
+            and root_identity != expected_ownership.root_identity
+        ):
+            self._authentication_failed = True
+            raise RuntimeError(
+                "publication callback root differs from captured ownership"
+            )
+
+    def capture_ownership(
+        self,
+        *,
+        required_root_file: str | None = None,
+        allow_empty_root: bool = False,
+        entry_policy: DirectoryEntryPolicy | None = None,
+    ) -> _TreeOwnership:
+        """Capture through the already-open directory authority."""
+
+        if not self._active:
+            raise RuntimeError("publication tree reader is no longer active")
+        try:
+            observed = self._capture(
+                required_root_file,
+                allow_empty_root,
+                entry_policy,
+            )
+            if self._expected_ownership is not None:
+                _require_matching_ownership(
+                    observed,
+                    self._expected_ownership,
+                    label="publication callback tree",
+                    allow_root_rename=True,
+                )
+            return observed
+        except BaseException:
+            self._authentication_failed = True
+            raise
+
+    def inventory(self) -> tuple[tuple[str, str], ...]:
+        if not self._active:
+            raise RuntimeError("publication tree reader is no longer active")
+        if self._expected_ownership is not None:
+            return self._expected_ownership.inventory
+        return self.capture_ownership().inventory
+
+    def file_records(self) -> tuple[TreeFileRecord, ...]:
+        if not self._active:
+            raise RuntimeError("publication tree reader is no longer active")
+        if self._expected_ownership is not None:
+            return self._expected_ownership.file_records
+        return self.capture_ownership().file_records
+
+    def authenticated_snapshot(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> PublicationFileSnapshot:
+        if not self._active:
+            raise RuntimeError("publication tree reader is no longer active")
+        if isinstance(max_bytes, bool) or not isinstance(max_bytes, int):
+            raise TypeError("publication snapshot limit must be an integer")
+        if max_bytes < 0 or max_bytes > _MAX_PUBLICATION_SNAPSHOT_BYTES:
+            raise ValueError("publication snapshot limit is out of bounds")
+        normalized = _publication_relative_path(relative)
+        chunks: list[bytes] = []
+        with self.open_authenticated_file(
+            normalized,
+            max_bytes=max_bytes,
+        ) as authenticated:
+            chunks.extend(authenticated.iter_bytes())
+        return PublicationFileSnapshot(
+            record=authenticated.record,
+            _payload=b"".join(chunks),
+        )
+
+    def read_bytes(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        return self.authenticated_snapshot(
+            relative,
+            max_bytes=max_bytes,
+        ).read_bytes()
+
+    @contextmanager
+    def open_authenticated_file(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> Iterator[PublicationAuthenticatedFile]:
+        if not self._active:
+            raise RuntimeError("publication tree reader is no longer active")
+        if isinstance(max_bytes, bool) or not isinstance(max_bytes, int):
+            raise TypeError("publication stream limit must be an integer")
+        if max_bytes < 0 or max_bytes > _MAX_OWNERSHIP_BYTES:
+            raise ValueError("publication stream limit is out of bounds")
+        normalized = _publication_relative_path(relative)
+        expected = self._expected_file(normalized)
+        try:
+            with self._open_file(normalized, max_bytes, expected) as authenticated:
+                if (
+                    authenticated.path,
+                    authenticated.mode,
+                    authenticated.size,
+                ) != (
+                    expected.record.path,
+                    expected.record.mode,
+                    expected.record.size,
+                ):
+                    raise RuntimeError(
+                        "publication file metadata differs from captured ownership"
+                    )
+                yield authenticated
+            if authenticated.record != expected.record:
+                raise RuntimeError(
+                    "publication file bytes differ from captured ownership"
+                )
+        except BaseException:
+            self._authentication_failed = True
+            raise
+
+    @contextmanager
+    def iter_authenticated_chunks(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+        chunk_size: int = _OWNERSHIP_COPY_BYTES,
+    ) -> Iterator[Iterator[bytes]]:
+        with self.open_authenticated_file(
+            relative,
+            max_bytes=max_bytes,
+        ) as authenticated:
+            yield authenticated.iter_bytes(chunk_size=chunk_size)
+
+    def _expected_file(
+        self,
+        relative: PurePosixPath,
+    ) -> _ExpectedPublicationFile:
+        ownership = self._expected_ownership
+        if ownership is None:
+            self._authentication_failed = True
+            raise RuntimeError(
+                "publication file reads require captured callback ownership"
+            )
+        normalized = relative.as_posix()
+        try:
+            record = self._records_by_path[normalized]
+            kind, file_identity = self._entries_by_path[normalized]
+        except KeyError as exc:
+            self._authentication_failed = True
+            raise ValueError(
+                f"publication file is absent from captured ownership: {normalized}"
+            ) from exc
+        if kind != "file":
+            self._authentication_failed = True
+            raise ValueError(f"publication path is not a captured file: {normalized}")
+        directories: list[tuple[str, tuple[int, ...]]] = []
+        for depth in range(1, len(relative.parts)):
+            directory = "/".join(relative.parts[:depth])
+            try:
+                directory_kind, identity = self._entries_by_path[directory]
+            except KeyError as exc:
+                self._authentication_failed = True
+                raise RuntimeError(
+                    f"publication directory is absent from ownership: {directory}"
+                ) from exc
+            if directory_kind != "directory":
+                self._authentication_failed = True
+                raise RuntimeError(
+                    f"publication ancestor is not a directory: {directory}"
+                )
+            directories.append((directory, identity))
+        return _ExpectedPublicationFile(
+            record=record,
+            file_identity=file_identity,
+            directory_identities=tuple(directories),
+        )
+
+    def _require_valid(self) -> None:
+        if self._authentication_failed:
+            raise RuntimeError("publication callback suppressed authentication failure")
+
+    def _deactivate(self) -> None:
+        self._active = False
+
+
+_PublicationTreeReader = PublicationDirectoryReader
+
+
+def _annotate_secondary_error(
+    primary_error: BaseException,
+    label: str,
+    secondary_error: BaseException,
+) -> None:
+    message = f"{label}: {secondary_error!r}"
+    if hasattr(primary_error, "add_note"):
+        primary_error.add_note(message)
+        return
+    notes = list(getattr(primary_error, "_codenib_cleanup_notes", ()))
+    notes.append(message)
+    primary_error._codenib_cleanup_notes = tuple(notes)  # type: ignore[attr-defined]
+    if primary_error.__cause__ is None:
+        primary_error.__cause__ = secondary_error
+
+
+def _retain_first_error(
+    primary_error: BaseException | None,
+    label: str,
+    secondary_error: BaseException,
+) -> BaseException:
+    if primary_error is None:
+        return secondary_error
+    _annotate_secondary_error(primary_error, label, secondary_error)
+    return primary_error
+
+
+@dataclass(slots=True)
+class _PosixDescriptorRecord:
+    descriptor: int
+    identity: tuple[int, ...] | None = None
+
+
+class _PosixResourceOwner:
+    """Track POSIX descriptors without removing ownership before close.
+
+    Python can recover every failure after an integer has reached a local or
+    this owner.  It cannot cover an arbitrary opcode interruption between a raw
+    ``os.open``/``os.dup`` return and Python's first STORE; closing that final
+    P2 gap requires a native owning object.
+    """
+
+    __slots__ = ("_records",)
+
+    def __init__(self) -> None:
+        self._records: list[_PosixDescriptorRecord] = []
+
+    @property
+    def closed(self) -> bool:
+        # A compatibility cleanup path may close a retained descriptor with a
+        # previously captured real close function.  Reconcile that observable
+        # outcome before reporting ownership completion.
+        for record in self._records:
+            descriptor = record.descriptor
+            if descriptor < 0:
+                continue
+            try:
+                observed = os.fstat(descriptor)
+            except OSError as probe_error:
+                if probe_error.errno == errno.EBADF:
+                    record.descriptor = -1
+                continue
+            if (
+                record.identity is not None
+                and _resource_owner_identity(observed) != record.identity
+            ):
+                record.descriptor = -1
+        return all(record.descriptor < 0 for record in self._records)
+
+    def open(
+        self,
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        descriptor = -1
+        record: _PosixDescriptorRecord | None = None
+        try:
+            if dir_fd is None:
+                descriptor = os.open(path, flags, mode)
+            else:
+                descriptor = os.open(path, flags, mode, dir_fd=dir_fd)
+            record = _PosixDescriptorRecord(descriptor)
+            self._records.append(record)
+            record.identity = _resource_owner_identity(os.fstat(descriptor))
+            return descriptor
+        except BaseException as primary_error:
+            if descriptor >= 0:
+                if record is None:
+                    record = _PosixDescriptorRecord(descriptor)
+                if not any(candidate is record for candidate in self._records):
+                    try:
+                        self._records.append(record)
+                    except BaseException as registration_error:  # noqa: B036
+                        _annotate_secondary_error(
+                            primary_error,
+                            "descriptor ownership registration also failed",
+                            registration_error,
+                        )
+                        close_error = self._close_record(record)
+                        if close_error is not None:
+                            _annotate_secondary_error(
+                                primary_error,
+                                "unregistered descriptor cleanup also failed",
+                                close_error,
+                            )
+                        raise primary_error
+                self.close_record_after_error(record, primary_error)
+            raise
+
+    def duplicate(self, descriptor: int) -> int:
+        duplicate = -1
+        record: _PosixDescriptorRecord | None = None
+        try:
+            duplicate = os.dup(descriptor)
+            record = _PosixDescriptorRecord(duplicate)
+            self._records.append(record)
+            record.identity = _resource_owner_identity(os.fstat(duplicate))
+            return duplicate
+        except BaseException as primary_error:
+            if duplicate >= 0:
+                if record is None:
+                    record = _PosixDescriptorRecord(duplicate)
+                if not any(candidate is record for candidate in self._records):
+                    try:
+                        self._records.append(record)
+                    except BaseException as registration_error:  # noqa: B036
+                        _annotate_secondary_error(
+                            primary_error,
+                            "descriptor ownership registration also failed",
+                            registration_error,
+                        )
+                        close_error = self._close_record(record)
+                        if close_error is not None:
+                            _annotate_secondary_error(
+                                primary_error,
+                                "unregistered descriptor cleanup also failed",
+                                close_error,
+                            )
+                        raise primary_error
+                self.close_record_after_error(record, primary_error)
+            raise
+
+    def close_descriptor(self, descriptor: int) -> None:
+        record = self._record_for(descriptor)
+        if record is None:
+            return
+        close_error = self._close_record(record)
+        if close_error is not None:
+            raise close_error
+
+    def close_record_after_error(
+        self,
+        record: _PosixDescriptorRecord,
+        primary_error: BaseException,
+    ) -> None:
+        close_error = self._close_record(record)
+        if close_error is not None:
+            _annotate_secondary_error(
+                primary_error,
+                "descriptor cleanup also failed",
+                close_error,
+            )
+
+    def close_all(self) -> None:
+        primary_error: BaseException | None = None
+        for record in reversed(tuple(self._records)):
+            close_error = self._close_record(record)
+            if close_error is not None:
+                primary_error = _retain_first_error(
+                    primary_error,
+                    "additional descriptor cleanup failed",
+                    close_error,
+                )
+        if primary_error is not None:
+            raise primary_error
+
+    def close_all_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close_all()
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "publication authority cleanup also failed",
+                close_error,
+            )
+
+    def _record_for(self, descriptor: int) -> _PosixDescriptorRecord | None:
+        for record in reversed(self._records):
+            if record.descriptor == descriptor:
+                return record
+        return None
+
+    def _close_record(
+        self,
+        record: _PosixDescriptorRecord,
+    ) -> BaseException | None:
+        descriptor = record.descriptor
+        if descriptor < 0:
+            return None
+        try:
+            observed = os.fstat(descriptor)
+        except OSError as probe_error:
+            if probe_error.errno == errno.EBADF:
+                record.descriptor = -1
+                return None
+            return probe_error
+        except BaseException as probe_error:  # noqa: B036 - retain owner
+            return probe_error
+        observed_identity = _resource_owner_identity(observed)
+        if record.identity is None:
+            record.identity = observed_identity
+        elif observed_identity != record.identity:
+            record.descriptor = -1
+            return RuntimeError("publication descriptor ownership changed")
+
+        try:
+            os.close(descriptor)
+            record.descriptor = -1
+        except BaseException as close_error:  # noqa: B036 - reconcile close
+            if record.descriptor < 0:
+                return close_error
+            try:
+                rebound = os.fstat(descriptor)
+            except OSError as probe_error:
+                if probe_error.errno == errno.EBADF:
+                    record.descriptor = -1
+                else:
+                    _annotate_secondary_error(
+                        close_error,
+                        "descriptor close reconciliation failed",
+                        probe_error,
+                    )
+            except BaseException as probe_error:  # noqa: B036 - keep close error
+                _annotate_secondary_error(
+                    close_error,
+                    "descriptor close reconciliation failed",
+                    probe_error,
+                )
+            else:
+                if _resource_owner_identity(rebound) != record.identity:
+                    # The owned fd closed and the number is observably reused.
+                    # Do not close the replacement descriptor.
+                    record.descriptor = -1
+                # An exact dup2 ABA of the same inode is indistinguishable from
+                # a before-close failure in pure Python.  Proving that final P2
+                # case requires a native owner for the open file description.
+            return close_error
+        return None
+
+
+@dataclass(slots=True)
+class _WindowsHandleRecord:
+    handle: int
+    identity: tuple[int, ...] | None = None
+
+
+def _windows_handle_is_invalid_error(exc: OSError) -> bool:
+    return exc.errno == errno.EBADF or getattr(exc, "winerror", None) == 6
+
+
+class _WindowsResourceOwner:
+    """Track Windows HANDLEs through one-pass, retryable cleanup.
+
+    As with POSIX file descriptors, Python cannot own a raw HANDLE during the
+    arbitrary-opcode gap between a native call's integer return and the first
+    Python STORE.  Closing that final P2 gap requires a native owning object;
+    this class covers failures once the value has reached ``acquire``'s local.
+    """
+
+    __slots__ = ("_api", "_records")
+
+    def __init__(self, api: _WindowsKernelApi) -> None:
+        self._api = api
+        self._records: list[_WindowsHandleRecord] = []
+
+    @property
+    def closed(self) -> bool:
+        for record in self._records:
+            handle = record.handle
+            if not handle:
+                continue
+            try:
+                observed = self._api.metadata(handle)
+            except KeyError:
+                record.handle = 0
+                continue
+            except OSError as probe_error:
+                if _windows_handle_is_invalid_error(probe_error):
+                    record.handle = 0
+                continue
+            if (
+                record.identity is not None
+                and _resource_owner_identity(observed) != record.identity
+            ):
+                record.handle = 0
+        return all(record.handle == 0 for record in self._records)
+
+    def acquire(self, callback: Callable[[], int]) -> int:
+        handle = 0
+        record: _WindowsHandleRecord | None = None
+        try:
+            handle = callback()
+            record = _WindowsHandleRecord(handle)
+            self._records.append(record)
+            metadata = self._api.metadata(handle)
+            record.identity = _resource_owner_identity(metadata)
+            return handle
+        except BaseException as primary_error:
+            if handle:
+                if record is None:
+                    record = _WindowsHandleRecord(handle)
+                if not any(candidate is record for candidate in self._records):
+                    try:
+                        self._records.append(record)
+                    except BaseException as registration_error:  # noqa: B036
+                        _annotate_secondary_error(
+                            primary_error,
+                            "HANDLE ownership registration also failed",
+                            registration_error,
+                        )
+                        close_error = self._close_record(record)
+                        if close_error is not None:
+                            _annotate_secondary_error(
+                                primary_error,
+                                "unregistered HANDLE cleanup also failed",
+                                close_error,
+                            )
+                        raise primary_error
+                self.close_record_after_error(record, primary_error)
+            raise
+
+    def bind_identity(self, handle: int, metadata: _WindowsHandleMetadata) -> None:
+        record = self._record_for(handle)
+        if record is None:
+            raise RuntimeError("Windows HANDLE is not owned")
+        record.identity = _resource_owner_identity(metadata)
+
+    def release(self, handle: int) -> int:
+        """Relinquish a handle to a raw-return caller at the documented P2 edge."""
+
+        record = self._record_for(handle)
+        if record is None:
+            raise RuntimeError("Windows HANDLE is not owned")
+        record.handle = 0
+        return handle
+
+    def close_handle(self, handle: int) -> None:
+        record = self._record_for(handle)
+        if record is None:
+            return
+        close_error = self._close_record(record)
+        if close_error is not None:
+            raise close_error
+
+    def close_record_after_error(
+        self,
+        record: _WindowsHandleRecord,
+        primary_error: BaseException,
+    ) -> None:
+        close_error = self._close_record(record)
+        if close_error is not None:
+            _annotate_secondary_error(
+                primary_error,
+                "Windows HANDLE cleanup also failed",
+                close_error,
+            )
+
+    def close_all(self) -> None:
+        primary_error: BaseException | None = None
+        for record in reversed(tuple(self._records)):
+            close_error = self._close_record(record)
+            if close_error is not None:
+                primary_error = _retain_first_error(
+                    primary_error,
+                    "additional Windows HANDLE cleanup failed",
+                    close_error,
+                )
+        if primary_error is not None:
+            raise primary_error
+
+    def close_all_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close_all()
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "Windows authority cleanup also failed",
+                close_error,
+            )
+
+    def _record_for(self, handle: int) -> _WindowsHandleRecord | None:
+        for record in reversed(self._records):
+            if record.handle == handle:
+                return record
+        return None
+
+    def _close_record(
+        self,
+        record: _WindowsHandleRecord,
+    ) -> BaseException | None:
+        handle = record.handle
+        if not handle:
+            return None
+        try:
+            observed = self._api.metadata(handle)
+        except KeyError:
+            record.handle = 0
+            return None
+        except OSError as probe_error:
+            if _windows_handle_is_invalid_error(probe_error):
+                record.handle = 0
+                return None
+            return probe_error
+        except BaseException as probe_error:  # noqa: B036 - retain owner
+            return probe_error
+        observed_identity = _resource_owner_identity(observed)
+        if record.identity is None:
+            record.identity = observed_identity
+        elif observed_identity != record.identity:
+            record.handle = 0
+            return RuntimeError("publication HANDLE ownership changed")
+
+        try:
+            self._api.close(handle)
+            record.handle = 0
+        except BaseException as close_error:  # noqa: B036 - reconcile close
+            if not record.handle:
+                return close_error
+            try:
+                rebound = self._api.metadata(handle)
+            except KeyError:
+                record.handle = 0
+            except OSError as probe_error:
+                if _windows_handle_is_invalid_error(probe_error):
+                    record.handle = 0
+                else:
+                    _annotate_secondary_error(
+                        close_error,
+                        "Windows HANDLE close reconciliation failed",
+                        probe_error,
+                    )
+            except BaseException as probe_error:  # noqa: B036 - keep close error
+                _annotate_secondary_error(
+                    close_error,
+                    "Windows HANDLE close reconciliation failed",
+                    probe_error,
+                )
+            else:
+                if _resource_owner_identity(rebound) != record.identity:
+                    record.handle = 0
+                # Exact same-FILE_ID HANDLE reuse is the Windows equivalent of
+                # the POSIX dup2 ABA above and likewise needs a native owner.
+            return close_error
+        return None
+
+
+class _PublicationAuthorityOwner:
+    """Pre-existing slot for cancellation-safe authority handoff."""
+
+    __slots__ = ("_authority",)
+
+    def __init__(self) -> None:
+        self._authority: _PublicationAuthority | None = None
+
+    @property
+    def authority(self) -> _PublicationAuthority | None:
+        return self._authority
+
+    def install(self, authority: _PublicationAuthority) -> None:
+        if self._authority is not None:
+            raise RuntimeError("publication authority owner is already active")
+        self._authority = authority
+
+    def close(self) -> None:
+        authority = self._authority
+        if authority is None:
+            return
+        primary_error: BaseException | None = None
+        try:
+            authority.close()
+        except BaseException as close_error:  # noqa: B036 - reconcile owner state
+            primary_error = close_error
+        try:
+            close_complete = authority._closed
+        except BaseException as reconciliation_error:  # noqa: B036
+            if primary_error is None:
+                raise
+            _annotate_secondary_error(
+                primary_error,
+                "publication authority owner reconciliation also failed",
+                reconciliation_error,
+            )
+        else:
+            if close_complete:
+                self._authority = None
+        if primary_error is not None:
+            raise primary_error
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close()
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "publication authority owner cleanup also failed",
+                close_error,
+            )
+
+    def __enter__(self) -> _PublicationAuthorityOwner:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        if exc is None:
+            self.close()
+        else:
+            self.close_after_error(exc)
+
+
+class _PublicationAuthority:
+    """One pinned parent namespace and its platform-specific operations.
+
+    Child handles never escape this object.  Callers receive a bounded reader
+    only for the duration of ``read_child``; this keeps validation and hashing
+    on the same parent/source authority without relying on procfs aliases.
+    """
+
+    __slots__ = (
+        "display_parent",
+        "identity",
+        "backend_tag",
+        "_resource",
+        "_close_callback",
+        "_metadata_callback",
+        "_reader_callback",
+        "_rename_callback",
+        "_verify_callback",
+        "_close_complete_callback",
+        "_close_state",
+    )
+
+    def __init__(
+        self,
+        *,
+        display_parent: Path,
+        identity: tuple[int, ...],
+        backend_tag: str,
+        resource: int,
+        close_callback: Callable[[int], None],
+        metadata_callback: Callable[[str, Path, str], object | None],
+        reader_callback: Callable[
+            [
+                str,
+                Path,
+                str,
+                _TreeOwnership | None,
+                Callable[[_PublicationTreeReader], _T],
+            ],
+            _T,
+        ],
+        rename_callback: Callable[[str, str], None],
+        verify_callback: Callable[[], None],
+        close_complete_callback: Callable[[], bool],
+    ) -> None:
+        self.display_parent = display_parent
+        self.identity = identity
+        self.backend_tag = backend_tag
+        self._resource = resource
+        self._close_callback = close_callback
+        self._metadata_callback = metadata_callback
+        self._reader_callback = reader_callback
+        self._rename_callback = rename_callback
+        self._verify_callback = verify_callback
+        self._close_complete_callback = close_complete_callback
+        self._close_state = False
+
+    @property
+    def _closed(self) -> bool:
+        # Compatibility cleanup may resume the callback directly after an
+        # interruption.  Reflect the resource owner's state whenever callers
+        # inspect completion so a successful resumed cleanup is not forgotten.
+        if not self._close_state and self._close_complete_callback():
+            self._close_state = True
+        return self._close_state
+
+    @_closed.setter
+    def _closed(self, value: bool) -> None:
+        self._close_state = value
+
+    @property
+    def resource(self) -> int:
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        return self._resource
+
+    def child_metadata(
+        self,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> object | None:
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        child_name = _simple_child_name(name, label=label)
+        return self._metadata_callback(child_name, path, label)
+
+    def read_child(
+        self,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+        expected_ownership: _TreeOwnership | None = None,
+        callback: Callable[[_PublicationTreeReader], _T],
+    ) -> _T:
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        child_name = _simple_child_name(name, label=label)
+        return self._reader_callback(
+            child_name,
+            path,
+            label,
+            expected_ownership,
+            callback,
+        )
+
+    def capture_child(
+        self,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+        required_root_file: str | None = None,
+        allow_empty_root: bool = False,
+        entry_policy: DirectoryEntryPolicy | None = None,
+    ) -> _TreeOwnership:
+        return self.read_child(
+            name,
+            path=path,
+            label=label,
+            expected_ownership=None,
+            callback=lambda reader: reader.capture_ownership(
+                required_root_file=required_root_file,
+                allow_empty_root=allow_empty_root,
+                entry_policy=entry_policy,
+            ),
+        )
+
+    def rename_noreplace(self, source: str, destination: str) -> None:
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        self._rename_callback(
+            _simple_child_name(source, label="rename source"),
+            _simple_child_name(destination, label="rename destination"),
+        )
+
+    def verify_path_binding(self) -> None:
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        self._verify_callback()
+
+    def close(self) -> None:
+        if self._close_state:
+            return
+        primary_error: BaseException | None = None
+        try:
+            self._close_callback(self._resource)
+        except BaseException as close_error:  # noqa: B036 - reconcile owner state
+            primary_error = close_error
+        try:
+            close_complete = self._close_complete_callback()
+        except BaseException as reconciliation_error:  # noqa: B036
+            if primary_error is None:
+                raise
+            _annotate_secondary_error(
+                primary_error,
+                "publication authority close-state reconciliation also failed",
+                reconciliation_error,
+            )
+        else:
+            # Cleanup owns the close state.  A before-close interruption or
+            # persistent EIO retains the resource and keeps close retryable;
+            # an after-close interruption may still mark the authority closed.
+            self._close_state = close_complete
+        if primary_error is not None:
+            raise primary_error
+
+    def __enter__(self) -> _PublicationAuthority:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+@dataclass(frozen=True, slots=True)
+class _DirectoryOrphanLocator:
+    """A display path bound to a parent authority and complete tree token."""
+
+    parent_path: Path
+    child_name: str
+    backend_tag: str
+    parent_identity: tuple[int, ...]
+    ownership: _TreeOwnership
+
+
+@dataclass(frozen=True, slots=True)
+class DirectoryOrphan:
+    """Bounded isolation receipt for a tree left for cooperative GC.
+
+    ``verified_at_isolation`` records only the publication boundary.  It is not
+    a persistent proof: a quiescent GC must capture and verify the tree again.
+    """
+
+    locator: _DirectoryOrphanLocator
+    ownership_digest: str
+    entries: int
+    byte_count: int
+    verified_at_isolation: bool = True
+
+    @property
+    def path(self) -> Path:
+        """Return the display path; callers must not treat it as authority."""
+
+        return self.locator.parent_path / self.locator.child_name
+
+    @property
+    def parent_identity(self) -> tuple[int, ...]:
+        return self.locator.parent_identity
+
+    def reopen(
+        self,
+        callback: Callable[[_PublicationTreeReader], _T],
+    ) -> _T:
+        """Reopen this orphan through its parent identity and verify both sides."""
+
+        with _PublicationAuthorityOwner() as authority_owner:
+            authority = _open_publication_authority(
+                self.locator.parent_path,
+                parent_resource=None,
+                expected_parent_identity=self.locator.parent_identity,
+                authority_owner=authority_owner,
+            )
+            if authority.backend_tag != self.locator.backend_tag:
+                raise RuntimeError("directory orphan platform authority changed")
+
+            def use_verified(reader: _PublicationTreeReader) -> _T:
+                before = reader.capture_ownership()
+                _require_matching_ownership(
+                    before,
+                    self.locator.ownership,
+                    label="directory orphan",
+                    allow_root_rename=True,
+                )
+                result = callback(reader)
+                after = reader.capture_ownership()
+                if after != before:
+                    raise RuntimeError("directory orphan changed while reopened")
+                return result
+
+            return authority.read_child(
+                self.locator.child_name,
+                path=self.path,
+                label="directory orphan",
+                expected_ownership=self.locator.ownership,
+                callback=use_verified,
+            )
+
+    def rebind(self) -> _TreeOwnership:
+        """Return a fresh complete token after authority-bound verification."""
+
+        return self.reopen(lambda reader: reader.capture_ownership())
+
+
 class _PreviousOutputIdentityLost(RuntimeError):
     """The moved previous tree can no longer be trusted for rollback."""
 
 
 def lexical_directory_path(path: Path) -> Path:
-    """Resolve the parent without ever following the final path component."""
+    """Return one absolute lexical path without following any component."""
 
     candidate = path.expanduser()
     if candidate.name in {"", ".", ".."}:
         raise ValueError(f"directory path has no safe final component: {path}")
-    return candidate.parent.resolve() / candidate.name
+    return Path(os.path.abspath(os.fspath(candidate)))
+
+
+def _open_posix_publication_authority(
+    path: Path,
+    *,
+    parent_resource: int | None,
+    expected_parent_identity: tuple[int, ...] | None,
+    create_missing: bool = False,
+    authority_owner: _PublicationAuthorityOwner | None = None,
+) -> _PublicationAuthority:
+    if not _SAFE_OWNERSHIP_DIRECTORY_FDS:
+        raise RuntimeError(
+            "publication authority requires no-follow directory-fd support"
+        )
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+    resources = _PosixResourceOwner()
+    authority: _PublicationAuthority | None = None
+    try:
+        if not path.is_absolute() or path.anchor != os.path.sep:
+            raise ValueError("publication parent must be an absolute lexical path")
+        root_descriptor = resources.open(path.anchor, flags)
+        root_identity = _ownership_binding_identity(os.fstat(root_descriptor))
+        if not root_identity[0] or not root_identity[1]:
+            raise RuntimeError("publication root has no reliable identity")
+        path_bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
+        path_descriptor = root_descriptor
+        for part in path.parts[1:]:
+            try:
+                before = os.stat(
+                    part,
+                    dir_fd=path_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                if not create_missing:
+                    raise
+                try:
+                    os.mkdir(part, mode=0o755, dir_fd=path_descriptor)
+                except FileExistsError as exc:
+                    raise RuntimeError(
+                        "publication parent appeared while it was created"
+                    ) from exc
+                os.fsync(path_descriptor)
+                before = os.stat(
+                    part,
+                    dir_fd=path_descriptor,
+                    follow_symlinks=False,
+                )
+            if (
+                _is_link_or_reparse(before)
+                or not stat.S_ISDIR(before.st_mode)
+                or not before.st_dev
+                or not before.st_ino
+            ):
+                raise ValueError("publication parent must be a real directory")
+            child = resources.open(part, flags, dir_fd=path_descriptor)
+            opened_child = os.fstat(child)
+            binding_identity = _ownership_binding_identity(opened_child)
+            if binding_identity != _ownership_binding_identity(before):
+                raise RuntimeError("publication parent changed while it was opened")
+            path_bindings.append((path_descriptor, part, child, binding_identity))
+            path_descriptor = child
+
+        path_identity = publication_parent_identity(path_descriptor)
+        if parent_resource is None:
+            owned_descriptor = path_descriptor
+        else:
+            owned_descriptor = resources.duplicate(parent_resource)
+            if publication_parent_identity(owned_descriptor) != path_identity:
+                raise RuntimeError("publication parent path changed")
+        identity = publication_parent_identity(owned_descriptor)
+        if expected_parent_identity is not None and identity != tuple(
+            expected_parent_identity
+        ):
+            raise RuntimeError("publication parent identity does not match authority")
+
+        def verify_callback() -> None:
+            if (
+                _ownership_binding_identity(os.fstat(root_descriptor)) != root_identity
+                or publication_parent_identity(owned_descriptor) != identity
+            ):
+                raise RuntimeError("publication parent authority changed")
+            for parent, name, child, binding_identity in path_bindings:
+                try:
+                    observed = os.stat(
+                        name,
+                        dir_fd=parent,
+                        follow_symlinks=False,
+                    )
+                    opened_child = os.fstat(child)
+                except OSError as exc:
+                    raise RuntimeError("publication parent path changed") from exc
+                if (
+                    _is_link_or_reparse(observed)
+                    or not stat.S_ISDIR(observed.st_mode)
+                    or _ownership_binding_identity(observed) != binding_identity
+                    or _ownership_binding_identity(opened_child) != binding_identity
+                ):
+                    raise RuntimeError("publication parent path changed")
+
+        verify_callback()
+
+        def metadata_callback(
+            name: str,
+            display_path: Path,
+            label: str,
+        ) -> os.stat_result | None:
+            try:
+                metadata = os.stat(
+                    name,
+                    dir_fd=owned_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                return None
+            if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+                raise ValueError(
+                    f"{label} is not a directory or is a link: {display_path}"
+                )
+            return metadata
+
+        def reader_callback(
+            name: str,
+            display_path: Path,
+            label: str,
+            expected_ownership: _TreeOwnership | None,
+            callback: Callable[[_PublicationTreeReader], _T],
+        ) -> _T:
+            metadata = metadata_callback(name, display_path, label)
+            if metadata is None:
+                raise RuntimeError(f"{label} disappeared: {display_path}")
+            child_descriptor = resources.open(
+                name,
+                flags,
+                dir_fd=owned_descriptor,
+            )
+            reader: _PublicationTreeReader | None = None
+            primary_error: BaseException | None = None
+            try:
+                opened_child = os.fstat(child_descriptor)
+                if (
+                    _is_link_or_reparse(opened_child)
+                    or not stat.S_ISDIR(opened_child.st_mode)
+                    or _ownership_binding_identity(opened_child)
+                    != _ownership_binding_identity(metadata)
+                ):
+                    raise RuntimeError(f"{label} changed while it was opened")
+                root_identity = _directory_inode_identity(opened_child)
+                reader = _PublicationTreeReader(
+                    display_path,
+                    root_identity,
+                    lambda required_root_file, allow_empty_root, entry_policy: (
+                        _capture_posix_directory_descriptor(
+                            child_descriptor,
+                            display_path,
+                            required_root_file=required_root_file,
+                            allow_empty_root=allow_empty_root,
+                            entry_policy=entry_policy,
+                        )
+                    ),
+                    lambda relative, max_bytes, expected: _open_posix_authenticated_file(
+                        child_descriptor,
+                        display_path,
+                        relative,
+                        max_bytes=max_bytes,
+                        expected=expected,
+                    ),
+                    expected_ownership,
+                )
+                result = callback(reader)
+                reader._require_valid()
+                after = os.stat(
+                    name,
+                    dir_fd=owned_descriptor,
+                    follow_symlinks=False,
+                )
+                if _directory_inode_identity(after) != root_identity:
+                    raise RuntimeError(f"{label} namespace binding changed")
+                return result
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                if reader is not None:
+                    reader._deactivate()
+                try:
+                    resources.close_descriptor(child_descriptor)
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        raise
+                    _annotate_secondary_error(
+                        primary_error,
+                        "publication child descriptor cleanup also failed",
+                        close_error,
+                    )
+
+        def rename_callback(source: str, destination: str) -> None:
+            _rename_noreplace_at(
+                source,
+                destination,
+                owned_descriptor,
+                owned_descriptor,
+            )
+
+        def close_resources(_resource: int) -> None:
+            resources.close_all()
+
+        authority = _PublicationAuthority(
+            display_parent=path,
+            identity=identity,
+            backend_tag=(
+                "linux-renameat2"
+                if sys.platform.startswith("linux")
+                else "darwin-renameatx-np"
+            ),
+            resource=owned_descriptor,
+            close_callback=close_resources,
+            metadata_callback=metadata_callback,
+            reader_callback=reader_callback,
+            rename_callback=rename_callback,
+            verify_callback=verify_callback,
+            close_complete_callback=lambda: resources.closed,
+        )
+        if authority_owner is not None:
+            authority_owner.install(authority)
+        return authority
+    except BaseException as primary_error:
+        if (
+            authority is not None
+            and authority_owner is not None
+            and authority_owner.authority is authority
+        ):
+            authority_owner.close_after_error(primary_error)
+        else:
+            resources.close_all_after_error(primary_error)
+        raise
+
+
+def _open_publication_authority(
+    path: Path,
+    *,
+    parent_resource: int | None,
+    expected_parent_identity: tuple[int, ...] | None,
+    create_missing: bool = False,
+    authority_owner: _PublicationAuthorityOwner | None = None,
+) -> _PublicationAuthority:
+    """Open a platform authority before any namespace mutation."""
+
+    _require_rename_noreplace_platform()
+    if sys.platform.startswith("linux") or sys.platform == "darwin":
+        return _open_posix_publication_authority(
+            path,
+            parent_resource=parent_resource,
+            expected_parent_identity=expected_parent_identity,
+            create_missing=create_missing,
+            authority_owner=authority_owner,
+        )
+    if sys.platform == "win32":
+        if create_missing:
+            raise RuntimeError(
+                "safe creation of publication parents is unavailable on Windows"
+            )
+        return _open_windows_publication_authority(
+            path,
+            parent_resource=parent_resource,
+            expected_parent_identity=expected_parent_identity,
+            authority_owner=authority_owner,
+        )
+    raise RuntimeError("atomic directory publication is unsupported on this host")
+
+
+def _require_publication_parent_path(
+    path: Path,
+    expected_identity: tuple[int, ...],
+) -> None:
+    try:
+        observed = path.lstat()
+    except OSError as exc:
+        raise RuntimeError("publication parent path changed") from exc
+    if _directory_inode_identity(observed) != expected_identity:
+        raise RuntimeError("publication parent path changed")
+
+
+def _directory_or_missing_at(
+    parent_authority: _PublicationAuthority | int,
+    name: str,
+    *,
+    path: Path,
+    label: str,
+) -> object | None:
+    if isinstance(parent_authority, _PublicationAuthority):
+        return parent_authority.child_metadata(name, path=path, label=label)
+    try:
+        metadata = os.stat(
+            name,
+            dir_fd=parent_authority,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        return None
+    if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError(f"{label} is not a directory or is a link: {path}")
+    return metadata
+
+
+def _random_orphan_path(
+    *,
+    display_parent: Path,
+    destination_name: str,
+    purpose: str,
+) -> Path:
+    destination_digest = hashlib.sha256(os.fsencode(destination_name)).hexdigest()[:16]
+    compatible_prefix = f".{destination_name}.{purpose}-"
+    if len(os.fsencode(compatible_prefix)) + 32 <= _MAX_OWNERSHIP_COMPONENT_BYTES:
+        prefix = compatible_prefix
+    else:
+        prefix = f".codenib-{purpose}-{destination_digest}-"
+    name = f"{prefix}{secrets.token_hex(16)}"
+    _simple_child_name(name, label="directory orphan")
+    return display_parent / name
+
+
+def _claim_child_as_orphan(
+    parent_authority: _PublicationAuthority | int,
+    source_name: str,
+    *,
+    display_parent: Path,
+    destination_name: str,
+    purpose: str,
+) -> Path:
+    for _attempt in range(_MAX_ORPHAN_NAME_ATTEMPTS):
+        orphan = _random_orphan_path(
+            display_parent=display_parent,
+            destination_name=destination_name,
+            purpose=purpose,
+        )
+        try:
+            if isinstance(parent_authority, _PublicationAuthority):
+                parent_authority.rename_noreplace(source_name, orphan.name)
+            else:
+                _rename_noreplace_at(
+                    source_name,
+                    orphan.name,
+                    parent_authority,
+                    parent_authority,
+                )
+        except FileExistsError:
+            continue
+        except BaseException:
+            # A signal or injected failure can arrive after the kernel moved
+            # the source.  Best-effort no-replace restoration never overwrites
+            # a raced active child and never destroys the unknown candidate.
+            try:
+                if isinstance(parent_authority, _PublicationAuthority):
+                    parent_authority.rename_noreplace(orphan.name, source_name)
+                else:
+                    _rename_noreplace_at(
+                        orphan.name,
+                        source_name,
+                        parent_authority,
+                        parent_authority,
+                    )
+            except BaseException:  # noqa: B036 - preserve the unknown object
+                pass
+            raise
+        return orphan
+    raise RuntimeError("could not claim directory under a bounded orphan name")
+
+
+def _orphan_metadata(
+    authority: _PublicationAuthority,
+    path: Path,
+    ownership: _TreeOwnership,
+    *,
+    verified_at_isolation: bool = True,
+) -> DirectoryOrphan:
+    rebound = ownership
+    if verified_at_isolation:
+        rebound = authority.capture_child(
+            path.name,
+            path=path,
+            label="directory orphan",
+        )
+        _require_matching_ownership(
+            rebound,
+            ownership,
+            label="directory orphan",
+            allow_root_rename=True,
+        )
+    return DirectoryOrphan(
+        locator=_DirectoryOrphanLocator(
+            parent_path=authority.display_parent,
+            child_name=path.name,
+            backend_tag=authority.backend_tag,
+            parent_identity=authority.identity,
+            ownership=rebound,
+        ),
+        ownership_digest=rebound.digest,
+        entries=rebound.entries,
+        byte_count=rebound.byte_count,
+        verified_at_isolation=verified_at_isolation,
+    )
+
+
+def _restore_exact_previous_directory(
+    backup: Path,
+    destination: Path,
+    *,
+    destination_was_missing: bool,
+    parent_authority: _PublicationAuthority,
+    ownership: _TreeOwnership,
+) -> None:
+    if destination_was_missing:
+        return
+    _require_tree_ownership_at(
+        parent_authority,
+        backup.name,
+        path=backup,
+        expected=ownership,
+        label="previous destination",
+        allow_root_rename=True,
+    )
+    parent_authority.rename_noreplace(backup.name, destination.name)
+    try:
+        _require_tree_ownership_at(
+            parent_authority,
+            destination.name,
+            path=destination,
+            expected=ownership,
+            label="moved destination",
+            allow_root_rename=True,
+        )
+    except BaseException as ownership_error:  # noqa: B036 - async-safe rollback
+        # A raced object is preserved under quarantine; never treat it as the
+        # authenticated previous output merely because the rename completed.
+        try:
+            _quarantine_destination(
+                destination,
+                parent_authority=parent_authority,
+            )
+        except BaseException:  # noqa: B036 - preserve the primary failure
+            pass
+        raise _PreviousOutputIdentityLost(
+            "restored destination does not match the previous ownership token"
+        ) from ownership_error
+
+
+def _restore_claimed_directory(
+    backup: Path,
+    destination: Path,
+    *,
+    parent_authority: _PublicationAuthority,
+    context: str,
+) -> None:
+    """Restore an unauthenticated claim without overwriting a raced object."""
+
+    try:
+        parent_authority.rename_noreplace(backup.name, destination.name)
+    except BaseException as restore_error:  # noqa: B036 - report isolation
+        raise RuntimeError(
+            f"{context}; claimed root remains isolated at {backup}"
+        ) from restore_error
 
 
 def _directory_or_missing(path: Path, *, label: str) -> os.stat_result | None:
@@ -134,6 +1766,838 @@ def _directory_inode_identity(metadata: os.stat_result) -> tuple[int, ...]:
     )
 
 
+def publication_parent_identity(descriptor: int) -> tuple[int, ...]:
+    """Return the stable identity expected by descriptor-bound publication."""
+
+    if sys.platform == "win32":
+        return _windows_directory_identity_from_handle(descriptor)
+    metadata = os.fstat(descriptor)
+    if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError("publication parent descriptor is not a real directory")
+    if not metadata.st_dev or not metadata.st_ino:
+        raise RuntimeError("publication parent has no reliable filesystem identity")
+    return _directory_inode_identity(metadata)
+
+
+def _simple_child_name(value: str, *, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+        or "\x00" in value
+        or len(os.fsencode(value)) > _MAX_OWNERSHIP_COMPONENT_BYTES
+    ):
+        raise ValueError(f"{label} must be one bounded file name")
+    if sys.platform == "win32" and (
+        value[-1] in {" ", "."}
+        or any(ord(character) < 32 or character in '<>:"|?*' for character in value)
+        or value.split(".", 1)[0].upper() in _WINDOWS_RESERVED_BASENAMES
+    ):
+        raise ValueError(f"{label} is not a canonical Windows file name")
+    return value
+
+
+def _publication_relative_path(
+    value: str | PurePosixPath,
+) -> PurePosixPath:
+    raw = value.as_posix() if isinstance(value, PurePosixPath) else value
+    if (
+        not isinstance(raw, str)
+        or not raw
+        or raw in {".", ".."}
+        or "\\" in raw
+        or "\x00" in raw
+    ):
+        raise ValueError("publication reader path must be relative POSIX")
+    relative = PurePosixPath(raw)
+    if (
+        relative.is_absolute()
+        or relative.as_posix() != raw
+        or len(relative.parts) > _MAX_SAFE_REMOVAL_DEPTH
+        or len(raw.encode("utf-8", errors="strict")) > _MAX_OWNERSHIP_PATH_BYTES
+    ):
+        raise ValueError("publication reader path must be normalized and bounded")
+    for part in relative.parts:
+        _simple_child_name(part, label="publication reader component")
+    return relative
+
+
+def _rename_noreplace_at(
+    src: str,
+    dst: str,
+    src_dir_fd: int,
+    dst_dir_fd: int,
+) -> None:
+    """Atomically rename one POSIX child without replacing the destination."""
+
+    source = _simple_child_name(src, label="rename source")
+    destination = _simple_child_name(dst, label="rename destination")
+    if sys.platform.startswith("linux"):
+        symbol_name = "renameat2"
+        flags = _RENAME_NOREPLACE
+        required = "Linux renameat2"
+    elif sys.platform == "darwin":
+        symbol_name = "renameatx_np"
+        flags = _RENAME_EXCL
+        required = "macOS renameatx_np"
+    else:
+        raise RuntimeError("atomic no-replace POSIX rename is unsupported on this host")
+    libc = ctypes.CDLL(None, use_errno=True)
+    rename = getattr(libc, symbol_name, None)
+    if rename is None:
+        raise RuntimeError(
+            f"atomic no-replace directory publication requires {required}"
+        )
+    rename.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    )
+    rename.restype = ctypes.c_int
+    result = rename(
+        src_dir_fd,
+        os.fsencode(source),
+        dst_dir_fd,
+        os.fsencode(destination),
+        flags,
+    )
+    if result == 0:
+        return
+    error = ctypes.get_errno()
+    if error in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise FileExistsError(
+            error,
+            os.strerror(error),
+            destination,
+        )
+    if error in {errno.ENOSYS, errno.EINVAL, errno.ENOTSUP, errno.EOPNOTSUPP}:
+        raise RuntimeError(
+            "filesystem does not support atomic no-replace directory publication"
+        )
+    raise OSError(error, os.strerror(error), source, destination)
+
+
+def _require_rename_noreplace_platform() -> None:
+    """Fail before publication-side effects on unsupported host platforms."""
+
+    if sys.platform.startswith("linux"):
+        required_symbol = "renameat2"
+        required_label = "Linux renameat2"
+    elif sys.platform == "darwin":
+        required_symbol = "renameatx_np"
+        required_label = "macOS renameatx_np"
+    elif sys.platform == "win32":
+        _windows_require_publication_api()
+        return
+    else:
+        raise RuntimeError("atomic directory publication is unsupported on this host")
+    libc = ctypes.CDLL(None, use_errno=True)
+    if getattr(libc, required_symbol, None) is None:
+        raise RuntimeError(
+            f"atomic no-replace directory publication requires {required_label}"
+        )
+
+
+def _windows_kernel_api() -> _WindowsKernelApi:
+    return _shared_windows_kernel_api()
+
+
+def _windows_require_publication_api() -> None:
+    _shared_windows_require_publication_api(_windows_kernel_api())
+
+
+def _windows_directory_identity_from_handle(handle: int) -> tuple[int, ...]:
+    metadata = _windows_kernel_api().metadata(handle)
+    if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError("publication parent handle is not a real directory")
+    if not metadata.st_dev or not metadata.st_ino:
+        raise RuntimeError("publication parent has no reliable FILE_ID identity")
+    return _directory_inode_identity(metadata)
+
+
+def _windows_find_child(
+    api: _WindowsKernelApi,
+    parent_handle: int,
+    name: str,
+) -> _WindowsDirectoryEntry | None:
+    folded = name.casefold()
+    matches = [
+        entry
+        for entry in api.enumerate_directory(parent_handle)
+        if entry.name.casefold() == folded
+    ]
+    if len(matches) > 1:
+        raise RuntimeError("Windows directory contains ambiguous child names")
+    return matches[0] if matches else None
+
+
+def _windows_open_child_by_id(
+    api: _WindowsKernelApi,
+    parent_handle: int,
+    entry: _WindowsDirectoryEntry,
+    *,
+    desired_access: int,
+    expected_directory: bool | None,
+    resource_owner: _WindowsResourceOwner | None = None,
+) -> tuple[int, _WindowsHandleMetadata]:
+    if not entry.file_id:
+        raise RuntimeError("Windows directory entry has no reliable FILE_ID")
+    if entry.attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT:
+        raise RuntimeError("Windows publication refuses reparse-point content")
+    is_directory = bool(entry.attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+    if expected_directory is not None and is_directory != expected_directory:
+        raise ValueError("Windows publication child has the wrong object type")
+    selected_owner = (
+        _WindowsResourceOwner(api) if resource_owner is None else resource_owner
+    )
+    handle = selected_owner.acquire(
+        lambda: api.open_by_id(
+            parent_handle,
+            entry.file_id,
+            desired_access=desired_access,
+            is_directory=is_directory,
+        )
+    )
+    try:
+        metadata = api.metadata(handle)
+        if (
+            not metadata.st_dev
+            or not metadata.st_ino
+            or metadata.st_ino != entry.file_id
+            or bool(metadata.st_file_attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+            != is_directory
+            or metadata.st_file_attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
+        ):
+            raise RuntimeError("Windows FILE_ID child changed while it was opened")
+        selected_owner.bind_identity(handle, metadata)
+        if resource_owner is None:
+            selected_owner.release(handle)
+        return handle, metadata
+    except BaseException as primary_error:
+        try:
+            selected_owner.close_handle(handle)
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "Windows child HANDLE cleanup also failed",
+                close_error,
+            )
+        raise
+
+
+def _windows_owned_file_record(
+    api: _WindowsKernelApi,
+    parent_handle: int,
+    entry: _WindowsDirectoryEntry,
+    path: Path,
+    *,
+    root_device: int,
+    budget: _OwnershipBudget,
+    relative: str,
+    entry_policy: DirectoryEntryPolicy | None,
+) -> tuple[int, str, tuple[int, ...]]:
+    handle, opened = _windows_open_child_by_id(
+        api,
+        parent_handle,
+        entry,
+        desired_access=_WINDOWS_FILE_READ_DATA
+        | _WINDOWS_FILE_READ_ATTRIBUTES
+        | _WINDOWS_SYNCHRONIZE,
+        expected_directory=False,
+    )
+    try:
+        if opened.st_dev != root_device:
+            raise RuntimeError(f"directory ownership crosses a volume: {path}")
+        size = opened.st_size
+        if entry_policy is not None:
+            entry_policy(relative, "file", stat.S_IMODE(opened.st_mode), size)
+        if size < 0 or budget.byte_count + size > _MAX_OWNERSHIP_BYTES:
+            raise RuntimeError("directory ownership scan exceeds its byte limit")
+        digest = hashlib.sha256()
+        remaining = size
+        while remaining:
+            block = api.read(handle, min(remaining, _OWNERSHIP_COPY_BYTES))
+            if not block:
+                raise RuntimeError(f"directory ownership file was truncated: {path}")
+            digest.update(block)
+            remaining -= len(block)
+        if api.read(handle, 1):
+            raise RuntimeError(f"directory ownership file grew while read: {path}")
+        after = api.metadata(handle)
+        if _ownership_version_identity(after) != _ownership_version_identity(opened):
+            raise RuntimeError(f"directory ownership file changed: {path}")
+        rebound = _windows_find_child(api, parent_handle, entry.name)
+        if rebound is None or rebound.file_id != entry.file_id:
+            raise RuntimeError(f"directory ownership file changed: {path}")
+    finally:
+        api.close(handle)
+    budget.byte_count += size
+    return size, digest.hexdigest(), _ownership_version_identity(after)
+
+
+@contextmanager
+def _open_windows_authenticated_file(
+    api: _WindowsKernelApi,
+    root_handle: int,
+    root_path: Path,
+    relative: PurePosixPath,
+    *,
+    max_bytes: int,
+    expected: _ExpectedPublicationFile,
+) -> Iterator[PublicationAuthenticatedFile]:
+    root_before = api.metadata(root_handle)
+    parent_handle = root_handle
+    opened_directories: list[int] = []
+    bindings: list[tuple[int, str, int, int, tuple[int, ...]]] = []
+    file_handle = 0
+    authenticated: PublicationAuthenticatedFile | None = None
+    expected_directories = dict(expected.directory_identities)
+    traversed: list[str] = []
+    try:
+        for part in relative.parts[:-1]:
+            traversed.append(part)
+            relative_directory = "/".join(traversed)
+            entry = _windows_find_child(api, parent_handle, part)
+            if entry is None:
+                raise FileNotFoundError(relative.as_posix())
+            child_handle, opened = _windows_open_child_by_id(
+                api,
+                parent_handle,
+                entry,
+                desired_access=_WINDOWS_FILE_LIST_DIRECTORY
+                | _WINDOWS_FILE_READ_ATTRIBUTES
+                | _WINDOWS_SYNCHRONIZE,
+                expected_directory=True,
+            )
+            if opened.st_dev != root_before.st_dev:
+                api.close(child_handle)
+                raise RuntimeError("publication stream crosses a volume")
+            if expected_directories.get(
+                relative_directory
+            ) != _ownership_version_identity(opened):
+                api.close(child_handle)
+                raise RuntimeError(
+                    "publication stream directory differs from captured ownership"
+                )
+            bindings.append(
+                (
+                    parent_handle,
+                    part,
+                    entry.file_id,
+                    child_handle,
+                    _ownership_version_identity(opened),
+                )
+            )
+            opened_directories.append(child_handle)
+            parent_handle = child_handle
+
+        entry = _windows_find_child(api, parent_handle, relative.name)
+        if entry is None:
+            raise FileNotFoundError(relative.as_posix())
+        file_handle, opened_file = _windows_open_child_by_id(
+            api,
+            parent_handle,
+            entry,
+            desired_access=_WINDOWS_FILE_READ_DATA
+            | _WINDOWS_FILE_READ_ATTRIBUTES
+            | _WINDOWS_SYNCHRONIZE,
+            expected_directory=False,
+        )
+        if opened_file.st_dev != root_before.st_dev:
+            raise RuntimeError("publication stream crosses a volume")
+        if _ownership_version_identity(opened_file) != expected.file_identity:
+            raise RuntimeError(
+                "publication stream file differs from captured ownership"
+            )
+        if opened_file.st_size < 0 or opened_file.st_size > max_bytes:
+            raise ValueError(
+                f"publication stream exceeds its {max_bytes}-byte limit: {relative}"
+            )
+
+        def verify() -> None:
+            after_file = api.metadata(file_handle)
+            if _ownership_version_identity(after_file) != _ownership_version_identity(
+                opened_file
+            ):
+                raise RuntimeError("publication stream file changed while read")
+            rebound_file = _windows_find_child(api, parent_handle, relative.name)
+            if rebound_file is None or rebound_file.file_id != entry.file_id:
+                raise RuntimeError("publication stream file binding changed")
+            for bound_parent, name, file_id, handle, expected in reversed(bindings):
+                rebound = _windows_find_child(api, bound_parent, name)
+                if rebound is None or rebound.file_id != file_id:
+                    raise RuntimeError("publication stream directory binding changed")
+                if _ownership_version_identity(api.metadata(handle)) != expected:
+                    raise RuntimeError("publication stream directory changed")
+            root_after = api.metadata(root_handle)
+            if _ownership_version_identity(root_after) != _ownership_version_identity(
+                root_before
+            ):
+                raise RuntimeError("publication stream root changed")
+
+        authenticated = PublicationAuthenticatedFile(
+            path=relative.as_posix(),
+            mode=stat.S_IMODE(opened_file.st_mode),
+            size=opened_file.st_size,
+            read_callback=lambda size: api.read(file_handle, size),
+            verify_callback=verify,
+        )
+        yield authenticated
+    finally:
+        try:
+            if authenticated is not None:
+                authenticated._finalize()
+        finally:
+            if file_handle:
+                api.close(file_handle)
+            for handle in reversed(opened_directories):
+                api.close(handle)
+
+
+def _scan_windows_owned_directory(
+    api: _WindowsKernelApi,
+    handle: int,
+    path: Path,
+    parts: tuple[bytes, ...],
+    *,
+    root_device: int,
+    budget: _OwnershipBudget,
+    inventory: list[tuple[str, str]],
+    file_records: list[TreeFileRecord],
+    entry_identities: list[tuple[str, str, tuple[int, ...]]],
+    entry_policy: DirectoryEntryPolicy | None,
+    depth: int,
+    required_root_file: str | None = None,
+    allow_empty_root: bool = False,
+) -> bytes:
+    if depth > _MAX_SAFE_REMOVAL_DEPTH:
+        raise RuntimeError("directory ownership scan exceeds its depth limit")
+    before = api.metadata(handle)
+    if not stat.S_ISDIR(before.st_mode) or before.st_dev != root_device:
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    entries: list[tuple[bytes, _WindowsDirectoryEntry]] = []
+    for entry in api.enumerate_directory(handle):
+        _simple_child_name(entry.name, label="directory ownership component")
+        try:
+            raw_name = entry.name.encode("utf-8", errors="strict")
+        except UnicodeEncodeError as exc:
+            raise RuntimeError("Windows directory name is not valid Unicode") from exc
+        if not raw_name or len(raw_name) > _MAX_OWNERSHIP_COMPONENT_BYTES:
+            raise RuntimeError("directory ownership component exceeds its byte limit")
+        relative = _ownership_relative_path(parts + (raw_name,))
+        _reserve_ownership_record(budget, relative=relative)
+        entries.append((raw_name, entry))
+    entries.sort(key=lambda item: item[0])
+    if (
+        required_root_file is not None
+        and not (allow_empty_root and not entries)
+        and not any(entry.name == required_root_file for _raw, entry in entries)
+    ):
+        raise RuntimeError("directory ownership root is missing its required marker")
+
+    hasher = hashlib.sha256()
+    hasher.update(b"codenib.atomic-directory.v1\x00")
+    hasher.update(stat.S_IMODE(before.st_mode).to_bytes(4, "big"))
+    for raw_name, entry in entries:
+        child_parts = parts + (raw_name,)
+        relative_bytes = _ownership_relative_path(child_parts)
+        relative = relative_bytes.decode("utf-8", errors="strict")
+        child_path = path / entry.name
+        if entry.attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT:
+            raise RuntimeError(
+                f"directory ownership scan refuses linked content: {child_path}"
+            )
+        is_directory = bool(entry.attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+        entry_hasher = hashlib.sha256()
+        if is_directory:
+            child_handle, opened = _windows_open_child_by_id(
+                api,
+                handle,
+                entry,
+                desired_access=_WINDOWS_FILE_LIST_DIRECTORY
+                | _WINDOWS_FILE_READ_ATTRIBUTES
+                | _WINDOWS_SYNCHRONIZE,
+                expected_directory=True,
+            )
+            try:
+                if opened.st_dev != root_device:
+                    raise RuntimeError(
+                        f"directory ownership crosses a volume: {child_path}"
+                    )
+                if entry_policy is not None:
+                    entry_policy(
+                        relative,
+                        "directory",
+                        stat.S_IMODE(opened.st_mode),
+                        0,
+                    )
+                child_digest = _scan_windows_owned_directory(
+                    api,
+                    child_handle,
+                    child_path,
+                    child_parts,
+                    root_device=root_device,
+                    budget=budget,
+                    inventory=inventory,
+                    file_records=file_records,
+                    entry_identities=entry_identities,
+                    entry_policy=entry_policy,
+                    depth=depth + 1,
+                )
+                after = api.metadata(child_handle)
+                if _ownership_version_identity(after) != _ownership_version_identity(
+                    opened
+                ):
+                    raise RuntimeError(
+                        f"directory ownership directory changed: {child_path}"
+                    )
+            finally:
+                api.close(child_handle)
+            rebound = _windows_find_child(api, handle, entry.name)
+            if rebound is None or rebound.file_id != entry.file_id:
+                raise RuntimeError(
+                    f"directory ownership directory changed: {child_path}"
+                )
+            entry_hasher.update(b"D")
+            _ownership_hash_field(entry_hasher, relative_bytes)
+            entry_hasher.update(stat.S_IMODE(opened.st_mode).to_bytes(4, "big"))
+            entry_hasher.update(child_digest)
+            inventory.append((relative, "directory"))
+            entry_identities.append(
+                (relative, "directory", _ownership_version_identity(after))
+            )
+        else:
+            size, digest, file_identity = _windows_owned_file_record(
+                api,
+                handle,
+                entry,
+                child_path,
+                root_device=root_device,
+                budget=budget,
+                relative=relative,
+                entry_policy=entry_policy,
+            )
+            digest_bytes = bytes.fromhex(digest)
+            file_mode = stat.S_IMODE(file_identity[2])
+            entry_hasher.update(b"F")
+            _ownership_hash_field(entry_hasher, relative_bytes)
+            entry_hasher.update(file_mode.to_bytes(4, "big"))
+            entry_hasher.update(size.to_bytes(8, "big"))
+            entry_hasher.update(digest_bytes)
+            inventory.append((relative, "file"))
+            file_records.append(
+                TreeFileRecord(
+                    path=relative,
+                    mode=file_mode,
+                    size=size,
+                    sha256=digest,
+                )
+            )
+            entry_identities.append((relative, "file", file_identity))
+        if entry.name == required_root_file and is_directory:
+            raise RuntimeError("directory ownership root marker is not a regular file")
+        hasher.update(entry_hasher.digest())
+    after = api.metadata(handle)
+    if _ownership_version_identity(after) != _ownership_version_identity(before):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    return hasher.digest()
+
+
+def _capture_windows_directory_handle(
+    api: _WindowsKernelApi,
+    handle: int,
+    path: Path,
+    *,
+    required_root_file: str | None,
+    allow_empty_root: bool,
+    entry_policy: DirectoryEntryPolicy | None,
+) -> _TreeOwnership:
+    _required_root_file_bytes(required_root_file)
+    opened = api.metadata(handle)
+    if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    if not opened.st_dev or not opened.st_ino:
+        raise RuntimeError("directory ownership root has no reliable FILE_ID identity")
+    budget = _OwnershipBudget()
+    inventory: list[tuple[str, str]] = []
+    file_records: list[TreeFileRecord] = []
+    entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
+    digest = _scan_windows_owned_directory(
+        api,
+        handle,
+        path,
+        (),
+        root_device=opened.st_dev,
+        budget=budget,
+        inventory=inventory,
+        file_records=file_records,
+        entry_identities=entry_identities,
+        entry_policy=entry_policy,
+        depth=0,
+        required_root_file=required_root_file,
+        allow_empty_root=allow_empty_root,
+    )
+    after = api.metadata(handle)
+    if _ownership_version_identity(after) != _ownership_version_identity(opened):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    return _TreeOwnership(
+        root_identity=_directory_inode_identity(opened),
+        root_version_identity=_ownership_version_identity(opened),
+        digest=digest.hex(),
+        entries=budget.entries,
+        byte_count=budget.byte_count,
+        metadata_bytes=budget.metadata_bytes,
+        inventory=tuple(sorted(inventory)),
+        file_records=tuple(sorted(file_records, key=lambda record: record.path)),
+        entry_identities=tuple(sorted(entry_identities)),
+    )
+
+
+def _open_windows_publication_authority(
+    path: Path,
+    *,
+    parent_resource: int | None,
+    expected_parent_identity: tuple[int, ...] | None,
+    authority_owner: _PublicationAuthorityOwner | None = None,
+) -> _PublicationAuthority:
+    api = _windows_kernel_api()
+    resources = _WindowsResourceOwner(api)
+    authority: _PublicationAuthority | None = None
+    try:
+        parent_handle = resources.acquire(
+            lambda: (
+                api.create_directory_handle(path)
+                if parent_resource is None
+                else api.duplicate_handle(parent_resource)
+            )
+        )
+        opened = api.metadata(parent_handle)
+        resources.bind_identity(parent_handle, opened)
+        if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
+            raise ValueError("publication parent must be a real directory")
+        identity = _directory_inode_identity(opened)
+        if not opened.st_dev or not opened.st_ino:
+            raise RuntimeError("publication parent has no reliable FILE_ID identity")
+        if expected_parent_identity is not None and identity != tuple(
+            expected_parent_identity
+        ):
+            raise RuntimeError("publication parent identity does not match authority")
+        path_handle = resources.acquire(lambda: api.create_directory_handle(path))
+        if _directory_inode_identity(api.metadata(path_handle)) != identity:
+            raise RuntimeError("publication parent path changed")
+        owned_parent_handle = parent_handle
+
+        def open_child(
+            name: str,
+            *,
+            desired_access: int,
+        ) -> tuple[int, _WindowsHandleMetadata] | None:
+            entry = _windows_find_child(api, owned_parent_handle, name)
+            if entry is None:
+                return None
+            return _windows_open_child_by_id(
+                api,
+                owned_parent_handle,
+                entry,
+                desired_access=desired_access,
+                expected_directory=True,
+                resource_owner=resources,
+            )
+
+        def metadata_callback(
+            name: str,
+            display_path: Path,
+            label: str,
+        ) -> _WindowsHandleMetadata | None:
+            opened_child = open_child(
+                name,
+                desired_access=_WINDOWS_FILE_READ_ATTRIBUTES | _WINDOWS_SYNCHRONIZE,
+            )
+            if opened_child is None:
+                return None
+            handle, metadata = opened_child
+            primary_error: BaseException | None = None
+            try:
+                if metadata.st_dev != opened.st_dev:
+                    raise RuntimeError("publication child crosses a volume")
+                if _is_link_or_reparse(metadata):
+                    raise ValueError(
+                        f"{label} is not a directory or is a link: {display_path}"
+                    )
+                return metadata
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                try:
+                    resources.close_handle(handle)
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        raise
+                    _annotate_secondary_error(
+                        primary_error,
+                        "Windows metadata HANDLE cleanup also failed",
+                        close_error,
+                    )
+
+        def reader_callback(
+            name: str,
+            display_path: Path,
+            label: str,
+            expected_ownership: _TreeOwnership | None,
+            callback: Callable[[_PublicationTreeReader], _T],
+        ) -> _T:
+            opened_child = open_child(
+                name,
+                desired_access=_WINDOWS_FILE_LIST_DIRECTORY
+                | _WINDOWS_FILE_READ_ATTRIBUTES
+                | _WINDOWS_SYNCHRONIZE,
+            )
+            if opened_child is None:
+                raise RuntimeError(f"{label} disappeared: {display_path}")
+            handle, metadata = opened_child
+            if metadata.st_dev != opened.st_dev:
+                resources.close_handle(handle)
+                raise RuntimeError("publication child crosses a volume")
+            reader: _PublicationTreeReader | None = None
+            primary_error: BaseException | None = None
+            try:
+                reader = _PublicationTreeReader(
+                    display_path,
+                    _directory_inode_identity(metadata),
+                    lambda required_root_file, allow_empty_root, entry_policy: (
+                        _capture_windows_directory_handle(
+                            api,
+                            handle,
+                            display_path,
+                            required_root_file=required_root_file,
+                            allow_empty_root=allow_empty_root,
+                            entry_policy=entry_policy,
+                        )
+                    ),
+                    lambda relative, max_bytes, expected: (
+                        _open_windows_authenticated_file(
+                            api,
+                            handle,
+                            display_path,
+                            relative,
+                            max_bytes=max_bytes,
+                            expected=expected,
+                        )
+                    ),
+                    expected_ownership,
+                )
+                result = callback(reader)
+                reader._require_valid()
+                rebound = _windows_find_child(api, owned_parent_handle, name)
+                if rebound is None or rebound.file_id != metadata.st_ino:
+                    raise RuntimeError(f"{label} namespace binding changed")
+                return result
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                if reader is not None:
+                    reader._deactivate()
+                try:
+                    resources.close_handle(handle)
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        raise
+                    _annotate_secondary_error(
+                        primary_error,
+                        "Windows reader HANDLE cleanup also failed",
+                        close_error,
+                    )
+
+        def rename_callback(source: str, destination: str) -> None:
+            opened_source = open_child(
+                source,
+                desired_access=_WINDOWS_DELETE
+                | _WINDOWS_FILE_READ_ATTRIBUTES
+                | _WINDOWS_SYNCHRONIZE,
+            )
+            if opened_source is None:
+                raise FileNotFoundError(source)
+            source_handle, _metadata = opened_source
+            primary_error: BaseException | None = None
+            try:
+                api.rename_noreplace(
+                    source_handle,
+                    owned_parent_handle,
+                    destination,
+                )
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                try:
+                    resources.close_handle(source_handle)
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        raise
+                    _annotate_secondary_error(
+                        primary_error,
+                        "Windows rename HANDLE cleanup also failed",
+                        close_error,
+                    )
+
+        def verify_callback() -> None:
+            if _directory_inode_identity(api.metadata(owned_parent_handle)) != identity:
+                raise RuntimeError("publication parent authority changed")
+            rebound_handle = resources.acquire(
+                lambda: api.create_directory_handle(path)
+            )
+            primary_error: BaseException | None = None
+            try:
+                if _directory_inode_identity(api.metadata(rebound_handle)) != identity:
+                    raise RuntimeError("publication parent path changed")
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                try:
+                    resources.close_handle(rebound_handle)
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        raise
+                    _annotate_secondary_error(
+                        primary_error,
+                        "Windows verification HANDLE cleanup also failed",
+                        close_error,
+                    )
+
+        authority = _PublicationAuthority(
+            display_parent=path,
+            identity=identity,
+            backend_tag="windows-file-id",
+            resource=owned_parent_handle,
+            close_callback=lambda _resource: resources.close_all(),
+            metadata_callback=metadata_callback,
+            reader_callback=reader_callback,
+            rename_callback=rename_callback,
+            verify_callback=verify_callback,
+            close_complete_callback=lambda: resources.closed,
+        )
+        if authority_owner is not None:
+            authority_owner.install(authority)
+        return authority
+    except BaseException as primary_error:
+        if (
+            authority is not None
+            and authority_owner is not None
+            and authority_owner.authority is authority
+        ):
+            authority_owner.close_after_error(primary_error)
+        else:
+            resources.close_all_after_error(primary_error)
+        raise
+
+
 def _is_link_or_reparse(metadata: os.stat_result) -> bool:
     return stat.S_ISLNK(metadata.st_mode) or bool(
         getattr(metadata, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
@@ -172,11 +2636,48 @@ def _path_is_mount_point(
     *,
     mount_points: frozenset[str] | None = None,
 ) -> bool:
-    lexical = os.path.normpath(os.path.abspath(path))
+    lexical = os.path.normpath(os.path.realpath(path))
     observed_mount_points = (
         _linux_mount_points() if mount_points is None else mount_points
     )
-    return os.path.ismount(path) or lexical in observed_mount_points
+    return (
+        os.path.ismount(path)
+        or os.path.ismount(lexical)
+        or lexical in observed_mount_points
+    )
+
+
+class _ResourceIdentityMetadata(Protocol):
+    @property
+    def st_dev(self) -> int: ...
+
+    @property
+    def st_ino(self) -> int: ...
+
+    @property
+    def st_mode(self) -> int: ...
+
+
+def _resource_owner_identity(
+    metadata: _ResourceIdentityMetadata,
+) -> tuple[int, ...]:
+    """Identify one owned kernel object using only immutable identity fields.
+
+    Permission bits, sizes, timestamps, link counts, and reparse attributes may
+    change while the same descriptor or HANDLE remains owned.  They therefore
+    belong in namespace/content authentication, not close reconciliation.  A
+    Windows 128-bit FILE_ID is preferred when present; POSIX and test backends
+    use the device/inode pair.  The file type is stable for an object's life.
+    """
+
+    device = int(metadata.st_dev)
+    mode = int(metadata.st_mode)
+    file_id_128 = (
+        metadata.file_id_128 if isinstance(metadata, _WindowsHandleMetadata) else b""
+    )
+    if file_id_128:
+        return (device, 1, int.from_bytes(file_id_128, "big"), stat.S_IFMT(mode))
+    return (device, 0, int(metadata.st_ino), stat.S_IFMT(mode))
 
 
 def _ownership_binding_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -200,6 +2701,132 @@ def _ownership_version_identity(metadata: os.stat_result) -> tuple[int, ...]:
         metadata.st_ctime_ns,
         metadata.st_nlink,
     )
+
+
+@contextmanager
+def _open_posix_authenticated_file(
+    root_descriptor: int,
+    root_path: Path,
+    relative: PurePosixPath,
+    *,
+    max_bytes: int,
+    expected: _ExpectedPublicationFile,
+) -> Iterator[PublicationAuthenticatedFile]:
+    root_before = os.fstat(root_descriptor)
+    root_device = root_before.st_dev
+    flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    directory_flags = flags | os.O_DIRECTORY | getattr(os, "O_NONBLOCK", 0)
+    file_flags = flags | getattr(os, "O_NONBLOCK", 0)
+    descriptors: list[int] = [os.dup(root_descriptor)]
+    bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
+    file_descriptor = -1
+    authenticated: PublicationAuthenticatedFile | None = None
+    expected_directories = dict(expected.directory_identities)
+    traversed: list[str] = []
+    try:
+        for part in relative.parts[:-1]:
+            traversed.append(part)
+            relative_directory = "/".join(traversed)
+            parent = descriptors[-1]
+            metadata = os.stat(part, dir_fd=parent, follow_symlinks=False)
+            if (
+                _is_link_or_reparse(metadata)
+                or not stat.S_ISDIR(metadata.st_mode)
+                or metadata.st_dev != root_device
+            ):
+                raise RuntimeError(
+                    f"publication stream refuses directory: {root_path / relative}"
+                )
+            child = os.open(part, directory_flags, dir_fd=parent)
+            descriptors.append(child)
+            opened = os.fstat(child)
+            if _ownership_binding_identity(opened) != _ownership_binding_identity(
+                metadata
+            ):
+                raise RuntimeError("publication stream directory changed")
+            if expected_directories.get(
+                relative_directory
+            ) != _ownership_version_identity(opened):
+                raise RuntimeError(
+                    "publication stream directory differs from captured ownership"
+                )
+            bindings.append((parent, part, child, _ownership_version_identity(opened)))
+
+        parent = descriptors[-1]
+        name = relative.name
+        metadata = os.stat(name, dir_fd=parent, follow_symlinks=False)
+        if (
+            _is_link_or_reparse(metadata)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_dev != root_device
+        ):
+            raise RuntimeError(
+                f"publication stream refuses non-file: {root_path / relative}"
+            )
+        file_descriptor = os.open(name, file_flags, dir_fd=parent)
+        opened_file = os.fstat(file_descriptor)
+        if _ownership_binding_identity(opened_file) != _ownership_binding_identity(
+            metadata
+        ):
+            raise RuntimeError("publication stream file changed while opened")
+        if _ownership_version_identity(opened_file) != expected.file_identity:
+            raise RuntimeError(
+                "publication stream file differs from captured ownership"
+            )
+        if opened_file.st_size < 0 or opened_file.st_size > max_bytes:
+            raise ValueError(
+                f"publication stream exceeds its {max_bytes}-byte limit: {relative}"
+            )
+
+        def verify() -> None:
+            after_file = os.fstat(file_descriptor)
+            if _ownership_version_identity(after_file) != _ownership_version_identity(
+                opened_file
+            ):
+                raise RuntimeError("publication stream file changed while read")
+            path_after = os.stat(name, dir_fd=parent, follow_symlinks=False)
+            if _ownership_binding_identity(path_after) != _ownership_binding_identity(
+                opened_file
+            ):
+                raise RuntimeError("publication stream file binding changed")
+            for parent_fd, child_name, child_fd, expected in reversed(bindings):
+                child_after = os.fstat(child_fd)
+                path_child_after = os.stat(
+                    child_name,
+                    dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+                if _ownership_version_identity(
+                    child_after
+                ) != expected or _ownership_binding_identity(
+                    path_child_after
+                ) != _ownership_binding_identity(
+                    child_after
+                ):
+                    raise RuntimeError("publication stream directory binding changed")
+            root_after = os.fstat(root_descriptor)
+            if _ownership_version_identity(root_after) != _ownership_version_identity(
+                root_before
+            ):
+                raise RuntimeError("publication stream root changed")
+
+        authenticated = PublicationAuthenticatedFile(
+            path=relative.as_posix(),
+            mode=stat.S_IMODE(opened_file.st_mode),
+            size=opened_file.st_size,
+            read_callback=lambda size: os.read(file_descriptor, size),
+            verify_callback=verify,
+        )
+        yield authenticated
+    finally:
+        try:
+            if authenticated is not None:
+                authenticated._finalize()
+        finally:
+            if file_descriptor >= 0:
+                os.close(file_descriptor)
+            for descriptor in reversed(descriptors):
+                os.close(descriptor)
 
 
 def _ownership_hash_field(hasher, value: bytes) -> None:
@@ -251,6 +2878,8 @@ def _hash_owned_regular_file(
         if (
             not stat.S_ISREG(opened.st_mode)
             or opened.st_dev != root_device
+            or not opened.st_dev
+            or not opened.st_ino
             or _ownership_binding_identity(opened)
             != _ownership_binding_identity(metadata)
         ):
@@ -307,7 +2936,12 @@ def _scan_owned_directory(
     if depth > _MAX_SAFE_REMOVAL_DEPTH:
         raise RuntimeError("directory ownership scan exceeds its depth limit")
     before = os.fstat(descriptor)
-    if not stat.S_ISDIR(before.st_mode) or before.st_dev != root_device:
+    if (
+        not stat.S_ISDIR(before.st_mode)
+        or before.st_dev != root_device
+        or not before.st_dev
+        or not before.st_ino
+    ):
         raise RuntimeError(f"directory ownership root changed: {path}")
 
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
@@ -463,15 +3097,7 @@ def _scan_owned_directory(
     return hasher.digest()
 
 
-def capture_directory_ownership(
-    path: Path,
-    *,
-    required_root_file: str | None = None,
-    allow_empty_root: bool = False,
-    entry_policy: DirectoryEntryPolicy | None = None,
-) -> _TreeOwnership:
-    """Return a bounded content token for one stable, real directory tree."""
-
+def _required_root_file_bytes(required_root_file: str | None) -> bytes | None:
     required_root_file_bytes: bytes | None = None
     if required_root_file is not None:
         if (
@@ -484,77 +3110,48 @@ def capture_directory_ownership(
         required_root_file_bytes = os.fsencode(required_root_file)
         if len(required_root_file_bytes) > _MAX_OWNERSHIP_COMPONENT_BYTES:
             raise ValueError("directory ownership marker exceeds its byte limit")
+    return required_root_file_bytes
 
-    metadata = _directory_or_missing(path, label="directory ownership root")
-    if metadata is None:
-        raise RuntimeError(f"directory ownership root disappeared: {path}")
+
+def _capture_posix_directory_descriptor(
+    descriptor: int,
+    path: Path,
+    *,
+    required_root_file: str | None,
+    allow_empty_root: bool,
+    entry_policy: DirectoryEntryPolicy | None,
+) -> _TreeOwnership:
+    """Capture one already-open POSIX directory without reacquiring its path."""
+
+    required_root_file_bytes = _required_root_file_bytes(required_root_file)
+    opened = os.fstat(descriptor)
+    if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    if not opened.st_dev or not opened.st_ino:
+        raise RuntimeError("directory ownership root has no reliable identity")
     if _path_is_mount_point(path):
         raise RuntimeError(f"directory ownership root is mounted: {path}")
-    if not _SAFE_OWNERSHIP_DIRECTORY_FDS:
-        # A path-only fallback cannot safely traverse a non-empty tree.  It can
-        # still bind the empty sentinel used for a first publication: a raced
-        # entry is checked again after the sentinel is moved and cleanup uses
-        # rmdir rather than recursive deletion on the same platforms.
-        with os.scandir(path) as entries:
-            if next(iter(entries), None) is not None:
-                raise RuntimeError(
-                    "safe directory ownership requires no-follow directory-fd "
-                    "support for non-empty trees"
-                )
-        after = _directory_or_missing(path, label="directory ownership root")
-        if after is None or _ownership_binding_identity(
-            after
-        ) != _ownership_binding_identity(metadata):
-            raise RuntimeError(f"directory ownership root changed: {path}")
-        digest = hashlib.sha256()
-        digest.update(b"codenib.atomic-directory.v1\x00")
-        digest.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
-        return _TreeOwnership(
-            root_identity=_directory_inode_identity(metadata),
-            root_version_identity=_ownership_version_identity(metadata),
-            digest=digest.hexdigest(),
-            entries=0,
-            byte_count=0,
-            metadata_bytes=0,
-            inventory=(),
-            file_records=(),
-            entry_identities=(),
-        )
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    flags |= getattr(os, "O_CLOEXEC", 0)
-    descriptor = os.open(path, flags)
-    try:
-        opened = os.fstat(descriptor)
-        if _ownership_binding_identity(opened) != _ownership_binding_identity(metadata):
-            raise RuntimeError(f"directory ownership root changed: {path}")
-        budget = _OwnershipBudget()
-        inventory: list[tuple[str, str]] = []
-        file_records: list[TreeFileRecord] = []
-        entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
-        digest = _scan_owned_directory(
-            descriptor,
-            path,
-            (),
-            root_device=opened.st_dev,
-            mount_points=_linux_mount_points(),
-            budget=budget,
-            inventory=inventory,
-            file_records=file_records,
-            entry_identities=entry_identities,
-            entry_policy=entry_policy,
-            depth=0,
-            required_root_file=required_root_file_bytes,
-            allow_empty_root=allow_empty_root,
-        )
-        after = os.fstat(descriptor)
-        if _ownership_version_identity(after) != _ownership_version_identity(opened):
-            raise RuntimeError(f"directory ownership root changed: {path}")
-    finally:
-        os.close(descriptor)
-    path_after = _directory_or_missing(path, label="directory ownership root")
-    if path_after is None or _ownership_binding_identity(
-        path_after
-    ) != _ownership_binding_identity(metadata):
+    budget = _OwnershipBudget()
+    inventory: list[tuple[str, str]] = []
+    file_records: list[TreeFileRecord] = []
+    entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
+    digest = _scan_owned_directory(
+        descriptor,
+        path,
+        (),
+        root_device=opened.st_dev,
+        mount_points=_linux_mount_points(),
+        budget=budget,
+        inventory=inventory,
+        file_records=file_records,
+        entry_identities=entry_identities,
+        entry_policy=entry_policy,
+        depth=0,
+        required_root_file=required_root_file_bytes,
+        allow_empty_root=allow_empty_root,
+    )
+    after = os.fstat(descriptor)
+    if _ownership_version_identity(after) != _ownership_version_identity(opened):
         raise RuntimeError(f"directory ownership root changed: {path}")
     return _TreeOwnership(
         root_identity=_directory_inode_identity(opened),
@@ -567,6 +3164,103 @@ def capture_directory_ownership(
         file_records=tuple(sorted(file_records, key=lambda record: record.path)),
         entry_identities=tuple(sorted(entry_identities)),
     )
+
+
+def capture_directory_ownership(
+    path: Path,
+    *,
+    required_root_file: str | None = None,
+    allow_empty_root: bool = False,
+    entry_policy: DirectoryEntryPolicy | None = None,
+) -> _TreeOwnership:
+    """Return a bounded token through a pinned parent/source authority."""
+
+    lexical = lexical_directory_path(path)
+    with _PublicationAuthorityOwner() as authority_owner:
+        if sys.platform.startswith("linux") or sys.platform == "darwin":
+            authority = _open_posix_publication_authority(
+                lexical.parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+                authority_owner=authority_owner,
+            )
+        elif sys.platform == "win32":
+            authority = _open_windows_publication_authority(
+                lexical.parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+                authority_owner=authority_owner,
+            )
+        else:
+            raise RuntimeError(
+                "safe directory ownership capture is unsupported on this host"
+            )
+        return authority.capture_child(
+            lexical.name,
+            path=lexical,
+            label="directory ownership root",
+            required_root_file=required_root_file,
+            allow_empty_root=allow_empty_root,
+            entry_policy=entry_policy,
+        )
+
+
+def capture_directory_ownership_if_exists(
+    path: Path,
+    *,
+    required_root_file: str | None = None,
+    allow_empty_root: bool = False,
+    entry_policy: DirectoryEntryPolicy | None = None,
+) -> _TreeOwnership | None:
+    """Capture one existing tree or atomically observe that its child is absent.
+
+    The missing observation and any capture use one pinned parent authority.
+    A child that appears after a missing observation is not opened or blessed;
+    callers can pass the returned ``None`` into a later no-replace operation.
+    """
+
+    _required_root_file_bytes(required_root_file)
+    lexical = lexical_directory_path(path)
+    with _PublicationAuthorityOwner() as authority_owner:
+        if sys.platform.startswith("linux") or sys.platform == "darwin":
+            authority = _open_posix_publication_authority(
+                lexical.parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+                authority_owner=authority_owner,
+            )
+        elif sys.platform == "win32":
+            authority = _open_windows_publication_authority(
+                lexical.parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+                authority_owner=authority_owner,
+            )
+        else:
+            raise RuntimeError(
+                "safe directory ownership capture is unsupported on this host"
+            )
+        metadata = authority.child_metadata(
+            lexical.name,
+            path=lexical,
+            label="directory ownership root",
+        )
+        if metadata is None:
+            authority.verify_path_binding()
+            return None
+        initial_root_identity = _directory_inode_identity(metadata)
+        ownership = authority.capture_child(
+            lexical.name,
+            path=lexical,
+            label="directory ownership root",
+            required_root_file=required_root_file,
+            allow_empty_root=allow_empty_root,
+            entry_policy=entry_policy,
+        )
+        if ownership.root_identity != initial_root_identity:
+            raise RuntimeError("directory ownership root changed while it was captured")
+        authority.verify_path_binding()
+        return ownership
 
 
 def directory_ownership_inventory(
@@ -627,8 +3321,32 @@ def directory_ownership_digest(ownership: _TreeOwnership) -> str:
     return ownership.digest
 
 
-def _require_tree_ownership(
-    path: Path,
+def require_publishable_directory_ownership(
+    ownership: _TreeOwnership,
+    *,
+    label: str = "staged directory",
+) -> None:
+    """Require strong IDs and private regular files for a future active tree.
+
+    Observation tokens may describe a legacy destination containing hard
+    links because online publication only isolates that old root.  A staged
+    tree is different: every regular file must have exactly one link, or an
+    alias outside the root could mutate bytes after successful publication.
+    """
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    if not ownership.root_identity[0] or not ownership.root_identity[1]:
+        raise RuntimeError(f"{label} has no reliable root identity")
+    for path, kind, identity in ownership.entry_identities:
+        if not identity[0] or not identity[1]:
+            raise RuntimeError(f"{label} entry has no reliable identity: {path}")
+        if kind == "file" and identity[-1] != 1:
+            raise RuntimeError(f"{label} file has an external hard link: {path}")
+
+
+def _require_matching_ownership(
+    observed: _TreeOwnership,
     expected: _TreeOwnership,
     *,
     label: str,
@@ -639,10 +3357,6 @@ def _require_tree_ownership(
         "previous destination",
         "published staged directory",
     }
-    try:
-        observed = capture_directory_ownership(path)
-    except (OSError, ValueError, RuntimeError) as exc:
-        raise RuntimeError(f"{label} changed during directory publication") from exc
     if observed != expected and not (
         allow_root_rename
         and replace(
@@ -654,325 +3368,728 @@ def _require_tree_ownership(
         raise RuntimeError(f"{label} changed during directory publication")
 
 
-def discard_owned_directory(path: Path, ownership: _TreeOwnership) -> None:
-    """Best-effort cleanup that never follows a substituted root path."""
-
-    try:
-        metadata = _directory_or_missing(path, label="owned temporary directory")
-    except (OSError, ValueError):
-        return
-    if (
-        metadata is None
-        or _directory_inode_identity(metadata) != ownership.root_identity
-    ):
-        return
-    try:
-        _remove_owned_directory(path, ownership.root_identity)
-    except (OSError, RuntimeError, ValueError):
-        # Temporary cleanup must not reacquire or remove a replacement path.
-        # A partially removed owned tree is left for explicit orphan GC.
-        return
-
-
-def _require_safe_tree(
-    path: Path,
-    *,
-    root_device: int,
-    mount_points: frozenset[str],
-    depth: int = 0,
-) -> None:
-    """Preflight cleanup without following links or crossing mount boundaries."""
-
-    if depth > _MAX_SAFE_REMOVAL_DEPTH:
-        raise RuntimeError(f"directory cleanup exceeds its depth limit: {path}")
-    metadata = path.lstat()
-    if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
-        raise RuntimeError(f"directory cleanup target changed: {path}")
-    if metadata.st_dev != root_device or _path_is_mount_point(
-        path,
-        mount_points=mount_points,
-    ):
-        raise RuntimeError(f"refusing to remove a mounted directory tree: {path}")
-    with os.scandir(path) as entries:
-        for entry in entries:
-            child = path / entry.name
-            child_metadata = entry.stat(follow_symlinks=False)
-            if child_metadata.st_dev != root_device:
-                raise RuntimeError(
-                    f"refusing to cross a device during directory cleanup: {child}"
-                )
-            if _path_is_mount_point(child, mount_points=mount_points):
-                raise RuntimeError(
-                    f"refusing to remove a mounted filesystem entry: {child}"
-                )
-            if _is_link_or_reparse(child_metadata):
-                if stat.S_ISDIR(child_metadata.st_mode) or bool(
-                    getattr(child_metadata, "st_file_attributes", 0)
-                    & _FILE_ATTRIBUTE_REPARSE_POINT
-                ):
-                    raise RuntimeError(
-                        f"refusing to follow a linked directory during cleanup: {child}"
-                    )
-                continue
-            if stat.S_ISDIR(child_metadata.st_mode):
-                _require_safe_tree(
-                    child,
-                    root_device=root_device,
-                    mount_points=mount_points,
-                    depth=depth + 1,
-                )
-
-
-def _remove_tree_at(
-    parent_descriptor: int,
+def _require_tree_ownership_at(
+    authority: _PublicationAuthority,
     name: str,
-    path: Path,
     *,
-    root_device: int,
-    mount_points: frozenset[str],
-    removal_state: _RemovalState,
-    depth: int,
+    path: Path,
+    expected: _TreeOwnership,
+    label: str,
+    allow_root_rename: bool = False,
 ) -> None:
-    if depth > _MAX_SAFE_REMOVAL_DEPTH:
-        raise RuntimeError(f"directory cleanup exceeds its depth limit: {path}")
-    metadata = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
-    if (
-        _is_link_or_reparse(metadata)
-        or not stat.S_ISDIR(metadata.st_mode)
-        or metadata.st_dev != root_device
-        or _path_is_mount_point(path, mount_points=mount_points)
-    ):
-        raise RuntimeError(f"directory cleanup target changed: {path}")
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    descriptor = os.open(name, flags, dir_fd=parent_descriptor)
     try:
-        opened = os.fstat(descriptor)
-        if _directory_inode_identity(opened) != _directory_inode_identity(metadata):
-            raise RuntimeError(f"directory cleanup target changed: {path}")
-        if opened.st_dev != root_device or _path_is_mount_point(
-            path,
-            mount_points=mount_points,
-        ):
-            raise RuntimeError(f"refusing to remove a mounted directory tree: {path}")
-        while True:
-            # A fresh open file description resets the directory stream without
-            # materializing an attacker-sized list of names.  ``dup`` is not
-            # sufficient because it shares the directory offset.
-            scan_descriptor = os.open(".", flags, dir_fd=descriptor)
-            try:
-                if _directory_inode_identity(
-                    os.fstat(scan_descriptor)
-                ) != _directory_inode_identity(opened):
-                    raise RuntimeError(f"directory cleanup target changed: {path}")
-                with os.scandir(scan_descriptor) as entries:
-                    entry = next(iter(entries), None)
-            finally:
-                os.close(scan_descriptor)
-            if entry is None:
-                break
-            child_metadata = os.stat(
-                entry.name,
-                dir_fd=descriptor,
-                follow_symlinks=False,
-            )
-            child_path = path / entry.name
-            if child_metadata.st_dev != root_device:
-                raise RuntimeError(
-                    f"refusing to cross a device during directory cleanup: {child_path}"
-                )
-            if _path_is_mount_point(child_path, mount_points=mount_points):
-                raise RuntimeError(
-                    f"refusing to remove a mounted filesystem entry: {child_path}"
-                )
-            if stat.S_ISDIR(child_metadata.st_mode) and not _is_link_or_reparse(
-                child_metadata
-            ):
-                _remove_tree_at(
-                    descriptor,
-                    entry.name,
-                    child_path,
-                    root_device=root_device,
-                    mount_points=mount_points,
-                    removal_state=removal_state,
-                    depth=depth + 1,
-                )
-            else:
-                if bool(
-                    getattr(child_metadata, "st_file_attributes", 0)
-                    & _FILE_ATTRIBUTE_REPARSE_POINT
-                ):
-                    raise RuntimeError(
-                        f"refusing to remove a reparse point during cleanup: {child_path}"
-                    )
-                removal_state.destructive_started = True
-                os.unlink(entry.name, dir_fd=descriptor)
-        if _directory_inode_identity(os.fstat(descriptor)) != _directory_inode_identity(
-            opened
-        ):
-            raise RuntimeError(f"directory cleanup target changed: {path}")
-    finally:
-        os.close(descriptor)
-    removal_state.destructive_started = True
-    os.rmdir(name, dir_fd=parent_descriptor)
+        observed = authority.capture_child(
+            name,
+            path=path,
+            label=label,
+        )
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise RuntimeError(f"{label} changed during directory publication") from exc
+    _require_matching_ownership(
+        observed,
+        expected,
+        label=label,
+        allow_root_rename=allow_root_rename,
+    )
 
 
-def _remove_owned_directory(
+def _require_tree_ownership(
     path: Path,
-    expected_identity: tuple[int, ...],
+    expected: _TreeOwnership,
     *,
-    removal_state: _RemovalState | None = None,
+    label: str,
+    allow_root_rename: bool = False,
 ) -> None:
-    """Remove an owned tree without following links or crossing mounts."""
+    """Compatibility wrapper for non-publication ownership checks."""
 
-    if removal_state is None:
-        removal_state = _RemovalState()
-    metadata = _directory_or_missing(path, label="directory cleanup target")
-    if metadata is None or _directory_inode_identity(metadata) != expected_identity:
-        raise RuntimeError(f"directory cleanup target changed: {path}")
-    root_device = metadata.st_dev
-    if not _SAFE_REMOVAL_DIRECTORY_FDS:
-        with os.scandir(path) as entries:
-            if next(iter(entries), None) is not None:
+    try:
+        observed = capture_directory_ownership(path)
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise RuntimeError(f"{label} changed during directory publication") from exc
+    _require_matching_ownership(
+        observed,
+        expected,
+        label=label,
+        allow_root_rename=allow_root_rename,
+    )
+
+
+def reopen_authenticated_directory(
+    path: Path,
+    expected_ownership: _TreeOwnership,
+    callback: Callable[[PublicationDirectoryReader], _T],
+    *,
+    expected_parent_identity: tuple[int, ...] | None = None,
+) -> _T:
+    """Consume an existing tree through one backend-neutral authority.
+
+    The complete tree is freshly matched before and after ``callback``.  File
+    reads remain bound to ``expected_ownership`` and the callback-scoped reader
+    cannot escape as a path authority.  Linux/macOS use retained directory fds;
+    Windows uses retained parent/root HANDLEs and FILE_ID traversal.
+    """
+
+    if not isinstance(expected_ownership, _TreeOwnership):
+        raise TypeError(
+            "expected ownership must be a captured directory ownership token"
+        )
+    if not callable(callback):
+        raise TypeError("authenticated directory callback must be callable")
+    lexical = lexical_directory_path(path)
+    with _PublicationAuthorityOwner() as authority_owner:
+        authority = _open_publication_authority(
+            lexical.parent,
+            parent_resource=None,
+            expected_parent_identity=expected_parent_identity,
+            authority_owner=authority_owner,
+        )
+
+        def consume(reader: PublicationDirectoryReader) -> _T:
+            before = reader.capture_ownership()
+            if before != expected_ownership:
                 raise RuntimeError(
-                    "safe directory cleanup requires no-follow directory-fd support"
+                    "authenticated directory differs from expected ownership"
                 )
-        final_metadata = _directory_or_missing(
-            path,
-            label="empty directory cleanup target",
+            result = callback(reader)
+            # A validator may deliberately catch a stream/snapshot failure.
+            # Reject before another namespace observation can hide that failure.
+            reader._require_valid()
+            after = reader.capture_ownership()
+            if after != expected_ownership:
+                raise RuntimeError(
+                    "authenticated directory changed while it was consumed"
+                )
+            return result
+
+        result = authority.read_child(
+            lexical.name,
+            path=lexical,
+            label="authenticated directory",
+            expected_ownership=expected_ownership,
+            callback=consume,
+        )
+        authority.verify_path_binding()
+        return result
+
+
+def discard_owned_directory(
+    path: Path,
+    ownership: _TreeOwnership,
+) -> DirectoryOrphan | None:
+    """Atomically isolate an exact owned tree without recursively deleting it.
+
+    Under a hostile same-UID process there is no safe final ``stat -> unlink``
+    sequence: a validated entry can always be replaced immediately before the
+    destructive syscall.  Online cleanup therefore claims the complete root
+    under a random hidden name and returns bounded metadata for a later,
+    explicitly cooperative GC pass.
+    """
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    lexical = lexical_directory_path(path)
+    _require_rename_noreplace_platform()
+    authority_owner = _PublicationAuthorityOwner()
+    authority: _PublicationAuthority | None = None
+    primary_error: BaseException | None = None
+    try:
+        authority = _open_publication_authority(
+            lexical.parent,
+            parent_resource=None,
+            expected_parent_identity=None,
+            authority_owner=authority_owner,
+        )
+        metadata = _directory_or_missing_at(
+            authority,
+            lexical.name,
+            path=lexical,
+            label="owned temporary directory",
         )
         if (
-            final_metadata is None
-            or _directory_inode_identity(final_metadata) != expected_identity
+            metadata is None
+            or _directory_inode_identity(metadata) != ownership.root_identity
         ):
-            raise RuntimeError(f"directory cleanup target changed: {path}")
-        removal_state.destructive_started = True
-        path.rmdir()
-        return
-    _require_safe_tree(
-        path,
-        root_device=root_device,
-        mount_points=_linux_mount_points(),
-    )
-    parent_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    parent_descriptor = os.open(path.parent, parent_flags)
-    try:
-        _remove_tree_at(
-            parent_descriptor,
-            path.name,
-            path,
-            root_device=root_device,
-            mount_points=_linux_mount_points(),
-            removal_state=removal_state,
-            depth=0,
+            return None
+        try:
+            _require_tree_ownership_at(
+                authority,
+                lexical.name,
+                path=lexical,
+                expected=ownership,
+                label="owned temporary directory",
+            )
+        except (OSError, RuntimeError, ValueError):
+            return None
+        orphan = _claim_child_as_orphan(
+            authority,
+            lexical.name,
+            display_parent=lexical.parent,
+            destination_name=lexical.name,
+            purpose="discarded",
         )
+        try:
+            moved = _directory_or_missing_at(
+                authority,
+                orphan.name,
+                path=orphan,
+                label="discarded directory orphan",
+            )
+            if (
+                moved is None
+                or _directory_inode_identity(moved) != ownership.root_identity
+            ):
+                raise RuntimeError("discarded directory identity changed at claim")
+            _require_tree_ownership_at(
+                authority,
+                orphan.name,
+                path=orphan,
+                expected=ownership,
+                label="moved destination",
+                allow_root_rename=True,
+            )
+        except (OSError, RuntimeError, ValueError):
+            try:
+                authority.rename_noreplace(orphan.name, lexical.name)
+            except (OSError, RuntimeError):
+                return _orphan_metadata(
+                    authority,
+                    orphan,
+                    ownership,
+                    verified_at_isolation=False,
+                )
+            return None
+        try:
+            return _orphan_metadata(authority, orphan, ownership)
+        except (OSError, RuntimeError, ValueError):
+            # Isolation completed but a raced mutation prevented a verified
+            # receipt.  Restore without replacement; if that is no longer
+            # possible, return an explicitly unverified authority locator.
+            try:
+                authority.rename_noreplace(orphan.name, lexical.name)
+            except (OSError, RuntimeError):
+                return _orphan_metadata(
+                    authority,
+                    orphan,
+                    ownership,
+                    verified_at_isolation=False,
+                )
+            return None
+    except (OSError, RuntimeError, ValueError):
+        return None
+    except BaseException as exc:
+        primary_error = exc
+        raise
     finally:
-        os.close(parent_descriptor)
+        if primary_error is None:
+            authority_owner.close()
+        else:
+            authority_owner.close_after_error(primary_error)
 
 
-def _restore_previous_directory(
-    backup: Path,
+def _quarantine_destination(
     destination: Path,
     *,
-    destination_was_missing: bool,
-) -> None:
-    os.replace(backup, destination)
-    if destination_was_missing:
-        destination.rmdir()
-
-
-def _quarantine_destination(destination: Path) -> Path | None:
+    parent_descriptor: int | None = None,
+    parent_authority: _PublicationAuthority | None = None,
+) -> Path | None:
     """Move an untrusted post-publication object out of the caller's stage path."""
 
+    lexical = lexical_directory_path(destination)
+    authority_owner = _PublicationAuthorityOwner()
+    owned_authority: _PublicationAuthority | None = None
+    authority = parent_authority
+    primary_error: BaseException | None = None
     try:
-        destination.lstat()
-    except FileNotFoundError:
-        return None
-    quarantine = Path(
-        tempfile.mkdtemp(
-            prefix=f".{destination.name}.quarantine-",
-            dir=str(destination.parent),
+        if authority is None:
+            owned_authority = _open_publication_authority(
+                lexical.parent,
+                parent_resource=parent_descriptor,
+                expected_parent_identity=None,
+                authority_owner=authority_owner,
+            )
+            authority = owned_authority
+        metadata = authority.child_metadata(
+            lexical.name,
+            path=lexical,
+            label="quarantine destination",
         )
-    )
-    quarantine.rmdir()
-    try:
-        os.replace(destination, quarantine)
-    except BaseException:
-        try:
-            quarantine.rmdir()
-        except OSError:
-            pass
+        if metadata is None:
+            return None
+        return _claim_child_as_orphan(
+            authority,
+            lexical.name,
+            display_parent=lexical.parent,
+            destination_name=lexical.name,
+            purpose="quarantine",
+        )
+    except BaseException as exc:
+        primary_error = exc
         raise
-    return quarantine
+    finally:
+        if primary_error is None:
+            authority_owner.close()
+        else:
+            authority_owner.close_after_error(primary_error)
 
 
-def _recover_invalid_publication(
-    backup: Path,
+def _require_durable_publication_commit_authority(
+    publication_authority: _PublicationAuthority,
+) -> None:
+    """Reject unsupported strict commit authorities before any mutation."""
+
+    if (
+        not sys.platform.startswith("linux")
+        or publication_authority.backend_tag not in _DURABLE_PUBLICATION_FSYNC_BACKENDS
+    ):
+        raise RuntimeError(
+            "durable directory commit requires a supported Linux publication "
+            "authority"
+        )
+    resource = publication_authority.resource
+    if isinstance(resource, bool) or not isinstance(resource, int) or resource < 0:
+        raise RuntimeError(
+            "durable directory commit requires a valid POSIX parent descriptor"
+        )
+
+
+def _fsync_publication_parent_for_commit(
+    publication_authority: _PublicationAuthority,
+) -> None:
+    """Durably order a supported strict commit before its ownership handoff."""
+
+    os.fsync(publication_authority.resource)
+
+
+def _publish_staged_directory_with_authority(
+    publication_authority: _PublicationAuthority,
+    stage: Path,
     destination: Path,
     *,
-    destination_was_missing: bool,
-    expected_backup_identity: tuple[int, ...],
-    published_output_trusted: bool,
-) -> Path | None:
-    def require_expected_backup(*, message: str) -> None:
-        try:
-            backup_metadata = _directory_or_missing(
-                backup,
-                label="previous destination",
-            )
-        except (OSError, ValueError) as exc:
-            raise _PreviousOutputIdentityLost(message) from exc
-        if (
-            backup_metadata is None
-            or _directory_inode_identity(backup_metadata) != expected_backup_identity
-        ):
-            raise _PreviousOutputIdentityLost(message)
+    expected_destination_identity: tuple[int, ...] | None | object = (
+        _EXPECTED_DESTINATION_UNSET
+    ),
+    expected_stage_identity: tuple[int, ...] | None = None,
+    expected_stage_root_ownership: _TreeOwnership | None = None,
+    expected_destination_ownership: _TreeOwnership | None | object = (
+        _EXPECTED_OWNERSHIP_UNSET
+    ),
+    validate_staged_directory: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    validate_moved_destination: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    validate_published_destination: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    commit_callback: (
+        Callable[[_TreeOwnership, _TreeOwnership, DirectoryOrphan | None], None] | None
+    ) = None,
+) -> DirectoryOrphan | None:
+    """Publish a complete stage through a caller-owned parent authority.
 
-    if published_output_trusted:
-        require_expected_backup(
-            message=(
-                "publication committed; cleanup incomplete; previous output "
-                "identity lost"
+    Every namespace mutation is an atomic no-replace rename relative to the
+    pinned parent descriptor.  The previous tree is intentionally retained as
+    a hidden, fully authenticated orphan for cooperative GC; online recursive
+    deletion cannot be made safe against a hostile same-UID replacement race.
+
+    This helper borrows ``publication_authority``.  It never acquires, closes,
+    or transfers that authority.  ``commit_callback`` receives the sealed
+    pre-rename token, a fresh post-rename token, and the previous orphan.  It is
+    the final fallible action after publication is fully authenticated and the
+    supported parent namespace has been durably synchronized; once the callback
+    starts, its failures propagate without rolling the publication back.
+
+    Parent fsync orders only the namespace publication.  Strict callers must
+    durably seal every staged file and directory before invoking this helper;
+    a ``_TreeOwnership`` token authenticates observations but is not itself a
+    durability receipt.
+    """
+
+    stage_display = lexical_directory_path(stage)
+    destination_display = lexical_directory_path(destination)
+    if stage_display == destination_display:
+        raise ValueError("staged and destination directories must differ")
+    if stage_display.parent != destination_display.parent:
+        raise ValueError("staged and destination directories must share a parent")
+    if stage_display.parent != publication_authority.display_parent:
+        raise ValueError(
+            "staged and destination directories must match the authority parent"
+        )
+    if commit_callback is not None:
+        if not callable(commit_callback):
+            raise TypeError("directory commit callback must be callable")
+        _require_durable_publication_commit_authority(publication_authority)
+
+    def perform_publication() -> DirectoryOrphan | None:
+        stage_metadata = _directory_or_missing_at(
+            publication_authority,
+            stage_display.name,
+            path=stage_display,
+            label="staged directory",
+        )
+        if stage_metadata is None:
+            raise ValueError(f"staged directory does not exist: {stage_display}")
+        if (
+            expected_stage_identity is not None
+            and _directory_identity(stage_metadata) != expected_stage_identity
+        ):
+            raise RuntimeError("staged directory changed before directory publication")
+        required_stage_inode_identity = _directory_inode_identity(stage_metadata)
+        if (
+            expected_stage_root_ownership is not None
+            and required_stage_inode_identity
+            != expected_stage_root_ownership.root_identity
+        ):
+            raise RuntimeError("staged directory root changed before publication")
+
+        stage_ownership = publication_authority.capture_child(
+            stage_display.name,
+            path=stage_display,
+            label="staged directory",
+        )
+        require_publishable_directory_ownership(
+            stage_ownership,
+            label="staged directory",
+        )
+        if (
+            expected_stage_root_ownership is not None
+            and stage_ownership != expected_stage_root_ownership
+        ):
+            raise RuntimeError("staged directory changed before publication")
+        if validate_staged_directory is not None:
+            publication_authority.read_child(
+                stage_display.name,
+                path=stage_display,
+                label="staged directory",
+                expected_ownership=stage_ownership,
+                callback=validate_staged_directory,
+            )
+            _require_tree_ownership_at(
+                publication_authority,
+                stage_display.name,
+                path=stage_display,
+                expected=stage_ownership,
+                label="staged directory",
+            )
+
+        destination_metadata = _directory_or_missing_at(
+            publication_authority,
+            destination_display.name,
+            path=destination_display,
+            label="destination",
+        )
+        observed_destination_ownership = (
+            None
+            if destination_metadata is None
+            else publication_authority.capture_child(
+                destination_display.name,
+                path=destination_display,
+                label="destination",
             )
         )
-    try:
-        quarantine = _quarantine_destination(destination)
-    except Exception as quarantine_error:
-        raise RuntimeError(
-            "published directory identity failed validation; the suspect "
-            f"output remains at {destination} and the previous output remains "
-            f"at {backup}"
-        ) from quarantine_error
-    if not published_output_trusted:
-        suspect_disposition = (
-            f"suspect output was quarantined at {quarantine}"
-            if quarantine is not None
-            else "suspect output vanished before quarantine"
-        )
-        require_expected_backup(
-            message=(
-                "published directory identity failed validation; "
-                f"{suspect_disposition}; previous output identity lost; active "
-                "destination is absent"
+        if expected_destination_ownership is not _EXPECTED_OWNERSHIP_UNSET and (
+            observed_destination_ownership != expected_destination_ownership
+        ):
+            raise RuntimeError("destination changed before directory publication")
+        if expected_destination_identity is not _EXPECTED_DESTINATION_UNSET:
+            observed_identity = (
+                None
+                if destination_metadata is None
+                else _directory_identity(destination_metadata)
             )
+            if observed_identity != expected_destination_identity:
+                raise RuntimeError("destination changed before directory publication")
+
+        destination_was_missing = destination_metadata is None
+        _require_tree_ownership_at(
+            publication_authority,
+            stage_display.name,
+            path=stage_display,
+            expected=stage_ownership,
+            label="staged directory",
         )
-    try:
-        _restore_previous_directory(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
+        backup: Path | None = None
+        moved_destination_ownership: _TreeOwnership | None = None
+        required_destination_inode_identity: tuple[int, ...] | None = None
+        if not destination_was_missing:
+            assert observed_destination_ownership is not None
+            moved_destination_ownership = observed_destination_ownership
+            required_destination_inode_identity = _directory_inode_identity(
+                destination_metadata
+            )
+            _require_tree_ownership_at(
+                publication_authority,
+                destination_display.name,
+                path=destination_display,
+                expected=moved_destination_ownership,
+                label="destination",
+            )
+            backup = _claim_child_as_orphan(
+                publication_authority,
+                destination_display.name,
+                display_parent=destination_display.parent,
+                destination_name=destination_display.name,
+                purpose="previous",
+            )
+
+        def restore_previous(*, context: str) -> None:
+            if destination_was_missing:
+                return
+            assert backup is not None
+            assert moved_destination_ownership is not None
+            try:
+                _restore_exact_previous_directory(
+                    backup,
+                    destination_display,
+                    destination_was_missing=destination_was_missing,
+                    parent_authority=publication_authority,
+                    ownership=moved_destination_ownership,
+                )
+            except BaseException as restore_error:  # noqa: B036 - report isolation
+                raise RuntimeError(
+                    f"{context}; previous output remains isolated at {backup}"
+                ) from restore_error
+
+        try:
+            if destination_was_missing:
+                _require_tree_ownership_at(
+                    publication_authority,
+                    stage_display.name,
+                    path=stage_display,
+                    expected=stage_ownership,
+                    label="staged directory",
+                )
+            else:
+                assert backup is not None
+                assert moved_destination_ownership is not None
+                assert required_destination_inode_identity is not None
+                moved_metadata = _directory_or_missing_at(
+                    publication_authority,
+                    backup.name,
+                    path=backup,
+                    label="moved destination",
+                )
+                if (
+                    moved_metadata is None
+                    or _directory_inode_identity(moved_metadata)
+                    != required_destination_inode_identity
+                ):
+                    raise RuntimeError(
+                        "destination changed at the publication boundary"
+                    )
+                _require_tree_ownership_at(
+                    publication_authority,
+                    backup.name,
+                    path=backup,
+                    expected=moved_destination_ownership,
+                    label="moved destination",
+                    allow_root_rename=True,
+                )
+                if validate_moved_destination is not None:
+                    publication_authority.read_child(
+                        backup.name,
+                        path=backup,
+                        label="moved destination",
+                        expected_ownership=moved_destination_ownership,
+                        callback=validate_moved_destination,
+                    )
+                    _require_tree_ownership_at(
+                        publication_authority,
+                        backup.name,
+                        path=backup,
+                        expected=moved_destination_ownership,
+                        label="moved destination",
+                        allow_root_rename=True,
+                    )
+                _require_tree_ownership_at(
+                    publication_authority,
+                    stage_display.name,
+                    path=stage_display,
+                    expected=stage_ownership,
+                    label="staged directory",
+                )
+        except BaseException:
+            if backup is not None:
+                _restore_claimed_directory(
+                    backup,
+                    destination_display,
+                    parent_authority=publication_authority,
+                    context="destination validation failed after isolation",
+                )
+            raise
+
+        try:
+            publication_authority.rename_noreplace(
+                stage_display.name,
+                destination_display.name,
+            )
+        except BaseException:
+            # If the kernel completed the rename before an asynchronous error,
+            # isolate only a tree that still matches the complete stage token.
+            try:
+                _require_tree_ownership_at(
+                    publication_authority,
+                    destination_display.name,
+                    path=destination_display,
+                    expected=stage_ownership,
+                    label="published staged directory",
+                    allow_root_rename=True,
+                )
+            except BaseException:  # noqa: B036 - probe unknown syscall outcome
+                pass
+            else:
+                _quarantine_destination(
+                    destination_display,
+                    parent_authority=publication_authority,
+                )
+            restore_previous(context="directory publication failed")
+            raise
+
+        try:
+            published_metadata = _directory_or_missing_at(
+                publication_authority,
+                destination_display.name,
+                path=destination_display,
+                label="published staged directory",
+            )
+            if (
+                published_metadata is None
+                or _directory_inode_identity(published_metadata)
+                != required_stage_inode_identity
+            ):
+                raise RuntimeError(
+                    "staged directory changed at the publication boundary"
+                )
+            _require_tree_ownership_at(
+                publication_authority,
+                destination_display.name,
+                path=destination_display,
+                expected=stage_ownership,
+                label="published staged directory",
+                allow_root_rename=True,
+            )
+            if validate_published_destination is not None:
+                publication_authority.read_child(
+                    destination_display.name,
+                    path=destination_display,
+                    label="published staged directory",
+                    expected_ownership=stage_ownership,
+                    callback=validate_published_destination,
+                )
+                _require_tree_ownership_at(
+                    publication_authority,
+                    destination_display.name,
+                    path=destination_display,
+                    expected=stage_ownership,
+                    label="published staged directory",
+                    allow_root_rename=True,
+                )
+        except BaseException as boundary_error:  # noqa: B036 - safe rollback
+            quarantine = _quarantine_destination(
+                destination_display,
+                parent_authority=publication_authority,
+            )
+            restore_previous(
+                context="published directory failed validation and rollback failed"
+            )
+            quarantine_message = (
+                f" at {quarantine}" if quarantine is not None else " after it vanished"
+            )
+            raise RuntimeError(
+                "published directory identity failed validation; suspect output was "
+                f"quarantined{quarantine_message}"
+            ) from boundary_error
+
+        if backup is not None:
+            assert moved_destination_ownership is not None
+            try:
+                _require_tree_ownership_at(
+                    publication_authority,
+                    backup.name,
+                    path=backup,
+                    expected=moved_destination_ownership,
+                    label="previous destination",
+                    allow_root_rename=True,
+                )
+                if validate_moved_destination is not None:
+                    publication_authority.read_child(
+                        backup.name,
+                        path=backup,
+                        label="previous destination",
+                        expected_ownership=moved_destination_ownership,
+                        callback=validate_moved_destination,
+                    )
+                    _require_tree_ownership_at(
+                        publication_authority,
+                        backup.name,
+                        path=backup,
+                        expected=moved_destination_ownership,
+                        label="previous destination",
+                        allow_root_rename=True,
+                    )
+            except BaseException as previous_error:  # noqa: B036 - safe rollback
+                try:
+                    _require_tree_ownership_at(
+                        publication_authority,
+                        backup.name,
+                        path=backup,
+                        expected=moved_destination_ownership,
+                        label="previous destination",
+                        allow_root_rename=True,
+                    )
+                except BaseException as identity_error:  # noqa: B036
+                    raise _PreviousOutputIdentityLost(
+                        "directory publication committed; previous output identity "
+                        "lost; new output remains active and suspect previous root is "
+                        f"at {backup}"
+                    ) from identity_error
+                quarantine = _quarantine_destination(
+                    destination_display,
+                    parent_authority=publication_authority,
+                )
+                restore_previous(
+                    context=(
+                        "previous destination validation failed and rollback failed"
+                    )
+                )
+                raise RuntimeError(
+                    "previous destination failed validation; newly published output "
+                    f"was quarantined at {quarantine}"
+                ) from previous_error
+
+        previous_orphan: DirectoryOrphan | None = None
+        if backup is not None:
+            assert moved_destination_ownership is not None
+            previous_orphan = _orphan_metadata(
+                publication_authority,
+                backup,
+                moved_destination_ownership,
+            )
+
+        try:
+            published_ownership = publication_authority.capture_child(
+                destination_display.name,
+                path=destination_display,
+                label="published staged directory",
+            )
+        except (OSError, ValueError, RuntimeError) as exc:
+            raise RuntimeError(
+                "published staged directory changed during directory publication"
+            ) from exc
+        _require_matching_ownership(
+            published_ownership,
+            stage_ownership,
+            label="published staged directory",
+            allow_root_rename=True,
         )
-    except OSError as restore_error:
-        quarantine_message = (
-            f"; suspect output is quarantined at {quarantine}"
-            if quarantine is not None
-            else ""
-        )
-        raise RuntimeError(
-            "published directory identity failed validation and the previous "
-            f"output could not be restored; it remains at {backup}"
-            f"{quarantine_message}"
-        ) from restore_error
-    return quarantine
+        publication_authority.verify_path_binding()
+        if commit_callback is not None:
+            _fsync_publication_parent_for_commit(publication_authority)
+            commit_callback(stage_ownership, published_ownership, previous_orphan)
+        return previous_orphan
+
+    return perform_publication()
 
 
 def publish_staged_directory(
@@ -987,520 +4104,78 @@ def publish_staged_directory(
     expected_destination_ownership: _TreeOwnership | None | object = (
         _EXPECTED_OWNERSHIP_UNSET
     ),
-    validate_staged_directory: Callable[[Path], None] | None = None,
-    validate_moved_destination: Callable[[Path], None] | None = None,
-    validate_published_destination: Callable[[Path], None] | None = None,
-) -> None:
-    """Publish *stage*, restoring an existing destination on rename failure.
+    validate_staged_directory: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    validate_moved_destination: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    validate_published_destination: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    parent_descriptor: int | None = None,
+    expected_parent_identity: tuple[int, ...] | None = None,
+) -> DirectoryOrphan | None:
+    """Publish a complete stage through one pinned parent directory authority.
 
-    Both paths must share a parent filesystem so each rename is atomic. A
-    successful call consumes *stage*. If the final rename fails, the previous
-    destination is restored and *stage* remains available to caller cleanup.
+    Every namespace mutation is an atomic no-replace rename relative to the
+    pinned parent descriptor.  The previous tree is intentionally retained as
+    a hidden, fully authenticated orphan for cooperative GC; online recursive
+    deletion cannot be made safe against a hostile same-UID replacement race.
 
-    The destination-to-backup rename is the old tree's ownership linearization
-    point. Callers that observed the destination before building a stage must
-    pass that opaque ``expected_destination_ownership`` token; the helper
-    rejects any completed pre-linearization change. ``validate_staged_directory``
-    reruns the caller's artifact-specific verifier inside the publication
-    boundary. ``validate_moved_destination`` runs against the exact moved old
-    tree both before and after stage publication, while
-    ``validate_published_destination`` verifies the new tree before cleanup.
-    All cleanup preflight runs before deletion. An untrusted published tree is
-    quarantined before the previous root is considered for restoration. During
-    cleanup, the already-verified new tree stays active if the moved old root
-    loses its captured identity. Once destructive cleanup starts, publication
-    is also committed and failures preserve whatever remains at the backup
-    path.
+    The public compatibility wrapper owns the authority it opens.  The
+    publication mechanics live in ``_publish_staged_directory_with_authority``
+    so strict callers can retain a pre-opened authority across publication and
+    synchronous receipt consumption.
     """
 
-    # Only parents are resolved.  Resolving the final destination component
-    # would turn ``destination -> victim`` into ``victim`` and let a raced
-    # symlink redirect the replacement into an unrelated directory.
-    stage = lexical_directory_path(stage)
-    destination = lexical_directory_path(destination)
-    if stage == destination:
+    stage_display = lexical_directory_path(stage)
+    destination_display = lexical_directory_path(destination)
+    if stage_display == destination_display:
         raise ValueError("staged and destination directories must differ")
-    if stage.parent != destination.parent:
+    if stage_display.parent != destination_display.parent:
         raise ValueError("staged and destination directories must share a parent")
-    stage_metadata = _directory_or_missing(stage, label="staged directory")
-    if stage_metadata is None:
-        raise ValueError(f"staged directory does not exist: {stage}")
-    observed_stage_identity = _directory_identity(stage_metadata)
-    if (
-        expected_stage_identity is not None
-        and observed_stage_identity != expected_stage_identity
-    ):
-        raise RuntimeError("staged directory changed before directory publication")
-    required_stage_inode_identity = _directory_inode_identity(stage_metadata)
-    if (
-        expected_stage_root_ownership is not None
-        and required_stage_inode_identity != expected_stage_root_ownership.root_identity
-    ):
-        raise RuntimeError("staged directory root changed before publication")
-    expected_stage_ownership = None
-    if validate_staged_directory is not None:
-        if _SAFE_OWNERSHIP_DIRECTORY_FDS:
-            expected_stage_ownership = capture_directory_ownership(stage)
-        validate_staged_directory(stage)
-        if expected_stage_ownership is not None:
-            _require_tree_ownership(
-                stage,
-                expected_stage_ownership,
-                label="staged directory",
-            )
-    elif validate_published_destination is None:
-        expected_stage_ownership = capture_directory_ownership(stage)
-    destination_metadata = _directory_or_missing(
-        destination,
-        label="destination",
-    )
-    if expected_destination_ownership is not _EXPECTED_OWNERSHIP_UNSET:
-        observed_ownership = (
-            None
-            if destination_metadata is None
-            else capture_directory_ownership(destination)
-        )
-        if observed_ownership != expected_destination_ownership:
-            raise RuntimeError("destination changed before directory publication")
-    if expected_destination_identity is not _EXPECTED_DESTINATION_UNSET:
-        observed_identity = (
-            None
-            if destination_metadata is None
-            else _directory_identity(destination_metadata)
-        )
-        if observed_identity != expected_destination_identity:
-            raise RuntimeError("destination changed before directory publication")
 
-    destination_was_missing = destination_metadata is None
-    if destination_was_missing:
-        try:
-            destination.mkdir(mode=0o700)
-        except FileExistsError as exc:
-            raise ValueError(
-                f"destination appeared during publication: {destination}"
-            ) from exc
-        destination_metadata = _directory_or_missing(
-            destination,
-            label="destination sentinel",
-        )
-
-    if destination_metadata is None:
-        raise RuntimeError("destination sentinel disappeared during publication")
-    required_destination_inode_identity = _directory_inode_identity(
-        destination_metadata
-    )
+    authority_owner = _PublicationAuthorityOwner()
+    primary_error: BaseException | None = None
     try:
-        if destination_was_missing:
-            moved_destination_ownership = capture_directory_ownership(destination)
-        elif expected_destination_ownership is not _EXPECTED_OWNERSHIP_UNSET:
-            moved_destination_ownership = expected_destination_ownership
-        elif validate_moved_destination is None:
-            moved_destination_ownership = capture_directory_ownership(destination)
+        publication_authority = _open_publication_authority(
+            stage_display.parent,
+            parent_resource=parent_descriptor,
+            expected_parent_identity=expected_parent_identity,
+            authority_owner=authority_owner,
+        )
+        return _publish_staged_directory_with_authority(
+            publication_authority,
+            stage_display,
+            destination_display,
+            expected_destination_identity=expected_destination_identity,
+            expected_stage_identity=expected_stage_identity,
+            expected_stage_root_ownership=expected_stage_root_ownership,
+            expected_destination_ownership=expected_destination_ownership,
+            validate_staged_directory=validate_staged_directory,
+            validate_moved_destination=validate_moved_destination,
+            validate_published_destination=validate_published_destination,
+        )
+    except BaseException as exc:
+        primary_error = exc
+        raise
+    finally:
+        if primary_error is None:
+            authority_owner.close()
         else:
-            moved_destination_ownership = None
-    except BaseException:
-        if destination_was_missing:
-            try:
-                destination.rmdir()
-            except OSError:
-                pass
-        raise
-    try:
-        backup = Path(
-            tempfile.mkdtemp(
-                prefix=f".{destination.name}.previous-",
-                dir=str(destination.parent),
-            )
-        )
-        backup.rmdir()
-    except BaseException:
-        if destination_was_missing:
-            destination.rmdir()
-        raise
-
-    if expected_stage_ownership is not None:
-        try:
-            _require_tree_ownership(
-                stage,
-                expected_stage_ownership,
-                label="staged directory",
-            )
-        except Exception as exc:
-            if destination_was_missing:
-                destination.rmdir()
-            raise RuntimeError(
-                "staged directory changed before destination publication"
-            ) from exc
-        except BaseException:
-            if destination_was_missing:
-                try:
-                    destination.rmdir()
-                except OSError:
-                    pass
-            raise
-    try:
-        stage_before_destination_rename = _directory_or_missing(
-            stage,
-            label="staged directory",
-        )
-    except (OSError, ValueError) as exc:
-        if destination_was_missing:
-            destination.rmdir()
-        raise RuntimeError(
-            "staged directory changed before destination publication"
-        ) from exc
-    if (
-        stage_before_destination_rename is None
-        or _directory_inode_identity(stage_before_destination_rename)
-        != required_stage_inode_identity
-    ):
-        if destination_was_missing:
-            destination.rmdir()
-        raise RuntimeError("staged directory changed before destination publication")
-
-    try:
-        os.replace(destination, backup)
-    except BaseException:
-        try:
-            backup_after_error = _directory_or_missing(
-                backup,
-                label="moved destination after interrupted rename",
-            )
-            destination_after_error = _directory_or_missing(
-                destination,
-                label="destination after interrupted rename",
-            )
-        except (OSError, ValueError) as inspection_error:
-            raise RuntimeError(
-                "destination rename was interrupted and its publication state "
-                f"could not be inspected; the previous output may remain at {backup}"
-            ) from inspection_error
-        rename_completed = (
-            backup_after_error is not None
-            and _directory_inode_identity(backup_after_error)
-            == required_destination_inode_identity
-            and destination_after_error is None
-        )
-        if rename_completed:
-            try:
-                _restore_previous_directory(
-                    backup,
-                    destination,
-                    destination_was_missing=destination_was_missing,
-                )
-            except OSError as restore_error:
-                raise RuntimeError(
-                    "destination rename was interrupted after completion and the "
-                    f"previous output could not be restored; inspect {backup} and "
-                    f"{destination}"
-                ) from restore_error
-        elif destination_was_missing and (
-            destination_after_error is not None
-            and _directory_inode_identity(destination_after_error)
-            == required_destination_inode_identity
-        ):
-            try:
-                destination.rmdir()
-            except OSError:
-                # Preserve raced content at a destination that was initially
-                # absent; it must never be recursively cleaned here.
-                pass
-        raise
-    try:
-        moved_metadata = _directory_or_missing(
-            backup,
-            label="moved destination",
-        )
-    except (OSError, ValueError) as exc:
-        try:
-            _restore_previous_directory(
-                backup,
-                destination,
-                destination_was_missing=destination_was_missing,
-            )
-        except OSError as restore_error:
-            raise RuntimeError(
-                "destination changed at the publication boundary and the previous "
-                f"output could not be restored; it remains at {backup}"
-            ) from restore_error
-        raise RuntimeError("destination changed at the publication boundary") from exc
-    except BaseException:
-        try:
-            _restore_previous_directory(
-                backup,
-                destination,
-                destination_was_missing=destination_was_missing,
-            )
-        except OSError as restore_error:
-            raise RuntimeError(
-                "destination boundary inspection was interrupted and the previous "
-                f"output could not be restored; it remains at {backup}"
-            ) from restore_error
-        raise
-    if moved_metadata is None:
-        raise RuntimeError("destination disappeared at the publication boundary")
-    if _directory_inode_identity(moved_metadata) != required_destination_inode_identity:
-        _restore_previous_directory(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-        )
-        raise RuntimeError("destination changed at the publication boundary")
-
-    if moved_destination_ownership is not None:
-        try:
-            _require_tree_ownership(
-                backup,
-                moved_destination_ownership,
-                label="moved destination",
-            )
-        except Exception as ownership_error:
-            try:
-                _restore_previous_directory(
-                    backup,
-                    destination,
-                    destination_was_missing=destination_was_missing,
-                )
-            except OSError as restore_error:
-                raise RuntimeError(
-                    "destination changed at the publication boundary; raced "
-                    f"content remains at {destination}"
-                ) from restore_error
-            raise RuntimeError(
-                "destination changed at the publication boundary"
-            ) from ownership_error
-        except BaseException:
-            try:
-                _restore_previous_directory(
-                    backup,
-                    destination,
-                    destination_was_missing=destination_was_missing,
-                )
-            except OSError as restore_error:
-                raise RuntimeError(
-                    "destination ownership scan was interrupted and the previous "
-                    f"output could not be restored; it remains at {backup}"
-                ) from restore_error
-            raise
-
-    if validate_moved_destination is not None and not destination_was_missing:
-        try:
-            validate_moved_destination(backup)
-        except BaseException:
-            try:
-                _restore_previous_directory(
-                    backup,
-                    destination,
-                    destination_was_missing=False,
-                )
-            except OSError as restore_error:
-                raise RuntimeError(
-                    "moved destination validation failed and the previous output "
-                    f"could not be restored; it remains at {backup}"
-                ) from restore_error
-            raise
-
-    if expected_stage_ownership is not None:
-        try:
-            _require_tree_ownership(
-                stage,
-                expected_stage_ownership,
-                label="staged directory",
-            )
-        except BaseException:
-            _restore_previous_directory(
-                backup,
-                destination,
-                destination_was_missing=destination_was_missing,
-            )
-            raise
-    try:
-        stage_before_publish = _directory_or_missing(
-            stage,
-            label="staged directory",
-        )
-    except (OSError, ValueError) as exc:
-        _restore_previous_directory(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-        )
-        raise RuntimeError("staged directory changed before final publication") from exc
-    except BaseException:
-        try:
-            _restore_previous_directory(
-                backup,
-                destination,
-                destination_was_missing=destination_was_missing,
-            )
-        except OSError as restore_error:
-            raise RuntimeError(
-                "staged directory inspection was interrupted and the previous "
-                f"output could not be restored; it remains at {backup}"
-            ) from restore_error
-        raise
-    if (
-        stage_before_publish is None
-        or _directory_inode_identity(stage_before_publish)
-        != required_stage_inode_identity
-    ):
-        _restore_previous_directory(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-        )
-        raise RuntimeError("staged directory changed before final publication")
-
-    try:
-        os.replace(stage, destination)
-    except BaseException:
-        try:
-            _restore_previous_directory(
-                backup,
-                destination,
-                destination_was_missing=destination_was_missing,
-            )
-        except OSError as restore_error:
-            raise RuntimeError(
-                "directory publication failed and the previous output could "
-                f"not be restored; it remains at {backup}"
-            ) from restore_error
-        raise
-
-    try:
-        published_metadata = _directory_or_missing(
-            destination,
-            label="published staged directory",
-        )
-        if published_metadata is None:
-            raise RuntimeError("staged directory disappeared during publication")
-        if (
-            _directory_inode_identity(published_metadata)
-            != required_stage_inode_identity
-        ):
-            raise RuntimeError("staged directory changed at the publication boundary")
-        if expected_stage_ownership is not None:
-            _require_tree_ownership(
-                destination,
-                expected_stage_ownership,
-                label="published staged directory",
-            )
-        if validate_published_destination is not None:
-            validate_published_destination(destination)
-        if expected_stage_ownership is not None:
-            _require_tree_ownership(
-                destination,
-                expected_stage_ownership,
-                label="published staged directory",
-            )
-    except Exception as boundary_error:
-        quarantine = _recover_invalid_publication(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-            expected_backup_identity=_directory_inode_identity(moved_metadata),
-            published_output_trusted=False,
-        )
-        quarantine_message = (
-            f" at {quarantine}" if quarantine is not None else " because it vanished"
-        )
-        raise RuntimeError(
-            "published directory identity failed validation; suspect output was "
-            f"quarantined{quarantine_message}"
-        ) from boundary_error
-    except BaseException:
-        _recover_invalid_publication(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-            expected_backup_identity=_directory_inode_identity(moved_metadata),
-            published_output_trusted=False,
-        )
-        raise
-    if moved_destination_ownership is not None:
-        try:
-            _require_tree_ownership(
-                backup,
-                moved_destination_ownership,
-                label="previous destination",
-            )
-        except Exception as cleanup_error:
-            try:
-                quarantine = _recover_invalid_publication(
-                    backup,
-                    destination,
-                    destination_was_missing=destination_was_missing,
-                    expected_backup_identity=_directory_inode_identity(moved_metadata),
-                    published_output_trusted=True,
-                )
-            except _PreviousOutputIdentityLost as recovery_error:
-                raise recovery_error from cleanup_error
-            quarantine_message = (
-                f" at {quarantine}"
-                if quarantine is not None
-                else " because it vanished"
-            )
-            raise RuntimeError(
-                "previous destination failed safe cleanup validation; newly "
-                f"published output was quarantined{quarantine_message}"
-            ) from cleanup_error
-    if validate_moved_destination is not None and not destination_was_missing:
-        try:
-            validate_moved_destination(backup)
-        except Exception as cleanup_error:
-            try:
-                quarantine = _recover_invalid_publication(
-                    backup,
-                    destination,
-                    destination_was_missing=destination_was_missing,
-                    expected_backup_identity=_directory_inode_identity(moved_metadata),
-                    published_output_trusted=True,
-                )
-            except _PreviousOutputIdentityLost as recovery_error:
-                raise recovery_error from cleanup_error
-            quarantine_message = (
-                f" at {quarantine}"
-                if quarantine is not None
-                else " because it vanished"
-            )
-            raise RuntimeError(
-                "previous destination failed safe cleanup validation; newly "
-                f"published output was quarantined{quarantine_message}"
-            ) from cleanup_error
-
-    removal_state = _RemovalState()
-    try:
-        _remove_owned_directory(
-            backup,
-            _directory_inode_identity(moved_metadata),
-            removal_state=removal_state,
-        )
-    except Exception as cleanup_error:
-        if removal_state.destructive_started:
-            raise RuntimeError(
-                "directory publication committed; cleanup incomplete; previous "
-                f"output remains partially at {backup}"
-            ) from cleanup_error
-        quarantine = _recover_invalid_publication(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-            expected_backup_identity=_directory_inode_identity(moved_metadata),
-            published_output_trusted=True,
-        )
-        quarantine_message = (
-            f" at {quarantine}" if quarantine is not None else " because it vanished"
-        )
-        raise RuntimeError(
-            "previous destination failed safe cleanup validation; newly "
-            f"published output was quarantined{quarantine_message}"
-        ) from cleanup_error
+            authority_owner.close_after_error(primary_error)
 
 
 __all__ = [
     "DirectoryEntryPolicy",
+    "DirectoryOrphan",
+    "PublicationAuthenticatedFile",
+    "PublicationDirectoryReader",
+    "PublicationFileSnapshot",
     "TreeFileRecord",
     "capture_directory_ownership",
+    "capture_directory_ownership_if_exists",
     "directory_ownership_digest",
     "directory_ownership_entry_identities",
     "directory_ownership_file_records",
@@ -1509,5 +4184,8 @@ __all__ = [
     "directory_ownership_root_version_identity",
     "discard_owned_directory",
     "lexical_directory_path",
+    "publication_parent_identity",
     "publish_staged_directory",
+    "reopen_authenticated_directory",
+    "require_publishable_directory_ownership",
 ]

--- a/codenib/_bounded_json.py
+++ b/codenib/_bounded_json.py
@@ -1,0 +1,456 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Incremental, complexity-bounded parsing for large JSON document arrays."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Iterator
+from typing import Any, BinaryIO, Protocol
+
+_READ_BYTES = 1024 * 1024
+DEFAULT_MAX_ARRAY_ITEMS = 1_000_000
+DEFAULT_MAX_ELEMENT_BYTES = 64 * 1024 * 1024
+DEFAULT_MAX_NODES_PER_ELEMENT = 100_000
+DEFAULT_MAX_LEXICAL_TOKENS = 200_000
+DEFAULT_MAX_DEPTH = 64
+DEFAULT_MAX_KEY_BYTES = 4_096
+
+
+class BinaryReader(Protocol):
+    def read(self, size: int = -1) -> bytes: ...
+
+
+def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_number(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def validate_json_complexity(
+    value: Any,
+    *,
+    label: str,
+    max_nodes: int = DEFAULT_MAX_NODES_PER_ELEMENT,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_key_bytes: int = DEFAULT_MAX_KEY_BYTES,
+) -> None:
+    """Reject one decoded value before recursive consumers can exhaust resources."""
+
+    # Depth is one-based in both the lexical framer and decoded-tree check: the
+    # element itself is level one and its direct children are level two.
+    stack: list[tuple[Any, int]] = [(value, 1)]
+    nodes = 0
+    while stack:
+        current, depth = stack.pop()
+        nodes += 1
+        if nodes > max_nodes:
+            raise ValueError(f"{label} exceeds its {max_nodes}-node limit")
+        if depth > max_depth:
+            raise ValueError(f"{label} exceeds its {max_depth}-level depth limit")
+        if isinstance(current, dict):
+            for key, child in current.items():
+                if len(key.encode("utf-8", errors="surrogatepass")) > max_key_bytes:
+                    raise ValueError(
+                        f"{label} contains a key exceeding {max_key_bytes} bytes"
+                    )
+                stack.append((child, depth + 1))
+        elif isinstance(current, list):
+            stack.extend((child, depth + 1) for child in current)
+
+
+class _ByteStream:
+    def __init__(self, source: BinaryReader) -> None:
+        self._source = source
+        self._block = b""
+        self._position = 0
+        self._eof = False
+        self.offset = 0
+
+    def current_block(self) -> tuple[bytes, int] | None:
+        """Return the unread block slice without a Python call per byte."""
+
+        while self._position >= len(self._block):
+            if self._eof:
+                return None
+            self._block = self._source.read(_READ_BYTES)
+            self._position = 0
+            if not self._block:
+                self._eof = True
+                return None
+        return self._block, self._position
+
+    def advance(self, count: int) -> None:
+        if count < 0 or self._position + count > len(self._block):
+            raise AssertionError("invalid bounded JSON stream advance")
+        self._position += count
+        self.offset += count
+
+    def next(self) -> int | None:
+        current = self.current_block()
+        if current is None:
+            return None
+        block, position = current
+        value = block[position]
+        self.advance(1)
+        return value
+
+
+_JSON_WHITESPACE = frozenset(b" \t\r\n")
+_ATOM_DELIMITERS = frozenset(b" \t\r\n,]}:")
+
+
+def _next_non_whitespace(stream: _ByteStream) -> int | None:
+    while (value := stream.next()) is not None:
+        if value not in _JSON_WHITESPACE:
+            return value
+    return None
+
+
+def _frame_json_element(
+    stream: _ByteStream,
+    first: int,
+    *,
+    label: str,
+    max_element_bytes: int,
+    max_tokens: int,
+    max_depth: int,
+) -> tuple[bytearray, int]:
+    """Frame one complete array element before allocating its decoded DOM."""
+
+    payload = bytearray()
+    stack: list[int] = []
+    in_string = False
+    escaped = False
+    string_bytes = 0
+    in_atom = False
+    atom_bytes = 0
+    token_count = 0
+    first_pending = True
+
+    def reserve(count: int) -> None:
+        if len(payload) + count > max_element_bytes:
+            raise ValueError(f"{label} element exceeds {max_element_bytes} bytes")
+
+    while True:
+        if first_pending:
+            # ``first`` was already consumed by _next_non_whitespace.
+            block = bytes((first,))
+            position = 0
+            first_pending = False
+            synthetic = True
+        else:
+            current_block = stream.current_block()
+            if current_block is None:
+                raise ValueError(f"{label} is truncated JSON")
+            block, position = current_block
+            synthetic = False
+        index = position
+        while index < len(block):
+            current = block[index]
+
+            if in_string:
+                if escaped:
+                    escaped = False
+                    string_bytes += 1
+                    index += 1
+                    continue
+                quote = block.find(b'"', index)
+                slash = block.find(b"\\", index)
+                candidates = tuple(item for item in (quote, slash) if item >= 0)
+                special = min(candidates) if candidates else -1
+                if special < 0:
+                    string_bytes += len(block) - index
+                    index = len(block)
+                    break
+                string_bytes += special - index + 1
+                if block[special] == ord("\\"):
+                    escaped = True
+                else:
+                    in_string = False
+                index = special + 1
+                if string_bytes > max_element_bytes:
+                    raise ValueError(
+                        f"{label} string exceeds {max_element_bytes} bytes"
+                    )
+                continue
+
+            if in_atom:
+                if current in _ATOM_DELIMITERS:
+                    in_atom = False
+                    atom_bytes = 0
+                else:
+                    atom_bytes += 1
+                    if atom_bytes > 1_024:
+                        raise ValueError(f"{label} number/literal exceeds 1024 bytes")
+                    index += 1
+                    continue
+
+            if not stack and current in {ord(","), ord("]")}:
+                reserve(index - position)
+                payload.extend(block[position:index])
+                if not synthetic:
+                    stream.advance(index - position + 1)
+                while payload and payload[-1] in _JSON_WHITESPACE:
+                    payload.pop()
+                if not payload:
+                    raise ValueError(f"{label} contains an empty JSON array element")
+                return payload, current
+
+            if current == ord('"'):
+                token_count += 1
+                in_string = True
+                string_bytes = 0
+            elif current in {ord("{"), ord("[")}:
+                token_count += 1
+                stack.append(current)
+                if len(stack) > max_depth:
+                    raise ValueError(
+                        f"{label} exceeds its {max_depth}-level depth limit"
+                    )
+            elif current in {ord("}"), ord("]")}:
+                expected = ord("{") if current == ord("}") else ord("[")
+                if not stack or stack[-1] != expected:
+                    raise ValueError(f"{label} contains mismatched JSON delimiters")
+                stack.pop()
+            elif current in b"-0123456789tfn":
+                token_count += 1
+                in_atom = True
+                atom_bytes = 1
+            if token_count > max_tokens:
+                raise ValueError(f"{label} exceeds its {max_tokens}-token limit")
+            index += 1
+
+        reserve(len(block) - position)
+        payload.extend(block[position:])
+        if not synthetic:
+            stream.advance(len(block) - position)
+    raise ValueError(f"{label} is truncated JSON")
+
+
+def _bounded_parse_int(value: str) -> int:
+    if len(value) > 1_024:
+        raise ValueError("JSON integer exceeds its 1024-character limit")
+    return int(value)
+
+
+def _bounded_parse_float(value: str) -> float:
+    if len(value) > 1_024:
+        raise ValueError("JSON number exceeds its 1024-character limit")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("JSON number is not finite")
+    return parsed
+
+
+def iter_bounded_json_array(
+    source: BinaryReader,
+    *,
+    label: str,
+    max_items: int = DEFAULT_MAX_ARRAY_ITEMS,
+    max_element_bytes: int = DEFAULT_MAX_ELEMENT_BYTES,
+    max_nodes_per_element: int = DEFAULT_MAX_NODES_PER_ELEMENT,
+    max_lexical_tokens: int = DEFAULT_MAX_LEXICAL_TOKENS,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_key_bytes: int = DEFAULT_MAX_KEY_BYTES,
+) -> Iterator[Any]:
+    """Yield a top-level JSON array without retaining the complete input or DOM."""
+
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value <= 0
+        for value in (
+            max_items,
+            max_element_bytes,
+            max_nodes_per_element,
+            max_lexical_tokens,
+            max_depth,
+            max_key_bytes,
+        )
+    ):
+        raise ValueError("bounded JSON limits must be positive integers")
+    stream = _ByteStream(source)
+    decoder = json.JSONDecoder(
+        object_pairs_hook=_reject_duplicate_object,
+        parse_constant=_reject_nonfinite_number,
+        parse_int=_bounded_parse_int,
+        parse_float=_bounded_parse_float,
+    )
+    first = _next_non_whitespace(stream)
+    if first != ord("["):
+        raise ValueError(f"{label} must be a JSON list")
+    item_count = 0
+    first = _next_non_whitespace(stream)
+    if first == ord("]"):
+        first = None
+    elif first is None:
+        raise ValueError(f"{label} is truncated JSON")
+    while True:
+        if first is None:
+            break
+        element_offset = stream.offset - 1
+        while True:
+            try:
+                framed, delimiter = _frame_json_element(
+                    stream,
+                    first,
+                    label=label,
+                    max_element_bytes=max_element_bytes,
+                    max_tokens=max_lexical_tokens,
+                    max_depth=max_depth,
+                )
+                text = framed.decode("utf-8", errors="strict")
+                value, end = decoder.raw_decode(text, 0)
+                if end != len(text):
+                    raise ValueError(f"{label} element contains trailing data")
+                del text, framed
+                break
+            except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+                raise ValueError(
+                    f"{label} element {item_count} at byte {element_offset} "
+                    "contains invalid JSON"
+                ) from exc
+        validate_json_complexity(
+            value,
+            label=f"{label} element {item_count}",
+            max_nodes=max_nodes_per_element,
+            max_depth=max_depth,
+            max_key_bytes=max_key_bytes,
+        )
+        item_count += 1
+        if item_count > max_items:
+            raise ValueError(f"{label} exceeds its {max_items}-item limit")
+        yield value
+        if delimiter == ord("]"):
+            first = None
+        else:
+            first = _next_non_whitespace(stream)
+            if first is None:
+                raise ValueError(f"{label} is truncated JSON")
+            if first == ord("]"):
+                raise ValueError(f"{label} has a trailing JSON array comma")
+
+    if _next_non_whitespace(stream) is not None:
+        raise ValueError(f"{label} contains trailing data")
+
+
+def _indent(level: int) -> bytes:
+    return b"  " * level
+
+
+def _canonical_string_chunks(value: str) -> Iterator[bytes]:
+    from json.encoder import encode_basestring_ascii
+
+    yield b'"'
+    for offset in range(0, len(value), 64 * 1024):
+        encoded = encode_basestring_ascii(value[offset : offset + 64 * 1024])
+        yield encoded[1:-1].encode("ascii")
+    yield b'"'
+
+
+def canonical_json_value_chunks(value: Any, *, level: int = 0) -> Iterator[bytes]:
+    """Stream the exact stdlib canonical representation of one decoded value."""
+
+    if value is None:
+        yield b"null"
+    elif value is True:
+        yield b"true"
+    elif value is False:
+        yield b"false"
+    elif isinstance(value, str):
+        yield from _canonical_string_chunks(value)
+    elif isinstance(value, int):
+        yield str(value).encode("ascii")
+    elif isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("JSON number is not finite")
+        yield repr(value).encode("ascii")
+    elif isinstance(value, list):
+        if not value:
+            yield b"[]"
+            return
+        yield b"[\n"
+        for index, item in enumerate(value):
+            if index:
+                yield b",\n"
+            yield _indent(level + 1)
+            yield from canonical_json_value_chunks(item, level=level + 1)
+        yield b"\n" + _indent(level) + b"]"
+    elif isinstance(value, dict):
+        if not value:
+            yield b"{}"
+            return
+        yield b"{\n"
+        for index, key in enumerate(sorted(value)):
+            if index:
+                yield b",\n"
+            yield _indent(level + 1)
+            yield from _canonical_string_chunks(key)
+            yield b": "
+            yield from canonical_json_value_chunks(value[key], level=level + 1)
+        yield b"\n" + _indent(level) + b"}"
+    else:
+        raise TypeError(f"unsupported decoded JSON value: {type(value).__name__}")
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return b"".join(canonical_json_value_chunks(value))
+
+
+def canonical_json_array_chunks(values: Iterable[Any]) -> Iterator[bytes]:
+    """Encode values exactly like ``json.dumps(list(values), indent=2, ...)``."""
+
+    iterator = iter(values)
+    emitted = False
+    try:
+        for value in iterator:
+            if not emitted:
+                yield b"[\n"
+                emitted = True
+            else:
+                yield b",\n"
+            yield b"  "
+            yield from canonical_json_value_chunks(value, level=1)
+        yield b"\n]\n" if emitted else b"[]\n"
+    finally:
+        close_iterator = getattr(iterator, "close", None)
+        if callable(close_iterator):
+            close_iterator()
+
+
+def write_chunks(handle: BinaryIO, chunks: Iterable[bytes]) -> tuple[int, str]:
+    """Write chunks while returning their size and SHA-256."""
+
+    import hashlib
+
+    size = 0
+    digest = hashlib.sha256()
+    for chunk in chunks:
+        handle.write(chunk)
+        size += len(chunk)
+        digest.update(chunk)
+    return size, digest.hexdigest()
+
+
+__all__ = [
+    "DEFAULT_MAX_ARRAY_ITEMS",
+    "DEFAULT_MAX_DEPTH",
+    "DEFAULT_MAX_ELEMENT_BYTES",
+    "DEFAULT_MAX_KEY_BYTES",
+    "DEFAULT_MAX_NODES_PER_ELEMENT",
+    "canonical_json_array_chunks",
+    "canonical_json_bytes",
+    "canonical_json_value_chunks",
+    "iter_bounded_json_array",
+    "validate_json_complexity",
+    "write_chunks",
+]

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -1,0 +1,596 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Descriptor-bound reads and writes for already-captured directory trees."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import stat
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Iterator
+
+from ._atomic_directory import (
+    TreeFileRecord,
+    capture_directory_ownership,
+    directory_ownership_entry_identities,
+    directory_ownership_file_records,
+    directory_ownership_root_identity,
+    directory_ownership_root_version_identity,
+    discard_owned_directory,
+    lexical_directory_path,
+    publish_staged_directory,
+)
+
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+_MAX_RELATIVE_PATH_BYTES = 4_096
+_MAX_COMPONENTS = 256
+_COPY_BYTES = 1024 * 1024
+
+
+def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _root_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _captured_version_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0,
+        getattr(metadata, "st_file_attributes", 0),
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+    )
+
+
+def _relative_path(value: str | Path | PurePosixPath) -> PurePosixPath:
+    raw = value.as_posix() if isinstance(value, (Path, PurePosixPath)) else value
+    if not isinstance(raw, str) or not raw or "\\" in raw or "\x00" in raw:
+        raise ValueError("captured directory path must be relative POSIX")
+    relative = PurePosixPath(raw)
+    if (
+        relative.is_absolute()
+        or relative.as_posix() != raw
+        or any(part in {"", ".", ".."} for part in relative.parts)
+        or len(relative.parts) > _MAX_COMPONENTS
+        or len(os.fsencode(raw)) > _MAX_RELATIVE_PATH_BYTES
+    ):
+        raise ValueError("captured directory path must be normalized and bounded")
+    return relative
+
+
+class AuthenticatedFile:
+    """One opened file whose bytes must match the initial tree record."""
+
+    def __init__(
+        self,
+        descriptor: int,
+        opened: os.stat_result,
+        record: TreeFileRecord,
+    ) -> None:
+        self.descriptor = descriptor
+        self.opened = opened
+        self.record = record
+        self._hasher = hashlib.sha256()
+        self._consumed = 0
+        self._authenticated = False
+        self._closed = False
+
+    @property
+    def size(self) -> int:
+        return self.record.size
+
+    def read(self, size: int = -1) -> bytes:
+        if self._closed:
+            raise ValueError("authenticated file is closed")
+        remaining = self.record.size - self._consumed
+        if size is None or size < 0:
+            requested = remaining + 1
+        else:
+            requested = min(size, remaining + 1)
+        if requested == 0:
+            return b""
+        try:
+            block = os.read(self.descriptor, requested)
+        except OSError as exc:
+            raise ValueError(
+                f"captured file is not readable: {self.record.path}"
+            ) from exc
+        if self._consumed + len(block) > self.record.size:
+            raise ValueError(f"captured file grew while reading: {self.record.path}")
+        self._hasher.update(block)
+        self._consumed += len(block)
+        return block
+
+    def authenticate(self) -> None:
+        if self._authenticated:
+            return
+        while self._consumed < self.record.size:
+            block = self.read(min(_COPY_BYTES, self.record.size - self._consumed))
+            if not block:
+                raise ValueError(f"captured file was truncated: {self.record.path}")
+        try:
+            if os.read(self.descriptor, 1):
+                raise ValueError(
+                    f"captured file grew while reading: {self.record.path}"
+                )
+            after = os.fstat(self.descriptor)
+        except OSError as exc:
+            raise ValueError(
+                f"captured file changed while reading: {self.record.path}"
+            ) from exc
+        if (
+            _file_identity(after) != _file_identity(self.opened)
+            or self._hasher.hexdigest() != self.record.sha256
+        ):
+            raise ValueError(
+                f"captured file differs from its initial record: {self.record.path}"
+            )
+        self._authenticated = True
+
+    def rewind_authenticated(self) -> int:
+        """Authenticate the bytes, rewind the same fd, and return that fd."""
+
+        self.authenticate()
+        try:
+            os.lseek(self.descriptor, 0, os.SEEK_SET)
+        except OSError as exc:
+            raise ValueError(
+                f"captured file cannot be rewound: {self.record.path}"
+            ) from exc
+        return self.descriptor
+
+    def verify_unchanged(self) -> None:
+        self.authenticate()
+        try:
+            after = os.fstat(self.descriptor)
+        except OSError as exc:
+            raise ValueError(
+                f"captured file changed after authentication: {self.record.path}"
+            ) from exc
+        if _file_identity(after) != _file_identity(self.opened):
+            raise ValueError(
+                f"captured file changed after authentication: {self.record.path}"
+            )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            os.close(self.descriptor)
+        except OSError:
+            pass
+
+    def __enter__(self) -> AuthenticatedFile:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        try:
+            if exc_type is None:
+                self.authenticate()
+        finally:
+            self.close()
+
+
+class CapturedDirectoryReader:
+    """Read a fixed ownership token through one pinned no-follow root fd."""
+
+    def __init__(self, root: Path, ownership: object) -> None:
+        if not hasattr(os, "O_DIRECTORY") or not hasattr(os, "O_NOFOLLOW"):
+            raise RuntimeError(
+                "captured directory reads require no-follow directory descriptors"
+            )
+        self.root = lexical_directory_path(root)
+        self.ownership = ownership
+        self._descriptor = -1
+        self._records = {
+            record.path: record
+            for record in directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+        }
+        self._entry_identities = {
+            path: (kind, identity)
+            for path, kind, identity in directory_ownership_entry_identities(
+                ownership  # type: ignore[arg-type]
+            )
+        }
+        try:
+            flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+            self._descriptor = os.open(self.root, flags)
+            opened = os.fstat(self._descriptor)
+            if _root_identity(opened) != directory_ownership_root_identity(
+                ownership
+            ) or _captured_version_identity(
+                opened
+            ) != directory_ownership_root_version_identity(
+                ownership
+            ):
+                raise RuntimeError("captured directory root changed after capture")
+            self._opened_root = opened
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        if self._descriptor >= 0:
+            try:
+                os.close(self._descriptor)
+            except OSError:
+                pass
+            self._descriptor = -1
+
+    def __enter__(self) -> CapturedDirectoryReader:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    @property
+    def file_records(self) -> tuple[TreeFileRecord, ...]:
+        return tuple(sorted(self._records.values(), key=lambda record: record.path))
+
+    def record(self, relative: str | Path | PurePosixPath) -> TreeFileRecord:
+        normalized = _relative_path(relative).as_posix()
+        try:
+            return self._records[normalized]
+        except KeyError as exc:
+            raise ValueError(
+                f"captured directory has no initial file record: {normalized}"
+            ) from exc
+
+    def verify_root(self) -> None:
+        try:
+            opened = os.fstat(self._descriptor)
+            path_metadata = self.root.lstat()
+        except OSError as exc:
+            raise RuntimeError("captured directory root changed") from exc
+        if _file_identity(opened) != _file_identity(
+            self._opened_root
+        ) or _root_identity(path_metadata) != _root_identity(opened):
+            raise RuntimeError("captured directory root changed")
+
+    def _open(self, relative: PurePosixPath) -> tuple[int, os.stat_result]:
+        record = self.record(relative)
+        directory_descriptor = os.dup(self._descriptor)
+        source_descriptor = -1
+        try:
+            directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            directory_flags |= getattr(os, "O_CLOEXEC", 0) | getattr(
+                os, "O_NONBLOCK", 0
+            )
+            prefix: list[str] = []
+            for part in relative.parts[:-1]:
+                prefix.append(part)
+                prefix_text = "/".join(prefix)
+                expected_kind, expected_identity = self._entry_identities.get(
+                    prefix_text,
+                    (None, None),
+                )
+                before = os.stat(
+                    part,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if (
+                    expected_kind != "directory"
+                    or expected_identity is None
+                    or _captured_version_identity(before) != expected_identity
+                    or not stat.S_ISDIR(before.st_mode)
+                    or bool(
+                        getattr(before, "st_file_attributes", 0)
+                        & _FILE_ATTRIBUTE_REPARSE_POINT
+                    )
+                ):
+                    raise ValueError(
+                        f"captured path is not a real directory: {relative}"
+                    )
+                child = -1
+                try:
+                    child = os.open(
+                        part,
+                        directory_flags,
+                        dir_fd=directory_descriptor,
+                    )
+                    opened = os.fstat(child)
+                    if _root_identity(opened) != _root_identity(before):
+                        raise ValueError(
+                            f"captured directory changed while opening: {relative}"
+                        )
+                except BaseException:
+                    if child >= 0:
+                        os.close(child)
+                    raise
+                os.close(directory_descriptor)
+                directory_descriptor = child
+
+            name = relative.parts[-1]
+            expected_kind, expected_identity = self._entry_identities.get(
+                relative.as_posix(),
+                (None, None),
+            )
+            before = os.stat(
+                name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or expected_kind != "file"
+                or expected_identity is None
+                or _captured_version_identity(before) != expected_identity
+                or before.st_nlink != 1
+                or bool(
+                    getattr(before, "st_file_attributes", 0)
+                    & _FILE_ATTRIBUTE_REPARSE_POINT
+                )
+            ):
+                raise ValueError(f"captured path is not a private file: {relative}")
+            flags = os.O_RDONLY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+            source_descriptor = os.open(name, flags, dir_fd=directory_descriptor)
+            opened = os.fstat(source_descriptor)
+            if (
+                _file_identity(opened) != _file_identity(before)
+                or stat.S_IMODE(opened.st_mode) != record.mode
+                or opened.st_size != record.size
+            ):
+                raise ValueError(f"captured file changed while opening: {relative}")
+            owned = source_descriptor
+            source_descriptor = -1
+            return owned, opened
+        except OSError as exc:
+            raise ValueError(
+                f"captured file is not safely readable: {relative}"
+            ) from exc
+        finally:
+            if source_descriptor >= 0:
+                os.close(source_descriptor)
+            os.close(directory_descriptor)
+
+    def open_file(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> AuthenticatedFile:
+        normalized = _relative_path(relative)
+        record = self.record(normalized)
+        if max_bytes is not None and record.size > max_bytes:
+            raise ValueError(
+                f"captured file exceeds its {max_bytes}-byte limit: {normalized}"
+            )
+        descriptor, opened = self._open(normalized)
+        return AuthenticatedFile(descriptor, opened, record)
+
+    def read_bytes(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        with self.open_file(relative, max_bytes=max_bytes) as source:
+            payload = bytearray()
+            while block := source.read(_COPY_BYTES):
+                payload.extend(block)
+            return bytes(payload)
+
+    def authenticate(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> TreeFileRecord:
+        with self.open_file(relative, max_bytes=max_bytes) as source:
+            source.authenticate()
+            return source.record
+
+    @contextmanager
+    def authenticated_descriptor(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> Iterator[tuple[int, TreeFileRecord]]:
+        source = self.open_file(relative, max_bytes=max_bytes)
+        try:
+            descriptor = source.rewind_authenticated()
+            yield descriptor, source.record
+            source.verify_unchanged()
+        finally:
+            source.close()
+
+    def copy_chunks(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> Iterator[bytes]:
+        source = self.open_file(relative, max_bytes=max_bytes)
+        try:
+            while block := source.read(_COPY_BYTES):
+                yield block
+            source.authenticate()
+        finally:
+            source.close()
+
+
+class OwnedDirectoryStage:
+    """Build one new private sibling tree without path-based file mutation."""
+
+    def __init__(self, destination: Path) -> None:
+        self.destination = lexical_directory_path(destination)
+        self.path = lexical_directory_path(
+            Path(
+                tempfile.mkdtemp(
+                    prefix=f".{self.destination.name}.normalize-",
+                    dir=str(self.destination.parent),
+                )
+            )
+        )
+        self._initial = capture_directory_ownership(self.path)
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+        self._descriptor = os.open(self.path, flags)
+        self._published = False
+
+    def close(self) -> None:
+        if self._descriptor >= 0:
+            try:
+                os.close(self._descriptor)
+            except OSError:
+                pass
+            self._descriptor = -1
+
+    def discard(self) -> None:
+        self.close()
+        if not self._published:
+            discard_owned_directory(self.path, self._initial)
+
+    def _parent_descriptor(self, relative: PurePosixPath) -> int:
+        descriptor = os.dup(self._descriptor)
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+        try:
+            for part in relative.parts[:-1]:
+                try:
+                    os.mkdir(part, mode=0o700, dir_fd=descriptor)
+                except FileExistsError:
+                    pass
+                child = -1
+                try:
+                    child = os.open(part, flags, dir_fd=descriptor)
+                    opened = os.fstat(child)
+                    if not stat.S_ISDIR(opened.st_mode):
+                        raise ValueError(
+                            f"owned stage component is not a directory: {relative}"
+                        )
+                except BaseException:
+                    if child >= 0:
+                        os.close(child)
+                    raise
+                os.close(descriptor)
+                descriptor = child
+            return descriptor
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    def write_file(
+        self,
+        relative: str | Path | PurePosixPath,
+        chunks: Iterable[bytes],
+        *,
+        mode: int = 0o600,
+        max_bytes: int | None = None,
+    ) -> None:
+        normalized = _relative_path(relative)
+        parent = self._parent_descriptor(normalized)
+        temporary = f".{normalized.name}.tmp-{secrets.token_hex(12)}"
+        descriptor = -1
+        renamed = False
+        byte_count = 0
+        iterator = iter(chunks)
+        try:
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            descriptor = os.open(temporary, flags, mode, dir_fd=parent)
+            for chunk in iterator:
+                if not isinstance(chunk, bytes):
+                    raise TypeError("owned stage file chunks must be bytes")
+                byte_count += len(chunk)
+                if max_bytes is not None and byte_count > max_bytes:
+                    raise ValueError(
+                        f"owned stage file exceeds its {max_bytes}-byte limit: "
+                        f"{normalized}"
+                    )
+                view = memoryview(chunk)
+                while view:
+                    written = os.write(descriptor, view)
+                    if written <= 0:
+                        raise OSError("could not write owned stage file")
+                    view = view[written:]
+            os.fchmod(descriptor, mode)
+            os.fsync(descriptor)
+            os.close(descriptor)
+            descriptor = -1
+            try:
+                os.stat(
+                    normalized.name,
+                    dir_fd=parent,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                pass
+            else:
+                raise ValueError(f"owned stage file already exists: {normalized}")
+            os.rename(
+                temporary,
+                normalized.name,
+                src_dir_fd=parent,
+                dst_dir_fd=parent,
+            )
+            renamed = True
+            os.fsync(parent)
+        finally:
+            close_iterator = getattr(iterator, "close", None)
+            if callable(close_iterator):
+                close_iterator()
+            if descriptor >= 0:
+                os.close(descriptor)
+            if not renamed:
+                try:
+                    os.unlink(temporary, dir_fd=parent)
+                except OSError:
+                    pass
+            os.close(parent)
+
+    def publish(
+        self,
+        *,
+        expected_destination_ownership: object,
+        validate_staged_directory=None,
+        validate_published_destination=None,
+    ) -> None:
+        self.close()
+        publish_staged_directory(
+            self.path,
+            self.destination,
+            expected_stage_root_ownership=self._initial,
+            expected_destination_ownership=expected_destination_ownership,
+            validate_staged_directory=validate_staged_directory,
+            validate_published_destination=validate_published_destination,
+        )
+        self._published = True
+
+
+__all__ = [
+    "AuthenticatedFile",
+    "CapturedDirectoryReader",
+    "OwnedDirectoryStage",
+]

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -454,6 +454,7 @@ class OwnedDirectoryStage:
             )
         )
         self._initial = capture_directory_ownership(self.path)
+        self._cleanup_ownership = self._initial
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
         self._descriptor = os.open(self.path, flags)
@@ -468,9 +469,22 @@ class OwnedDirectoryStage:
             self._descriptor = -1
 
     def discard(self) -> None:
+        if not self._published:
+            try:
+                self._cleanup_ownership = self._capture_current_ownership()
+            except (OSError, RuntimeError, ValueError):
+                pass
         self.close()
         if not self._published:
-            discard_owned_directory(self.path, self._initial)
+            discard_owned_directory(self.path, self._cleanup_ownership)
+
+    def _capture_current_ownership(self):
+        observed = capture_directory_ownership(self.path)
+        if directory_ownership_root_identity(observed) != (
+            directory_ownership_root_identity(self._initial)
+        ):
+            raise RuntimeError("owned stage root changed")
+        return observed
 
     def _parent_descriptor(self, relative: PurePosixPath) -> int:
         descriptor = os.dup(self._descriptor)
@@ -577,11 +591,12 @@ class OwnedDirectoryStage:
         validate_staged_directory=None,
         validate_published_destination=None,
     ) -> None:
+        self._cleanup_ownership = self._capture_current_ownership()
         self.close()
         publish_staged_directory(
             self.path,
             self.destination,
-            expected_stage_root_ownership=self._initial,
+            expected_stage_root_ownership=self._cleanup_ownership,
             expected_destination_ownership=expected_destination_ownership,
             validate_staged_directory=validate_staged_directory,
             validate_published_destination=validate_published_destination,

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -10,11 +10,13 @@ import hashlib
 import os
 import secrets
 import stat
+import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
-from typing import Iterable, Iterator
+from typing import Callable, Iterable, Iterator
 
+from . import _windows_fs_authority as _windows_fs
 from ._atomic_directory import (
     TreeFileRecord,
     capture_directory_ownership,
@@ -44,6 +46,112 @@ def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
         metadata.st_nlink,
         getattr(metadata, "st_file_attributes", 0),
     )
+
+
+def _opened_file_identity(metadata: object) -> tuple[object, ...]:
+    if isinstance(metadata, _windows_fs.WindowsHandleMetadata):
+        return _windows_fs.windows_metadata_identity(metadata)
+    return _file_identity(metadata)  # type: ignore[arg-type]
+
+
+def _use_windows_handles() -> bool:
+    return sys.platform == "win32"
+
+
+class _WindowsCleanupSlot:
+    """Retain retryable HANDLE owners before native acquisition starts."""
+
+    def __init__(self) -> None:
+        self.resources: list[object] = []
+
+    @property
+    def closed(self) -> bool:
+        return not self.resources
+
+    def own(self, resource: object) -> None:
+        if not any(candidate is resource for candidate in self.resources):
+            self.resources.append(resource)
+
+    def forget(self, resource: object) -> None:
+        for index, candidate in enumerate(self.resources):
+            if candidate is resource:
+                self.resources.pop(index)
+                return
+
+    def close(self) -> None:
+        primary: BaseException | None = None
+        for resource in reversed(tuple(self.resources)):
+            try:
+                resource.close()  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - visit every owner
+                if primary is None:
+                    primary = exc
+            try:
+                closed = bool(resource.closed)  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - retain uncertain owner
+                if primary is None:
+                    primary = exc
+                closed = False
+            if closed:
+                self.forget(resource)
+        if primary is not None:
+            raise primary
+
+
+class _WindowsHandleOwner:
+    """Own a small set of read HANDLEs with retryable close reconciliation."""
+
+    def __init__(
+        self,
+        api: _windows_fs.WindowsKernelApi,
+        cleanup_slot: _WindowsCleanupSlot,
+    ) -> None:
+        self.api = api
+        self.cleanup_slot = cleanup_slot
+        self.handles: list[int] = []
+        self.identities: dict[int, tuple[object, ...]] = {}
+        cleanup_slot.own(self)
+
+    @property
+    def closed(self) -> bool:
+        return not self.handles
+
+    def acquire(self, operation: Callable[[], int]) -> int:
+        handle = 0
+        try:
+            handle = operation()
+            self.handles.append(handle)
+            return handle
+        except BaseException:  # noqa: B036 - commit returned HANDLE ownership
+            if handle and handle not in self.handles:
+                try:
+                    self.handles.append(handle)
+                except BaseException:  # noqa: B036 - preserve acquisition failure
+                    pass
+            raise
+
+    def bind(self, handle: int, metadata: _windows_fs.WindowsHandleMetadata) -> None:
+        self.identities[handle] = _windows_fs.windows_handle_ownership_identity(
+            metadata
+        )
+
+    def close(self) -> None:
+        failure = _windows_fs._close_windows_handles(  # type: ignore[attr-defined]
+            self.api,
+            self.handles,
+            self.identities,
+        )
+        if failure is not None:
+            raise failure
+        if self.closed:
+            self.cleanup_slot.forget(self)
+
+
+def _attach_cleanup_owner(failure: BaseException, owner: object) -> None:
+    try:
+        failure.captured_directory_cleanup_owner = owner  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - local ownership remains authoritative
+        pass
 
 
 def _root_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -85,13 +193,19 @@ def _relative_path(value: str | Path | PurePosixPath) -> PurePosixPath:
 
 
 class AuthenticatedFile:
-    """One opened file whose bytes must match the initial tree record."""
+    """One opened fd or HANDLE whose bytes match the initial tree record."""
 
     def __init__(
         self,
         descriptor: int,
-        opened: os.stat_result,
+        opened: object,
         record: TreeFileRecord,
+        *,
+        read_callback: Callable[[int], bytes] | None = None,
+        metadata_callback: Callable[[], object] | None = None,
+        rewind_callback: Callable[[], None] | None = None,
+        verify_callback: Callable[[], None] | None = None,
+        close_callback: Callable[[], None] | None = None,
     ) -> None:
         self.descriptor = descriptor
         self.opened = opened
@@ -100,6 +214,17 @@ class AuthenticatedFile:
         self._consumed = 0
         self._authenticated = False
         self._closed = False
+        self._read_callback = read_callback or (
+            lambda size: os.read(self.descriptor, size)
+        )
+        self._metadata_callback = metadata_callback or (
+            lambda: os.fstat(self.descriptor)
+        )
+        self._rewind_callback = rewind_callback or (
+            lambda: os.lseek(self.descriptor, 0, os.SEEK_SET)
+        )
+        self._verify_callback = verify_callback or (lambda: None)
+        self._close_callback = close_callback
 
     @property
     def size(self) -> int:
@@ -116,11 +241,13 @@ class AuthenticatedFile:
         if requested == 0:
             return b""
         try:
-            block = os.read(self.descriptor, requested)
+            block = self._read_callback(requested)
         except OSError as exc:
             raise ValueError(
                 f"captured file is not readable: {self.record.path}"
             ) from exc
+        if not isinstance(block, bytes):
+            raise RuntimeError("captured file backend returned non-bytes data")
         if self._consumed + len(block) > self.record.size:
             raise ValueError(f"captured file grew while reading: {self.record.path}")
         self._hasher.update(block)
@@ -135,17 +262,18 @@ class AuthenticatedFile:
             if not block:
                 raise ValueError(f"captured file was truncated: {self.record.path}")
         try:
-            if os.read(self.descriptor, 1):
+            if self._read_callback(1):
                 raise ValueError(
                     f"captured file grew while reading: {self.record.path}"
                 )
-            after = os.fstat(self.descriptor)
+            after = self._metadata_callback()
+            self._verify_callback()
         except OSError as exc:
             raise ValueError(
                 f"captured file changed while reading: {self.record.path}"
             ) from exc
         if (
-            _file_identity(after) != _file_identity(self.opened)
+            _opened_file_identity(after) != _opened_file_identity(self.opened)
             or self._hasher.hexdigest() != self.record.sha256
         ):
             raise ValueError(
@@ -154,11 +282,11 @@ class AuthenticatedFile:
         self._authenticated = True
 
     def rewind_authenticated(self) -> int:
-        """Authenticate the bytes, rewind the same fd, and return that fd."""
+        """Authenticate the bytes, rewind the same fd/HANDLE, and return it."""
 
         self.authenticate()
         try:
-            os.lseek(self.descriptor, 0, os.SEEK_SET)
+            self._rewind_callback()
         except OSError as exc:
             raise ValueError(
                 f"captured file cannot be rewound: {self.record.path}"
@@ -168,12 +296,13 @@ class AuthenticatedFile:
     def verify_unchanged(self) -> None:
         self.authenticate()
         try:
-            after = os.fstat(self.descriptor)
+            after = self._metadata_callback()
+            self._verify_callback()
         except OSError as exc:
             raise ValueError(
                 f"captured file changed after authentication: {self.record.path}"
             ) from exc
-        if _file_identity(after) != _file_identity(self.opened):
+        if _opened_file_identity(after) != _opened_file_identity(self.opened):
             raise ValueError(
                 f"captured file changed after authentication: {self.record.path}"
             )
@@ -181,34 +310,69 @@ class AuthenticatedFile:
     def close(self) -> None:
         if self._closed:
             return
-        self._closed = True
+        if self._close_callback is None:
+            self._closed = True
+            try:
+                os.close(self.descriptor)
+            except OSError:
+                pass
+            return
+        owner = getattr(self._close_callback, "__self__", None)
         try:
-            os.close(self.descriptor)
-        except OSError:
-            pass
+            self._close_callback()
+        except BaseException as close_error:  # noqa: B036 - retain retry owner
+            try:
+                self._closed = bool(getattr(owner, "closed", False))
+            except BaseException:  # noqa: B036 - uncertain ownership stays live
+                self._closed = False
+            if not self._closed:
+                _attach_cleanup_owner(close_error, self)
+            raise
+        self._closed = bool(getattr(owner, "closed", False))
+        if not self._closed:
+            failure = RuntimeError("captured file HANDLE cleanup is incomplete")
+            _attach_cleanup_owner(failure, self)
+            raise failure
 
     def __enter__(self) -> AuthenticatedFile:
         return self
 
     def __exit__(self, exc_type, exc, traceback) -> None:
-        try:
-            if exc_type is None:
+        if exc_type is None:
+            try:
                 self.authenticate()
-        finally:
+            except BaseException as primary:  # noqa: B036 - preserve auth failure
+                try:
+                    self.close()
+                except BaseException as cleanup:  # noqa: B036
+                    _attach_cleanup_owner(primary, self)
+                    raise primary from cleanup
+                raise
             self.close()
+            return
+        try:
+            self.close()
+        except BaseException:  # noqa: B036 - never replace the body failure
+            if exc is not None:
+                _attach_cleanup_owner(exc, self)
 
 
 class CapturedDirectoryReader:
-    """Read a fixed ownership token through one pinned no-follow root fd."""
+    """Read a fixed ownership token through one pinned no-follow authority."""
 
     def __init__(self, root: Path, ownership: object) -> None:
-        if not hasattr(os, "O_DIRECTORY") or not hasattr(os, "O_NOFOLLOW"):
+        if not _use_windows_handles() and (
+            not hasattr(os, "O_DIRECTORY") or not hasattr(os, "O_NOFOLLOW")
+        ):
             raise RuntimeError(
                 "captured directory reads require no-follow directory descriptors"
             )
         self.root = lexical_directory_path(root)
         self.ownership = ownership
         self._descriptor = -1
+        self._windows_slot: _WindowsCleanupSlot | None = None
+        self._windows_authority: _windows_fs.WindowsDirectoryAuthority | None = None
+        self._windows_api: _windows_fs.WindowsKernelApi | None = None
         self._records = {
             record.path: record
             for record in directory_ownership_file_records(ownership)  # type: ignore[arg-type]
@@ -220,6 +384,9 @@ class CapturedDirectoryReader:
             )
         }
         try:
+            if _use_windows_handles():
+                self._open_windows_root()
+                return
             flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
             flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
             self._descriptor = os.open(self.root, flags)
@@ -233,11 +400,52 @@ class CapturedDirectoryReader:
             ):
                 raise RuntimeError("captured directory root changed after capture")
             self._opened_root = opened
-        except BaseException:
-            self.close()
+        except BaseException as primary:  # noqa: B036 - preserve open failure
+            try:
+                self.close()
+            except BaseException as cleanup:  # noqa: B036
+                _attach_cleanup_owner(primary, self)
+                raise primary from cleanup
             raise
 
+    def _open_windows_root(self) -> None:
+        slot = _WindowsCleanupSlot()
+        self._windows_slot = slot
+        authority = _windows_fs.open_lexical_directory_authority(
+            self.root,
+            cleanup_slot=slot,
+        )
+        self._windows_authority = authority
+        self._windows_api = authority.api
+        opened = authority.api.metadata(authority.handle)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or opened.st_file_attributes & _FILE_ATTRIBUTE_REPARSE_POINT
+            or opened.delete_pending
+            or not _windows_fs.windows_file_id_is_reliable(opened.file_id_128)
+            or _root_identity(opened)
+            != directory_ownership_root_identity(self.ownership)  # type: ignore[arg-type]
+            or _captured_version_identity(opened)
+            != directory_ownership_root_version_identity(
+                self.ownership  # type: ignore[arg-type]
+            )
+        ):
+            raise RuntimeError("captured directory root changed after capture")
+        self._opened_root = opened
+        authority.verify()
+
     def close(self) -> None:
+        if self._windows_slot is not None:
+            try:
+                self._windows_slot.close()
+            except BaseException as close_error:  # noqa: B036 - retryable owner
+                _attach_cleanup_owner(close_error, self)
+                raise
+            if self._windows_slot.closed:
+                self._windows_slot = None
+                self._windows_authority = None
+                self._windows_api = None
+            return
         if self._descriptor >= 0:
             try:
                 os.close(self._descriptor)
@@ -249,7 +457,12 @@ class CapturedDirectoryReader:
         return self
 
     def __exit__(self, exc_type, exc, traceback) -> None:
-        self.close()
+        try:
+            self.close()
+        except BaseException:  # noqa: B036 - preserve body failure
+            if exc is None:
+                raise
+            _attach_cleanup_owner(exc, self)
 
     @property
     def file_records(self) -> tuple[TreeFileRecord, ...]:
@@ -265,6 +478,20 @@ class CapturedDirectoryReader:
             ) from exc
 
     def verify_root(self) -> None:
+        if self._windows_authority is not None and self._windows_api is not None:
+            self._windows_authority.verify()
+            opened = self._windows_api.metadata(self._windows_authority.handle)
+            if _windows_fs.windows_metadata_identity(
+                opened
+            ) != _windows_fs.windows_metadata_identity(
+                self._opened_root
+            ) or _captured_version_identity(
+                opened
+            ) != directory_ownership_root_version_identity(
+                self.ownership  # type: ignore[arg-type]
+            ):
+                raise RuntimeError("captured directory root changed")
+            return
         try:
             opened = os.fstat(self._descriptor)
             path_metadata = self.root.lstat()
@@ -274,6 +501,213 @@ class CapturedDirectoryReader:
             self._opened_root
         ) or _root_identity(path_metadata) != _root_identity(opened):
             raise RuntimeError("captured directory root changed")
+
+    def _windows_find_child(
+        self,
+        api: _windows_fs.WindowsKernelApi,
+        parent_handle: int,
+        name: str,
+    ) -> _windows_fs.WindowsDirectoryEntry | None:
+        iterator = getattr(api, "iter_directory", None)
+        entries = (
+            iterator(parent_handle)
+            if callable(iterator)
+            else api.enumerate_directory(parent_handle)
+        )
+        folded = name.casefold()
+        match: _windows_fs.WindowsDirectoryEntry | None = None
+        entry_limit = len(self._entry_identities)
+        for index, entry in enumerate(entries):
+            if index >= entry_limit:
+                raise RuntimeError(
+                    "captured Windows directory exceeds its ownership entry limit"
+                )
+            if entry.name.casefold() != folded:
+                continue
+            if match is not None:
+                raise RuntimeError(
+                    "captured Windows directory has ambiguous child names"
+                )
+            match = entry
+        return match
+
+    def _windows_open_child(
+        self,
+        owner: _WindowsHandleOwner,
+        parent_handle: int,
+        name: str,
+        *,
+        expected_directory: bool,
+    ) -> tuple[
+        int, _windows_fs.WindowsDirectoryEntry, _windows_fs.WindowsHandleMetadata
+    ]:
+        assert self._windows_api is not None
+        api = self._windows_api
+        entry = self._windows_find_child(api, parent_handle, name)
+        if entry is None:
+            raise FileNotFoundError(name)
+        is_directory = bool(entry.attributes & _windows_fs.FILE_ATTRIBUTE_DIRECTORY)
+        if (
+            is_directory != expected_directory
+            or entry.attributes & _windows_fs.FILE_ATTRIBUTE_REPARSE_POINT
+            or not _windows_fs.windows_file_id_is_reliable(entry.file_id_128)
+        ):
+            raise ValueError("captured path is not a private real entry")
+        access = _windows_fs.FILE_READ_ATTRIBUTES | _windows_fs.SYNCHRONIZE
+        access |= (
+            _windows_fs.FILE_LIST_DIRECTORY
+            if expected_directory
+            else _windows_fs.FILE_READ_DATA
+        )
+        handle = owner.acquire(
+            lambda: api.open_relative(
+                parent_handle,
+                entry.name,
+                desired_access=access,
+                is_directory=expected_directory,
+                allow_reparse=False,
+            )
+        )
+        opened = api.metadata(handle)
+        owner.bind(handle, opened)
+        rebound = self._windows_find_child(api, parent_handle, entry.name)
+        if (
+            opened.file_id_128 != entry.file_id_128
+            or not _windows_fs.windows_file_id_is_reliable(opened.file_id_128)
+            or opened.st_file_attributes & _windows_fs.FILE_ATTRIBUTE_REPARSE_POINT
+            or opened.delete_pending
+            or bool(opened.st_file_attributes & _windows_fs.FILE_ATTRIBUTE_DIRECTORY)
+            != expected_directory
+            or rebound is None
+            or rebound.file_id_128 != entry.file_id_128
+        ):
+            raise RuntimeError("captured Windows entry changed while opening")
+        return handle, entry, opened
+
+    def _open_windows(
+        self,
+        relative: PurePosixPath,
+    ) -> AuthenticatedFile:
+        record = self.record(relative)
+        if self._windows_authority is None or self._windows_api is None:
+            raise RuntimeError("captured directory reader is closed")
+        if self._windows_slot is None:
+            raise RuntimeError("captured directory reader has no cleanup authority")
+        self.verify_root()
+        api = self._windows_api
+        owner = _WindowsHandleOwner(api, self._windows_slot)
+        parent_handle = self._windows_authority.handle
+        bindings: list[tuple[int, str, bytes, int, tuple[int, ...]]] = []
+        prefix: list[str] = []
+        try:
+            for part in relative.parts[:-1]:
+                prefix.append(part)
+                prefix_text = "/".join(prefix)
+                expected_kind, expected_identity = self._entry_identities.get(
+                    prefix_text,
+                    (None, None),
+                )
+                handle, entry, opened = self._windows_open_child(
+                    owner,
+                    parent_handle,
+                    part,
+                    expected_directory=True,
+                )
+                if (
+                    expected_kind != "directory"
+                    or expected_identity is None
+                    or _captured_version_identity(opened) != expected_identity
+                ):
+                    raise ValueError(
+                        f"captured path is not a real directory: {relative}"
+                    )
+                bindings.append(
+                    (
+                        parent_handle,
+                        entry.name,
+                        entry.file_id_128,
+                        handle,
+                        expected_identity,
+                    )
+                )
+                parent_handle = handle
+
+            expected_kind, expected_identity = self._entry_identities.get(
+                relative.as_posix(),
+                (None, None),
+            )
+            handle, entry, opened = self._windows_open_child(
+                owner,
+                parent_handle,
+                relative.name,
+                expected_directory=False,
+            )
+            if (
+                expected_kind != "file"
+                or expected_identity is None
+                or _captured_version_identity(opened) != expected_identity
+                or opened.st_nlink != 1
+                or stat.S_IMODE(opened.st_mode) != record.mode
+                or opened.st_size != record.size
+            ):
+                raise ValueError(f"captured path is not a private file: {relative}")
+
+            def verify() -> None:
+                current = api.metadata(handle)
+                rebound_file = self._windows_find_child(
+                    api,
+                    parent_handle,
+                    entry.name,
+                )
+                if (
+                    _captured_version_identity(current) != expected_identity
+                    or _windows_fs.windows_metadata_identity(current)
+                    != _windows_fs.windows_metadata_identity(opened)
+                    or rebound_file is None
+                    or rebound_file.file_id_128 != entry.file_id_128
+                ):
+                    raise ValueError(f"captured file changed while reading: {relative}")
+                for (
+                    bound_parent,
+                    name,
+                    file_id,
+                    directory_handle,
+                    identity,
+                ) in reversed(bindings):
+                    rebound = self._windows_find_child(api, bound_parent, name)
+                    if (
+                        rebound is None
+                        or rebound.file_id_128 != file_id
+                        or _captured_version_identity(api.metadata(directory_handle))
+                        != identity
+                    ):
+                        raise ValueError(
+                            f"captured directory changed while reading: {relative}"
+                        )
+                self.verify_root()
+
+            def rewind() -> None:
+                raise OSError(
+                    "captured authenticated descriptors are unavailable on Windows"
+                )
+
+            return AuthenticatedFile(
+                handle,
+                opened,
+                record,
+                read_callback=lambda size: api.read(handle, size),
+                metadata_callback=lambda: api.metadata(handle),
+                rewind_callback=rewind,
+                verify_callback=verify,
+                close_callback=owner.close,
+            )
+        except BaseException as primary:  # noqa: B036 - preserve open failure
+            try:
+                owner.close()
+            except BaseException as cleanup:  # noqa: B036
+                _attach_cleanup_owner(primary, owner)
+                raise primary from cleanup
+            raise
 
     def _open(self, relative: PurePosixPath) -> tuple[int, os.stat_result]:
         record = self.record(relative)
@@ -385,6 +819,8 @@ class CapturedDirectoryReader:
             raise ValueError(
                 f"captured file exceeds its {max_bytes}-byte limit: {normalized}"
             )
+        if self._windows_authority is not None:
+            return self._open_windows(normalized)
         descriptor, opened = self._open(normalized)
         return AuthenticatedFile(descriptor, opened, record)
 
@@ -417,6 +853,10 @@ class CapturedDirectoryReader:
         *,
         max_bytes: int | None = None,
     ) -> Iterator[tuple[int, TreeFileRecord]]:
+        if self._windows_authority is not None:
+            raise RuntimeError(
+                "captured authenticated descriptors are available only on POSIX"
+            )
         source = self.open_file(relative, max_bytes=max_bytes)
         try:
             descriptor = source.rewind_authenticated()
@@ -436,7 +876,14 @@ class CapturedDirectoryReader:
             while block := source.read(_COPY_BYTES):
                 yield block
             source.authenticate()
-        finally:
+        except BaseException as primary:  # noqa: B036 - preserve consumer failure
+            try:
+                source.close()
+            except BaseException as cleanup:  # noqa: B036 - attach retry owner
+                _attach_cleanup_owner(primary, source)
+                raise primary from cleanup
+            raise
+        else:
             source.close()
 
 

--- a/codenib/_contained_source.py
+++ b/codenib/_contained_source.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 
 import os
 import stat
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
+from typing import Iterator
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _MAX_COMPONENTS = 256
+_MAX_RELATIVE_PATH_BYTES = 4_096
 _MAX_SYMLINKS = 40
 _MAX_SYMLINK_TARGET_BYTES = 4_096
 _READ_CHUNK_BYTES = 1024 * 1024
@@ -25,6 +28,10 @@ SECURE_CONTAINED_SYMLINKS = (
     and os.stat in getattr(os, "supports_follow_symlinks", ())
     and os.readlink in getattr(os, "supports_dir_fd", ())
 )
+
+
+class ContainedSourceMissingError(ValueError):
+    """A lexically present source link has no resolvable regular target."""
 
 
 def _is_link_or_reparse(metadata: os.stat_result) -> bool:
@@ -52,8 +59,17 @@ def _version_identity(metadata: os.stat_result) -> tuple[int, ...]:
     )
 
 
+def _identity_is_reliable(metadata: os.stat_result) -> bool:
+    return bool(metadata.st_dev) and bool(metadata.st_ino)
+
+
 def _relative_parts(value: str) -> tuple[str, ...]:
-    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+    if (
+        not isinstance(value, str)
+        or not value
+        or (os.name == "nt" and "\\" in value)
+        or "\x00" in value
+    ):
         raise ValueError("source path must be a repository-relative POSIX path")
     relative = PurePosixPath(value)
     if (
@@ -61,20 +77,30 @@ def _relative_parts(value: str) -> tuple[str, ...]:
         or relative.as_posix() != value
         or any(part in {"", ".", ".."} for part in relative.parts)
         or len(relative.parts) > _MAX_COMPONENTS
+        or len(os.fsencode(value)) > _MAX_RELATIVE_PATH_BYTES
     ):
         raise ValueError("source path must be a repository-relative POSIX path")
     return relative.parts
 
 
 def _normalize_link_target(
+    root: Path,
     prefix: tuple[str, ...],
     target: str,
 ) -> tuple[str, ...]:
-    if not target or "\x00" in target or os.path.isabs(target):
-        raise ValueError("source symlink target must be relative")
+    if not target or "\x00" in target:
+        raise ValueError("source symlink target must be non-empty")
     if len(os.fsencode(target)) > _MAX_SYMLINK_TARGET_BYTES:
         raise ValueError("source symlink target exceeds its byte limit")
-    resolved = list(prefix)
+    if os.path.isabs(target):
+        normalized_target = Path(os.path.normpath(target))
+        try:
+            target = normalized_target.relative_to(root).as_posix()
+        except ValueError as exc:
+            raise ValueError("source symlink resolves outside the repository") from exc
+        resolved: list[str] = []
+    else:
+        resolved = list(prefix)
     for part in target.split("/"):
         if part in {"", "."}:
             continue
@@ -107,6 +133,29 @@ class _BoundRepositoryFile:
     root_descriptor: int
     root_identity: tuple[int, ...]
     observations: list[_PathObservation]
+    is_regular = True
+
+    def update_hash(self, hasher: object) -> None:
+        update = getattr(hasher, "update", None)
+        if not callable(update):
+            raise TypeError("hasher must provide an update method")
+        opened = os.fstat(self.descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or _version_identity(opened) != self.opened_identity
+            or not _identity_is_reliable(opened)
+        ):
+            raise ValueError("source file is not a stable regular file")
+        remaining = opened.st_size
+        while remaining:
+            block = os.read(self.descriptor, min(remaining, _READ_CHUNK_BYTES))
+            if not block:
+                raise ValueError("source file was truncated while hashing")
+            update(block)
+            remaining -= len(block)
+        if os.read(self.descriptor, 1):
+            raise ValueError("source file grew while hashing")
+        self.verify()
 
     def read_bytes(self, *, max_bytes: int) -> bytes:
         if (
@@ -137,33 +186,12 @@ class _BoundRepositoryFile:
         return bytes(payload)
 
     def verify(self) -> None:
-        if _version_identity(os.fstat(self.root_descriptor)) != self.root_identity:
-            raise ValueError("repository root changed during source resolution")
-        root_after = self.root.lstat()
-        if _binding_identity(root_after) != _binding_identity(
-            os.fstat(self.root_descriptor)
-        ):
-            raise ValueError("repository root changed during source resolution")
-        for observation in self.observations:
-            current = os.stat(
-                observation.name,
-                dir_fd=observation.parent_descriptor,
-                follow_symlinks=False,
-            )
-            if _version_identity(current) != observation.identity:
-                raise ValueError("source path changed during contained resolution")
-            if observation.link_target is not None:
-                if (
-                    not stat.S_ISLNK(current.st_mode)
-                    or os.readlink(
-                        observation.name,
-                        dir_fd=observation.parent_descriptor,
-                    )
-                    != observation.link_target
-                ):
-                    raise ValueError(
-                        "source symlink changed during contained resolution"
-                    )
+        _verify_resolution_state(
+            self.root,
+            self.root_descriptor,
+            self.root_identity,
+            self.observations,
+        )
         if _version_identity(os.fstat(self.descriptor)) != self.opened_identity:
             raise ValueError("source file changed while it was being read")
 
@@ -171,6 +199,43 @@ class _BoundRepositoryFile:
         descriptors = [
             self.descriptor,
             self.root_descriptor,
+            *(item.parent_descriptor for item in self.observations),
+        ]
+        for descriptor in descriptors:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+@dataclass(slots=True)
+class _StableUnresolvedRepositoryFile:
+    root: Path
+    root_descriptor: int
+    root_identity: tuple[int, ...]
+    observations: list[_PathObservation]
+    parent_descriptor: int
+    parent_identity: tuple[int, ...]
+    name: str
+    expected: tuple[int, ...] | None
+    is_regular = False
+
+    def verify(self) -> None:
+        _verify_stable_unresolved(
+            root=self.root,
+            root_descriptor=self.root_descriptor,
+            root_identity=self.root_identity,
+            observations=self.observations,
+            parent_descriptor=self.parent_descriptor,
+            parent_identity=self.parent_identity,
+            name=self.name,
+            expected=self.expected,
+        )
+
+    def close(self) -> None:
+        descriptors = [
+            self.root_descriptor,
+            self.parent_descriptor,
             *(item.parent_descriptor for item in self.observations),
         ]
         for descriptor in descriptors:
@@ -200,10 +265,85 @@ def _regular_flags() -> int:
     )
 
 
-def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
-    root_before = root.lstat()
+def _verify_resolution_state(
+    root: Path,
+    root_descriptor: int,
+    root_identity: tuple[int, ...],
+    observations: list[_PathObservation],
+) -> None:
+    root_opened = os.fstat(root_descriptor)
+    if _version_identity(root_opened) != root_identity:
+        raise ValueError("repository root changed during source resolution")
+    root_after = root.lstat()
+    if _binding_identity(root_after) != _binding_identity(root_opened):
+        raise ValueError("repository root changed during source resolution")
+    for observation in observations:
+        current = os.stat(
+            observation.name,
+            dir_fd=observation.parent_descriptor,
+            follow_symlinks=False,
+        )
+        if _version_identity(current) != observation.identity:
+            raise ValueError("source path changed during contained resolution")
+        if observation.link_target is not None and (
+            not stat.S_ISLNK(current.st_mode)
+            or os.readlink(
+                observation.name,
+                dir_fd=observation.parent_descriptor,
+            )
+            != observation.link_target
+        ):
+            raise ValueError("source symlink changed during contained resolution")
+
+
+def _verify_stable_unresolved(
+    *,
+    root: Path,
+    root_descriptor: int,
+    root_identity: tuple[int, ...],
+    observations: list[_PathObservation],
+    parent_descriptor: int,
+    parent_identity: tuple[int, ...],
+    name: str,
+    expected: tuple[int, ...] | None,
+) -> None:
+    """Prove a missing or nonregular terminal outcome without opening it."""
+
+    _verify_resolution_state(root, root_descriptor, root_identity, observations)
+    if _version_identity(os.fstat(parent_descriptor)) != parent_identity:
+        raise ValueError("source parent changed during contained resolution")
+    try:
+        observed = os.stat(
+            name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        observed_identity = None
+    else:
+        observed_identity = _version_identity(observed)
+    if observed_identity != expected:
+        raise ValueError("source terminal changed during contained resolution")
+    _verify_resolution_state(root, root_descriptor, root_identity, observations)
+    if _version_identity(os.fstat(parent_descriptor)) != parent_identity:
+        raise ValueError("source parent changed during contained resolution")
+
+
+def _open_secure(
+    root: Path,
+    parts: tuple[str, ...],
+    *,
+    expected_final_identity: tuple[int, ...] | None = None,
+    allow_stable_unresolved: bool = False,
+) -> _BoundRepositoryFile | _StableUnresolvedRepositoryFile:
+    try:
+        root_before = root.lstat()
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError("repository root does not exist") from exc
     if _is_link_or_reparse(root_before) or not stat.S_ISDIR(root_before.st_mode):
         raise ValueError("repository root must be a real directory")
+    if not _identity_is_reliable(root_before):
+        raise ValueError("repository root has no reliable filesystem identity")
     root_descriptor = os.open(root, _directory_flags())
     current_descriptor = -1
     source_descriptor = -1
@@ -213,13 +353,72 @@ def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
         root_opened = os.fstat(root_descriptor)
         if _binding_identity(root_opened) != _binding_identity(root_before):
             raise ValueError("repository root changed during source resolution")
+
+        def retain_unresolved(
+            *,
+            parent_descriptor: int,
+            parent_identity: tuple[int, ...],
+            name: str,
+            expected: tuple[int, ...] | None,
+        ) -> _StableUnresolvedRepositoryFile:
+            nonlocal root_descriptor, observations
+            _verify_stable_unresolved(
+                root=root,
+                root_descriptor=root_descriptor,
+                root_identity=_version_identity(root_opened),
+                observations=observations,
+                parent_descriptor=parent_descriptor,
+                parent_identity=parent_identity,
+                name=name,
+                expected=expected,
+            )
+            retained = _StableUnresolvedRepositoryFile(
+                root=root,
+                root_descriptor=root_descriptor,
+                root_identity=_version_identity(root_opened),
+                observations=observations,
+                parent_descriptor=os.dup(parent_descriptor),
+                parent_identity=parent_identity,
+                name=name,
+                expected=expected,
+            )
+            root_descriptor = -1
+            observations = []
+            return retained
+
         current_descriptor = os.dup(root_descriptor)
-        pending = list(parts)
+        pending = [(name, index == len(parts) - 1) for index, name in enumerate(parts)]
         resolved_prefix: tuple[str, ...] = ()
         symlink_count = 0
         while pending:
-            name = pending.pop(0)
-            before = os.stat(name, dir_fd=current_descriptor, follow_symlinks=False)
+            name, is_lexical_final = pending.pop(0)
+            parent_identity = _version_identity(os.fstat(current_descriptor))
+            try:
+                before = os.stat(
+                    name,
+                    dir_fd=current_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                expected_is_link = expected_final_identity is not None and stat.S_ISLNK(
+                    expected_final_identity[2]
+                )
+                if not allow_stable_unresolved or not expected_is_link:
+                    raise
+                return retain_unresolved(
+                    parent_descriptor=current_descriptor,
+                    parent_identity=parent_identity,
+                    name=name,
+                    expected=None,
+                )
+            if not _identity_is_reliable(before):
+                raise ValueError("source path has no reliable filesystem identity")
+            if (
+                is_lexical_final
+                and expected_final_identity is not None
+                and _version_identity(before) != expected_final_identity
+            ):
+                raise ValueError("source path differs from its initial observation")
             if bool(
                 getattr(before, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
             ):
@@ -229,9 +428,6 @@ def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
                 if symlink_count > _MAX_SYMLINKS:
                     raise ValueError("source symlink resolution exceeds its limit")
                 link_identity = (before.st_dev, before.st_ino)
-                if link_identity in seen_links:
-                    raise ValueError("source symlink resolution contains a loop")
-                seen_links.add(link_identity)
                 target = os.readlink(name, dir_fd=current_descriptor)
                 after = os.stat(
                     name,
@@ -250,10 +446,24 @@ def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
                         link_target=target,
                     )
                 )
-                target_parts = _normalize_link_target(resolved_prefix, target)
+                if link_identity in seen_links:
+                    expected_is_link = (
+                        expected_final_identity is not None
+                        and stat.S_ISLNK(expected_final_identity[2])
+                    )
+                    if not allow_stable_unresolved or not expected_is_link:
+                        raise ValueError("source symlink resolution contains a loop")
+                    return retain_unresolved(
+                        parent_descriptor=current_descriptor,
+                        parent_identity=parent_identity,
+                        name=name,
+                        expected=_version_identity(before),
+                    )
+                seen_links.add(link_identity)
+                target_parts = _normalize_link_target(root, resolved_prefix, target)
                 if len(target_parts) + len(pending) > _MAX_COMPONENTS:
                     raise ValueError("resolved source path exceeds its component limit")
-                pending = [*target_parts, *pending]
+                pending = [*((part, False) for part in target_parts), *pending]
                 resolved_prefix = ()
                 os.close(current_descriptor)
                 current_descriptor = os.dup(root_descriptor)
@@ -269,21 +479,40 @@ def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
             if pending:
                 if not stat.S_ISDIR(before.st_mode):
                     raise ValueError("source path has a non-directory component")
-                child_descriptor = os.open(
-                    name,
-                    _directory_flags(),
-                    dir_fd=current_descriptor,
-                )
-                opened = os.fstat(child_descriptor)
-                if _binding_identity(opened) != _binding_identity(before):
-                    os.close(child_descriptor)
-                    raise ValueError("source directory changed while opening")
+                child_descriptor = -1
+                try:
+                    child_descriptor = os.open(
+                        name,
+                        _directory_flags(),
+                        dir_fd=current_descriptor,
+                    )
+                    opened = os.fstat(child_descriptor)
+                    if _binding_identity(opened) != _binding_identity(before):
+                        raise ValueError("source directory changed while opening")
+                except BaseException:
+                    if child_descriptor >= 0:
+                        os.close(child_descriptor)
+                    raise
                 os.close(current_descriptor)
                 current_descriptor = child_descriptor
                 resolved_prefix = (*resolved_prefix, name)
                 continue
 
             if not stat.S_ISREG(before.st_mode):
+                expected_is_link = expected_final_identity is not None and stat.S_ISLNK(
+                    expected_final_identity[2]
+                )
+                if (
+                    allow_stable_unresolved
+                    and expected_is_link
+                    and not stat.S_ISDIR(before.st_mode)
+                ):
+                    return retain_unresolved(
+                        parent_descriptor=current_descriptor,
+                        parent_identity=parent_identity,
+                        name=name,
+                        expected=_version_identity(before),
+                    )
                 raise ValueError("source path is not a regular repository file")
             source_descriptor = os.open(
                 name,
@@ -310,6 +539,10 @@ def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
                 raise
             return binding
         raise ValueError("source path does not resolve to a file")
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError(
+            "source path has no resolvable regular target"
+        ) from exc
     except OSError as exc:
         raise ValueError("source path could not be resolved safely") from exc
     finally:
@@ -337,9 +570,13 @@ def _static_components(
     if _is_link_or_reparse(root_metadata) or not stat.S_ISDIR(root_metadata.st_mode):
         raise ValueError("repository root must be a real directory")
     identities.append(_version_identity(root_metadata))
+    if not _identity_is_reliable(root_metadata):
+        raise ValueError("repository root has no reliable filesystem identity")
     for index, part in enumerate(parts):
         current /= part
         metadata = current.lstat()
+        if not _identity_is_reliable(metadata):
+            raise ValueError("source path has no reliable filesystem identity")
         if _is_link_or_reparse(metadata):
             raise ValueError(
                 "safe contained symlink resolution requires directory-fd support"
@@ -385,19 +622,26 @@ def _read_static(root: Path, parts: tuple[str, ...], *, max_bytes: int) -> bytes
 def validate_repository_file(root: str | Path, relative: str) -> None:
     """Require one stable regular source file resolving beneath *root*."""
 
-    repository = Path(root).expanduser().resolve()
-    parts = _relative_parts(relative)
-    if SECURE_CONTAINED_SYMLINKS:
-        binding = _open_secure(repository, parts)
-        try:
+    try:
+        repository = Path(root).expanduser().resolve()
+        parts = _relative_parts(relative)
+        if SECURE_CONTAINED_SYMLINKS:
+            binding = _open_secure(repository, parts)
+            if not isinstance(binding, _BoundRepositoryFile):  # pragma: no cover
+                raise AssertionError("regular source resolver returned no binding")
             try:
-                binding.verify()
-            except OSError as exc:
-                raise ValueError("source path could not be resolved safely") from exc
-        finally:
-            binding.close()
-        return
-    _static_components(repository, parts)
+                try:
+                    binding.verify()
+                except OSError as exc:
+                    raise ValueError(
+                        "source path could not be resolved safely"
+                    ) from exc
+            finally:
+                binding.close()
+            return
+        _static_components(repository, parts)
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError("source path does not exist") from exc
 
 
 def read_repository_file(
@@ -410,23 +654,59 @@ def read_repository_file(
 
     if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes <= 0:
         raise ValueError("source byte limit must be positive")
+    try:
+        repository = Path(root).expanduser().resolve()
+        parts = _relative_parts(relative)
+        if SECURE_CONTAINED_SYMLINKS:
+            binding = _open_secure(repository, parts)
+            if not isinstance(binding, _BoundRepositoryFile):  # pragma: no cover
+                raise AssertionError("regular source resolver returned no binding")
+            try:
+                return binding.read_bytes(max_bytes=max_bytes)
+            except OSError as exc:
+                raise ValueError("source path could not be read safely") from exc
+            finally:
+                binding.close()
+        return _read_static(repository, parts, max_bytes=max_bytes)
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError("source path does not exist") from exc
+
+
+@contextmanager
+def resolved_repository_file(
+    root: str | Path,
+    relative: str,
+    *,
+    expected_final_identity: tuple[int, ...],
+) -> Iterator[_BoundRepositoryFile | _StableUnresolvedRepositoryFile]:
+    """Yield a pinned regular file or a retained stable link-only outcome."""
+
+    if not SECURE_CONTAINED_SYMLINKS:
+        raise ValueError("stable link-only resolution requires directory-fd support")
     repository = Path(root).expanduser().resolve()
     parts = _relative_parts(relative)
-    if SECURE_CONTAINED_SYMLINKS:
-        binding = _open_secure(repository, parts)
-        try:
-            return binding.read_bytes(max_bytes=max_bytes)
-        except OSError as exc:
-            raise ValueError("source path could not be read safely") from exc
-        finally:
-            binding.close()
-    return _read_static(repository, parts, max_bytes=max_bytes)
+    try:
+        binding = _open_secure(
+            repository,
+            parts,
+            expected_final_identity=expected_final_identity,
+            allow_stable_unresolved=True,
+        )
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError("source path does not exist") from exc
+    try:
+        yield binding
+        binding.verify()
+    finally:
+        binding.close()
 
 
 def update_repository_file_hash(
     root: str | Path,
     relative: str,
     hasher: object,
+    *,
+    expected_final_identity: tuple[int, ...] | None = None,
 ) -> None:
     """Stream one stable contained source file into a hashlib-compatible hash."""
 
@@ -436,7 +716,15 @@ def update_repository_file_hash(
     repository = Path(root).expanduser().resolve()
     parts = _relative_parts(relative)
     if not SECURE_CONTAINED_SYMLINKS:
-        source, identities = _static_components(repository, parts)
+        try:
+            source, identities = _static_components(repository, parts)
+        except FileNotFoundError as exc:
+            raise ContainedSourceMissingError("source path does not exist") from exc
+        if (
+            expected_final_identity is not None
+            and identities[-1] != expected_final_identity
+        ):
+            raise ValueError("source path differs from its initial observation")
         descriptor = -1
         try:
             descriptor = os.open(source, _regular_flags())
@@ -462,19 +750,18 @@ def update_repository_file_hash(
             if descriptor >= 0:
                 os.close(descriptor)
 
-    binding = _open_secure(repository, parts)
     try:
-        opened = os.fstat(binding.descriptor)
-        remaining = opened.st_size
-        while remaining:
-            block = os.read(binding.descriptor, min(remaining, _READ_CHUNK_BYTES))
-            if not block:
-                raise ValueError("source file was truncated while hashing")
-            update(block)
-            remaining -= len(block)
-        if os.read(binding.descriptor, 1):
-            raise ValueError("source file grew while hashing")
-        binding.verify()
+        binding = _open_secure(
+            repository,
+            parts,
+            expected_final_identity=expected_final_identity,
+        )
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError("source path does not exist") from exc
+    if not isinstance(binding, _BoundRepositoryFile):  # pragma: no cover
+        raise AssertionError("regular source resolver returned no binding")
+    try:
+        binding.update_hash(hasher)
     except OSError as exc:
         raise ValueError("source path could not be hashed safely") from exc
     finally:
@@ -482,8 +769,10 @@ def update_repository_file_hash(
 
 
 __all__ = [
+    "ContainedSourceMissingError",
     "SECURE_CONTAINED_SYMLINKS",
     "read_repository_file",
+    "resolved_repository_file",
     "update_repository_file_hash",
     "validate_repository_file",
 ]

--- a/codenib/_contained_source.py
+++ b/codenib/_contained_source.py
@@ -87,12 +87,16 @@ def _normalize_link_target(
     root: Path,
     prefix: tuple[str, ...],
     target: str,
+    *,
+    allow_absolute: bool,
 ) -> tuple[str, ...]:
     if not target or "\x00" in target:
         raise ValueError("source symlink target must be non-empty")
     if len(os.fsencode(target)) > _MAX_SYMLINK_TARGET_BYTES:
         raise ValueError("source symlink target exceeds its byte limit")
     if os.path.isabs(target):
+        if not allow_absolute:
+            raise ValueError("source symlink target must be relative")
         normalized_target = Path(os.path.normpath(target))
         try:
             target = normalized_target.relative_to(root).as_posix()
@@ -335,6 +339,7 @@ def _open_secure(
     *,
     expected_final_identity: tuple[int, ...] | None = None,
     allow_stable_unresolved: bool = False,
+    allow_absolute_symlinks: bool = False,
 ) -> _BoundRepositoryFile | _StableUnresolvedRepositoryFile:
     try:
         root_before = root.lstat()
@@ -460,7 +465,12 @@ def _open_secure(
                         expected=_version_identity(before),
                     )
                 seen_links.add(link_identity)
-                target_parts = _normalize_link_target(root, resolved_prefix, target)
+                target_parts = _normalize_link_target(
+                    root,
+                    resolved_prefix,
+                    target,
+                    allow_absolute=allow_absolute_symlinks,
+                )
                 if len(target_parts) + len(pending) > _MAX_COMPONENTS:
                     raise ValueError("resolved source path exceeds its component limit")
                 pending = [*((part, False) for part in target_parts), *pending]
@@ -691,6 +701,7 @@ def resolved_repository_file(
             parts,
             expected_final_identity=expected_final_identity,
             allow_stable_unresolved=True,
+            allow_absolute_symlinks=True,
         )
     except FileNotFoundError as exc:
         raise ContainedSourceMissingError("source path does not exist") from exc

--- a/codenib/_secret_fields.py
+++ b/codenib/_secret_fields.py
@@ -69,38 +69,82 @@ class SecretFieldError(ValueError):
     """A decoded value contains credential-shaped publication data."""
 
 
+def _trim_bounds(value: str) -> tuple[int, int]:
+    start = 0
+    end = len(value)
+    while start < end and value[start].isspace():
+        start += 1
+    while end > start and value[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
+def _authority_contains_userinfo(value: str, start: int, end: int) -> bool:
+    """Check a URL authority without copying a potentially huge document."""
+
+    position = start
+    while position < end:
+        char = value[position]
+        if char in "/?#" or char.isspace():
+            break
+        if char == "@":
+            return True
+        position += 1
+    return False
+
+
+def _string_contains_url_credentials(value: str, start: int, end: int) -> bool:
+    if end - start <= 8_192:
+        candidate = value[start:end]
+        if "://" not in candidate and not candidate.startswith("//"):
+            return False
+        try:
+            parsed = urlsplit(candidate)
+        except ValueError as exc:
+            raise SecretFieldError("value contains an invalid URL") from exc
+        return parsed.username is not None or parsed.password is not None
+
+    if value.startswith("//", start) and _authority_contains_userinfo(
+        value, start + 2, end
+    ):
+        return True
+    search_from = start
+    while (separator := value.find("://", search_from, end)) >= 0:
+        if _authority_contains_userinfo(value, separator + 3, end):
+            return True
+        search_from = separator + 3
+    return False
+
+
 def assert_no_secret_fields(value: Any, *, source: str = "value") -> None:
     """Reject decoded credential keys, URL userinfo, and auth header values."""
 
-    if isinstance(value, Mapping):
-        for key, child in value.items():
-            normalized = re.sub(r"[^a-z0-9]", "", str(key).casefold())
-            if (
-                normalized in _NORMALIZED_SECRET_FIELD_NAMES
-                or normalized.endswith(_NORMALIZED_SECRET_FIELD_SUFFIXES)
-                or normalized.startswith(_NORMALIZED_SECRET_HEADER_PREFIXES)
-            ):
-                raise SecretFieldError(
-                    f"{source} contains a credential field or secret field: {key}"
-                )
-            assert_no_secret_fields(child, source=source)
-    elif isinstance(value, (list, tuple)):
-        for child in value:
-            assert_no_secret_fields(child, source=source)
-    elif isinstance(value, str):
-        stripped = value.strip()
-        if "://" in stripped or stripped.startswith("//"):
-            try:
-                parsed = urlsplit(stripped)
-            except ValueError as exc:
-                raise SecretFieldError(f"{source} contains an invalid URL") from exc
-            if parsed.username is not None or parsed.password is not None:
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            for key, child in current.items():
+                normalized = re.sub(r"[^a-z0-9]", "", str(key).casefold())
+                if (
+                    normalized in _NORMALIZED_SECRET_FIELD_NAMES
+                    or normalized.endswith(_NORMALIZED_SECRET_FIELD_SUFFIXES)
+                    or normalized.startswith(_NORMALIZED_SECRET_HEADER_PREFIXES)
+                ):
+                    raise SecretFieldError(
+                        f"{source} contains a credential field or secret field: {key}"
+                    )
+                stack.append(child)
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+        elif isinstance(current, str):
+            start, end = _trim_bounds(current)
+            if _string_contains_url_credentials(current, start, end):
                 raise SecretFieldError(f"{source} must not contain URL credentials")
-        normalized = stripped.casefold()
-        if normalized.startswith(("bearer ", "basic ")):
-            raise SecretFieldError(
-                f"{source} must not contain authorization credentials"
-            )
+            prefix = current[start : min(end, start + 7)].casefold()
+            if prefix.startswith(("bearer ", "basic ")):
+                raise SecretFieldError(
+                    f"{source} must not contain authorization credentials"
+                )
 
 
 __all__ = ["SecretFieldError", "assert_no_secret_fields"]

--- a/codenib/_windows_fs_authority.py
+++ b/codenib/_windows_fs_authority.py
@@ -1,0 +1,1424 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared Win32 HANDLE and FILE_ID filesystem primitives.
+
+This module owns only kernel bindings and handle-level metadata operations.
+Publication, source-containment, and staging policy remain in their respective
+callers.  Child paths are deliberately absent from this interface: callers
+enumerate an already-open parent and reopen entries by filesystem identity.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import ntpath
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+from typing import Callable, Iterator
+
+INVALID_HANDLE_VALUE = -1
+FILE_LIST_DIRECTORY = 0x0001
+FILE_READ_DATA = 0x0001
+FILE_READ_ATTRIBUTES = 0x0080
+DELETE = 0x00010000
+SYNCHRONIZE = 0x00100000
+FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+OPEN_EXISTING = 3
+FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+FILE_ATTRIBUTE_DIRECTORY = 0x00000010
+FILE_ATTRIBUTE_READONLY = 0x00000001
+FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+FILE_ID_BOTH_DIRECTORY_INFO = 10
+FILE_ID_BOTH_DIRECTORY_RESTART_INFO = 11
+FILE_STANDARD_INFO = 1
+FILE_ATTRIBUTE_TAG_INFO = 9
+FILE_ID_INFO = 18
+FILE_ID_EXTD_DIRECTORY_INFO = 19
+FILE_ID_EXTD_DIRECTORY_RESTART_INFO = 20
+FILE_RENAME_INFO = 3
+FILE_ID_TYPE = 0
+EXTENDED_FILE_ID_TYPE = 2
+FSCTL_GET_REPARSE_POINT = 0x000900A8
+IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003
+IO_REPARSE_TAG_SYMLINK = 0xA000000C
+SYMLINK_FLAG_RELATIVE = 0x00000001
+MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 16 * 1024
+OBJ_DONT_REPARSE = 0x00001000
+FILE_OPEN = 0x00000001
+FILE_DIRECTORY_FILE = 0x00000001
+FILE_NON_DIRECTORY_FILE = 0x00000040
+FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020
+FILE_OPEN_REPARSE_POINT = 0x00200000
+ERROR_FILE_NOT_FOUND = 2
+ERROR_PATH_NOT_FOUND = 3
+ERROR_NO_MORE_FILES = 18
+ERROR_FILE_EXISTS = 80
+ERROR_ALREADY_EXISTS = 183
+ERROR_INVALID_FUNCTION = 1
+ERROR_NOT_SUPPORTED = 50
+DIRECTORY_QUERY_BYTES = 64 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsFileId:
+    """One volume-scoped 128-bit Windows filesystem identity."""
+
+    volume_serial: int
+    value: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsHandleMetadata:
+    """Windows-native metadata retained by handle-bound policy layers."""
+
+    st_dev: int
+    st_ino: int
+    st_mode: int
+    st_size: int
+    st_mtime_ns: int
+    st_ctime_ns: int
+    st_nlink: int
+    st_file_attributes: int
+    file_id_128: bytes = b""
+    reparse_tag: int = 0
+    delete_pending: bool = False
+
+    @property
+    def file_identity(self) -> WindowsFileId:
+        """Return the exact volume-scoped identity reported for this handle."""
+
+        return WindowsFileId(self.st_dev, self.file_id_128)
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsDirectoryEntry:
+    """One enumerated child name and its filesystem identity."""
+
+    name: str
+    file_id: int
+    attributes: int
+    file_id_128: bytes = b""
+    reparse_tag: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsReparsePoint:
+    """Parsed data for one no-follow reparse-point handle."""
+
+    tag: int
+    substitute_name: str | None
+    print_name: str | None
+    flags: int = 0
+
+
+def parse_windows_reparse_data(payload: bytes) -> WindowsReparsePoint:
+    """Strictly decode one FSCTL_GET_REPARSE_POINT response buffer."""
+
+    if not isinstance(payload, bytes) or len(payload) < 8:
+        raise RuntimeError("Windows reparse-point data is truncated")
+    tag = int.from_bytes(payload[0:4], "little")
+    data_length = int.from_bytes(payload[4:6], "little")
+    data_end = 8 + data_length
+    if data_end > len(payload) or data_end > MAXIMUM_REPARSE_DATA_BUFFER_SIZE:
+        raise RuntimeError("Windows reparse-point data length is invalid")
+    if tag != IO_REPARSE_TAG_SYMLINK:
+        return WindowsReparsePoint(tag, None, None)
+    if data_length < 12 or data_end < 20:
+        raise RuntimeError("Windows symbolic-link reparse data is truncated")
+    substitute_offset = int.from_bytes(payload[8:10], "little")
+    substitute_length = int.from_bytes(payload[10:12], "little")
+    print_offset = int.from_bytes(payload[12:14], "little")
+    print_length = int.from_bytes(payload[14:16], "little")
+    flags = int.from_bytes(payload[16:20], "little")
+    path_start = 20
+
+    def decode_name(offset: int, length: int) -> str:
+        if offset % 2 or length % 2:
+            raise RuntimeError("Windows symbolic-link name is misaligned")
+        start = path_start + offset
+        end = start + length
+        if start < path_start or end > data_end:
+            raise RuntimeError("Windows symbolic-link name is out of bounds")
+        try:
+            return payload[start:end].decode("utf-16-le", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise RuntimeError(
+                "Windows symbolic-link name is not valid UTF-16"
+            ) from exc
+
+    return WindowsReparsePoint(
+        tag=tag,
+        substitute_name=decode_name(substitute_offset, substitute_length),
+        print_name=decode_name(print_offset, print_length),
+        flags=flags,
+    )
+
+
+def windows_file_id_is_reliable(value: object) -> bool:
+    """Return whether *value* is one non-zero 128-bit FILE_ID."""
+
+    return isinstance(value, bytes) and len(value) == 16 and any(value)
+
+
+def windows_metadata_identity(
+    metadata: WindowsHandleMetadata,
+) -> tuple[object, ...]:
+    """Return the exact version token used by HANDLE authority checks."""
+
+    return (
+        metadata.st_dev,
+        metadata.file_id_128,
+        metadata.st_mode,
+        metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0,
+        metadata.st_file_attributes,
+        metadata.reparse_tag,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        metadata.delete_pending,
+    )
+
+
+def windows_handle_ownership_identity(
+    metadata: WindowsHandleMetadata,
+) -> tuple[object, ...]:
+    """Return the stable kernel-object identity used only for HANDLE cleanup.
+
+    Directory timestamps, link counts, attributes, and delete-pending state are
+    version/authentication data. They may change while the retained HANDLE still
+    names the same kernel object and therefore must not decide close ownership.
+    """
+
+    return (metadata.st_dev, metadata.file_id_128)
+
+
+def windows_extended_path(path: Path) -> str:
+    """Return one canonical extended-length path for opening a root authority."""
+
+    absolute = str(path.absolute())
+    if absolute.startswith("\\\\?\\"):
+        return absolute
+    if absolute.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + absolute[2:]
+    return "\\\\?\\" + absolute
+
+
+def windows_mode_from_attributes(attributes: int) -> int:
+    """Mirror Windows readonly semantics without inventing execute bits."""
+
+    readonly = bool(attributes & FILE_ATTRIBUTE_READONLY)
+    if attributes & FILE_ATTRIBUTE_DIRECTORY:
+        permissions = 0o555 if readonly else 0o777
+        return stat.S_IFDIR | permissions
+    permissions = 0o444 if readonly else 0o666
+    return stat.S_IFREG | permissions
+
+
+class WindowsKernelApi:
+    """Small HANDLE API shared by filesystem authority policy layers.
+
+    The higher-level methods make the ABI replaceable in simulation tests.
+    Future source-containment and staging work can extend this class with
+    reparse queries and root-relative opens without duplicating ctypes.
+    """
+
+    __slots__ = (
+        "kernel32",
+        "ntdll",
+        "wintypes",
+        "BY_HANDLE_FILE_INFORMATION",
+        "FILE_BASIC_INFO",
+        "FILE_STANDARD_INFO",
+        "FILE_ATTRIBUTE_TAG_INFO",
+        "FILE_ID_128",
+        "FILE_ID_INFO",
+        "FILE_ID_DESCRIPTOR",
+        "FILE_ID_BOTH_DIR_INFO",
+        "FILE_ID_EXTD_DIR_INFO",
+        "FILE_RENAME_INFO",
+        "UNICODE_STRING",
+        "OBJECT_ATTRIBUTES",
+        "IO_STATUS_BLOCK",
+        "invalid_handle",
+    )
+
+    def __init__(self) -> None:
+        if sys.platform != "win32" or not hasattr(ctypes, "WinDLL"):
+            raise RuntimeError("Windows HANDLE filesystem API is unavailable")
+        import ctypes.wintypes as wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        ntdll = ctypes.WinDLL("ntdll", use_last_error=True)
+
+        class BY_HANDLE_FILE_INFORMATION(ctypes.Structure):
+            _fields_ = [
+                ("dwFileAttributes", wintypes.DWORD),
+                ("ftCreationTime", wintypes.FILETIME),
+                ("ftLastAccessTime", wintypes.FILETIME),
+                ("ftLastWriteTime", wintypes.FILETIME),
+                ("dwVolumeSerialNumber", wintypes.DWORD),
+                ("nFileSizeHigh", wintypes.DWORD),
+                ("nFileSizeLow", wintypes.DWORD),
+                ("nNumberOfLinks", wintypes.DWORD),
+                ("nFileIndexHigh", wintypes.DWORD),
+                ("nFileIndexLow", wintypes.DWORD),
+            ]
+
+        class FILE_BASIC_INFO(ctypes.Structure):
+            _fields_ = [
+                ("CreationTime", ctypes.c_longlong),
+                ("LastAccessTime", ctypes.c_longlong),
+                ("LastWriteTime", ctypes.c_longlong),
+                ("ChangeTime", ctypes.c_longlong),
+                ("FileAttributes", wintypes.DWORD),
+            ]
+
+        class FILE_STANDARD_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("AllocationSize", ctypes.c_longlong),
+                ("EndOfFile", ctypes.c_longlong),
+                ("NumberOfLinks", wintypes.DWORD),
+                ("DeletePending", wintypes.BOOLEAN),
+                ("Directory", wintypes.BOOLEAN),
+            ]
+
+        class FILE_ATTRIBUTE_TAG_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("FileAttributes", wintypes.DWORD),
+                ("ReparseTag", wintypes.DWORD),
+            ]
+
+        class FILE_ID_128_STRUCT(ctypes.Structure):
+            _fields_ = [("Identifier", ctypes.c_ubyte * 16)]
+
+        class FILE_ID_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("VolumeSerialNumber", ctypes.c_ulonglong),
+                ("FileId", FILE_ID_128_STRUCT),
+            ]
+
+        class FILE_ID_VALUE(ctypes.Union):
+            _fields_ = [
+                ("FileId", ctypes.c_longlong),
+                ("ObjectId", ctypes.c_ubyte * 16),
+                ("ExtendedFileId", ctypes.c_ubyte * 16),
+            ]
+
+        class FILE_ID_DESCRIPTOR(ctypes.Structure):
+            _anonymous_ = ("value",)
+            _fields_ = [
+                ("dwSize", wintypes.DWORD),
+                ("Type", ctypes.c_int),
+                ("value", FILE_ID_VALUE),
+            ]
+
+        class FILE_ID_EXTD_DIR_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("NextEntryOffset", wintypes.DWORD),
+                ("FileIndex", wintypes.DWORD),
+                ("CreationTime", ctypes.c_longlong),
+                ("LastAccessTime", ctypes.c_longlong),
+                ("LastWriteTime", ctypes.c_longlong),
+                ("ChangeTime", ctypes.c_longlong),
+                ("EndOfFile", ctypes.c_longlong),
+                ("AllocationSize", ctypes.c_longlong),
+                ("FileAttributes", wintypes.DWORD),
+                ("FileNameLength", wintypes.DWORD),
+                ("EaSize", wintypes.DWORD),
+                ("ReparsePointTag", wintypes.DWORD),
+                ("FileId", FILE_ID_128_STRUCT),
+                ("FileName", wintypes.WCHAR * 1),
+            ]
+
+        class FILE_ID_BOTH_DIR_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("NextEntryOffset", wintypes.DWORD),
+                ("FileIndex", wintypes.DWORD),
+                ("CreationTime", ctypes.c_longlong),
+                ("LastAccessTime", ctypes.c_longlong),
+                ("LastWriteTime", ctypes.c_longlong),
+                ("ChangeTime", ctypes.c_longlong),
+                ("EndOfFile", ctypes.c_longlong),
+                ("AllocationSize", ctypes.c_longlong),
+                ("FileAttributes", wintypes.DWORD),
+                ("FileNameLength", wintypes.DWORD),
+                ("EaSize", wintypes.DWORD),
+                ("ShortNameLength", ctypes.c_byte),
+                ("ShortName", wintypes.WCHAR * 12),
+                ("FileId", ctypes.c_longlong),
+                ("FileName", wintypes.WCHAR * 1),
+            ]
+
+        class FILE_RENAME_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("ReplaceIfExists", wintypes.BOOLEAN),
+                ("RootDirectory", wintypes.HANDLE),
+                ("FileNameLength", wintypes.DWORD),
+                ("FileName", wintypes.WCHAR * 1),
+            ]
+
+        class UNICODE_STRING_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("Length", wintypes.USHORT),
+                ("MaximumLength", wintypes.USHORT),
+                ("Buffer", wintypes.LPWSTR),
+            ]
+
+        class OBJECT_ATTRIBUTES_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("Length", wintypes.ULONG),
+                ("RootDirectory", wintypes.HANDLE),
+                ("ObjectName", ctypes.POINTER(UNICODE_STRING_STRUCT)),
+                ("Attributes", wintypes.ULONG),
+                ("SecurityDescriptor", wintypes.LPVOID),
+                ("SecurityQualityOfService", wintypes.LPVOID),
+            ]
+
+        class IO_STATUS_BLOCK_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("Status", ctypes.c_void_p),
+                ("Information", ctypes.c_size_t),
+            ]
+
+        kernel32.CreateFileW.argtypes = (
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        )
+        kernel32.CreateFileW.restype = wintypes.HANDLE
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        kernel32.GetFileInformationByHandle.argtypes = (
+            wintypes.HANDLE,
+            ctypes.POINTER(BY_HANDLE_FILE_INFORMATION),
+        )
+        kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+        kernel32.GetFileInformationByHandleEx.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        )
+        kernel32.GetFileInformationByHandleEx.restype = wintypes.BOOL
+        kernel32.OpenFileById.argtypes = (
+            wintypes.HANDLE,
+            ctypes.POINTER(FILE_ID_DESCRIPTOR),
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        )
+        kernel32.OpenFileById.restype = wintypes.HANDLE
+        kernel32.ReadFile.argtypes = (
+            wintypes.HANDLE,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+            wintypes.LPVOID,
+        )
+        kernel32.ReadFile.restype = wintypes.BOOL
+        kernel32.DeviceIoControl.argtypes = (
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+            wintypes.LPVOID,
+        )
+        kernel32.DeviceIoControl.restype = wintypes.BOOL
+        kernel32.SetFileInformationByHandle.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        )
+        kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+        kernel32.GetCurrentProcess.argtypes = ()
+        kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        kernel32.DuplicateHandle.argtypes = (
+            wintypes.HANDLE,
+            wintypes.HANDLE,
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.HANDLE),
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        )
+        kernel32.DuplicateHandle.restype = wintypes.BOOL
+
+        ntdll.NtCreateFile.argtypes = (
+            ctypes.POINTER(wintypes.HANDLE),
+            wintypes.DWORD,
+            ctypes.POINTER(OBJECT_ATTRIBUTES_STRUCT),
+            ctypes.POINTER(IO_STATUS_BLOCK_STRUCT),
+            ctypes.c_void_p,
+            wintypes.ULONG,
+            wintypes.ULONG,
+            wintypes.ULONG,
+            wintypes.ULONG,
+            ctypes.c_void_p,
+            wintypes.ULONG,
+        )
+        ntdll.NtCreateFile.restype = ctypes.c_long
+        ntdll.RtlNtStatusToDosError.argtypes = (wintypes.ULONG,)
+        ntdll.RtlNtStatusToDosError.restype = wintypes.ULONG
+
+        self.kernel32 = kernel32
+        self.ntdll = ntdll
+        self.wintypes = wintypes
+        self.BY_HANDLE_FILE_INFORMATION = BY_HANDLE_FILE_INFORMATION
+        self.FILE_BASIC_INFO = FILE_BASIC_INFO
+        self.FILE_STANDARD_INFO = FILE_STANDARD_INFO_STRUCT
+        self.FILE_ATTRIBUTE_TAG_INFO = FILE_ATTRIBUTE_TAG_INFO_STRUCT
+        self.FILE_ID_128 = FILE_ID_128_STRUCT
+        self.FILE_ID_INFO = FILE_ID_INFO_STRUCT
+        self.FILE_ID_DESCRIPTOR = FILE_ID_DESCRIPTOR
+        self.FILE_ID_BOTH_DIR_INFO = FILE_ID_BOTH_DIR_INFO_STRUCT
+        self.FILE_ID_EXTD_DIR_INFO = FILE_ID_EXTD_DIR_INFO_STRUCT
+        self.FILE_RENAME_INFO = FILE_RENAME_INFO_STRUCT
+        self.UNICODE_STRING = UNICODE_STRING_STRUCT
+        self.OBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES_STRUCT
+        self.IO_STATUS_BLOCK = IO_STATUS_BLOCK_STRUCT
+        self.invalid_handle = ctypes.c_void_p(INVALID_HANDLE_VALUE).value
+
+    def _raise_last_error(self, context: str) -> None:
+        error = ctypes.get_last_error()
+        if error in {ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND}:
+            raise FileNotFoundError(error, context)
+        if error in {ERROR_FILE_EXISTS, ERROR_ALREADY_EXISTS}:
+            raise FileExistsError(error, context)
+        if error in {ERROR_INVALID_FUNCTION, ERROR_NOT_SUPPORTED}:
+            raise RuntimeError(
+                "filesystem does not support HANDLE-bound directory authority"
+            )
+        raise ctypes.WinError(error)
+
+    def _raise_ntstatus(self, status: int, context: str) -> None:
+        error = int(self.ntdll.RtlNtStatusToDosError(status & 0xFFFFFFFF))
+        ctypes.set_last_error(error)
+        self._raise_last_error(context)
+
+    @staticmethod
+    def _handle_value(handle: object) -> int:
+        value = getattr(handle, "value", handle)
+        return 0 if value is None else int(value)
+
+    def create_directory_handle(self, path: Path) -> int:
+        handle = self.kernel32.CreateFileW(
+            windows_extended_path(path),
+            FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            None,
+        )
+        value = self._handle_value(handle)
+        if value == self.invalid_handle:
+            self._raise_last_error(f"could not open filesystem authority: {path}")
+        return value
+
+    def duplicate_handle(self, handle: int) -> int:
+        duplicate = self.wintypes.HANDLE()
+        process = self.kernel32.GetCurrentProcess()
+        if not self.kernel32.DuplicateHandle(
+            process,
+            handle,
+            process,
+            ctypes.byref(duplicate),
+            0,
+            False,
+            0x00000002,  # DUPLICATE_SAME_ACCESS
+        ):
+            self._raise_last_error("could not duplicate filesystem authority handle")
+        return self._handle_value(duplicate)
+
+    def close(self, handle: int) -> None:
+        if handle not in {0, self.invalid_handle}:
+            if not self.kernel32.CloseHandle(handle):
+                self._raise_last_error("could not close filesystem authority HANDLE")
+
+    def metadata(self, handle: int) -> WindowsHandleMetadata:
+        information = self.BY_HANDLE_FILE_INFORMATION()
+        if not self.kernel32.GetFileInformationByHandle(
+            handle,
+            ctypes.byref(information),
+        ):
+            self._raise_last_error("could not read HANDLE identity")
+        basic = self.FILE_BASIC_INFO()
+        if not self.kernel32.GetFileInformationByHandleEx(
+            handle,
+            0,  # FileBasicInfo
+            ctypes.byref(basic),
+            ctypes.sizeof(basic),
+        ):
+            self._raise_last_error("could not read HANDLE version metadata")
+        standard = self.FILE_STANDARD_INFO()
+        if not self.kernel32.GetFileInformationByHandleEx(
+            handle,
+            FILE_STANDARD_INFO,
+            ctypes.byref(standard),
+            ctypes.sizeof(standard),
+        ):
+            self._raise_last_error("could not read HANDLE standard metadata")
+        identity = self.FILE_ID_INFO()
+        if not self.kernel32.GetFileInformationByHandleEx(
+            handle,
+            FILE_ID_INFO,
+            ctypes.byref(identity),
+            ctypes.sizeof(identity),
+        ):
+            self._raise_last_error("could not read HANDLE 128-bit identity")
+        tag = self.FILE_ATTRIBUTE_TAG_INFO()
+        if not self.kernel32.GetFileInformationByHandleEx(
+            handle,
+            FILE_ATTRIBUTE_TAG_INFO,
+            ctypes.byref(tag),
+            ctypes.sizeof(tag),
+        ):
+            self._raise_last_error("could not read HANDLE reparse metadata")
+        attributes = int(tag.FileAttributes)
+        file_id_128 = bytes(identity.FileId.Identifier)
+        legacy_file_id = (int(information.nFileIndexHigh) << 32) | int(
+            information.nFileIndexLow
+        )
+        return WindowsHandleMetadata(
+            st_dev=int(identity.VolumeSerialNumber),
+            st_ino=legacy_file_id,
+            st_mode=windows_mode_from_attributes(attributes),
+            st_size=int(standard.EndOfFile),
+            st_mtime_ns=int(basic.LastWriteTime) * 100,
+            st_ctime_ns=int(basic.ChangeTime) * 100,
+            st_nlink=int(standard.NumberOfLinks),
+            st_file_attributes=attributes,
+            file_id_128=file_id_128,
+            reparse_tag=(
+                int(tag.ReparseTag) if attributes & FILE_ATTRIBUTE_REPARSE_POINT else 0
+            ),
+            delete_pending=bool(standard.DeletePending),
+        )
+
+    def iter_directory(self, handle: int) -> Iterator[WindowsDirectoryEntry]:
+        """Yield children incrementally from an already-open directory HANDLE."""
+
+        information_class = FILE_ID_EXTD_DIRECTORY_RESTART_INFO
+        while True:
+            buffer = ctypes.create_string_buffer(DIRECTORY_QUERY_BYTES)
+            if not self.kernel32.GetFileInformationByHandleEx(
+                handle,
+                information_class,
+                buffer,
+                len(buffer),
+            ):
+                error = ctypes.get_last_error()
+                if error == ERROR_NO_MORE_FILES:
+                    break
+                self._raise_last_error("could not enumerate directory HANDLE")
+            information_class = FILE_ID_EXTD_DIRECTORY_INFO
+            offset = 0
+            while True:
+                entry = self.FILE_ID_EXTD_DIR_INFO.from_buffer(buffer, offset)
+                name_offset = offset + self.FILE_ID_EXTD_DIR_INFO.FileName.offset
+                name_bytes = bytes(
+                    buffer[name_offset : name_offset + int(entry.FileNameLength)]
+                )
+                try:
+                    name = name_bytes.decode("utf-16-le", errors="strict")
+                except UnicodeDecodeError as exc:
+                    raise RuntimeError(
+                        "Windows directory name is not valid UTF-16"
+                    ) from exc
+                if name not in {".", ".."}:
+                    file_id_128 = bytes(entry.FileId.Identifier)
+                    yield WindowsDirectoryEntry(
+                        name=name,
+                        file_id=int.from_bytes(file_id_128[:8], "little"),
+                        attributes=int(entry.FileAttributes),
+                        file_id_128=file_id_128,
+                        reparse_tag=(
+                            int(entry.ReparsePointTag)
+                            if int(entry.FileAttributes) & FILE_ATTRIBUTE_REPARSE_POINT
+                            else 0
+                        ),
+                    )
+                next_offset = int(entry.NextEntryOffset)
+                if not next_offset:
+                    break
+                offset += next_offset
+                if offset >= len(buffer):
+                    raise RuntimeError("Windows directory enumeration is malformed")
+
+    def enumerate_directory(self, handle: int) -> tuple[WindowsDirectoryEntry, ...]:
+        """Return all children for compatibility with publication callers."""
+
+        output: list[WindowsDirectoryEntry] = []
+        information_class = FILE_ID_BOTH_DIRECTORY_RESTART_INFO
+        while True:
+            buffer = ctypes.create_string_buffer(DIRECTORY_QUERY_BYTES)
+            if not self.kernel32.GetFileInformationByHandleEx(
+                handle,
+                information_class,
+                buffer,
+                len(buffer),
+            ):
+                error = ctypes.get_last_error()
+                if error == ERROR_NO_MORE_FILES:
+                    break
+                self._raise_last_error("could not enumerate directory HANDLE")
+            information_class = FILE_ID_BOTH_DIRECTORY_INFO
+            offset = 0
+            while True:
+                entry = self.FILE_ID_BOTH_DIR_INFO.from_buffer(buffer, offset)
+                name_offset = offset + self.FILE_ID_BOTH_DIR_INFO.FileName.offset
+                name_bytes = bytes(
+                    buffer[name_offset : name_offset + int(entry.FileNameLength)]
+                )
+                try:
+                    name = name_bytes.decode("utf-16-le", errors="strict")
+                except UnicodeDecodeError as exc:
+                    raise RuntimeError(
+                        "Windows directory name is not valid UTF-16"
+                    ) from exc
+                if name not in {".", ".."}:
+                    output.append(
+                        WindowsDirectoryEntry(
+                            name=name,
+                            file_id=int(entry.FileId) & ((1 << 64) - 1),
+                            attributes=int(entry.FileAttributes),
+                        )
+                    )
+                next_offset = int(entry.NextEntryOffset)
+                if not next_offset:
+                    break
+                offset += next_offset
+                if offset >= len(buffer):
+                    raise RuntimeError("Windows directory enumeration is malformed")
+        return tuple(output)
+
+    def open_by_extended_id(
+        self,
+        volume_hint: int,
+        file_id_128: bytes,
+        *,
+        desired_access: int,
+        is_directory: bool,
+    ) -> int:
+        """Open one object by its exact 128-bit FILE_ID without following it."""
+
+        if not windows_file_id_is_reliable(file_id_128):
+            raise ValueError("Windows extended FILE_ID is not reliable")
+        descriptor = self.FILE_ID_DESCRIPTOR()
+        descriptor.dwSize = ctypes.sizeof(descriptor)
+        descriptor.Type = EXTENDED_FILE_ID_TYPE
+        ctypes.memmove(
+            ctypes.addressof(descriptor.ExtendedFileId),
+            file_id_128,
+            len(file_id_128),
+        )
+        flags = FILE_FLAG_OPEN_REPARSE_POINT
+        if is_directory:
+            flags |= FILE_FLAG_BACKUP_SEMANTICS
+        handle = self.kernel32.OpenFileById(
+            volume_hint,
+            ctypes.byref(descriptor),
+            desired_access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            flags,
+        )
+        value = self._handle_value(handle)
+        if value == self.invalid_handle:
+            self._raise_last_error("could not open directory entry by extended FILE_ID")
+        return value
+
+    def open_relative(
+        self,
+        parent_handle: int,
+        name: str,
+        *,
+        desired_access: int,
+        is_directory: bool,
+        allow_reparse: bool,
+    ) -> int:
+        """Open one simple child relative to a retained directory HANDLE."""
+
+        if (
+            not isinstance(name, str)
+            or not name
+            or name in {".", ".."}
+            or "\\" in name
+            or "/" in name
+            or "\x00" in name
+        ):
+            raise ValueError("Windows relative open requires one simple child name")
+        encoded = name.encode("utf-16-le", errors="strict")
+        if len(encoded) > 0xFFFE:
+            raise ValueError("Windows relative child name is too long")
+        name_buffer = ctypes.create_unicode_buffer(name)
+        unicode_name = self.UNICODE_STRING()
+        unicode_name.Length = len(encoded)
+        unicode_name.MaximumLength = len(encoded) + 2
+        unicode_name.Buffer = ctypes.cast(name_buffer, self.wintypes.LPWSTR)
+        attributes = self.OBJECT_ATTRIBUTES()
+        attributes.Length = ctypes.sizeof(attributes)
+        attributes.RootDirectory = parent_handle
+        attributes.ObjectName = ctypes.pointer(unicode_name)
+        attributes.Attributes = 0 if allow_reparse else OBJ_DONT_REPARSE
+        attributes.SecurityDescriptor = None
+        attributes.SecurityQualityOfService = None
+        io_status = self.IO_STATUS_BLOCK()
+        opened = self.wintypes.HANDLE()
+        options = FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT
+        options |= FILE_DIRECTORY_FILE if is_directory else FILE_NON_DIRECTORY_FILE
+        status = int(
+            self.ntdll.NtCreateFile(
+                ctypes.byref(opened),
+                desired_access,
+                ctypes.byref(attributes),
+                ctypes.byref(io_status),
+                None,
+                0,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                FILE_OPEN,
+                options,
+                None,
+                0,
+            )
+        )
+        if status < 0:
+            self._raise_ntstatus(status, "could not open HANDLE-relative child")
+        return self._handle_value(opened)
+
+    def query_reparse_point(self, handle: int) -> WindowsReparsePoint:
+        """Read and strictly parse one already-open reparse point."""
+
+        buffer = ctypes.create_string_buffer(MAXIMUM_REPARSE_DATA_BUFFER_SIZE)
+        returned = self.wintypes.DWORD()
+        if not self.kernel32.DeviceIoControl(
+            handle,
+            FSCTL_GET_REPARSE_POINT,
+            None,
+            0,
+            buffer,
+            len(buffer),
+            ctypes.byref(returned),
+            None,
+        ):
+            self._raise_last_error("could not read HANDLE reparse-point data")
+        payload = bytes(buffer[: int(returned.value)])
+        return parse_windows_reparse_data(payload)
+
+    def open_by_id(
+        self,
+        volume_hint: int,
+        file_id: int,
+        *,
+        desired_access: int,
+        is_directory: bool,
+    ) -> int:
+        descriptor = self.FILE_ID_DESCRIPTOR()
+        descriptor.dwSize = ctypes.sizeof(descriptor)
+        descriptor.Type = FILE_ID_TYPE
+        signed_id = file_id if file_id < (1 << 63) else file_id - (1 << 64)
+        descriptor.FileId = signed_id
+        flags = FILE_FLAG_OPEN_REPARSE_POINT
+        if is_directory:
+            flags |= FILE_FLAG_BACKUP_SEMANTICS
+        handle = self.kernel32.OpenFileById(
+            volume_hint,
+            ctypes.byref(descriptor),
+            desired_access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            flags,
+        )
+        value = self._handle_value(handle)
+        if value == self.invalid_handle:
+            self._raise_last_error("could not open directory entry by FILE_ID")
+        return value
+
+    def read(self, handle: int, size: int) -> bytes:
+        if size <= 0:
+            return b""
+        buffer = ctypes.create_string_buffer(size)
+        read = self.wintypes.DWORD()
+        if not self.kernel32.ReadFile(
+            handle,
+            buffer,
+            size,
+            ctypes.byref(read),
+            None,
+        ):
+            self._raise_last_error("could not read FILE_ID-bound file")
+        return bytes(buffer[: int(read.value)])
+
+    def rename_noreplace(
+        self,
+        source_handle: int,
+        parent_handle: int,
+        destination: str,
+    ) -> None:
+        encoded = destination.encode("utf-16-le", errors="strict")
+        structure_type = self.FILE_RENAME_INFO
+        size = structure_type.FileName.offset + len(encoded)
+        buffer = ctypes.create_string_buffer(size)
+        information = structure_type.from_buffer(buffer)
+        information.ReplaceIfExists = False
+        information.RootDirectory = parent_handle
+        information.FileNameLength = len(encoded)
+        ctypes.memmove(
+            ctypes.addressof(buffer) + structure_type.FileName.offset,
+            encoded,
+            len(encoded),
+        )
+        if not self.kernel32.SetFileInformationByHandle(
+            source_handle,
+            FILE_RENAME_INFO,
+            buffer,
+            size,
+        ):
+            self._raise_last_error("could not perform no-replace HANDLE rename")
+
+
+@dataclass(frozen=True, slots=True)
+class _WindowsAuthorityObservation:
+    parent_handle: int
+    parent_identity: tuple[object, ...]
+    name: str
+    child_handle: int
+    child_identity: tuple[object, ...]
+    child_file_id: bytes
+
+
+class WindowsDirectoryAuthority:
+    """Retained no-follow HANDLE chain for one lexical Windows directory."""
+
+    __slots__ = (
+        "api",
+        "path",
+        "handles",
+        "observations",
+        "anchor_identity",
+        "closed",
+    )
+
+    def __init__(
+        self,
+        *,
+        api: WindowsKernelApi,
+        path: Path,
+        handles: list[int],
+        observations: list[_WindowsAuthorityObservation],
+        anchor_identity: tuple[object, ...],
+    ) -> None:
+        self.api = api
+        self.path = path
+        self.handles = handles
+        self.observations = observations
+        self.anchor_identity = anchor_identity
+        self.closed = False
+
+    @property
+    def handle(self) -> int:
+        if self.closed or not self.handles:
+            raise RuntimeError("Windows directory authority is closed")
+        return self.handles[-1]
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return windows_metadata_identity(self.api.metadata(self.handle))
+
+    def _find_exact_child(
+        self,
+        parent_handle: int,
+        name: str,
+    ) -> WindowsDirectoryEntry | None:
+        iterator = getattr(self.api, "iter_directory", None)
+        entries = (
+            iterator(parent_handle)
+            if callable(iterator)
+            else self.api.enumerate_directory(parent_handle)
+        )
+        matches = [entry for entry in entries if entry.name == name]
+        if len(matches) > 1:
+            raise RuntimeError(
+                "Windows authority directory has duplicate exact child names"
+            )
+        return matches[0] if matches else None
+
+    def verify(self) -> None:
+        if self.closed or not self.handles:
+            raise RuntimeError("Windows directory authority is closed")
+        anchor = self.api.metadata(self.handles[0])
+        if (
+            windows_metadata_identity(anchor) != self.anchor_identity
+            or not stat.S_ISDIR(anchor.st_mode)
+            or anchor.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+            or not anchor.st_dev
+            or not windows_file_id_is_reliable(anchor.file_id_128)
+            or anchor.delete_pending
+        ):
+            raise RuntimeError("Windows lexical anchor changed")
+        for observation in self.observations:
+            if (
+                windows_metadata_identity(self.api.metadata(observation.parent_handle))
+                != observation.parent_identity
+            ):
+                raise RuntimeError("Windows lexical parent changed")
+            entry = self._find_exact_child(
+                observation.parent_handle,
+                observation.name,
+            )
+            if entry is None or entry.file_id_128 != observation.child_file_id:
+                raise RuntimeError("Windows lexical directory binding changed")
+            opened = self.api.metadata(observation.child_handle)
+            if (
+                windows_metadata_identity(opened) != observation.child_identity
+                or not stat.S_ISDIR(opened.st_mode)
+                or opened.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+                or not windows_file_id_is_reliable(opened.file_id_128)
+                or opened.delete_pending
+            ):
+                raise RuntimeError("Windows lexical directory component changed")
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        # A cancellation may land after the final HANDLE was confirmed closed
+        # but before the prior call could publish ``closed``.  Empty ownership
+        # is authoritative and makes the retry a finite state transition.
+        if not self.handles:
+            self.closed = True
+            return
+        expected = {self.handles[0]: self.anchor_identity[:2]}
+        expected.update(
+            {
+                observation.child_handle: observation.child_identity[:2]
+                for observation in self.observations
+            }
+        )
+        failure = _close_windows_handles(self.api, self.handles, expected)
+        self.closed = not self.handles
+        if failure is not None:
+            raise failure
+
+
+def _close_windows_handles(
+    api: WindowsKernelApi,
+    handles: list[int],
+    expected_identities: dict[int, tuple[object, ...]],
+) -> BaseException | None:
+    """Visit every HANDLE and retain the first delayed close failure."""
+
+    deferred: BaseException | None = None
+    for handle in reversed(tuple(handles)):
+        closed = False
+        while True:
+            try:
+                observed = api.metadata(handle)
+                expected = expected_identities.get(handle)
+                if (
+                    expected is not None
+                    and windows_handle_ownership_identity(observed) != expected
+                ):
+                    deferred = deferred or RuntimeError(
+                        "Windows HANDLE ownership changed"
+                    )
+                    closed = True
+                    break
+            except KeyError:
+                closed = True
+                break
+            except OSError as exc:
+                if exc.errno == errno.EBADF or getattr(exc, "winerror", None) == 6:
+                    closed = True
+                    break
+                deferred = deferred or exc
+                break
+            except BaseException as exc:  # noqa: B036 - confirm close result
+                if isinstance(exc, Exception):
+                    deferred = deferred or exc
+                    break
+                deferred = deferred or exc
+                continue
+
+            expected_at_close = windows_handle_ownership_identity(observed)
+            try:
+                api.close(handle)
+                closed = True
+            except BaseException as exc:  # noqa: B036 - confirm close result
+                deferred = deferred or exc
+                while True:
+                    try:
+                        visible = api.metadata(handle)
+                    except KeyError:
+                        closed = True
+                        break
+                    except OSError as probe_error:
+                        if (
+                            probe_error.errno == errno.EBADF
+                            or getattr(probe_error, "winerror", None) == 6
+                        ):
+                            closed = True
+                        else:
+                            deferred = deferred or probe_error
+                        break
+                    except BaseException as probe_error:  # noqa: B036
+                        if isinstance(probe_error, Exception):
+                            deferred = deferred or probe_error
+                            break
+                        deferred = deferred or probe_error
+                        continue
+                    if windows_handle_ownership_identity(visible) != expected_at_close:
+                        # The owned HANDLE closed and its numeric value was
+                        # reused. Never close the replacement authority.
+                        closed = True
+                    break
+                if closed or isinstance(exc, Exception):
+                    break
+                continue
+            break
+
+        if closed:
+            while handle in handles:
+                try:
+                    handles.pop(handles.index(handle))
+                except BaseException as exc:
+                    if isinstance(exc, Exception):
+                        raise
+                    deferred = deferred or exc
+            while handle in expected_identities:
+                try:
+                    expected_identities.pop(handle, None)
+                except BaseException as exc:
+                    if isinstance(exc, Exception):
+                        raise
+                    deferred = deferred or exc
+    return deferred
+
+
+class _WindowsHandleCleanup:
+    """Retryable owner installed before the first Windows HANDLE acquisition."""
+
+    __slots__ = ("api", "handles", "expected_identities")
+
+    def __init__(self, api: WindowsKernelApi) -> None:
+        self.api = api
+        self.handles: list[int] = []
+        self.expected_identities: dict[int, tuple[object, ...]] = {}
+
+    @property
+    def closed(self) -> bool:
+        return not self.handles
+
+    def retain(
+        self,
+        handle: int,
+        metadata: WindowsHandleMetadata | None = None,
+    ) -> int:
+        deferred = _append_owned_windows_handle(self.handles, handle)
+        if deferred is not None:
+            raise deferred
+        if metadata is not None:
+            self.expected_identities[handle] = windows_handle_ownership_identity(
+                metadata
+            )
+        return handle
+
+    def close(self) -> None:
+        failure = _close_windows_handles(
+            self.api,
+            self.handles,
+            self.expected_identities,
+        )
+        if failure is not None:
+            raise failure
+
+
+def _install_cleanup_resource(slot: object | None, resource: object) -> None:
+    if slot is None:
+        return
+    own = getattr(slot, "own", None)
+    if not callable(own):
+        raise TypeError("source cleanup slot must provide own()")
+    own(resource)
+
+
+def _attach_cleanup_resource(failure: BaseException, resource: object) -> None:
+    try:
+        if bool(resource.closed):  # type: ignore[attr-defined]
+            return
+    except BaseException:  # noqa: B036 - uncertain ownership stays reachable
+        pass
+    try:
+        failure.source_cleanup_owner = resource  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - local ownership remains authoritative
+        pass
+
+
+def _append_owned_windows_handle(
+    handles: list[int],
+    handle: int,
+    deferred: BaseException | None = None,
+) -> BaseException | None:
+    while handle not in handles:
+        try:
+            handles.append(handle)
+        except BaseException as exc:
+            if isinstance(exc, Exception):
+                raise
+            deferred = deferred or exc
+    return deferred
+
+
+def _open_owned_windows_handle(
+    operation: Callable[[], int],
+    handles: list[int],
+) -> int:
+    """Open and register a HANDLE at the first Python-owned opportunity.
+
+    A raw integer can still be lost if arbitrary opcode injection lands between
+    the native API return and Python's result store. Full coverage of that
+    interpreter boundary requires a native helper returning an owning object.
+    """
+
+    handle = 0
+    try:
+        handle = operation()
+        deferred = _append_owned_windows_handle(handles, handle)
+        if deferred is not None:
+            raise deferred
+        return handle
+    except BaseException:  # noqa: B036 - commit HANDLE ownership
+        if handle:
+            try:
+                _append_owned_windows_handle(handles, handle)
+            except BaseException:  # noqa: B036 - preserve primary failure
+                pass
+        raise
+
+
+def open_lexical_directory_authority(
+    path: str | Path,
+    *,
+    api: WindowsKernelApi | None = None,
+    cleanup_slot: object | None = None,
+) -> WindowsDirectoryAuthority:
+    """Pin every component of an absolute lexical Windows directory path."""
+
+    selected = windows_kernel_api() if api is None else api
+    if api is None:
+        windows_require_source_api(selected)
+    raw = str(path)
+    if not raw or "\x00" in raw:
+        raise ValueError("Windows lexical directory path is invalid")
+    normalized = ntpath.normpath(ntpath.abspath(raw))
+    pure = PureWindowsPath(normalized)
+    if not pure.is_absolute() or not pure.anchor:
+        raise ValueError("Windows lexical directory path must be absolute")
+    components = pure.parts[1:]
+    if (
+        len(components) > 256
+        or len(normalized.encode("utf-8", errors="strict")) > 4_096
+    ):
+        raise ValueError("Windows lexical directory path exceeds its limits")
+    for component in components:
+        if (
+            not component
+            or component in {".", ".."}
+            or "\\" in component
+            or "/" in component
+            or "\x00" in component
+        ):
+            raise ValueError("Windows lexical directory component is invalid")
+
+    cleanup = _WindowsHandleCleanup(selected)
+    _install_cleanup_resource(cleanup_slot, cleanup)
+    handles = cleanup.handles
+    handle_identities = cleanup.expected_identities
+    observations: list[_WindowsAuthorityObservation] = []
+    try:
+        anchor_handle = _open_owned_windows_handle(
+            lambda: selected.create_directory_handle(Path(pure.anchor)),
+            handles,
+        )
+        anchor = selected.metadata(anchor_handle)
+        if (
+            not stat.S_ISDIR(anchor.st_mode)
+            or anchor.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+            or not anchor.st_dev
+            or not windows_file_id_is_reliable(anchor.file_id_128)
+            or anchor.delete_pending
+        ):
+            raise RuntimeError("Windows lexical anchor is not identity-bound")
+        handle_identities[anchor_handle] = windows_handle_ownership_identity(anchor)
+        current_handle = anchor_handle
+        for component in components:
+            parent_identity = windows_metadata_identity(
+                selected.metadata(current_handle)
+            )
+
+            def open_component(
+                current_handle: int = current_handle,
+                component: str = component,
+            ) -> int:
+                return selected.open_relative(
+                    current_handle,
+                    component,
+                    desired_access=(
+                        FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE
+                    ),
+                    is_directory=True,
+                    allow_reparse=False,
+                )
+
+            child_handle = _open_owned_windows_handle(
+                open_component,
+                handles,
+            )
+            child = selected.metadata(child_handle)
+            if (
+                not stat.S_ISDIR(child.st_mode)
+                or child.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+                or child.st_dev != anchor.st_dev
+                or not windows_file_id_is_reliable(child.file_id_128)
+                or child.delete_pending
+            ):
+                raise RuntimeError(
+                    "Windows lexical directory component is not identity-bound"
+                )
+            handle_identities[child_handle] = windows_handle_ownership_identity(child)
+            iterator = getattr(selected, "iter_directory", None)
+            entries = (
+                iterator(current_handle)
+                if callable(iterator)
+                else selected.enumerate_directory(current_handle)
+            )
+            matches = [entry for entry in entries if entry.name == component]
+            if len(matches) != 1 or matches[0].file_id_128 != child.file_id_128:
+                raise RuntimeError("Windows lexical directory changed while opening")
+            observations.append(
+                _WindowsAuthorityObservation(
+                    parent_handle=current_handle,
+                    parent_identity=parent_identity,
+                    name=component,
+                    child_handle=child_handle,
+                    child_identity=windows_metadata_identity(child),
+                    child_file_id=child.file_id_128,
+                )
+            )
+            current_handle = child_handle
+        authority = WindowsDirectoryAuthority(
+            api=selected,
+            path=Path(normalized),
+            handles=handles,
+            observations=observations,
+            anchor_identity=windows_metadata_identity(anchor),
+        )
+        authority.verify()
+        _install_cleanup_resource(cleanup_slot, authority)
+        return authority
+    except BaseException as primary:  # noqa: B036 - preserve acquisition failure
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup.close()
+        except BaseException as exc:  # noqa: B036 - retain explicit retry owner
+            cleanup_failure = exc
+        _attach_cleanup_resource(primary, cleanup_slot or cleanup)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+
+
+_KERNEL_API: WindowsKernelApi | None = None
+
+
+def windows_kernel_api() -> WindowsKernelApi:
+    """Return the process-wide Win32 filesystem binding."""
+
+    global _KERNEL_API
+    if _KERNEL_API is None:
+        try:
+            _KERNEL_API = WindowsKernelApi()
+        except (AttributeError, OSError) as exc:
+            raise RuntimeError(
+                "Windows FILE_ID HANDLE filesystem APIs are unavailable"
+            ) from exc
+    return _KERNEL_API
+
+
+def windows_require_publication_api(api: WindowsKernelApi | None = None) -> None:
+    """Fail closed unless the no-replace publication primitives are callable."""
+
+    selected = windows_kernel_api() if api is None else api
+    required = (
+        "GetFileInformationByHandleEx",
+        "OpenFileById",
+        "SetFileInformationByHandle",
+    )
+    if any(not hasattr(selected.kernel32, name) for name in required):
+        raise RuntimeError(
+            "atomic directory publication requires Windows FILE_ID HANDLE APIs"
+        )
+
+
+def windows_require_source_api(api: WindowsKernelApi | None = None) -> None:
+    """Fail closed unless the Windows source-authority primitives are callable."""
+
+    selected = windows_kernel_api() if api is None else api
+    kernel_required = (
+        "DeviceIoControl",
+        "GetFileInformationByHandleEx",
+        "OpenFileById",
+    )
+    if any(not hasattr(selected.kernel32, name) for name in kernel_required) or not (
+        hasattr(selected.ntdll, "NtCreateFile")
+        and hasattr(selected.ntdll, "RtlNtStatusToDosError")
+    ):
+        raise RuntimeError(
+            "secure source reads require Windows 128-bit FILE_ID, relative-open, "
+            "and reparse-point APIs"
+        )
+
+
+__all__ = [
+    "DELETE",
+    "FILE_ATTRIBUTE_DIRECTORY",
+    "FILE_ATTRIBUTE_READONLY",
+    "FILE_ATTRIBUTE_REPARSE_POINT",
+    "FILE_LIST_DIRECTORY",
+    "FILE_READ_ATTRIBUTES",
+    "FILE_READ_DATA",
+    "IO_REPARSE_TAG_MOUNT_POINT",
+    "IO_REPARSE_TAG_SYMLINK",
+    "SYNCHRONIZE",
+    "WindowsDirectoryAuthority",
+    "WindowsDirectoryEntry",
+    "WindowsFileId",
+    "WindowsHandleMetadata",
+    "WindowsKernelApi",
+    "WindowsReparsePoint",
+    "parse_windows_reparse_data",
+    "windows_extended_path",
+    "windows_file_id_is_reliable",
+    "windows_handle_ownership_identity",
+    "windows_kernel_api",
+    "windows_metadata_identity",
+    "windows_mode_from_attributes",
+    "open_lexical_directory_authority",
+    "windows_require_publication_api",
+    "windows_require_source_api",
+]

--- a/codenib/_windows_fs_authority.py
+++ b/codenib/_windows_fs_authority.py
@@ -994,6 +994,49 @@ class WindowsDirectoryAuthority:
             ):
                 raise RuntimeError("Windows lexical directory component changed")
 
+    def verify_binding(self) -> None:
+        """Verify stable HANDLE and lexical-name bindings after mutation."""
+
+        if self.closed or not self.handles:
+            raise RuntimeError("Windows directory authority is closed")
+        anchor = self.api.metadata(self.handles[0])
+        if (
+            windows_handle_ownership_identity(anchor) != self.anchor_identity[:2]
+            or not stat.S_ISDIR(anchor.st_mode)
+            or anchor.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+            or not anchor.st_dev
+            or not windows_file_id_is_reliable(anchor.file_id_128)
+            or anchor.delete_pending
+        ):
+            raise RuntimeError("Windows lexical anchor binding changed")
+        for observation in self.observations:
+            parent = self.api.metadata(observation.parent_handle)
+            if (
+                windows_handle_ownership_identity(parent)
+                != observation.parent_identity[:2]
+                or not stat.S_ISDIR(parent.st_mode)
+                or parent.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+                or not windows_file_id_is_reliable(parent.file_id_128)
+                or parent.delete_pending
+            ):
+                raise RuntimeError("Windows lexical parent binding changed")
+            entry = self._find_exact_child(
+                observation.parent_handle,
+                observation.name,
+            )
+            if entry is None or entry.file_id_128 != observation.child_file_id:
+                raise RuntimeError("Windows lexical directory binding changed")
+            opened = self.api.metadata(observation.child_handle)
+            if (
+                windows_handle_ownership_identity(opened)
+                != observation.child_identity[:2]
+                or not stat.S_ISDIR(opened.st_mode)
+                or opened.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+                or not windows_file_id_is_reliable(opened.file_id_128)
+                or opened.delete_pending
+            ):
+                raise RuntimeError("Windows lexical component binding changed")
+
     def close(self) -> None:
         if self.closed:
             return
@@ -1307,14 +1350,18 @@ def open_lexical_directory_authority(
                 if callable(iterator)
                 else selected.enumerate_directory(current_handle)
             )
-            matches = [entry for entry in entries if entry.name == component]
+            folded_component = component.casefold()
+            matches = [
+                entry for entry in entries if entry.name.casefold() == folded_component
+            ]
             if len(matches) != 1 or matches[0].file_id_128 != child.file_id_128:
                 raise RuntimeError("Windows lexical directory changed while opening")
+            bound_name = matches[0].name
             observations.append(
                 _WindowsAuthorityObservation(
                     parent_handle=current_handle,
                     parent_identity=parent_identity,
-                    name=component,
+                    name=bound_name,
                     child_handle=child_handle,
                     child_identity=windows_metadata_identity(child),
                     child_file_id=child.file_id_128,

--- a/codenib/artifacts/archive.py
+++ b/codenib/artifacts/archive.py
@@ -6,13 +6,18 @@
 
 from __future__ import annotations
 
+import json
 import stat
 import tempfile
 import zipfile
+from dataclasses import replace
 from pathlib import Path, PurePosixPath
 
 from .._atomic_directory import (
+    PublicationDirectoryReader,
+    _annotate_secondary_error,
     capture_directory_ownership,
+    directory_ownership_root_identity,
     discard_owned_directory,
     lexical_directory_path,
     publish_staged_directory,
@@ -23,6 +28,7 @@ from .runtime import VerifiedContextArtifact, verify_context_artifact
 DEFAULT_MAX_ARCHIVE_FILES = 100_000
 DEFAULT_MAX_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
 _COPY_CHUNK_BYTES = 1024 * 1024
+_MAX_CONTEXT_METADATA_BYTES = 16 * 1024 * 1024
 
 
 def _member_path(value: str) -> PurePosixPath:
@@ -187,6 +193,9 @@ def extract_context_artifact_archive(
         )
     )
     stage_root_ownership = capture_directory_ownership(stage)
+    initial_stage_root_identity = directory_ownership_root_identity(
+        stage_root_ownership
+    )
     try:
         with zipfile.ZipFile(archive_path) as archive:
             members = _validated_members(
@@ -197,16 +206,56 @@ def extract_context_artifact_archive(
             for info, relative in members:
                 _extract_member(archive, info, relative, stage)
 
-        def validate_artifact(candidate: Path) -> None:
-            verify_context_artifact(
-                candidate,
-                expected_repository=expected_repository,
-                expected_commit=expected_commit,
-                max_files=max_files,
-                max_bytes=max_bytes,
-            )
+        verified = verify_context_artifact(
+            stage,
+            expected_repository=expected_repository,
+            expected_commit=expected_commit,
+            max_files=max_files,
+            max_bytes=max_bytes,
+        )
+        publication_ownership = capture_directory_ownership(stage)
+        if (
+            directory_ownership_root_identity(publication_ownership)
+            != initial_stage_root_identity
+        ):
+            raise RuntimeError("context artifact stage root changed during extraction")
+        stage_root_ownership = publication_ownership
+        expected_files = {
+            item["path"]: (item["bytes"], item["sha256"])
+            for item in verified.metadata["files"]
+        }
 
-        validate_artifact(stage)
+        def validate_artifact(candidate: PublicationDirectoryReader) -> None:
+            records = {record.path: record for record in candidate.file_records()}
+            metadata_record = records.pop(CONTEXT_ARTIFACT_MANIFEST, None)
+            if (
+                metadata_record is None
+                or metadata_record.size > _MAX_CONTEXT_METADATA_BYTES
+                or set(records) != set(expected_files)
+                or any(
+                    (record.size, record.sha256) != expected_files[path]
+                    for path, record in records.items()
+                )
+            ):
+                raise ValueError(
+                    "published context artifact differs from its verified identity"
+                )
+            try:
+                metadata = json.loads(
+                    candidate.read_bytes(
+                        CONTEXT_ARTIFACT_MANIFEST,
+                        max_bytes=_MAX_CONTEXT_METADATA_BYTES,
+                    ).decode("utf-8", errors="strict")
+                )
+            except (UnicodeError, json.JSONDecodeError) as exc:
+                raise ValueError(
+                    "published context artifact metadata is invalid"
+                ) from exc
+            if metadata != verified.metadata:
+                raise ValueError(
+                    "published context artifact metadata changed after verification"
+                )
+
         publish_staged_directory(
             stage,
             output,
@@ -216,20 +265,60 @@ def extract_context_artifact_archive(
             validate_published_destination=validate_artifact,
         )
     except zipfile.BadZipFile as exc:
-        discard_owned_directory(stage, stage_root_ownership)
-        raise ValueError(
+        primary_error = ValueError(
             f"context artifact archive is not a valid ZIP: {archive_path}"
-        ) from exc
-    except BaseException:
-        discard_owned_directory(stage, stage_root_ownership)
+        )
+        try:
+            observed_stage_ownership = capture_directory_ownership(stage)
+            if (
+                directory_ownership_root_identity(observed_stage_ownership)
+                == initial_stage_root_identity
+            ):
+                stage_root_ownership = observed_stage_ownership
+        except BaseException as capture_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context archive stage cleanup capture also failed",
+                capture_error,
+            )
+        try:
+            discard_owned_directory(stage, stage_root_ownership)
+        except BaseException as discard_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context archive stage discard also failed",
+                discard_error,
+            )
+        raise primary_error from exc
+    except BaseException as primary_error:
+        try:
+            observed_stage_ownership = capture_directory_ownership(stage)
+            if (
+                directory_ownership_root_identity(observed_stage_ownership)
+                == initial_stage_root_identity
+            ):
+                stage_root_ownership = observed_stage_ownership
+        except BaseException as capture_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context archive stage cleanup capture also failed",
+                capture_error,
+            )
+        try:
+            discard_owned_directory(stage, stage_root_ownership)
+        except BaseException as discard_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context archive stage discard also failed",
+                discard_error,
+            )
         raise
 
-    return verify_context_artifact(
-        output,
-        expected_repository=expected_repository,
-        expected_commit=expected_commit,
-        max_files=max_files,
-        max_bytes=max_bytes,
+    return replace(
+        verified,
+        root=output,
+        metadata_path=output / CONTEXT_ARTIFACT_MANIFEST,
+        manifest_path=output / verified.manifest_path.relative_to(stage),
     )
 
 

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -17,7 +17,10 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping, Sequence
 
 from .._atomic_directory import (
+    PublicationDirectoryReader,
+    _annotate_secondary_error,
     capture_directory_ownership,
+    directory_ownership_root_identity,
     discard_owned_directory,
     lexical_directory_path,
     publish_staged_directory,
@@ -265,6 +268,9 @@ def stage_context_artifact(
         )
     )
     stage_root_ownership = capture_directory_ownership(stage)
+    initial_stage_root_identity = directory_ownership_root_identity(
+        stage_root_ownership
+    )
     try:
         portable = manifest.to_dict()
         portable["repo"]["path"] = "source"
@@ -368,7 +374,7 @@ def stage_context_artifact(
 
         expected_metadata_bytes = _json_bytes(metadata)
 
-        def validate_artifact(candidate: Path) -> None:
+        def validate_artifact_path(candidate: Path) -> None:
             for view, (relative, config) in portable_validation.items():
                 validate_portable_query_view(
                     candidate.joinpath(*PurePosixPath(relative).parts),
@@ -399,6 +405,57 @@ def stage_context_artifact(
                     "published context artifact differs from its staged identity"
                 )
 
+        # The path-based validators run before the final ownership capture.
+        # Publication callbacks receive a descriptor-bound reader, never a Path;
+        # the exact captured tree then carries those validation results across
+        # both the staged and published callbacks.
+        validate_artifact_path(stage)
+        publication_ownership = capture_directory_ownership(stage)
+        if (
+            directory_ownership_root_identity(publication_ownership)
+            != initial_stage_root_identity
+        ):
+            raise RuntimeError("context artifact stage root changed during build")
+        stage_root_ownership = publication_ownership
+        expected_metadata_size, expected_metadata_digest = file_sha256(metadata_path)
+
+        def validate_artifact(candidate: PublicationDirectoryReader) -> None:
+            records = candidate.file_records()
+            candidate_metadata = next(
+                (
+                    record
+                    for record in records
+                    if record.path == CONTEXT_ARTIFACT_MANIFEST
+                ),
+                None,
+            )
+            actual_files = [
+                {
+                    "path": record.path,
+                    "bytes": record.size,
+                    "sha256": record.sha256,
+                }
+                for record in sorted(
+                    records,
+                    key=lambda item: PurePosixPath(item.path),
+                )
+                if record.path != CONTEXT_ARTIFACT_MANIFEST
+            ]
+            if (
+                candidate_metadata is None
+                or candidate_metadata.size != expected_metadata_size
+                or candidate_metadata.sha256 != expected_metadata_digest
+                or candidate.read_bytes(
+                    CONTEXT_ARTIFACT_MANIFEST,
+                    max_bytes=expected_metadata_size,
+                )
+                != expected_metadata_bytes
+                or actual_files != files
+            ):
+                raise ValueError(
+                    "published context artifact differs from its staged identity"
+                )
+
         publish_staged_directory(
             stage,
             output_dir,
@@ -407,8 +464,28 @@ def stage_context_artifact(
             validate_staged_directory=validate_artifact,
             validate_published_destination=validate_artifact,
         )
-    except BaseException:
-        discard_owned_directory(stage, stage_root_ownership)
+    except BaseException as primary_error:
+        try:
+            observed_stage_ownership = capture_directory_ownership(stage)
+            if (
+                directory_ownership_root_identity(observed_stage_ownership)
+                == initial_stage_root_identity
+            ):
+                stage_root_ownership = observed_stage_ownership
+        except BaseException as capture_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context artifact stage cleanup capture also failed",
+                capture_error,
+            )
+        try:
+            discard_owned_directory(stage, stage_root_ownership)
+        except BaseException as discard_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context artifact stage discard also failed",
+                discard_error,
+            )
         raise
 
     byte_count = sum(int(item["bytes"]) for item in files)

--- a/codenib/artifacts/security.py
+++ b/codenib/artifacts/security.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
@@ -46,24 +47,49 @@ def assert_publishable_json_value(
     """Scan decoded JSON semantics without depending on their source encoding."""
 
     assert_no_credential_fields(value, source=label)
-    payload = json.dumps(
-        value,
-        allow_nan=False,
-        ensure_ascii=True,
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("ascii")
     forbidden_values: list[str] = []
     for path in forbidden_paths:
         resolved = path.expanduser().resolve()
         forbidden_values.extend((str(resolved), resolved.as_posix()))
-    if any(
-        pattern and pattern in payload
-        for pattern in _serialized_patterns(forbidden_values)
-    ):
-        raise ValueError(f"{label} contains an absolute build-machine path")
-    if any(pattern and pattern in payload for pattern in _secret_values(environ)):
-        raise ValueError(f"{label} contains a configured credential")
+    forbidden = tuple(item for item in forbidden_values if item)
+    secrets = tuple(
+        value
+        for name, value in environ.items()
+        if isinstance(value, str)
+        and len(value) >= 8
+        and (
+            name.upper() in _SENSITIVE_ENV_NAMES
+            or name.upper().endswith(_SENSITIVE_ENV_SUFFIXES)
+        )
+    )
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            for key, child in current.items():
+                if not isinstance(key, str):
+                    raise ValueError(f"{label} contains a non-text JSON object key")
+                if any(pattern in key for pattern in forbidden):
+                    raise ValueError(f"{label} contains an absolute build-machine path")
+                if any(pattern in key for pattern in secrets):
+                    raise ValueError(f"{label} contains a configured credential")
+                stack.append(child)
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+        elif isinstance(current, str):
+            if any(pattern in current for pattern in forbidden):
+                raise ValueError(f"{label} contains an absolute build-machine path")
+            if any(pattern in current for pattern in secrets):
+                raise ValueError(f"{label} contains a configured credential")
+        elif current is None or isinstance(current, (bool, int)):
+            continue
+        elif isinstance(current, float):
+            if not math.isfinite(current):
+                raise ValueError(f"{label} contains a non-finite JSON number")
+        else:
+            raise ValueError(
+                f"{label} contains unsupported JSON value: " f"{type(current).__name__}"
+            )
 
 
 def _serialized_patterns(values: Iterable[str]) -> tuple[bytes, ...]:

--- a/codenib/native_index_authorization.py
+++ b/codenib/native_index_authorization.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Out-of-band authorization for native index parsers.
+
+Artifact bytes and manifests can describe an index, but they can never mint this
+capability.  A trusted caller first binds a captured tree and semantic contract,
+then passes the resulting process-local token to the exact native consumer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+from ._atomic_directory import (
+    directory_ownership_digest,
+    directory_ownership_file_records,
+    directory_ownership_root_identity,
+)
+
+NATIVE_INDEX_SUBJECT_SCHEMA = "codenib.native-index-subject.v1"
+FAISS_PARSER_CONTRACT = "codenib.faiss-read-index.v1"
+NativeTrustClass = Literal["trusted-local"]
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_TOKEN_SEAL = object()
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _semantic_digest(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class NativeIndexSubject:
+    parser_contract: str
+    view_type: str
+    tree_digest: str
+    semantic_contract_digest: str
+    files: tuple[tuple[str, int, int, str], ...]
+
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json(
+            {
+                "schema": NATIVE_INDEX_SUBJECT_SCHEMA,
+                "parser_contract": self.parser_contract,
+                "view_type": self.view_type,
+                "tree_digest": self.tree_digest,
+                "semantic_contract_digest": self.semantic_contract_digest,
+                "files": [
+                    {
+                        "path": path,
+                        "mode": mode,
+                        "size": size,
+                        "sha256": digest,
+                    }
+                    for path, mode, size, digest in self.files
+                ],
+            }
+        )
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.canonical_bytes()).hexdigest()
+
+
+class NativeIndexAuthorization:
+    """Non-serializable, process-local capability for one native subject."""
+
+    __slots__ = (
+        "_seal",
+        "trust_class",
+        "view_type",
+        "subject_digest",
+        "root_identity",
+        "evidence",
+    )
+
+    def __init__(
+        self,
+        seal: object,
+        *,
+        trust_class: NativeTrustClass,
+        view_type: str,
+        subject_digest: str,
+        root_identity: tuple[int, ...] | None,
+        evidence: tuple[str, ...],
+    ) -> None:
+        if seal is not _TOKEN_SEAL:
+            raise TypeError("native index authorization cannot be constructed directly")
+        self._seal = seal
+        self.trust_class = trust_class
+        self.view_type = view_type
+        self.subject_digest = subject_digest
+        self.root_identity = root_identity
+        self.evidence = evidence
+
+    def __reduce__(self):
+        raise TypeError(
+            "native index authorization is process-local and not serializable"
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "NativeIndexAuthorization("
+            f"trust_class={self.trust_class!r}, view_type={self.view_type!r}, "
+            f"subject_digest={self.subject_digest[:12]}...)"
+        )
+
+
+def native_index_subject(
+    ownership: object,
+    *,
+    view_type: str,
+    semantic_contract: Mapping[str, Any],
+    parser_contract: str = FAISS_PARSER_CONTRACT,
+) -> NativeIndexSubject:
+    if not isinstance(view_type, str) or not view_type:
+        raise ValueError("native index view type must be non-empty")
+    if not isinstance(semantic_contract, Mapping):
+        raise TypeError("native index semantic contract must be a mapping")
+    records = directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+    return NativeIndexSubject(
+        parser_contract=parser_contract,
+        view_type=view_type,
+        tree_digest=directory_ownership_digest(ownership),  # type: ignore[arg-type]
+        semantic_contract_digest=_semantic_digest(dict(semantic_contract)),
+        files=tuple(
+            (record.path, record.mode, record.size, record.sha256) for record in records
+        ),
+    )
+
+
+def mint_trusted_local_authorization(
+    ownership: object,
+    *,
+    view_type: str,
+    semantic_contract: Mapping[str, Any],
+    evidence: Sequence[str] = (),
+) -> NativeIndexAuthorization:
+    """Mint after the caller's local lock/source/config checks have succeeded."""
+
+    subject = native_index_subject(
+        ownership,
+        view_type=view_type,
+        semantic_contract=semantic_contract,
+    )
+    normalized_evidence = tuple(evidence)
+    if any(not isinstance(item, str) or not item for item in normalized_evidence):
+        raise ValueError(
+            "native index authorization evidence must be non-empty strings"
+        )
+    return NativeIndexAuthorization(
+        _TOKEN_SEAL,
+        trust_class="trusted-local",
+        view_type=view_type,
+        subject_digest=subject.digest,
+        root_identity=directory_ownership_root_identity(ownership),  # type: ignore[arg-type]
+        evidence=normalized_evidence,
+    )
+
+
+def require_native_index_authorization(
+    authorization: NativeIndexAuthorization | None,
+    ownership: object,
+    *,
+    view_type: str,
+    semantic_contract: Mapping[str, Any],
+) -> NativeIndexSubject:
+    if (
+        not isinstance(authorization, NativeIndexAuthorization)
+        or authorization._seal is not _TOKEN_SEAL
+    ):
+        raise ValueError("native index parsing requires external authorization")
+    subject = native_index_subject(
+        ownership,
+        view_type=view_type,
+        semantic_contract=semantic_contract,
+    )
+    if (
+        authorization.view_type != view_type
+        or authorization.subject_digest != subject.digest
+        or not _DIGEST_RE.fullmatch(authorization.subject_digest)
+    ):
+        raise ValueError("native index authorization does not match captured bytes")
+    if (
+        authorization.trust_class == "trusted-local"
+        and authorization.root_identity
+        != (directory_ownership_root_identity(ownership))  # type: ignore[arg-type]
+    ):
+        raise ValueError("trusted-local authorization does not match the root identity")
+    if authorization.trust_class != "trusted-local":
+        raise ValueError("native index authorization has an unsupported trust class")
+    return subject
+
+
+__all__ = [
+    "FAISS_PARSER_CONTRACT",
+    "NATIVE_INDEX_SUBJECT_SCHEMA",
+    "NativeIndexAuthorization",
+    "NativeIndexSubject",
+    "mint_trusted_local_authorization",
+    "native_index_subject",
+    "require_native_index_authorization",
+]

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -14,7 +14,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-from ._contained_source import update_repository_file_hash
+from ._contained_source import (
+    _version_identity,
+    resolved_repository_file,
+    update_repository_file_hash,
+)
 from .repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     repository_path_is_visible,
@@ -22,7 +26,6 @@ from .repository_filters import (
 )
 
 SOURCE_FINGERPRINT_VERSION = 1
-_READ_SIZE = 1024 * 1024
 
 
 class RepositoryChangedError(RuntimeError):
@@ -37,20 +40,20 @@ class SourceFingerprint:
     file_count: int
 
 
-def _update_file(hasher: "hashlib._Hash", path: Path) -> None:
-    before = path.stat()
-    with path.open("rb") as handle:
-        while block := handle.read(_READ_SIZE):
-            hasher.update(block)
-    after = path.stat()
-    if (
-        before.st_size != after.st_size
-        or before.st_mtime_ns != after.st_mtime_ns
-        or before.st_ino != after.st_ino
-    ):
-        raise RepositoryChangedError(
-            f"repository file changed while it was being read: {path}"
-        )
+def _link_matches(
+    path: Path,
+    *,
+    initial: os.stat_result,
+    target: str,
+) -> bool:
+    try:
+        observed = path.lstat()
+        observed_target = os.readlink(path)
+    except OSError:
+        return False
+    return _version_identity(observed) == _version_identity(initial) and (
+        observed_target == target
+    )
 
 
 def fingerprint_repository(
@@ -77,15 +80,15 @@ def fingerprint_repository(
         relative_text = path.relative_to(root_path).as_posix()
         relative = relative_text.encode("utf-8", errors="surrogateescape")
         try:
-            mode = path.lstat().st_mode
+            initial_metadata = path.lstat()
         except OSError as exc:
             raise RepositoryChangedError(
                 f"repository file disappeared while it was being inspected: {path}"
             ) from exc
 
+        mode = initial_metadata.st_mode
         if stat.S_ISLNK(mode):
             try:
-                before_link = path.lstat()
                 raw_target = os.readlink(path)
                 target = raw_target.encode("utf-8", errors="surrogateescape")
             except OSError as exc:
@@ -97,28 +100,25 @@ def fingerprint_repository(
             hasher.update(b"\0")
             hasher.update(target)
             hasher.update(b"\0")
-            hasher.update(b"C\0")
             try:
-                update_repository_file_hash(root_path, relative_text, hasher)
-                after_link = path.lstat()
-                after_target = os.readlink(path)
+                with resolved_repository_file(
+                    root_path,
+                    relative_text,
+                    expected_final_identity=_version_identity(initial_metadata),
+                ) as binding:
+                    if binding.is_regular:
+                        hasher.update(b"C\0")
+                        binding.update_hash(hasher)
             except (OSError, ValueError) as exc:
                 raise RepositoryChangedError(
                     "repository link target could not be read consistently: " f"{path}"
                 ) from exc
-            if (
-                before_link.st_dev != after_link.st_dev
-                or before_link.st_ino != after_link.st_ino
-                or before_link.st_mode != after_link.st_mode
-                or before_link.st_size != after_link.st_size
-                or before_link.st_mtime_ns != after_link.st_mtime_ns
-                or before_link.st_ctime_ns != after_link.st_ctime_ns
-                or raw_target != after_target
-            ):
+            if not _link_matches(path, initial=initial_metadata, target=raw_target):
                 raise RepositoryChangedError(
                     f"repository link changed while it was being read: {path}"
                 )
-            hasher.update(b"\0")
+            if binding.is_regular:
+                hasher.update(b"\0")
             file_count += 1
             continue
 
@@ -129,8 +129,13 @@ def fingerprint_repository(
         hasher.update(relative)
         hasher.update(b"\0")
         try:
-            _update_file(hasher, path)
-        except OSError as exc:
+            update_repository_file_hash(
+                root_path,
+                relative_text,
+                hasher,
+                expected_final_identity=_version_identity(initial_metadata),
+            )
+        except (OSError, ValueError) as exc:
             raise RepositoryChangedError(
                 f"repository file could not be read consistently: {path}"
             ) from exc

--- a/codenib/storage/view_bundle.py
+++ b/codenib/storage/view_bundle.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import re
 import stat
@@ -17,14 +18,22 @@ import unicodedata
 import zipfile
 from contextlib import contextmanager
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from pathlib import Path, PurePosixPath
-from typing import Any, BinaryIO, Iterable, Iterator, Mapping
+from typing import Any, BinaryIO, Callable, Iterable, Iterator, Mapping
 
 from .._atomic_directory import (
+    DirectoryOrphan,
+    PublicationDirectoryReader,
     _directory_identity,
     _linux_mount_points,
     _path_is_mount_point,
-    _remove_owned_directory,
+    capture_directory_ownership,
+    directory_ownership_entry_identities,
+    directory_ownership_file_records,
+    directory_ownership_inventory,
+    directory_ownership_root_identity,
+    discard_owned_directory,
     publish_staged_directory,
 )
 from .models import (
@@ -39,6 +48,27 @@ VIEW_BUNDLE_SCHEMA = "codenib.view-bundle.v1"
 VIEW_BUNDLE_MANIFEST = "bundle.json"
 VIEW_BUNDLE_PAYLOAD = "payload"
 VIEW_BUNDLE_MEDIA_TYPE = "application/vnd.codenib.view-bundle.v1+zip"
+logger = logging.getLogger(__name__)
+
+
+def _record_publication_orphan(
+    orphan: DirectoryOrphan | None,
+    *,
+    operation: str,
+) -> None:
+    if orphan is None:
+        return
+    logger.warning(
+        "View-bundle %s retained an orphan for quiescent GC: "
+        "path=%s digest=%s entries=%d bytes=%d verified=%s",
+        operation,
+        orphan.path,
+        orphan.ownership_digest,
+        orphan.entries,
+        orphan.byte_count,
+        orphan.verified_at_isolation,
+    )
+
 
 DEFAULT_MAX_BUNDLE_FILES = 100_000
 DEFAULT_MAX_BUNDLE_BYTES = 64 * 1024 * 1024 * 1024
@@ -94,6 +124,7 @@ class MaterializedViewBundle:
 
     output_dir: Path
     payload_dir: Path
+    ownership: object = dataclass_field(repr=False, compare=False)
     view_type: str
     digest: str
     byte_size: int
@@ -451,6 +482,7 @@ def materialize_view_bundle(
         )
     )
     stage_root_identity = _directory_inode_identity(stage.lstat())
+    published_ownership: list[object] = []
     try:
         with _open_extraction_root(stage, stage_root_identity) as stage_descriptor:
             with _open_stable_regular_file(
@@ -512,9 +544,11 @@ def materialize_view_bundle(
                     "view bundle materialization stage changed before publication"
                 )
 
-        def validate_moved_destination(moved: Path) -> None:
+        def validate_moved_destination(
+            moved: PublicationDirectoryReader,
+        ) -> None:
             try:
-                observed = _validate_materialization_target(
+                observed, _ownership = _validate_materialization_reader(
                     moved,
                     max_files=max_files,
                     max_bytes=max_bytes,
@@ -524,14 +558,19 @@ def materialize_view_bundle(
                 raise StorageIntegrityError(
                     "moved destination failed publication-boundary validation"
                 ) from exc
-            if observed != expected_ownership:
+            if not _same_materialization_semantics(
+                observed,
+                expected_ownership,
+            ):
                 raise StorageIntegrityError(
                     "moved destination failed publication-boundary validation"
                 )
 
-        def validate_published_destination(published: Path) -> None:
+        def validate_published_destination(
+            published: PublicationDirectoryReader,
+        ) -> None:
             try:
-                observed = _validate_materialization_target(
+                observed, ownership = _validate_materialization_reader(
                     published,
                     max_files=max_files,
                     max_bytes=max_bytes,
@@ -541,12 +580,16 @@ def materialize_view_bundle(
                 raise StorageIntegrityError(
                     "published stage failed publication-boundary validation"
                 ) from exc
-            if observed != expected_new_ownership:
+            if not _same_materialization_semantics(
+                observed,
+                expected_new_ownership,
+            ):
                 raise StorageIntegrityError(
                     "published stage failed publication-boundary validation"
                 )
+            published_ownership.append(ownership)
 
-        publish_staged_directory(
+        publication_orphan = publish_staged_directory(
             stage,
             output,
             expected_destination_identity=expected_ownership.root_identity,
@@ -554,9 +597,15 @@ def materialize_view_bundle(
             validate_moved_destination=validate_moved_destination,
             validate_published_destination=validate_published_destination,
         )
+        _record_publication_orphan(publication_orphan, operation="publication")
+        if len(published_ownership) != 1:
+            raise StorageIntegrityError(
+                "published materialized bundle has no authenticated ownership"
+            )
         return MaterializedViewBundle(
             output_dir=output,
             payload_dir=output / VIEW_BUNDLE_PAYLOAD,
+            ownership=published_ownership[0],
             view_type=record.view_type,
             digest=record.digest,
             byte_size=record.byte_size,
@@ -2583,6 +2632,185 @@ def _remove_owned_temporary_file(
         pass
 
 
+def _same_materialization_semantics(
+    left: _MaterializationOwnership,
+    right: _MaterializationOwnership,
+) -> bool:
+    """Compare bundle semantics without reinterpreting filesystem identities.
+
+    PublicationDirectoryReader is already bound to the exact outer ownership
+    token.  Its portable root identity intentionally differs in shape from the
+    legacy path validator's platform-specific identity, so semantic callbacks
+    compare only the authenticated bundle state here.
+    """
+
+    return (
+        left.state,
+        left.manifest_digest,
+        left.members,
+        left.directory_modes,
+    ) == (
+        right.state,
+        right.manifest_digest,
+        right.members,
+        right.directory_modes,
+    )
+
+
+def _materialization_entry_policy(
+    *,
+    max_files: int,
+    max_bytes: int,
+    max_metadata_bytes: int,
+) -> Callable[[str, str, int, int], None]:
+    payload_files = 0
+    payload_bytes = 0
+    payload_directories = 0
+
+    def validate(path: str, kind: str, mode: int, size: int) -> None:
+        nonlocal payload_files, payload_bytes, payload_directories
+        if path == VIEW_BUNDLE_MANIFEST:
+            if kind != "file" or mode != 0o644 or size > max_metadata_bytes:
+                raise StorageValidationError(
+                    "refusing to replace a non-CodeNib directory"
+                )
+            return
+        if path == VIEW_BUNDLE_PAYLOAD:
+            if kind != "directory":
+                raise StorageValidationError(
+                    "refusing to replace a non-CodeNib directory"
+                )
+            payload_directories += 1
+            return
+        prefix = f"{VIEW_BUNDLE_PAYLOAD}/"
+        if not path.startswith(prefix):
+            raise StorageValidationError("refusing to replace a non-CodeNib directory")
+        relative = path[len(prefix) :]
+        _canonical_member_path(relative)
+        if kind == "directory":
+            payload_directories += 1
+            if payload_directories > max_files + 1:
+                raise StorageValidationError(
+                    f"view bundle exceeds {max_files + 1} directories"
+                )
+            return
+        if kind != "file" or mode not in {0o644, 0o755}:
+            raise StorageValidationError("refusing to replace a non-CodeNib directory")
+        payload_files += 1
+        payload_bytes += size
+        if payload_files > max_files or payload_bytes > max_bytes:
+            raise StorageValidationError("refusing to replace a non-CodeNib directory")
+
+    return validate
+
+
+def _validate_materialization_reader(
+    reader: PublicationDirectoryReader,
+    *,
+    max_files: int,
+    max_bytes: int,
+    max_metadata_bytes: int,
+) -> tuple[_MaterializationOwnership, object]:
+    """Validate materialized bundle semantics through one pinned authority."""
+
+    ownership = reader.capture_ownership(
+        allow_empty_root=True,
+        entry_policy=_materialization_entry_policy(
+            max_files=max_files,
+            max_bytes=max_bytes,
+            max_metadata_bytes=max_metadata_bytes,
+        ),
+    )
+    inventory = directory_ownership_inventory(ownership)
+    root_identity = directory_ownership_root_identity(ownership)
+    if not inventory:
+        return (
+            _MaterializationOwnership(
+                "empty",
+                root_identity,
+                None,
+                (),
+                (),
+            ),
+            ownership,
+        )
+
+    inventory_by_path = dict(inventory)
+    if (
+        inventory_by_path.get(VIEW_BUNDLE_MANIFEST) != "file"
+        or inventory_by_path.get(VIEW_BUNDLE_PAYLOAD) != "directory"
+        or any(
+            path not in {VIEW_BUNDLE_MANIFEST, VIEW_BUNDLE_PAYLOAD}
+            and not path.startswith(f"{VIEW_BUNDLE_PAYLOAD}/")
+            for path in inventory_by_path
+        )
+    ):
+        raise StorageValidationError("refusing to replace a non-CodeNib directory")
+
+    records = {
+        record.path: record for record in directory_ownership_file_records(ownership)
+    }
+    manifest_record = records.get(VIEW_BUNDLE_MANIFEST)
+    if (
+        manifest_record is None
+        or manifest_record.mode != 0o644
+        or manifest_record.size > max_metadata_bytes
+    ):
+        raise StorageValidationError("refusing to replace a non-CodeNib directory")
+    metadata_bytes = reader.read_bytes(
+        VIEW_BUNDLE_MANIFEST,
+        max_bytes=max_metadata_bytes,
+    )
+    _view_type, members = _manifest_from_bytes(
+        metadata_bytes,
+        max_files=max_files,
+        max_bytes=max_bytes,
+    )
+
+    prefix = f"{VIEW_BUNDLE_PAYLOAD}/"
+    observed_files = tuple(
+        (
+            record.path[len(prefix) :],
+            record.size,
+            record.mode,
+            record.sha256,
+        )
+        for record in directory_ownership_file_records(ownership)
+        if record.path.startswith(prefix)
+    )
+    expected_files = tuple(
+        (member.path, member.byte_size, member.mode, member.digest)
+        for member in members
+    )
+    if observed_files != expected_files:
+        raise StorageValidationError("refusing to replace a non-CodeNib directory")
+
+    path_trie = _validate_member_paths(members, max_files=max_files)
+    directory_modes: list[tuple[str, int]] = []
+    for path, kind, identity in directory_ownership_entry_identities(ownership):
+        if kind != "directory" or not (
+            path == VIEW_BUNDLE_PAYLOAD or path.startswith(prefix)
+        ):
+            continue
+        relative = "" if path == VIEW_BUNDLE_PAYLOAD else path[len(prefix) :]
+        parts = () if not relative else tuple(PurePosixPath(relative).parts)
+        if not _trie_contains_directory(path_trie, parts):
+            raise StorageValidationError("refusing to replace a non-CodeNib directory")
+        directory_modes.append((relative, stat.S_IMODE(identity[2])))
+    if len(directory_modes) != len(path_trie.directory_nodes):
+        raise StorageValidationError("refusing to replace a non-CodeNib directory")
+    return (
+        _MaterializationOwnership(
+            "bundle",
+            root_identity,
+            manifest_record.sha256,
+            members,
+            tuple(sorted(directory_modes)),
+        ),
+        ownership,
+    )
+
+
 def _validate_materialization_target(
     path: Path,
     *,
@@ -2776,7 +3004,7 @@ def _require_owned_stage_path(
 
 
 def _remove_owned_stage(stage: Path, expected_identity: tuple[int, ...]) -> None:
-    """Remove only the original temporary root, preserving path substitutions."""
+    """Isolate only the original temporary root for cooperative orphan GC."""
 
     try:
         metadata = stage.lstat()
@@ -2788,43 +3016,16 @@ def _remove_owned_stage(stage: Path, expected_identity: tuple[int, ...]) -> None
         or _directory_inode_identity(metadata) != expected_identity
     ):
         return
-    cleanup: Path | None = None
     try:
-        cleanup = Path(
-            tempfile.mkdtemp(
-                prefix=f".{stage.name}.cleanup-",
-                dir=str(stage.parent),
-            )
-        )
-        cleanup.rmdir()
-        os.replace(stage, cleanup)
-    except OSError:
-        if cleanup is not None:
-            try:
-                cleanup.rmdir()
-            except OSError:
-                pass
-        return
-    try:
-        moved_metadata = cleanup.lstat()
-    except FileNotFoundError:
-        return
-    if (
-        _is_link_or_reparse(moved_metadata)
-        or not stat.S_ISDIR(moved_metadata.st_mode)
-        or _directory_inode_identity(moved_metadata) != expected_identity
-    ):
-        try:
-            os.replace(cleanup, stage)
-        except OSError:
-            pass
-        return
-    try:
-        _remove_owned_directory(cleanup, _directory_inode_identity(moved_metadata))
+        ownership = capture_directory_ownership(stage)
     except (OSError, RuntimeError, ValueError):
-        # Cleanup is best effort.  The owned tree remains quarantined under a
-        # unique sibling name rather than following a changed path.
-        pass
+        return
+    if directory_ownership_root_identity(ownership) != expected_identity:
+        return
+    _record_publication_orphan(
+        discard_owned_directory(stage, ownership),
+        operation="discard",
+    )
 
 
 def _reject_forbidden_roots(

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -18,7 +18,10 @@ from typing import Any, Iterable, Mapping
 from urllib.parse import quote, unquote, urlsplit
 
 from .._atomic_directory import (
+    PublicationDirectoryReader,
+    _annotate_secondary_error,
     capture_directory_ownership,
+    directory_ownership_root_identity,
     discard_owned_directory,
     lexical_directory_path,
     publish_staged_directory,
@@ -825,6 +828,9 @@ def export_static_wiki(
         )
     )
     stage_root_ownership = capture_directory_ownership(stage)
+    initial_stage_root_identity = directory_ownership_root_identity(
+        stage_root_ownership
+    )
     try:
         _copy_frontend(frontend, stage, base_path=base_path)
         _write_bytes(stage, "runtime-config.js", _runtime_config(base_path))
@@ -900,7 +906,7 @@ def export_static_wiki(
 
         expected_manifest_bytes = _json_bytes(export_manifest)
 
-        def validate_export(candidate: Path) -> None:
+        def validate_export_path(candidate: Path) -> None:
             assert_publishable_tree(
                 candidate,
                 forbidden_paths=(repo_path, manifest_path.parent),
@@ -917,6 +923,52 @@ def export_static_wiki(
                     "published static export differs from its staged identity"
                 )
 
+        # Carry the path validators' result across publication with one exact
+        # full-tree token. Publication callbacks receive a retained reader and
+        # must never reopen the staged or published path.
+        validate_export_path(stage)
+        publication_ownership = capture_directory_ownership(stage)
+        if (
+            directory_ownership_root_identity(publication_ownership)
+            != initial_stage_root_identity
+        ):
+            raise RuntimeError("static export stage root changed during build")
+        stage_root_ownership = publication_ownership
+        expected_manifest_size, expected_manifest_digest = file_sha256(manifest_file)
+
+        def validate_export(candidate: PublicationDirectoryReader) -> None:
+            records = candidate.file_records()
+            candidate_manifest = next(
+                (record for record in records if record.path == STATIC_EXPORT_MANIFEST),
+                None,
+            )
+            actual_files = [
+                {
+                    "path": record.path,
+                    "bytes": record.size,
+                    "sha256": record.sha256,
+                }
+                for record in sorted(
+                    records,
+                    key=lambda item: PurePosixPath(item.path),
+                )
+                if record.path != STATIC_EXPORT_MANIFEST
+            ]
+            if (
+                candidate_manifest is None
+                or candidate_manifest.size != expected_manifest_size
+                or candidate_manifest.sha256 != expected_manifest_digest
+                or candidate.read_bytes(
+                    STATIC_EXPORT_MANIFEST,
+                    max_bytes=expected_manifest_size,
+                )
+                != expected_manifest_bytes
+                or actual_files != export_manifest["files"]
+            ):
+                raise ValueError(
+                    "published static export differs from its staged identity"
+                )
+
         publish_staged_directory(
             stage,
             output_dir,
@@ -926,8 +978,28 @@ def export_static_wiki(
             validate_published_destination=validate_export,
         )
         manifest_file = output_dir / manifest_file.relative_to(stage)
-    except BaseException:
-        discard_owned_directory(stage, stage_root_ownership)
+    except BaseException as primary_error:
+        try:
+            observed_stage_ownership = capture_directory_ownership(stage)
+            if (
+                directory_ownership_root_identity(observed_stage_ownership)
+                == initial_stage_root_identity
+            ):
+                stage_root_ownership = observed_stage_ownership
+        except BaseException as capture_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "static export stage cleanup capture also failed",
+                capture_error,
+            )
+        try:
+            discard_owned_directory(stage, stage_root_ownership)
+        except BaseException as discard_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "static export stage discard also failed",
+                discard_error,
+            )
         raise
 
     return StaticExportResult(

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
-import os
 import pickle
 from pathlib import Path
 from types import SimpleNamespace
@@ -294,15 +293,19 @@ def test_context_artifact_restores_previous_output_on_publish_failure(
         bm25_artifact_file_fingerprints(view_path)
     )
     manifest.save(manifest_path)
-    real_replace = os.replace
+    from codenib import _atomic_directory as atomic_module
 
-    def fail_final_publish(source, target):
-        source_path = Path(source)
-        if source_path.name.startswith(".context.tmp-") and Path(target) == output:
+    real_rename = atomic_module._rename_noreplace_at
+
+    def fail_final_publish(source, target, source_parent, target_parent):
+        if source.startswith(".context.tmp-") and target == output.name:
             raise OSError("injected context publish failure")
-        return real_replace(source, target)
+        return real_rename(source, target, source_parent, target_parent)
 
-    monkeypatch.setattr("codenib._atomic_directory.os.replace", fail_final_publish)
+    monkeypatch.setattr(
+        "codenib._atomic_directory._rename_noreplace_at",
+        fail_final_publish,
+    )
 
     with pytest.raises(OSError, match="injected context publish failure"):
         stage_context_artifact(

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -9,7 +9,6 @@ import hashlib
 import io
 import json
 import math
-import os
 import shlex
 import shutil
 import stat
@@ -513,18 +512,19 @@ def test_extract_archive_restores_previous_output_on_publish_failure(
     extract_context_artifact_archive(archive, output)
     marker = output / "previous-output.marker"
     marker.write_text("preserve", encoding="utf-8")
-    real_replace = os.replace
+    from codenib import _atomic_directory as atomic_directory
 
-    def fail_final_publish(source, target):
-        source_path = Path(source)
-        if (
-            source_path.name.startswith(".extracted.extract-")
-            and Path(target) == output
-        ):
+    real_rename = atomic_directory._rename_noreplace_at
+
+    def fail_final_publish(source, target, source_dir_fd, target_dir_fd):
+        if source.startswith(".extracted.extract-") and target == output.name:
             raise OSError("injected archive publish failure")
-        return real_replace(source, target)
+        return real_rename(source, target, source_dir_fd, target_dir_fd)
 
-    monkeypatch.setattr("codenib._atomic_directory.os.replace", fail_final_publish)
+    monkeypatch.setattr(
+        "codenib._atomic_directory._rename_noreplace_at",
+        fail_final_publish,
+    )
 
     with pytest.raises(OSError, match="injected archive publish failure"):
         extract_context_artifact_archive(archive, output)

--- a/test/storage/test_view_bundle.py
+++ b/test/storage/test_view_bundle.py
@@ -43,6 +43,16 @@ def _source(root: Path) -> Path:
     return source
 
 
+def _moved_publication_root(destination: Path) -> Path:
+    matches = tuple(
+        path
+        for path in destination.parent.iterdir()
+        if path.name.startswith(f".{destination.name}.previous-")
+    )
+    assert len(matches) == 1
+    return matches[0]
+
+
 def _canonical_info(
     name: str,
     mode: int = 0o644,
@@ -164,6 +174,10 @@ def test_build_verify_and_materialize_round_trip(tmp_path: Path) -> None:
     ]
     assert [member.mode for member in built.members] == [0o644, 0o755]
     assert materialized.payload_dir == materialized.output_dir / "payload"
+    assert (
+        atomic_module.capture_directory_ownership(materialized.output_dir)
+        == materialized.ownership
+    )
     assert _tree(materialized.payload_dir) == {
         "documents.json": (b"[]\n", 0o644),
         "index/shard": (b"immutable shard", 0o755),
@@ -1517,13 +1531,16 @@ def test_materialization_rolls_back_late_payload_mode_change(
         validate = kwargs["validate_moved_destination"]
         calls = 0
 
-        def validate_then_mutate(moved: Path) -> None:
+        def validate_then_mutate(
+            moved: atomic_module.PublicationDirectoryReader,
+        ) -> None:
             nonlocal calls
             assert callable(validate)
             validate(moved)
             calls += 1
             if calls == 1:
-                (moved / "payload" / "documents.json").chmod(0o600)
+                moved_root = _moved_publication_root(destination)
+                (moved_root / "payload" / "documents.json").chmod(0o600)
 
         kwargs["validate_moved_destination"] = validate_then_mutate
         original_publish(stage, destination, **kwargs)
@@ -1534,7 +1551,7 @@ def test_materialization_rolls_back_late_payload_mode_change(
         publish_with_late_chmod,
     )
 
-    with pytest.raises(RuntimeError, match="safe cleanup validation"):
+    with pytest.raises(RuntimeError, match="moved destination changed"):
         materialize_view_bundle(archive, output)
 
     assert stat.S_IMODE((output / "payload" / "documents.json").stat().st_mode) == 0o600
@@ -1560,13 +1577,16 @@ def test_materialization_rolls_back_write_after_first_boundary_validation(
         validate = kwargs["validate_moved_destination"]
         calls = 0
 
-        def validate_then_write(moved: Path) -> None:
+        def validate_then_write(
+            moved: atomic_module.PublicationDirectoryReader,
+        ) -> None:
             nonlocal calls
             assert callable(validate)
             validate(moved)
             calls += 1
             if calls == 1:
-                (moved / "payload" / "index" / "late.txt").write_text(
+                moved_root = _moved_publication_root(destination)
+                (moved_root / "payload" / "index" / "late.txt").write_text(
                     "preserve",
                     encoding="utf-8",
                 )
@@ -1580,7 +1600,7 @@ def test_materialization_rolls_back_write_after_first_boundary_validation(
         publish_with_late_write,
     )
 
-    with pytest.raises(RuntimeError, match="safe cleanup validation"):
+    with pytest.raises(RuntimeError, match="moved destination changed"):
         materialize_view_bundle(archive, output)
 
     assert (output / "payload" / "index" / "late.txt").read_text(
@@ -1685,17 +1705,30 @@ def test_materialization_revalidates_published_stage_before_old_cleanup(
     (source / "documents.json").write_bytes(b"new")
     second_archive = tmp_path / "second.zip"
     build_view_bundle(source, second_archive, view_type="bm25")
-    real_replace = atomic_module.os.replace
+    real_rename = atomic_module._rename_noreplace_at
 
-    def mutate_after_stage_publish(source_path, destination_path):
-        result = real_replace(source_path, destination_path)
-        if Path(destination_path) == output and Path(source_path).name.startswith(
+    def mutate_after_stage_publish(
+        source_name: str,
+        destination_name: str,
+        source_descriptor: int,
+        destination_descriptor: int,
+    ) -> None:
+        real_rename(
+            source_name,
+            destination_name,
+            source_descriptor,
+            destination_descriptor,
+        )
+        if destination_name == output.name and source_name.startswith(
             ".runtime.materialize-"
         ):
             (output / "payload" / "documents.json").write_bytes(b"bad")
-        return result
 
-    monkeypatch.setattr(atomic_module.os, "replace", mutate_after_stage_publish)
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        mutate_after_stage_publish,
+    )
 
     with pytest.raises(RuntimeError, match="published directory identity"):
         materialize_view_bundle(second_archive, output)
@@ -1732,7 +1765,7 @@ def test_materialization_rejects_owned_payload_mount_without_deleting_it(
     output = tmp_path / "runtime"
     materialize_view_bundle(archive, output)
     mounted = output / "payload" / "index"
-    original_mount_check = bundle_module._path_is_mount_point
+    original_mount_check = atomic_module._path_is_mount_point
 
     def fake_mount_check(path: Path, **kwargs: object) -> bool:
         return Path(path) == mounted or original_mount_check(path, **kwargs)
@@ -1777,7 +1810,9 @@ def test_materialization_rolls_back_mount_detected_after_linearization(
         validate = kwargs["validate_moved_destination"]
         calls = 0
 
-        def validate_then_mount(moved: Path) -> None:
+        def validate_then_mount(
+            moved: atomic_module.PublicationDirectoryReader,
+        ) -> None:
             nonlocal calls, mounted
             assert callable(validate)
             validate(moved)
@@ -1788,14 +1823,14 @@ def test_materialization_rolls_back_mount_detected_after_linearization(
         kwargs["validate_moved_destination"] = validate_then_mount
         original_publish(stage, destination, **kwargs)
 
-    monkeypatch.setattr(bundle_module, "_path_is_mount_point", fake_mount_check)
+    monkeypatch.setattr(atomic_module, "_path_is_mount_point", fake_mount_check)
     monkeypatch.setattr(
         bundle_module,
         "publish_staged_directory",
         publish_with_late_mount,
     )
 
-    with pytest.raises(RuntimeError, match="safe cleanup validation"):
+    with pytest.raises(RuntimeError, match="moved destination changed"):
         materialize_view_bundle(archive, output)
 
     assert (output / "payload" / "index" / "shard").read_bytes() == b"immutable shard"

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -101,10 +101,14 @@ class _FakeWindowsApi:
         parent = self.nodes[self.handles[parent_handle]]
         children = parent["children"]
         assert isinstance(children, dict)
-        try:
-            file_id = children[name]
-        except KeyError as exc:
-            raise FileNotFoundError(name) from exc
+        matches = [
+            file_id
+            for child_name, file_id in children.items()
+            if child_name.casefold() == name.casefold()
+        ]
+        if len(matches) != 1:
+            raise FileNotFoundError(name)
+        file_id = matches[0]
         assert self.nodes[file_id]["directory"] is is_directory
         return self._new_handle(file_id)
 
@@ -200,6 +204,30 @@ class _FakeWindowsApi:
         children[destination] = children.pop(source_name)
         parent["version"] = int(parent["version"]) + 1
         self.rename_calls.append((source_handle, parent_handle, destination))
+
+
+def _install_fake_windows_api(
+    monkeypatch: pytest.MonkeyPatch,
+    api: _FakeWindowsApi,
+) -> None:
+    """Install the fake under POSIX while preserving Windows path spelling."""
+
+    real_open = windows_authority_module.open_lexical_directory_authority
+
+    def open_lexical(path: Path, **kwargs: object) -> object:
+        raw = os.fspath(path).replace("\\", "/")
+        drive_offset = raw.casefold().rfind("c:/")
+        if drive_offset >= 0:
+            path = Path(raw[drive_offset:])
+        return real_open(path, **kwargs)
+
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    monkeypatch.setattr(
+        atomic_module._windows_fs,
+        "open_lexical_directory_authority",
+        open_lexical,
+    )
 
 
 def test_publish_staged_directory_replaces_existing_tree(
@@ -2423,19 +2451,19 @@ def test_windows_ownership_rejects_zero_directory_entry_file_id() -> None:
     api = _FakeWindowsApi()
     api.add_file(api.root_id, "payload.txt", b"payload")
     root_handle = api.create_directory_handle(Path("C:/authority"))
-    enumerate_directory = api.enumerate_directory
+    iter_directory = api.iter_directory
 
-    def enumerate_with_zero_id(handle: int) -> tuple[object, ...]:
-        return tuple(
+    def iterate_with_zero_id(handle: int):
+        yield from (
             atomic_module._WindowsDirectoryEntry(
                 name=entry.name,
                 file_id=0,
                 attributes=entry.attributes,
             )
-            for entry in enumerate_directory(handle)
+            for entry in iter_directory(handle)
         )
 
-    api.enumerate_directory = enumerate_with_zero_id  # type: ignore[method-assign]
+    api.iter_directory = iterate_with_zero_id  # type: ignore[method-assign]
     try:
         with pytest.raises(RuntimeError, match="reliable FILE_ID"):
             atomic_module._capture_windows_directory_handle(
@@ -2448,6 +2476,163 @@ def test_windows_ownership_rejects_zero_directory_entry_file_id() -> None:
             )
     finally:
         api.close(root_handle)
+
+
+def test_windows_ownership_uses_streaming_directory_enumeration() -> None:
+    api = _FakeWindowsApi()
+    api.add_file(api.root_id, "one.txt", b"one")
+    api.add_file(api.root_id, "two.txt", b"two")
+    root_handle = api.create_directory_handle(Path("C:/authority"))
+
+    def forbid_materialized_enumeration(_handle: int) -> tuple[object, ...]:
+        raise AssertionError("ownership scan must not materialize enumeration first")
+
+    api.enumerate_directory = forbid_materialized_enumeration  # type: ignore[method-assign]
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            root_handle,
+            Path("C:/authority"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+    finally:
+        api.close(root_handle)
+
+    assert ownership.inventory == (("one.txt", "file"), ("two.txt", "file"))
+
+
+def test_windows_ownership_stops_stream_when_entry_budget_is_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    for name in ("one.txt", "two.txt", "unreachable.txt"):
+        api.add_file(api.root_id, name, name.encode())
+    root_handle = api.create_directory_handle(Path("C:/authority"))
+    real_iter = api.iter_directory
+    yielded: list[str] = []
+
+    def bounded_iter(handle: int):
+        for entry in real_iter(handle):
+            if len(yielded) == 2:
+                raise AssertionError("ownership scan consumed beyond its entry budget")
+            yielded.append(entry.name)
+            yield entry
+
+    api.iter_directory = bounded_iter  # type: ignore[method-assign]
+    monkeypatch.setattr(atomic_module, "_MAX_OWNERSHIP_ENTRIES", 1)
+    try:
+        with pytest.raises(RuntimeError, match="entry limit"):
+            atomic_module._capture_windows_directory_handle(
+                api,
+                root_handle,
+                Path("C:/authority"),
+                required_root_file=None,
+                allow_empty_root=False,
+                entry_policy=None,
+            )
+    finally:
+        api.close(root_handle)
+
+    assert yielded == ["one.txt", "two.txt"]
+
+
+def test_windows_publication_rejects_ancestor_swap_during_lexical_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    volume_children = api.nodes[api.volume_root_id]["children"]
+    assert isinstance(volume_children, dict)
+    volume_children.pop("authority")
+    trusted = api.add_directory(api.volume_root_id, "trusted")
+    trusted_children = api.nodes[trusted]["children"]
+    assert isinstance(trusted_children, dict)
+    trusted_children["authority"] = api.root_id
+    foreign = api.add_directory()
+    api.add_directory(foreign, "authority")
+    real_iter = api.iter_directory
+    opened_paths: list[str] = []
+    real_create = api.create_directory_handle
+    swapped = False
+
+    def create_anchor_only(path: Path) -> int:
+        opened_paths.append(str(path))
+        normalized = str(path).replace("/", "\\").rstrip("\\").casefold()
+        if normalized != "c:":
+            raise AssertionError("publication must not reopen the full lexical path")
+        return real_create(path)
+
+    def swap_before_binding_check(handle: int):
+        nonlocal swapped
+        if api.handles[handle] == api.volume_root_id and not swapped:
+            swapped = True
+            volume_children["trusted"] = foreign
+        yield from real_iter(handle)
+
+    api.create_directory_handle = create_anchor_only  # type: ignore[method-assign]
+    api.iter_directory = swap_before_binding_check  # type: ignore[method-assign]
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+
+    with pytest.raises(RuntimeError, match="changed while opening"):
+        atomic_module._open_windows_publication_authority(
+            Path("C:/trusted/authority"),
+            parent_resource=None,
+            expected_parent_identity=None,
+        )
+
+    assert swapped
+    assert opened_paths == ["C:\\"]
+    assert api.handles == {}
+
+
+def test_windows_publication_retains_lexical_ancestor_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    volume_children = api.nodes[api.volume_root_id]["children"]
+    assert isinstance(volume_children, dict)
+    volume_children.pop("authority")
+    trusted = api.add_directory(api.volume_root_id, "trusted")
+    trusted_children = api.nodes[trusted]["children"]
+    assert isinstance(trusted_children, dict)
+    trusted_children["authority"] = api.root_id
+    foreign = api.add_directory()
+    api.add_directory(foreign, "authority")
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+
+    authority = atomic_module._open_windows_publication_authority(
+        Path("C:/trusted/authority"),
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        volume_children["trusted"] = foreign
+        with pytest.raises(RuntimeError, match="binding changed"):
+            authority.verify_path_binding()
+    finally:
+        authority.close()
+
+    assert api.handles == {}
+
+
+def test_windows_publication_accepts_lexical_component_case_variation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+
+    authority = atomic_module._open_windows_publication_authority(
+        Path("C:/AUTHORITY"),
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        authority.verify_path_binding()
+    finally:
+        authority.close()
+
+    assert api.handles == {}
 
 
 def test_windows_authority_closes_handles_after_reader_failure(
@@ -2698,6 +2883,7 @@ def test_windows_authority_renames_source_handle_without_replace_or_share_delete
             label="stage",
         )
         authority.rename_noreplace("stage", "published")
+        authority.verify_path_binding()
     finally:
         authority.close()
 
@@ -3242,9 +3428,8 @@ def test_reopen_authenticated_directory_fake_windows_survives_root_swap(
     api.add_file(directory_id, "payload.txt", b"payload")
     foreign_id = api.add_directory()
     api.add_file(foreign_id, "payload.txt", b"foreign")
-    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
     monkeypatch.setattr(atomic_module, "_windows_require_publication_api", lambda: None)
-    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    _install_fake_windows_api(monkeypatch, api)
     path = Path("C:/authority/existing")
     authority = atomic_module._open_windows_publication_authority(
         path.parent,
@@ -3291,9 +3476,8 @@ def test_reopen_authenticated_directory_fake_windows_rejects_suppressed_error(
     directory_id = api.add_directory(api.root_id, "existing")
     original_id = api.add_file(directory_id, "payload.txt", b"payload")
     foreign_id = api.add_file(directory_id, "foreign.txt", b"foreign")
-    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
     monkeypatch.setattr(atomic_module, "_windows_require_publication_api", lambda: None)
-    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    _install_fake_windows_api(monkeypatch, api)
     path = Path("C:/authority/existing")
     authority = atomic_module._open_windows_publication_authority(
         path.parent,
@@ -3533,8 +3717,7 @@ def test_capture_directory_ownership_if_exists_fake_windows_missing_race_closes_
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     api = _FakeWindowsApi()
-    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
-    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    _install_fake_windows_api(monkeypatch, api)
     path = Path("C:/authority/appeared")
     child_metadata = atomic_module._PublicationAuthority.child_metadata
     injected = False
@@ -3683,10 +3866,7 @@ def _call_with_interrupt_after_store(
         if (
             frame.f_code is code
             and (
-                (
-                    event == "opcode"
-                    and frame.f_lasti in opcode_offsets_after_store
-                )
+                (event == "opcode" and frame.f_lasti in opcode_offsets_after_store)
                 or (event == "line" and frame.f_lasti in line_offsets_after_store)
             )
             and int(frame.f_locals.get(local_name, -1)) >= 0
@@ -4432,6 +4612,7 @@ def test_windows_factory_recovers_interrupt_after_registered_handle_return(
     monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
     external = api.create_directory_handle(Path("C:/external")) if use_duplicate else 0
     real_acquire = atomic_module._WindowsResourceOwner.acquire
+    real_own = atomic_module._WindowsLexicalAuthorityOwner.own
     error = KeyboardInterrupt("after registered HANDLE return")
     injected = False
 
@@ -4447,6 +4628,23 @@ def test_windows_factory_recovers_interrupt_after_registered_handle_return(
         atomic_module._WindowsResourceOwner,
         "acquire",
         acquire_then_interrupt,
+    )
+
+    def own_then_interrupt(self: object, resource: object) -> None:
+        nonlocal injected
+        real_own(self, resource)
+        if (
+            not use_duplicate
+            and isinstance(resource, windows_authority_module.WindowsDirectoryAuthority)
+            and not injected
+        ):
+            injected = True
+            raise error
+
+    monkeypatch.setattr(
+        atomic_module._WindowsLexicalAuthorityOwner,
+        "own",
+        own_then_interrupt,
     )
 
     with pytest.raises(KeyboardInterrupt) as caught:

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -44,7 +44,8 @@ class _FakeWindowsApi:
         self.next_handle = 100
         self.open_by_id_calls: list[tuple[int, int, int, bool]] = []
         self.rename_calls: list[tuple[int, int, str]] = []
-        self.root_id = self.add_directory()
+        self.volume_root_id = self.add_directory()
+        self.root_id = self.add_directory(self.volume_root_id, "authority")
 
     def add_directory(self, parent: int | None = None, name: str = "") -> int:
         file_id = self.next_file_id
@@ -82,8 +83,30 @@ class _FakeWindowsApi:
         self.offsets[handle] = 0
         return handle
 
-    def create_directory_handle(self, _path: Path) -> int:
-        return self._new_handle(self.root_id)
+    def create_directory_handle(self, path: Path) -> int:
+        normalized = str(path).replace("/", "\\").rstrip("\\").casefold()
+        file_id = self.volume_root_id if normalized == "c:" else self.root_id
+        return self._new_handle(file_id)
+
+    def open_relative(
+        self,
+        parent_handle: int,
+        name: str,
+        *,
+        desired_access: int,
+        is_directory: bool,
+        allow_reparse: bool,
+    ) -> int:
+        del desired_access, allow_reparse
+        parent = self.nodes[self.handles[parent_handle]]
+        children = parent["children"]
+        assert isinstance(children, dict)
+        try:
+            file_id = children[name]
+        except KeyError as exc:
+            raise FileNotFoundError(name) from exc
+        assert self.nodes[file_id]["directory"] is is_directory
+        return self._new_handle(file_id)
 
     def duplicate_handle(self, handle: int) -> int:
         return self._new_handle(self.handles[handle])
@@ -108,17 +131,15 @@ class _FakeWindowsApi:
             st_ctime_ns=version,
             st_nlink=int(node.get("nlink", 1)),
             st_file_attributes=attributes,
+            file_id_128=self.handles[handle].to_bytes(16, "little"),
         )
 
-    def enumerate_directory(
-        self,
-        handle: int,
-    ) -> tuple[object, ...]:
+    def iter_directory(self, handle: int):
         node = self.nodes[self.handles[handle]]
         children = node["children"]
         assert isinstance(children, dict)
-        return tuple(
-            atomic_module._WindowsDirectoryEntry(
+        for name, file_id in children.items():
+            yield atomic_module._WindowsDirectoryEntry(
                 name=name,
                 file_id=file_id,
                 attributes=(
@@ -126,9 +147,14 @@ class _FakeWindowsApi:
                     if self.nodes[file_id]["directory"]
                     else 0
                 ),
+                file_id_128=file_id.to_bytes(16, "little"),
             )
-            for name, file_id in children.items()
-        )
+
+    def enumerate_directory(
+        self,
+        handle: int,
+    ) -> tuple[object, ...]:
+        return tuple(self.iter_directory(handle))
 
     def open_by_id(
         self,
@@ -3622,24 +3648,51 @@ def _call_with_interrupt_after_store(
     assert predicate is None or callable(predicate)
     code = function.__code__
     instructions = tuple(dis.get_instructions(function))
-    offsets_after_store = {
-        instructions[index + 1].offset
+    result_store_indexes = {
+        index
         for index, instruction in enumerate(instructions[:-1])
-        if instruction.opname == "STORE_FAST" and instruction.argval == local_name
+        if instruction.opname == "STORE_FAST"
+        and instruction.argval == local_name
+        and index > 0
+        and instructions[index - 1].opname.startswith("CALL")
     }
+    opcode_offsets_after_store = {
+        instructions[index + 1].offset for index in result_store_indexes
+    }
+    result_store_offsets = {
+        instructions[index].offset for index in result_store_indexes
+    }
+    line_offsets_after_store = {
+        instruction.offset
+        for instruction in instructions
+        if instruction.starts_line is not None
+        and any(
+            instruction.offset > store_offset for store_offset in result_store_offsets
+        )
+    }
+    assert result_store_indexes
     previous_trace = sys.gettrace()
+    injected = False
 
     def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
         if event == "call" and frame.f_code is code:
             frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
             return trace
         if (
-            event == "opcode"
-            and frame.f_code is code
-            and frame.f_lasti in offsets_after_store
+            frame.f_code is code
+            and (
+                (
+                    event == "opcode"
+                    and frame.f_lasti in opcode_offsets_after_store
+                )
+                or (event == "line" and frame.f_lasti in line_offsets_after_store)
+            )
             and int(frame.f_locals.get(local_name, -1)) >= 0
             and (predicate is None or predicate(frame.f_locals))
         ):
+            injected = True
             sys.settrace(None)
             raise error
         return trace
@@ -3649,6 +3702,7 @@ def _call_with_interrupt_after_store(
         callback()
     finally:
         sys.settrace(previous_trace)
+        assert injected, f"failed to inject after {local_name} result store"
 
 
 def _posix_authority_resources(

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -4,38 +4,243 @@
 
 from __future__ import annotations
 
+import dis
+import errno
+import hashlib
+import inspect
 import os
 import stat
-from pathlib import Path
+import sys
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 
 import pytest
 
 import codenib._atomic_directory as atomic_module
+import codenib._windows_fs_authority as windows_authority_module
 from codenib._atomic_directory import (
+    DirectoryOrphan,
     capture_directory_ownership,
     directory_ownership_inventory,
+    publication_parent_identity,
     publish_staged_directory,
 )
 
 
-def test_publish_staged_directory_replaces_existing_tree(tmp_path: Path) -> None:
+def _write_tree(root: Path, name: str, value: str) -> None:
+    root.mkdir()
+    (root / name).write_text(value, encoding="utf-8")
+
+
+class _FakeWindowsApi:
+    """In-memory HANDLE/FILE_ID model; it intentionally has no path reads."""
+
+    def __init__(self) -> None:
+        self.nodes: dict[int, dict[str, object]] = {}
+        self.handles: dict[int, int] = {}
+        self.offsets: dict[int, int] = {}
+        self.next_file_id = 10
+        self.next_handle = 100
+        self.open_by_id_calls: list[tuple[int, int, int, bool]] = []
+        self.rename_calls: list[tuple[int, int, str]] = []
+        self.root_id = self.add_directory()
+
+    def add_directory(self, parent: int | None = None, name: str = "") -> int:
+        file_id = self.next_file_id
+        self.next_file_id += 1
+        self.nodes[file_id] = {
+            "directory": True,
+            "children": {},
+            "data": b"",
+            "version": 1,
+        }
+        if parent is not None:
+            children = self.nodes[parent]["children"]
+            assert isinstance(children, dict)
+            children[name] = file_id
+        return file_id
+
+    def add_file(self, parent: int, name: str, data: bytes) -> int:
+        file_id = self.next_file_id
+        self.next_file_id += 1
+        self.nodes[file_id] = {
+            "directory": False,
+            "children": {},
+            "data": data,
+            "version": 1,
+        }
+        children = self.nodes[parent]["children"]
+        assert isinstance(children, dict)
+        children[name] = file_id
+        return file_id
+
+    def _new_handle(self, file_id: int) -> int:
+        handle = self.next_handle
+        self.next_handle += 1
+        self.handles[handle] = file_id
+        self.offsets[handle] = 0
+        return handle
+
+    def create_directory_handle(self, _path: Path) -> int:
+        return self._new_handle(self.root_id)
+
+    def duplicate_handle(self, handle: int) -> int:
+        return self._new_handle(self.handles[handle])
+
+    def close(self, handle: int) -> None:
+        self.handles.pop(handle, None)
+        self.offsets.pop(handle, None)
+
+    def metadata(self, handle: int) -> object:
+        node = self.nodes[self.handles[handle]]
+        directory = bool(node["directory"])
+        data = node["data"]
+        assert isinstance(data, bytes)
+        version = int(node["version"])
+        attributes = atomic_module._WINDOWS_FILE_ATTRIBUTE_DIRECTORY if directory else 0
+        return atomic_module._WindowsHandleMetadata(
+            st_dev=7,
+            st_ino=self.handles[handle],
+            st_mode=atomic_module._windows_mode_from_attributes(attributes),
+            st_size=0 if directory else len(data),
+            st_mtime_ns=version,
+            st_ctime_ns=version,
+            st_nlink=int(node.get("nlink", 1)),
+            st_file_attributes=attributes,
+        )
+
+    def enumerate_directory(
+        self,
+        handle: int,
+    ) -> tuple[object, ...]:
+        node = self.nodes[self.handles[handle]]
+        children = node["children"]
+        assert isinstance(children, dict)
+        return tuple(
+            atomic_module._WindowsDirectoryEntry(
+                name=name,
+                file_id=file_id,
+                attributes=(
+                    atomic_module._WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+                    if self.nodes[file_id]["directory"]
+                    else 0
+                ),
+            )
+            for name, file_id in children.items()
+        )
+
+    def open_by_id(
+        self,
+        volume_hint: int,
+        file_id: int,
+        *,
+        desired_access: int,
+        is_directory: bool,
+    ) -> int:
+        assert self.nodes[file_id]["directory"] is is_directory
+        self.open_by_id_calls.append(
+            (volume_hint, file_id, desired_access, is_directory)
+        )
+        return self._new_handle(file_id)
+
+    def read(self, handle: int, size: int) -> bytes:
+        node = self.nodes[self.handles[handle]]
+        data = node["data"]
+        assert isinstance(data, bytes)
+        offset = self.offsets[handle]
+        block = data[offset : offset + size]
+        self.offsets[handle] += len(block)
+        return block
+
+    def rename_noreplace(
+        self,
+        source_handle: int,
+        parent_handle: int,
+        destination: str,
+    ) -> None:
+        parent = self.nodes[self.handles[parent_handle]]
+        children = parent["children"]
+        assert isinstance(children, dict)
+        if any(name.casefold() == destination.casefold() for name in children):
+            raise FileExistsError(destination)
+        source_id = self.handles[source_handle]
+        source_names = [
+            name for name, file_id in children.items() if file_id == source_id
+        ]
+        if len(source_names) != 1:
+            raise FileNotFoundError(source_id)
+        source_name = source_names[0]
+        children[destination] = children.pop(source_name)
+        parent["version"] = int(parent["version"]) + 1
+        self.rename_calls.append((source_handle, parent_handle, destination))
+
+
+def test_publish_staged_directory_replaces_existing_tree(
+    tmp_path: Path,
+) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     nested = destination / "nested"
     nested.mkdir()
     (nested / "one.txt").write_text("one", encoding="utf-8")
-    (nested / "two.txt").write_text("two", encoding="utf-8")
-    stage = tmp_path / ".published.tmp"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
 
-    publish_staged_directory(stage, destination)
+    orphan = publish_staged_directory(stage, destination)
 
+    assert isinstance(orphan, DirectoryOrphan)
+    assert orphan.verified_at_isolation
+    assert orphan.path.name.startswith(".published.previous-")
+    assert (orphan.path / "old.txt").read_text(encoding="utf-8") == "old"
     assert not stage.exists()
-    assert not (destination / "old.txt").exists()
     assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_first_publication_does_not_create_an_empty_orphan(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is None
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+def test_rename_noreplace_at_moves_without_overwriting(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.write_text("source", encoding="utf-8")
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        atomic_module._rename_noreplace_at("source", "moved", descriptor, descriptor)
+        assert not source.exists()
+        assert (tmp_path / "moved").read_text(encoding="utf-8") == "source"
+
+        source.write_text("new source", encoding="utf-8")
+        with pytest.raises(FileExistsError):
+            atomic_module._rename_noreplace_at(
+                "source", "moved", descriptor, descriptor
+            )
+    finally:
+        os.close(descriptor)
+
+    assert source.read_text(encoding="utf-8") == "new source"
+    assert (tmp_path / "moved").read_text(encoding="utf-8") == "source"
+
+
+@pytest.mark.parametrize("name", ["", ".", "..", "a/b", "a\\b", "a\x00b"])
+def test_rename_noreplace_at_rejects_non_child_names(
+    tmp_path: Path,
+    name: str,
+) -> None:
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(ValueError, match="one bounded file name"):
+            atomic_module._rename_noreplace_at(name, "target", descriptor, descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def test_publish_staged_directory_restores_previous_tree_on_failure(
@@ -43,25 +248,24 @@ def test_publish_staged_directory_restores_previous_tree_on_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / ".published.tmp"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_replace = os.replace
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
 
-    def fail_stage_publish(source, target):
-        if Path(source) == stage and Path(target) == destination:
+    def fail_final(src: str, dst: str, src_dir_fd: int, dst_dir_fd: int) -> None:
+        if src == stage.name and dst == destination.name:
             raise OSError("injected final rename failure")
-        return real_replace(source, target)
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
 
-    monkeypatch.setattr("codenib._atomic_directory.os.replace", fail_stage_publish)
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", fail_final)
 
     with pytest.raises(OSError, match="injected final rename failure"):
         publish_staged_directory(stage, destination)
 
     assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
 
 
 def test_publish_staged_directory_restores_missing_target_on_failure(
@@ -70,16 +274,15 @@ def test_publish_staged_directory_restores_missing_target_on_failure(
 ) -> None:
     destination = tmp_path / "published"
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_replace = os.replace
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
 
-    def fail_stage_publish(source, target):
-        if Path(source) == stage and Path(target) == destination:
+    def fail_final(src: str, dst: str, src_dir_fd: int, dst_dir_fd: int) -> None:
+        if src == stage.name and dst == destination.name:
             raise OSError("injected final rename failure")
-        return real_replace(source, target)
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
 
-    monkeypatch.setattr("codenib._atomic_directory.os.replace", fail_stage_publish)
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", fail_final)
 
     with pytest.raises(OSError, match="injected final rename failure"):
         publish_staged_directory(stage, destination)
@@ -94,11 +297,11 @@ def test_publish_staged_directory_rejects_invalid_relationships(
 ) -> None:
     stage = tmp_path / "stage"
     stage.mkdir()
-    destination_file = tmp_path / "published"
-    destination_file.write_text("keep", encoding="utf-8")
-
     with pytest.raises(ValueError, match="must differ"):
         publish_staged_directory(stage, stage)
+
+    destination_file = tmp_path / "published"
+    destination_file.write_text("keep", encoding="utf-8")
     with pytest.raises(ValueError, match="not a directory"):
         publish_staged_directory(stage, destination_file)
 
@@ -106,21 +309,17 @@ def test_publish_staged_directory_rejects_invalid_relationships(
 def test_publish_staged_directory_does_not_follow_destination_symlink(
     tmp_path: Path,
 ) -> None:
-    victim = tmp_path / "victim"
-    victim.mkdir()
-    (victim / "keep.txt").write_text("keep", encoding="utf-8")
-    destination = tmp_path / "published"
-    destination.symlink_to(victim, target_is_directory=True)
     stage = tmp_path / "stage"
     stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-
+    victim = tmp_path / "victim"
+    _write_tree(victim, "keep.txt", "keep")
+    destination = tmp_path / "published"
+    destination.symlink_to(victim, target_is_directory=True)
     with pytest.raises(ValueError, match="link"):
         publish_staged_directory(stage, destination)
 
     assert destination.is_symlink()
     assert (victim / "keep.txt").read_text(encoding="utf-8") == "keep"
-    assert not (victim / "new.txt").exists()
 
 
 def test_publish_staged_directory_detects_destination_swap_at_boundary(
@@ -128,31 +327,955 @@ def test_publish_staged_directory_detects_destination_swap_at_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stolen = tmp_path / "stolen"
-    victim = tmp_path / "victim"
-    victim.mkdir()
-    (victim / "keep.txt").write_text("keep", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-old"
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
 
-    def swap_then_allocate(*args, **kwargs):
-        destination.rename(stolen)
-        destination.symlink_to(victim, target_is_directory=True)
-        return real_mkdtemp(*args, **kwargs)
+    def replace_before_claim(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == destination.name and ".published.previous-" in dst and not injected:
+            injected = True
+            destination.rename(stolen)
+            _write_tree(destination, "foreign.txt", "preserve")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
 
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", swap_then_allocate)
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        replace_before_claim,
+    )
 
     with pytest.raises(RuntimeError, match="changed at the publication boundary"):
         publish_staged_directory(stage, destination)
 
-    assert destination.is_symlink()
-    assert (victim / "keep.txt").read_text(encoding="utf-8") == "keep"
-    assert not (victim / "new.txt").exists()
+    assert (destination / "foreign.txt").read_text(encoding="utf-8") == "preserve"
     assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_raced_destination_before_final_rename_is_never_overwritten(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def insert_foreign(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            _write_tree(destination, "foreign.txt", "preserve")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", insert_foreign)
+
+    with pytest.raises(RuntimeError, match="previous output remains isolated"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    previous = list(tmp_path.glob(".published.previous-*"))
+    assert len(previous) == 1
+    assert (previous[0] / "old.txt").read_text(encoding="utf-8") == "old"
+
+
+def test_publish_staged_directory_rejects_real_stage_swap_before_destination_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-stage"
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def replace_stage(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            stage.rename(stolen)
+            _write_tree(stage, "foreign.txt", "preserve")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", replace_stage)
+
+    with pytest.raises(RuntimeError, match="suspect output was quarantined"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stolen / "new.txt").read_text(encoding="utf-8") == "new"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "foreign.txt").read_text(encoding="utf-8") == ("preserve")
+
+
+def test_expected_stage_ownership_requires_the_complete_token(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    expected = capture_directory_ownership(stage)
+    (stage / "new.txt").write_text("NEW", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="changed before publication"):
+        publish_staged_directory(
+            stage,
+            destination,
+            expected_stage_root_ownership=expected,
+        )
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "NEW"
+
+
+def test_publish_uses_borrowed_parent_descriptor_without_closing_it(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    expected_parent = publication_parent_identity(descriptor)
+    try:
+        orphan = publish_staged_directory(
+            stage,
+            destination,
+            parent_descriptor=descriptor,
+            expected_parent_identity=expected_parent,
+        )
+        assert publication_parent_identity(descriptor) == expected_parent
+    finally:
+        os.close(descriptor)
+
+    assert orphan is not None
+    assert orphan.parent_identity == expected_parent
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_public_publish_wrapper_does_not_request_strict_commit_fsync(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    def forbidden_fsync(_descriptor: int) -> None:
+        raise AssertionError("compatibility publication must not use strict fsync")
+
+    monkeypatch.setattr(atomic_module.os, "fsync", forbidden_fsync)
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is not None
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_authority_publish_helper_rejects_noncallable_commit_before_mutation(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        with pytest.raises(TypeError, match="commit callback must be callable"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                commit_callback=object(),  # type: ignore[arg-type]
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict commit durability currently requires Linux directory fsync",
+)
+def test_authority_publish_helper_borrows_authority_and_commits_exact_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    expected_previous = capture_directory_ownership(destination)
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    expected_stage = capture_directory_ownership(stage)
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    events: list[str] = []
+    observed: list[tuple[object, object, DirectoryOrphan | None]] = []
+    real_verify = authority._verify_callback
+    real_fsync = atomic_module.os.fsync
+
+    def verify_parent_binding() -> None:
+        real_verify()
+        events.append("verified")
+
+    def fsync_parent(descriptor: int) -> None:
+        assert descriptor == authority.resource
+        real_fsync(descriptor)
+        events.append("synced")
+
+    def commit(
+        sealed: object,
+        published: object,
+        previous: DirectoryOrphan | None,
+    ) -> None:
+        assert events == ["verified", "synced"]
+        events.append("committed")
+        observed.append((sealed, published, previous))
+
+    authority._verify_callback = verify_parent_binding
+    monkeypatch.setattr(atomic_module.os, "fsync", fsync_parent)
+    try:
+        orphan = atomic_module._publish_staged_directory_with_authority(
+            authority,
+            stage,
+            destination,
+            expected_stage_root_ownership=expected_stage,
+            commit_callback=commit,
+        )
+        assert not authority._closed
+        authority.verify_path_binding()
+    finally:
+        authority.close()
+
+    assert authority._closed
+    assert events == ["verified", "synced", "committed", "verified"]
+    assert len(observed) == 1
+    assert observed[0][0] == expected_stage
+    published = observed[0][1]
+    assert isinstance(published, type(expected_stage))
+    assert (
+        replace(
+            published,
+            root_version_identity=expected_stage.root_version_identity,
+        )
+        == expected_stage
+    )
+    assert observed[0][2] is orphan
+    assert orphan is not None
+    assert orphan.ownership_digest == expected_previous.digest
+    assert (orphan.path / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert published == capture_directory_ownership(destination)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict commit durability currently requires Linux directory fsync",
+)
+def test_authority_publish_helper_does_not_commit_before_validation_finishes(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    commits: list[object] = []
+
+    def fail_validation(_reader: object) -> None:
+        raise RuntimeError("injected pre-commit validation failure")
+
+    try:
+        with pytest.raises(RuntimeError, match="suspect output was quarantined"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                validate_published_destination=fail_validation,
+                commit_callback=lambda sealed, _published, _previous: commits.append(
+                    sealed
+                ),
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert commits == []
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict commit durability currently requires Linux directory fsync",
+)
+def test_authority_publish_helper_rechecks_exact_tree_after_orphan_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    commits: list[object] = []
+    real_orphan_metadata = atomic_module._orphan_metadata
+
+    def mutate_after_orphan_receipt(*args: object, **kwargs: object) -> DirectoryOrphan:
+        orphan = real_orphan_metadata(*args, **kwargs)
+        (destination / "late.txt").write_text("late", encoding="utf-8")
+        return orphan
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_orphan_metadata",
+        mutate_after_orphan_receipt,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="published staged directory changed"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                commit_callback=lambda sealed, _published, _previous: commits.append(
+                    sealed
+                ),
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert commits == []
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (destination / "late.txt").read_text(encoding="utf-8") == "late"
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict commit durability currently requires Linux directory fsync",
+)
+def test_authority_publish_helper_fsync_failure_prevents_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    commits: list[object] = []
+    error = OSError(errno.EIO, "injected parent fsync failure")
+
+    def fail_parent_fsync(descriptor: int) -> None:
+        assert descriptor == authority.resource
+        raise error
+
+    monkeypatch.setattr(atomic_module.os, "fsync", fail_parent_fsync)
+    try:
+        with pytest.raises(OSError) as caught:
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                commit_callback=lambda sealed, _published, _previous: commits.append(
+                    sealed
+                ),
+            )
+        assert caught.value is error
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert commits == []
+    assert not stage.exists()
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    previous = list(tmp_path.glob(".published.previous-*"))
+    assert len(previous) == 1
+    assert (previous[0] / "old.txt").read_text(encoding="utf-8") == "old"
+
+
+@pytest.mark.parametrize("backend_tag", ["windows-file-id", "darwin-renameatx-np"])
+def test_authority_publish_helper_rejects_unsupported_durable_commit(
+    tmp_path: Path,
+    backend_tag: str,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    authority.backend_tag = backend_tag
+    commits: list[object] = []
+    try:
+        with pytest.raises(RuntimeError, match="supported Linux"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                commit_callback=lambda sealed, _published, _previous: commits.append(
+                    sealed
+                ),
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert commits == []
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+@pytest.mark.parametrize("error_type", [KeyboardInterrupt, SystemExit])
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict commit durability currently requires Linux directory fsync",
+)
+def test_authority_publish_helper_never_rolls_back_commit_interruptions(
+    tmp_path: Path,
+    error_type: type[BaseException],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    expected_stage = capture_directory_ownership(stage)
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    observed: list[tuple[object, object, DirectoryOrphan | None]] = []
+    synced = False
+    real_fsync = atomic_module.os.fsync
+
+    def fsync_parent(descriptor: int) -> None:
+        nonlocal synced
+        assert descriptor == authority.resource
+        real_fsync(descriptor)
+        synced = True
+
+    def interrupt_commit(
+        sealed: object,
+        published: object,
+        previous: DirectoryOrphan | None,
+    ) -> None:
+        assert synced
+        observed.append((sealed, published, previous))
+        raise error_type("injected commit interruption")
+
+    monkeypatch.setattr(atomic_module.os, "fsync", fsync_parent)
+    try:
+        with pytest.raises(error_type, match="injected commit interruption"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                commit_callback=interrupt_commit,
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert len(observed) == 1
+    assert observed[0][0] == expected_stage
+    published = observed[0][1]
+    assert isinstance(published, type(expected_stage))
+    assert (
+        replace(
+            published,
+            root_version_identity=expected_stage.root_version_identity,
+        )
+        == expected_stage
+    )
+    previous = observed[0][2]
+    assert previous is not None
+    assert (previous.path / "old.txt").read_text(encoding="utf-8") == "old"
+    assert not stage.exists()
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_authority_publish_helper_rejects_paths_outside_authority_parent(
+    tmp_path: Path,
+) -> None:
+    foreign_parent = tmp_path / "foreign"
+    foreign_parent.mkdir()
+    destination = foreign_parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = foreign_parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        with pytest.raises(ValueError, match="match the authority parent"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_rejects_wrong_parent_authority_before_mutation(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(RuntimeError, match="does not match authority"):
+            publish_staged_directory(
+                stage,
+                destination,
+                parent_descriptor=descriptor,
+                expected_parent_identity=(0,),
+            )
+    finally:
+        os.close(descriptor)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publication_paths_never_call_path_resolve(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    def forbidden_resolve(*_args: object, **_kwargs: object) -> Path:
+        raise AssertionError("publication authority must not resolve lexical paths")
+
+    monkeypatch.setattr(Path, "resolve", forbidden_resolve)
+
+    publish_staged_directory(stage, destination)
+
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publication_rejects_preexisting_parent_symlink(
+    tmp_path: Path,
+) -> None:
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    destination = foreign / "published"
+    _write_tree(destination, "valuable.txt", "preserve")
+    stage = foreign / "stage"
+    _write_tree(stage, "new.txt", "new")
+    alias = tmp_path / "alias"
+    alias.symlink_to(foreign, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="real directory"):
+        publish_staged_directory(alias / "stage", alias / "published")
+
+    assert (destination / "valuable.txt").read_text(encoding="utf-8") == "preserve"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publication_rejects_reversible_intermediate_parent_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trusted = tmp_path / "trusted"
+    intermediate = trusted / "intermediate"
+    parent = intermediate / "parent"
+    parent.mkdir(parents=True)
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    foreign = tmp_path / "foreign-intermediate"
+    foreign_parent = foreign / "parent"
+    foreign_parent.mkdir(parents=True)
+    _write_tree(foreign_parent / "published", "valuable.txt", "preserve")
+    saved = tmp_path / "saved-intermediate"
+    real_open = atomic_module.os.open
+    swapped = False
+
+    def reversible_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if path == "intermediate" and dir_fd is not None and not swapped:
+            swapped = True
+            intermediate.rename(saved)
+            foreign.rename(intermediate)
+            try:
+                return real_open(path, flags, mode, dir_fd=dir_fd)
+            finally:
+                intermediate.rename(foreign)
+                saved.rename(intermediate)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(atomic_module.os, "open", reversible_open)
+
+    with pytest.raises(RuntimeError, match="changed while it was opened"):
+        publish_staged_directory(stage, destination)
+
+    assert swapped
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (foreign_parent / "published" / "valuable.txt").read_text(
+        encoding="utf-8"
+    ) == "preserve"
+
+
+def test_parent_path_replacement_cannot_redirect_pinned_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "active-parent"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    moved_parent = tmp_path / "moved-parent"
+    descriptor = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+    expected_parent = publication_parent_identity(descriptor)
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def replace_parent(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            parent.rename(moved_parent)
+            parent.mkdir()
+            foreign = parent / destination.name
+            _write_tree(foreign, "foreign.txt", "preserve")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", replace_parent)
+    try:
+        with pytest.raises(RuntimeError, match="parent path changed"):
+            publish_staged_directory(
+                stage,
+                destination,
+                parent_descriptor=descriptor,
+                expected_parent_identity=expected_parent,
+            )
+    finally:
+        os.close(descriptor)
+
+    assert (parent / "published" / "foreign.txt").read_text(
+        encoding="utf-8"
+    ) == "preserve"
+    assert (moved_parent / "published" / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_discard_owned_directory_isolates_instead_of_deleting(tmp_path: Path) -> None:
+    root = tmp_path / "owned"
+    _write_tree(root, "payload.txt", "payload")
+    ownership = capture_directory_ownership(root)
+
+    orphan = atomic_module.discard_owned_directory(root, ownership)
+
+    assert isinstance(orphan, DirectoryOrphan)
+    assert orphan.verified_at_isolation
+    assert not root.exists()
+    assert (orphan.path / "payload.txt").read_text(encoding="utf-8") == "payload"
+
+
+def test_discard_restores_foreign_replacement_claimed_at_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "owned"
+    _write_tree(root, "payload.txt", "payload")
+    ownership = capture_directory_ownership(root)
+    stolen = tmp_path / "stolen-owned"
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def replace_before_claim(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == root.name and ".owned.discarded-" in dst and not injected:
+            injected = True
+            root.rename(stolen)
+            _write_tree(root, "foreign.txt", "preserve")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        replace_before_claim,
+    )
+
+    orphan = atomic_module.discard_owned_directory(root, ownership)
+
+    assert orphan is None
+    assert (root / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+    assert (stolen / "payload.txt").read_text(encoding="utf-8") == "payload"
+
+
+def test_publish_and_discard_never_recursively_unlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("online cleanup must not delete entries")
+
+    monkeypatch.setattr(atomic_module.os, "unlink", forbidden)
+    monkeypatch.setattr(atomic_module.os, "rmdir", forbidden)
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    previous = publish_staged_directory(stage, destination)
+    assert previous is not None
+    published = capture_directory_ownership(destination)
+    discarded = atomic_module.discard_owned_directory(destination, published)
+
+    assert discarded is not None
+    assert (previous.path / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (discarded.path / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_restores_old_tree_when_rename_completes_then_interrupts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def interrupt_after_claim(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+        if src == destination.name and ".published.previous-" in dst and not injected:
+            injected = True
+            raise KeyboardInterrupt("post-claim interruption")
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", interrupt_after_claim)
+
+    with pytest.raises(KeyboardInterrupt, match="post-claim interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_final_rename_that_completes_before_interrupt_is_rolled_back(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def interrupt_after_publish(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            raise KeyboardInterrupt("post-publish interruption")
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        interrupt_after_publish,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="post-publish interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_published_callback_cannot_bypass_exact_tree_token(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    def mutate(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        assert reader.read_bytes("new.txt", max_bytes=16) == b"new"
+        (destination / "late.txt").write_text("late", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="suspect output was quarantined"):
+        publish_staged_directory(
+            stage,
+            destination,
+            validate_published_destination=mutate,
+        )
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
+
+
+def test_publish_staged_directory_never_restores_swapped_callback_backup(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-old"
+    calls = 0
+
+    def swap_on_second_validation(reader: object) -> None:
+        nonlocal calls
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        assert reader.read_bytes("old.txt", max_bytes=16) == b"old"
+        calls += 1
+        if calls == 2:
+            backup = next(tmp_path.glob(".published.previous-*"))
+            backup.rename(stolen)
+            _write_tree(backup, "foreign.txt", "preserve")
+            raise RuntimeError("injected previous validation failure")
+
+    with pytest.raises(
+        RuntimeError,
+        match="previous output identity lost",
+    ):
+        publish_staged_directory(
+            stage,
+            destination,
+            validate_moved_destination=swap_on_second_validation,
+        )
+
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    previous = list(tmp_path.glob(".published.previous-*"))
+    assert len(previous) == 1
+    assert (previous[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_publication_fails_closed_on_unsupported_platform(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    monkeypatch.setattr(atomic_module.sys, "platform", "freebsd14")
+
+    with pytest.raises(RuntimeError, match="unsupported on this host"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_orphan_name_collision_budget_fails_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    monkeypatch.setattr(atomic_module.secrets, "token_hex", lambda _size: "a" * 32)
+    collision = tmp_path / f".published.previous-{'a' * 32}"
+    collision.write_text("foreign", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="claim directory under a bounded orphan"):
+        publish_staged_directory(stage, destination)
+
+    assert collision.read_text(encoding="utf-8") == "foreign"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
 
 
@@ -161,25 +1284,22 @@ def test_publish_staged_directory_preserves_late_destination_entry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    _write_tree(stage, "new.txt", "new")
+    real_claim = atomic_module._claim_child_as_orphan
+    injected = False
 
-    def mutate_then_allocate(*args, **kwargs):
-        (destination / "late.txt").write_text("late", encoding="utf-8")
-        return real_mkdtemp(*args, **kwargs)
+    def mutate_then_claim(*args: object, **kwargs: object) -> Path:
+        nonlocal injected
+        if not injected:
+            injected = True
+            (destination / "late.txt").write_text("late", encoding="utf-8")
+        return real_claim(*args, **kwargs)
 
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_identity",
-        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
-    )
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+    monkeypatch.setattr(atomic_module, "_claim_child_as_orphan", mutate_then_claim)
 
-    with pytest.raises(RuntimeError, match="changed at the publication boundary"):
+    with pytest.raises(RuntimeError, match="changed during directory publication"):
         publish_staged_directory(stage, destination)
 
     assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
@@ -196,26 +1316,24 @@ def test_publish_staged_directory_preserves_nested_late_destination_entry(
     nested.mkdir(parents=True)
     (nested / "old.txt").write_text("old", encoding="utf-8")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    _write_tree(stage, "new.txt", "new")
+    real_claim = atomic_module._claim_child_as_orphan
+    injected = False
 
-    def mutate_then_allocate(*args, **kwargs):
-        (nested / "late.txt").write_text("late", encoding="utf-8")
-        return real_mkdtemp(*args, **kwargs)
+    def mutate_then_claim(*args: object, **kwargs: object) -> Path:
+        nonlocal injected
+        if not injected:
+            injected = True
+            (nested / "late.txt").write_text("late", encoding="utf-8")
+        return real_claim(*args, **kwargs)
 
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_identity",
-        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
-    )
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+    monkeypatch.setattr(atomic_module, "_claim_child_as_orphan", mutate_then_claim)
 
-    with pytest.raises(RuntimeError, match="changed at the publication boundary"):
+    with pytest.raises(RuntimeError, match="changed during directory publication"):
         publish_staged_directory(stage, destination)
 
     assert (destination / "nested" / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (destination / "nested" / "late.txt").read_text(encoding="utf-8") == ("late")
+    assert (destination / "nested" / "late.txt").read_text(encoding="utf-8") == "late"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
 
 
@@ -224,26 +1342,24 @@ def test_publish_staged_directory_rejects_nested_stage_mutation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     stage = tmp_path / "stage"
     nested = stage / "nested"
     nested.mkdir(parents=True)
     (nested / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    real_claim = atomic_module._claim_child_as_orphan
+    injected = False
 
-    def mutate_then_allocate(*args, **kwargs):
-        (nested / "late.txt").write_text("late", encoding="utf-8")
-        return real_mkdtemp(*args, **kwargs)
+    def mutate_then_claim(*args: object, **kwargs: object) -> Path:
+        nonlocal injected
+        if not injected:
+            injected = True
+            (nested / "late.txt").write_text("late", encoding="utf-8")
+        return real_claim(*args, **kwargs)
 
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_identity",
-        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
-    )
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+    monkeypatch.setattr(atomic_module, "_claim_child_as_orphan", mutate_then_claim)
 
-    with pytest.raises(RuntimeError, match="before destination publication"):
+    with pytest.raises(RuntimeError, match="staged directory changed"):
         publish_staged_directory(stage, destination)
 
     assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
@@ -256,26 +1372,23 @@ def test_publish_staged_directory_rejects_same_size_destination_rewrite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
+    _write_tree(destination, "old.txt", "old")
     previous = destination / "old.txt"
-    previous.write_text("old", encoding="utf-8")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    _write_tree(stage, "new.txt", "new")
+    real_claim = atomic_module._claim_child_as_orphan
+    injected = False
 
-    def mutate_then_allocate(*args, **kwargs):
-        previous.write_text("NEW", encoding="utf-8")
-        return real_mkdtemp(*args, **kwargs)
+    def rewrite_then_claim(*args: object, **kwargs: object) -> Path:
+        nonlocal injected
+        if not injected:
+            injected = True
+            previous.write_text("NEW", encoding="utf-8")
+        return real_claim(*args, **kwargs)
 
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_identity",
-        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
-    )
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+    monkeypatch.setattr(atomic_module, "_claim_child_as_orphan", rewrite_then_claim)
 
-    with pytest.raises(RuntimeError, match="changed at the publication boundary"):
+    with pytest.raises(RuntimeError, match="changed during directory publication"):
         publish_staged_directory(stage, destination)
 
     assert previous.read_text(encoding="utf-8") == "NEW"
@@ -288,32 +1401,457 @@ def test_publish_staged_directory_preserves_raced_missing_target_content(
 ) -> None:
     destination = tmp_path / "published"
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
 
-    def mutate_then_allocate(*args, **kwargs):
-        (destination / "late.txt").write_text("late", encoding="utf-8")
-        return real_mkdtemp(*args, **kwargs)
+    def race_missing_target(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            _write_tree(destination, "late.txt", "late")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
 
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_identity",
-        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
-    )
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", race_missing_target)
 
-    with pytest.raises(RuntimeError, match="raced content remains"):
+    with pytest.raises(FileExistsError):
         publish_staged_directory(
             stage,
             destination,
             expected_destination_identity=None,
-            validate_moved_destination=lambda _path: None,
-            validate_published_destination=lambda _path: None,
         )
 
     assert (destination / "late.txt").read_text(encoding="utf-8") == "late"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_restores_old_tree_on_scan_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_require = atomic_module._require_tree_ownership_at
+
+    def interrupt_moved_tree(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        expected: object,
+        label: str,
+        allow_root_rename: bool = False,
+    ) -> None:
+        if label == "moved destination":
+            raise KeyboardInterrupt("injected ownership interruption")
+        real_require(
+            authority,
+            name,
+            path=path,
+            expected=expected,
+            label=label,
+            allow_root_rename=allow_root_rename,
+        )
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_require_tree_ownership_at",
+        interrupt_moved_tree,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="ownership interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+def test_publish_restores_old_tree_when_moved_lstat_is_interrupted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_directory_or_missing = atomic_module._directory_or_missing_at
+
+    def interrupt_moved_lstat(
+        parent_descriptor: int,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> os.stat_result | None:
+        if label == "moved destination":
+            raise KeyboardInterrupt("injected moved lstat interruption")
+        return real_directory_or_missing(
+            parent_descriptor,
+            name,
+            path=path,
+            label=label,
+        )
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_directory_or_missing_at",
+        interrupt_moved_lstat,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="moved lstat interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_restores_old_tree_when_final_stage_lstat_is_interrupted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_require = atomic_module._require_tree_ownership_at
+    stage_checks = 0
+
+    def interrupt_final_stage_check(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        expected: object,
+        label: str,
+        allow_root_rename: bool = False,
+    ) -> None:
+        nonlocal stage_checks
+        if label == "staged directory":
+            stage_checks += 1
+            if stage_checks == 2:
+                raise KeyboardInterrupt("injected final stage interruption")
+        real_require(
+            authority,
+            name,
+            path=path,
+            expected=expected,
+            label=label,
+            allow_root_rename=allow_root_rename,
+        )
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_require_tree_ownership_at",
+        interrupt_final_stage_check,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="final stage interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert stage_checks == 2
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_first_publication_fails_closed_without_safe_ownership_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    monkeypatch.setattr(atomic_module, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
+
+    with pytest.raises(RuntimeError, match="no-follow directory-fd support"):
+        publish_staged_directory(stage, destination)
+
+    assert stage.is_dir()
+    assert not destination.exists()
+
+
+def test_existing_publication_fails_closed_without_safe_ownership_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    monkeypatch.setattr(atomic_module, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
+
+    with pytest.raises(RuntimeError, match="no-follow directory-fd support"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_quarantines_failed_published_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def mutate_after_publish(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            (destination / "late.txt").write_text("late", encoding="utf-8")
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", mutate_after_publish)
+
+    with pytest.raises(RuntimeError, match="suspect output was quarantined"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
+
+
+def test_published_boundary_quarantines_new_before_lost_backup_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-old"
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def lose_backup_after_publish(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            backup = next(tmp_path.glob(".published.previous-*"))
+            backup.rename(stolen)
+            _write_tree(backup, "foreign.txt", "preserve")
+            (destination / "late.txt").write_text("late", encoding="utf-8")
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        lose_backup_after_publish,
+    )
+
+    with pytest.raises(RuntimeError, match="previous output remains isolated"):
+        publish_staged_directory(stage, destination)
+
+    assert not destination.exists()
+    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    backups = list(tmp_path.glob(".published.previous-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
+
+
+def test_published_callback_quarantines_new_before_lost_backup_check(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-old"
+
+    def lose_backup_during_validation(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        assert reader.read_bytes("new.txt", max_bytes=16) == b"new"
+        backup = next(tmp_path.glob(".published.previous-*"))
+        backup.rename(stolen)
+        _write_tree(backup, "foreign.txt", "preserve")
+        raise RuntimeError("injected published validation failure")
+
+    with pytest.raises(RuntimeError, match="previous output remains isolated"):
+        publish_staged_directory(
+            stage,
+            destination,
+            validate_published_destination=lose_backup_during_validation,
+        )
+
+    assert not destination.exists()
+    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    backups = list(tmp_path.glob(".published.previous-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_fails_closed_without_safe_cleanup_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("orphan-only publication must not delete")
+
+    monkeypatch.setattr(atomic_module.os, "unlink", forbidden)
+    monkeypatch.setattr(atomic_module.os, "rmdir", forbidden)
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is not None
+    assert (orphan.path / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_removes_empty_sentinel_without_cleanup_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("first publication must not create/delete a sentinel")
+
+    monkeypatch.setattr(atomic_module.os, "unlink", forbidden)
+    monkeypatch.setattr(atomic_module.os, "rmdir", forbidden)
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is None
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+def test_expected_stage_root_preserves_substituted_cleanup_path(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    expected = capture_directory_ownership(stage)
+    stolen = tmp_path / "stolen-stage"
+    stage.rename(stolen)
+    _write_tree(stage, "foreign.txt", "preserve")
+
+    with pytest.raises(RuntimeError, match="root changed before publication"):
+        publish_staged_directory(
+            stage,
+            destination,
+            expected_stage_root_ownership=expected,
+        )
+    atomic_module.discard_owned_directory(stage, expected)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stolen / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (stage / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_publish_staged_directory_does_not_reacquire_swapped_backup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-old"
+    real_require = atomic_module._require_tree_ownership_at
+    injected = False
+
+    def swap_before_previous_check(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        expected: object,
+        label: str,
+        allow_root_rename: bool = False,
+    ) -> None:
+        nonlocal injected
+        if label == "previous destination" and not injected:
+            injected = True
+            path.rename(stolen)
+            _write_tree(path, "foreign.txt", "preserve")
+        real_require(
+            authority,
+            name,
+            path=path,
+            expected=expected,
+            label=label,
+            allow_root_rename=allow_root_rename,
+        )
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_require_tree_ownership_at",
+        swap_before_previous_check,
+    )
+
+    with pytest.raises(RuntimeError, match="previous output identity lost"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    backups = list(tmp_path.glob(".published.previous-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_publish_staged_directory_does_not_rollback_after_cleanup_starts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "one.txt", "one")
+    (destination / "two.txt").write_text("two", encoding="utf-8")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    unlink_calls = 0
+
+    def count_forbidden(*_args: object, **_kwargs: object) -> None:
+        nonlocal unlink_calls
+        unlink_calls += 1
+        raise AssertionError("destructive cleanup is unreachable")
+
+    monkeypatch.setattr(atomic_module.os, "unlink", count_forbidden)
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert unlink_calls == 0
+    assert orphan is not None
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (orphan.path / "one.txt").read_text(encoding="utf-8") == "one"
+    assert (orphan.path / "two.txt").read_text(encoding="utf-8") == "two"
 
 
 @pytest.mark.parametrize(
@@ -333,8 +1871,9 @@ def test_publish_staged_directory_bounds_builtin_ownership_scan(
     files: dict[str, str],
     error: str,
 ) -> None:
-    destination = tmp_path / "published"
-    stage = tmp_path / "stage"
+    short_names = constant == "_MAX_OWNERSHIP_COMPONENT_BYTES"
+    destination = tmp_path / ("d" if short_names else "published")
+    stage = tmp_path / ("s" if short_names else "stage")
     stage.mkdir()
     for name, content in files.items():
         (stage / name).write_text(content, encoding="utf-8")
@@ -344,8 +1883,6 @@ def test_publish_staged_directory_bounds_builtin_ownership_scan(
         publish_staged_directory(stage, destination)
 
     assert not destination.exists()
-    for name, content in files.items():
-        assert (stage / name).read_text(encoding="utf-8") == content
 
 
 def test_directory_ownership_is_independent_of_entry_order(tmp_path: Path) -> None:
@@ -487,16 +2024,13 @@ def test_expected_destination_ownership_rejects_identical_root_swap(
     tmp_path: Path,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     expected = capture_directory_ownership(destination)
     stolen = tmp_path / "stolen"
     destination.rename(stolen)
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
+    _write_tree(stage, "new.txt", "new")
 
     with pytest.raises(RuntimeError, match="changed before directory publication"):
         publish_staged_directory(
@@ -507,358 +2041,6 @@ def test_expected_destination_ownership_rejects_identical_root_swap(
 
     assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
     assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-
-
-def test_expected_stage_root_preserves_substituted_cleanup_path(
-    tmp_path: Path,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    expected = capture_directory_ownership(stage)
-    stolen = tmp_path / "stolen-stage"
-    stage.rename(stolen)
-    stage.mkdir()
-    (stage / "foreign.txt").write_text("preserve", encoding="utf-8")
-
-    with pytest.raises(RuntimeError, match="root changed before publication"):
-        publish_staged_directory(
-            stage,
-            destination,
-            expected_stage_root_ownership=expected,
-        )
-    atomic_module.discard_owned_directory(stage, expected)
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert stolen.is_dir()
-    assert (stage / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-
-
-def test_publish_staged_directory_restores_old_tree_on_scan_interrupt(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_require = atomic_module._require_tree_ownership
-
-    def interrupt_moved_tree(path, expected, *, label):
-        if label == "moved destination":
-            raise KeyboardInterrupt("injected ownership interruption")
-        return real_require(path, expected, label=label)
-
-    monkeypatch.setattr(
-        atomic_module,
-        "_require_tree_ownership",
-        interrupt_moved_tree,
-    )
-
-    with pytest.raises(KeyboardInterrupt, match="ownership interruption"):
-        publish_staged_directory(stage, destination)
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.previous-*"))
-
-
-def test_publish_restores_old_tree_when_moved_lstat_is_interrupted(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_directory_or_missing = atomic_module._directory_or_missing
-
-    def interrupt_moved_lstat(path: Path, *, label: str):
-        if label == "moved destination":
-            raise KeyboardInterrupt("injected moved lstat interruption")
-        return real_directory_or_missing(path, label=label)
-
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_or_missing",
-        interrupt_moved_lstat,
-    )
-
-    with pytest.raises(KeyboardInterrupt, match="moved lstat interruption"):
-        publish_staged_directory(stage, destination)
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.previous-*"))
-
-
-def test_publish_restores_old_tree_when_rename_completes_then_interrupts(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_replace = atomic_module.os.replace
-
-    def interrupt_after_old_rename(source, target):
-        result = real_replace(source, target)
-        if Path(source) == destination and Path(target).name.startswith(
-            ".published.previous-"
-        ):
-            raise KeyboardInterrupt("injected post-rename interruption")
-        return result
-
-    monkeypatch.setattr(atomic_module.os, "replace", interrupt_after_old_rename)
-
-    with pytest.raises(KeyboardInterrupt, match="post-rename interruption"):
-        publish_staged_directory(stage, destination)
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.previous-*"))
-
-
-def test_publish_restores_old_tree_when_final_stage_lstat_is_interrupted(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_directory_or_missing = atomic_module._directory_or_missing
-    staged_calls = 0
-
-    def interrupt_final_stage_lstat(path: Path, *, label: str):
-        nonlocal staged_calls
-        if label == "staged directory":
-            staged_calls += 1
-            if staged_calls == 3:
-                raise KeyboardInterrupt("injected final stage lstat interruption")
-        return real_directory_or_missing(path, label=label)
-
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_or_missing",
-        interrupt_final_stage_lstat,
-    )
-
-    with pytest.raises(KeyboardInterrupt, match="final stage lstat interruption"):
-        publish_staged_directory(stage, destination)
-
-    assert staged_calls == 3
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.previous-*"))
-
-
-def test_first_publication_works_without_safe_ownership_fds(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    monkeypatch.setattr(atomic_module, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
-
-    publish_staged_directory(
-        stage,
-        destination,
-        expected_destination_ownership=None,
-        validate_staged_directory=lambda _path: None,
-        validate_published_destination=lambda _path: None,
-    )
-
-    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
-
-
-def test_existing_publication_fails_closed_without_safe_ownership_fds(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    monkeypatch.setattr(atomic_module, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
-
-    with pytest.raises(RuntimeError, match="non-empty trees"):
-        publish_staged_directory(
-            stage,
-            destination,
-            validate_staged_directory=lambda _path: None,
-            validate_published_destination=lambda _path: None,
-        )
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-
-
-def test_publish_staged_directory_quarantines_failed_published_identity(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_replace = os.replace
-
-    def mutate_after_publish(source, target):
-        result = real_replace(source, target)
-        if Path(source) == stage and Path(target) == destination:
-            (destination / "late.txt").write_text("late", encoding="utf-8")
-        return result
-
-    monkeypatch.setattr(atomic_module.os, "replace", mutate_after_publish)
-
-    with pytest.raises(RuntimeError, match="quarantined"):
-        publish_staged_directory(stage, destination)
-
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
-    assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert not stage.exists()
-
-
-def test_published_callback_cannot_bypass_exact_tree_token(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_replace = os.replace
-
-    def add_empty_directory_after_publish(source, target):
-        result = real_replace(source, target)
-        if Path(source) == stage and Path(target) == destination:
-            (destination / "late-empty").mkdir()
-        return result
-
-    monkeypatch.setattr(atomic_module.os, "replace", add_empty_directory_after_publish)
-
-    with pytest.raises(RuntimeError, match="quarantined"):
-        publish_staged_directory(
-            stage,
-            destination,
-            validate_staged_directory=lambda _path: None,
-            validate_published_destination=lambda _path: None,
-        )
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "late-empty").is_dir()
-
-
-def test_published_boundary_quarantines_new_before_lost_backup_check(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    stolen = tmp_path / "stolen-old"
-    real_replace = os.replace
-
-    def lose_backup_after_publish(source, target):
-        result = real_replace(source, target)
-        if Path(source) == stage and Path(target) == destination:
-            backup = next(tmp_path.glob(".published.previous-*"))
-            backup.rename(stolen)
-            backup.mkdir()
-            (backup / "foreign.txt").write_text("preserve", encoding="utf-8")
-            (destination / "late.txt").write_text("late", encoding="utf-8")
-        return result
-
-    monkeypatch.setattr(atomic_module.os, "replace", lose_backup_after_publish)
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "suspect output was quarantined at .*previous output identity lost; "
-            "active destination is absent"
-        ),
-    ):
-        publish_staged_directory(stage, destination)
-
-    assert not destination.exists()
-    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
-    backups = list(tmp_path.glob(".published.previous-*"))
-    assert len(backups) == 1
-    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
-    assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
-
-
-def test_published_callback_quarantines_new_before_lost_backup_check(
-    tmp_path: Path,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    stolen = tmp_path / "stolen-old"
-
-    def lose_backup_during_published_validation(_path: Path) -> None:
-        backup = next(tmp_path.glob(".published.previous-*"))
-        backup.rename(stolen)
-        backup.mkdir()
-        (backup / "foreign.txt").write_text("preserve", encoding="utf-8")
-        raise RuntimeError("injected published-token validation failure")
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "suspect output was quarantined at .*previous output identity lost; "
-            "active destination is absent"
-        ),
-    ):
-        publish_staged_directory(
-            stage,
-            destination,
-            validate_published_destination=lose_backup_during_published_validation,
-        )
-
-    assert not destination.exists()
-    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
-    backups = list(tmp_path.glob(".published.previous-*"))
-    assert len(backups) == 1
-    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
 
 
 def test_publish_staged_directory_rejects_mounted_tree_before_publication(
@@ -870,219 +2052,19 @@ def test_publish_staged_directory_rejects_mounted_tree_before_publication(
     mounted.mkdir(parents=True)
     (mounted / "external.txt").write_text("preserve", encoding="utf-8")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    original_mount_check = atomic_module._path_is_mount_point
+    _write_tree(stage, "new.txt", "new")
+    real_mount_check = atomic_module._path_is_mount_point
 
-    def fake_mount_check(
-        path: Path,
-        **kwargs: object,
-    ) -> bool:
-        return Path(path).name == "mounted" or original_mount_check(path, **kwargs)
+    def fake_mount_check(path: Path, **kwargs: object) -> bool:
+        return Path(path).name == "mounted" or real_mount_check(path, **kwargs)
 
     monkeypatch.setattr(atomic_module, "_path_is_mount_point", fake_mount_check)
 
     with pytest.raises(RuntimeError, match="ownership scan refuses mounted"):
         publish_staged_directory(stage, destination)
 
-    assert (destination / "mounted" / "external.txt").read_text(
-        encoding="utf-8"
-    ) == "preserve"
+    assert (mounted / "external.txt").read_text(encoding="utf-8") == "preserve"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.quarantine-*"))
-
-
-def test_publish_staged_directory_fails_closed_without_safe_cleanup_fds(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "foreign.txt").write_text("preserve", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    monkeypatch.setattr(atomic_module, "_SAFE_REMOVAL_DIRECTORY_FDS", False)
-
-    with pytest.raises(RuntimeError, match="safe cleanup validation"):
-        publish_staged_directory(stage, destination)
-
-    assert (destination / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
-
-
-def test_publish_staged_directory_removes_empty_sentinel_without_cleanup_fds(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    monkeypatch.setattr(atomic_module, "_SAFE_REMOVAL_DIRECTORY_FDS", False)
-
-    publish_staged_directory(stage, destination)
-
-    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.previous-*"))
-
-
-def test_publish_staged_directory_rejects_real_stage_swap_before_destination_rename(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    expected_stage_identity = atomic_module._directory_identity(stage.lstat())
-    stolen = tmp_path / "stolen-stage"
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
-
-    def swap_stage_then_allocate(*args, **kwargs):
-        allocated = real_mkdtemp(*args, **kwargs)
-        stage.rename(stolen)
-        stage.mkdir()
-        (stage / "foreign.txt").write_text("preserve", encoding="utf-8")
-        return allocated
-
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", swap_stage_then_allocate)
-
-    with pytest.raises(RuntimeError, match="before destination publication"):
-        publish_staged_directory(
-            stage,
-            destination,
-            expected_stage_identity=expected_stage_identity,
-        )
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stolen / "new.txt").read_text(encoding="utf-8") == "new"
-    assert (stage / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-
-
-def test_publish_staged_directory_does_not_reacquire_swapped_backup(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    stolen = tmp_path / "stolen-old"
-    original_remove = atomic_module._remove_owned_directory
-
-    def swap_backup_then_remove(
-        path: Path,
-        expected_identity: tuple[int, ...],
-        **kwargs: object,
-    ) -> None:
-        path.rename(stolen)
-        path.mkdir()
-        (path / "foreign.txt").write_text("preserve", encoding="utf-8")
-        original_remove(path, expected_identity, **kwargs)
-
-    monkeypatch.setattr(
-        atomic_module,
-        "_remove_owned_directory",
-        swap_backup_then_remove,
-    )
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "publication committed; cleanup incomplete; previous output identity lost"
-        ),
-    ):
-        publish_staged_directory(stage, destination)
-
-    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
-    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
-    backups = list(tmp_path.glob(".published.previous-*"))
-    assert len(backups) == 1
-    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-    assert not list(tmp_path.glob(".published.quarantine-*"))
-
-
-def test_publish_staged_directory_never_restores_swapped_callback_backup(
-    tmp_path: Path,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    stolen = tmp_path / "stolen-old"
-    callback_calls = 0
-
-    def swap_backup_on_second_validation(path: Path) -> None:
-        nonlocal callback_calls
-        callback_calls += 1
-        if callback_calls == 2:
-            path.rename(stolen)
-            path.mkdir()
-            (path / "foreign.txt").write_text("preserve", encoding="utf-8")
-            raise RuntimeError("injected second validation failure")
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "publication committed; cleanup incomplete; previous output identity lost"
-        ),
-    ):
-        publish_staged_directory(
-            stage,
-            destination,
-            validate_moved_destination=swap_backup_on_second_validation,
-        )
-
-    assert callback_calls == 2
-    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
-    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
-    backups = list(tmp_path.glob(".published.previous-*"))
-    assert len(backups) == 1
-    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-    assert not list(tmp_path.glob(".published.quarantine-*"))
-
-
-def test_publish_staged_directory_does_not_rollback_after_cleanup_starts(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "one.txt").write_text("one", encoding="utf-8")
-    (destination / "two.txt").write_text("two", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_unlink = atomic_module.os.unlink
-    unlink_calls = 0
-
-    def fail_second_unlink(path, *args, **kwargs):
-        nonlocal unlink_calls
-        unlink_calls += 1
-        if unlink_calls == 2:
-            raise OSError("injected second unlink failure")
-        return real_unlink(path, *args, **kwargs)
-
-    monkeypatch.setattr(atomic_module.os, "unlink", fail_second_unlink)
-
-    with pytest.raises(RuntimeError, match="publication committed; cleanup incomplete"):
-        publish_staged_directory(stage, destination)
-
-    assert unlink_calls == 2
-    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
-    backups = list(tmp_path.glob(".published.previous-*"))
-    assert len(backups) == 1
-    assert len(list(backups[0].iterdir())) == 1
-    assert not list(tmp_path.glob(".published.quarantine-*"))
 
 
 def test_quarantine_replace_failure_preserves_original_exception(
@@ -1092,16 +2074,20 @@ def test_quarantine_replace_failure_preserves_original_exception(
     destination = tmp_path / "published"
     destination.mkdir()
 
-    def fail_replace(_source, _target):
+    def fail_rename(
+        _src: str,
+        _dst: str,
+        _src_dir_fd: int,
+        _dst_dir_fd: int,
+    ) -> None:
         raise OSError("injected quarantine rename failure")
 
-    monkeypatch.setattr(atomic_module.os, "replace", fail_replace)
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", fail_rename)
 
     with pytest.raises(OSError, match="injected quarantine rename failure"):
         atomic_module._quarantine_destination(destination)
 
     assert destination.is_dir()
-    assert not list(tmp_path.glob(".published.quarantine-*"))
 
 
 def test_directory_check_rejects_windows_reparse_directory(
@@ -1116,3 +2102,2379 @@ def test_directory_check_rejects_windows_reparse_directory(
 
     with pytest.raises(ValueError, match="link"):
         atomic_module._directory_or_missing(tmp_path / "junction", label="target")
+
+
+def test_darwin_rename_uses_exclusive_renameatx_np(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[int, bytes, int, bytes, int]] = []
+
+    class FakeRename:
+        argtypes: object = None
+        restype: object = None
+
+        def __call__(
+            self,
+            source_fd: int,
+            source: bytes,
+            destination_fd: int,
+            destination: bytes,
+            flags: int,
+        ) -> int:
+            calls.append((source_fd, source, destination_fd, destination, flags))
+            return 0
+
+    fake_rename = FakeRename()
+    fake_libc = SimpleNamespace(renameatx_np=fake_rename)
+    monkeypatch.setattr(atomic_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        atomic_module.ctypes,
+        "CDLL",
+        lambda *_args, **_kwargs: fake_libc,
+    )
+
+    atomic_module._rename_noreplace_at("source", "target", 11, 12)
+
+    assert calls == [(11, b"source", 12, b"target", 0x4)]
+
+
+def test_darwin_exclusive_rename_preserves_existing_destination_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ExistingRename:
+        argtypes: object = None
+        restype: object = None
+
+        def __call__(self, *_args: object) -> int:
+            atomic_module.ctypes.set_errno(errno.EEXIST)
+            return -1
+
+    monkeypatch.setattr(atomic_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        atomic_module.ctypes,
+        "CDLL",
+        lambda *_args, **_kwargs: SimpleNamespace(renameatx_np=ExistingRename()),
+    )
+
+    with pytest.raises(FileExistsError):
+        atomic_module._rename_noreplace_at("source", "target", 11, 12)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires real macOS syscalls")
+def test_darwin_real_exclusive_rename_does_not_replace(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "source.txt").write_text("source", encoding="utf-8")
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    (destination / "destination.txt").write_text("destination", encoding="utf-8")
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(FileExistsError):
+            atomic_module._rename_noreplace_at(
+                source.name,
+                destination.name,
+                descriptor,
+                descriptor,
+            )
+    finally:
+        os.close(descriptor)
+
+    assert (source / "source.txt").read_text(encoding="utf-8") == "source"
+    assert (destination / "destination.txt").read_text(
+        encoding="utf-8"
+    ) == "destination"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires real macOS syscalls")
+def test_darwin_real_publication_reader_and_orphan_locator(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    observed: list[bytes] = []
+
+    def validate(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        observed.append(reader.read_bytes("new.txt", max_bytes=16))
+
+    orphan = publish_staged_directory(
+        stage,
+        destination,
+        validate_staged_directory=validate,
+        validate_published_destination=validate,
+    )
+
+    assert orphan is not None
+    assert observed == [b"new", b"new"]
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("old.txt", max_bytes=16))
+        == b"old"
+    )
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires real macOS syscalls")
+def test_darwin_real_authority_closes_fds_after_reader_failure(
+    tmp_path: Path,
+) -> None:
+    stage = tmp_path / "stage"
+    _write_tree(stage, "payload.txt", "payload")
+    before = len(os.listdir("/dev/fd"))
+
+    for _attempt in range(16):
+        authority = atomic_module._open_publication_authority(
+            tmp_path,
+            parent_resource=None,
+            expected_parent_identity=None,
+        )
+        try:
+            ownership = authority.capture_child(
+                stage.name,
+                path=stage,
+                label="stage",
+            )
+
+            def fail(reader: object) -> None:
+                assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+                reader.read_bytes("missing.txt", max_bytes=16)
+
+            with pytest.raises(ValueError, match="absent from captured ownership"):
+                authority.read_child(
+                    stage.name,
+                    path=stage,
+                    label="stage",
+                    expected_ownership=ownership,
+                    callback=fail,
+                )
+        finally:
+            authority.close()
+
+    assert len(os.listdir("/dev/fd")) <= before
+
+
+def test_publication_authority_has_no_proc_path_dependency() -> None:
+    atomic_source = inspect.getsource(atomic_module)
+    windows_source = inspect.getsource(windows_authority_module)
+    assert "/proc/self/fd" not in atomic_source
+    assert "/proc/self/fd" not in windows_source
+    assert "renameatx_np" in atomic_source
+    assert "SetFileInformationByHandle" in windows_source
+
+
+def test_windows_handle_primitives_are_owned_by_neutral_module() -> None:
+    atomic_source = inspect.getsource(atomic_module)
+    windows_source = inspect.getsource(windows_authority_module)
+    assert atomic_module._WindowsKernelApi is windows_authority_module.WindowsKernelApi
+    assert (
+        atomic_module._WindowsHandleMetadata
+        is windows_authority_module.WindowsHandleMetadata
+    )
+    assert (
+        atomic_module._WindowsDirectoryEntry
+        is windows_authority_module.WindowsDirectoryEntry
+    )
+    assert "class _WindowsKernelApi" not in atomic_source
+    assert "OpenFileById" not in atomic_source
+    assert "SetFileInformationByHandle" not in atomic_source
+    assert "OpenFileById" in windows_source
+    assert "SetFileInformationByHandle" in windows_source
+    assert "_atomic_directory" not in windows_source
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux fd accounting",
+)
+def test_linux_authority_closes_fds_after_preopen_authentication_failure(
+    tmp_path: Path,
+) -> None:
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    nested = stage / "nested"
+    _write_tree(nested, "payload.txt", "payload")
+    before = len(os.listdir("/proc/self/fd"))
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            stage.name,
+            path=stage,
+            label="stage",
+        )
+        original = nested / "payload.txt"
+        held = nested / ".payload.txt.held"
+        original.rename(held)
+        original.write_bytes(b"foreign")
+
+        def read_replaced_file(reader: object) -> None:
+            assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+            reader.read_bytes("nested/payload.txt", max_bytes=16)
+
+        with pytest.raises(RuntimeError, match="differs from captured ownership"):
+            authority.read_child(
+                stage.name,
+                path=stage,
+                label="stage",
+                expected_ownership=ownership,
+                callback=read_replaced_file,
+            )
+    finally:
+        authority.close()
+
+    assert len(os.listdir("/proc/self/fd")) <= before
+
+
+def test_windows_ownership_and_authenticated_reader_traverse_file_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    nested = api.add_directory(api.root_id, "nested")
+    nested_file = api.add_file(nested, "one.txt", b"one")
+    root_file = api.add_file(api.root_id, "two.txt", b"two")
+    root_handle = api.create_directory_handle(Path("C:/authority"))
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            root_handle,
+            Path("C:/authority"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+        reader = atomic_module.PublicationDirectoryReader(
+            Path("C:/authority"),
+            ownership.root_identity,
+            lambda required_root_file, allow_empty_root, entry_policy: (
+                atomic_module._capture_windows_directory_handle(
+                    api,
+                    root_handle,
+                    Path("C:/authority"),
+                    required_root_file=required_root_file,
+                    allow_empty_root=allow_empty_root,
+                    entry_policy=entry_policy,
+                )
+            ),
+            lambda relative, max_bytes, expected: (
+                atomic_module._open_windows_authenticated_file(
+                    api,
+                    root_handle,
+                    Path("C:/authority"),
+                    relative,
+                    max_bytes=max_bytes,
+                    expected=expected,
+                )
+            ),
+            ownership,
+        )
+        try:
+            snapshot = reader.authenticated_snapshot(
+                "nested/one.txt",
+                max_bytes=16,
+            )
+        finally:
+            reader._deactivate()
+    finally:
+        api.close(root_handle)
+
+    assert ownership.inventory == (
+        ("nested", "directory"),
+        ("nested/one.txt", "file"),
+        ("two.txt", "file"),
+    )
+    assert snapshot.read_bytes() == b"one"
+    assert snapshot.record.sha256 == hashlib.sha256(b"one").hexdigest()
+    opened_ids = {
+        file_id for _volume, file_id, _access, _directory in api.open_by_id_calls
+    }
+    assert {nested, nested_file, root_file} <= opened_ids
+
+
+def test_windows_ownership_rejects_zero_directory_entry_file_id() -> None:
+    api = _FakeWindowsApi()
+    api.add_file(api.root_id, "payload.txt", b"payload")
+    root_handle = api.create_directory_handle(Path("C:/authority"))
+    enumerate_directory = api.enumerate_directory
+
+    def enumerate_with_zero_id(handle: int) -> tuple[object, ...]:
+        return tuple(
+            atomic_module._WindowsDirectoryEntry(
+                name=entry.name,
+                file_id=0,
+                attributes=entry.attributes,
+            )
+            for entry in enumerate_directory(handle)
+        )
+
+    api.enumerate_directory = enumerate_with_zero_id  # type: ignore[method-assign]
+    try:
+        with pytest.raises(RuntimeError, match="reliable FILE_ID"):
+            atomic_module._capture_windows_directory_handle(
+                api,
+                root_handle,
+                Path("C:/authority"),
+                required_root_file=None,
+                allow_empty_root=False,
+                entry_policy=None,
+            )
+    finally:
+        api.close(root_handle)
+
+
+def test_windows_authority_closes_handles_after_reader_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    stage = api.add_directory(api.root_id, "stage")
+    api.add_file(stage, "payload.txt", b"payload")
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+
+    authority = atomic_module._open_windows_publication_authority(
+        Path("C:/authority"),
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            "stage",
+            path=Path("C:/authority/stage"),
+            label="stage",
+        )
+
+        def fail(reader: object) -> None:
+            assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+            reader.read_bytes("missing.txt", max_bytes=16)
+
+        with pytest.raises(ValueError, match="absent from captured ownership"):
+            authority.read_child(
+                "stage",
+                path=Path("C:/authority/stage"),
+                label="stage",
+                expected_ownership=ownership,
+                callback=fail,
+            )
+        wrong_root = replace(
+            ownership,
+            root_identity=(
+                ownership.root_identity[0],
+                ownership.root_identity[1] + 1,
+                *ownership.root_identity[2:],
+            ),
+        )
+        with pytest.raises(RuntimeError, match="differs from captured ownership"):
+            authority.read_child(
+                "stage",
+                path=Path("C:/authority/stage"),
+                label="stage",
+                expected_ownership=wrong_root,
+                callback=lambda _reader: None,
+            )
+    finally:
+        authority.close()
+
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_handle_rename_does_not_replace(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    _write_tree(source, "source.txt", "source")
+    destination = tmp_path / "destination"
+    _write_tree(destination, "destination.txt", "destination")
+    authority = atomic_module._open_windows_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        with pytest.raises(FileExistsError):
+            authority.rename_noreplace(source.name, destination.name)
+    finally:
+        authority.close()
+
+    assert (source / "source.txt").read_text(encoding="utf-8") == "source"
+    assert (destination / "destination.txt").read_text(
+        encoding="utf-8"
+    ) == "destination"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_publication_blocks_root_rename_and_reopens_orphan(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    held = tmp_path / "held"
+    observed: list[bytes] = []
+
+    def validate_stage(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        with pytest.raises(OSError):
+            stage.rename(held)
+        observed.append(reader.read_bytes("new.txt", max_bytes=16))
+
+    orphan = publish_staged_directory(
+        stage,
+        destination,
+        validate_staged_directory=validate_stage,
+        validate_published_destination=lambda reader: observed.append(
+            reader.read_bytes("new.txt", max_bytes=16)
+        ),
+    )
+
+    assert orphan is not None
+    assert observed == [b"new", b"new"]
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("old.txt", max_bytes=16))
+        == b"old"
+    )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_mode_contract_is_readonly_and_execute_neutral(
+    tmp_path: Path,
+) -> None:
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    writable = stage / "writable.bin"
+    writable.write_bytes(b"writable")
+    readonly = stage / "readonly.bin"
+    readonly.write_bytes(b"readonly")
+    readonly.chmod(stat.S_IREAD)
+    executable = stage / "tool.exe"
+    executable.write_bytes(b"tool")
+    executable.chmod(0o755)
+    try:
+        ownership = capture_directory_ownership(stage)
+        modes = {
+            record.path: record.mode
+            for record in atomic_module.directory_ownership_file_records(ownership)
+        }
+        assert modes == {
+            "readonly.bin": 0o444,
+            "tool.exe": 0o666,
+            "writable.bin": 0o666,
+        }
+
+        def require_posix_modes(
+            path: str,
+            kind: str,
+            mode: int,
+            _size: int,
+        ) -> None:
+            if kind == "file" and mode not in {0o644, 0o755}:
+                raise ValueError(f"unrepresentable portable mode: {path}")
+
+        with pytest.raises(ValueError, match="unrepresentable portable mode"):
+            capture_directory_ownership(stage, entry_policy=require_posix_modes)
+    finally:
+        readonly.chmod(stat.S_IWRITE)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_publishable_stage_rejects_hard_link(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "payload.txt", "payload")
+    alias = tmp_path / "payload-alias.txt"
+    os.link(stage / "payload.txt", alias)
+
+    with pytest.raises(RuntimeError, match="external hard link"):
+        publish_staged_directory(stage, destination)
+
+    assert alias.read_text(encoding="utf-8") == "payload"
+    assert (stage / "payload.txt").read_text(encoding="utf-8") == "payload"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_authority_closes_handles_after_reader_failure(
+    tmp_path: Path,
+) -> None:
+    import ctypes.wintypes as wintypes
+
+    kernel32 = atomic_module.ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.GetProcessHandleCount.argtypes = (
+        wintypes.HANDLE,
+        atomic_module.ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.GetProcessHandleCount.restype = wintypes.BOOL
+
+    def handle_count() -> int:
+        count = wintypes.DWORD()
+        if not kernel32.GetProcessHandleCount(
+            kernel32.GetCurrentProcess(),
+            atomic_module.ctypes.byref(count),
+        ):
+            raise atomic_module.ctypes.WinError(atomic_module.ctypes.get_last_error())
+        return int(count.value)
+
+    stage = tmp_path / "stage"
+    _write_tree(stage, "payload.txt", "payload")
+    before = handle_count()
+    for _attempt in range(16):
+        authority = atomic_module._open_windows_publication_authority(
+            tmp_path,
+            parent_resource=None,
+            expected_parent_identity=None,
+        )
+        try:
+            ownership = authority.capture_child(
+                stage.name,
+                path=stage,
+                label="stage",
+            )
+
+            def fail(reader: object) -> None:
+                assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+                reader.read_bytes("missing.txt", max_bytes=16)
+
+            with pytest.raises(ValueError, match="absent from captured ownership"):
+                authority.read_child(
+                    stage.name,
+                    path=stage,
+                    label="stage",
+                    expected_ownership=ownership,
+                    callback=fail,
+                )
+        finally:
+            authority.close()
+
+    assert handle_count() <= before
+
+
+def test_windows_authority_renames_source_handle_without_replace_or_share_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    stage = api.add_directory(api.root_id, "stage")
+    api.add_file(stage, "payload.txt", b"payload")
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+
+    authority = atomic_module._open_windows_publication_authority(
+        Path("C:/authority"),
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            "stage",
+            path=Path("C:/authority/stage"),
+            label="stage",
+        )
+        authority.rename_noreplace("stage", "published")
+    finally:
+        authority.close()
+
+    assert ownership.inventory == (("payload.txt", "file"),)
+    assert api.rename_calls
+    source_opens = [
+        call
+        for call in api.open_by_id_calls
+        if call[1] == stage and call[2] & atomic_module._WINDOWS_DELETE
+    ]
+    assert source_opens
+    implementation = inspect.getsource(atomic_module._WindowsKernelApi)
+    assert "ReplaceIfExists = False" in implementation
+    assert "FILE_SHARE_DELETE" not in implementation
+
+
+def test_windows_stage_gate_rejects_external_file_id_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    stage = api.add_directory(api.root_id, "stage")
+    payload = api.add_file(stage, "payload.txt", b"payload")
+    api.nodes[payload]["nlink"] = 2
+    root_handle = api._new_handle(stage)
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            root_handle,
+            Path("C:/authority/stage"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+    finally:
+        api.close(root_handle)
+
+    with pytest.raises(RuntimeError, match="external hard link"):
+        atomic_module.require_publishable_directory_ownership(ownership)
+    assert api.nodes[payload]["data"] == b"payload"
+
+
+def test_windows_modes_follow_readonly_attributes_without_posix_fabrication() -> None:
+    writable_file = atomic_module._windows_mode_from_attributes(0)
+    readonly_file = atomic_module._windows_mode_from_attributes(
+        atomic_module._WINDOWS_FILE_ATTRIBUTE_READONLY
+    )
+    writable_directory = atomic_module._windows_mode_from_attributes(
+        atomic_module._WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+    )
+    readonly_directory = atomic_module._windows_mode_from_attributes(
+        atomic_module._WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+        | atomic_module._WINDOWS_FILE_ATTRIBUTE_READONLY
+    )
+
+    assert stat.S_IMODE(writable_file) == 0o666
+    assert stat.S_IMODE(readonly_file) == 0o444
+    assert stat.S_IMODE(writable_directory) == 0o777
+    assert stat.S_IMODE(readonly_directory) == 0o555
+
+
+@pytest.mark.parametrize(
+    ("name", "error"),
+    [
+        ("payload:stream", "canonical Windows"),
+        ("CON", "canonical Windows"),
+        ("trailing.", "canonical Windows"),
+        ("trailing ", "canonical Windows"),
+    ],
+)
+def test_windows_authority_rejects_aliased_child_names(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    error: str,
+) -> None:
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    with pytest.raises(ValueError, match=error):
+        atomic_module._simple_child_name(name, label="child")
+
+
+def test_publishable_stage_rejects_external_posix_hard_link(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "payload.txt", "payload")
+    alias = tmp_path / "payload-alias.txt"
+    os.link(stage / "payload.txt", alias)
+
+    with pytest.raises(RuntimeError, match="external hard link"):
+        publish_staged_directory(stage, destination)
+
+    assert alias.read_text(encoding="utf-8") == "payload"
+    assert (stage / "payload.txt").read_text(encoding="utf-8") == "payload"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+
+
+def test_legacy_destination_hard_link_can_be_observed_and_isolated(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    alias = tmp_path / "old-alias.txt"
+    os.link(destination / "old.txt", alias)
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is not None
+    assert alias.read_text(encoding="utf-8") == "old"
+    assert (orphan.path / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_directory_orphan_reopens_through_parent_authority(tmp_path: Path) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is not None
+    rebound = orphan.rebind()
+    assert rebound.digest == orphan.ownership_digest
+    saved_reader: list[object] = []
+
+    def read_old(reader: object) -> bytes:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        saved_reader.append(reader)
+        return reader.read_bytes("old.txt", max_bytes=16)
+
+    assert orphan.reopen(read_old) == b"old"
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_reader[0].capture_ownership()
+
+
+def test_publication_reader_streams_and_authenticates_on_context_exit(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    payload = (b"0123456789abcdef" * 131_072) + b"tail"
+    stage.mkdir()
+    (stage / "documents.json").write_bytes(payload)
+    records: list[object] = []
+    prefixes: list[bytes] = []
+
+    def validate(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        with reader.open_authenticated_file(
+            "documents.json",
+            max_bytes=4 << 20,
+        ) as authenticated:
+            prefixes.append(authenticated.read(17))
+            # Stop early deliberately. Context exit must drain and authenticate
+            # the same handle without retaining the complete payload.
+        records.append(authenticated.record)
+
+    orphan = publish_staged_directory(
+        stage,
+        destination,
+        validate_staged_directory=validate,
+        validate_published_destination=validate,
+    )
+
+    assert orphan is None
+    assert prefixes == [payload[:17], payload[:17]]
+    assert all(
+        record.sha256 == hashlib.sha256(payload).hexdigest() for record in records
+    )
+
+
+def test_directory_orphan_rebind_rejects_replaced_parent(tmp_path: Path) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    orphan = publish_staged_directory(stage, destination)
+    assert orphan is not None
+    moved_parent = tmp_path / "moved-authority"
+    parent.rename(moved_parent)
+    parent.mkdir()
+
+    with pytest.raises(RuntimeError, match="does not match authority"):
+        orphan.rebind()
+
+    assert (moved_parent / orphan.path.name / "old.txt").read_text(
+        encoding="utf-8"
+    ) == "old"
+
+
+@pytest.mark.parametrize("window", ["stage", "moved", "published"])
+def test_reader_callbacks_survive_reversible_parent_swap(
+    tmp_path: Path,
+    window: str,
+) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    moved_parent = tmp_path / f"moved-parent-{window}"
+    foreign_parent = tmp_path / f"foreign-parent-{window}"
+    injected = False
+    observed: list[bytes] = []
+
+    def validate(reader: object) -> None:
+        nonlocal injected
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        expected_name = "old.txt" if window == "moved" else "new.txt"
+        if not injected:
+            injected = True
+            if window == "stage":
+                active_name = stage.name
+            elif window == "moved":
+                active_name = next(parent.glob(".published.previous-*")).name
+            else:
+                active_name = destination.name
+            parent.rename(moved_parent)
+            parent.mkdir()
+            _write_tree(parent / active_name, "foreign.txt", "foreign")
+            observed.append(reader.read_bytes(expected_name, max_bytes=16))
+            parent.rename(foreign_parent)
+            moved_parent.rename(parent)
+        else:
+            observed.append(reader.read_bytes(expected_name, max_bytes=16))
+
+    callbacks = {
+        "stage": {"validate_staged_directory": validate},
+        "moved": {"validate_moved_destination": validate},
+        "published": {"validate_published_destination": validate},
+    }
+    orphan = publish_staged_directory(
+        stage,
+        destination,
+        **callbacks[window],
+    )
+
+    assert orphan is not None
+    assert observed and set(observed) == ({b"old"} if window == "moved" else {b"new"})
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    foreign_children = list(foreign_parent.iterdir())
+    assert len(foreign_children) == 1
+    assert (foreign_children[0] / "foreign.txt").read_text(
+        encoding="utf-8"
+    ) == "foreign"
+
+
+@pytest.mark.parametrize("window", ["stage", "moved", "published"])
+def test_reader_callbacks_survive_reversible_root_swap(
+    tmp_path: Path,
+    window: str,
+) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    held = parent / f"held-{window}"
+    foreign = parent / f"foreign-{window}"
+    injected = False
+    observed: list[bytes] = []
+
+    def validate(reader: object) -> None:
+        nonlocal injected
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        expected_name = "old.txt" if window == "moved" else "new.txt"
+        if not injected:
+            injected = True
+            if window == "stage":
+                active = stage
+            elif window == "moved":
+                active = next(parent.glob(".published.previous-*"))
+            else:
+                active = destination
+            active.rename(held)
+            _write_tree(active, "foreign.txt", "foreign")
+            observed.append(reader.read_bytes(expected_name, max_bytes=16))
+            active.rename(foreign)
+            held.rename(active)
+        else:
+            observed.append(reader.read_bytes(expected_name, max_bytes=16))
+
+    callbacks = {
+        "stage": {"validate_staged_directory": validate},
+        "moved": {"validate_moved_destination": validate},
+        "published": {"validate_published_destination": validate},
+    }
+    if window == "stage":
+        with pytest.raises(RuntimeError, match="staged directory changed"):
+            publish_staged_directory(stage, destination, **callbacks[window])
+        assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    else:
+        orphan = publish_staged_directory(
+            stage,
+            destination,
+            **callbacks[window],
+        )
+        assert orphan is not None
+        assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+    assert observed and set(observed) == ({b"old"} if window == "moved" else {b"new"})
+    assert (foreign / "foreign.txt").read_text(encoding="utf-8") == "foreign"
+
+
+@pytest.mark.parametrize("window", ["stage", "moved", "published"])
+def test_reader_rejects_suppressed_file_swap_authentication_failure(
+    tmp_path: Path,
+    window: str,
+) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    evil_store = tmp_path / f"evil-{window}.txt"
+    injected = False
+    suppressed: list[bool] = []
+
+    def validate(reader: object) -> None:
+        nonlocal injected
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        if injected:
+            return
+        injected = True
+        expected_name = "old.txt" if window == "moved" else "new.txt"
+        if window == "stage":
+            active = stage
+        elif window == "moved":
+            active = next(parent.glob(".published.previous-*"))
+        else:
+            active = destination
+        expected_file = active / expected_name
+        held_original = active / f".{expected_name}.held"
+        expected_file.rename(held_original)
+        expected_file.write_bytes(b"foreign bytes")
+        try:
+            try:
+                reader.read_bytes(expected_name, max_bytes=64)
+            except RuntimeError:
+                suppressed.append(True)
+        finally:
+            expected_file.rename(evil_store)
+            held_original.rename(expected_file)
+
+    callbacks = {
+        "stage": {"validate_staged_directory": validate},
+        "moved": {"validate_moved_destination": validate},
+        "published": {"validate_published_destination": validate},
+    }
+    with pytest.raises(RuntimeError) as raised:
+        publish_staged_directory(stage, destination, **callbacks[window])
+
+    messages: list[str] = []
+    pending: list[BaseException | None] = [raised.value]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        messages.append(str(current))
+        pending.extend([current.__cause__, current.__context__])
+    assert any("suppressed authentication failure" in message for message in messages)
+    assert suppressed == [True]
+    assert evil_store.read_bytes() == b"foreign bytes"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    if window in {"stage", "moved"}:
+        assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    else:
+        quarantines = list(parent.glob(".published.quarantine-*"))
+        assert len(quarantines) == 1
+        assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publication_reader_builds_expected_lookup_maps_once(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    for index in range(1_000):
+        (stage / f"file-{index:04d}.txt").touch()
+    observations: list[tuple[int, int]] = []
+
+    def validate(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        records = reader.file_records()
+        assert reader.file_records() is records
+        record_map_id = id(reader._records_by_path)
+        entry_map_id = id(reader._entries_by_path)
+        for record in records:
+            expected = reader._expected_file(PurePosixPath(record.path))
+            assert expected.record is record
+        observations.append((record_map_id, entry_map_id))
+        assert id(reader._records_by_path) == record_map_id
+        assert id(reader._entries_by_path) == entry_map_id
+
+    orphan = publish_staged_directory(
+        stage,
+        destination,
+        validate_staged_directory=validate,
+    )
+
+    assert orphan is None
+    assert len(observations) == 1
+    assert len(list(destination.iterdir())) == 1_000
+
+
+def test_reopen_authenticated_directory_freshly_matches_before_and_after(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    parent_descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        parent_identity = publication_parent_identity(parent_descriptor)
+    finally:
+        os.close(parent_descriptor)
+    capture_calls = 0
+    capture_descriptor = atomic_module._capture_posix_directory_descriptor
+
+    def count_capture(*args: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        return capture_descriptor(*args, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_capture_posix_directory_descriptor",
+        count_capture,
+    )
+    saved_readers: list[object] = []
+
+    def consume(reader: object) -> tuple[bytes, tuple[tuple[str, str], ...]]:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        saved_readers.append(reader)
+        return reader.read_bytes("payload.txt", max_bytes=16), reader.inventory()
+
+    result = atomic_module.reopen_authenticated_directory(
+        directory,
+        ownership,
+        consume,
+        expected_parent_identity=parent_identity,
+    )
+
+    assert result == (b"payload", (("payload.txt", "file"),))
+    assert capture_calls == 2
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
+def test_reopen_authenticated_directory_rejects_reversible_root_swap(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    held = tmp_path / "held"
+    foreign = tmp_path / "foreign"
+    observed: list[bytes] = []
+
+    def consume(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        directory.rename(held)
+        _write_tree(directory, "payload.txt", "foreign")
+        try:
+            observed.append(reader.read_bytes("payload.txt", max_bytes=16))
+        finally:
+            directory.rename(foreign)
+            held.rename(directory)
+
+    with pytest.raises(RuntimeError, match="changed while it was consumed"):
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            consume,
+        )
+
+    assert observed == [b"payload"]
+    assert (directory / "payload.txt").read_text(encoding="utf-8") == "payload"
+    assert (foreign / "payload.txt").read_text(encoding="utf-8") == "foreign"
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux fd accounting",
+)
+def test_reopen_authenticated_directory_rejects_suppressed_error_without_fd_leak(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    evil = tmp_path / "evil.txt"
+    before = len(os.listdir("/proc/self/fd"))
+    suppressed: list[bool] = []
+
+    def consume(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        payload = directory / "payload.txt"
+        held = directory / ".payload.txt.held"
+        payload.rename(held)
+        payload.write_bytes(b"foreign")
+        try:
+            try:
+                reader.read_bytes("payload.txt", max_bytes=16)
+            except RuntimeError:
+                suppressed.append(True)
+        finally:
+            payload.rename(evil)
+            held.rename(payload)
+
+    with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            consume,
+        )
+
+    assert suppressed == [True]
+    assert evil.read_bytes() == b"foreign"
+    assert (directory / "payload.txt").read_bytes() == b"payload"
+    assert len(os.listdir("/proc/self/fd")) <= before
+
+
+def test_reopen_authenticated_directory_fake_windows_survives_root_swap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    directory_id = api.add_directory(api.root_id, "existing")
+    api.add_file(directory_id, "payload.txt", b"payload")
+    foreign_id = api.add_directory()
+    api.add_file(foreign_id, "payload.txt", b"foreign")
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_require_publication_api", lambda: None)
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    path = Path("C:/authority/existing")
+    authority = atomic_module._open_windows_publication_authority(
+        path.parent,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            path.name,
+            path=path,
+            label="existing",
+        )
+    finally:
+        authority.close()
+    assert api.handles == {}
+
+    def consume(reader: object) -> bytes:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        root_children = api.nodes[api.root_id]["children"]
+        assert isinstance(root_children, dict)
+        root_children["held"] = root_children.pop("existing")
+        root_children["existing"] = foreign_id
+        try:
+            return reader.read_bytes("payload.txt", max_bytes=16)
+        finally:
+            root_children["foreign"] = root_children.pop("existing")
+            root_children["existing"] = root_children.pop("held")
+
+    assert (
+        atomic_module.reopen_authenticated_directory(path, ownership, consume)
+        == b"payload"
+    )
+    assert api.handles == {}
+    root_children = api.nodes[api.root_id]["children"]
+    assert isinstance(root_children, dict)
+    assert root_children["existing"] == directory_id
+    assert root_children["foreign"] == foreign_id
+
+
+def test_reopen_authenticated_directory_fake_windows_rejects_suppressed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    directory_id = api.add_directory(api.root_id, "existing")
+    original_id = api.add_file(directory_id, "payload.txt", b"payload")
+    foreign_id = api.add_file(directory_id, "foreign.txt", b"foreign")
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_require_publication_api", lambda: None)
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    path = Path("C:/authority/existing")
+    authority = atomic_module._open_windows_publication_authority(
+        path.parent,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            path.name,
+            path=path,
+            label="existing",
+        )
+    finally:
+        authority.close()
+    suppressed: list[bool] = []
+
+    def consume(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        children = api.nodes[directory_id]["children"]
+        assert isinstance(children, dict)
+        children["held.txt"] = children.pop("payload.txt")
+        children["payload.txt"] = children.pop("foreign.txt")
+        try:
+            try:
+                reader.read_bytes("payload.txt", max_bytes=16)
+            except RuntimeError:
+                suppressed.append(True)
+        finally:
+            children["foreign.txt"] = children.pop("payload.txt")
+            children["payload.txt"] = children.pop("held.txt")
+
+    with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+        atomic_module.reopen_authenticated_directory(path, ownership, consume)
+
+    assert suppressed == [True]
+    assert api.handles == {}
+    children = api.nodes[directory_id]["children"]
+    assert isinstance(children, dict)
+    assert children["payload.txt"] == original_id
+    assert children["foreign.txt"] == foreign_id
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_reopen_authenticated_directory_gates_swaps_and_handles(
+    tmp_path: Path,
+) -> None:
+    import ctypes.wintypes as wintypes
+
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    kernel32 = atomic_module.ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.GetProcessHandleCount.argtypes = (
+        wintypes.HANDLE,
+        atomic_module.ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.GetProcessHandleCount.restype = wintypes.BOOL
+
+    def handle_count() -> int:
+        count = wintypes.DWORD()
+        if not kernel32.GetProcessHandleCount(
+            kernel32.GetCurrentProcess(),
+            atomic_module.ctypes.byref(count),
+        ):
+            raise atomic_module.ctypes.WinError(atomic_module.ctypes.get_last_error())
+        return int(count.value)
+
+    held_root = tmp_path / "held-root"
+
+    def consume_original(reader: object) -> bytes:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        with pytest.raises(OSError):
+            directory.rename(held_root)
+        return reader.read_bytes("payload.txt", max_bytes=16)
+
+    assert (
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            consume_original,
+        )
+        == b"payload"
+    )
+
+    before = handle_count()
+    evil = tmp_path / "evil.txt"
+
+    def suppress_file_swap(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        payload = directory / "payload.txt"
+        held = directory / ".payload.txt.held"
+        payload.rename(held)
+        payload.write_bytes(b"foreign")
+        try:
+            try:
+                reader.read_bytes("payload.txt", max_bytes=16)
+            except RuntimeError:
+                pass
+        finally:
+            payload.rename(evil)
+            held.rename(payload)
+
+    with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            suppress_file_swap,
+        )
+
+    assert evil.read_bytes() == b"foreign"
+    assert (directory / "payload.txt").read_bytes() == b"payload"
+    assert handle_count() <= before
+
+
+def test_capture_directory_ownership_if_exists_captures_existing_tree(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+
+    ownership = atomic_module.capture_directory_ownership_if_exists(directory)
+
+    assert ownership is not None
+    assert ownership == capture_directory_ownership(directory)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux fd accounting",
+)
+def test_capture_directory_ownership_if_exists_does_not_bless_missing_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "appeared"
+    before = len(os.listdir("/proc/self/fd"))
+    child_metadata = atomic_module._PublicationAuthority.child_metadata
+    injected = False
+
+    def inject_after_missing(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> object | None:
+        nonlocal injected
+        observed = child_metadata(
+            authority,
+            name,
+            path=path,
+            label=label,
+        )
+        if observed is None and path == directory and not injected:
+            injected = True
+            _write_tree(directory, "foreign.txt", "foreign")
+        return observed
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "child_metadata",
+        inject_after_missing,
+    )
+
+    ownership = atomic_module.capture_directory_ownership_if_exists(directory)
+
+    assert ownership is None
+    assert injected
+    assert (directory / "foreign.txt").read_text(encoding="utf-8") == "foreign"
+    assert len(os.listdir("/proc/self/fd")) <= before
+    source = inspect.getsource(atomic_module.capture_directory_ownership_if_exists)
+    assert ".exists(" not in source
+    assert "except RuntimeError" not in source
+
+
+def test_capture_directory_ownership_if_exists_rejects_existing_root_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "original.txt", "original")
+    held = tmp_path / "held"
+    child_metadata = atomic_module._PublicationAuthority.child_metadata
+    observations = 0
+
+    def replace_after_first_observation(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> object | None:
+        nonlocal observations
+        observed = child_metadata(
+            authority,
+            name,
+            path=path,
+            label=label,
+        )
+        if path == directory and observed is not None:
+            observations += 1
+            if observations == 1:
+                directory.rename(held)
+                _write_tree(directory, "foreign.txt", "foreign")
+        return observed
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "child_metadata",
+        replace_after_first_observation,
+    )
+
+    with pytest.raises(RuntimeError, match="changed while it was captured"):
+        atomic_module.capture_directory_ownership_if_exists(directory)
+
+    assert (held / "original.txt").read_text(encoding="utf-8") == "original"
+    assert (directory / "foreign.txt").read_text(encoding="utf-8") == "foreign"
+
+
+@pytest.mark.parametrize("kind", ["file", "symlink"])
+def test_capture_directory_ownership_if_exists_rejects_unsafe_child_kind(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    child = tmp_path / "unsafe"
+    if kind == "file":
+        child.write_text("file", encoding="utf-8")
+    else:
+        child.symlink_to(tmp_path / "missing-target", target_is_directory=True)
+
+    with pytest.raises(ValueError, match="not a directory or is a link"):
+        atomic_module.capture_directory_ownership_if_exists(child)
+
+
+def test_capture_directory_ownership_if_exists_fake_windows_missing_race_closes_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    path = Path("C:/authority/appeared")
+    child_metadata = atomic_module._PublicationAuthority.child_metadata
+    injected = False
+
+    def inject_after_missing(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> object | None:
+        nonlocal injected
+        observed = child_metadata(
+            authority,
+            name,
+            path=path,
+            label=label,
+        )
+        if observed is None and not injected:
+            injected = True
+            foreign = api.add_directory(api.root_id, name)
+            api.add_file(foreign, "foreign.txt", b"foreign")
+        return observed
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "child_metadata",
+        inject_after_missing,
+    )
+
+    ownership = atomic_module.capture_directory_ownership_if_exists(path)
+
+    assert ownership is None
+    assert injected
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_capture_if_exists_missing_race_closes_handles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ctypes.wintypes as wintypes
+
+    directory = tmp_path / "appeared"
+    kernel32 = atomic_module.ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.GetProcessHandleCount.argtypes = (
+        wintypes.HANDLE,
+        atomic_module.ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.GetProcessHandleCount.restype = wintypes.BOOL
+
+    def handle_count() -> int:
+        count = wintypes.DWORD()
+        if not kernel32.GetProcessHandleCount(
+            kernel32.GetCurrentProcess(),
+            atomic_module.ctypes.byref(count),
+        ):
+            raise atomic_module.ctypes.WinError(atomic_module.ctypes.get_last_error())
+        return int(count.value)
+
+    atomic_module._windows_kernel_api()
+    before = handle_count()
+    child_metadata = atomic_module._PublicationAuthority.child_metadata
+    injected = False
+
+    def inject_after_missing(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> object | None:
+        nonlocal injected
+        observed = child_metadata(
+            authority,
+            name,
+            path=path,
+            label=label,
+        )
+        if observed is None and not injected:
+            injected = True
+            _write_tree(directory, "foreign.txt", "foreign")
+        return observed
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "child_metadata",
+        inject_after_missing,
+    )
+
+    ownership = atomic_module.capture_directory_ownership_if_exists(directory)
+
+    assert ownership is None
+    assert injected
+    assert (directory / "foreign.txt").read_text(encoding="utf-8") == "foreign"
+    assert handle_count() <= before
+
+
+def _call_with_interrupt_after_store(
+    function: object,
+    local_name: str,
+    callback: object,
+    *,
+    predicate: object | None = None,
+    error: BaseException,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    assert predicate is None or callable(predicate)
+    code = function.__code__
+    instructions = tuple(dis.get_instructions(function))
+    offsets_after_store = {
+        instructions[index + 1].offset
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_FAST" and instruction.argval == local_name
+    }
+    previous_trace = sys.gettrace()
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            event == "opcode"
+            and frame.f_code is code
+            and frame.f_lasti in offsets_after_store
+            and int(frame.f_locals.get(local_name, -1)) >= 0
+            and (predicate is None or predicate(frame.f_locals))
+        ):
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+
+
+def _posix_authority_resources(
+    authority: object,
+) -> atomic_module._PosixResourceOwner:
+    closure = authority._close_callback.__closure__ or ()
+    matches = [
+        cell.cell_contents
+        for cell in closure
+        if isinstance(cell.cell_contents, atomic_module._PosixResourceOwner)
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _assert_descriptor_closed(descriptor: int) -> None:
+    with pytest.raises(OSError) as caught:
+        os.fstat(descriptor)
+    assert caught.value.errno == errno.EBADF
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_owner_recovers_interrupt_after_open_result_store(tmp_path: Path) -> None:
+    owner = atomic_module._PosixResourceOwner()
+    error = KeyboardInterrupt("after os.open result store")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _call_with_interrupt_after_store(
+            atomic_module._PosixResourceOwner.open,
+            "descriptor",
+            lambda: owner.open(
+                tmp_path,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            ),
+            error=error,
+        )
+
+    assert caught.value is error
+    assert owner.closed
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_owner_closes_same_directory_after_permission_change(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "mutable-mode"
+    directory.mkdir()
+    directory.chmod(0o755)
+    owner = atomic_module._PosixResourceOwner()
+    descriptor = owner.open(
+        directory,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    before = os.fstat(descriptor)
+    try:
+        directory.chmod(0o700)
+        after = os.fstat(descriptor)
+        assert atomic_module._ownership_binding_identity(before) != (
+            atomic_module._ownership_binding_identity(after)
+        )
+        assert atomic_module._resource_owner_identity(before) == (
+            atomic_module._resource_owner_identity(after)
+        )
+
+        owner.close_all()
+
+        assert owner.closed
+        _assert_descriptor_closed(descriptor)
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError as exc:
+            if exc.errno != errno.EBADF:
+                raise
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_owner_retries_persistent_eio_after_permission_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "mutable-mode-eio"
+    directory.mkdir()
+    directory.chmod(0o755)
+    owner = atomic_module._PosixResourceOwner()
+    descriptor = owner.open(
+        directory,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    directory.chmod(0o700)
+    real_close = atomic_module.os.close
+    error = OSError(errno.EIO, "persistent close failure after chmod")
+
+    def fail_owned_descriptor(candidate: int) -> None:
+        if candidate == descriptor:
+            raise error
+        real_close(candidate)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", fail_owned_descriptor)
+        for _attempt in range(2):
+            with pytest.raises(OSError) as caught:
+                owner.close_all()
+            assert caught.value is error
+            assert not owner.closed
+            os.fstat(descriptor)
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        owner.close_all()
+
+    assert owner.closed
+    _assert_descriptor_closed(descriptor)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_factory_recovers_interrupt_in_child_open_registration(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "registration-child"
+    parent.mkdir()
+    error = SystemExit("after child descriptor store")
+
+    with pytest.raises(SystemExit) as caught:
+        _call_with_interrupt_after_store(
+            atomic_module._PosixResourceOwner.open,
+            "descriptor",
+            lambda: atomic_module._open_posix_publication_authority(
+                parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+            ),
+            predicate=lambda local: local["path"] == parent.name,
+            error=error,
+        )
+
+    assert caught.value is error
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_owner_recovers_interrupt_after_dup_result_store(tmp_path: Path) -> None:
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    owner = atomic_module._PosixResourceOwner()
+    error = KeyboardInterrupt("after os.dup result store")
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            _call_with_interrupt_after_store(
+                atomic_module._PosixResourceOwner.duplicate,
+                "duplicate",
+                lambda: owner.duplicate(descriptor),
+                error=error,
+            )
+        assert caught.value is error
+        assert owner.closed
+        os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_authority_handoff_closes_on_interrupt_before_caller_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "owned"
+    _write_tree(directory, "payload.txt", "payload")
+    real_open = atomic_module._open_posix_publication_authority
+    opened: list[object] = []
+    error = KeyboardInterrupt("after authority factory return")
+
+    def open_then_interrupt(*args: object, **kwargs: object) -> object:
+        authority = real_open(*args, **kwargs)
+        opened.append(authority)
+        raise error
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_open_posix_publication_authority",
+        open_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        capture_directory_ownership(directory)
+
+    assert caught.value is error
+    assert len(opened) == 1
+    authority = opened[0]
+    assert authority._closed
+    assert _posix_authority_resources(authority).closed
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_authority_close_before_close_interrupt_is_retryable_and_cleans_all(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    target = descriptors[-1]
+    real_close = atomic_module.os.close
+    error = KeyboardInterrupt("before real close")
+    injected = False
+
+    def interrupt_before_close(descriptor: int) -> None:
+        nonlocal injected
+        if descriptor == target and not injected:
+            injected = True
+            raise error
+        real_close(descriptor)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", interrupt_before_close)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is error
+        assert injected
+        assert not authority._closed
+        os.fstat(target)
+        for descriptor in descriptors[:-1]:
+            _assert_descriptor_closed(descriptor)
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        authority.close()
+
+    assert authority._closed
+    _assert_descriptor_closed(target)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_authority_close_after_close_system_exit_closes_everything(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    target = descriptors[-1]
+    real_close = atomic_module.os.close
+    error = SystemExit("after real close")
+    injected = False
+
+    def interrupt_after_close(descriptor: int) -> None:
+        nonlocal injected
+        real_close(descriptor)
+        if descriptor == target and not injected:
+            injected = True
+            raise error
+
+    monkeypatch.setattr(atomic_module.os, "close", interrupt_after_close)
+    with pytest.raises(SystemExit) as caught:
+        authority.close()
+
+    assert caught.value is error
+    assert injected
+    assert authority._closed
+    assert resources.closed
+    for descriptor in descriptors:
+        _assert_descriptor_closed(descriptor)
+    authority.close()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_authority_persistent_eio_retains_only_failed_owner_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    target = descriptors[-1]
+    real_close = atomic_module.os.close
+    error = OSError(errno.EIO, "persistent close failure")
+
+    def fail_target(descriptor: int) -> None:
+        if descriptor == target:
+            raise error
+        real_close(descriptor)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", fail_target)
+        for _attempt in range(2):
+            with pytest.raises(OSError) as caught:
+                authority.close()
+            assert caught.value is error
+            assert not authority._closed
+            os.fstat(target)
+        for descriptor in descriptors[:-1]:
+            _assert_descriptor_closed(descriptor)
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        authority.close()
+
+    assert authority._closed
+    _assert_descriptor_closed(target)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_authority_close_preserves_first_error_and_attempts_all(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    first_target, second_target = descriptors[-1], descriptors[-2]
+    real_close = atomic_module.os.close
+    first_error = KeyboardInterrupt("first close failure")
+    second_error = SystemExit("second close failure")
+
+    def fail_two(descriptor: int) -> None:
+        if descriptor == first_target:
+            raise first_error
+        if descriptor == second_target:
+            raise second_error
+        real_close(descriptor)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", fail_two)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is first_error
+        assert not authority._closed
+        notes = (
+            *getattr(first_error, "__notes__", ()),
+            *getattr(first_error, "_codenib_cleanup_notes", ()),
+        )
+        assert any("second close failure" in note for note in notes)
+        os.fstat(first_target)
+        os.fstat(second_target)
+        for descriptor in descriptors[:-2]:
+            _assert_descriptor_closed(descriptor)
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        authority.close()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_authority_owner_preserves_operation_error_over_close_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority_owner = atomic_module._PublicationAuthorityOwner()
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+        authority_owner=authority_owner,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    target = descriptors[-1]
+    real_close = atomic_module.os.close
+    primary_error = SystemExit("original operation interruption")
+    close_error = OSError(errno.EIO, "cleanup failure")
+
+    def fail_target(descriptor: int) -> None:
+        if descriptor == target:
+            raise close_error
+        real_close(descriptor)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", fail_target)
+        with pytest.raises(SystemExit) as caught:
+            with authority_owner:
+                raise primary_error
+        assert caught.value is primary_error
+        notes = (
+            *getattr(primary_error, "__notes__", ()),
+            *getattr(primary_error, "_codenib_cleanup_notes", ()),
+        )
+        assert any("cleanup failure" in note for note in notes)
+        assert not authority._closed
+        os.fstat(target)
+        for descriptor in descriptors[:-1]:
+            _assert_descriptor_closed(descriptor)
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        authority_owner.close()
+
+
+def test_publication_authority_close_preserves_close_error_over_state_probe() -> None:
+    close_error = KeyboardInterrupt("primary authority close interruption")
+    probe_error = SystemExit("secondary close-state interruption")
+
+    def fail_close(_resource: int) -> None:
+        raise close_error
+
+    def fail_probe() -> bool:
+        raise probe_error
+
+    authority = atomic_module._PublicationAuthority(
+        display_parent=Path("/authority"),
+        identity=(1, 2),
+        backend_tag="test",
+        resource=7,
+        close_callback=fail_close,
+        metadata_callback=lambda _name, _path, _label: None,
+        reader_callback=lambda *_args: None,
+        rename_callback=lambda _source, _destination: None,
+        verify_callback=lambda: None,
+        close_complete_callback=fail_probe,
+    )
+    authority_owner = atomic_module._PublicationAuthorityOwner()
+    authority_owner.install(authority)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        authority_owner.close()
+
+    assert caught.value is close_error
+    notes = (
+        *getattr(close_error, "__notes__", ()),
+        *getattr(close_error, "_codenib_cleanup_notes", ()),
+    )
+    assert any("secondary close-state interruption" in note for note in notes)
+    assert not authority._close_state
+    assert authority_owner.authority is authority
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_close_reconciliation_does_not_close_observable_reused_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    target = descriptors[-1]
+    foreign_path = tmp_path / "foreign-directory"
+    foreign_path.mkdir()
+    foreign_source = os.open(
+        foreign_path,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    foreign_identity = atomic_module._resource_owner_identity(os.fstat(foreign_source))
+    real_close = atomic_module.os.close
+    error = KeyboardInterrupt("after close and observable fd reuse")
+    replacement_installed = False
+
+    def close_then_reuse(descriptor: int) -> None:
+        nonlocal replacement_installed
+        real_close(descriptor)
+        if descriptor == target and not replacement_installed:
+            os.dup2(foreign_source, target)
+            replacement_installed = True
+            raise error
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", close_then_reuse)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is error
+        assert replacement_installed
+        assert authority._closed
+        assert resources.closed
+        assert atomic_module._resource_owner_identity(os.fstat(target)) == (
+            foreign_identity
+        )
+        authority.close()
+        assert atomic_module._resource_owner_identity(os.fstat(target)) == (
+            foreign_identity
+        )
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        real_close(target)
+        real_close(foreign_source)
+
+
+def _open_fake_windows_authority(
+    api: _FakeWindowsApi,
+    monkeypatch: pytest.MonkeyPatch,
+) -> object:
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    return atomic_module._open_windows_publication_authority(
+        Path("C:/authority"),
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+
+
+def test_windows_owner_closes_same_file_after_content_change() -> None:
+    api = _FakeWindowsApi()
+    file_id = api.add_file(api.root_id, "mutable.txt", b"one")
+    handle = api._new_handle(file_id)
+    owner = atomic_module._WindowsResourceOwner(api)
+    owned_handle = owner.acquire(lambda: handle)
+    before = api.metadata(owned_handle)
+
+    node = api.nodes[file_id]
+    node["data"] = b"changed content"
+    node["version"] = int(node["version"]) + 1
+    after = api.metadata(owned_handle)
+    assert atomic_module._ownership_binding_identity(before) != (
+        atomic_module._ownership_binding_identity(after)
+    )
+    assert atomic_module._resource_owner_identity(before) == (
+        atomic_module._resource_owner_identity(after)
+    )
+
+    owner.close_all()
+
+    assert owner.closed
+    assert owned_handle not in api.handles
+
+
+def test_windows_authority_close_before_close_interrupt_is_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    real_close = api.close
+    error = KeyboardInterrupt("before CloseHandle")
+    target: int | None = None
+
+    def interrupt_before_close(handle: int) -> None:
+        nonlocal target
+        if target is None:
+            target = handle
+            raise error
+        real_close(handle)
+
+    try:
+        monkeypatch.setattr(api, "close", interrupt_before_close)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is error
+        assert not authority._closed
+        assert target is not None
+        assert set(api.handles) == {target}
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        authority.close()
+
+    assert authority._closed
+    assert api.handles == {}
+
+
+def test_windows_authority_close_after_close_system_exit_closes_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    real_close = api.close
+    error = SystemExit("after CloseHandle")
+    injected = False
+
+    def interrupt_after_close(handle: int) -> None:
+        nonlocal injected
+        real_close(handle)
+        if not injected:
+            injected = True
+            raise error
+
+    monkeypatch.setattr(api, "close", interrupt_after_close)
+    with pytest.raises(SystemExit) as caught:
+        authority.close()
+
+    assert caught.value is error
+    assert injected
+    assert authority._closed
+    assert api.handles == {}
+    authority.close()
+
+
+def test_windows_authority_persistent_eio_retains_failed_handle_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    real_close = api.close
+    target = max(api.handles)
+    error = OSError(errno.EIO, "persistent CloseHandle failure")
+
+    def fail_target(handle: int) -> None:
+        if handle == target:
+            raise error
+        real_close(handle)
+
+    try:
+        monkeypatch.setattr(api, "close", fail_target)
+        for _attempt in range(2):
+            with pytest.raises(OSError) as caught:
+                authority.close()
+            assert caught.value is error
+            assert not authority._closed
+            assert set(api.handles) == {target}
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        authority.close()
+
+    assert authority._closed
+    assert api.handles == {}
+
+
+def test_windows_authority_close_preserves_first_error_and_attempts_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    first_target, second_target = sorted(api.handles, reverse=True)
+    real_close = api.close
+    first_error = KeyboardInterrupt("first CloseHandle failure")
+    second_error = SystemExit("second CloseHandle failure")
+
+    def fail_two(handle: int) -> None:
+        if handle == first_target:
+            raise first_error
+        if handle == second_target:
+            raise second_error
+        real_close(handle)
+
+    try:
+        monkeypatch.setattr(api, "close", fail_two)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is first_error
+        assert not authority._closed
+        notes = (
+            *getattr(first_error, "__notes__", ()),
+            *getattr(first_error, "_codenib_cleanup_notes", ()),
+        )
+        assert any("second CloseHandle failure" in note for note in notes)
+        assert set(api.handles) == {first_target, second_target}
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        authority.close()
+
+    assert api.handles == {}
+
+
+def test_windows_close_reconciliation_does_not_close_observable_reused_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    foreign_id = api.add_directory()
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    target = max(api.handles)
+    real_close = api.close
+    error = KeyboardInterrupt("after close and observable HANDLE reuse")
+    replacement_installed = False
+
+    def close_then_reuse(handle: int) -> None:
+        nonlocal replacement_installed
+        real_close(handle)
+        if handle == target and not replacement_installed:
+            api.handles[target] = foreign_id
+            api.offsets[target] = 0
+            replacement_installed = True
+            raise error
+
+    try:
+        monkeypatch.setattr(api, "close", close_then_reuse)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is error
+        assert replacement_installed
+        assert authority._closed
+        assert api.handles == {target: foreign_id}
+        authority.close()
+        assert api.handles == {target: foreign_id}
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        real_close(target)
+
+
+@pytest.mark.parametrize("use_duplicate", [False, True])
+def test_windows_factory_recovers_interrupt_after_registered_handle_return(
+    monkeypatch: pytest.MonkeyPatch,
+    use_duplicate: bool,
+) -> None:
+    api = _FakeWindowsApi()
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    external = api.create_directory_handle(Path("C:/external")) if use_duplicate else 0
+    real_acquire = atomic_module._WindowsResourceOwner.acquire
+    error = KeyboardInterrupt("after registered HANDLE return")
+    injected = False
+
+    def acquire_then_interrupt(self: object, callback: object) -> int:
+        nonlocal injected
+        handle = real_acquire(self, callback)
+        if not injected:
+            injected = True
+            raise error
+        return handle
+
+    monkeypatch.setattr(
+        atomic_module._WindowsResourceOwner,
+        "acquire",
+        acquire_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        atomic_module._open_windows_publication_authority(
+            Path("C:/authority"),
+            parent_resource=external or None,
+            expected_parent_identity=None,
+        )
+
+    assert caught.value is error
+    assert injected
+    assert set(api.handles) == ({external} if external else set())
+    if external:
+        api.close(external)
+
+
+def test_windows_owner_recovers_interrupt_after_handle_result_store() -> None:
+    api = _FakeWindowsApi()
+    owner = atomic_module._WindowsResourceOwner(api)
+    error = KeyboardInterrupt("after raw HANDLE result store")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _call_with_interrupt_after_store(
+            atomic_module._WindowsResourceOwner.acquire,
+            "handle",
+            lambda: owner.acquire(
+                lambda: api.create_directory_handle(Path("C:/authority"))
+            ),
+            error=error,
+        )
+
+    assert caught.value is error
+    assert owner.closed
+    assert api.handles == {}
+
+
+def test_windows_child_open_return_interrupt_remains_authority_owned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    api.add_directory(api.root_id, "child")
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    baseline_handles = set(api.handles)
+    real_acquire = atomic_module._WindowsResourceOwner.acquire
+    error = SystemExit("after child HANDLE owner return")
+    injected = False
+
+    def acquire_then_interrupt(self: object, callback: object) -> int:
+        nonlocal injected
+        handle = real_acquire(self, callback)
+        if not injected:
+            injected = True
+            raise error
+        return handle
+
+    monkeypatch.setattr(
+        atomic_module._WindowsResourceOwner,
+        "acquire",
+        acquire_then_interrupt,
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        authority.child_metadata(
+            "child",
+            path=Path("C:/authority/child"),
+            label="child",
+        )
+
+    assert caught.value is error
+    assert injected
+    assert set(api.handles) > baseline_handles
+    authority.close()
+    assert api.handles == {}
+
+
+def test_resource_owner_documents_native_p2_boundary() -> None:
+    posix_source = inspect.getsource(atomic_module._PosixResourceOwner)
+    windows_source = inspect.getsource(atomic_module._WindowsResourceOwner)
+    reconciliation_source = inspect.getsource(
+        atomic_module._PosixResourceOwner._close_record
+    )
+
+    assert "raw" in posix_source and "native owning object" in posix_source
+    assert "raw HANDLE" in windows_source and "native owning object" in windows_source
+    assert "exact dup2 ABA" in reconciliation_source

--- a/test/test_bounded_json.py
+++ b/test/test_bounded_json.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import json
+import math
+
+import pytest
+
+from codenib._bounded_json import canonical_json_array_chunks, iter_bounded_json_array
+
+
+class _ChunkReader:
+    def __init__(self, payload: bytes, chunk_size: int) -> None:
+        self.payload = payload
+        self.chunk_size = chunk_size
+        self.offset = 0
+
+    def read(self, _size: int = -1) -> bytes:
+        block = self.payload[self.offset : self.offset + self.chunk_size]
+        self.offset += len(block)
+        return block
+
+
+def test_bounded_array_handles_every_chunk_boundary() -> None:
+    values = [
+        123,
+        {"content": 'é\\"😀', "values": [True, None, -0.0, 1e-10]},
+        "tail",
+    ]
+    payload = json.dumps(values, ensure_ascii=False, separators=(",", ":")).encode()
+
+    for chunk_size in range(1, len(payload) + 1):
+        assert (
+            list(
+                iter_bounded_json_array(
+                    _ChunkReader(payload, chunk_size),
+                    label="documents",
+                )
+            )
+            == values
+        )
+
+
+def test_bounded_array_does_not_accept_a_number_prefix_at_a_chunk_end() -> None:
+    assert list(
+        iter_bounded_json_array(
+            _ChunkReader(b"[123,4]", 3),
+            label="documents",
+        )
+    ) == [123, 4]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b'[{"a":1,"\\u0061":2}]',
+        b"[NaN]",
+        b"[Infinity]",
+        b"[1e9999]",
+        b"[" + b"1" * 1_025 + b"]",
+    ],
+)
+def test_bounded_array_rejects_ambiguous_or_unbounded_numbers(payload: bytes) -> None:
+    with pytest.raises(ValueError):
+        list(iter_bounded_json_array(io.BytesIO(payload), label="documents"))
+
+
+def test_bounded_array_enforces_complexity_before_decode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._bounded_json as bounded_json
+
+    decode_called = False
+
+    class _ForbiddenDecoder:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def raw_decode(self, _value: str, _offset: int):
+            nonlocal decode_called
+            decode_called = True
+            raise AssertionError("lexical budget must reject before DOM allocation")
+
+    monkeypatch.setattr(bounded_json.json, "JSONDecoder", _ForbiddenDecoder)
+    with pytest.raises(ValueError, match="token limit"):
+        list(
+            bounded_json.iter_bounded_json_array(
+                io.BytesIO(b"[[" + b",".join(b"0" for _ in range(20)) + b"]]"),
+                label="documents",
+                max_lexical_tokens=10,
+            )
+        )
+    assert decode_called is False
+
+
+def test_canonical_array_chunks_match_the_existing_json_contract() -> None:
+    values = [
+        {},
+        {"z": [1, {"é": "line\n😀"}], "a": -0.0},
+        [True, False, None, math.nextafter(1.0, 2.0)],
+        "\ud800",
+    ]
+    observed = b"".join(canonical_json_array_chunks(iter(values)))
+    expected = (
+        json.dumps(
+            values,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("ascii")
+
+    assert observed == expected

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -13,7 +13,7 @@ from codenib._atomic_directory import (
     capture_directory_ownership,
     directory_ownership_file_records,
 )
-from codenib._captured_directory import CapturedDirectoryReader
+from codenib._captured_directory import CapturedDirectoryReader, OwnedDirectoryStage
 
 
 def test_tree_ownership_exposes_canonical_file_records(tmp_path: Path) -> None:
@@ -78,3 +78,33 @@ def test_captured_reader_rejects_identical_nested_a_b_a_replacement(
         reader.close()
 
     assert (replacement / "payload").read_bytes() == b"same bytes"
+
+
+def test_owned_stage_publishes_its_final_full_tree(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    stage = OwnedDirectoryStage(destination)
+    stage.write_file("nested/payload", [b"owned bytes"])
+
+    stage.publish(expected_destination_ownership=None)
+
+    assert (destination / "nested" / "payload").read_bytes() == b"owned bytes"
+
+
+def test_owned_stage_rejects_root_replacement_before_publish(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    stage = OwnedDirectoryStage(destination)
+    stage.write_file("payload", [b"owned bytes"])
+    stolen = tmp_path / "stolen-stage"
+    stage.path.rename(stolen)
+    stage.path.mkdir()
+    (stage.path / "foreign").write_bytes(b"foreign")
+
+    try:
+        with pytest.raises(RuntimeError, match="owned stage root changed"):
+            stage.publish(expected_destination_ownership=None)
+    finally:
+        stage.discard()
+
+    assert not destination.exists()
+    assert (stolen / "payload").read_bytes() == b"owned bytes"
+    assert (stage.path / "foreign").read_bytes() == b"foreign"

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import codenib._atomic_directory as atomic_directory
+from codenib._atomic_directory import (
+    capture_directory_ownership,
+    directory_ownership_file_records,
+)
+from codenib._captured_directory import CapturedDirectoryReader
+
+
+def test_tree_ownership_exposes_canonical_file_records(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (root / "b.txt").write_bytes(b"b")
+    (nested / "a.txt").write_bytes(b"alpha")
+
+    records = directory_ownership_file_records(capture_directory_ownership(root))
+
+    assert [(record.path, record.size) for record in records] == [
+        ("b.txt", 1),
+        ("nested/a.txt", 5),
+    ]
+    assert all(len(record.sha256) == 64 for record in records)
+
+
+def test_entry_policy_rejects_before_file_bytes_are_hashed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "documents.json").write_bytes(b"x" * 32)
+
+    def reject_large(_path: str, kind: str, _mode: int, size: int) -> None:
+        if kind == "file" and size > 16:
+            raise ValueError("prehash size policy")
+
+    def forbidden_read(_descriptor: int, _size: int) -> bytes:
+        raise AssertionError("oversized file must be rejected before hashing")
+
+    monkeypatch.setattr(atomic_directory.os, "read", forbidden_read)
+    with pytest.raises(ValueError, match="prehash size policy"):
+        capture_directory_ownership(root, entry_policy=reject_large)
+
+
+def test_captured_reader_rejects_identical_nested_a_b_a_replacement(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    source = nested / "payload"
+    source.write_bytes(b"same bytes")
+    ownership = capture_directory_ownership(root)
+    reader = CapturedDirectoryReader(root, ownership)
+    saved = tmp_path / "saved-nested"
+
+    nested.rename(saved)
+    nested.mkdir()
+    (nested / "payload").write_bytes(b"same bytes")
+    replacement = tmp_path / "replacement-nested"
+    nested.rename(replacement)
+    saved.rename(nested)
+
+    try:
+        with pytest.raises(ValueError, match="captured path is not a real directory"):
+            reader.read_bytes("nested/payload", max_bytes=64)
+    finally:
+        reader.close()
+
+    assert (replacement / "payload").read_bytes() == b"same bytes"

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -4,16 +4,273 @@
 
 from __future__ import annotations
 
+import stat
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
 import codenib._atomic_directory as atomic_directory
+import codenib._captured_directory as captured_directory
+import codenib._windows_fs_authority as windows_authority
 from codenib._atomic_directory import (
     capture_directory_ownership,
     directory_ownership_file_records,
 )
 from codenib._captured_directory import CapturedDirectoryReader, OwnedDirectoryStage
+
+
+def _as_windows_ownership(ownership: object) -> object:
+    root_identity = list(atomic_directory.directory_ownership_root_identity(ownership))
+    root_identity[3] |= windows_authority.FILE_ATTRIBUTE_DIRECTORY
+    root_version = list(
+        atomic_directory.directory_ownership_root_version_identity(ownership)
+    )
+    root_version[4] |= windows_authority.FILE_ATTRIBUTE_DIRECTORY
+    entries = []
+    for path, kind, identity in atomic_directory.directory_ownership_entry_identities(
+        ownership
+    ):
+        adjusted = list(identity)
+        if kind == "directory":
+            adjusted[4] |= windows_authority.FILE_ATTRIBUTE_DIRECTORY
+        entries.append((path, kind, tuple(adjusted)))
+    return replace(
+        ownership,
+        root_identity=tuple(root_identity),
+        root_version_identity=tuple(root_version),
+        entry_identities=tuple(entries),
+    )
+
+
+class _FakeCapturedWindowsApi:
+    """HANDLE-relative tree model with no path-based file access."""
+
+    def __init__(self, ownership: object, payloads: dict[str, bytes]) -> None:
+        root_identity = atomic_directory.directory_ownership_root_version_identity(
+            ownership
+        )
+        entries = atomic_directory.directory_ownership_entry_identities(ownership)
+        self.nodes: dict[int, dict[str, object]] = {}
+        self.handles: dict[int, int] = {}
+        self.offsets: dict[int, int] = {}
+        self.next_node = 1
+        self.next_handle = 100
+        self.open_relative_calls: list[tuple[int, str, bool, bool]] = []
+        self.fail_next_close = False
+        self.root_id = self._add_node(root_identity, data=b"")
+        paths: dict[str, int] = {"": self.root_id}
+        for path, kind, identity in sorted(
+            entries,
+            key=lambda item: (item[0].count("/"), item[0]),
+        ):
+            parent, _, name = path.rpartition("/")
+            node = self._add_node(identity, data=payloads.get(path, b""))
+            children = self.nodes[paths[parent]]["children"]
+            assert isinstance(children, dict)
+            children[name] = node
+            paths[path] = node
+            assert stat.S_ISDIR(identity[2]) is (kind == "directory")
+
+    def _add_node(self, identity: tuple[int, ...], *, data: bytes) -> int:
+        node = self.next_node
+        self.next_node += 1
+        self.nodes[node] = {
+            "identity": identity,
+            "file_id_128": node.to_bytes(16, "big"),
+            "data": data,
+            "children": {},
+        }
+        return node
+
+    def _new_handle(self, node: int) -> int:
+        handle = self.next_handle
+        self.next_handle += 1
+        self.handles[handle] = node
+        self.offsets[handle] = 0
+        return handle
+
+    def root_handle(self) -> int:
+        return self._new_handle(self.root_id)
+
+    def metadata(self, handle: int) -> windows_authority.WindowsHandleMetadata:
+        node = self.nodes[self.handles[handle]]
+        identity = node["identity"]
+        file_id_128 = node["file_id_128"]
+        assert isinstance(identity, tuple)
+        assert isinstance(file_id_128, bytes)
+        return windows_authority.WindowsHandleMetadata(
+            st_dev=identity[0],
+            st_ino=identity[1],
+            st_mode=identity[2],
+            st_size=identity[3],
+            st_file_attributes=identity[4],
+            st_mtime_ns=identity[5],
+            st_ctime_ns=identity[6],
+            st_nlink=identity[7],
+            file_id_128=file_id_128,
+        )
+
+    def iter_directory(
+        self,
+        handle: int,
+    ) -> tuple[windows_authority.WindowsDirectoryEntry, ...]:
+        node = self.nodes[self.handles[handle]]
+        children = node["children"]
+        assert isinstance(children, dict)
+        output = []
+        for name, child_id in children.items():
+            child = self.nodes[child_id]
+            identity = child["identity"]
+            file_id_128 = child["file_id_128"]
+            assert isinstance(identity, tuple)
+            assert isinstance(file_id_128, bytes)
+            output.append(
+                windows_authority.WindowsDirectoryEntry(
+                    name=name,
+                    file_id=identity[1],
+                    attributes=identity[4]
+                    | (
+                        windows_authority.FILE_ATTRIBUTE_DIRECTORY
+                        if stat.S_ISDIR(identity[2])
+                        else 0
+                    ),
+                    file_id_128=file_id_128,
+                )
+            )
+        return tuple(output)
+
+    def open_relative(
+        self,
+        parent_handle: int,
+        name: str,
+        *,
+        desired_access: int,
+        is_directory: bool,
+        allow_reparse: bool,
+    ) -> int:
+        del desired_access
+        self.open_relative_calls.append(
+            (parent_handle, name, is_directory, allow_reparse)
+        )
+        parent = self.nodes[self.handles[parent_handle]]
+        children = parent["children"]
+        assert isinstance(children, dict)
+        matches = [
+            child
+            for child_name, child in children.items()
+            if child_name.casefold() == name.casefold()
+        ]
+        if len(matches) != 1:
+            raise FileNotFoundError(name)
+        child = matches[0]
+        identity = self.nodes[child]["identity"]
+        assert isinstance(identity, tuple)
+        assert stat.S_ISDIR(identity[2]) is is_directory
+        assert not allow_reparse
+        return self._new_handle(child)
+
+    def read(self, handle: int, size: int) -> bytes:
+        node = self.nodes[self.handles[handle]]
+        data = node["data"]
+        assert isinstance(data, bytes)
+        offset = self.offsets[handle]
+        block = data[offset : offset + size]
+        self.offsets[handle] += len(block)
+        return block
+
+    def close(self, handle: int) -> None:
+        if self.fail_next_close:
+            self.fail_next_close = False
+            raise OSError("injected HANDLE close failure")
+        self.handles.pop(handle)
+        self.offsets.pop(handle)
+
+    def replace_child_with_identical_tree(self, name: str) -> None:
+        children = self.nodes[self.root_id]["children"]
+        assert isinstance(children, dict)
+        old_id = children[name]
+        old = self.nodes[old_id]
+        identity = old["identity"]
+        assert isinstance(identity, tuple)
+        replacement_identity = (
+            identity[0],
+            identity[1] + 10_000,
+            *identity[2:],
+        )
+        replacement = self._add_node(replacement_identity, data=b"")
+        replacement_children = self.nodes[replacement]["children"]
+        old_children = old["children"]
+        assert isinstance(replacement_children, dict)
+        assert isinstance(old_children, dict)
+        replacement_children.update(old_children)
+        children[name] = replacement
+
+    def replace_nested_file_with_identical_bytes(
+        self,
+        directory: str,
+        name: str,
+    ) -> None:
+        root_children = self.nodes[self.root_id]["children"]
+        assert isinstance(root_children, dict)
+        directory_node = self.nodes[root_children[directory]]
+        children = directory_node["children"]
+        assert isinstance(children, dict)
+        old = self.nodes[children[name]]
+        identity = old["identity"]
+        data = old["data"]
+        assert isinstance(identity, tuple)
+        assert isinstance(data, bytes)
+        children[name] = self._add_node(identity, data=data)
+
+
+class _FakeCapturedWindowsAuthority:
+    def __init__(self, api: _FakeCapturedWindowsApi) -> None:
+        self.api = api
+        self.handles = [api.root_handle()]
+        self.closed = False
+        self.expected_root = api.root_id
+
+    @property
+    def handle(self) -> int:
+        if self.closed:
+            raise RuntimeError("fake Windows authority is closed")
+        return self.handles[-1]
+
+    def verify(self) -> None:
+        if self.closed or self.api.root_id != self.expected_root:
+            raise RuntimeError("Windows lexical directory binding changed")
+        self.api.metadata(self.handle)
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        for handle in reversed(self.handles):
+            self.api.close(handle)
+        self.handles.clear()
+        self.closed = True
+
+
+def _install_fake_windows_reader(
+    monkeypatch: pytest.MonkeyPatch,
+    api: _FakeCapturedWindowsApi,
+) -> None:
+    monkeypatch.setattr(captured_directory, "_use_windows_handles", lambda: True)
+
+    def open_authority(
+        _path: Path,
+        *,
+        cleanup_slot: object,
+    ) -> _FakeCapturedWindowsAuthority:
+        authority = _FakeCapturedWindowsAuthority(api)
+        cleanup_slot.own(authority)  # type: ignore[attr-defined]
+        return authority
+
+    monkeypatch.setattr(
+        captured_directory._windows_fs,
+        "open_lexical_directory_authority",
+        open_authority,
+    )
 
 
 def test_tree_ownership_exposes_canonical_file_records(tmp_path: Path) -> None:
@@ -78,6 +335,259 @@ def test_captured_reader_rejects_identical_nested_a_b_a_replacement(
         reader.close()
 
     assert (replacement / "payload").read_bytes() == b"same bytes"
+
+
+def test_captured_reader_uses_windows_handle_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload").write_bytes(b"captured bytes")
+    ownership = _as_windows_ownership(capture_directory_ownership(root))
+    api = _FakeCapturedWindowsApi(
+        ownership,
+        {"nested/payload": b"captured bytes"},
+    )
+    _install_fake_windows_reader(monkeypatch, api)
+
+    reader = CapturedDirectoryReader(root, ownership)
+    try:
+        assert reader.record("nested/payload").size == len(b"captured bytes")
+        assert reader.read_bytes("nested/payload", max_bytes=64) == b"captured bytes"
+        reader.verify_root()
+    finally:
+        reader.close()
+
+    assert api.open_relative_calls
+    assert all(not call[3] for call in api.open_relative_calls)
+    assert not api.handles
+
+
+def test_captured_windows_reader_rejects_identical_nested_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload").write_bytes(b"same bytes")
+    ownership = _as_windows_ownership(capture_directory_ownership(root))
+    api = _FakeCapturedWindowsApi(
+        ownership,
+        {"nested/payload": b"same bytes"},
+    )
+    _install_fake_windows_reader(monkeypatch, api)
+    reader = CapturedDirectoryReader(root, ownership)
+    api.replace_child_with_identical_tree("nested")
+
+    try:
+        with pytest.raises(ValueError, match="captured path is not a real directory"):
+            reader.read_bytes("nested/payload", max_bytes=64)
+    finally:
+        reader.close()
+
+    assert not api.handles
+
+
+def test_captured_windows_reader_rejects_open_file_namespace_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload").write_bytes(b"same bytes")
+    ownership = _as_windows_ownership(capture_directory_ownership(root))
+    api = _FakeCapturedWindowsApi(
+        ownership,
+        {"nested/payload": b"same bytes"},
+    )
+    _install_fake_windows_reader(monkeypatch, api)
+    reader = CapturedDirectoryReader(root, ownership)
+    source = reader.open_file("nested/payload", max_bytes=64)
+    api.replace_nested_file_with_identical_bytes("nested", "payload")
+
+    try:
+        with pytest.raises(ValueError, match="captured file changed while reading"):
+            source.authenticate()
+    finally:
+        source.close()
+        reader.close()
+
+    assert not api.handles
+
+
+def test_captured_windows_reader_preserves_primary_and_retries_handle_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_bytes(b"bytes")
+    ownership = _as_windows_ownership(capture_directory_ownership(root))
+    api = _FakeCapturedWindowsApi(ownership, {"payload": b"bytes"})
+    _install_fake_windows_reader(monkeypatch, api)
+    reader = CapturedDirectoryReader(root, ownership)
+    source = reader.open_file("payload", max_bytes=64)
+    api.fail_next_close = True
+
+    with pytest.raises(RuntimeError, match="primary failure") as caught:
+        with source:
+            raise RuntimeError("primary failure")
+
+    assert caught.value.captured_directory_cleanup_owner is source
+    assert api.handles
+    source.close()
+    reader.close()
+    assert not api.handles
+
+
+def test_captured_windows_reader_retains_success_path_close_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_bytes(b"bytes")
+    ownership = _as_windows_ownership(capture_directory_ownership(root))
+    api = _FakeCapturedWindowsApi(ownership, {"payload": b"bytes"})
+    _install_fake_windows_reader(monkeypatch, api)
+    reader = CapturedDirectoryReader(root, ownership)
+    api.fail_next_close = True
+
+    with pytest.raises(OSError, match="injected HANDLE close failure") as caught:
+        reader.read_bytes("payload", max_bytes=64)
+
+    source = caught.value.captured_directory_cleanup_owner
+    assert isinstance(source, captured_directory.AuthenticatedFile)
+    assert api.handles
+    source.close()
+    reader.close()
+    assert not api.handles
+
+
+def test_captured_windows_reader_rejects_descriptor_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_bytes(b"bytes")
+    ownership = _as_windows_ownership(capture_directory_ownership(root))
+    api = _FakeCapturedWindowsApi(ownership, {"payload": b"bytes"})
+    _install_fake_windows_reader(monkeypatch, api)
+    reader = CapturedDirectoryReader(root, ownership)
+    root_handles = set(api.handles)
+
+    try:
+        with pytest.raises(RuntimeError, match="available only on POSIX"):
+            with reader.authenticated_descriptor("payload", max_bytes=64):
+                raise AssertionError("descriptor authority must not be yielded")
+        assert set(api.handles) == root_handles
+    finally:
+        reader.close()
+
+    assert not api.handles
+
+
+def test_captured_windows_reader_bounds_live_namespace_enumeration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_bytes(b"bytes")
+    ownership = _as_windows_ownership(capture_directory_ownership(root))
+    api = _FakeCapturedWindowsApi(ownership, {"payload": b"bytes"})
+    _install_fake_windows_reader(monkeypatch, api)
+    reader = CapturedDirectoryReader(root, ownership)
+    yielded = 0
+
+    def unbounded_entries(_handle: int):
+        nonlocal yielded
+        while True:
+            yielded += 1
+            yield windows_authority.WindowsDirectoryEntry(
+                name=f"foreign-{yielded}",
+                file_id=10_000 + yielded,
+                attributes=0,
+                file_id_128=(10_000 + yielded).to_bytes(16, "big"),
+            )
+
+    monkeypatch.setattr(api, "iter_directory", unbounded_entries)
+    try:
+        with pytest.raises(RuntimeError, match="ownership entry limit"):
+            reader.open_file("payload", max_bytes=64)
+    finally:
+        reader.close()
+
+    assert yielded == len(reader._entry_identities) + 1
+    assert not api.handles
+
+
+def test_captured_windows_reader_retains_file_owner_during_return_interruption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_bytes(b"bytes")
+    ownership = _as_windows_ownership(capture_directory_ownership(root))
+    api = _FakeCapturedWindowsApi(ownership, {"payload": b"bytes"})
+    _install_fake_windows_reader(monkeypatch, api)
+    reader = CapturedDirectoryReader(root, ownership)
+    real_open = captured_directory.CapturedDirectoryReader._open_windows
+    interruption = KeyboardInterrupt("after authenticated HANDLE acquisition")
+
+    def open_then_interrupt(
+        self: CapturedDirectoryReader,
+        relative: object,
+    ) -> object:
+        real_open(self, relative)  # type: ignore[arg-type]
+        raise interruption
+
+    monkeypatch.setattr(
+        captured_directory.CapturedDirectoryReader,
+        "_open_windows",
+        open_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        reader.open_file("payload", max_bytes=64)
+
+    assert caught.value is interruption
+    assert len(api.handles) == 2
+    reader.close()
+    assert not api.handles
+
+
+def test_captured_windows_copy_chunks_preserves_consumer_primary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_bytes(b"bytes")
+    ownership = _as_windows_ownership(capture_directory_ownership(root))
+    api = _FakeCapturedWindowsApi(ownership, {"payload": b"bytes"})
+    _install_fake_windows_reader(monkeypatch, api)
+    reader = CapturedDirectoryReader(root, ownership)
+    chunks = reader.copy_chunks("payload", max_bytes=64)
+    primary = KeyboardInterrupt("consumer cancellation")
+
+    assert next(chunks) == b"bytes"
+    api.fail_next_close = True
+    with pytest.raises(KeyboardInterrupt) as caught:
+        chunks.throw(primary)
+
+    assert caught.value is primary
+    source = primary.captured_directory_cleanup_owner
+    assert isinstance(source, captured_directory.AuthenticatedFile)
+    source.close()
+    reader.close()
+    assert not api.handles
 
 
 def test_owned_stage_publishes_its_final_full_tree(tmp_path: Path) -> None:

--- a/test/test_native_index_authorization.py
+++ b/test/test_native_index_authorization.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+import pytest
+
+from codenib._atomic_directory import capture_directory_ownership
+from codenib.native_index_authorization import (
+    NATIVE_INDEX_SUBJECT_SCHEMA,
+    mint_trusted_local_authorization,
+    native_index_subject,
+    require_native_index_authorization,
+)
+
+
+def test_native_index_subject_commits_tree_files_and_semantics(tmp_path: Path) -> None:
+    root = tmp_path / "vector"
+    root.mkdir()
+    (root / "index.faiss").write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+
+    subject = native_index_subject(
+        ownership,
+        view_type="vector",
+        semantic_contract={"dimension": 3, "index_metric": "ip"},
+    )
+
+    assert NATIVE_INDEX_SUBJECT_SCHEMA.encode("ascii") in subject.canonical_bytes()
+    assert subject.files[0][0] == "index.faiss"
+    assert len(subject.digest) == 64
+
+
+def test_native_index_authorization_is_process_local_and_exact(tmp_path: Path) -> None:
+    root = tmp_path / "vector"
+    root.mkdir()
+    payload = root / "index.faiss"
+    payload.write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+    semantic = {"dimension": 3, "index_metric": "ip"}
+    authorization = mint_trusted_local_authorization(
+        ownership,
+        view_type="vector",
+        semantic_contract=semantic,
+        evidence=("compiler-lock-and-checkout",),
+    )
+
+    require_native_index_authorization(
+        authorization,
+        ownership,
+        view_type="vector",
+        semantic_contract=semantic,
+    )
+    with pytest.raises(TypeError, match="process-local"):
+        pickle.dumps(authorization)
+
+    payload.write_bytes(b"changed")
+    changed = capture_directory_ownership(root)
+    with pytest.raises(ValueError, match="does not match captured bytes"):
+        require_native_index_authorization(
+            authorization,
+            changed,
+            view_type="vector",
+            semantic_contract=semantic,
+        )
+
+
+def test_native_index_authorization_defaults_to_deny(tmp_path: Path) -> None:
+    root = tmp_path / "vector"
+    root.mkdir()
+    (root / "index.faiss").write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+
+    with pytest.raises(ValueError, match="requires external authorization"):
+        require_native_index_authorization(
+            None,
+            ownership,
+            view_type="vector",
+            semantic_contract={"dimension": 3},
+        )

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -4,16 +4,33 @@
 
 from __future__ import annotations
 
+import hashlib
+import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
 import codenib._contained_source as contained_source_module
+from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
 from codenib.source_fingerprint import (
+    SOURCE_FINGERPRINT_VERSION,
     RepositoryChangedError,
     fingerprint_repository,
     repository_source_is_dirty,
 )
+
+
+def _legacy_link_only_digest(path: bytes, target: bytes) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        (
+            f"codenib-source-fingerprint:{SOURCE_FINGERPRINT_VERSION}:"
+            f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
+        ).encode("ascii")
+    )
+    digest.update(b"L\0" + path + b"\0" + target + b"\0")
+    return f"sha256:{digest.hexdigest()}"
 
 
 def test_fingerprint_changes_with_source_content_and_path(tmp_path):
@@ -74,6 +91,41 @@ def test_fingerprint_includes_symlink_target_and_content(tmp_path):
     (repo / "other.py").write_text("VALUE = 3\n")
     link.symlink_to("other.py")
     assert fingerprint_repository(repo).value != changed_content.value
+
+
+@pytest.mark.parametrize("terminal", ["missing", "fifo", "loop"])
+def test_fingerprint_preserves_v1_link_only_terminal_digest(
+    tmp_path: Path,
+    terminal: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    link = repo / "link.py"
+    if terminal == "missing":
+        target = "missing.py"
+    elif terminal == "fifo":
+        target = ".codenib-hidden-pipe"
+        os.mkfifo(repo / target)
+    else:
+        target = "link.py"
+    link.symlink_to(target)
+
+    observed = fingerprint_repository(repo)
+
+    assert observed.file_count == 1
+    assert observed.value == _legacy_link_only_digest(b"link.py", os.fsencode(target))
+
+
+def test_fingerprint_accepts_absolute_contained_symlink(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "target.py"
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+    (repo / "link.py").symlink_to(target)
+
+    observed = fingerprint_repository(repo)
+
+    assert observed.file_count == 2
 
 
 def test_fingerprint_rejects_source_symlink_outside_repository(tmp_path) -> None:


### PR DESCRIPTION
## Summary
Add descriptor-bound artifact readers and cross-platform directory publication authority on top of the merged #584 foundation.

## Changes
- add bounded JSON parsing and authenticated captured-file/directory readers
- bind native index authorization to exact captured tree and semantic subjects
- harden POSIX and Windows no-follow directory publication, cleanup, and postcondition checks
- pin every Windows lexical path component and stream directory enumeration under ownership budgets
- support HANDLE-backed captured reads while keeping authenticated descriptor export POSIX-only
- migrate view-bundle materialization and existing static/context/archive producers to final full-tree ownership tokens and reader callbacks
- preserve the relative-symlink read policy while retaining repository fingerprint compatibility

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- 339 passed, 10 skipped across the changed authority, artifact, view-bundle, runtime, and source surfaces
- 4 focused resource-registration probes passed on Python 3.10, 3.11, 3.12, 3.13, and 3.14
- 4,389 passed, 65 skipped, 190 deselected across the unit tier with the Docker-only file excluded because `/usr/bin/docker` is unavailable locally
- the unmodified unit command reached 2,606 passed before stopping only on the missing local Docker binary
- Black 24.8, isort 5.13, flake8, compileall, and git diff --check passed for all 21 changed Python files

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Dependency #584 is merged into `main`.
