### PR TITLE
feat(storage): add owned publication authority

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -16,7 +16,15 @@ import sys
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
-from typing import Callable, ContextManager, Iterator, Literal, Protocol, TypeVar
+from typing import (
+    Callable,
+    ContextManager,
+    Iterable,
+    Iterator,
+    Literal,
+    Protocol,
+    TypeVar,
+)
 
 from . import _windows_fs_authority as _windows_fs
 
@@ -1961,7 +1969,7 @@ def _publication_relative_path(
         relative.is_absolute()
         or relative.as_posix() != raw
         or len(relative.parts) > _MAX_SAFE_REMOVAL_DEPTH
-        or len(raw.encode("utf-8", errors="strict")) > _MAX_OWNERSHIP_PATH_BYTES
+        or len(os.fsencode(raw)) > _MAX_OWNERSHIP_PATH_BYTES
     ):
         raise ValueError("publication reader path must be normalized and bounded")
     for part in relative.parts:
@@ -3047,6 +3055,14 @@ def _reserve_ownership_record(
     budget.metadata_bytes += 8 + len(relative) + 1 + 4 + 8 + 32
     if budget.metadata_bytes > _MAX_OWNERSHIP_METADATA_BYTES:
         raise RuntimeError("directory ownership scan exceeds its metadata limit")
+
+
+def _validate_ownership_inventory_budget(relative_paths: Iterable[bytes]) -> None:
+    """Apply the scanner's exact entry and metadata budget to a planned tree."""
+
+    budget = _OwnershipBudget()
+    for relative in relative_paths:
+        _reserve_ownership_record(budget, relative=relative)
 
 
 def _hash_owned_regular_file(

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -26,6 +26,7 @@ except ImportError:  # pragma: no cover - Windows fails closed when requested
 
 from . import _windows_fs_authority as _windows_fs
 from ._atomic_directory import (
+    _MAX_OWNERSHIP_COMPONENT_BYTES,
     DirectoryOrphan,
     PublicationDirectoryReader,
     TreeFileRecord,
@@ -37,6 +38,7 @@ from ._atomic_directory import (
     _publish_staged_directory_with_authority,
     _rename_noreplace_at,
     _require_matching_ownership,
+    _validate_ownership_inventory_budget,
     directory_ownership_entry_identities,
     directory_ownership_file_records,
     directory_ownership_inventory,
@@ -68,7 +70,6 @@ _F_SEAL_GROW = 0x0004
 _F_SEAL_WRITE = 0x0008
 _REQUIRED_SNAPSHOT_SEALS = _F_SEAL_SEAL | _F_SEAL_SHRINK | _F_SEAL_GROW | _F_SEAL_WRITE
 _UNSET_DESTINATION_OWNERSHIP = object()
-_MAX_WORKSPACE_ENTRIES = 500_000
 _MAX_WORKSPACE_FILE_BYTES = 64 * 1024 * 1024 * 1024
 _MAX_WORKSPACE_TOTAL_BYTES = 64 * 1024 * 1024 * 1024
 _WORKSPACE_PLAN_DOMAIN = b"codenib-owned-workspace-plan-v1"
@@ -291,6 +292,10 @@ def _relative_path(value: str | Path | PurePosixPath) -> PurePosixPath:
         or relative.as_posix() != raw
         or any(part in {"", ".", ".."} for part in relative.parts)
         or len(relative.parts) > _MAX_COMPONENTS
+        or any(
+            len(os.fsencode(part)) > _MAX_OWNERSHIP_COMPONENT_BYTES
+            for part in relative.parts
+        )
         or len(os.fsencode(raw)) > _MAX_RELATIVE_PATH_BYTES
     ):
         raise ValueError("captured directory path must be normalized and bounded")
@@ -368,8 +373,6 @@ class WorkspacePlan:
             raise ValueError("workspace plan subject digest must be lowercase sha256")
         directories = tuple(self.directories)
         files = tuple(self.files)
-        if len(directories) + len(files) > _MAX_WORKSPACE_ENTRIES:
-            raise ValueError("workspace plan has too many entries")
         if not all(
             isinstance(directory_item, WorkspaceDirectory)
             for directory_item in directories
@@ -430,6 +433,15 @@ class WorkspacePlan:
             sorted(directories, key=lambda item: item.path.as_posix())
         )
         canonical_files = tuple(sorted(files, key=lambda item: item.path.as_posix()))
+        try:
+            _validate_ownership_inventory_budget(
+                os.fsencode(item.path.as_posix())
+                for item in (*canonical_directories, *canonical_files)
+            )
+        except RuntimeError as exc:
+            raise ValueError(
+                "workspace plan exceeds the ownership scanner budget"
+            ) from exc
         plan_digest = hashlib.sha256()
         _workspace_frame(plan_digest, b"domain", _WORKSPACE_PLAN_DOMAIN)
         _workspace_frame(plan_digest, b"subject", subject.encode("ascii"))
@@ -438,7 +450,7 @@ class WorkspacePlan:
             _workspace_frame(
                 plan_digest,
                 b"directory-path",
-                directory_item.path.as_posix().encode("utf-8"),
+                os.fsencode(directory_item.path.as_posix()),
             )
             _workspace_frame(
                 plan_digest,
@@ -449,7 +461,7 @@ class WorkspacePlan:
             _workspace_frame(
                 plan_digest,
                 b"file-path",
-                file_item.path.as_posix().encode("utf-8"),
+                os.fsencode(file_item.path.as_posix()),
             )
             _workspace_frame(
                 plan_digest,

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -6,33 +6,138 @@
 
 from __future__ import annotations
 
+import ctypes
+import errno
 import hashlib
+import logging
 import os
 import secrets
 import stat
 import sys
-import tempfile
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Callable, Iterable, Iterator
+from typing import Callable, Iterable, Iterator, Mapping, TypeVar
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - Windows fails closed when requested
+    _fcntl = None  # type: ignore[assignment]
 
 from . import _windows_fs_authority as _windows_fs
 from ._atomic_directory import (
+    DirectoryOrphan,
+    PublicationDirectoryReader,
     TreeFileRecord,
-    capture_directory_ownership,
+    _annotate_secondary_error,
+    _open_publication_authority,
+    _PosixResourceOwner,
+    _PublicationAuthority,
+    _PublicationAuthorityOwner,
+    _publish_staged_directory_with_authority,
+    _rename_noreplace_at,
+    _require_matching_ownership,
     directory_ownership_entry_identities,
     directory_ownership_file_records,
+    directory_ownership_inventory,
     directory_ownership_root_identity,
     directory_ownership_root_version_identity,
     discard_owned_directory,
     lexical_directory_path,
+    publication_parent_identity,
     publish_staged_directory,
 )
+from ._owned_file_publication import _CancellationSafeRLock, _DescriptorOwner
+from ._owned_file_publication import _file_identity as _owned_file_identity
+
+logger = logging.getLogger(__name__)
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _MAX_RELATIVE_PATH_BYTES = 4_096
 _MAX_COMPONENTS = 256
 _COPY_BYTES = 1024 * 1024
+_MAX_IN_MEMORY_SNAPSHOT_BYTES = 512 * 1024 * 1024
+_MAX_SNAPSHOT_CONSUMER_READ_BYTES = 8 * 1024 * 1024
+_MFD_CLOEXEC = 0x0001
+_MFD_ALLOW_SEALING = 0x0002
+_F_ADD_SEALS = 1033
+_F_GET_SEALS = 1034
+_F_SEAL_SEAL = 0x0001
+_F_SEAL_SHRINK = 0x0002
+_F_SEAL_GROW = 0x0004
+_F_SEAL_WRITE = 0x0008
+_REQUIRED_SNAPSHOT_SEALS = _F_SEAL_SEAL | _F_SEAL_SHRINK | _F_SEAL_GROW | _F_SEAL_WRITE
+_UNSET_DESTINATION_OWNERSHIP = object()
+_MAX_WORKSPACE_ENTRIES = 500_000
+_MAX_WORKSPACE_FILE_BYTES = 64 * 1024 * 1024 * 1024
+_MAX_WORKSPACE_TOTAL_BYTES = 64 * 1024 * 1024 * 1024
+_WORKSPACE_PLAN_DOMAIN = b"codenib-owned-workspace-plan-v1"
+_WORKSPACE_RECEIPT_EMPTY = object()
+_WORKSPACE_RECEIPT_CLOSED = object()
+_WORKSPACE_RECEIPT_CLOSE = object()
+_WORKSPACE_OWNER_RECOVERY_LIMIT = 64
+_WorkspaceResult = TypeVar("_WorkspaceResult")
+
+
+class _SnapshotUnavailable(RuntimeError):
+    """The host cannot provide a sealed anonymous descriptor."""
+
+
+def _create_sealable_memfd() -> int:
+    """Create one anonymous Linux file or fail closed on unsupported hosts."""
+
+    create = getattr(os, "memfd_create", None)
+    if callable(create) and _fcntl is not None:
+        return create(
+            "codenib-authenticated-snapshot",
+            _MFD_CLOEXEC | _MFD_ALLOW_SEALING,
+        )
+    if os.name != "posix" or _fcntl is None:
+        raise _SnapshotUnavailable(
+            "sealed authenticated snapshots are unavailable on this host"
+        )
+    libc = ctypes.CDLL(None, use_errno=True)
+    create = getattr(libc, "memfd_create", None)
+    if create is None:
+        raise _SnapshotUnavailable(
+            "sealed authenticated snapshots are unavailable on this host"
+        )
+    create.argtypes = (ctypes.c_char_p, ctypes.c_uint)
+    create.restype = ctypes.c_int
+    descriptor = create(
+        b"codenib-authenticated-snapshot",
+        _MFD_CLOEXEC | _MFD_ALLOW_SEALING,
+    )
+    if descriptor < 0:
+        error = ctypes.get_errno()
+        raise _SnapshotUnavailable(
+            "sealed authenticated snapshots are unavailable on this host"
+        ) from OSError(error, os.strerror(error))
+    return descriptor
+
+
+def _write_all(descriptor: int, block: bytes) -> None:
+    view = memoryview(block)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError("could not write authenticated snapshot")
+        view = view[written:]
+
+
+def _seal_snapshot_descriptor(descriptor: int) -> None:
+    """Seal one fully written anonymous snapshot against later mutation."""
+
+    os.fsync(descriptor)
+    if _fcntl is None:
+        raise _SnapshotUnavailable(
+            "sealed authenticated snapshots are unavailable on this host"
+        )
+    _fcntl.fcntl(descriptor, _F_ADD_SEALS, _REQUIRED_SNAPSHOT_SEALS)
+    observed = _fcntl.fcntl(descriptor, _F_GET_SEALS)
+    if observed & _REQUIRED_SNAPSHOT_SEALS != _REQUIRED_SNAPSHOT_SEALS:
+        raise RuntimeError("authenticated snapshot could not be sealed")
+    os.lseek(descriptor, 0, os.SEEK_SET)
 
 
 def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -192,6 +297,749 @@ def _relative_path(value: str | Path | PurePosixPath) -> PurePosixPath:
     return relative
 
 
+def _workspace_mode(value: int, *, directory: bool) -> int:
+    label = "workspace directory mode" if directory else "workspace file mode"
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{label} must be an integer")
+    if value < 0 or value > 0o777:
+        raise ValueError(f"{label} must contain only portable permission bits")
+    if value & 0o022:
+        raise ValueError(f"{label} must not be group/world writable")
+    required = 0o700 if directory else 0o400
+    if value & required != required:
+        requirement = "owner rwx" if directory else "owner read"
+        raise ValueError(f"{label} must grant {requirement} permission")
+    return value
+
+
+def _workspace_frame(digest: "hashlib._Hash", domain: bytes, payload: bytes) -> None:
+    digest.update(len(domain).to_bytes(2, "big"))
+    digest.update(domain)
+    digest.update(len(payload).to_bytes(8, "big"))
+    digest.update(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceDirectory:
+    """One directory that a trusted provisioner must pre-open for a plan."""
+
+    path: PurePosixPath
+    mode: int = 0o700
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", _relative_path(self.path))
+        object.__setattr__(self, "mode", _workspace_mode(self.mode, directory=True))
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceFile:
+    """One required regular-file slot in an exact workspace plan."""
+
+    path: PurePosixPath
+    mode: int = 0o600
+    max_bytes: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", _relative_path(self.path))
+        object.__setattr__(self, "mode", _workspace_mode(self.mode, directory=False))
+        if isinstance(self.max_bytes, bool) or not isinstance(self.max_bytes, int):
+            raise TypeError("workspace file size limit must be an integer")
+        if self.max_bytes < 0 or self.max_bytes > _MAX_WORKSPACE_FILE_BYTES:
+            raise ValueError("workspace file size limit is out of bounds")
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspacePlan:
+    """Immutable exact skeleton and required file slots for one workspace."""
+
+    subject_digest: str
+    directories: tuple[WorkspaceDirectory, ...] = ()
+    files: tuple[WorkspaceFile, ...] = ()
+    root_mode: int = 0o700
+    digest: str = ""
+
+    def __post_init__(self) -> None:
+        subject = self.subject_digest
+        if (
+            not isinstance(subject, str)
+            or len(subject) != 64
+            or any(character not in "0123456789abcdef" for character in subject)
+        ):
+            raise ValueError("workspace plan subject digest must be lowercase sha256")
+        directories = tuple(self.directories)
+        files = tuple(self.files)
+        if len(directories) + len(files) > _MAX_WORKSPACE_ENTRIES:
+            raise ValueError("workspace plan has too many entries")
+        if not all(
+            isinstance(directory_item, WorkspaceDirectory)
+            for directory_item in directories
+        ):
+            raise TypeError("workspace plan directories must be WorkspaceDirectory")
+        if not all(isinstance(file_item, WorkspaceFile) for file_item in files):
+            raise TypeError("workspace plan files must be WorkspaceFile")
+        root_mode = _workspace_mode(self.root_mode, directory=True)
+
+        directory_by_path: dict[str, WorkspaceDirectory] = {}
+        file_by_path: dict[str, WorkspaceFile] = {}
+        portable_paths: dict[str, str] = {}
+        for directory_item in directories:
+            path = directory_item.path.as_posix()
+            if path in directory_by_path:
+                raise ValueError(f"workspace plan repeats directory: {path}")
+            portable = path.casefold()
+            previous = portable_paths.get(portable)
+            if previous is not None:
+                raise ValueError(
+                    "workspace plan has a portable path collision: "
+                    f"{previous!r} and {path!r}"
+                )
+            portable_paths[portable] = path
+            directory_by_path[path] = directory_item
+        total_bytes = 0
+        for file_item in files:
+            path = file_item.path.as_posix()
+            if path in file_by_path:
+                raise ValueError(f"workspace plan repeats file: {path}")
+            if path in directory_by_path:
+                raise ValueError(
+                    f"workspace plan path is both file and directory: {path}"
+                )
+            portable = path.casefold()
+            previous = portable_paths.get(portable)
+            if previous is not None:
+                raise ValueError(
+                    "workspace plan has a portable path collision: "
+                    f"{previous!r} and {path!r}"
+                )
+            portable_paths[portable] = path
+            file_by_path[path] = file_item
+            total_bytes += file_item.max_bytes
+            if total_bytes > _MAX_WORKSPACE_TOTAL_BYTES:
+                raise ValueError("workspace plan total byte limit is out of bounds")
+
+        for path in tuple(directory_by_path) + tuple(file_by_path):
+            relative = PurePosixPath(path)
+            for depth in range(1, len(relative.parts)):
+                ancestor = "/".join(relative.parts[:depth])
+                if ancestor not in directory_by_path:
+                    raise ValueError(
+                        f"workspace plan is missing directory ancestor: {ancestor}"
+                    )
+
+        canonical_directories = tuple(
+            sorted(directories, key=lambda item: item.path.as_posix())
+        )
+        canonical_files = tuple(sorted(files, key=lambda item: item.path.as_posix()))
+        plan_digest = hashlib.sha256()
+        _workspace_frame(plan_digest, b"domain", _WORKSPACE_PLAN_DOMAIN)
+        _workspace_frame(plan_digest, b"subject", subject.encode("ascii"))
+        _workspace_frame(plan_digest, b"root-mode", root_mode.to_bytes(2, "big"))
+        for directory_item in canonical_directories:
+            _workspace_frame(
+                plan_digest,
+                b"directory-path",
+                directory_item.path.as_posix().encode("utf-8"),
+            )
+            _workspace_frame(
+                plan_digest,
+                b"directory-mode",
+                directory_item.mode.to_bytes(2, "big"),
+            )
+        for file_item in canonical_files:
+            _workspace_frame(
+                plan_digest,
+                b"file-path",
+                file_item.path.as_posix().encode("utf-8"),
+            )
+            _workspace_frame(
+                plan_digest,
+                b"file-mode",
+                file_item.mode.to_bytes(2, "big"),
+            )
+            _workspace_frame(
+                plan_digest,
+                b"file-max-bytes",
+                file_item.max_bytes.to_bytes(8, "big"),
+            )
+        _workspace_frame(
+            plan_digest,
+            b"entry-count",
+            (len(canonical_directories) + len(canonical_files)).to_bytes(8, "big"),
+        )
+        object.__setattr__(self, "directories", canonical_directories)
+        object.__setattr__(self, "files", canonical_files)
+        object.__setattr__(self, "root_mode", root_mode)
+        object.__setattr__(self, "digest", plan_digest.hexdigest())
+
+
+class UnsupportedWorkspaceCreation(RuntimeError):
+    """Strict workspace creation is unavailable without a native creator."""
+
+
+@dataclass(slots=True)
+class _WorkspaceFileOwner:
+    owner: _DescriptorOwner
+    identity: tuple[int, ...] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkspacePublicationTransfer:
+    """Shared aggregate owner installed before any publication mutation."""
+
+    workspace: "OwnedWorkspaceAuthority"
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkspaceReservation:
+    transfer: _WorkspacePublicationTransfer
+
+
+@dataclass(slots=True)
+class _WorkspaceCleanup:
+    transfer: _WorkspacePublicationTransfer
+    attempted: bool = False
+
+
+class PublishedWorkspaceReceipt:
+    """Borrowed exact-generation receipt controlled by its caller-owned slot."""
+
+    __slots__ = (
+        "path",
+        "plan",
+        "sealed_ownership",
+        "ownership",
+        "parent_identity",
+        "orphan",
+        "durable",
+        "_transfer",
+        "_owner_pid",
+    )
+
+    def __init__(
+        self,
+        *,
+        transfer: _WorkspacePublicationTransfer,
+        path: Path,
+        plan: WorkspacePlan,
+        sealed_ownership: object,
+        published_ownership: object,
+        parent_identity: tuple[int, ...],
+        orphan: DirectoryOrphan | None,
+    ) -> None:
+        # Store the shared aggregate first.  A constructor interruption can
+        # therefore be reconciled against the same transfer held by the owner.
+        self._transfer = transfer
+        self.path = path
+        self.plan = plan
+        self.sealed_ownership = sealed_ownership
+        self.ownership = published_ownership
+        self.parent_identity = parent_identity
+        self.orphan = orphan
+        self.durable = True
+        self._owner_pid = os.getpid()
+
+    @property
+    def plan_digest(self) -> str:
+        return self.plan.digest
+
+    @property
+    def closed(self) -> bool:
+        return self._transfer.workspace._publication_transfer_closed(self._transfer)
+
+    def close(self) -> None:
+        raise RuntimeError("close the PublishedWorkspaceReceiptOwner, not its receipt")
+
+    def _consume_from_owner(
+        self,
+        close_authority: object,
+        callback: Callable[
+            ["PublishedWorkspaceReceipt", PublicationDirectoryReader],
+            _WorkspaceResult,
+        ],
+    ) -> _WorkspaceResult:
+        if close_authority is not _WORKSPACE_RECEIPT_CLOSE:
+            raise RuntimeError("published workspace receipt authority is invalid")
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "published workspace receipt cannot cross a PID boundary"
+            )
+        return self._transfer.workspace._consume_published_workspace(
+            self,
+            callback,
+        )
+
+    def _close_from_owner(self, close_authority: object) -> None:
+        if close_authority is not _WORKSPACE_RECEIPT_CLOSE:
+            raise RuntimeError("published workspace receipt close authority is invalid")
+        self._transfer.workspace._close_publication_transfer(self._transfer)
+
+
+class PublishedWorkspaceReceiptOwner:
+    """Caller-precreated one-shot owner for a published workspace generation."""
+
+    __slots__ = ("_slot", "_lock", "_owner_pid", "_process_locks")
+
+    def __init__(self) -> None:
+        self._slot: object = _WORKSPACE_RECEIPT_EMPTY
+        self._lock = _CancellationSafeRLock()
+        self._owner_pid = os.getpid()
+        self._process_locks = {self._owner_pid: self._lock}
+
+    @property
+    def state(self) -> str:
+        self._require_owner_pid()
+
+        def observe() -> str:
+            self._normalize_closed_locked()
+            return self._state_locked()
+
+        return self._lock.run(observe)
+
+    @property
+    def active(self) -> bool:
+        return self.state == "active"
+
+    @property
+    def closed(self) -> bool:
+        return self.state == "closed"
+
+    @property
+    def receipt(self) -> PublishedWorkspaceReceipt:
+        self._require_owner_pid()
+
+        def borrow() -> PublishedWorkspaceReceipt:
+            self._normalize_closed_locked()
+            if not isinstance(self._slot, PublishedWorkspaceReceipt):
+                raise RuntimeError(
+                    "published workspace receipt owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            return self._slot
+
+        return self._lock.run(borrow)
+
+    def consume(
+        self,
+        callback: Callable[
+            [PublishedWorkspaceReceipt, PublicationDirectoryReader],
+            _WorkspaceResult,
+        ],
+    ) -> _WorkspaceResult:
+        """Synchronously borrow one exact authenticated publication reader."""
+
+        if not callable(callback):
+            raise TypeError("published workspace receipt consumer must be callable")
+        self._require_owner_pid()
+        if self._lock.held_by_current_thread():
+            raise RuntimeError("published workspace receipt consume is reentrant")
+
+        def consume_locked() -> _WorkspaceResult:
+            self._normalize_closed_locked()
+            if not isinstance(self._slot, PublishedWorkspaceReceipt):
+                raise RuntimeError(
+                    "published workspace receipt owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            return self._slot._consume_from_owner(
+                _WORKSPACE_RECEIPT_CLOSE,
+                callback,
+            )
+
+        return self._lock.run(consume_locked)
+
+    def close(self) -> None:
+        current_pid = os.getpid()
+        owner_changed = current_pid != self._owner_pid
+        if owner_changed:
+            lifecycle_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+        else:
+            if self._lock.held_by_current_thread():
+                raise RuntimeError("published workspace receipt close is reentrant")
+            lifecycle_lock = self._lock
+
+        close_error: BaseException | None = None
+        try:
+            lifecycle_lock.run(self._close_locked)
+        except BaseException as exc:  # noqa: B036 - reconcile before PID report
+            close_error = exc
+
+        if owner_changed:
+            boundary_error = RuntimeError(
+                "published workspace receipt owner cannot cross a PID boundary"
+            )
+            if close_error is not None:
+                raise boundary_error from close_error
+            raise boundary_error
+        if close_error is not None:
+            raise close_error
+
+    def _close_locked(self) -> None:
+        self._normalize_closed_locked()
+        if self._slot is _WORKSPACE_RECEIPT_CLOSED:
+            return
+        if self._slot is _WORKSPACE_RECEIPT_EMPTY:
+            self._slot = _WORKSPACE_RECEIPT_CLOSED
+            return
+        if isinstance(self._slot, _WorkspaceReservation):
+            if os.getpid() == self._owner_pid:
+                raise RuntimeError(
+                    "published workspace receipt publication is in progress"
+                )
+            # The child owns only its inherited descriptor references.  It
+            # cannot wait for or affect the parent's in-flight publication,
+            # so revoke the child copy and run the transfer's raw inherited-fd
+            # cleanup before reporting the PID boundary.
+            cleanup = _WorkspaceCleanup(self._slot.transfer, attempted=True)
+            self._slot = cleanup
+        if isinstance(self._slot, PublishedWorkspaceReceipt):
+            receipt = self._slot
+            cleanup = _WorkspaceCleanup(receipt._transfer, attempted=True)
+            self._slot = cleanup
+        elif isinstance(self._slot, _WorkspaceCleanup):
+            cleanup = self._slot
+            cleanup.attempted = True
+        else:  # pragma: no cover - all private slot states are exhaustive
+            raise RuntimeError("published workspace receipt owner state is invalid")
+
+        primary_error: BaseException | None = None
+        try:
+            cleanup.transfer.workspace._close_publication_transfer(cleanup.transfer)
+        except BaseException as close_error:  # noqa: B036 - settle aggregate
+            primary_error = close_error
+        try:
+            if cleanup.transfer.workspace._publication_transfer_closed(
+                cleanup.transfer
+            ):
+                self._slot = _WORKSPACE_RECEIPT_CLOSED
+        except BaseException as observation_error:  # noqa: B036
+            if primary_error is None:
+                primary_error = observation_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace receipt close-state observation also failed",
+                    observation_error,
+                )
+        if primary_error is not None:
+            raise primary_error
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close()
+        except BaseException as cleanup_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "published workspace receipt cleanup also failed",
+                cleanup_error,
+            )
+
+    def _reserve(self, reservation: _WorkspaceReservation) -> None:
+        self._require_owner_pid()
+
+        def reserve() -> None:
+            if self._slot is not _WORKSPACE_RECEIPT_EMPTY:
+                raise RuntimeError(
+                    "published workspace receipt owner is "
+                    f"{self._state_locked()}, expected empty"
+                )
+            self._slot = reservation
+
+        self._lock.run(reserve)
+
+    def _install(
+        self,
+        reservation: _WorkspaceReservation,
+        receipt: PublishedWorkspaceReceipt,
+    ) -> None:
+        self._require_owner_pid()
+
+        def install() -> None:
+            if self._slot is not reservation:
+                raise RuntimeError("published workspace receipt reservation changed")
+            if receipt._transfer is not reservation.transfer:
+                raise RuntimeError("published workspace receipt transfer changed")
+            self._slot = receipt
+
+        self._lock.run(install)
+
+    def _owns_transfer(self, transfer: _WorkspacePublicationTransfer) -> bool:
+        def owns() -> bool:
+            return self._slot_transfer_locked() is transfer
+
+        return self._lock.run(owns)
+
+    def _has_active_transfer(self, transfer: _WorkspacePublicationTransfer) -> bool:
+        def active() -> bool:
+            return (
+                isinstance(self._slot, PublishedWorkspaceReceipt)
+                and self._slot._transfer is transfer
+            )
+
+        return self._lock.run(active)
+
+    def _transfer_state(self, transfer: _WorkspacePublicationTransfer) -> str:
+        def observe() -> str:
+            if isinstance(self._slot, PublishedWorkspaceReceipt):
+                return "active" if self._slot._transfer is transfer else "absent"
+            if isinstance(self._slot, _WorkspaceReservation):
+                return "reserved" if self._slot.transfer is transfer else "absent"
+            if isinstance(self._slot, _WorkspaceCleanup):
+                return "cleanup" if self._slot.transfer is transfer else "absent"
+            return "absent"
+
+        return self._lock.run(observe)
+
+    def _cancel_reservation(self, reservation: _WorkspaceReservation) -> None:
+        deferred: BaseException | None = None
+        for _attempt in range(_WORKSPACE_OWNER_RECOVERY_LIMIT):
+            try:
+                terminal = self._lock.run(
+                    lambda: self._cancel_reservation_locked(reservation)
+                )
+            except BaseException as cleanup_error:  # noqa: B036 - converge slot
+                if deferred is None:
+                    deferred = cleanup_error
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "workspace reservation cancellation also failed",
+                        cleanup_error,
+                    )
+                continue
+            if terminal:
+                if deferred is not None:
+                    raise deferred
+                return
+        if deferred is not None:
+            raise deferred
+        raise RuntimeError("workspace receipt reservation did not converge")
+
+    def _cancel_reservation_locked(
+        self,
+        reservation: _WorkspaceReservation,
+    ) -> bool:
+        if self._slot is reservation:
+            self._slot = _WorkspaceCleanup(reservation.transfer)
+        return self._slot is not reservation
+
+    def _normalize_closed_locked(self) -> None:
+        transfer = self._slot_transfer_locked()
+        if (
+            transfer is not None
+            and not isinstance(self._slot, _WorkspaceReservation)
+            and transfer.workspace._publication_transfer_closed(transfer)
+        ):
+            self._slot = _WORKSPACE_RECEIPT_CLOSED
+
+    def _slot_transfer_locked(self) -> _WorkspacePublicationTransfer | None:
+        if isinstance(self._slot, _WorkspaceReservation):
+            return self._slot.transfer
+        if isinstance(self._slot, _WorkspaceCleanup):
+            return self._slot.transfer
+        if isinstance(self._slot, PublishedWorkspaceReceipt):
+            return self._slot._transfer
+        return None
+
+    def _state_locked(self) -> str:
+        if self._slot is _WORKSPACE_RECEIPT_EMPTY:
+            return "empty"
+        if self._slot is _WORKSPACE_RECEIPT_CLOSED:
+            return "closed"
+        if isinstance(self._slot, _WorkspaceReservation):
+            return "reserved"
+        if isinstance(self._slot, PublishedWorkspaceReceipt):
+            return "active"
+        if isinstance(self._slot, _WorkspaceCleanup):
+            return "close-failed" if self._slot.attempted else "cleanup"
+        raise RuntimeError("published workspace receipt owner state is invalid")
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "published workspace receipt owner cannot cross a PID boundary"
+            )
+
+    def __enter__(self) -> "PublishedWorkspaceReceiptOwner":
+        self._require_owner_pid()
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        if exc is None:
+            self.close()
+        else:
+            self.close_after_error(exc)
+
+
+class AuthenticatedSnapshot:
+    """Read-only immutable bytes produced by one successful authentication."""
+
+    __slots__ = (
+        "record",
+        "_descriptor",
+        "_chunks",
+        "_chunk_index",
+        "_chunk_offset",
+        "_consumed",
+        "_closed",
+    )
+
+    def __init__(
+        self,
+        record: TreeFileRecord,
+        *,
+        descriptor: int = -1,
+        chunks: tuple[bytes, ...] | None = None,
+    ) -> None:
+        if (descriptor >= 0) == (chunks is not None):
+            raise ValueError("authenticated snapshot needs exactly one backing")
+        self.record = record
+        self._descriptor = descriptor
+        self._chunks = () if chunks is None else chunks
+        self._chunk_index = 0
+        self._chunk_offset = 0
+        self._consumed = 0
+        self._closed = False
+
+    @property
+    def descriptor(self) -> int:
+        if self._closed or self._descriptor < 0:
+            raise RuntimeError("authenticated snapshot has no sealed descriptor")
+        return self._descriptor
+
+    def read(self, size: int = -1) -> bytes:
+        if self._closed:
+            raise ValueError("authenticated snapshot is closed")
+        if self._descriptor >= 0:
+            requested = (
+                size
+                if size is not None and size >= 0
+                else self.record.size - self._consumed
+            )
+            block = os.read(self._descriptor, requested)
+            self._consumed += len(block)
+            return block
+        remaining = self.record.size - self._consumed
+        requested = remaining if size is None or size < 0 else min(size, remaining)
+        if requested <= 0:
+            return b""
+        output = bytearray()
+        while requested and self._chunk_index < len(self._chunks):
+            chunk = self._chunks[self._chunk_index]
+            available = len(chunk) - self._chunk_offset
+            consumed = min(requested, available)
+            output.extend(chunk[self._chunk_offset : self._chunk_offset + consumed])
+            requested -= consumed
+            self._consumed += consumed
+            self._chunk_offset += consumed
+            if self._chunk_offset == len(chunk):
+                self._chunk_index += 1
+                self._chunk_offset = 0
+        return bytes(output)
+
+    def readline(self, size: int = -1) -> bytes:
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError("authenticated snapshot readline size must be an integer")
+        limit = self.record.size if size < 0 else size
+        output = bytearray()
+        while len(output) < limit:
+            block = self.read(min(_COPY_BYTES, limit - len(output)))
+            if not block:
+                break
+            newline = block.find(b"\n")
+            if newline < 0:
+                output.extend(block)
+                continue
+            output.extend(block[: newline + 1])
+            # Pickle only uses readline during sequential consumption. A line
+            # with trailing bytes is rare; preserve them by rewinding the
+            # sealed fd or the immutable chunk cursor.
+            trailing = len(block) - newline - 1
+            if trailing:
+                self._rewind(trailing)
+            break
+        return bytes(output)
+
+    def _rewind(self, count: int) -> None:
+        if self._descriptor >= 0:
+            os.lseek(self._descriptor, -count, os.SEEK_CUR)
+            self._consumed -= count
+            return
+        self._consumed -= count
+        while count:
+            if self._chunk_offset:
+                moved = min(count, self._chunk_offset)
+                self._chunk_offset -= moved
+                count -= moved
+            else:
+                self._chunk_index -= 1
+                self._chunk_offset = len(self._chunks[self._chunk_index])
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._descriptor >= 0:
+            try:
+                os.close(self._descriptor)
+            except OSError:
+                pass
+            self._descriptor = -1
+        self._chunks = ()
+
+    def __enter__(self) -> AuthenticatedSnapshot:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+
+class AuthenticatedSnapshotReader:
+    """Bound each parser read while exposing only authenticated immutable bytes."""
+
+    __slots__ = ("record", "_snapshot", "_remaining")
+
+    def __init__(self, snapshot: AuthenticatedSnapshot) -> None:
+        self.record = snapshot.record
+        self._snapshot = snapshot
+        self._remaining = snapshot.record.size
+
+    def read(self, size: int = -1) -> bytes:
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError("authenticated snapshot read size must be an integer")
+        if self._remaining <= 0 or size == 0:
+            return b""
+        requested = (
+            _MAX_SNAPSHOT_CONSUMER_READ_BYTES
+            if size < 0
+            else min(size, _MAX_SNAPSHOT_CONSUMER_READ_BYTES)
+        )
+        block = self._snapshot.read(min(requested, self._remaining))
+        self._remaining -= len(block)
+        return block
+
+    def readline(self, size: int = -1) -> bytes:
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError("authenticated snapshot readline size must be an integer")
+        if self._remaining <= 0 or size == 0:
+            return b""
+        requested = (
+            _MAX_SNAPSHOT_CONSUMER_READ_BYTES
+            if size < 0
+            else min(size, _MAX_SNAPSHOT_CONSUMER_READ_BYTES)
+        )
+        block = self._snapshot.readline(min(requested, self._remaining))
+        self._remaining -= len(block)
+        return block
+
+
 class AuthenticatedFile:
     """One opened fd or HANDLE whose bytes match the initial tree record."""
 
@@ -254,6 +1102,22 @@ class AuthenticatedFile:
         self._consumed += len(block)
         return block
 
+    def readline(self, size: int = -1) -> bytes:
+        """Provide the file protocol required by trusted-local Unpickler."""
+
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError("authenticated readline size must be an integer")
+        limit = self.record.size - self._consumed if size < 0 else size
+        payload = bytearray()
+        while len(payload) < limit:
+            block = self.read(1)
+            if not block:
+                break
+            payload.extend(block)
+            if block == b"\n":
+                break
+        return bytes(payload)
+
     def authenticate(self) -> None:
         if self._authenticated:
             return
@@ -281,17 +1145,93 @@ class AuthenticatedFile:
             )
         self._authenticated = True
 
-    def rewind_authenticated(self) -> int:
-        """Authenticate the bytes, rewind the same fd/HANDLE, and return it."""
+    def _copy_authenticated_from_start(
+        self,
+        sink: Callable[[bytes], None],
+    ) -> None:
+        """Copy and independently authenticate every byte from offset zero."""
 
         self.authenticate()
         try:
             self._rewind_callback()
         except OSError as exc:
             raise ValueError(
-                f"captured file cannot be rewound: {self.record.path}"
+                f"captured file could not be copied immutably: {self.record.path}"
             ) from exc
-        return self.descriptor
+
+        remaining = self.record.size
+        digest = hashlib.sha256()
+        try:
+            while remaining:
+                block = self._read_callback(min(_COPY_BYTES, remaining))
+                if not isinstance(block, bytes):
+                    raise RuntimeError("captured file backend returned non-bytes data")
+                if not block:
+                    raise ValueError(f"captured file was truncated: {self.record.path}")
+                if len(block) > remaining:
+                    raise ValueError(
+                        f"captured file grew while reading: {self.record.path}"
+                    )
+                sink(block)
+                digest.update(block)
+                remaining -= len(block)
+            if self._read_callback(1):
+                raise ValueError(
+                    f"captured file grew while reading: {self.record.path}"
+                )
+            after = self._metadata_callback()
+            self._verify_callback()
+        except OSError as exc:
+            raise ValueError(
+                f"captured file could not be copied immutably: {self.record.path}"
+            ) from exc
+        if (
+            _opened_file_identity(after) != _opened_file_identity(self.opened)
+            or digest.hexdigest() != self.record.sha256
+        ):
+            raise ValueError(
+                f"captured file differs from its initial record: {self.record.path}"
+            )
+
+    def sealed_snapshot(self) -> int:
+        """Return an immutable private copy authenticated against the record."""
+
+        snapshot = -1
+        try:
+            snapshot = _create_sealable_memfd()
+            self._copy_authenticated_from_start(
+                lambda block: _write_all(snapshot, block)
+            )
+            _seal_snapshot_descriptor(snapshot)
+            owned = snapshot
+            snapshot = -1
+            return owned
+        except (OSError, RuntimeError) as exc:
+            raise ValueError(
+                f"captured file could not be copied immutably: {self.record.path}"
+            ) from exc
+        finally:
+            if snapshot >= 0:
+                os.close(snapshot)
+
+    def immutable_snapshot(self) -> AuthenticatedSnapshot:
+        """Authenticate into sealed Linux storage or bounded immutable bytes."""
+
+        try:
+            descriptor = self.sealed_snapshot()
+        except ValueError as exc:
+            if not isinstance(exc.__cause__, _SnapshotUnavailable):
+                raise
+            if self.record.size > _MAX_IN_MEMORY_SNAPSHOT_BYTES:
+                raise ValueError(
+                    "captured file needs a sealed snapshot above the "
+                    f"{_MAX_IN_MEMORY_SNAPSHOT_BYTES}-byte fallback limit: "
+                    f"{self.record.path}"
+                ) from exc
+            chunks: list[bytes] = []
+            self._copy_authenticated_from_start(chunks.append)
+            return AuthenticatedSnapshot(self.record, chunks=tuple(chunks))
+        return AuthenticatedSnapshot(self.record, descriptor=descriptor)
 
     def verify_unchanged(self) -> None:
         self.authenticate()
@@ -847,23 +1787,41 @@ class CapturedDirectoryReader:
             return source.record
 
     @contextmanager
+    def authenticated_snapshot(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> Iterator[tuple[AuthenticatedSnapshot, TreeFileRecord]]:
+        source = self.open_file(relative, max_bytes=max_bytes)
+        snapshot: AuthenticatedSnapshot | None = None
+        try:
+            snapshot = source.immutable_snapshot()
+            yield snapshot, source.record
+            source.verify_unchanged()
+        finally:
+            if snapshot is not None:
+                snapshot.close()
+            source.close()
+
+    @contextmanager
     def authenticated_descriptor(
         self,
         relative: str | Path | PurePosixPath,
         *,
         max_bytes: int | None = None,
     ) -> Iterator[tuple[int, TreeFileRecord]]:
+        """Yield a sealed Linux fd; portable consumers should use snapshot()."""
+
         if self._windows_authority is not None:
             raise RuntimeError(
                 "captured authenticated descriptors are available only on POSIX"
             )
-        source = self.open_file(relative, max_bytes=max_bytes)
-        try:
-            descriptor = source.rewind_authenticated()
-            yield descriptor, source.record
-            source.verify_unchanged()
-        finally:
-            source.close()
+        with self.authenticated_snapshot(relative, max_bytes=max_bytes) as (
+            snapshot,
+            record,
+        ):
+            yield snapshot.descriptor, record
 
     def copy_chunks(
         self,
@@ -887,25 +1845,1469 @@ class CapturedDirectoryReader:
             source.close()
 
 
+class OwnedWorkspaceAuthority:
+    """Caller-owned strict writer for one pre-opened exact directory skeleton.
+
+    POSIX cannot atomically create a directory and return its descriptor.  This
+    authority therefore never provisions directories.  A trusted/quiescent
+    caller creates and opens the complete skeleton first, constructs this empty
+    owner, and then calls :meth:`adopt`.  Every later file create is relative to
+    a retained planned-parent descriptor; no runtime path is promoted into an
+    ownership boundary.
+
+    The object is deliberately pre-created before descriptor acquisition.  Its
+    resource owners remain reachable if ``KeyboardInterrupt`` or ``SystemExit``
+    lands at a Python return/store boundary.  ``close`` is retryable after a
+    persistent descriptor-close failure and never removes a path.
+    """
+
+    def __init__(self) -> None:
+        self._lock = _CancellationSafeRLock()
+        self._owner_pid = os.getpid()
+        self._process_locks = {self._owner_pid: self._lock}
+        self._state = "empty"
+        self._parent_owner = _PublicationAuthorityOwner()
+        self._resources = _PosixResourceOwner()
+        self._destination: Path | None = None
+        self._stage_path: Path | None = None
+        self._plan: WorkspacePlan | None = None
+        self._expected_destination: object | None = None
+        self._root_descriptor = -1
+        self._root_identity: tuple[int, ...] | None = None
+        self._directory_descriptors: dict[str, int] = {}
+        self._directory_identities: dict[str, tuple[int, ...]] = {}
+        self._file_owners: list[_WorkspaceFileOwner] = []
+        self._file_specs: dict[str, WorkspaceFile] = {}
+        self._written_files: dict[
+            str,
+            tuple[tuple[int, ...], int, int, str],
+        ] = {}
+        self._sealed_ownership: object | None = None
+        self._publication_transfer: _WorkspacePublicationTransfer | None = None
+        self._resources_transferred = False
+
+    @property
+    def state(self) -> str:
+        self._require_owner_pid()
+        return self._lock.run(lambda: self._state)
+
+    @property
+    def plan(self) -> WorkspacePlan:
+        self._require_owner_pid()
+
+        def get_plan() -> WorkspacePlan:
+            if self._plan is None:
+                raise RuntimeError("owned workspace authority has not been adopted")
+            return self._plan
+
+        return self._lock.run(get_plan)
+
+    @classmethod
+    def create(cls, *_args: object, **_kwargs: object) -> OwnedWorkspaceAuthority:
+        """Fail before mutation until a native create-and-open backend exists."""
+
+        raise UnsupportedWorkspaceCreation(
+            "strict workspace creation requires a trusted pre-opened skeleton"
+        )
+
+    def adopt(
+        self,
+        *,
+        destination: Path,
+        stage_name: str,
+        parent_descriptor: int,
+        root_descriptor: int,
+        directory_descriptors: Mapping[
+            str | Path | PurePosixPath,
+            int,
+        ],
+        plan: WorkspacePlan,
+        expected_destination: object | None,
+    ) -> None:
+        """Adopt a pre-opened sibling root and exact empty-file skeleton."""
+
+        self._require_owner_pid()
+        self._reject_reentrant("adopt")
+        self._lock.run(
+            lambda: self._adopt_locked(
+                destination=destination,
+                stage_name=stage_name,
+                parent_descriptor=parent_descriptor,
+                root_descriptor=root_descriptor,
+                directory_descriptors=directory_descriptors,
+                plan=plan,
+                expected_destination=expected_destination,
+            )
+        )
+
+    def _adopt_locked(
+        self,
+        *,
+        destination: Path,
+        stage_name: str,
+        parent_descriptor: int,
+        root_descriptor: int,
+        directory_descriptors: Mapping[
+            str | Path | PurePosixPath,
+            int,
+        ],
+        plan: WorkspacePlan,
+        expected_destination: object | None,
+    ) -> None:
+        self._require_owner_pid()
+        if self._state != "empty":
+            raise RuntimeError("owned workspace authority is not empty")
+        if not (sys.platform.startswith("linux") or sys.platform == "darwin"):
+            raise UnsupportedWorkspaceCreation(
+                "strict pre-opened workspaces require POSIX directory fds"
+            )
+        if not isinstance(plan, WorkspacePlan):
+            raise TypeError("owned workspace plan must be WorkspacePlan")
+        if (
+            isinstance(parent_descriptor, bool)
+            or not isinstance(parent_descriptor, int)
+            or parent_descriptor < 0
+            or isinstance(root_descriptor, bool)
+            or not isinstance(root_descriptor, int)
+            or root_descriptor < 0
+        ):
+            raise ValueError("workspace descriptors must be open integer descriptors")
+        stage_relative = _relative_path(stage_name)
+        if len(stage_relative.parts) != 1:
+            raise ValueError("workspace stage name must be one bounded file name")
+        destination_path = lexical_directory_path(destination)
+        stage_path = destination_path.parent / stage_relative.name
+        if stage_path == destination_path:
+            raise ValueError("workspace stage and destination must differ")
+
+        expected_directory_paths = {item.path.as_posix() for item in plan.directories}
+        normalized_descriptors: dict[str, int] = {}
+        if not isinstance(directory_descriptors, Mapping):
+            raise TypeError("workspace directory descriptors must be a mapping")
+        for raw_path, descriptor in directory_descriptors.items():
+            path = _relative_path(raw_path).as_posix()
+            if path in normalized_descriptors:
+                raise ValueError(f"workspace repeats directory descriptor: {path}")
+            if (
+                isinstance(descriptor, bool)
+                or not isinstance(descriptor, int)
+                or descriptor < 0
+            ):
+                raise ValueError(
+                    "workspace directory descriptors must be open integers"
+                )
+            normalized_descriptors[path] = descriptor
+        if set(normalized_descriptors) != expected_directory_paths:
+            raise ValueError(
+                "workspace directory descriptors must exactly match the plan"
+            )
+
+        if expected_destination is not None:
+            # Validate the private token before acquiring any authority.
+            directory_ownership_root_identity(expected_destination)
+
+        self._state = "adopting"
+        self._destination = destination_path
+        self._stage_path = stage_path
+        self._plan = plan
+        self._expected_destination = expected_destination
+        self._file_specs = {item.path.as_posix(): item for item in plan.files}
+        try:
+            _open_publication_authority(
+                destination_path.parent,
+                parent_resource=parent_descriptor,
+                expected_parent_identity=publication_parent_identity(parent_descriptor),
+                authority_owner=self._parent_owner,
+            )
+            authority = self._require_parent_authority()
+            flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0) | getattr(
+                os,
+                "O_NONBLOCK",
+                0,
+            )
+            self._root_descriptor = self._resources.open(
+                ".",
+                flags,
+                dir_fd=root_descriptor,
+            )
+            root_metadata = os.fstat(self._root_descriptor)
+            if not stat.S_ISDIR(root_metadata.st_mode):
+                raise ValueError("workspace root descriptor is not a directory")
+            if stat.S_IMODE(root_metadata.st_mode) != plan.root_mode:
+                raise ValueError("workspace root mode differs from its plan")
+            self._root_identity = _root_identity(root_metadata)
+            if self._root_identity[0] != authority.identity[0]:
+                raise ValueError(
+                    "workspace root and destination parent differ by device"
+                )
+
+            stage_metadata = authority.child_metadata(
+                stage_relative.name,
+                path=stage_path,
+                label="owned workspace stage",
+            )
+            if stage_metadata is None:
+                raise ValueError("owned workspace stage does not exist")
+            if _root_identity(stage_metadata) != self._root_identity:
+                raise RuntimeError("workspace stage name differs from its root handle")
+
+            expected_directory_modes = {
+                item.path.as_posix(): item.mode for item in plan.directories
+            }
+
+            def skeleton_policy(path: str, kind: str, mode: int, _size: int) -> None:
+                if kind != "directory":
+                    raise ValueError("workspace skeleton must contain no files")
+                expected_mode = expected_directory_modes.get(path)
+                if expected_mode is None or mode != expected_mode:
+                    raise ValueError(
+                        f"workspace skeleton directory differs from plan: {path}"
+                    )
+
+            skeleton = authority.capture_child(
+                stage_relative.name,
+                path=stage_path,
+                label="owned workspace stage",
+                allow_empty_root=True,
+                entry_policy=skeleton_policy,
+            )
+            expected_inventory = tuple(
+                (item.path.as_posix(), "directory") for item in plan.directories
+            )
+            if directory_ownership_inventory(skeleton) != expected_inventory:
+                raise ValueError("workspace skeleton differs from its exact plan")
+            if directory_ownership_root_identity(skeleton) != self._root_identity:
+                raise RuntimeError("workspace root changed while it was adopted")
+
+            captured_identities = {
+                path: (
+                    identity[0],
+                    identity[1],
+                    stat.S_IFMT(identity[2]),
+                    identity[4],
+                )
+                for path, kind, identity in directory_ownership_entry_identities(
+                    skeleton
+                )
+                if kind == "directory"
+            }
+            self._directory_descriptors = {"": self._root_descriptor}
+            self._directory_identities = {"": self._root_identity}
+            for item in plan.directories:
+                path = item.path.as_posix()
+                descriptor = self._resources.open(
+                    ".",
+                    flags,
+                    dir_fd=normalized_descriptors[path],
+                )
+                metadata = os.fstat(descriptor)
+                identity = _root_identity(metadata)
+                if (
+                    not stat.S_ISDIR(metadata.st_mode)
+                    or stat.S_IMODE(metadata.st_mode) != item.mode
+                    or identity != captured_identities.get(path)
+                    or identity[0] != self._root_identity[0]
+                ):
+                    raise RuntimeError(
+                        f"workspace directory handle differs from plan: {path}"
+                    )
+                parent_path = item.path.parent.as_posix()
+                if parent_path == ".":
+                    parent_path = ""
+                parent = self._directory_descriptors.get(parent_path)
+                if parent is None:
+                    raise RuntimeError(
+                        f"workspace directory parent was not retained: {path}"
+                    )
+                observed = os.stat(
+                    item.path.name,
+                    dir_fd=parent,
+                    follow_symlinks=False,
+                )
+                if _root_identity(observed) != identity:
+                    raise RuntimeError(
+                        f"workspace directory binding changed during adopt: {path}"
+                    )
+                self._directory_descriptors[path] = descriptor
+                self._directory_identities[path] = identity
+
+            destination_metadata = authority.child_metadata(
+                destination_path.name,
+                path=destination_path,
+                label="owned workspace destination",
+            )
+            if expected_destination is None:
+                if destination_metadata is not None:
+                    raise RuntimeError(
+                        "owned workspace destination was expected missing"
+                    )
+            else:
+                if destination_metadata is None:
+                    raise RuntimeError("owned workspace destination disappeared")
+                observed_destination = authority.capture_child(
+                    destination_path.name,
+                    path=destination_path,
+                    label="owned workspace destination",
+                    allow_empty_root=True,
+                )
+                if observed_destination != expected_destination:
+                    raise RuntimeError("owned workspace destination changed")
+            authority.verify_path_binding()
+            self._refresh_locked(require_complete=False)
+            self._state = "adopted"
+        except BaseException as refresh_error:
+            self._state = "failed"
+            self._close_resources_after_error_locked(refresh_error)
+            raise
+
+    def write_file(
+        self,
+        relative: str | Path | PurePosixPath,
+        chunks: Iterable[bytes],
+    ) -> None:
+        self._require_owner_pid()
+        self._reject_reentrant("write")
+        self._lock.run(lambda: self._write_file_locked(relative, chunks))
+
+    def _write_file_locked(
+        self,
+        relative: str | Path | PurePosixPath,
+        chunks: Iterable[bytes],
+    ) -> None:
+        self._require_owner_pid()
+        if self._state not in {"adopted", "writing"}:
+            raise RuntimeError(f"owned workspace cannot write while {self._state}")
+        normalized = _relative_path(relative)
+        path = normalized.as_posix()
+        spec = self._file_specs.get(path)
+        if spec is None:
+            raise ValueError(f"workspace file is absent from its plan: {path}")
+        if path in self._written_files:
+            raise ValueError(f"workspace file was already written: {path}")
+
+        descriptor = -1
+        descriptor_record = _WorkspaceFileOwner(_DescriptorOwner())
+        self._file_owners.append(descriptor_record)
+        iterator = None
+        primary_error: BaseException | None = None
+        record: tuple[tuple[int, ...], int, int, str] | None = None
+        try:
+            self._refresh_locked(require_complete=False)
+            iterator = iter(chunks)
+            parent_path = normalized.parent.as_posix()
+            if parent_path == ".":
+                parent_path = ""
+            parent = self._directory_descriptors[parent_path]
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            descriptor = descriptor_record.owner.open(
+                normalized.name,
+                flags,
+                0o600,
+                dir_fd=parent,
+            )
+            byte_count = 0
+            digest = hashlib.sha256()
+            for chunk in iterator:
+                if not isinstance(chunk, bytes):
+                    raise TypeError("owned workspace file chunks must be bytes")
+                byte_count += len(chunk)
+                if byte_count > spec.max_bytes:
+                    raise ValueError(
+                        f"workspace file exceeds its {spec.max_bytes}-byte limit: "
+                        f"{path}"
+                    )
+                digest.update(chunk)
+                view = memoryview(chunk)
+                while view:
+                    written = os.write(descriptor, view)
+                    if written <= 0:
+                        raise OSError("could not write owned workspace file")
+                    view = view[written:]
+            os.fchmod(descriptor, spec.mode)
+            os.fsync(descriptor)
+            opened = os.fstat(descriptor)
+            published = os.stat(
+                normalized.name,
+                dir_fd=parent,
+                follow_symlinks=False,
+            )
+            identity = _root_identity(opened)
+            descriptor_record.identity = _owned_file_identity(opened)
+            descriptor_record.owner.bind_identity(opened)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_nlink != 1
+                or stat.S_IMODE(opened.st_mode) != spec.mode
+                or opened.st_size != byte_count
+                or identity != _root_identity(published)
+                or self._root_identity is None
+                or identity[0] != self._root_identity[0]
+            ):
+                raise RuntimeError(f"owned workspace file changed: {path}")
+            os.fsync(parent)
+            record = (identity, spec.mode, byte_count, digest.hexdigest())
+        except BaseException as exc:  # noqa: B036 - cleanup before re-raise
+            primary_error = exc
+        finally:
+            try:
+                close_iterator = getattr(iterator, "close", None)
+            except BaseException as close_error:  # noqa: B036
+                if primary_error is None:
+                    primary_error = close_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "workspace producer cleanup lookup also failed",
+                        close_error,
+                    )
+            else:
+                if callable(close_iterator):
+                    try:
+                        close_iterator()
+                    except BaseException as close_error:  # noqa: B036
+                        if primary_error is None:
+                            primary_error = close_error
+                        else:
+                            _annotate_secondary_error(
+                                primary_error,
+                                "workspace producer cleanup also failed",
+                                close_error,
+                            )
+            if descriptor >= 0:
+                try:
+                    if descriptor_record.identity is None:
+                        metadata = os.fstat(descriptor)
+                        descriptor_record.identity = _owned_file_identity(metadata)
+                        descriptor_record.owner.bind_identity(metadata)
+                    assert descriptor_record.identity is not None
+                    descriptor_record.owner.close(
+                        expected_identity=descriptor_record.identity,
+                        retryable=True,
+                    )
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        primary_error = close_error
+                    else:
+                        _annotate_secondary_error(
+                            primary_error,
+                            "workspace file descriptor cleanup also failed",
+                            close_error,
+                        )
+
+        if primary_error is not None:
+            self._state = "failed"
+            self._close_resources_after_error_locked(primary_error)
+            raise primary_error.with_traceback(primary_error.__traceback__)
+        assert record is not None
+        try:
+            self._written_files[path] = record
+            self._refresh_locked(require_complete=False)
+            self._state = "writing"
+        except BaseException as transition_error:
+            self._state = "failed"
+            self._close_resources_after_error_locked(transition_error)
+            raise
+
+    def seal(self) -> object:
+        self._require_owner_pid()
+        self._reject_reentrant("seal")
+
+        def seal_locked() -> object:
+            self._require_owner_pid()
+            if self._state == "sealed" and self._sealed_ownership is not None:
+                return self._sealed_ownership
+            if self._state not in {"adopted", "writing"}:
+                raise RuntimeError(f"owned workspace cannot seal while {self._state}")
+            try:
+                ownership = self._refresh_locked(require_complete=True)
+                self._fsync_directories_locked()
+                ownership = self._refresh_locked(require_complete=True)
+            except BaseException as primary_error:
+                self._state = "failed"
+                self._close_resources_after_error_locked(primary_error)
+                raise
+            self._sealed_ownership = ownership
+            self._state = "sealed"
+            return ownership
+
+        return self._lock.run(seal_locked)
+
+    def _fsync_directories_locked(self) -> None:
+        """Persist the complete pre-opened skeleton from leaves to its root."""
+
+        ordered_paths = sorted(
+            self._directory_descriptors,
+            key=lambda path: (path.count("/") + bool(path), path),
+            reverse=True,
+        )
+        for path in ordered_paths:
+            os.fsync(self._directory_descriptors[path])
+
+    def publish_into(self, receipt_owner: PublishedWorkspaceReceiptOwner) -> None:
+        """Durably publish and install ownership in a pre-created caller slot."""
+
+        self._require_owner_pid()
+        self._reject_reentrant("publish")
+        if not isinstance(receipt_owner, PublishedWorkspaceReceiptOwner):
+            raise TypeError("receipt_owner must be a PublishedWorkspaceReceiptOwner")
+        transfer = _WorkspacePublicationTransfer(self)
+        reservation = _WorkspaceReservation(transfer)
+        try:
+            self._lock.run(
+                lambda: self._publish_into_locked(
+                    receipt_owner,
+                    transfer,
+                    reservation,
+                )
+            )
+        except BaseException as primary_error:  # noqa: B036 - reconcile owners
+            self._reconcile_publish_failure_outside_lock(
+                receipt_owner,
+                transfer,
+                reservation,
+                primary_error,
+            )
+            raise
+
+    def _publish_into_locked(
+        self,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        transfer: _WorkspacePublicationTransfer,
+        reservation: _WorkspaceReservation,
+    ) -> None:
+        self._require_owner_pid()
+        if self._state != "sealed" or self._sealed_ownership is None:
+            raise RuntimeError(f"owned workspace cannot publish while {self._state}")
+        if self._destination is None or self._stage_path is None or self._plan is None:
+            raise RuntimeError("owned workspace publication state is incomplete")
+
+        # This first ownership store and every later publication operation are
+        # covered by publish_into's outer exception reconciliation.  Keeping
+        # that reconciliation outside the workspace lock avoids an ABBA with
+        # receipt consume/close, whose lifecycle order is owner then workspace.
+        self._publication_transfer = transfer
+        self._resources_transferred = True
+        self._state = "reserving-publication"
+        receipt_owner._reserve(reservation)
+        self._state = "publishing"
+        sealed_ownership = self._sealed_ownership
+        destination = self._destination
+        plan = self._plan
+        authority = self._require_parent_authority()
+
+        def install_receipt(
+            committed_sealed: object,
+            published_ownership: object,
+            previous_orphan: DirectoryOrphan | None,
+        ) -> None:
+            if committed_sealed != sealed_ownership:
+                raise RuntimeError("published workspace sealed token changed")
+            _require_matching_ownership(
+                published_ownership,
+                sealed_ownership,
+                label="published workspace",
+                allow_root_rename=True,
+            )
+            receipt = PublishedWorkspaceReceipt(
+                transfer=transfer,
+                path=destination,
+                plan=plan,
+                sealed_ownership=sealed_ownership,
+                published_ownership=published_ownership,
+                parent_identity=authority.identity,
+                orphan=previous_orphan,
+            )
+            # State is written before install.  If install is interrupted
+            # before its slot store, the outer reconciliation demotes this to
+            # failed; after the store no later state write is required.
+            self._state = "published"
+            receipt_owner._install(reservation, receipt)
+
+        _publish_staged_directory_with_authority(
+            authority,
+            self._stage_path,
+            self._destination,
+            expected_stage_root_ownership=sealed_ownership,
+            expected_destination_ownership=self._expected_destination,
+            commit_callback=install_receipt,
+        )
+
+    def _reconcile_publish_failure_outside_lock(
+        self,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        transfer: _WorkspacePublicationTransfer,
+        reservation: _WorkspaceReservation,
+        primary_error: BaseException,
+    ) -> None:
+        """Settle a failed publication without ever nesting owner/workspace locks."""
+
+        deferred: BaseException | None = None
+        for _attempt in range(_WORKSPACE_OWNER_RECOVERY_LIMIT):
+            try:
+                terminal = self._reconcile_publish_failure_once(
+                    receipt_owner,
+                    transfer,
+                    reservation,
+                    primary_error,
+                )
+            except BaseException as reconciliation_error:  # noqa: B036
+                if deferred is None:
+                    deferred = reconciliation_error
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "workspace publication reconciliation also failed",
+                        reconciliation_error,
+                    )
+                continue
+            if terminal:
+                if deferred is not None:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "workspace publication reconciliation was interrupted",
+                        deferred,
+                    )
+                return
+        recovery_error = RuntimeError(
+            "workspace publication reconciliation did not converge"
+        )
+        if deferred is not None:
+            _annotate_secondary_error(
+                recovery_error,
+                "workspace publication reconciliation recovery also failed",
+                deferred,
+            )
+        _annotate_secondary_error(
+            primary_error,
+            "workspace publication ownership is unknown",
+            recovery_error,
+        )
+
+    def _reconcile_publish_failure_once(
+        self,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        transfer: _WorkspacePublicationTransfer,
+        reservation: _WorkspaceReservation,
+        primary_error: BaseException,
+    ) -> bool:
+        publication_started = self._lock.run(
+            lambda: self._publication_transfer is transfer
+        )
+        if not publication_started:
+            return True
+
+        transfer_state = self._receipt_transfer_state_after_error(
+            receipt_owner,
+            transfer,
+            primary_error,
+        )
+        if transfer_state == "unknown":
+            raise RuntimeError("workspace receipt ownership is unknown")
+        if transfer_state == "reserved":
+            receipt_owner._cancel_reservation(reservation)
+            transfer_state = self._receipt_transfer_state_after_error(
+                receipt_owner,
+                transfer,
+                primary_error,
+            )
+            if transfer_state in {"reserved", "unknown"}:
+                raise RuntimeError(
+                    "workspace receipt reservation cancellation did not settle"
+                )
+
+        def settle_workspace() -> None:
+            # The receipt owner lock is not held here.  A concurrent close may
+            # have completed after the owner snapshot; identity is therefore
+            # checked again before touching workspace state.
+            if self._publication_transfer is not transfer:
+                return
+            if transfer_state == "active":
+                self._state = "published"
+                return
+            if transfer_state == "cleanup":
+                self._state = "failed"
+                return
+            if transfer_state != "absent":
+                raise RuntimeError(
+                    "workspace receipt ownership state is invalid: " f"{transfer_state}"
+                )
+            # The owner never received the transfer.  Make public workspace
+            # close retryable before attempting aggregate cleanup, and clear
+            # the transfer marker last so an interrupted settle can resume.
+            self._resources_transferred = False
+            self._state = "failed"
+            self._close_resources_after_error_locked(primary_error)
+            self._publication_transfer = None
+
+        self._lock.run(settle_workspace)
+        return True
+
+    @staticmethod
+    def _receipt_transfer_state_after_error(
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        transfer: _WorkspacePublicationTransfer,
+        primary_error: BaseException,
+    ) -> str:
+        deferred: BaseException | None = None
+        for _attempt in range(_WORKSPACE_OWNER_RECOVERY_LIMIT):
+            try:
+                state = receipt_owner._transfer_state(transfer)
+            except BaseException as state_error:  # noqa: B036 - bounded recovery
+                if deferred is None:
+                    deferred = state_error
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "workspace receipt ownership observation also failed",
+                        state_error,
+                    )
+                continue
+            if deferred is not None:
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace receipt ownership observation was interrupted",
+                    deferred,
+                )
+            return state
+        recovery_error = RuntimeError(
+            "workspace receipt ownership observation did not converge"
+        )
+        if deferred is not None:
+            _annotate_secondary_error(
+                recovery_error,
+                "workspace receipt ownership recovery also failed",
+                deferred,
+            )
+        _annotate_secondary_error(
+            primary_error,
+            "workspace receipt ownership is unknown",
+            recovery_error,
+        )
+        # Unknown ownership must never trigger a competing resource close.
+        return "unknown"
+
+    def _consume_published_workspace(
+        self,
+        receipt: PublishedWorkspaceReceipt,
+        callback: Callable[
+            [PublishedWorkspaceReceipt, PublicationDirectoryReader],
+            _WorkspaceResult,
+        ],
+    ) -> _WorkspaceResult:
+        self._require_owner_pid()
+        self._reject_reentrant("consume")
+
+        def consume_locked() -> _WorkspaceResult:
+            if (
+                self._state != "published"
+                or self._publication_transfer is not receipt._transfer
+                or self._destination != receipt.path
+                or self._plan != receipt.plan
+            ):
+                raise RuntimeError("published workspace receipt is not active")
+            authority = self._require_parent_authority()
+            if authority.identity != receipt.parent_identity:
+                raise RuntimeError("published workspace parent authority changed")
+            root_before = os.fstat(self._root_descriptor)
+            if _root_identity(root_before) != directory_ownership_root_identity(
+                receipt.ownership
+            ) or _captured_version_identity(
+                root_before
+            ) != directory_ownership_root_version_identity(
+                receipt.ownership
+            ):
+                raise RuntimeError("published workspace root handle changed")
+            authority.verify_path_binding()
+
+            def exact_reader(
+                reader: PublicationDirectoryReader,
+            ) -> _WorkspaceResult:
+                before = reader.capture_ownership(allow_empty_root=True)
+                if before != receipt.ownership:
+                    raise RuntimeError("published workspace generation changed")
+                result = callback(receipt, reader)
+                after = reader.capture_ownership(allow_empty_root=True)
+                if after != before:
+                    raise RuntimeError(
+                        "published workspace changed during receipt consumption"
+                    )
+                return result
+
+            result = authority.read_child(
+                receipt.path.name,
+                path=receipt.path,
+                label="published workspace",
+                expected_ownership=receipt.ownership,
+                callback=exact_reader,
+            )
+            authority.verify_path_binding()
+            root_after = os.fstat(self._root_descriptor)
+            if _captured_version_identity(root_after) != _captured_version_identity(
+                root_before
+            ):
+                raise RuntimeError(
+                    "published workspace root changed during receipt consumption"
+                )
+            return result
+
+        return self._lock.run(consume_locked)
+
+    def _close_publication_transfer(
+        self,
+        transfer: _WorkspacePublicationTransfer,
+    ) -> None:
+        current_pid = os.getpid()
+        if current_pid != self._owner_pid:
+            child_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+            inherited_close_error: BaseException | None = None
+
+            def close_inherited() -> None:
+                self._require_publication_transfer_locked(transfer)
+                self._close_inherited_resources_locked()
+                if self._state == "closed":
+                    self._finish_publication_transfer_closed_locked(transfer)
+
+            try:
+                child_lock.run(close_inherited)
+            except BaseException as exc:  # noqa: B036 - report PID boundary
+                inherited_close_error = exc
+            boundary_error = RuntimeError(
+                "published workspace transfer cannot cross a PID boundary"
+            )
+            if inherited_close_error is not None:
+                raise boundary_error from inherited_close_error
+            raise boundary_error
+
+        self._reject_reentrant("receipt close")
+
+        def close_locked() -> None:
+            self._require_publication_transfer_locked(transfer)
+            primary_error: BaseException | None = None
+            try:
+                self._close_resources_locked()
+            except BaseException as close_error:  # noqa: B036 - reconcile transfer
+                primary_error = close_error
+            try:
+                if self._state == "closed":
+                    self._finish_publication_transfer_closed_locked(transfer)
+            except BaseException as transition_error:  # noqa: B036
+                if primary_error is None:
+                    primary_error = transition_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "workspace transfer close transition also failed",
+                        transition_error,
+                    )
+            if primary_error is not None:
+                raise primary_error
+
+        self._lock.run(close_locked)
+
+    def _publication_transfer_closed(
+        self,
+        transfer: _WorkspacePublicationTransfer,
+    ) -> bool:
+        def observe() -> bool:
+            return self._state == "closed" and (
+                self._publication_transfer is None
+                or self._publication_transfer is transfer
+            )
+
+        if os.getpid() != self._owner_pid:
+            return observe()
+        return self._lock.run(observe)
+
+    def _require_publication_transfer_locked(
+        self,
+        transfer: _WorkspacePublicationTransfer,
+    ) -> None:
+        if (
+            transfer.workspace is not self
+            or self._publication_transfer is not transfer
+            or not self._resources_transferred
+        ):
+            raise RuntimeError("published workspace transfer authority changed")
+
+    def _finish_publication_transfer_closed_locked(
+        self,
+        transfer: _WorkspacePublicationTransfer,
+    ) -> None:
+        self._require_publication_transfer_locked(transfer)
+        self._resources_transferred = False
+        self._publication_transfer = None
+
+    def _refresh_locked(self, *, require_complete: bool) -> object:
+        authority = self._require_parent_authority()
+        if (
+            self._stage_path is None
+            or self._root_identity is None
+            or self._plan is None
+        ):
+            raise RuntimeError("owned workspace authority is incomplete")
+        authority.verify_path_binding()
+        root_metadata = authority.child_metadata(
+            self._stage_path.name,
+            path=self._stage_path,
+            label="owned workspace stage",
+        )
+        if (
+            root_metadata is None
+            or _root_identity(root_metadata) != self._root_identity
+        ):
+            raise RuntimeError("owned workspace root changed")
+        if _root_identity(os.fstat(self._root_descriptor)) != self._root_identity:
+            raise RuntimeError("owned workspace root handle changed")
+
+        directory_specs = {
+            item.path.as_posix(): item for item in self._plan.directories
+        }
+        for path, descriptor in self._directory_descriptors.items():
+            metadata = os.fstat(descriptor)
+            expected_identity = self._directory_identities[path]
+            expected_mode = (
+                self._plan.root_mode if not path else directory_specs[path].mode
+            )
+            if (
+                _root_identity(metadata) != expected_identity
+                or stat.S_IMODE(metadata.st_mode) != expected_mode
+            ):
+                raise RuntimeError(
+                    "owned workspace directory handle changed"
+                    + (f": {path}" if path else "")
+                )
+            if path:
+                relative = PurePosixPath(path)
+                parent_path = relative.parent.as_posix()
+                if parent_path == ".":
+                    parent_path = ""
+                observed = os.stat(
+                    relative.name,
+                    dir_fd=self._directory_descriptors[parent_path],
+                    follow_symlinks=False,
+                )
+                if _root_identity(observed) != expected_identity:
+                    raise RuntimeError(
+                        f"owned workspace directory binding changed: {path}"
+                    )
+
+        allowed_files = self._written_files
+
+        def entry_policy(path: str, kind: str, mode: int, size: int) -> None:
+            if kind == "directory":
+                spec = directory_specs.get(path)
+                if spec is None or mode != spec.mode:
+                    raise RuntimeError(
+                        f"owned workspace contains an unplanned directory: {path}"
+                    )
+                return
+            record = allowed_files.get(path)
+            if record is None or (mode, size) != (record[1], record[2]):
+                raise RuntimeError(
+                    f"owned workspace contains an unplanned file: {path}"
+                )
+
+        observed = authority.capture_child(
+            self._stage_path.name,
+            path=self._stage_path,
+            label="owned workspace stage",
+            allow_empty_root=True,
+            entry_policy=entry_policy,
+        )
+        expected_inventory = tuple(
+            sorted(
+                [(path, "directory") for path in directory_specs]
+                + [(path, "file") for path in allowed_files]
+            )
+        )
+        if directory_ownership_inventory(observed) != expected_inventory:
+            raise RuntimeError("owned workspace inventory differs from its plan")
+        if directory_ownership_root_identity(observed) != self._root_identity:
+            raise RuntimeError("owned workspace root changed during verification")
+        identities = {
+            path: identity
+            for path, _kind, identity in directory_ownership_entry_identities(observed)
+        }
+        records = {
+            record.path: record for record in directory_ownership_file_records(observed)
+        }
+        for path, identity in self._directory_identities.items():
+            if not path:
+                continue
+            observed_identity = identities.get(path)
+            if (
+                observed_identity is None
+                or (
+                    observed_identity[0],
+                    observed_identity[1],
+                    stat.S_IFMT(observed_identity[2]),
+                    observed_identity[4],
+                )
+                != identity
+            ):
+                raise RuntimeError(f"owned workspace directory changed: {path}")
+        for path, (identity, mode, size, digest) in allowed_files.items():
+            observed_identity = identities.get(path)
+            record = records.get(path)
+            if (
+                observed_identity is None
+                or (
+                    observed_identity[0],
+                    observed_identity[1],
+                    stat.S_IFMT(observed_identity[2]),
+                    observed_identity[4],
+                )
+                != identity
+                or observed_identity[7] != 1
+                or record is None
+                or (record.mode, record.size, record.sha256) != (mode, size, digest)
+            ):
+                raise RuntimeError(f"owned workspace file changed: {path}")
+        if require_complete and set(allowed_files) != set(self._file_specs):
+            missing = sorted(set(self._file_specs) - set(allowed_files))
+            raise RuntimeError(
+                "owned workspace is missing required files: " + ", ".join(missing)
+            )
+        authority.verify_path_binding()
+        return observed
+
+    def close(self) -> None:
+        current_pid = os.getpid()
+        if current_pid != self._owner_pid:
+            if self._resources_transferred:
+                raise RuntimeError(
+                    "close the PublishedWorkspaceReceiptOwner for this transfer"
+                )
+            # An RLock held by another thread at fork can never be released in
+            # the child.  CPython's single dict.setdefault call installs one
+            # process-local lock before its return can be interrupted; every
+            # later child thread and cleanup retry therefore serializes on the
+            # same lock.  Close inherited descriptors without an OFD-offset
+            # cookie; the parent keeps independent object and fd state.
+            child_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+            inherited_close_error: BaseException | None = None
+            try:
+                child_lock.run(self._close_inherited_resources_locked)
+            except BaseException as exc:  # noqa: B036 - report PID boundary
+                inherited_close_error = exc
+            boundary_error = RuntimeError(
+                "owned workspace authority cannot cross a PID boundary"
+            )
+            if inherited_close_error is not None:
+                raise boundary_error from inherited_close_error
+            raise boundary_error
+        self._reject_reentrant("close")
+
+        def close_locked() -> None:
+            if self._resources_transferred:
+                raise RuntimeError(
+                    "close the PublishedWorkspaceReceiptOwner for this transfer"
+                )
+            self._close_resources_locked()
+
+        close_error: BaseException | None = None
+        try:
+            self._lock.run(close_locked)
+        except BaseException as exc:  # noqa: B036 - report PID after cleanup
+            close_error = exc
+        if close_error is not None:
+            raise close_error
+
+    def _close_inherited_resources_locked(self) -> None:
+        """Close only this fork child's inherited descriptor references."""
+
+        if self._state == "closed":
+            return
+        primary_error: BaseException | None = None
+        for record in reversed(tuple(self._file_owners)):
+            descriptor = record.owner.descriptor
+            if descriptor < 0:
+                continue
+            try:
+                close_error = self._close_inherited_file_descriptor(record)
+            except BaseException as unexpected_close_error:  # noqa: B036
+                close_error = unexpected_close_error
+            if close_error is not None:
+                if primary_error is None:
+                    primary_error = close_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "additional inherited workspace file cleanup failed",
+                        close_error,
+                    )
+        try:
+            self._resources.close_all()
+        except BaseException as close_error:  # noqa: B036 - cleanup all owners
+            if primary_error is None:
+                primary_error = close_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "inherited workspace directory cleanup also failed",
+                    close_error,
+                )
+        try:
+            self._parent_owner.close()
+        except BaseException as close_error:  # noqa: B036 - cleanup all owners
+            if primary_error is None:
+                primary_error = close_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "inherited workspace parent cleanup also failed",
+                    close_error,
+                )
+        try:
+            close_complete = (
+                all(record.owner.descriptor < 0 for record in self._file_owners)
+                and self._resources.closed
+                and self._parent_owner.authority is None
+            )
+        except BaseException as reconciliation_error:  # noqa: B036
+            if primary_error is None:
+                primary_error = reconciliation_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "inherited workspace close-state reconciliation also failed",
+                    reconciliation_error,
+                )
+        else:
+            if close_complete:
+                self._state = "closed"
+                self._root_descriptor = -1
+                self._directory_descriptors.clear()
+        if primary_error is not None:
+            raise primary_error
+
+    @staticmethod
+    def _close_inherited_file_descriptor(
+        record: _WorkspaceFileOwner,
+    ) -> BaseException | None:
+        descriptor = record.owner.descriptor
+        if descriptor < 0:
+            return None
+        try:
+            metadata = os.fstat(descriptor)
+        except OSError as probe_error:
+            if probe_error.errno == errno.EBADF:
+                OwnedWorkspaceAuthority._invalidate_inherited_file_owner(record)
+                return None
+            return probe_error
+        except BaseException as probe_error:  # noqa: B036 - retain owner
+            return probe_error
+        observed_identity = _owned_file_identity(metadata)
+        if record.identity is None:
+            record.identity = observed_identity
+            record.owner.bind_identity(metadata)
+        elif observed_identity != record.identity:
+            OwnedWorkspaceAuthority._invalidate_inherited_file_owner(record)
+            return RuntimeError("inherited workspace file descriptor changed")
+        try:
+            os.close(descriptor)
+        except BaseException as close_error:  # noqa: B036 - reconcile close
+            try:
+                rebound = os.fstat(descriptor)
+            except OSError as probe_error:
+                if probe_error.errno == errno.EBADF:
+                    OwnedWorkspaceAuthority._invalidate_inherited_file_owner(record)
+                else:
+                    _annotate_secondary_error(
+                        close_error,
+                        "inherited file close reconciliation also failed",
+                        probe_error,
+                    )
+            except BaseException as probe_error:  # noqa: B036 - keep close error
+                _annotate_secondary_error(
+                    close_error,
+                    "inherited file close reconciliation also failed",
+                    probe_error,
+                )
+            else:
+                if _owned_file_identity(rebound) != record.identity:
+                    OwnedWorkspaceAuthority._invalidate_inherited_file_owner(record)
+            return close_error
+        OwnedWorkspaceAuthority._invalidate_inherited_file_owner(record)
+        return None
+
+    @staticmethod
+    def _invalidate_inherited_file_owner(record: _WorkspaceFileOwner) -> None:
+        # This mutates only the post-fork child copy.  It intentionally avoids
+        # _DescriptorOwner.close(), whose lseek cookie would alter the parent's
+        # shared open-file-description offset.
+        record.owner._descriptor = -1
+        record.owner._identity = None
+        record.owner._close_cookie = None
+
+    def _close_resources_locked(self) -> None:
+        if self._state == "closed":
+            return
+        primary_error: BaseException | None = None
+        for record in reversed(tuple(self._file_owners)):
+            descriptor = record.owner.descriptor
+            if descriptor < 0:
+                continue
+            try:
+                if record.identity is None:
+                    metadata = os.fstat(descriptor)
+                    record.identity = _owned_file_identity(metadata)
+                    record.owner.bind_identity(metadata)
+                assert record.identity is not None
+                record.owner.close(
+                    expected_identity=record.identity,
+                    retryable=True,
+                )
+            except BaseException as close_error:  # noqa: B036 - cleanup all
+                if primary_error is None:
+                    primary_error = close_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "additional workspace file cleanup also failed",
+                        close_error,
+                    )
+        try:
+            self._resources.close_all()
+        except BaseException as close_error:  # noqa: B036 - cleanup all owners
+            if primary_error is None:
+                primary_error = close_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace directory cleanup also failed",
+                    close_error,
+                )
+        try:
+            self._parent_owner.close()
+        except BaseException as close_error:  # noqa: B036 - cleanup all owners
+            if primary_error is None:
+                primary_error = close_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace parent authority cleanup also failed",
+                    close_error,
+                )
+        try:
+            close_complete = (
+                all(record.owner.descriptor < 0 for record in self._file_owners)
+                and self._resources.closed
+                and self._parent_owner.authority is None
+            )
+        except BaseException as reconciliation_error:  # noqa: B036
+            if primary_error is None:
+                primary_error = reconciliation_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace close-state reconciliation also failed",
+                    reconciliation_error,
+                )
+        else:
+            if close_complete:
+                self._state = "closed"
+                self._root_descriptor = -1
+                self._directory_descriptors.clear()
+        if primary_error is not None:
+            raise primary_error
+
+    def _close_resources_after_error_locked(
+        self,
+        primary_error: BaseException,
+    ) -> None:
+        try:
+            self._close_resources_locked()
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "owned workspace cleanup also failed",
+                close_error,
+            )
+
+    def _require_parent_authority(self) -> _PublicationAuthority:
+        authority = self._parent_owner.authority
+        if authority is None:
+            raise RuntimeError("owned workspace parent authority is closed")
+        return authority
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError("owned workspace authority cannot cross a PID boundary")
+
+    def _reject_reentrant(self, operation: str) -> None:
+        if self._lock.held_by_current_thread():
+            raise RuntimeError(f"owned workspace {operation} is reentrant")
+
+    def __enter__(self) -> OwnedWorkspaceAuthority:
+        self._require_owner_pid()
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        if exc is None:
+            self.close()
+        else:
+            try:
+                self.close()
+            except BaseException as close_error:  # noqa: B036 - keep primary
+                _annotate_secondary_error(
+                    exc,
+                    "owned workspace context cleanup also failed",
+                    close_error,
+                )
+
+
 class OwnedDirectoryStage:
     """Build one new private sibling tree without path-based file mutation."""
 
-    def __init__(self, destination: Path) -> None:
+    def __init__(
+        self,
+        destination: Path,
+        *,
+        _parent_authority: _PublicationAuthority | None = None,
+        _expected_destination_ownership: object = _UNSET_DESTINATION_OWNERSHIP,
+    ) -> None:
         self.destination = lexical_directory_path(destination)
-        self.path = lexical_directory_path(
-            Path(
-                tempfile.mkdtemp(
-                    prefix=f".{self.destination.name}.normalize-",
-                    dir=str(self.destination.parent),
-                )
-            )
+        self.path = self.destination.parent / (
+            f".{self.destination.name}.normalize-{secrets.token_hex(12)}"
         )
-        self._initial = capture_directory_ownership(self.path)
-        self._cleanup_ownership = self._initial
+        self._stage_parent_fd = -1
+        self._descriptor = -1
+        self._parent_authority = _parent_authority
+        self._has_expected_destination_ownership = (
+            _expected_destination_ownership is not _UNSET_DESTINATION_OWNERSHIP
+        )
+        self._expected_destination_ownership = _expected_destination_ownership
+        self._published = False
+        self._owned_directories: dict[str, tuple[int, ...]] = {}
+        self._owned_files: dict[
+            str,
+            tuple[tuple[int, ...], int, int, str],
+        ] = {}
+        self._cleanup_ownership = None
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
-        self._descriptor = os.open(self.path, flags)
-        self._published = False
+        created = False
+        try:
+            if self._parent_authority is None:
+                self._parent_authority = _open_publication_authority(
+                    self.destination.parent,
+                    parent_resource=None,
+                    expected_parent_identity=None,
+                )
+            self._stage_parent_fd = os.dup(self._parent_authority.resource)
+            self._parent_identity = self._parent_authority.identity
+            os.mkdir(
+                self.path.name,
+                mode=0o700,
+                dir_fd=self._stage_parent_fd,
+            )
+            created = True
+            created_metadata = os.stat(
+                self.path.name,
+                dir_fd=self._stage_parent_fd,
+                follow_symlinks=False,
+            )
+            try:
+                self._initial = self._parent_authority.capture_child(
+                    self.path.name,
+                    path=self.path,
+                    label="owned stage",
+                    allow_empty_root=True,
+                )
+            except RuntimeError as exc:
+                raise RuntimeError(
+                    "owned stage root changed during initialization"
+                ) from exc
+            self._descriptor = os.open(
+                self.path.name,
+                flags,
+                dir_fd=self._stage_parent_fd,
+            )
+            opened = os.fstat(self._descriptor)
+            if (
+                _root_identity(created_metadata) != _root_identity(opened)
+                or _root_identity(opened)
+                != directory_ownership_root_identity(self._initial)
+                or _captured_version_identity(opened)
+                != directory_ownership_root_version_identity(self._initial)
+            ):
+                raise RuntimeError("owned stage root changed during initialization")
+            self._stage_identity = _root_identity(opened)
+            self._cleanup_ownership = self._initial
+            self._verify_parent_path()
+        except BaseException:
+            self.close()
+            # A created but unverified stage is intentionally left as an
+            # orphan; deleting by name could remove a raced foreign object.
+            if not created:
+                self.path = self.destination.parent / self.path.name
+            raise
+
+    @classmethod
+    def prepare(
+        cls,
+        destination: Path,
+        *,
+        required_destination_file: str | None = None,
+        allow_empty_destination: bool = False,
+        create_parent: bool = True,
+    ) -> OwnedDirectoryStage:
+        """Capture the destination and build under one retained authority."""
+
+        lexical = lexical_directory_path(destination)
+        authority = _open_publication_authority(
+            lexical.parent,
+            parent_resource=None,
+            expected_parent_identity=None,
+            create_missing=create_parent,
+        )
+        try:
+            metadata = authority.child_metadata(
+                lexical.name,
+                path=lexical,
+                label="owned stage destination",
+            )
+            if metadata is None:
+                expected_ownership = None
+            else:
+                expected_ownership = authority.capture_child(
+                    lexical.name,
+                    path=lexical,
+                    label="owned stage destination",
+                    required_root_file=required_destination_file,
+                    allow_empty_root=allow_empty_destination,
+                )
+            authority.verify_path_binding()
+            return cls(
+                lexical,
+                _parent_authority=authority,
+                _expected_destination_ownership=expected_ownership,
+            )
+        except BaseException:
+            authority.close()
+            raise
+
+    @property
+    def expected_destination_ownership(self) -> object | None:
+        """Return the destination token captured by :meth:`prepare`."""
+
+        if not self._has_expected_destination_ownership:
+            raise RuntimeError("owned stage did not capture its destination")
+        return self._expected_destination_ownership
 
     def close(self) -> None:
         if self._descriptor >= 0:
@@ -914,47 +3316,113 @@ class OwnedDirectoryStage:
             except OSError:
                 pass
             self._descriptor = -1
-
-    def discard(self) -> None:
-        if not self._published:
+        if self._stage_parent_fd >= 0:
             try:
-                self._cleanup_ownership = self._capture_current_ownership()
-            except (OSError, RuntimeError, ValueError):
+                os.close(self._stage_parent_fd)
+            except OSError:
                 pass
-        self.close()
-        if not self._published:
-            discard_owned_directory(self.path, self._cleanup_ownership)
+            self._stage_parent_fd = -1
+        if self._parent_authority is not None:
+            self._parent_authority.close()
+            self._parent_authority = None
 
-    def _capture_current_ownership(self):
-        observed = capture_directory_ownership(self.path)
-        if directory_ownership_root_identity(observed) != (
-            directory_ownership_root_identity(self._initial)
+    @staticmethod
+    def _record_orphan(orphan: DirectoryOrphan | None, *, operation: str) -> None:
+        if orphan is None:
+            return
+        logger.warning(
+            "Owned directory %s retained an orphan for quiescent GC: "
+            "path=%s digest=%s entries=%d bytes=%d verified=%s",
+            operation,
+            orphan.path,
+            orphan.ownership_digest,
+            orphan.entries,
+            orphan.byte_count,
+            orphan.verified_at_isolation,
+        )
+
+    def discard(self) -> DirectoryOrphan | None:
+        ownership = self._cleanup_ownership
+        self.close()
+        if not self._published and ownership is not None:
+            orphan = discard_owned_directory(self.path, ownership)
+            self._record_orphan(orphan, operation="discard")
+            return orphan
+        return None
+
+    def _verify_parent_path(self) -> None:
+        if self._stage_parent_fd < 0 or self._parent_authority is None:
+            raise RuntimeError("owned stage parent is closed")
+        try:
+            opened = os.fstat(self._stage_parent_fd)
+            self._parent_authority.verify_path_binding()
+        except OSError as exc:
+            raise RuntimeError("owned stage parent changed") from exc
+        if _root_identity(opened) != self._parent_identity:
+            raise RuntimeError("owned stage parent changed")
+
+    def _verify_root_descriptor(self) -> None:
+        if self._descriptor < 0:
+            raise RuntimeError("owned stage is closed")
+        try:
+            opened = os.fstat(self._descriptor)
+            path_metadata = os.stat(
+                self.path.name,
+                dir_fd=self._stage_parent_fd,
+                follow_symlinks=False,
+            )
+        except OSError as exc:
+            raise RuntimeError("owned stage root changed") from exc
+        if (
+            _root_identity(opened) != self._stage_identity
+            or _root_identity(path_metadata) != self._stage_identity
         ):
             raise RuntimeError("owned stage root changed")
-        return observed
 
     def _parent_descriptor(self, relative: PurePosixPath) -> int:
+        self._verify_parent_path()
+        self._verify_root_descriptor()
         descriptor = os.dup(self._descriptor)
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+        prefix: list[str] = []
         try:
             for part in relative.parts[:-1]:
+                prefix.append(part)
+                tracked_path = "/".join(prefix)
+                created = False
                 try:
                     os.mkdir(part, mode=0o700, dir_fd=descriptor)
-                except FileExistsError:
-                    pass
+                except FileExistsError as exc:
+                    if tracked_path not in self._owned_directories:
+                        raise ValueError(
+                            f"owned stage component was not created here: {relative}"
+                        ) from exc
+                else:
+                    created = True
                 child = -1
                 try:
                     child = os.open(part, flags, dir_fd=descriptor)
                     opened = os.fstat(child)
-                    if not stat.S_ISDIR(opened.st_mode):
-                        raise ValueError(
-                            f"owned stage component is not a directory: {relative}"
-                        )
+                    identity = _root_identity(opened)
+                    if not stat.S_ISDIR(opened.st_mode) or (
+                        not created
+                        and self._owned_directories.get(tracked_path) != identity
+                    ):
+                        raise ValueError(f"owned stage component changed: {relative}")
+                    path_metadata = os.stat(
+                        part,
+                        dir_fd=descriptor,
+                        follow_symlinks=False,
+                    )
+                    if _root_identity(path_metadata) != identity:
+                        raise ValueError(f"owned stage component changed: {relative}")
                 except BaseException:
                     if child >= 0:
                         os.close(child)
                     raise
+                if created:
+                    self._owned_directories[tracked_path] = identity
                 os.close(descriptor)
                 descriptor = child
             return descriptor
@@ -971,13 +3439,15 @@ class OwnedDirectoryStage:
         max_bytes: int | None = None,
     ) -> None:
         normalized = _relative_path(relative)
-        parent = self._parent_descriptor(normalized)
         temporary = f".{normalized.name}.tmp-{secrets.token_hex(12)}"
+        parent = -1
         descriptor = -1
-        renamed = False
         byte_count = 0
-        iterator = iter(chunks)
+        digest = hashlib.sha256()
+        iterator = None
         try:
+            parent = self._parent_descriptor(normalized)
+            iterator = iter(chunks)
             flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
             flags |= getattr(os, "O_CLOEXEC", 0)
             descriptor = os.open(temporary, flags, mode, dir_fd=parent)
@@ -990,6 +3460,7 @@ class OwnedDirectoryStage:
                         f"owned stage file exceeds its {max_bytes}-byte limit: "
                         f"{normalized}"
                     )
+                digest.update(chunk)
                 view = memoryview(chunk)
                 while view:
                     written = os.write(descriptor, view)
@@ -998,61 +3469,151 @@ class OwnedDirectoryStage:
                     view = view[written:]
             os.fchmod(descriptor, mode)
             os.fsync(descriptor)
-            os.close(descriptor)
-            descriptor = -1
             try:
-                os.stat(
+                _rename_noreplace_at(
+                    temporary,
                     normalized.name,
-                    dir_fd=parent,
-                    follow_symlinks=False,
+                    parent,
+                    parent,
                 )
-            except FileNotFoundError:
-                pass
-            else:
-                raise ValueError(f"owned stage file already exists: {normalized}")
-            os.rename(
-                temporary,
+            except FileExistsError as exc:
+                raise ValueError(
+                    f"owned stage file already exists: {normalized}"
+                ) from exc
+            opened = os.fstat(descriptor)
+            published = os.stat(
                 normalized.name,
-                src_dir_fd=parent,
-                dst_dir_fd=parent,
+                dir_fd=parent,
+                follow_symlinks=False,
             )
-            renamed = True
+            if _root_identity(opened) != _root_identity(published):
+                raise RuntimeError(f"owned stage file changed: {normalized}")
+            self._owned_files[normalized.as_posix()] = (
+                _root_identity(opened),
+                stat.S_IMODE(opened.st_mode),
+                byte_count,
+                digest.hexdigest(),
+            )
             os.fsync(parent)
+            self._refresh_cleanup_ownership()
         finally:
-            close_iterator = getattr(iterator, "close", None)
-            if callable(close_iterator):
-                close_iterator()
-            if descriptor >= 0:
-                os.close(descriptor)
-            if not renamed:
-                try:
-                    os.unlink(temporary, dir_fd=parent)
-                except OSError:
-                    pass
-            os.close(parent)
+            try:
+                close_iterator = getattr(iterator, "close", None)
+                if callable(close_iterator):
+                    close_iterator()
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
+                # A failed temporary is left in the private stage. Name-based
+                # unlink cannot prove it is still the owned inode at deletion.
+                if parent >= 0:
+                    os.close(parent)
+
+    def _refresh_cleanup_ownership(self) -> None:
+        self._verify_parent_path()
+        self._verify_root_descriptor()
+        assert self._parent_authority is not None
+        observed = self._parent_authority.capture_child(
+            self.path.name,
+            path=self.path,
+            label="owned stage",
+            allow_empty_root=True,
+        )
+        expected_inventory = tuple(
+            sorted(
+                [(path, "directory") for path in self._owned_directories]
+                + [(path, "file") for path in self._owned_files]
+            )
+        )
+        if directory_ownership_inventory(observed) != expected_inventory:
+            raise RuntimeError("owned stage contains an untracked entry")
+        identities = {
+            path: identity
+            for path, _kind, identity in directory_ownership_entry_identities(observed)
+        }
+        records = {
+            record.path: record for record in directory_ownership_file_records(observed)
+        }
+        for path, identity in self._owned_directories.items():
+            observed_identity = identities.get(path)
+            if (
+                observed_identity is None
+                or (
+                    observed_identity[0],
+                    observed_identity[1],
+                    stat.S_IFMT(observed_identity[2]),
+                    observed_identity[4],
+                )
+                != identity
+            ):
+                raise RuntimeError(f"owned stage directory changed: {path}")
+        for path, (identity, mode, size, digest) in self._owned_files.items():
+            observed_identity = identities.get(path)
+            record = records.get(path)
+            if (
+                observed_identity is None
+                or (
+                    observed_identity[0],
+                    observed_identity[1],
+                    stat.S_IFMT(observed_identity[2]),
+                    observed_identity[4],
+                )
+                != identity
+                or record is None
+                or (record.mode, record.size, record.sha256) != (mode, size, digest)
+            ):
+                raise RuntimeError(f"owned stage file changed: {path}")
+        if directory_ownership_root_identity(observed) != self._stage_identity:
+            raise RuntimeError("owned stage root changed")
+        self._cleanup_ownership = observed
+
+    def capture_ownership(self) -> object:
+        """Return the exact current token for this owned stage."""
+
+        self._refresh_cleanup_ownership()
+        return self._cleanup_ownership
 
     def publish(
         self,
         *,
-        expected_destination_ownership: object,
+        expected_destination_ownership: object = _UNSET_DESTINATION_OWNERSHIP,
         validate_staged_directory=None,
         validate_published_destination=None,
-    ) -> None:
-        self._cleanup_ownership = self._capture_current_ownership()
-        self.close()
-        publish_staged_directory(
+    ) -> DirectoryOrphan | None:
+        if expected_destination_ownership is _UNSET_DESTINATION_OWNERSHIP:
+            if not self._has_expected_destination_ownership:
+                raise TypeError(
+                    "expected_destination_ownership is required for an "
+                    "unprepared owned stage"
+                )
+            expected_destination_ownership = self._expected_destination_ownership
+        self._refresh_cleanup_ownership()
+        orphan = publish_staged_directory(
             self.path,
             self.destination,
             expected_stage_root_ownership=self._cleanup_ownership,
             expected_destination_ownership=expected_destination_ownership,
             validate_staged_directory=validate_staged_directory,
             validate_published_destination=validate_published_destination,
+            parent_descriptor=self._stage_parent_fd,
+            expected_parent_identity=self._parent_identity,
         )
+        self._record_orphan(orphan, operation="publication")
         self._published = True
+        self.close()
+        return orphan
 
 
 __all__ = [
     "AuthenticatedFile",
+    "AuthenticatedSnapshotReader",
     "CapturedDirectoryReader",
     "OwnedDirectoryStage",
+    "OwnedWorkspaceAuthority",
+    "PublishedWorkspaceReceipt",
+    "PublishedWorkspaceReceiptOwner",
+    "UnsupportedWorkspaceCreation",
+    "WorkspaceDirectory",
+    "WorkspaceFile",
+    "WorkspacePlan",
 ]

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -69,6 +69,18 @@ _F_SEAL_SHRINK = 0x0002
 _F_SEAL_GROW = 0x0004
 _F_SEAL_WRITE = 0x0008
 _REQUIRED_SNAPSHOT_SEALS = _F_SEAL_SEAL | _F_SEAL_SHRINK | _F_SEAL_GROW | _F_SEAL_WRITE
+_SNAPSHOT_UNAVAILABLE_ERRNOS = {
+    value
+    for value in (
+        getattr(errno, "EACCES", None),
+        getattr(errno, "EINVAL", None),
+        getattr(errno, "ENOSYS", None),
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+        getattr(errno, "EPERM", None),
+    )
+    if value is not None
+}
 _UNSET_DESTINATION_OWNERSHIP = object()
 _MAX_WORKSPACE_FILE_BYTES = 64 * 1024 * 1024 * 1024
 _MAX_WORKSPACE_TOTAL_BYTES = 64 * 1024 * 1024 * 1024
@@ -89,10 +101,17 @@ def _create_sealable_memfd() -> int:
 
     create = getattr(os, "memfd_create", None)
     if callable(create) and _fcntl is not None:
-        return create(
-            "codenib-authenticated-snapshot",
-            _MFD_CLOEXEC | _MFD_ALLOW_SEALING,
-        )
+        try:
+            return create(
+                "codenib-authenticated-snapshot",
+                _MFD_CLOEXEC | _MFD_ALLOW_SEALING,
+            )
+        except OSError as exc:
+            if exc.errno not in _SNAPSHOT_UNAVAILABLE_ERRNOS:
+                raise
+            raise _SnapshotUnavailable(
+                "sealed authenticated snapshots are unavailable on this host"
+            ) from exc
     if os.name != "posix" or _fcntl is None:
         raise _SnapshotUnavailable(
             "sealed authenticated snapshots are unavailable on this host"
@@ -111,9 +130,12 @@ def _create_sealable_memfd() -> int:
     )
     if descriptor < 0:
         error = ctypes.get_errno()
+        failure = OSError(error, os.strerror(error))
+        if error not in _SNAPSHOT_UNAVAILABLE_ERRNOS:
+            raise failure
         raise _SnapshotUnavailable(
             "sealed authenticated snapshots are unavailable on this host"
-        ) from OSError(error, os.strerror(error))
+        ) from failure
     return descriptor
 
 
@@ -134,10 +156,17 @@ def _seal_snapshot_descriptor(descriptor: int) -> None:
         raise _SnapshotUnavailable(
             "sealed authenticated snapshots are unavailable on this host"
         )
-    _fcntl.fcntl(descriptor, _F_ADD_SEALS, _REQUIRED_SNAPSHOT_SEALS)
-    observed = _fcntl.fcntl(descriptor, _F_GET_SEALS)
+    try:
+        _fcntl.fcntl(descriptor, _F_ADD_SEALS, _REQUIRED_SNAPSHOT_SEALS)
+        observed = _fcntl.fcntl(descriptor, _F_GET_SEALS)
+    except OSError as exc:
+        if exc.errno not in _SNAPSHOT_UNAVAILABLE_ERRNOS:
+            raise
+        raise _SnapshotUnavailable(
+            "sealed authenticated snapshots are unavailable on this host"
+        ) from exc
     if observed & _REQUIRED_SNAPSHOT_SEALS != _REQUIRED_SNAPSHOT_SEALS:
-        raise RuntimeError("authenticated snapshot could not be sealed")
+        raise _SnapshotUnavailable("authenticated snapshot could not be sealed")
     os.lseek(descriptor, 0, os.SEEK_SET)
 
 
@@ -484,6 +513,88 @@ class WorkspacePlan:
         object.__setattr__(self, "digest", plan_digest.hexdigest())
 
 
+def _snapshot_workspace_plan(plan: object) -> WorkspacePlan:
+    """Detach one exact plan from caller-visible frozen dataclasses."""
+
+    if type(plan) is not WorkspacePlan:
+        raise TypeError("owned workspace plan must be an exact WorkspacePlan")
+    subject_digest = plan.subject_digest
+    root_mode = plan.root_mode
+    source_directories = plan.directories
+    source_files = plan.files
+    source_digest = plan.digest
+    if (
+        type(subject_digest) is not str
+        or type(root_mode) is not int
+        or type(source_directories) is not tuple
+        or type(source_files) is not tuple
+        or type(source_digest) is not str
+    ):
+        raise TypeError("owned workspace plan fields must use exact types")
+
+    directory_fields: list[tuple[str, int]] = []
+    file_fields: list[tuple[str, int, int]] = []
+
+    def snapshot_paths() -> Iterator[bytes]:
+        for directory in source_directories:
+            if type(directory) is not WorkspaceDirectory:
+                raise TypeError("owned workspace directories must use exact types")
+            path = directory.path
+            mode = directory.mode
+            if type(path) is not PurePosixPath or type(mode) is not int:
+                raise TypeError("owned workspace directory fields must use exact types")
+            path_text = path.as_posix()
+            directory_fields.append((path_text, mode))
+            yield os.fsencode(path_text)
+        for file in source_files:
+            if type(file) is not WorkspaceFile:
+                raise TypeError("owned workspace files must use exact types")
+            path = file.path
+            mode = file.mode
+            max_bytes = file.max_bytes
+            if (
+                type(path) is not PurePosixPath
+                or type(mode) is not int
+                or type(max_bytes) is not int
+            ):
+                raise TypeError("owned workspace file fields must use exact types")
+            path_text = path.as_posix()
+            file_fields.append((path_text, mode, max_bytes))
+            yield os.fsencode(path_text)
+
+    try:
+        _validate_ownership_inventory_budget(snapshot_paths())
+    except RuntimeError as exc:
+        raise ValueError(
+            "owned workspace plan exceeds the ownership scanner budget"
+        ) from exc
+
+    directories = tuple(
+        WorkspaceDirectory(
+            PurePosixPath(path),
+            mode=mode,
+        )
+        for path, mode in directory_fields
+    )
+    files = tuple(
+        WorkspaceFile(
+            PurePosixPath(path),
+            mode=mode,
+            max_bytes=max_bytes,
+        )
+        for path, mode, max_bytes in file_fields
+    )
+    detached = WorkspacePlan(
+        subject_digest=subject_digest,
+        directories=directories,
+        files=files,
+        root_mode=root_mode,
+    )
+    if detached.digest != source_digest:
+        raise ValueError("owned workspace plan digest is inconsistent")
+    return detached
+
+
 class UnsupportedWorkspaceCreation(RuntimeError):
     """Strict workspace creation is unavailable without a native creator."""
 
@@ -517,7 +628,7 @@ class PublishedWorkspaceReceipt:
 
     __slots__ = (
         "path",
-        "plan",
+        "_plan",
         "sealed_ownership",
         "ownership",
         "parent_identity",
@@ -542,7 +653,7 @@ class PublishedWorkspaceReceipt:
         # therefore be reconciled against the same transfer held by the owner.
         self._transfer = transfer
         self.path = path
-        self.plan = plan
+        self._plan = _snapshot_workspace_plan(plan)
         self.sealed_ownership = sealed_ownership
         self.ownership = published_ownership
         self.parent_identity = parent_identity
@@ -552,7 +663,13 @@ class PublishedWorkspaceReceipt:
 
     @property
     def plan_digest(self) -> str:
-        return self.plan.digest
+        return self._plan.digest
+
+    @property
+    def plan(self) -> WorkspacePlan:
+        """Return a detached diagnostic copy of the publication plan."""
+
+        return _snapshot_workspace_plan(self._plan)
 
     @property
     def closed(self) -> bool:
@@ -1910,7 +2027,7 @@ class OwnedWorkspaceAuthority:
         def get_plan() -> WorkspacePlan:
             if self._plan is None:
                 raise RuntimeError("owned workspace authority has not been adopted")
-            return self._plan
+            return _snapshot_workspace_plan(self._plan)
 
         return self._lock.run(get_plan)
 
@@ -1939,6 +2056,10 @@ class OwnedWorkspaceAuthority:
         """Adopt a pre-opened sibling root and exact empty-file skeleton."""
 
         self._require_owner_pid()
+        if not sys.platform.startswith("linux"):
+            raise UnsupportedWorkspaceCreation(
+                "strict pre-opened workspace publication requires Linux"
+            )
         self._reject_reentrant("adopt")
         self._lock.run(
             lambda: self._adopt_locked(
@@ -1969,12 +2090,7 @@ class OwnedWorkspaceAuthority:
         self._require_owner_pid()
         if self._state != "empty":
             raise RuntimeError("owned workspace authority is not empty")
-        if not (sys.platform.startswith("linux") or sys.platform == "darwin"):
-            raise UnsupportedWorkspaceCreation(
-                "strict pre-opened workspaces require POSIX directory fds"
-            )
-        if not isinstance(plan, WorkspacePlan):
-            raise TypeError("owned workspace plan must be WorkspacePlan")
+        plan = _snapshot_workspace_plan(plan)
         if (
             isinstance(parent_descriptor, bool)
             or not isinstance(parent_descriptor, int)
@@ -2399,7 +2515,7 @@ class OwnedWorkspaceAuthority:
         # covered by publish_into's outer exception reconciliation.  Keeping
         # that reconciliation outside the workspace lock avoids an ABBA with
         # receipt consume/close, whose lifecycle order is owner then workspace.
-        self._publication_transfer = transfer
+        self._store_publication_transfer_locked(transfer)
         self._resources_transferred = True
         self._state = "reserving-publication"
         receipt_owner._reserve(reservation)
@@ -2425,7 +2541,7 @@ class OwnedWorkspaceAuthority:
             receipt = PublishedWorkspaceReceipt(
                 transfer=transfer,
                 path=destination,
-                plan=plan,
+                plan=_snapshot_workspace_plan(plan),
                 sealed_ownership=sealed_ownership,
                 published_ownership=published_ownership,
                 parent_identity=authority.identity,
@@ -2445,6 +2561,14 @@ class OwnedWorkspaceAuthority:
             expected_destination_ownership=self._expected_destination,
             commit_callback=install_receipt,
         )
+
+    def _store_publication_transfer_locked(
+        self,
+        transfer: _WorkspacePublicationTransfer,
+    ) -> None:
+        """Install the first recoverable publication ownership marker."""
+
+        self._publication_transfer = transfer
 
     def _reconcile_publish_failure_outside_lock(
         self,
@@ -2616,7 +2740,7 @@ class OwnedWorkspaceAuthority:
                 self._state != "published"
                 or self._publication_transfer is not receipt._transfer
                 or self._destination != receipt.path
-                or self._plan != receipt.plan
+                or self._plan != receipt._plan
             ):
                 raise RuntimeError("published workspace receipt is not active")
             authority = self._require_parent_authority()

--- a/codenib/_owned_file_publication.py
+++ b/codenib/_owned_file_publication.py
@@ -1,0 +1,2293 @@
+# SPDX-FileCopyrightText: 2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Descriptor-bound no-overwrite publication of one regular file.
+
+This module deliberately leaves failed and redundant stages in place for a
+later, quiescent garbage collector.  POSIX has no inode-conditional unlink, so
+online cleanup cannot prove that a name still denotes the file this process
+created.
+
+Publication never returns a descriptor-owning receipt.  The caller creates a
+``PublishedFileReceiptOwner`` first; publication installs a borrowed receipt in
+that owner before returning, closing the return-to-caller cancellation window.
+
+The receipt authenticates an exact retained descriptor at publication and on
+each bounded read.  A normal filesystem writable by another process with the
+same UID cannot guarantee byte immutability across time; that stronger property
+requires a protected object store, fs-verity, or a service ownership boundary.
+
+The descriptor guards cover asynchronous failure after an fd reaches its Python
+owner and cover ordinary fd-number reuse.  One native promotion gate remains:
+``os.open`` and ``os.dup`` return bare integers, so arbitrary opcode injection
+between the C return and the first Python ownership store cannot be closed in
+Python.  Full closure requires a native owning-fd object that installs itself in
+the supplied owner before returning, matching the atomic-directory promotion
+gate.
+
+These guards are not a sandbox against arbitrary code already executing in this
+process; such code can directly close, seek, or reassign any process descriptor.
+In particular, a callback can ``dup2`` an alias of the same open-file
+description onto a just-closed number.  That exact ABA is indistinguishable from
+a close that did not happen.  A retryable receipt owner therefore retains that
+exact alias after an interrupted close.  Its stored offset cookie rejects later
+observable fd reuse before another close, but arbitrary same-process code can
+continually recreate the exact alias and defeats any proof available in Python.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import secrets
+import stat
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Iterator, TypeVar
+
+from . import _atomic_directory as _atomic
+
+_COPY_BYTES = 1 << 20
+_MAX_STAGE_ATTEMPTS = 128
+_CLOSE_COOKIE_FLOOR = 1 << 20
+_CLOSE_COOKIE_SPAN = 1 << 30
+_OWNER_STATE_RECOVERY_LIMIT = 64
+_TERMINAL_DESCRIPTOR_RECOVERY_LIMIT = 8
+_REAL_OS_CLOSE = os.close
+_T = TypeVar("_T")
+_SAFE_POSIX_FILE_FDS = (
+    hasattr(os, "O_NOFOLLOW")
+    and hasattr(os, "O_CLOEXEC")
+    and os.open in os.supports_dir_fd
+    and os.stat in os.supports_dir_fd
+    and os.stat in os.supports_follow_symlinks
+)
+
+
+def require_owned_file_publication_support() -> None:
+    """Fail before mutation when strict regular-file publication is unavailable."""
+
+    # The shared Windows authority does not yet expose a RootDirectory-bound
+    # regular-file create HANDLE.  Keep this gate ahead of every parent or stage
+    # mutation so callers can safely select an unsupported-platform fallback.
+    if sys.platform == "win32":
+        raise RuntimeError("owned regular-file publication is unsupported on Windows")
+    if not (sys.platform.startswith("linux") or sys.platform == "darwin"):
+        raise RuntimeError("owned regular-file publication is unsupported on this host")
+    if not _SAFE_POSIX_FILE_FDS:
+        raise RuntimeError(
+            "owned regular-file publication requires POSIX dir-fd support"
+        )
+    if not _atomic._SAFE_OWNERSHIP_DIRECTORY_FDS:
+        raise RuntimeError(
+            "owned regular-file publication requires anchored directory-fd support"
+        )
+    _atomic._require_rename_noreplace_platform()
+
+
+class _DescriptorOwner:
+    """One shared, invalidatable owner slot for a POSIX descriptor.
+
+    Sharing the slot, rather than copying an fd number between locals and
+    result objects, makes every alias observe cleanup performed after a
+    constructor or return-path ``BaseException``.
+    """
+
+    __slots__ = ("_descriptor", "_identity", "_close_cookie")
+
+    def __init__(self) -> None:
+        self._descriptor = -1
+        self._identity: tuple[int, ...] | None = None
+        self._close_cookie: int | None = None
+
+    @property
+    def descriptor(self) -> int:
+        return self._descriptor
+
+    def open(
+        self,
+        path: str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        if self._descriptor >= 0:
+            raise RuntimeError("descriptor owner is already active")
+        descriptor = -1
+        try:
+            if dir_fd is None:
+                descriptor = os.open(path, flags, mode)
+            else:
+                descriptor = os.open(path, flags, mode, dir_fd=dir_fd)
+            self._descriptor = descriptor
+            self._close_cookie = None
+            return descriptor
+        except BaseException as primary_error:
+            if descriptor >= 0:
+                if self._descriptor == descriptor:
+                    self.close_after_error(primary_error)
+                else:
+                    _cleanup_untransferred_descriptor(descriptor, primary_error)
+            raise
+
+    def duplicate(self, descriptor: int) -> int:
+        if self._descriptor >= 0:
+            raise RuntimeError("descriptor owner is already active")
+        duplicate = -1
+        try:
+            duplicate = os.dup(descriptor)
+            self._descriptor = duplicate
+            self._close_cookie = None
+            return duplicate
+        except BaseException as primary_error:
+            if duplicate >= 0:
+                if self._descriptor == duplicate:
+                    self.close_after_error(primary_error)
+                else:
+                    _cleanup_untransferred_descriptor(duplicate, primary_error)
+            raise
+
+    def bind_identity(self, metadata: os.stat_result) -> None:
+        identity = _file_identity(metadata)
+        if self._descriptor < 0:
+            raise RuntimeError("cannot bind an inactive descriptor owner")
+        self._identity = identity
+
+    def close(
+        self,
+        *,
+        expected_identity: tuple[int, ...],
+        retryable: bool = False,
+    ) -> None:
+        descriptor = self._descriptor
+        if descriptor < 0:
+            return
+        if retryable:
+            self._close_retryable(
+                descriptor,
+                expected_identity=expected_identity,
+            )
+            return
+        close_cookie: int | None = None
+        try:
+            close_cookie = _arm_descriptor_for_close(descriptor)
+            # Clearing the shared slot is the close linearization point.  It is
+            # deliberately before the syscall: if close succeeds and delivery
+            # of an asynchronous exception follows, no alias retains a stale
+            # descriptor number that it could close again after fd reuse.
+            self._descriptor = -1
+            self._identity = None
+            self._close_cookie = None
+            os.close(descriptor)
+        except BaseException as close_error:
+            if self._descriptor < 0:
+                _finish_close_after_error(
+                    descriptor,
+                    expected_identity,
+                    close_error,
+                    close_cookie=close_cookie,
+                )
+            else:
+                # Arming itself, or the tiny arm-to-owner-clear window, can be
+                # interrupted.  This is still unquestionably our descriptor:
+                # invalidate the shared owner and finish one terminal cleanup
+                # attempt while keeping the interruption primary.
+                self._descriptor = -1
+                self._identity = None
+                self._close_cookie = None
+                _cleanup_descriptor_after_error(
+                    descriptor,
+                    expected_identity,
+                    close_error,
+                )
+            raise
+
+    def _close_retryable(
+        self,
+        descriptor: int,
+        *,
+        expected_identity: tuple[int, ...],
+    ) -> None:
+        """Attempt one close while retaining a provably open owner for retry."""
+
+        previous_cookie = self._close_cookie
+        if previous_cookie is not None:
+            try:
+                still_owned = _descriptor_still_exact(
+                    descriptor,
+                    expected_identity,
+                    close_cookie=previous_cookie,
+                )
+            except BaseException as ownership_error:  # noqa: B036
+                self._descriptor = -1
+                self._identity = None
+                self._close_cookie = None
+                raise RuntimeError(
+                    "published receipt descriptor ownership is unknown"
+                ) from ownership_error
+            if not still_owned:
+                self._descriptor = -1
+                self._identity = None
+                self._close_cookie = None
+                raise RuntimeError(
+                    "published receipt descriptor changed before close retry"
+                )
+
+        close_cookie = _arm_descriptor_for_close(
+            descriptor,
+            cookie_owner=self,
+        )
+        try:
+            os.close(descriptor)
+            self._descriptor = -1
+            self._identity = None
+            self._close_cookie = None
+        except BaseException as close_error:  # noqa: B036 - reconcile syscall
+            if self._descriptor < 0:
+                self._identity = None
+                self._close_cookie = None
+                raise
+            try:
+                still_exact = _descriptor_still_exact(
+                    descriptor,
+                    expected_identity,
+                    close_cookie=close_cookie,
+                )
+            except BaseException as reconciliation_error:  # noqa: B036
+                _annotate_error(
+                    close_error,
+                    "descriptor close reconciliation failed",
+                    reconciliation_error,
+                )
+                # Unknown is not sufficient authority for another close.  A
+                # retry is offered only when identity plus the OFD cookie were
+                # positively re-observed after the failed syscall.
+                self._descriptor = -1
+                self._identity = None
+                self._close_cookie = None
+            else:
+                if not still_exact:
+                    self._descriptor = -1
+                    self._identity = None
+                    self._close_cookie = None
+            raise
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        """Terminally clean while retaining ownership across cancellation."""
+
+        deferred: BaseException | None = None
+        for _attempt in range(_TERMINAL_DESCRIPTOR_RECOVERY_LIMIT):
+            descriptor = self._descriptor
+            if descriptor < 0:
+                deferred = self._invalidate_converged(deferred)
+                self._note_deferred_cleanup(primary_error, deferred)
+                return
+
+            identity = self._identity
+            if identity is None:
+                try:
+                    metadata = os.fstat(descriptor)
+                except OSError as error:
+                    if error.errno == errno.EBADF:
+                        deferred = self._invalidate_converged(deferred)
+                        self._note_deferred_cleanup(primary_error, deferred)
+                        return
+                    deferred = _remember_first_cleanup_error(deferred, error)
+                    continue
+                except BaseException as error:  # noqa: B036 - bounded recovery
+                    deferred = _remember_first_cleanup_error(deferred, error)
+                    continue
+                try:
+                    self.bind_identity(metadata)
+                except BaseException as error:  # noqa: B036 - observe next pass
+                    deferred = _remember_first_cleanup_error(deferred, error)
+                continue
+
+            try:
+                self._close_retryable(
+                    descriptor,
+                    expected_identity=identity,
+                )
+            except BaseException as error:  # noqa: B036 - bounded recovery
+                deferred = _remember_first_cleanup_error(deferred, error)
+                if self._descriptor < 0:
+                    deferred = self._invalidate_converged(deferred)
+                    self._note_deferred_cleanup(primary_error, deferred)
+                    return
+                continue
+
+            deferred = self._invalidate_converged(deferred)
+            self._note_deferred_cleanup(primary_error, deferred)
+            return
+
+        descriptor = self._descriptor
+        identity = self._identity
+        if descriptor < 0:
+            deferred = self._invalidate_converged(deferred)
+            self._note_deferred_cleanup(primary_error, deferred)
+            return
+        try:
+            if identity is None:
+                closed = _cleanup_untransferred_descriptor(
+                    descriptor,
+                    primary_error,
+                )
+            else:
+                closed = _cleanup_descriptor_after_error(
+                    descriptor,
+                    identity,
+                    primary_error,
+                    cookie_owner=self,
+                )
+        except BaseException as error:  # noqa: B036 - observe terminal outcome
+            deferred = _remember_first_cleanup_error(deferred, error)
+            closed = self._descriptor < 0
+            if not closed and self._close_cookie is not None and identity is not None:
+                try:
+                    closed = not _descriptor_still_exact(
+                        descriptor,
+                        identity,
+                        close_cookie=self._close_cookie,
+                    )
+                except BaseException as reconciliation_error:  # noqa: B036
+                    deferred = _remember_first_cleanup_error(
+                        deferred,
+                        reconciliation_error,
+                    )
+        if closed:
+            deferred = self._invalidate_converged(deferred)
+        self._note_deferred_cleanup(primary_error, deferred)
+
+    def _invalidate_converged(
+        self,
+        deferred: BaseException | None,
+    ) -> BaseException | None:
+        for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+            try:
+                self._invalidate()
+            except BaseException as error:  # noqa: B036 - converge owner state
+                deferred = _remember_first_cleanup_error(deferred, error)
+                continue
+            if (
+                self._descriptor < 0
+                and self._identity is None
+                and self._close_cookie is None
+            ):
+                return deferred
+        return _remember_first_cleanup_error(
+            deferred,
+            RuntimeError("descriptor owner invalidation did not converge"),
+        )
+
+    def _invalidate(self) -> None:
+        self._descriptor = -1
+        self._identity = None
+        self._close_cookie = None
+
+    @staticmethod
+    def _note_deferred_cleanup(
+        primary_error: BaseException,
+        deferred: BaseException | None,
+    ) -> None:
+        if deferred is not None:
+            _annotate_error(
+                primary_error,
+                "descriptor terminal cleanup was interrupted",
+                deferred,
+            )
+
+
+def _close_posix_resources(
+    resources: _atomic._PosixResourceOwner,
+    *,
+    primary_error: BaseException | None = None,
+) -> None:
+    """Close an independent directory bridge while retaining its first error."""
+
+    first_error = primary_error
+    for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+        if resources.closed:
+            break
+        try:
+            resources.close_all()
+        except BaseException as close_error:  # noqa: B036 - converge ownership
+            if first_error is None:
+                first_error = close_error
+            else:
+                _annotate_error(
+                    first_error,
+                    "borrowed parent bridge cleanup also failed",
+                    close_error,
+                )
+    if not resources.closed:
+        convergence_error = RuntimeError(
+            "borrowed parent bridge cleanup did not converge"
+        )
+        if first_error is None:
+            first_error = convergence_error
+        else:
+            _annotate_error(
+                first_error,
+                "borrowed parent bridge cleanup did not converge",
+                convergence_error,
+            )
+    if primary_error is None and first_error is not None:
+        raise first_error
+
+
+class _PublicationAuthorityOwner:
+    """Owner installed before the shared parent authority is acquired."""
+
+    __slots__ = ("_authority",)
+
+    def __init__(self) -> None:
+        self._authority: _atomic._PublicationAuthority | None = None
+
+    @property
+    def authority(self) -> _atomic._PublicationAuthority | None:
+        return self._authority
+
+    def install(self, authority: _atomic._PublicationAuthority) -> None:
+        """Accept authority ownership before the factory returns to Python."""
+
+        if self._authority is not None:
+            raise RuntimeError("publication authority owner is already active")
+        self._authority = authority
+
+    def acquire(self, path: Path, *, parent_resource: int | None = None) -> None:
+        if self._authority is not None:
+            raise RuntimeError("publication authority owner is already active")
+        bridge_resources = _atomic._PosixResourceOwner()
+        authority_parent: int | None = None
+        if parent_resource is not None:
+            if isinstance(parent_resource, bool) or not isinstance(
+                parent_resource, int
+            ):
+                raise TypeError(
+                    "borrowed publication parent resource must be an integer"
+                )
+            if parent_resource < 0:
+                raise ValueError(
+                    "borrowed publication parent resource must be non-negative"
+                )
+            expected_parent_identity = _atomic.publication_parent_identity(
+                parent_resource
+            )
+        else:
+            expected_parent_identity = None
+        try:
+            if parent_resource is not None:
+                # ``dup(parent_resource)`` would share the caller's open-file
+                # description and therefore its directory offset.  Open "."
+                # relative to the borrowed descriptor to create an independent
+                # OFD before atomic takes its own duplicate.  Close cookies can
+                # then never perturb the caller's offset.
+                flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+                flags |= getattr(os, "O_NONBLOCK", 0)
+                authority_parent = bridge_resources.open(
+                    ".",
+                    flags,
+                    dir_fd=parent_resource,
+                )
+                if (
+                    _atomic.publication_parent_identity(authority_parent)
+                    != expected_parent_identity
+                ):
+                    raise RuntimeError(
+                        "borrowed publication parent resource changed while opened"
+                    )
+            _atomic._open_publication_authority(
+                path,
+                parent_resource=authority_parent,
+                expected_parent_identity=expected_parent_identity,
+                create_missing=False,
+                authority_owner=self,
+            )
+            if self._authority is None:
+                raise RuntimeError("publication authority was not installed")
+            if authority_parent is not None:
+                _close_posix_resources(bridge_resources)
+        except BaseException as primary_error:
+            if self._authority is not None:
+                self.close_after_error(primary_error)
+            _close_posix_resources(
+                bridge_resources,
+                primary_error=primary_error,
+            )
+            raise
+
+    def close(self) -> None:
+        authority = self._authority
+        if authority is None:
+            return
+        try:
+            _close_publication_authority(authority)
+        finally:
+            if authority._closed:
+                self._authority = None
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close()
+        except BaseException as cleanup_error:  # noqa: B036 - keep primary
+            _annotate_error(
+                primary_error,
+                "parent authority cleanup also failed",
+                cleanup_error,
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedFileRecord:
+    """Canonical content and mode authenticated by publication."""
+
+    size: int
+    sha256: str
+    mode: int
+
+
+@dataclass(frozen=True, slots=True)
+class OwnedFileOrphan:
+    """A diagnostic locator for an owned stage that was not published.
+
+    The path is not an authority and this type intentionally has no deletion
+    operation.  Reclamation belongs to a separate cooperative-GC boundary.
+    """
+
+    path: Path
+    parent_identity: tuple[int, ...]
+    file_identity: tuple[int, ...]
+    record: PublishedFileRecord
+
+
+class OwnedFileConflictError(RuntimeError):
+    """The destination is not the requested receipt-time-authenticated object."""
+
+    def __init__(
+        self,
+        destination: Path,
+        expected: PublishedFileRecord,
+        observed: PublishedFileRecord | None,
+        orphan: OwnedFileOrphan,
+    ) -> None:
+        super().__init__(destination, expected, observed, orphan)
+        self.destination = destination
+        self.expected = expected
+        self.observed = observed
+        self.orphan = orphan
+
+    def __str__(self) -> str:
+        return f"owned file publication conflicts at {self.destination}"
+
+
+_RECEIPT_OWNER_CLOSE = object()
+
+
+class PublishedFileReceipt:
+    """A borrowed handle-bound view that re-authenticates each bounded read.
+
+    Retaining the handle prevents path substitution; it does not make a normal
+    same-UID writable filesystem immutable after publication.  Its caller owns
+    the corresponding :class:`PublishedFileReceiptOwner`, which controls close.
+    """
+
+    __slots__ = (
+        "path",
+        "record",
+        "file_identity",
+        "parent_identity",
+        "reused",
+        "orphan",
+        "_descriptor_owner",
+        "_owner_pid",
+        "_version_identity",
+    )
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        record: PublishedFileRecord,
+        file_identity: tuple[int, ...],
+        version_identity: tuple[int, ...],
+        parent_identity: tuple[int, ...],
+        reused: bool,
+        orphan: OwnedFileOrphan | None,
+        descriptor_owner: _DescriptorOwner,
+    ) -> None:
+        # Store the shared owner first.  If any later constructor operation is
+        # interrupted, the publisher can invalidate the same slot seen by a
+        # partially constructed receipt retained by an injected callback.
+        self._descriptor_owner = descriptor_owner
+        self.path = path
+        self.record = record
+        self.file_identity = file_identity
+        self.parent_identity = parent_identity
+        self.reused = reused
+        self.orphan = orphan
+        self._owner_pid = os.getpid()
+        self._version_identity = version_identity
+
+    @property
+    def _descriptor(self) -> int:
+        return self._descriptor_owner.descriptor
+
+    @property
+    def closed(self) -> bool:
+        return self._descriptor < 0
+
+    def read_bytes(self, *, max_bytes: int) -> bytes:
+        """Read and re-authenticate bytes through the retained exact handle."""
+
+        self._require_active()
+        limit = _bounded_size(max_bytes, label="receipt read limit")
+        if self.record.size > limit:
+            raise ValueError("published file exceeds the receipt read limit")
+        before = os.fstat(self._descriptor)
+        _require_exact_regular(
+            before,
+            identity=self.file_identity,
+            version_identity=self._version_identity,
+            mode=self.record.mode,
+            size=self.record.size,
+            label="published file receipt",
+        )
+        payload = bytearray()
+        digest = hashlib.sha256()
+        offset = 0
+        while offset < self.record.size:
+            block = os.pread(
+                self._descriptor,
+                min(_COPY_BYTES, self.record.size - offset),
+                offset,
+            )
+            if not block:
+                raise RuntimeError("published file was truncated")
+            payload.extend(block)
+            digest.update(block)
+            offset += len(block)
+        if os.pread(self._descriptor, 1, offset):
+            raise RuntimeError("published file grew")
+        after = os.fstat(self._descriptor)
+        _require_exact_regular(
+            after,
+            identity=self.file_identity,
+            version_identity=self._version_identity,
+            mode=self.record.mode,
+            size=self.record.size,
+            label="published file receipt",
+        )
+        if digest.hexdigest() != self.record.sha256:
+            raise RuntimeError("published file bytes changed")
+        return bytes(payload)
+
+    def close(self) -> None:
+        """Reject detached cleanup of this borrowed receipt view."""
+
+        raise RuntimeError("close the PublishedFileReceiptOwner, not its receipt")
+
+    def _close_from_owner(self, authority: object) -> None:
+        if authority is not _RECEIPT_OWNER_CLOSE:
+            raise RuntimeError("published file receipt close authority is invalid")
+        if self._descriptor < 0:
+            return
+        owner_changed = os.getpid() != self._owner_pid
+        self._descriptor_owner.close(
+            expected_identity=self.file_identity,
+            retryable=True,
+        )
+        if owner_changed:
+            raise RuntimeError("published file receipt cannot cross a PID boundary")
+
+    def _require_active(self) -> None:
+        if self._descriptor < 0:
+            raise RuntimeError("published file receipt is closed")
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError("published file receipt cannot cross a PID boundary")
+
+
+_RECEIPT_OWNER_EMPTY = object()
+_RECEIPT_OWNER_CLOSED = object()
+
+
+class _CancellationSafeRLock:
+    """RLock whose logical depth makes interrupted transitions recoverable."""
+
+    __slots__ = ("_depth", "_lock")
+
+    _RECOVERY_LIMIT = 64
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._depth = threading.local()
+
+    def run(self, callback: Callable[[], _T]) -> _T:
+        baseline = self._logical_depth()
+        try:
+            acquisition_error = self._acquire_reconciled(baseline)
+        except BaseException as primary_error:  # noqa: B036 - restore baseline
+            self._release_preserving(baseline, primary_error)
+            raise
+        if acquisition_error is not None:
+            self._release_preserving(baseline, acquisition_error)
+            raise acquisition_error
+        try:
+            result = callback()
+        except BaseException as primary_error:  # noqa: B036 - restore then preserve
+            self._release_preserving(baseline, primary_error)
+            raise
+        try:
+            release_error = self._release_reconciled(baseline)
+        except BaseException:
+            raise
+        if release_error is not None:
+            raise release_error
+        return result
+
+    def _acquire(self) -> None:
+        depth = self._logical_depth()
+        if depth:
+            self._set_logical_depth(depth + 1)
+            return
+        if not self._lock.acquire():
+            raise RuntimeError("receipt owner lifecycle lock acquisition failed")
+        self._set_logical_depth(1)
+
+    def _release(self) -> None:
+        depth = self._logical_depth()
+        if depth < 1 or not self._native_is_owned():
+            raise RuntimeError("cannot release an unowned receipt lifecycle lock")
+        if depth > 1:
+            self._set_logical_depth(depth - 1)
+            return
+        self._lock.release()
+        self._set_logical_depth(0)
+
+    def _logical_depth(self) -> int:
+        return int(getattr(self._depth, "value", 0))
+
+    def _set_logical_depth(self, depth: int) -> None:
+        self._depth.value = depth
+
+    def _native_is_owned(self) -> bool:
+        ownership_check = getattr(self._lock, "_is_owned", None)
+        if not callable(ownership_check):
+            raise RuntimeError("receipt lifecycle lock lacks owner tracking")
+        return bool(ownership_check())
+
+    def held_by_current_thread(self) -> bool:
+        """Return whether this thread is already inside a lifecycle lease."""
+
+        return self._logical_depth() > 0 and self._native_is_owned()
+
+    @staticmethod
+    def _defer_failure(
+        deferred: BaseException | None,
+        failure: BaseException,
+    ) -> BaseException:
+        if deferred is None:
+            return failure
+        if failure is not deferred:
+            _annotate_error(
+                deferred,
+                "receipt lifecycle lock recovery also failed",
+                failure,
+            )
+        return deferred
+
+    def _acquire_reconciled(self, baseline: int) -> BaseException | None:
+        """Acquire one logical level without repeating a completed acquire."""
+
+        deferred: BaseException | None = None
+        for _attempt in range(self._RECOVERY_LIMIT):
+            try:
+                depth = self._logical_depth()
+                native_owned = self._native_is_owned()
+            except BaseException as error:  # noqa: B036 - bounded recovery
+                deferred = self._defer_failure(deferred, error)
+                continue
+
+            if native_owned:
+                if depth > baseline:
+                    return deferred
+                try:
+                    # A completed zero-depth acquire, or an interrupted
+                    # reentrant logical acquire, needs no second native call.
+                    self._set_logical_depth(baseline + 1)
+                except BaseException as error:  # noqa: B036
+                    deferred = self._defer_failure(deferred, error)
+                    continue
+                return deferred
+
+            if depth > baseline:
+                try:
+                    self._set_logical_depth(baseline)
+                except BaseException as error:  # noqa: B036
+                    deferred = self._defer_failure(deferred, error)
+                    continue
+
+            if deferred is not None:
+                # A successful ownership probe now proves that an interrupted
+                # acquire did not take the native lock.  This operation will
+                # not execute its callback, so reacquiring would only defer
+                # cancellation behind an unrelated owner.
+                return deferred
+
+            try:
+                self._acquire()
+                return deferred
+            except BaseException as error:  # noqa: B036 - reconcile next
+                deferred = self._defer_failure(deferred, error)
+
+        if deferred is not None:
+            raise deferred
+        raise RuntimeError("receipt lifecycle lock acquisition did not converge")
+
+    def _release_reconciled(self, baseline: int) -> BaseException | None:
+        """Restore the logical baseline without repeating a completed release."""
+
+        deferred: BaseException | None = None
+        for _attempt in range(self._RECOVERY_LIMIT):
+            try:
+                depth = self._logical_depth()
+                native_owned = self._native_is_owned()
+            except BaseException as error:  # noqa: B036 - bounded recovery
+                deferred = self._defer_failure(deferred, error)
+                continue
+
+            if baseline:
+                if not native_owned:
+                    try:
+                        self._set_logical_depth(0)
+                    except BaseException as error:  # noqa: B036
+                        deferred = self._defer_failure(deferred, error)
+                        continue
+                    return self._defer_failure(
+                        deferred,
+                        RuntimeError(
+                            "receipt lifecycle lock lost its outer native owner"
+                        ),
+                    )
+                if depth != baseline:
+                    try:
+                        self._set_logical_depth(baseline)
+                    except BaseException as error:  # noqa: B036
+                        deferred = self._defer_failure(deferred, error)
+                        continue
+                return deferred
+
+            if not native_owned:
+                if depth:
+                    try:
+                        self._set_logical_depth(0)
+                    except BaseException as error:  # noqa: B036
+                        deferred = self._defer_failure(deferred, error)
+                        continue
+                return deferred
+
+            if depth != 1:
+                try:
+                    self._set_logical_depth(1)
+                except BaseException as error:  # noqa: B036
+                    deferred = self._defer_failure(deferred, error)
+                    continue
+
+            try:
+                self._release()
+            except BaseException as error:  # noqa: B036 - reconcile next
+                deferred = self._defer_failure(deferred, error)
+
+        if deferred is not None:
+            raise deferred
+        raise RuntimeError("receipt lifecycle lock release did not converge")
+
+    def _release_preserving(
+        self,
+        baseline: int,
+        primary_error: BaseException,
+    ) -> None:
+        try:
+            release_error = self._release_reconciled(baseline)
+        except BaseException as release_error:  # noqa: B036 - keep primary
+            _annotate_error(
+                primary_error,
+                "receipt lifecycle lock release also failed",
+                release_error,
+            )
+            return
+        if release_error is not None:
+            _annotate_error(
+                primary_error,
+                "receipt lifecycle lock release was interrupted",
+                release_error,
+            )
+
+
+class PublishedFileReceiptOwner:
+    """One-shot caller-owned slot for a borrowed published-file receipt.
+
+    The caller creates this owner before publication.  Publication reserves it
+    before any rename and installs the receipt before returning, so an
+    asynchronous exception at any later Python return/STORE boundary cannot
+    strand the retained descriptor on the evaluation stack.
+    """
+
+    __slots__ = ("_slot", "_lock", "_owner_pid")
+
+    def __init__(self) -> None:
+        self._slot: object = _RECEIPT_OWNER_EMPTY
+        self._lock = _CancellationSafeRLock()
+        self._owner_pid = os.getpid()
+
+    @property
+    def state(self) -> str:
+        self._require_owner_pid()
+
+        def observe() -> str:
+            self._normalize_closed_locked()
+            return self._state_locked()
+
+        deferred: BaseException | None = None
+        for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+            try:
+                observed = self._lock.run(observe)
+            except BaseException as state_error:  # noqa: B036 - converge state
+                deferred = _remember_first_cleanup_error(deferred, state_error)
+                continue
+            if deferred is not None:
+                raise deferred
+            return observed
+        if deferred is not None:
+            raise deferred
+        raise RuntimeError("receipt owner state observation did not converge")
+
+    @property
+    def active(self) -> bool:
+        return self.state == "active"
+
+    @property
+    def closed(self) -> bool:
+        return self.state == "closed"
+
+    @property
+    def receipt(self) -> PublishedFileReceipt:
+        """Return a borrowed receipt while this owner retains its ownership."""
+
+        self._require_owner_pid()
+
+        def borrow() -> PublishedFileReceipt:
+            self._normalize_closed_locked()
+            if not isinstance(self._slot, PublishedFileReceipt):
+                raise RuntimeError(
+                    "published file receipt owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            return self._slot
+
+        return self._lock.run(borrow)
+
+    def consume(self, callback: Callable[[PublishedFileReceipt], object]) -> None:
+        """Run a synchronous callback with a borrowed, never-detached receipt."""
+
+        if not callable(callback):
+            raise TypeError("published file receipt consumer must be callable")
+        self._require_owner_pid()
+        if self._lock.held_by_current_thread():
+            raise RuntimeError("published file receipt owner consume is reentrant")
+
+        def consume_locked() -> None:
+            self._normalize_closed_locked()
+            if not isinstance(self._slot, PublishedFileReceipt):
+                raise RuntimeError(
+                    "published file receipt owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            receipt = self._slot
+            callback(receipt)
+            self._normalize_closed_locked()
+
+        # Holding the lifecycle lease for the callback makes consume and close
+        # linear: a concurrent close either wins first or waits for the entire
+        # synchronous borrow to finish.
+        self._lock.run(consume_locked)
+
+    def close(self) -> None:
+        owner_changed = os.getpid() != self._owner_pid
+        if self._lock.held_by_current_thread():
+            raise RuntimeError("published file receipt owner close is reentrant")
+
+        def close_locked() -> None:
+            self._normalize_closed_locked()
+            if self._slot is _RECEIPT_OWNER_CLOSED:
+                return
+            if isinstance(self._slot, PublishedFileReceipt):
+                receipt = self._slot
+                # Keep the lifecycle lock across descriptor reconciliation.  A
+                # receipt never moves through a return/store handoff inside
+                # close, and another thread cannot start a competing cleanup.
+                try:
+                    receipt._close_from_owner(_RECEIPT_OWNER_CLOSE)
+                except BaseException as close_error:  # noqa: B036 - settle state
+                    try:
+                        settle_error = self._settle_receipt_locked(receipt)
+                    except BaseException as observation_error:  # noqa: B036
+                        _annotate_error(
+                            close_error,
+                            "receipt owner close-state observation also failed",
+                            observation_error,
+                        )
+                        raise close_error
+                    if settle_error is not None:
+                        _annotate_error(
+                            close_error,
+                            "receipt owner close-state cleanup also failed",
+                            settle_error,
+                        )
+                    raise
+                settle_error = self._settle_receipt_locked(receipt)
+                if settle_error is not None:
+                    raise settle_error
+                return
+            if self._slot is _RECEIPT_OWNER_EMPTY:
+                self._slot = _RECEIPT_OWNER_CLOSED
+                return
+            raise RuntimeError("published file receipt publication is in progress")
+
+        close_error: BaseException | None = None
+        try:
+            self._lock.run(close_locked)
+        except BaseException as exc:  # noqa: B036 - report PID after cleanup
+            close_error = exc
+
+        if owner_changed:
+            boundary_error = RuntimeError(
+                "published file receipt owner cannot cross a PID boundary"
+            )
+            if close_error is not None:
+                raise boundary_error from close_error
+            raise boundary_error
+        if close_error is not None:
+            raise close_error
+
+    def _settle_receipt_locked(
+        self,
+        receipt: PublishedFileReceipt,
+    ) -> BaseException | None:
+        deferred: BaseException | None = None
+        for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+            try:
+                closed = receipt.closed
+            except BaseException as state_error:  # noqa: B036 - bounded recovery
+                deferred = _remember_first_cleanup_error(deferred, state_error)
+                continue
+            if not closed:
+                return deferred
+            try:
+                if self._slot is receipt:
+                    self._slot = _RECEIPT_OWNER_CLOSED
+            except BaseException as state_error:  # noqa: B036 - observe next
+                deferred = _remember_first_cleanup_error(deferred, state_error)
+                continue
+            if self._slot is not receipt:
+                return deferred
+        return _remember_first_cleanup_error(
+            deferred,
+            RuntimeError("receipt owner close state did not converge"),
+        )
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close()
+        except BaseException as cleanup_error:  # noqa: B036 - keep primary
+            _annotate_error(
+                primary_error,
+                "published receipt owner cleanup also failed",
+                cleanup_error,
+            )
+
+    def _reserve(self, reservation: object) -> None:
+        self._require_owner_pid()
+
+        def reserve() -> None:
+            if self._slot is not _RECEIPT_OWNER_EMPTY:
+                raise RuntimeError(
+                    "published file receipt owner is "
+                    f"{self._state_locked()}, expected empty"
+                )
+            self._slot = reservation
+
+        self._lock.run(reserve)
+
+    def _install(
+        self,
+        reservation: object,
+        receipt: PublishedFileReceipt,
+    ) -> None:
+        self._require_owner_pid()
+
+        def install() -> None:
+            if self._slot is not reservation:
+                raise RuntimeError("published file receipt reservation changed")
+            self._slot = receipt
+
+        self._lock.run(install)
+
+    def _owns_descriptor_owner(self, descriptor_owner: _DescriptorOwner) -> bool:
+        def owns() -> bool:
+            return (
+                isinstance(self._slot, PublishedFileReceipt)
+                and self._slot._descriptor_owner is descriptor_owner
+            )
+
+        return self._lock.run(owns)
+
+    def _cancel_reservation(self, reservation: object) -> None:
+        deferred: BaseException | None = None
+        for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+            try:
+                terminal = self._lock.run(
+                    lambda: self._cancel_reservation_locked(reservation)
+                )
+            except BaseException as cleanup_error:  # noqa: B036 - converge state
+                deferred = _remember_first_cleanup_error(deferred, cleanup_error)
+                continue
+            if terminal:
+                if deferred is not None:
+                    raise deferred
+                return
+        if deferred is not None:
+            raise deferred
+        raise RuntimeError("receipt reservation cancellation did not converge")
+
+    def _cancel_reservation_locked(self, reservation: object) -> bool:
+        if self._slot is reservation:
+            self._slot = _RECEIPT_OWNER_CLOSED
+        return self._slot is not reservation
+
+    def _close_terminal_after_error(self, primary_error: BaseException) -> None:
+        """Terminally clean a helper-local owner that cannot escape to retry."""
+
+        deferred: BaseException | None = None
+        for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+            try:
+                terminal = self._lock.run(
+                    lambda: self._close_terminal_locked(primary_error)
+                )
+            except BaseException as cleanup_error:  # noqa: B036 - converge state
+                deferred = _remember_first_cleanup_error(deferred, cleanup_error)
+                continue
+            if terminal:
+                if deferred is not None:
+                    _annotate_error(
+                        primary_error,
+                        "terminal receipt owner cleanup was interrupted",
+                        deferred,
+                    )
+                return
+        convergence_error = RuntimeError(
+            "terminal receipt owner cleanup did not converge"
+        )
+        deferred = _remember_first_cleanup_error(deferred, convergence_error)
+        _annotate_error(
+            primary_error,
+            "terminal receipt owner cleanup also failed",
+            deferred,
+        )
+
+    def _close_terminal_locked(self, primary_error: BaseException) -> bool:
+        self._normalize_closed_locked()
+        if isinstance(self._slot, PublishedFileReceipt):
+            receipt = self._slot
+            receipt._descriptor_owner.close_after_error(primary_error)
+            if receipt.closed and self._slot is receipt:
+                self._slot = _RECEIPT_OWNER_CLOSED
+            return receipt.closed
+        if self._slot is not _RECEIPT_OWNER_CLOSED:
+            self._slot = _RECEIPT_OWNER_CLOSED
+        return self._slot is _RECEIPT_OWNER_CLOSED
+
+    def _normalize_closed_locked(self) -> None:
+        if isinstance(self._slot, PublishedFileReceipt) and self._slot.closed:
+            self._slot = _RECEIPT_OWNER_CLOSED
+
+    def _state_locked(self) -> str:
+        if self._slot is _RECEIPT_OWNER_EMPTY:
+            return "empty"
+        if self._slot is _RECEIPT_OWNER_CLOSED:
+            return "closed"
+        if isinstance(self._slot, PublishedFileReceipt):
+            return "active"
+        return "reserved"
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "published file receipt owner cannot cross a PID boundary"
+            )
+
+    def __enter__(self) -> PublishedFileReceiptOwner:
+        self._require_owner_pid()
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        if exc is None:
+            self.close()
+        else:
+            self.close_after_error(exc)
+
+
+class OwnedFilePublicationAuthority:
+    """Linear, PID-bound authority for producing and publishing one file."""
+
+    __slots__ = (
+        "destination",
+        "max_bytes",
+        "mode",
+        "_authority_owner",
+        "_stage_owner",
+        "_owner_pid",
+        "_stage_name",
+        "_state",
+        "_record",
+        "_stage_identity",
+        "_renamed",
+    )
+
+    def __init__(
+        self,
+        destination: Path,
+        *,
+        max_bytes: int,
+        mode: int = 0o644,
+        parent_resource: int | None = None,
+    ) -> None:
+        self.destination = _atomic.lexical_directory_path(Path(destination))
+        _atomic._simple_child_name(
+            self.destination.name,
+            label="owned file destination",
+        )
+        self.max_bytes = _bounded_size(max_bytes, label="publication byte limit")
+        self.mode = _file_mode(mode)
+        self._authority_owner = _PublicationAuthorityOwner()
+        self._stage_owner = _DescriptorOwner()
+        self._owner_pid = os.getpid()
+        self._stage_name = ""
+        self._state = "opening"
+        self._record: PublishedFileRecord | None = None
+        self._stage_identity: tuple[int, ...] | None = None
+        self._renamed = False
+
+        try:
+            require_owned_file_publication_support()
+        except BaseException:
+            self._state = "closed"
+            raise
+
+        try:
+            if parent_resource is None:
+                self._authority_owner.acquire(self.destination.parent)
+            else:
+                self._authority_owner.acquire(
+                    self.destination.parent,
+                    parent_resource=parent_resource,
+                )
+            self._stage_name = self._create_stage()
+            self._state = "staged"
+        except BaseException as primary_error:
+            self._state = "failed"
+            self._stage_owner.close_after_error(primary_error)
+            self._authority_owner.close_after_error(primary_error)
+            raise
+
+    @property
+    def _authority(self) -> _atomic._PublicationAuthority | None:
+        return self._authority_owner.authority
+
+    @property
+    def _descriptor(self) -> int:
+        return self._stage_owner.descriptor
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def orphan(self) -> OwnedFileOrphan | None:
+        if (
+            self._record is None
+            or self._stage_identity is None
+            or not self._stage_name
+            or self._renamed
+        ):
+            return None
+        assert self._authority is not None
+        return OwnedFileOrphan(
+            path=self.destination.parent / self._stage_name,
+            parent_identity=self._authority.identity,
+            file_identity=self._stage_identity,
+            record=self._record,
+        )
+
+    def write(self, chunks: Iterable[bytes] | bytes) -> PublishedFileRecord:
+        """Consume one bounded producer exactly once, then flush the file.
+
+        A closeable iterator is always closed.  If iteration already failed, a
+        close failure is attached as a note and the iteration error remains the
+        primary exception.
+        """
+
+        self._require_state("staged")
+        self._state = "writing"
+        iterator: Iterator[bytes] | None = None
+        primary_error: BaseException | None = None
+        digest = hashlib.sha256()
+        size = 0
+        try:
+            iterator = iter((chunks,) if isinstance(chunks, bytes) else chunks)
+            for block in iterator:
+                if not isinstance(block, bytes):
+                    raise TypeError("publication producer must yield bytes")
+                if len(block) > self.max_bytes - size:
+                    raise ValueError("publication producer exceeds its byte limit")
+                view = memoryview(block)
+                while view:
+                    written = os.write(self._descriptor, view)
+                    if written <= 0:
+                        raise RuntimeError("publication write made no progress")
+                    digest.update(view[:written])
+                    size += written
+                    view = view[written:]
+        except BaseException as exc:
+            primary_error = exc
+            raise
+        finally:
+            self._record = PublishedFileRecord(
+                size=size,
+                sha256=digest.hexdigest(),
+                mode=self.mode,
+            )
+            if iterator is not None:
+                close = getattr(iterator, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except BaseException as close_error:
+                        if primary_error is None:
+                            self._state = "failed"
+                            raise
+                        _annotate_error(
+                            primary_error,
+                            "publication iterator cleanup also failed",
+                            close_error,
+                        )
+            if primary_error is not None:
+                self._state = "failed"
+
+        record = PublishedFileRecord(
+            size=size,
+            sha256=digest.hexdigest(),
+            mode=self.mode,
+        )
+        self._record = record
+        try:
+            self._bind_stage(record)
+            os.fsync(self._descriptor)
+            self._bind_stage(record)
+        except BaseException:
+            self._state = "failed"
+            raise
+        self._state = "written"
+        return record
+
+    def publish_into(self, receipt_owner: PublishedFileReceiptOwner) -> None:
+        """Publish and install the receipt in a caller-precreated owner.
+
+        The owner is reserved before any rename.  Installation is complete
+        before this method returns, so even an asynchronous exception at the
+        caller's first bytecode cannot lose the descriptor-owning object.
+        """
+
+        self._require_state("written")
+        if not isinstance(receipt_owner, PublishedFileReceiptOwner):
+            raise TypeError("receipt_owner must be a PublishedFileReceiptOwner")
+
+        reservation = object()
+        receipt_descriptor_owner = _DescriptorOwner()
+        try:
+            self._state = "publishing"
+            receipt_owner._reserve(reservation)
+            assert self._authority is not None
+            assert self._record is not None
+            self._bind_stage(self._record)
+            self._authenticate_descriptor(
+                self._descriptor,
+                expected=self._record,
+                identity=self._stage_identity,
+                label="owned file stage",
+            )
+            self._authority.verify_path_binding()
+
+            try:
+                self._authority.rename_noreplace(
+                    self._stage_name,
+                    self.destination.name,
+                )
+                renamed = True
+            except FileExistsError:
+                renamed = False
+            except BaseException as rename_error:
+                # The syscall may have committed before an injected exception.
+                # That outcome is recorded only to avoid mislabelling a final
+                # name as an orphan.  An ambiguous operation never installs a
+                # receipt; a fresh call must authenticate the existing file.
+                self._state = "failed"
+                self._renamed = True
+                try:
+                    self._renamed = self._rename_committed()
+                except BaseException as reconciliation_error:  # noqa: B036
+                    _annotate_error(
+                        rename_error,
+                        "rename outcome reconciliation also failed",
+                        reconciliation_error,
+                    )
+                raise
+            self._renamed = renamed
+
+            if renamed:
+                metadata = self._authenticate_descriptor(
+                    self._descriptor,
+                    expected=self._record,
+                    identity=self._stage_identity,
+                    label="published file",
+                )
+                receipt_descriptor = receipt_descriptor_owner.duplicate(
+                    self._descriptor
+                )
+                receipt_metadata = os.fstat(receipt_descriptor)
+                receipt_descriptor_owner.bind_identity(receipt_metadata)
+                if _file_version_identity(receipt_metadata) != _file_version_identity(
+                    metadata
+                ):
+                    raise RuntimeError("published receipt descriptor changed")
+                os.set_inheritable(receipt_descriptor, False)
+                orphan = None
+                receipt_record = self._record
+            else:
+                try:
+                    metadata, observed = self._authenticate_existing(
+                        receipt_descriptor_owner
+                    )
+                except ValueError as exc:
+                    orphan = self.orphan
+                    assert orphan is not None
+                    self._state = "failed"
+                    raise OwnedFileConflictError(
+                        self.destination,
+                        self._record,
+                        None,
+                        orphan,
+                    ) from exc
+                if (
+                    observed.mode != self._record.mode
+                    or observed.size != self._record.size
+                    or observed.sha256 != self._record.sha256
+                ):
+                    orphan = self.orphan
+                    assert orphan is not None
+                    self._state = "failed"
+                    raise OwnedFileConflictError(
+                        self.destination,
+                        self._record,
+                        observed,
+                        orphan,
+                    )
+                orphan = self.orphan
+                receipt_record = observed
+
+            os.fsync(self._authority.resource)
+            self._authority.verify_path_binding()
+            rebound = os.stat(
+                self.destination.name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+            if _file_version_identity(rebound) != _file_version_identity(metadata):
+                raise RuntimeError("published file binding changed before receipt")
+            self._close_stage_descriptor()
+            parent_identity = self._authority.identity
+            self._close_parent_authority()
+            receipt = PublishedFileReceipt(
+                path=self.destination,
+                record=receipt_record,
+                file_identity=_file_identity(metadata),
+                version_identity=_file_version_identity(metadata),
+                parent_identity=parent_identity,
+                reused=not renamed,
+                orphan=orphan,
+                descriptor_owner=receipt_descriptor_owner,
+            )
+            receipt_owner._install(reservation, receipt)
+            self._state = "published"
+            self._stage_name = ""
+            return None
+        except BaseException as primary_error:
+            try:
+                installed = receipt_owner._owns_descriptor_owner(
+                    receipt_descriptor_owner
+                )
+            except BaseException as ownership_error:  # noqa: B036
+                _annotate_error(
+                    primary_error,
+                    "receipt ownership reconciliation also failed",
+                    ownership_error,
+                )
+                installed = False
+            if installed:
+                receipt_owner.close_after_error(primary_error)
+            else:
+                receipt_descriptor_owner.close_after_error(primary_error)
+                try:
+                    receipt_owner._cancel_reservation(reservation)
+                except BaseException as reservation_error:  # noqa: B036
+                    _annotate_error(
+                        primary_error,
+                        "receipt reservation cleanup also failed",
+                        reservation_error,
+                    )
+            if self._state != "failed":
+                self._state = "failed"
+            raise
+
+    def publish(self, *, receipt_owner: PublishedFileReceiptOwner) -> None:
+        """Compatibility spelling for :meth:`publish_into`, with strict owner."""
+
+        self.publish_into(receipt_owner)
+
+    def close(self) -> None:
+        if self._state == "closed":
+            return
+        owner_changed = os.getpid() != self._owner_pid
+        close_error: BaseException | None = None
+        if self._stage_owner.descriptor >= 0:
+            try:
+                self._close_stage_descriptor()
+            except BaseException as exc:  # noqa: B036 - finish all cleanup
+                close_error = exc
+        if self._authority_owner.authority is not None:
+            try:
+                self._close_parent_authority()
+            except BaseException as exc:  # noqa: B036 - finish all cleanup
+                if close_error is None:
+                    close_error = exc
+                else:
+                    _annotate_error(
+                        close_error,
+                        "parent authority close also failed",
+                        exc,
+                    )
+        cleanup_complete = (
+            self._stage_owner.descriptor < 0 and self._authority_owner.authority is None
+        )
+        if self._state != "published" and cleanup_complete:
+            self._state = "closed"
+        elif not cleanup_complete:
+            self._state = "close-failed"
+        if owner_changed:
+            raise RuntimeError(
+                "owned file publication authority cannot cross a PID boundary"
+            ) from close_error
+        if close_error is not None:
+            raise close_error
+
+    def _create_stage(self) -> str:
+        assert self._authority is not None
+        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC
+        destination_digest = hashlib.sha256(
+            os.fsencode(self.destination.name)
+        ).hexdigest()[:16]
+        for _attempt in range(_MAX_STAGE_ATTEMPTS):
+            name = f".codenib-file-{destination_digest}-{secrets.token_hex(16)}"
+            _atomic._simple_child_name(name, label="owned file stage")
+            try:
+                try:
+                    descriptor = self._stage_owner.open(
+                        name,
+                        flags,
+                        0o600,
+                        dir_fd=self._authority.resource,
+                    )
+                except FileExistsError:
+                    continue
+                created = os.fstat(descriptor)
+                self._stage_owner.bind_identity(created)
+                os.fchmod(descriptor, self.mode)
+                metadata = os.fstat(descriptor)
+                _require_new_regular(metadata, mode=self.mode)
+                self._stage_owner.bind_identity(metadata)
+                self._stage_identity = _file_identity(metadata)
+                return name
+            except BaseException as primary_error:
+                self._stage_owner.close_after_error(primary_error)
+                raise
+        raise RuntimeError("could not reserve a bounded owned file stage")
+
+    def _bind_stage(self, record: PublishedFileRecord) -> None:
+        assert self._authority is not None
+        descriptor_metadata = os.fstat(self._descriptor)
+        _require_exact_regular(
+            descriptor_metadata,
+            identity=self._stage_identity,
+            version_identity=None,
+            mode=record.mode,
+            size=record.size,
+            label="owned file stage",
+        )
+        try:
+            bound = os.stat(
+                self._stage_name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "owned file stage namespace binding disappeared"
+            ) from exc
+        _require_exact_regular(
+            bound,
+            identity=self._stage_identity,
+            version_identity=None,
+            mode=record.mode,
+            size=record.size,
+            label="owned file stage binding",
+        )
+
+    def _open_regular(
+        self,
+        name: str,
+        *,
+        label: str,
+        owner: _DescriptorOwner,
+    ) -> os.stat_result:
+        assert self._authority is not None
+        try:
+            before = os.stat(
+                name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"{label} disappeared") from exc
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            raise ValueError(f"{label} must be an unlinked regular file")
+        flags = (
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC | getattr(os, "O_NONBLOCK", 0)
+        )
+        try:
+            descriptor = owner.open(name, flags, dir_fd=self._authority.resource)
+            opened = os.fstat(descriptor)
+            owner.bind_identity(opened)
+            if _file_identity(opened) != _file_identity(before):
+                raise RuntimeError(f"{label} changed while it was opened")
+            _require_new_regular(opened, mode=stat.S_IMODE(opened.st_mode))
+            return opened
+        except BaseException as primary_error:
+            owner.close_after_error(primary_error)
+            raise
+
+    def _authenticate_existing(
+        self,
+        owner: _DescriptorOwner,
+    ) -> tuple[os.stat_result, PublishedFileRecord]:
+        assert self._authority is not None
+        before = self._open_regular(
+            self.destination.name,
+            label="existing publication",
+            owner=owner,
+        )
+        descriptor = owner.descriptor
+        try:
+            if before.st_size < 0 or before.st_size > self.max_bytes:
+                assert self._record is not None
+                orphan = self.orphan
+                assert orphan is not None
+                raise OwnedFileConflictError(
+                    self.destination,
+                    self._record,
+                    None,
+                    orphan,
+                )
+            digest = hashlib.sha256()
+            offset = 0
+            while offset < before.st_size:
+                block = os.pread(
+                    descriptor,
+                    min(_COPY_BYTES, before.st_size - offset),
+                    offset,
+                )
+                if not block:
+                    raise RuntimeError("existing publication was truncated")
+                digest.update(block)
+                offset += len(block)
+            if os.pread(descriptor, 1, offset):
+                raise RuntimeError("existing publication grew")
+            after = os.fstat(descriptor)
+            if _file_version_identity(after) != _file_version_identity(before):
+                raise RuntimeError("existing publication changed while authenticated")
+            observed_mode = _file_mode(stat.S_IMODE(after.st_mode))
+            rebound = os.stat(
+                self.destination.name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+            if _file_version_identity(rebound) != _file_version_identity(after):
+                raise RuntimeError("existing publication binding changed")
+            return (
+                after,
+                PublishedFileRecord(
+                    size=after.st_size,
+                    sha256=digest.hexdigest(),
+                    mode=observed_mode,
+                ),
+            )
+        except BaseException as primary_error:
+            owner.close_after_error(primary_error)
+            raise
+
+    def _authenticate_descriptor(
+        self,
+        descriptor: int,
+        *,
+        expected: PublishedFileRecord,
+        identity: tuple[int, ...] | None,
+        label: str,
+    ) -> os.stat_result:
+        before = os.fstat(descriptor)
+        _require_exact_regular(
+            before,
+            identity=identity,
+            version_identity=None,
+            mode=expected.mode,
+            size=expected.size,
+            label=label,
+        )
+        digest = hashlib.sha256()
+        offset = 0
+        while offset < expected.size:
+            block = os.pread(
+                descriptor,
+                min(_COPY_BYTES, expected.size - offset),
+                offset,
+            )
+            if not block:
+                raise RuntimeError(f"{label} was truncated")
+            digest.update(block)
+            offset += len(block)
+        if os.pread(descriptor, 1, offset):
+            raise RuntimeError(f"{label} grew")
+        after = os.fstat(descriptor)
+        if _file_version_identity(after) != _file_version_identity(before):
+            raise RuntimeError(f"{label} changed while authenticated")
+        if digest.hexdigest() != expected.sha256:
+            raise RuntimeError(f"{label} bytes differ from the producer digest")
+        return after
+
+    def _rename_committed(self) -> bool:
+        assert self._authority is not None
+        try:
+            source = os.stat(
+                self._stage_name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            source = None
+        try:
+            destination = os.stat(
+                self.destination.name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            destination = None
+        return (
+            source is None
+            and destination is not None
+            and _file_identity(destination) == self._stage_identity
+        )
+
+    def _close_stage_descriptor(self) -> None:
+        assert self._stage_identity is not None
+        self._stage_owner.close(expected_identity=self._stage_identity)
+
+    def _close_parent_authority(self) -> None:
+        assert self._authority_owner.authority is not None
+        self._authority_owner.close()
+
+    def _require_state(self, expected: str) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "owned file publication authority cannot cross a PID boundary"
+            )
+        if self._state != expected:
+            raise RuntimeError(
+                f"owned file publication is {self._state}, expected {expected}"
+            )
+
+    def __enter__(self) -> OwnedFilePublicationAuthority:
+        self._require_state("staged")
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        try:
+            self.close()
+        except BaseException as close_error:
+            if exc is None:
+                raise
+            _annotate_error(exc, "publication cleanup also failed", close_error)
+
+
+def publish_owned_file(
+    destination: Path,
+    chunks: Iterable[bytes] | bytes,
+    *,
+    max_bytes: int,
+    mode: int = 0o644,
+    parent_resource: int | None = None,
+    receipt_owner: PublishedFileReceiptOwner | None = None,
+    consume: Callable[[PublishedFileReceipt], object] | None = None,
+) -> None:
+    """Publish into a caller owner or synchronously consume a borrowed receipt.
+
+    The receipt retains the exact authenticated handle, but a same-UID process
+    can still mutate a normal writable filesystem after publication.  A
+    consumer-only receipt is valid solely for the synchronous callback and is
+    terminally cleaned before this helper returns or propagates an exception.
+    """
+
+    if (receipt_owner is None) == (consume is None):
+        raise TypeError("provide exactly one of receipt_owner or consume")
+    if receipt_owner is not None and not isinstance(
+        receipt_owner, PublishedFileReceiptOwner
+    ):
+        raise TypeError("receipt_owner must be a PublishedFileReceiptOwner")
+    if consume is not None and not callable(consume):
+        raise TypeError("published file receipt consumer must be callable")
+
+    if receipt_owner is not None:
+        with OwnedFilePublicationAuthority(
+            destination,
+            max_bytes=max_bytes,
+            mode=mode,
+            parent_resource=parent_resource,
+        ) as publication:
+            publication.write(chunks)
+            publication.publish_into(receipt_owner)
+        return None
+
+    local_owner = PublishedFileReceiptOwner()
+    try:
+        with OwnedFilePublicationAuthority(
+            destination,
+            max_bytes=max_bytes,
+            mode=mode,
+            parent_resource=parent_resource,
+        ) as publication:
+            publication.write(chunks)
+            publication.publish_into(local_owner)
+        assert consume is not None
+        local_owner.consume(consume)
+    except BaseException as primary_error:
+        try:
+            local_owner._close_terminal_after_error(primary_error)
+        except BaseException as cleanup_error:  # noqa: B036 - keep primary
+            _annotate_error(
+                primary_error,
+                "helper-local receipt owner cleanup also failed",
+                cleanup_error,
+            )
+        raise
+    try:
+        local_owner.close()
+    except BaseException as close_error:
+        try:
+            local_owner._close_terminal_after_error(close_error)
+        except BaseException as cleanup_error:  # noqa: B036 - keep close error
+            _annotate_error(
+                close_error,
+                "helper-local terminal cleanup also failed",
+                cleanup_error,
+            )
+        raise
+    return None
+
+
+def _bounded_size(value: int, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{label} must be an integer")
+    if value < 0 or value > (64 << 30):
+        raise ValueError(f"{label} is out of bounds")
+    return value
+
+
+def _file_mode(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("publication mode must be an integer")
+    if value < 0 or value > 0o777 or value & 0o022:
+        raise ValueError("publication mode must be a non-writable-group POSIX mode")
+    return value
+
+
+def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (metadata.st_dev, metadata.st_ino, stat.S_IFMT(metadata.st_mode))
+
+
+def _file_version_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _annotate_error(
+    primary_error: BaseException,
+    label: str,
+    cleanup_error: BaseException,
+) -> None:
+    message = f"{label}: {cleanup_error!r}"
+    if hasattr(primary_error, "add_note"):
+        primary_error.add_note(message)
+        return
+    notes = list(getattr(primary_error, "_codenib_cleanup_notes", ()))
+    notes.append(message)
+    primary_error._codenib_cleanup_notes = tuple(notes)  # type: ignore[attr-defined]
+    if primary_error.__cause__ is None:
+        primary_error.__cause__ = cleanup_error
+
+
+def _remember_first_cleanup_error(
+    deferred: BaseException | None,
+    failure: BaseException,
+) -> BaseException:
+    if deferred is None:
+        return failure
+    if failure is not deferred:
+        _annotate_error(deferred, "additional cleanup interruption", failure)
+    return deferred
+
+
+def _arm_descriptor_for_close(
+    descriptor: int,
+    *,
+    cookie_owner: _DescriptorOwner | None = None,
+) -> int:
+    """Place an unguessable cookie on this open-file description before close."""
+
+    cookie = _CLOSE_COOKIE_FLOOR + secrets.randbelow(_CLOSE_COOKIE_SPAN)
+    observed = os.lseek(descriptor, cookie, os.SEEK_SET)
+    if observed != cookie or os.lseek(descriptor, 0, os.SEEK_CUR) != cookie:
+        raise RuntimeError("could not arm descriptor close ownership")
+    if cookie_owner is not None:
+        if cookie_owner.descriptor != descriptor:
+            raise RuntimeError("descriptor close-cookie owner changed")
+        # Install before returning so interruption at the caller's first
+        # bytecode still leaves a proof for any later retry.
+        cookie_owner._close_cookie = cookie
+    return cookie
+
+
+def _descriptor_still_exact(
+    descriptor: int,
+    identity: tuple[int, ...],
+    *,
+    close_cookie: int | None,
+) -> bool:
+    """Best-effort recognition of the pre-close open-file description.
+
+    A same-process ``dup2`` of an alias sharing both inode and file offset is an
+    intentionally documented, unprovable ABA boundary.
+    """
+
+    if close_cookie is None:
+        return False
+
+    try:
+        metadata = os.fstat(descriptor)
+    except OSError as exc:
+        if exc.errno == errno.EBADF:
+            return False
+        raise
+    if _file_identity(metadata) != identity:
+        return False
+    try:
+        return os.lseek(descriptor, 0, os.SEEK_CUR) == close_cookie
+    except OSError as exc:
+        if exc.errno == errno.EBADF:
+            return False
+        raise
+
+
+def _finish_close_after_error(
+    descriptor: int,
+    identity: tuple[int, ...],
+    close_error: BaseException,
+    *,
+    close_cookie: int | None,
+) -> bool:
+    """Finish an ambiguous close unless the descriptor is observably reused."""
+
+    try:
+        still_exact = _descriptor_still_exact(
+            descriptor,
+            identity,
+            close_cookie=close_cookie,
+        )
+    except BaseException as reconciliation_error:  # noqa: B036 - keep close error
+        _annotate_error(
+            close_error,
+            "descriptor close reconciliation failed",
+            reconciliation_error,
+        )
+        return False
+    if not still_exact:
+        return True
+    try:
+        _REAL_OS_CLOSE(descriptor)
+    except BaseException as cleanup_error:  # noqa: B036 - keep close error
+        _annotate_error(
+            close_error,
+            "descriptor fallback close failed",
+            cleanup_error,
+        )
+        try:
+            return not _descriptor_still_exact(
+                descriptor,
+                identity,
+                close_cookie=close_cookie,
+            )
+        except BaseException as reconciliation_error:  # noqa: B036 - keep primary
+            _annotate_error(
+                close_error,
+                "descriptor fallback reconciliation failed",
+                reconciliation_error,
+            )
+            return False
+    return True
+
+
+def _cleanup_descriptor_after_error(
+    descriptor: int,
+    identity: tuple[int, ...] | None,
+    primary_error: BaseException,
+    *,
+    cookie_owner: _DescriptorOwner | None = None,
+) -> bool:
+    if identity is None:
+        return _cleanup_untransferred_descriptor(descriptor, primary_error)
+    close_cookie: int | None = None
+    try:
+        close_cookie = _arm_descriptor_for_close(
+            descriptor,
+            cookie_owner=cookie_owner,
+        )
+    except BaseException as ownership_error:  # noqa: B036 - keep primary error
+        _annotate_error(
+            primary_error,
+            "descriptor cleanup ownership check failed",
+            ownership_error,
+        )
+    try:
+        os.close(descriptor)
+    except BaseException as close_error:  # noqa: B036 - keep primary error
+        closed = _finish_close_after_error(
+            descriptor,
+            identity,
+            close_error,
+            close_cookie=close_cookie,
+        )
+        _annotate_error(primary_error, "descriptor cleanup also failed", close_error)
+        if not closed:
+            _annotate_error(
+                primary_error,
+                "owned descriptor close outcome remains unknown",
+                close_error,
+            )
+        return closed
+    return True
+
+
+def _cleanup_untransferred_descriptor(
+    descriptor: int,
+    primary_error: BaseException,
+) -> bool:
+    try:
+        metadata = os.fstat(descriptor)
+    except OSError as exc:
+        if exc.errno == errno.EBADF:
+            return True
+        _annotate_error(primary_error, "descriptor cleanup identity failed", exc)
+        try:
+            os.close(descriptor)
+        except BaseException as close_error:  # noqa: B036 - keep primary error
+            _annotate_error(
+                primary_error,
+                "unidentified descriptor cleanup also failed",
+                close_error,
+            )
+            return False
+        return True
+    except BaseException as identity_error:  # noqa: B036 - keep primary error
+        _annotate_error(
+            primary_error,
+            "descriptor cleanup identity was interrupted",
+            identity_error,
+        )
+        try:
+            os.close(descriptor)
+        except BaseException as close_error:  # noqa: B036 - keep primary error
+            _annotate_error(
+                primary_error,
+                "unidentified descriptor cleanup also failed",
+                close_error,
+            )
+            return False
+        return True
+    return _cleanup_descriptor_after_error(
+        descriptor,
+        _file_identity(metadata),
+        primary_error,
+    )
+
+
+def _close_publication_authority(
+    authority: _atomic._PublicationAuthority,
+) -> None:
+    """Close a shared authority while retaining the first BaseException."""
+
+    resource = authority._resource
+    resource_identity: tuple[int, ...] | None = None
+    close_cookie: int | None = None
+    primary_error: BaseException | None = None
+    try:
+        resource_identity = _file_identity(os.fstat(resource))
+        close_cookie = _arm_descriptor_for_close(resource)
+    except BaseException as ownership_error:  # noqa: B036 - cleanup must continue
+        primary_error = ownership_error
+
+    try:
+        authority.close()
+    except BaseException as close_error:  # noqa: B036 - finish all cleanup
+        if primary_error is None:
+            primary_error = close_error
+        else:
+            _annotate_error(
+                primary_error,
+                "parent authority close also failed",
+                close_error,
+            )
+        try:
+            # The callback owns the complete lexical walk.  It is deliberately
+            # resumed after an interrupt even though the authority is closed.
+            authority._close_callback(resource)
+        except BaseException as cleanup_error:  # noqa: B036 - keep first error
+            _annotate_error(
+                primary_error,
+                "parent authority cleanup also failed",
+                cleanup_error,
+            )
+
+    if resource_identity is not None:
+        try:
+            still_open = _descriptor_still_exact(
+                resource,
+                resource_identity,
+                close_cookie=close_cookie,
+            )
+        except BaseException as reconciliation_error:  # noqa: B036
+            if primary_error is None:
+                primary_error = reconciliation_error
+            else:
+                _annotate_error(
+                    primary_error,
+                    "parent descriptor reconciliation failed",
+                    reconciliation_error,
+                )
+        else:
+            if still_open:
+                try:
+                    _REAL_OS_CLOSE(resource)
+                except BaseException as cleanup_error:  # noqa: B036
+                    if primary_error is None:
+                        primary_error = cleanup_error
+                    else:
+                        _annotate_error(
+                            primary_error,
+                            "parent descriptor cleanup failed",
+                            cleanup_error,
+                        )
+
+    if primary_error is not None:
+        raise primary_error
+
+
+def _require_new_regular(metadata: os.stat_result, *, mode: int) -> None:
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_nlink != 1
+        or stat.S_IMODE(metadata.st_mode) != mode
+    ):
+        raise RuntimeError("owned file must be one exact regular inode")
+
+
+def _require_exact_regular(
+    metadata: os.stat_result,
+    *,
+    identity: tuple[int, ...] | None,
+    version_identity: tuple[int, ...] | None,
+    mode: int,
+    size: int,
+    label: str,
+) -> None:
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_nlink != 1
+        or stat.S_IMODE(metadata.st_mode) != mode
+        or metadata.st_size != size
+        or (identity is not None and _file_identity(metadata) != identity)
+        or (
+            version_identity is not None
+            and _file_version_identity(metadata) != version_identity
+        )
+    ):
+        raise RuntimeError(f"{label} identity changed")
+
+
+__all__ = [
+    "OwnedFileConflictError",
+    "OwnedFileOrphan",
+    "OwnedFilePublicationAuthority",
+    "PublishedFileReceipt",
+    "PublishedFileReceiptOwner",
+    "PublishedFileRecord",
+    "publish_owned_file",
+    "require_owned_file_publication_support",
+]

--- a/codenib/_owned_file_publication.py
+++ b/codenib/_owned_file_publication.py
@@ -207,6 +207,41 @@ class _DescriptorOwner:
                 )
             raise
 
+    def close_inherited(
+        self,
+        *,
+        expected_identity: tuple[int, ...] | None = None,
+    ) -> None:
+        """Close only this fork child's fd reference without seeking its OFD."""
+
+        descriptor = self._descriptor
+        if descriptor < 0:
+            return
+        identity = expected_identity or self._identity
+        try:
+            metadata = os.fstat(descriptor)
+        except OSError as exc:
+            if exc.errno == errno.EBADF:
+                self._invalidate()
+                return
+            raise
+        if identity is not None and _file_identity(metadata) != identity:
+            self._invalidate()
+            raise RuntimeError("inherited descriptor changed before close")
+        try:
+            os.close(descriptor)
+        except BaseException:
+            try:
+                rebound = os.fstat(descriptor)
+            except OSError as exc:
+                if exc.errno == errno.EBADF:
+                    self._invalidate()
+            else:
+                if identity is not None and _file_identity(rebound) != identity:
+                    self._invalidate()
+            raise
+        self._invalidate()
+
     def _close_retryable(
         self,
         descriptor: int,
@@ -531,6 +566,18 @@ class _PublicationAuthorityOwner:
             if authority._closed:
                 self._authority = None
 
+    def close_inherited(self) -> None:
+        """Close the child copy without arming the parent's shared OFD."""
+
+        authority = self._authority
+        if authority is None:
+            return
+        try:
+            authority.close()
+        finally:
+            if authority._closed:
+                self._authority = None
+
     def close_after_error(self, primary_error: BaseException) -> None:
         try:
             self.close()
@@ -697,12 +744,24 @@ class PublishedFileReceipt:
         if self._descriptor < 0:
             return
         owner_changed = os.getpid() != self._owner_pid
+        if owner_changed:
+            close_error: BaseException | None = None
+            try:
+                self._descriptor_owner.close_inherited(
+                    expected_identity=self.file_identity,
+                )
+            except BaseException as exc:  # noqa: B036 - report PID boundary
+                close_error = exc
+            boundary_error = RuntimeError(
+                "published file receipt cannot cross a PID boundary"
+            )
+            if close_error is not None:
+                raise boundary_error from close_error
+            raise boundary_error
         self._descriptor_owner.close(
             expected_identity=self.file_identity,
             retryable=True,
         )
-        if owner_changed:
-            raise RuntimeError("published file receipt cannot cross a PID boundary")
 
     def _require_active(self) -> None:
         if self._descriptor < 0:
@@ -937,12 +996,13 @@ class PublishedFileReceiptOwner:
     strand the retained descriptor on the evaluation stack.
     """
 
-    __slots__ = ("_slot", "_lock", "_owner_pid")
+    __slots__ = ("_slot", "_lock", "_owner_pid", "_process_locks")
 
     def __init__(self) -> None:
         self._slot: object = _RECEIPT_OWNER_EMPTY
         self._lock = _CancellationSafeRLock()
         self._owner_pid = os.getpid()
+        self._process_locks = {self._owner_pid: self._lock}
 
     @property
     def state(self) -> str:
@@ -1017,9 +1077,17 @@ class PublishedFileReceiptOwner:
         self._lock.run(consume_locked)
 
     def close(self) -> None:
-        owner_changed = os.getpid() != self._owner_pid
-        if self._lock.held_by_current_thread():
-            raise RuntimeError("published file receipt owner close is reentrant")
+        current_pid = os.getpid()
+        owner_changed = current_pid != self._owner_pid
+        if owner_changed:
+            lifecycle_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+        else:
+            if self._lock.held_by_current_thread():
+                raise RuntimeError("published file receipt owner close is reentrant")
+            lifecycle_lock = self._lock
 
         def close_locked() -> None:
             self._normalize_closed_locked()
@@ -1060,7 +1128,7 @@ class PublishedFileReceiptOwner:
 
         close_error: BaseException | None = None
         try:
-            self._lock.run(close_locked)
+            lifecycle_lock.run(close_locked)
         except BaseException as exc:  # noqa: B036 - report PID after cleanup
             close_error = exc
 
@@ -1577,6 +1645,40 @@ class OwnedFilePublicationAuthority:
         if self._state == "closed":
             return
         owner_changed = os.getpid() != self._owner_pid
+        if owner_changed:
+            close_error: BaseException | None = None
+            if self._stage_owner.descriptor >= 0:
+                try:
+                    self._stage_owner.close_inherited(
+                        expected_identity=self._stage_identity,
+                    )
+                except BaseException as exc:  # noqa: B036 - close all child fds
+                    close_error = exc
+            if self._authority_owner.authority is not None:
+                try:
+                    self._authority_owner.close_inherited()
+                except BaseException as exc:  # noqa: B036 - close all child fds
+                    if close_error is None:
+                        close_error = exc
+                    else:
+                        _annotate_error(
+                            close_error,
+                            "inherited parent authority close also failed",
+                            exc,
+                        )
+            if (
+                self._stage_owner.descriptor < 0
+                and self._authority_owner.authority is None
+            ):
+                self._state = "closed"
+            else:
+                self._state = "close-failed"
+            boundary_error = RuntimeError(
+                "owned file publication authority cannot cross a PID boundary"
+            )
+            if close_error is not None:
+                raise boundary_error from close_error
+            raise boundary_error
         close_error: BaseException | None = None
         if self._stage_owner.descriptor >= 0:
             try:
@@ -1602,10 +1704,6 @@ class OwnedFilePublicationAuthority:
             self._state = "closed"
         elif not cleanup_complete:
             self._state = "close-failed"
-        if owner_changed:
-            raise RuntimeError(
-                "owned file publication authority cannot cross a PID boundary"
-            ) from close_error
         if close_error is not None:
             raise close_error
 

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -16,13 +16,14 @@ import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO, Iterable, Iterator
+from typing import BinaryIO, Callable, Iterable, Iterator, TypeVar
 
 from .. import _atomic_directory as _atomic
 from .._owned_file_publication import (
     OwnedFileConflictError,
     PublishedFileReceipt,
     PublishedFileRecord,
+    _CancellationSafeRLock,
     publish_owned_file,
     require_owned_file_publication_support,
 )
@@ -53,6 +54,7 @@ _PORTABLE_LINK_UNSUPPORTED_ERRNOS = {
     if value is not None
 }
 _PORTABLE_PUBLISH_LOCKS = tuple(threading.Lock() for _ in range(64))
+_CASResult = TypeVar("_CASResult")
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,6 +112,9 @@ class LocalCAS:
         *,
         require_preprovisioned: bool = False,
     ) -> None:
+        self._lifecycle_lock = _CancellationSafeRLock()
+        self._owner_pid = os.getpid()
+        self._process_locks = {self._owner_pid: self._lifecycle_lock}
         if not isinstance(require_preprovisioned, bool):
             raise TypeError("require_preprovisioned must be a boolean")
         try:
@@ -274,14 +279,81 @@ class LocalCAS:
     def close(self) -> None:
         """Release strict generation anchors retained for this store."""
 
+        if not getattr(self, "_require_preprovisioned", False):
+            return
+        current_pid = os.getpid()
+        if current_pid != self._owner_pid:
+            child_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+            close_error: BaseException | None = None
+            try:
+                child_lock.run(self._close_strict_resources_locked)
+            except BaseException as exc:  # noqa: B036 - report PID boundary
+                close_error = exc
+            boundary_error = StorageIntegrityError(
+                "strict CAS authority crossed a PID boundary"
+            )
+            if close_error is not None:
+                raise boundary_error from close_error
+            raise boundary_error
+        self._run_lifecycle(self._close_strict_resources_locked)
+
+    def _run_lifecycle(self, callback: Callable[[], _CASResult]) -> _CASResult:
+        """Run one same-process strict lifecycle transition linearly."""
+
+        return self._lifecycle_lock.run(callback)
+
+    def _close_strict_resources_locked(self) -> None:
         resources = self._strict_resources
         if resources is None:
             return
-        _close_posix_resources(resources)
-        self._strict_resources = None
-        self._strict_root_descriptor = None
-        self._strict_sha256_descriptor = None
-        self._strict_shard_descriptors.clear()
+        primary_error: BaseException | None = None
+        try:
+            _close_posix_resources(resources)
+        except BaseException as exc:  # noqa: B036 - settle closed ownership
+            primary_error = exc
+        try:
+            closed = resources.closed
+        except BaseException as observation_error:  # noqa: B036
+            if primary_error is None:
+                primary_error = observation_error
+            else:
+                _atomic._annotate_secondary_error(
+                    primary_error,
+                    "strict CAS close-state observation also failed",
+                    observation_error,
+                )
+            closed = False
+        if closed:
+            # Clear the owner first.  If cancellation interrupts a later store,
+            # every operation still observes the lifecycle as terminal.
+            self._strict_resources = None
+            self._strict_root_descriptor = None
+            self._strict_sha256_descriptor = None
+            self._strict_shard_descriptors = {}
+        if primary_error is not None:
+            raise primary_error.with_traceback(primary_error.__traceback__)
+
+    def _run_strict_operation(
+        self,
+        callback: Callable[[], _CASResult],
+    ) -> _CASResult:
+        """Serialize one strict operation with anchor cleanup."""
+
+        if not self._require_preprovisioned:
+            return callback()
+        if os.getpid() != self._owner_pid:
+            raise StorageIntegrityError("strict CAS authority crossed a PID boundary")
+
+        def run_locked() -> _CASResult:
+            resources = self._strict_resources
+            if resources is None or resources.closed:
+                raise StorageIntegrityError("strict CAS authority is closed")
+            return callback()
+
+        return self._run_lifecycle(run_locked)
 
     def __enter__(self) -> LocalCAS:
         return self
@@ -364,10 +436,13 @@ class LocalCAS:
     def put_bytes(self, data: bytes) -> BlobInfo:
         """Store *data*, deduplicating an already-valid immutable object."""
 
-        if not isinstance(data, bytes):
-            raise TypeError("CAS payload must be bytes")
-        digest = hashlib.sha256(data).hexdigest()
-        return self._publish_object(digest, len(data), data)
+        def put() -> BlobInfo:
+            if not isinstance(data, bytes):
+                raise TypeError("CAS payload must be bytes")
+            digest = hashlib.sha256(data).hexdigest()
+            return self._publish_object(digest, len(data), data)
+
+        return self._run_strict_operation(put)
 
     def put_file(self, source: str | Path) -> BlobInfo:
         """Store a stable snapshot of a regular file.
@@ -378,15 +453,18 @@ class LocalCAS:
         replaced or modified while it is being stored.
         """
 
-        source_path = Path(source)
-        digest, byte_size, source_signature = _hash_stable_file(source_path)
-        chunks = _stable_file_chunks(
-            source_path,
-            expected_signature=source_signature,
-            expected_digest=digest,
-            expected_size=byte_size,
-        )
-        return self._publish_object(digest, byte_size, chunks)
+        def put() -> BlobInfo:
+            source_path = Path(source)
+            digest, byte_size, source_signature = _hash_stable_file(source_path)
+            chunks = _stable_file_chunks(
+                source_path,
+                expected_signature=source_signature,
+                expected_digest=digest,
+                expected_size=byte_size,
+            )
+            return self._publish_object(digest, byte_size, chunks)
+
+        return self._run_strict_operation(put)
 
     def has(self, digest: str) -> bool:
         """Return whether a regular object exists for *digest*.
@@ -395,51 +473,74 @@ class LocalCAS:
         before trusting an object at a publication boundary.
         """
 
-        try:
-            handle = self.open(digest)
-        except FileNotFoundError:
-            return False
-        handle.close()
-        return True
+        def check() -> bool:
+            try:
+                handle = self.open(digest)
+            except FileNotFoundError:
+                return False
+            handle.close()
+            return True
+
+        return self._run_strict_operation(check)
 
     def open(self, digest: str) -> BinaryIO:
         """Open a CAS object for binary reading without following symlinks."""
 
-        digest = _validate_digest(digest)
-        with self._open_shard(digest) as (shard_descriptor, shard_path):
-            return _open_regular_at(
-                shard_descriptor,
-                shard_path,
-                digest[2:],
-                label="CAS object",
-            )
+        def open_object() -> BinaryIO:
+            validated = _validate_digest(digest)
+            with self._open_shard(validated) as (shard_descriptor, shard_path):
+                return _open_regular_at(
+                    shard_descriptor,
+                    shard_path,
+                    validated[2:],
+                    label="CAS object",
+                )
+
+        return self._run_strict_operation(open_object)
 
     def read_bytes(self, digest: str) -> bytes:
         """Read an object and reject content that does not match its key."""
 
-        chunks: list[bytes] = []
-        observed_digest, byte_size = self._consume_object(digest, chunks=chunks)
-        if observed_digest != digest:
-            raise StorageIntegrityError(f"CAS object digest mismatch for {digest}")
-        # ``byte_size`` is consumed to keep the full-read and verify paths
-        # symmetrical; joining the recorded chunks cannot change its value.
-        payload = b"".join(chunks)
-        if len(payload) != byte_size:
-            raise StorageIntegrityError(
-                f"CAS object size changed while reading {digest}"
-            )
-        return payload
+        def read() -> bytes:
+            chunks: list[bytes] = []
+            observed_digest, byte_size = self._consume_object(digest, chunks=chunks)
+            if observed_digest != digest:
+                raise StorageIntegrityError(f"CAS object digest mismatch for {digest}")
+            # ``byte_size`` is consumed to keep the full-read and verify paths
+            # symmetrical; joining the recorded chunks cannot change its value.
+            payload = b"".join(chunks)
+            if len(payload) != byte_size:
+                raise StorageIntegrityError(
+                    f"CAS object size changed while reading {digest}"
+                )
+            return payload
+
+        return self._run_strict_operation(read)
 
     def verify(self, digest: str) -> BlobInfo:
         """Fully verify an object and return its canonical metadata."""
 
-        observed_digest, byte_size = self._consume_object(digest)
-        if observed_digest != digest:
-            raise StorageIntegrityError(f"CAS object digest mismatch for {digest}")
-        return self._blob_info(digest, byte_size)
+        def verify_object() -> BlobInfo:
+            observed_digest, byte_size = self._consume_object(digest)
+            if observed_digest != digest:
+                raise StorageIntegrityError(f"CAS object digest mismatch for {digest}")
+            return self._blob_info(digest, byte_size)
+
+        return self._run_strict_operation(verify_object)
 
     def materialize(self, digest: str, destination: str | Path) -> Path:
         """Atomically copy a verified object to a regular destination path."""
+
+        return self._run_strict_operation(
+            lambda: self._materialize_locked(digest, destination)
+        )
+
+    def _materialize_locked(
+        self,
+        digest: str,
+        destination: str | Path,
+    ) -> Path:
+        """Copy an object while the strict lifecycle lease is held."""
 
         digest = _validate_digest(digest)
         source = self._object_path(digest)
@@ -565,7 +666,7 @@ class LocalCAS:
             return
         if os.getpid() != self._owner_pid:
             raise StorageIntegrityError("strict CAS authority crossed a PID boundary")
-        if self._strict_resources is None:
+        if self._strict_resources is None or self._strict_resources.closed:
             raise StorageIntegrityError("strict CAS authority is closed")
         anchors = (
             (

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -6,11 +6,13 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import os
 import re
 import stat
 import tempfile
+import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,6 +41,18 @@ _SAFE_DIRECTORY_FDS = (
 _CAS_OBJECT_MODE = 0o600
 _SHARD_NAMES = tuple(f"{value:02x}" for value in range(256))
 _DIRECTORY_CLOSE_RECOVERY_LIMIT = 64
+_PORTABLE_LINK_UNSUPPORTED_ERRNOS = {
+    value
+    for value in (
+        getattr(errno, "ENOSYS", None),
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+        getattr(errno, "EPERM", None),
+        getattr(errno, "EXDEV", None),
+    )
+    if value is not None
+}
+_PORTABLE_PUBLISH_LOCKS = tuple(threading.Lock() for _ in range(64))
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,6 +75,9 @@ class LocalCAS:
     directory descriptor and never creates a directory during ``put``. The
     default lazy layout remains a cooperative compatibility mode because POSIX
     cannot bind ``mkdir`` and the following ``open`` into one authority step.
+    Platforms without owned publication retain the pre-existing portable lazy
+    backend with explicit lstat/fstat checks and weaker replacement-race
+    protection; strict mode remains fail-closed there.
     """
 
     def __init__(
@@ -71,11 +88,53 @@ class LocalCAS:
     ) -> None:
         if not isinstance(require_preprovisioned, bool):
             raise TypeError("require_preprovisioned must be a boolean")
-        # This capability check is deliberately before lstat/mkdir.  In
-        # particular, unsupported Windows publication must not create even the
-        # legacy cooperative layout before it fails.
-        _require_local_cas_support()
+        try:
+            _require_local_cas_support()
+        except RuntimeError:
+            if require_preprovisioned:
+                # Strict mode must reject unsupported hosts before even
+                # interpreting or inspecting the requested filesystem path.
+                raise
+            portable_lazy = True
+        else:
+            portable_lazy = False
         requested_root = Path(root).expanduser()
+        self._portable_lazy = portable_lazy
+        if portable_lazy:
+            try:
+                requested_metadata = requested_root.lstat()
+            except FileNotFoundError:
+                pass
+            else:
+                if not stat.S_ISDIR(requested_metadata.st_mode):
+                    raise StorageValidationError(
+                        f"path is not a real directory: {requested_root}"
+                    )
+            self.root = requested_root.resolve()
+            self._require_preprovisioned = False
+            _ensure_directory(self.root)
+            self._sha256_root = self.root / "sha256"
+            with _open_portable_directory_path(
+                self.root,
+                label="CAS root",
+            ) as root_descriptor:
+                with _open_or_create_portable_child_directory(
+                    root_descriptor,
+                    self.root,
+                    "sha256",
+                    label="CAS SHA-256 root",
+                ):
+                    pass
+            self._strict_root_identity = None
+            self._strict_sha256_identity = None
+            self._strict_shard_identities = {}
+            self._strict_resources = None
+            self._strict_root_descriptor = None
+            self._strict_sha256_descriptor = None
+            self._strict_shard_descriptors = {}
+            self._owner_pid = os.getpid()
+            return
+
         self.root = Path(os.path.abspath(os.fspath(requested_root)))
         self._require_preprovisioned = require_preprovisioned
         strict_root_identity: tuple[int, ...] | None = None
@@ -414,6 +473,31 @@ class LocalCAS:
         create: bool = False,
     ) -> Iterator[tuple[int | None, Path]]:
         digest = _validate_digest(digest)
+        if self._portable_lazy:
+            with _open_portable_directory_path(
+                self.root,
+                label="CAS root",
+            ) as root_descriptor:
+                with _open_portable_child_directory(
+                    root_descriptor,
+                    self.root,
+                    "sha256",
+                    label="CAS SHA-256 root",
+                ) as (sha256_descriptor, sha256_path):
+                    open_child = (
+                        _open_or_create_portable_child_directory
+                        if create
+                        else _open_portable_child_directory
+                    )
+                    with open_child(
+                        sha256_descriptor,
+                        sha256_path,
+                        digest[:2],
+                        label="CAS digest shard",
+                    ) as shard:
+                        yield shard
+            return
+
         self._require_strict_anchors(digest[:2])
         with _open_directory_path(self.root, label="CAS root") as root_descriptor:
             _require_directory_generation(
@@ -503,6 +587,9 @@ class LocalCAS:
         byte_size: int,
         chunks: Iterable[bytes] | bytes,
     ) -> BlobInfo:
+        if self._portable_lazy:
+            return self._publish_portable_object(digest, byte_size, chunks)
+
         expected = PublishedFileRecord(
             size=byte_size,
             sha256=digest,
@@ -549,6 +636,117 @@ class LocalCAS:
         # synchronously consumed, and terminally closed the post-directory-fsync
         # receipt.  No descriptor-owning resource crosses this return boundary.
         return self._blob_info(digest, byte_size)
+
+    def _publish_portable_object(
+        self,
+        digest: str,
+        byte_size: int,
+        chunks: Iterable[bytes] | bytes,
+    ) -> BlobInfo:
+        """Publish with the pre-owned-publication compatibility backend."""
+
+        info = self._blob_info(digest, byte_size)
+        with self._open_shard(digest, create=True) as (
+            shard_descriptor,
+            shard_path,
+        ):
+            if shard_descriptor is not None:
+                raise RuntimeError("portable CAS unexpectedly acquired a directory fd")
+            if self._verify_portable_existing(shard_path, info) is not None:
+                _fsync_directory_handle(None, shard_path)
+                return info
+
+            descriptor, temporary_name = _create_portable_temporary_file(
+                shard_path,
+                digest[2:],
+            )
+            try:
+                with os.fdopen(descriptor, "wb") as handle:
+                    if isinstance(chunks, bytes):
+                        handle.write(chunks)
+                    else:
+                        for block in chunks:
+                            handle.write(block)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                self._publish_portable_temporary(
+                    shard_path,
+                    temporary_name,
+                    info,
+                )
+                return info
+            finally:
+                _unlink_portable(shard_path, temporary_name)
+                _fsync_directory_handle(None, shard_path)
+
+    def _verify_portable_existing(
+        self,
+        shard_path: Path,
+        expected: BlobInfo,
+    ) -> BlobInfo | None:
+        path = shard_path / expected.digest[2:]
+        try:
+            with _open_regular_at(
+                None,
+                shard_path,
+                expected.digest[2:],
+                label="existing CAS object",
+            ) as handle:
+                signature = _object_signature(os.fstat(handle.fileno()))
+                observed = hashlib.sha256()
+                byte_size = 0
+                while block := handle.read(_COPY_BUFFER_SIZE):
+                    observed.update(block)
+                    byte_size += len(block)
+                if _object_signature(os.fstat(handle.fileno())) != signature:
+                    raise StorageIntegrityError(
+                        f"existing CAS object changed while read: {path}"
+                    )
+        except FileNotFoundError:
+            return None
+
+        if byte_size != expected.byte_size or observed.hexdigest() != expected.digest:
+            raise StorageIntegrityError(
+                f"existing CAS object failed integrity validation: {path}"
+            )
+        return expected
+
+    def _publish_portable_temporary(
+        self,
+        shard_path: Path,
+        temporary_name: str,
+        info: BlobInfo,
+    ) -> None:
+        destination_name = info.digest[2:]
+        if self._verify_portable_existing(shard_path, info) is not None:
+            return
+
+        try:
+            os.link(
+                shard_path / temporary_name,
+                shard_path / destination_name,
+            )
+            return
+        except FileExistsError:
+            if self._verify_portable_existing(shard_path, info) is None:
+                raise StorageIntegrityError(
+                    f"CAS object disappeared during publication: {info.digest}"
+                ) from None
+            return
+        except OSError as exc:
+            if exc.errno not in _PORTABLE_LINK_UNSUPPORTED_ERRNOS:
+                raise
+
+        lock = _PORTABLE_PUBLISH_LOCKS[
+            int(info.digest[:2], 16) % len(_PORTABLE_PUBLISH_LOCKS)
+        ]
+        with lock:
+            if self._verify_portable_existing(shard_path, info) is not None:
+                return
+            os.replace(
+                shard_path / temporary_name,
+                shard_path / destination_name,
+            )
 
     def _consume_object(
         self,
@@ -690,6 +888,66 @@ def _close_publication_authority_owner(
 
 
 @contextmanager
+def _open_portable_directory_path(
+    path: Path,
+    *,
+    label: str,
+) -> Iterator[int | None]:
+    """Open a directory through the legacy path-only compatibility checks."""
+
+    metadata = path.lstat()
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise StorageIntegrityError(f"{label} is not a real directory: {path}")
+    # Unsupported platforms cannot anchor later child operations to this exact
+    # generation.  Keep this intentionally separate from the POSIX authority
+    # helpers so a supported host never falls through to weaker semantics.
+    yield None
+
+
+@contextmanager
+def _open_portable_child_directory(
+    parent_descriptor: int | None,
+    parent_path: Path,
+    name: str,
+    *,
+    label: str,
+) -> Iterator[tuple[int | None, Path]]:
+    if parent_descriptor is not None:
+        raise RuntimeError("portable CAS unexpectedly acquired a directory fd")
+    path = parent_path / name
+    with _open_portable_directory_path(path, label=label) as descriptor:
+        yield descriptor, path
+
+
+@contextmanager
+def _open_or_create_portable_child_directory(
+    parent_descriptor: int | None,
+    parent_path: Path,
+    name: str,
+    *,
+    label: str,
+) -> Iterator[tuple[int | None, Path]]:
+    if parent_descriptor is not None:
+        raise RuntimeError("portable CAS unexpectedly acquired a directory fd")
+    created = False
+    path = parent_path / name
+    try:
+        path.mkdir()
+        created = True
+    except FileExistsError:
+        pass
+    if created:
+        _fsync_directory(parent_path)
+    with _open_portable_child_directory(
+        None,
+        parent_path,
+        name,
+        label=label,
+    ) as child:
+        yield child
+
+
+@contextmanager
 def _open_directory_path(path: Path, *, label: str) -> Iterator[int | None]:
     authority_owner = _atomic._PublicationAuthorityOwner()
     try:
@@ -823,6 +1081,25 @@ def _open_regular_at(
     except BaseException:
         os.close(descriptor)
         raise
+
+
+def _create_portable_temporary_file(
+    directory_path: Path,
+    object_name: str,
+) -> tuple[int, str]:
+    descriptor, temporary_path = tempfile.mkstemp(
+        dir=str(directory_path),
+        prefix=f".{object_name}.",
+        suffix=".tmp",
+    )
+    return descriptor, Path(temporary_path).name
+
+
+def _unlink_portable(directory_path: Path, name: str) -> None:
+    try:
+        (directory_path / name).unlink()
+    except FileNotFoundError:
+        pass
 
 
 def _validate_digest(digest: str) -> str:

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -81,6 +81,10 @@ class LocalCAS:
         strict_root_identity: tuple[int, ...] | None = None
         strict_sha256_identity: tuple[int, ...] | None = None
         strict_shard_identities: dict[str, tuple[int, ...]] = {}
+        strict_resources = _atomic._PosixResourceOwner()
+        strict_root_descriptor: int | None = None
+        strict_sha256_descriptor: int | None = None
+        strict_shard_descriptors: dict[str, int] = {}
         if not require_preprovisioned:
             try:
                 _ensure_cas_root(self.root)
@@ -95,8 +99,12 @@ class LocalCAS:
                 label="CAS root",
             ) as root_descriptor:
                 if require_preprovisioned:
-                    strict_root_identity = _directory_resource_identity(
+                    strict_root_descriptor = _retain_directory_descriptor(
+                        strict_resources,
                         root_descriptor,
+                    )
+                    strict_root_identity = _directory_resource_identity(
+                        strict_root_descriptor,
                         path=self.root,
                         label="CAS root",
                     )
@@ -112,8 +120,12 @@ class LocalCAS:
                     label="CAS SHA-256 root",
                 ) as (sha256_descriptor, sha256_path):
                     if require_preprovisioned:
-                        strict_sha256_identity = _directory_resource_identity(
+                        strict_sha256_descriptor = _retain_directory_descriptor(
+                            strict_resources,
                             sha256_descriptor,
+                        )
+                        strict_sha256_identity = _directory_resource_identity(
+                            strict_sha256_descriptor,
                             path=sha256_path,
                             label="CAS SHA-256 root",
                         )
@@ -124,14 +136,20 @@ class LocalCAS:
                                 shard_name,
                                 label="CAS digest shard",
                             ) as (shard_descriptor, shard_path):
+                                retained_shard = _retain_directory_descriptor(
+                                    strict_resources,
+                                    shard_descriptor,
+                                )
+                                strict_shard_descriptors[shard_name] = retained_shard
                                 strict_shard_identities[shard_name] = (
                                     _directory_resource_identity(
-                                        shard_descriptor,
+                                        retained_shard,
                                         path=shard_path,
                                         label="CAS digest shard",
                                     )
                                 )
         except FileNotFoundError as exc:
+            _close_posix_resources(strict_resources, primary_error=exc)
             if require_preprovisioned:
                 try:
                     self.root.lstat()
@@ -145,12 +163,52 @@ class LocalCAS:
                 ) from exc
             raise
         except ValueError as exc:
+            _close_posix_resources(strict_resources, primary_error=exc)
             raise StorageValidationError(
                 f"path is not a real directory: {self.root}"
             ) from exc
+        except BaseException as exc:
+            _close_posix_resources(strict_resources, primary_error=exc)
+            raise
+        if not require_preprovisioned:
+            _close_posix_resources(strict_resources)
         self._strict_root_identity = strict_root_identity
         self._strict_sha256_identity = strict_sha256_identity
         self._strict_shard_identities = strict_shard_identities
+        self._strict_resources = strict_resources if require_preprovisioned else None
+        self._strict_root_descriptor = strict_root_descriptor
+        self._strict_sha256_descriptor = strict_sha256_descriptor
+        self._strict_shard_descriptors = strict_shard_descriptors
+        self._owner_pid = os.getpid()
+
+    def close(self) -> None:
+        """Release strict generation anchors retained for this store."""
+
+        resources = self._strict_resources
+        if resources is None:
+            return
+        _close_posix_resources(resources)
+        self._strict_resources = None
+        self._strict_root_descriptor = None
+        self._strict_sha256_descriptor = None
+        self._strict_shard_descriptors.clear()
+
+    def __enter__(self) -> LocalCAS:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        _exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
     @classmethod
     def provision(cls, root: str | Path) -> LocalCAS:
@@ -350,6 +408,7 @@ class LocalCAS:
         create: bool = False,
     ) -> Iterator[tuple[int | None, Path]]:
         digest = _validate_digest(digest)
+        self._require_strict_anchors(digest[:2])
         with _open_directory_path(self.root, label="CAS root") as root_descriptor:
             _require_directory_generation(
                 root_descriptor,
@@ -385,6 +444,43 @@ class LocalCAS:
                         label="CAS digest shard",
                     )
                     yield shard_descriptor, shard_path
+
+    def _require_strict_anchors(self, shard_name: str) -> None:
+        if not self._require_preprovisioned:
+            return
+        if os.getpid() != self._owner_pid:
+            raise StorageIntegrityError("strict CAS authority crossed a PID boundary")
+        if self._strict_resources is None:
+            raise StorageIntegrityError("strict CAS authority is closed")
+        anchors = (
+            (
+                self._strict_root_descriptor,
+                self._strict_root_identity,
+                self.root,
+                "CAS root",
+            ),
+            (
+                self._strict_sha256_descriptor,
+                self._strict_sha256_identity,
+                self._sha256_root,
+                "CAS SHA-256 root",
+            ),
+            (
+                self._strict_shard_descriptors.get(shard_name),
+                self._strict_shard_identities.get(shard_name),
+                self._sha256_root / shard_name,
+                "CAS digest shard",
+            ),
+        )
+        for descriptor, expected, path, label in anchors:
+            if descriptor is None or expected is None:
+                raise StorageIntegrityError(f"{label} generation anchor is absent")
+            _require_directory_generation(
+                descriptor,
+                expected,
+                path=path,
+                label=label,
+            )
 
     @staticmethod
     def _blob_info(digest: str, byte_size: int) -> BlobInfo:
@@ -485,6 +581,19 @@ def _directory_resource_identity(
         raise StorageIntegrityError(
             f"{label} authority could not be identified: {path}"
         ) from exc
+
+
+def _retain_directory_descriptor(
+    resources: _atomic._PosixResourceOwner,
+    descriptor: int | None,
+) -> int:
+    if descriptor is None:
+        raise RuntimeError("strict CAS has no directory descriptor to retain")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+    retained = resources.open(".", flags, dir_fd=descriptor)
+    os.set_inheritable(retained, False)
+    return retained
 
 
 def _require_directory_generation(

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -148,6 +148,22 @@ class LocalCAS:
                                         label="CAS digest shard",
                                     )
                                 )
+            if not require_preprovisioned:
+                _close_posix_resources(strict_resources)
+            # Keep the complete local owner inside this exception boundary
+            # until every retained descriptor is reachable from ``self``.
+            # Otherwise cancellation after the last shard is retained but before
+            # the first attribute store can strand all 258 strict anchors.
+            self._strict_root_identity = strict_root_identity
+            self._strict_sha256_identity = strict_sha256_identity
+            self._strict_shard_identities = strict_shard_identities
+            self._strict_resources = (
+                strict_resources if require_preprovisioned else None
+            )
+            self._strict_root_descriptor = strict_root_descriptor
+            self._strict_sha256_descriptor = strict_sha256_descriptor
+            self._strict_shard_descriptors = strict_shard_descriptors
+            self._owner_pid = os.getpid()
         except FileNotFoundError as exc:
             _close_posix_resources(strict_resources, primary_error=exc)
             if require_preprovisioned:
@@ -170,16 +186,6 @@ class LocalCAS:
         except BaseException as exc:
             _close_posix_resources(strict_resources, primary_error=exc)
             raise
-        if not require_preprovisioned:
-            _close_posix_resources(strict_resources)
-        self._strict_root_identity = strict_root_identity
-        self._strict_sha256_identity = strict_sha256_identity
-        self._strict_shard_identities = strict_shard_identities
-        self._strict_resources = strict_resources if require_preprovisioned else None
-        self._strict_root_descriptor = strict_root_descriptor
-        self._strict_sha256_descriptor = strict_sha256_descriptor
-        self._strict_shard_descriptors = strict_shard_descriptors
-        self._owner_pid = os.getpid()
 
     def close(self) -> None:
         """Release strict generation anchors retained for this store."""

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -6,19 +6,24 @@
 
 from __future__ import annotations
 
-import errno
 import hashlib
 import os
 import re
-import secrets
 import stat
 import tempfile
-import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO, Iterator
+from typing import BinaryIO, Iterable, Iterator
 
+from .. import _atomic_directory as _atomic
+from .._owned_file_publication import (
+    OwnedFileConflictError,
+    PublishedFileReceipt,
+    PublishedFileRecord,
+    publish_owned_file,
+    require_owned_file_publication_support,
+)
 from .models import StorageIntegrityError, StorageValidationError
 
 _DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
@@ -30,20 +35,10 @@ _SAFE_DIRECTORY_FDS = (
     and os.stat in os.supports_dir_fd
     and os.stat in os.supports_follow_symlinks
     and os.mkdir in os.supports_dir_fd
-    and os.unlink in os.supports_dir_fd
 )
-_LINK_UNSUPPORTED_ERRNOS = {
-    value
-    for value in (
-        getattr(errno, "ENOSYS", None),
-        getattr(errno, "ENOTSUP", None),
-        getattr(errno, "EOPNOTSUPP", None),
-        getattr(errno, "EPERM", None),
-        getattr(errno, "EXDEV", None),
-    )
-    if value is not None
-}
-_PUBLISH_LOCKS = tuple(threading.Lock() for _ in range(64))
+_CAS_OBJECT_MODE = 0o600
+_SHARD_NAMES = tuple(f"{value:02x}" for value in range(256))
+_DIRECTORY_CLOSE_RECOVERY_LIMIT = 64
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,34 +56,162 @@ class LocalCAS:
     Objects are stored below ``sha256/<first two hex digits>/<remaining hex>``.
     A digest is always the bare, lowercase, 64-character hexadecimal value.
 
-    On platforms with ``dir_fd``, ``O_DIRECTORY``, and ``O_NOFOLLOW`` support,
-    every internal path component is opened relative to its verified parent.
-    Other platforms retain explicit lstat/fstat checks, but cannot eliminate a
-    concurrent directory-replacement race as completely as the anchored path.
+    ``provision()`` plus ``require_preprovisioned=True`` is the strict
+    publication mode. It opens every internal component relative to a held
+    directory descriptor and never creates a directory during ``put``. The
+    default lazy layout remains a cooperative compatibility mode because POSIX
+    cannot bind ``mkdir`` and the following ``open`` into one authority step.
     """
 
-    def __init__(self, root: str | Path) -> None:
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        require_preprovisioned: bool = False,
+    ) -> None:
+        if not isinstance(require_preprovisioned, bool):
+            raise TypeError("require_preprovisioned must be a boolean")
+        # This capability check is deliberately before lstat/mkdir.  In
+        # particular, unsupported Windows publication must not create even the
+        # legacy cooperative layout before it fails.
+        _require_local_cas_support()
         requested_root = Path(root).expanduser()
-        try:
-            requested_metadata = requested_root.lstat()
-        except FileNotFoundError:
-            pass
-        else:
-            if not stat.S_ISDIR(requested_metadata.st_mode):
+        self.root = Path(os.path.abspath(os.fspath(requested_root)))
+        self._require_preprovisioned = require_preprovisioned
+        strict_root_identity: tuple[int, ...] | None = None
+        strict_sha256_identity: tuple[int, ...] | None = None
+        strict_shard_identities: dict[str, tuple[int, ...]] = {}
+        if not require_preprovisioned:
+            try:
+                _ensure_cas_root(self.root)
+            except ValueError as exc:
                 raise StorageValidationError(
-                    f"path is not a real directory: {requested_root}"
-                )
-        self.root = requested_root.resolve()
-        _ensure_directory(self.root)
+                    f"path is not a real directory: {self.root}"
+                ) from exc
         self._sha256_root = self.root / "sha256"
-        with _open_directory_path(self.root, label="CAS root") as root_descriptor:
-            with _open_or_create_child_directory(
-                root_descriptor,
+        try:
+            with _open_directory_path(
                 self.root,
-                "sha256",
-                label="CAS SHA-256 root",
-            ):
-                pass
+                label="CAS root",
+            ) as root_descriptor:
+                if require_preprovisioned:
+                    strict_root_identity = _directory_resource_identity(
+                        root_descriptor,
+                        path=self.root,
+                        label="CAS root",
+                    )
+                open_sha256 = (
+                    _open_child_directory
+                    if require_preprovisioned
+                    else _open_or_create_child_directory
+                )
+                with open_sha256(
+                    root_descriptor,
+                    self.root,
+                    "sha256",
+                    label="CAS SHA-256 root",
+                ) as (sha256_descriptor, sha256_path):
+                    if require_preprovisioned:
+                        strict_sha256_identity = _directory_resource_identity(
+                            sha256_descriptor,
+                            path=sha256_path,
+                            label="CAS SHA-256 root",
+                        )
+                        for shard_name in _SHARD_NAMES:
+                            with _open_child_directory(
+                                sha256_descriptor,
+                                sha256_path,
+                                shard_name,
+                                label="CAS digest shard",
+                            ) as (shard_descriptor, shard_path):
+                                strict_shard_identities[shard_name] = (
+                                    _directory_resource_identity(
+                                        shard_descriptor,
+                                        path=shard_path,
+                                        label="CAS digest shard",
+                                    )
+                                )
+        except FileNotFoundError as exc:
+            if require_preprovisioned:
+                try:
+                    self.root.lstat()
+                except FileNotFoundError:
+                    raise StorageValidationError(
+                        f"preprovisioned CAS root does not exist: {self.root}"
+                    ) from exc
+                raise StorageValidationError(
+                    "preprovisioned CAS layout must contain sha256 and all 256 "
+                    "digest shards"
+                ) from exc
+            raise
+        except ValueError as exc:
+            raise StorageValidationError(
+                f"path is not a real directory: {self.root}"
+            ) from exc
+        self._strict_root_identity = strict_root_identity
+        self._strict_sha256_identity = strict_sha256_identity
+        self._strict_shard_identities = strict_shard_identities
+
+    @classmethod
+    def provision(cls, root: str | Path) -> LocalCAS:
+        """Create the complete layout inside a trusted, quiescent boundary.
+
+        POSIX ``mkdir`` followed by ``open`` cannot prove that a same-UID actor
+        did not replace the new directory in between.  Provisioning therefore
+        creates every shard before strict publication begins; it is not a safe
+        online operation in the adversarial replacement model.
+        """
+
+        _require_local_cas_support()
+        requested_root = Path(root).expanduser()
+        lexical_root = Path(os.path.abspath(os.fspath(requested_root)))
+        root_parent = lexical_root.parent
+        if root_parent == lexical_root or not lexical_root.name:
+            raise StorageValidationError("CAS root must have a lexical parent")
+        try:
+            with _open_directory_path(
+                root_parent,
+                label="CAS root parent",
+            ) as root_parent_descriptor:
+                # Only the final root leaf may be created.  Requiring its
+                # lexical parent to pre-exist makes the unconditional replay
+                # below a complete durability chain, including after an
+                # ambiguous parent-fsync failure on an earlier attempt.
+                with _open_or_create_child_directory(
+                    root_parent_descriptor,
+                    root_parent,
+                    lexical_root.name,
+                    label="CAS root",
+                ) as (root_descriptor, rebound_root):
+                    with _open_or_create_child_directory(
+                        root_descriptor,
+                        rebound_root,
+                        "sha256",
+                        label="CAS SHA-256 root",
+                    ) as (sha256_descriptor, sha256_path):
+                        for shard_name in _SHARD_NAMES:
+                            with _open_or_create_child_directory(
+                                sha256_descriptor,
+                                sha256_path,
+                                shard_name,
+                                label="CAS digest shard",
+                            ):
+                                pass
+                        # Replay the complete durability chain unconditionally.
+                        # A previous mkdir may have committed before its parent
+                        # fsync raised, so an existing entry is not a receipt.
+                        os.fsync(sha256_descriptor)
+                    os.fsync(root_descriptor)
+                os.fsync(root_parent_descriptor)
+        except FileNotFoundError as exc:
+            raise StorageValidationError(
+                f"CAS root parent must already exist: {root_parent}"
+            ) from exc
+        except ValueError as exc:
+            raise StorageValidationError(
+                f"CAS root parent must be a real directory: {root_parent}"
+            ) from exc
+        return cls(lexical_root, require_preprovisioned=True)
 
     def put_bytes(self, data: bytes) -> BlobInfo:
         """Store *data*, deduplicating an already-valid immutable object."""
@@ -96,86 +219,26 @@ class LocalCAS:
         if not isinstance(data, bytes):
             raise TypeError("CAS payload must be bytes")
         digest = hashlib.sha256(data).hexdigest()
-        info = self._blob_info(digest, len(data))
-        with self._open_shard(digest, create=True) as (
-            shard_descriptor,
-            shard_path,
-        ):
-            if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
-                # A concurrent publisher may have linked this entry but not
-                # yet flushed the shard.  A successful deduplicated put is a
-                # durability receipt too, so it must not return before the
-                # canonical directory entry is persistent.
-                _fsync_directory_handle(shard_descriptor, shard_path)
-                return info
-
-            descriptor, temporary_name = _create_temporary_file(
-                shard_descriptor,
-                shard_path,
-                digest[2:],
-            )
-            try:
-                with os.fdopen(descriptor, "wb") as handle:
-                    handle.write(data)
-                    handle.flush()
-                    os.fsync(handle.fileno())
-                self._publish_temporary_at(
-                    shard_descriptor,
-                    shard_path,
-                    temporary_name,
-                    info,
-                )
-                return info
-            finally:
-                _unlink_at(shard_descriptor, shard_path, temporary_name)
-                _fsync_directory_handle(shard_descriptor, shard_path)
+        return self._publish_object(digest, len(data), data)
 
     def put_file(self, source: str | Path) -> BlobInfo:
         """Store a stable snapshot of a regular file.
 
         The source is read twice.  The first pass establishes its digest and
-        destination; the second writes the destination-directory temporary.
+        destination; the second feeds an owned destination-directory stage.
         Identity and metadata checks around both passes reject a source that is
         replaced or modified while it is being stored.
         """
 
         source_path = Path(source)
         digest, byte_size, source_signature = _hash_stable_file(source_path)
-        info = self._blob_info(digest, byte_size)
-        with self._open_shard(digest, create=True) as (
-            shard_descriptor,
-            shard_path,
-        ):
-            if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
-                _fsync_directory_handle(shard_descriptor, shard_path)
-                return info
-
-            descriptor, temporary_name = _create_temporary_file(
-                shard_descriptor,
-                shard_path,
-                digest[2:],
-            )
-            try:
-                with os.fdopen(descriptor, "wb") as target:
-                    copied_digest, copied_size = _copy_stable_file(
-                        source_path,
-                        target,
-                        expected_signature=source_signature,
-                    )
-                    target.flush()
-                    os.fsync(target.fileno())
-                if copied_digest != digest or copied_size != byte_size:
-                    raise OSError(f"source changed while being stored: {source_path}")
-                self._publish_temporary_at(
-                    shard_descriptor,
-                    shard_path,
-                    temporary_name,
-                    info,
-                )
-                return info
-            finally:
-                _unlink_at(shard_descriptor, shard_path, temporary_name)
-                _fsync_directory_handle(shard_descriptor, shard_path)
+        chunks = _stable_file_chunks(
+            source_path,
+            expected_signature=source_signature,
+            expected_digest=digest,
+            expected_size=byte_size,
+        )
+        return self._publish_object(digest, byte_size, chunks)
 
     def has(self, digest: str) -> bool:
         """Return whether a regular object exists for *digest*.
@@ -288,12 +351,24 @@ class LocalCAS:
     ) -> Iterator[tuple[int | None, Path]]:
         digest = _validate_digest(digest)
         with _open_directory_path(self.root, label="CAS root") as root_descriptor:
+            _require_directory_generation(
+                root_descriptor,
+                self._strict_root_identity,
+                path=self.root,
+                label="CAS root",
+            )
             with _open_child_directory(
                 root_descriptor,
                 self.root,
                 "sha256",
                 label="CAS SHA-256 root",
             ) as (sha256_descriptor, sha256_path):
+                _require_directory_generation(
+                    sha256_descriptor,
+                    self._strict_sha256_identity,
+                    path=sha256_path,
+                    label="CAS SHA-256 root",
+                )
                 open_child = (
                     _open_or_create_child_directory if create else _open_child_directory
                 )
@@ -302,8 +377,14 @@ class LocalCAS:
                     sha256_path,
                     digest[:2],
                     label="CAS digest shard",
-                ) as shard:
-                    yield shard
+                ) as (shard_descriptor, shard_path):
+                    _require_directory_generation(
+                        shard_descriptor,
+                        self._strict_shard_identities.get(digest[:2]),
+                        path=shard_path,
+                        label="CAS digest shard",
+                    )
+                    yield shard_descriptor, shard_path
 
     @staticmethod
     def _blob_info(digest: str, byte_size: int) -> BlobInfo:
@@ -314,85 +395,58 @@ class LocalCAS:
             storage_key=f"sha256/{digest[:2]}/{digest[2:]}",
         )
 
-    def _verify_existing_at(
+    def _publish_object(
         self,
-        shard_descriptor: int | None,
-        shard_path: Path,
-        expected: BlobInfo,
-    ) -> BlobInfo | None:
-        path = shard_path / expected.digest[2:]
-        try:
-            with _open_regular_at(
-                shard_descriptor,
-                shard_path,
-                expected.digest[2:],
-                label="existing CAS object",
-            ) as handle:
-                signature = _object_signature(os.fstat(handle.fileno()))
-                observed = hashlib.sha256()
-                byte_size = 0
-                while block := handle.read(_COPY_BUFFER_SIZE):
-                    observed.update(block)
-                    byte_size += len(block)
-                if _object_signature(os.fstat(handle.fileno())) != signature:
+        digest: str,
+        byte_size: int,
+        chunks: Iterable[bytes] | bytes,
+    ) -> BlobInfo:
+        expected = PublishedFileRecord(
+            size=byte_size,
+            sha256=digest,
+            mode=_CAS_OBJECT_MODE,
+        )
+        with self._open_shard(
+            digest,
+            create=not self._require_preprovisioned,
+        ) as (shard_descriptor, shard_path):
+            if shard_descriptor is None:
+                raise RuntimeError(
+                    "strict CAS publication requires an anchored shard descriptor"
+                )
+            destination = shard_path / digest[2:]
+            expected_parent_identity = _atomic.publication_parent_identity(
+                shard_descriptor
+            )
+
+            def consume(receipt: PublishedFileReceipt) -> None:
+                if (
+                    receipt.path != destination
+                    or receipt.record != expected
+                    or receipt.parent_identity != expected_parent_identity
+                ):
                     raise StorageIntegrityError(
-                        f"existing CAS object changed while read: {path}"
+                        f"CAS publication receipt conflicts for {digest}"
                     )
-        except FileNotFoundError:
-            return None
 
-        if byte_size != expected.byte_size or observed.hexdigest() != expected.digest:
-            raise StorageIntegrityError(
-                f"existing CAS object failed integrity validation: {path}"
-            )
-        return expected
-
-    def _publish_temporary_at(
-        self,
-        shard_descriptor: int | None,
-        shard_path: Path,
-        temporary_name: str,
-        info: BlobInfo,
-    ) -> None:
-        destination_name = info.digest[2:]
-        # Another writer may have completed while this writer populated its
-        # temporary.  A valid winner is reused; an invalid one is never healed
-        # silently because that could hide corruption of a published object.
-        if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
-            return
-
-        try:
-            _link_at(
-                shard_descriptor,
-                shard_path,
-                temporary_name,
-                destination_name,
-            )
-            return
-        except FileExistsError:
-            # A concurrent publisher won the no-replace link operation.
-            if self._verify_existing_at(shard_descriptor, shard_path, info) is None:
+            try:
+                publish_owned_file(
+                    destination,
+                    chunks,
+                    max_bytes=byte_size,
+                    mode=_CAS_OBJECT_MODE,
+                    parent_resource=shard_descriptor,
+                    consume=consume,
+                )
+            except OwnedFileConflictError as exc:
                 raise StorageIntegrityError(
-                    f"CAS object disappeared during publication: {info.digest}"
-                ) from None
-            return
-        except OSError as exc:
-            if exc.errno not in _LINK_UNSUPPORTED_ERRNOS:
-                raise
+                    f"existing CAS object failed integrity validation: {destination}"
+                ) from exc
 
-        # Hard links may be unavailable on some filesystems.  Serialize local
-        # writers before the atomic-replace fallback; cross-process writers can
-        # still race here, but they can only publish identical verified bytes.
-        lock = _PUBLISH_LOCKS[int(info.digest[:2], 16) % len(_PUBLISH_LOCKS)]
-        with lock:
-            if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
-                return
-            _replace_at(
-                shard_descriptor,
-                shard_path,
-                temporary_name,
-                destination_name,
-            )
+        # BlobInfo is deliberately created only after the helper has installed,
+        # synchronously consumed, and terminally closed the post-directory-fsync
+        # receipt.  No descriptor-owning resource crosses this return boundary.
+        return self._blob_info(digest, byte_size)
 
     def _consume_object(
         self,
@@ -417,32 +471,134 @@ class LocalCAS:
         return observed.hexdigest(), byte_size
 
 
+def _directory_resource_identity(
+    descriptor: int | None,
+    *,
+    path: Path,
+    label: str,
+) -> tuple[int, ...]:
+    if descriptor is None:
+        raise RuntimeError(f"{label} has no anchored directory descriptor: {path}")
+    try:
+        return _atomic.publication_parent_identity(descriptor)
+    except OSError as exc:
+        raise StorageIntegrityError(
+            f"{label} authority could not be identified: {path}"
+        ) from exc
+
+
+def _require_directory_generation(
+    descriptor: int | None,
+    expected: tuple[int, ...] | None,
+    *,
+    path: Path,
+    label: str,
+) -> None:
+    if expected is None:
+        return
+    if _directory_resource_identity(descriptor, path=path, label=label) != expected:
+        raise StorageIntegrityError(f"{label} generation changed: {path}")
+
+
+def _close_posix_resources(
+    resources: _atomic._PosixResourceOwner,
+    *,
+    primary_error: BaseException | None = None,
+) -> None:
+    """Close every directory fd, retrying while retaining the first error."""
+
+    first_error = primary_error
+    for _attempt in range(_DIRECTORY_CLOSE_RECOVERY_LIMIT):
+        if resources.closed:
+            break
+        try:
+            resources.close_all()
+        except BaseException as close_error:  # noqa: B036 - converge ownership
+            if first_error is None:
+                first_error = close_error
+            else:
+                _atomic._annotate_secondary_error(
+                    first_error,
+                    "directory descriptor cleanup also failed",
+                    close_error,
+                )
+    if not resources.closed:
+        convergence_error = RuntimeError(
+            "directory descriptor cleanup did not converge"
+        )
+        if first_error is None:
+            first_error = convergence_error
+        else:
+            _atomic._annotate_secondary_error(
+                first_error,
+                "directory descriptor cleanup did not converge",
+                convergence_error,
+            )
+    if primary_error is None and first_error is not None:
+        raise first_error
+
+
+def _close_publication_authority_owner(
+    authority_owner: _atomic._PublicationAuthorityOwner,
+    *,
+    primary_error: BaseException | None = None,
+) -> None:
+    """Retry atomic authority cleanup without directory-offset cookies."""
+
+    first_error = primary_error
+    for _attempt in range(_DIRECTORY_CLOSE_RECOVERY_LIMIT):
+        if authority_owner.authority is None:
+            break
+        try:
+            authority_owner.close()
+        except BaseException as close_error:  # noqa: B036 - converge ownership
+            if first_error is None:
+                first_error = close_error
+            else:
+                _atomic._annotate_secondary_error(
+                    first_error,
+                    "directory authority cleanup also failed",
+                    close_error,
+                )
+    if authority_owner.authority is not None:
+        convergence_error = RuntimeError("directory authority cleanup did not converge")
+        if first_error is None:
+            first_error = convergence_error
+        else:
+            _atomic._annotate_secondary_error(
+                first_error,
+                "directory authority cleanup did not converge",
+                convergence_error,
+            )
+    if primary_error is None and first_error is not None:
+        raise first_error
+
+
 @contextmanager
 def _open_directory_path(path: Path, *, label: str) -> Iterator[int | None]:
-    metadata = path.lstat()
-    if not stat.S_ISDIR(metadata.st_mode):
-        raise StorageIntegrityError(f"{label} is not a real directory: {path}")
-
-    if not _SAFE_DIRECTORY_FDS:
-        # The visible component is still rejected when it is a link.  Without
-        # anchored directory descriptors, however, another process can replace
-        # it between this check and a later child operation.
-        yield None
-        return
-
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
-    descriptor = os.open(path, flags)
+    authority_owner = _atomic._PublicationAuthorityOwner()
     try:
-        opened = os.fstat(descriptor)
-        if not stat.S_ISDIR(opened.st_mode):
-            raise StorageIntegrityError(f"{label} is not a directory: {path}")
-        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
-            raise StorageIntegrityError(f"{label} changed while opening: {path}")
-        yield descriptor
-    finally:
-        os.close(descriptor)
+        _atomic._open_publication_authority(
+            path,
+            parent_resource=None,
+            expected_parent_identity=None,
+            create_missing=False,
+            authority_owner=authority_owner,
+        )
+        authority = authority_owner.authority
+        if authority is None:
+            raise RuntimeError(f"{label} authority was not installed: {path}")
+        authority.verify_path_binding()
+        yield authority.resource
+        authority.verify_path_binding()
+    except BaseException as primary_error:
+        _close_publication_authority_owner(
+            authority_owner,
+            primary_error=primary_error,
+        )
+        raise
+    else:
+        _close_publication_authority_owner(authority_owner)
 
 
 @contextmanager
@@ -459,23 +615,29 @@ def _open_child_directory(
             yield descriptor, path
         return
 
-    metadata = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
-    if not stat.S_ISDIR(metadata.st_mode):
-        raise StorageIntegrityError(f"{label} is not a real directory: {path}")
-
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
-    descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+    resources = _atomic._PosixResourceOwner()
     try:
+        metadata = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise StorageIntegrityError(f"{label} is not a real directory: {path}")
+
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+        descriptor = resources.open(name, flags, dir_fd=parent_descriptor)
         opened = os.fstat(descriptor)
         if not stat.S_ISDIR(opened.st_mode):
             raise StorageIntegrityError(f"{label} is not a directory: {path}")
         if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
             raise StorageIntegrityError(f"{label} changed while opening: {path}")
         yield descriptor, path
-    finally:
-        os.close(descriptor)
+        rebound = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        if (rebound.st_dev, rebound.st_ino) != (opened.st_dev, opened.st_ino):
+            raise StorageIntegrityError(f"{label} binding changed: {path}")
+    except BaseException as primary_error:
+        _close_posix_resources(resources, primary_error=primary_error)
+        raise
+    else:
+        _close_posix_resources(resources)
 
 
 @contextmanager
@@ -548,94 +710,46 @@ def _open_regular_at(
         raise
 
 
-def _create_temporary_file(
-    directory_descriptor: int | None,
-    directory_path: Path,
-    object_name: str,
-) -> tuple[int, str]:
-    if directory_descriptor is None:
-        descriptor, temporary_path = tempfile.mkstemp(
-            dir=str(directory_path),
-            prefix=f".{object_name}.",
-            suffix=".tmp",
-        )
-        return descriptor, Path(temporary_path).name
-
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
-    if hasattr(os, "O_BINARY"):
-        flags |= os.O_BINARY
-    if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
-    for _attempt in range(100):
-        name = f".{object_name}.{secrets.token_hex(8)}.tmp"
-        try:
-            descriptor = os.open(
-                name,
-                flags,
-                0o600,
-                dir_fd=directory_descriptor,
-            )
-        except FileExistsError:
-            continue
-        return descriptor, name
-    raise FileExistsError(f"could not allocate CAS temporary in {directory_path}")
-
-
-def _link_at(
-    directory_descriptor: int | None,
-    directory_path: Path,
-    source_name: str,
-    destination_name: str,
-) -> None:
-    if directory_descriptor is not None and os.link in os.supports_dir_fd:
-        os.link(
-            source_name,
-            destination_name,
-            src_dir_fd=directory_descriptor,
-            dst_dir_fd=directory_descriptor,
-            follow_symlinks=False,
-        )
-        return
-    os.link(directory_path / source_name, directory_path / destination_name)
-
-
-def _replace_at(
-    directory_descriptor: int | None,
-    directory_path: Path,
-    source_name: str,
-    destination_name: str,
-) -> None:
-    if directory_descriptor is not None:
-        os.replace(
-            source_name,
-            destination_name,
-            src_dir_fd=directory_descriptor,
-            dst_dir_fd=directory_descriptor,
-        )
-        return
-    os.replace(directory_path / source_name, directory_path / destination_name)
-
-
-def _unlink_at(
-    directory_descriptor: int | None,
-    directory_path: Path,
-    name: str,
-) -> None:
-    try:
-        if directory_descriptor is None:
-            (directory_path / name).unlink()
-        else:
-            os.unlink(name, dir_fd=directory_descriptor)
-    except FileNotFoundError:
-        pass
-
-
 def _validate_digest(digest: str) -> str:
     if not isinstance(digest, str) or _DIGEST_RE.fullmatch(digest) is None:
         raise StorageValidationError(
             "digest must be 64 lowercase hexadecimal characters"
         )
     return digest
+
+
+def _require_local_cas_support() -> None:
+    """Fail before layout mutation unless anchored shard fds are available."""
+
+    require_owned_file_publication_support()
+    if not _SAFE_DIRECTORY_FDS:
+        raise RuntimeError("LocalCAS requires POSIX directory-fd support")
+
+
+def _ensure_cas_root(path: Path) -> None:
+    """Create a cooperative root through one lexical no-follow authority."""
+
+    authority_owner = _atomic._PublicationAuthorityOwner()
+    try:
+        _atomic._open_publication_authority(
+            path,
+            parent_resource=None,
+            expected_parent_identity=None,
+            create_missing=True,
+            authority_owner=authority_owner,
+        )
+        authority = authority_owner.authority
+        if authority is None:
+            raise RuntimeError("CAS root authority was not installed")
+        authority.verify_path_binding()
+    except BaseException as primary_error:
+        _close_publication_authority_owner(
+            authority_owner,
+            primary_error=primary_error,
+        )
+        raise
+    else:
+        _close_publication_authority_owner(authority_owner)
 
 
 def _ensure_directory(path: Path) -> None:
@@ -709,12 +823,15 @@ def _hash_stable_file(path: Path) -> tuple[str, int, tuple[int, ...]]:
     return observed.hexdigest(), byte_size, signature
 
 
-def _copy_stable_file(
+def _stable_file_chunks(
     path: Path,
-    target: BinaryIO,
     *,
     expected_signature: tuple[int, ...],
-) -> tuple[str, int]:
+    expected_digest: str,
+    expected_size: int,
+) -> Iterator[bytes]:
+    """Yield pass-two bytes and reject drift before normal iterator completion."""
+
     observed = hashlib.sha256()
     byte_size = 0
     with _open_regular_file(path, label="CAS source") as source:
@@ -724,11 +841,14 @@ def _copy_stable_file(
         while block := source.read(_COPY_BUFFER_SIZE):
             observed.update(block)
             byte_size += len(block)
-            target.write(block)
+            yield block
         if _file_signature(os.fstat(source.fileno())) != signature:
             raise OSError(f"source changed while being stored: {path}")
     _require_path_signature(path, signature, label="CAS source")
-    return observed.hexdigest(), byte_size
+    if observed.hexdigest() != expected_digest or byte_size != expected_size:
+        # This check runs before StopIteration reaches OwnedFile.write(), so a
+        # pass-two mismatch can leave only an owned stage and is never renamed.
+        raise OSError(f"source changed while being stored: {path}")
 
 
 def _file_signature(metadata: os.stat_result) -> tuple[int, ...]:

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -54,6 +54,11 @@ _PORTABLE_LINK_UNSUPPORTED_ERRNOS = {
     if value is not None
 }
 _PORTABLE_PUBLISH_LOCKS = tuple(threading.Lock() for _ in range(64))
+_STRICT_STATE_INACTIVE = "inactive"
+_STRICT_STATE_INITIALIZING = "initializing"
+_STRICT_STATE_ACTIVE = "active"
+_STRICT_STATE_CLOSING = "closing"
+_STRICT_STATE_CLOSED = "closed"
 _CASResult = TypeVar("_CASResult")
 
 
@@ -88,6 +93,9 @@ def _install_strict_state(
     store._strict_sha256_descriptor = strict_sha256_descriptor
     store._strict_shard_descriptors = strict_shard_descriptors
     store._owner_pid = os.getpid()
+    store._strict_lifecycle_state = (
+        _STRICT_STATE_ACTIVE if require_preprovisioned else _STRICT_STATE_INACTIVE
+    )
 
 
 class LocalCAS:
@@ -115,6 +123,7 @@ class LocalCAS:
         self._lifecycle_lock = _CancellationSafeRLock()
         self._owner_pid = os.getpid()
         self._process_locks = {self._owner_pid: self._lifecycle_lock}
+        self._strict_lifecycle_state = _STRICT_STATE_INACTIVE
         if not isinstance(require_preprovisioned, bool):
             raise TypeError("require_preprovisioned must be a boolean")
         try:
@@ -166,6 +175,8 @@ class LocalCAS:
 
         self.root = Path(os.path.abspath(os.fspath(requested_root)))
         self._require_preprovisioned = require_preprovisioned
+        if require_preprovisioned:
+            self._strict_lifecycle_state = _STRICT_STATE_INITIALIZING
         strict_root_identity: tuple[int, ...] | None = None
         strict_sha256_identity: tuple[int, ...] | None = None
         strict_shard_identities: dict[str, tuple[int, ...]] = {}
@@ -306,8 +317,20 @@ class LocalCAS:
         return self._lifecycle_lock.run(callback)
 
     def _close_strict_resources_locked(self) -> None:
-        resources = self._strict_resources
+        state = self._strict_lifecycle_state
+        if state in {_STRICT_STATE_INACTIVE, _STRICT_STATE_CLOSED}:
+            return
+        if state in {_STRICT_STATE_ACTIVE, _STRICT_STATE_INITIALIZING}:
+            # Store the terminal intent before touching the first descriptor.
+            # A failed or interrupted close can then be retried, while no later
+            # operation can enter against a partially released anchor set.
+            self._strict_lifecycle_state = _STRICT_STATE_CLOSING
+        elif state != _STRICT_STATE_CLOSING:
+            raise RuntimeError(f"strict CAS lifecycle state is invalid: {state}")
+
+        resources = getattr(self, "_strict_resources", None)
         if resources is None:
+            self._strict_lifecycle_state = _STRICT_STATE_CLOSED
             return
         primary_error: BaseException | None = None
         try:
@@ -327,12 +350,14 @@ class LocalCAS:
                 )
             closed = False
         if closed:
-            # Clear the owner first.  If cancellation interrupts a later store,
-            # every operation still observes the lifecycle as terminal.
+            # State remains ``closing`` while these stores run, so an
+            # interruption cannot make a later operation observe an active
+            # authority after any descriptor has been released.
             self._strict_resources = None
             self._strict_root_descriptor = None
             self._strict_sha256_descriptor = None
             self._strict_shard_descriptors = {}
+            self._strict_lifecycle_state = _STRICT_STATE_CLOSED
         if primary_error is not None:
             raise primary_error.with_traceback(primary_error.__traceback__)
 
@@ -348,8 +373,10 @@ class LocalCAS:
             raise StorageIntegrityError("strict CAS authority crossed a PID boundary")
 
         def run_locked() -> _CASResult:
-            resources = self._strict_resources
-            if resources is None or resources.closed:
+            if (
+                self._strict_lifecycle_state != _STRICT_STATE_ACTIVE
+                or self._strict_resources is None
+            ):
                 raise StorageIntegrityError("strict CAS authority is closed")
             return callback()
 
@@ -666,7 +693,10 @@ class LocalCAS:
             return
         if os.getpid() != self._owner_pid:
             raise StorageIntegrityError("strict CAS authority crossed a PID boundary")
-        if self._strict_resources is None or self._strict_resources.closed:
+        if (
+            self._strict_lifecycle_state != _STRICT_STATE_ACTIVE
+            or self._strict_resources is None
+        ):
             raise StorageIntegrityError("strict CAS authority is closed")
         anchors = (
             (

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -64,6 +64,30 @@ class BlobInfo:
     storage_key: str
 
 
+def _install_strict_state(
+    store: LocalCAS,
+    *,
+    require_preprovisioned: bool,
+    strict_root_identity: tuple[int, ...] | None,
+    strict_sha256_identity: tuple[int, ...] | None,
+    strict_shard_identities: dict[str, tuple[int, ...]],
+    strict_resources: _atomic._PosixResourceOwner,
+    strict_root_descriptor: int | None,
+    strict_sha256_descriptor: int | None,
+    strict_shard_descriptors: dict[str, int],
+) -> None:
+    """Transfer constructor-local strict resources to a LocalCAS instance."""
+
+    store._strict_root_identity = strict_root_identity
+    store._strict_sha256_identity = strict_sha256_identity
+    store._strict_shard_identities = strict_shard_identities
+    store._strict_resources = strict_resources if require_preprovisioned else None
+    store._strict_root_descriptor = strict_root_descriptor
+    store._strict_sha256_descriptor = strict_sha256_descriptor
+    store._strict_shard_descriptors = strict_shard_descriptors
+    store._owner_pid = os.getpid()
+
+
 class LocalCAS:
     """A SHA-256 content-addressed store backed by regular local files.
 
@@ -213,16 +237,17 @@ class LocalCAS:
             # until every retained descriptor is reachable from ``self``.
             # Otherwise cancellation after the last shard is retained but before
             # the first attribute store can strand all 258 strict anchors.
-            self._strict_root_identity = strict_root_identity
-            self._strict_sha256_identity = strict_sha256_identity
-            self._strict_shard_identities = strict_shard_identities
-            self._strict_resources = (
-                strict_resources if require_preprovisioned else None
+            _install_strict_state(
+                self,
+                require_preprovisioned=require_preprovisioned,
+                strict_root_identity=strict_root_identity,
+                strict_sha256_identity=strict_sha256_identity,
+                strict_shard_identities=strict_shard_identities,
+                strict_resources=strict_resources,
+                strict_root_descriptor=strict_root_descriptor,
+                strict_sha256_descriptor=strict_sha256_descriptor,
+                strict_shard_descriptors=strict_shard_descriptors,
             )
-            self._strict_root_descriptor = strict_root_descriptor
-            self._strict_sha256_descriptor = strict_sha256_descriptor
-            self._strict_shard_descriptors = strict_shard_descriptors
-            self._owner_pid = os.getpid()
         except FileNotFoundError as exc:
             _close_posix_resources(strict_resources, primary_error=exc)
             if require_preprovisioned:

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -249,7 +249,10 @@ requires a fully preprovisioned `sha256` layout and retains anchored authorities
 for the root, hash directory, and every shard for the store lifetime; these
 anchors prevent device/inode reuse from making a replacement generation look
 valid. Lazy directory creation remains a cooperative compatibility mode and is
-not an adversarial generation boundary. The current strict implementation is
+not an adversarial generation boundary. Where owned publication or anchored
+directory descriptors are unavailable, default lazy `LocalCAS` retains its
+path-checked portable hard-link/atomic-replace backend; strict construction and
+provisioning fail before filesystem I/O. The current strict implementation is
 POSIX-only, requires callers to close the store to release its generation
 anchors, and does not make ordinary same-UID writable files immutable after
 publication. Preopened workspace publication applies the same ownership model

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -240,6 +240,22 @@ not depend on the catalog implementation.  These gates close the current
 portable context publication surface; they are a prerequisite for, but do not
 complete, the remaining legacy manifest import/export adapter or a future
 streaming payload revision.
+
+Local filesystem publication now has an explicit strict-authority gate. Regular
+files are written through caller-owned staged descriptors, installed with
+no-replace rename, authenticated through a retained receipt, and reported
+durable only after the parent directory is flushed. Strict `LocalCAS` mode
+requires a fully preprovisioned `sha256` layout and retains anchored authorities
+for the root, hash directory, and every shard for the store lifetime; these
+anchors prevent device/inode reuse from making a replacement generation look
+valid. Lazy directory creation remains a cooperative compatibility mode and is
+not an adversarial generation boundary. The current strict implementation is
+POSIX-only, requires callers to close the store to release its generation
+anchors, and does not make ordinary same-UID writable files immutable after
+publication. Preopened workspace publication applies the same ownership model
+to exact, scanner-bounded directory plans and returns a caller-owned receipt
+whose authenticated reader remains pinned through synchronous consumption.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -263,6 +263,7 @@ def test_put_file_rejects_source_changed_between_passes(
 
 def test_second_file_pass_checks_same_size_mutation_before_stop_iteration(
     tmp_path: Path,
+    filesystem_ctime_tick,
 ) -> None:
     source = tmp_path / "source.bin"
     original = b"same-size-original"
@@ -278,6 +279,7 @@ def test_second_file_pass_checks_same_size_mutation_before_stop_iteration(
     )
 
     assert next(chunks) == original
+    filesystem_ctime_tick(signature[5])
     source.write_bytes(replacement)
 
     with pytest.raises(OSError, match="source changed"):
@@ -585,6 +587,8 @@ def test_provision_builds_complete_strict_layout_and_put_never_mkdirs(
     assert store._strict_root_identity is not None
     assert store._strict_sha256_identity is not None
     assert len(store._strict_shard_identities) == 256
+    assert store._strict_resources is not None
+    assert len(store._strict_shard_descriptors) == 256
 
     def forbidden_mkdir(*_args, **_kwargs) -> None:
         raise AssertionError("strict CAS put attempted to create a directory")
@@ -612,6 +616,40 @@ def test_strict_put_rejects_preprovisioned_shard_generation_replacement(
 
     assert list(shard.iterdir()) == []
     assert list(previous.iterdir()) == []
+
+
+def test_strict_put_retains_unlinked_shard_generation_authority(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = b"pinned shard generation"
+    digest = hashlib.sha256(payload).hexdigest()
+    shard_name = digest[:2]
+    shard = root / "sha256" / shard_name
+    retained = store._strict_shard_descriptors[shard_name]
+    retained_identity = cas_module._directory_resource_identity(
+        retained,
+        path=shard,
+        label="retained test shard",
+    )
+
+    shard.rmdir()
+    shard.mkdir()
+
+    assert (
+        cas_module._directory_resource_identity(
+            retained,
+            path=shard,
+            label="retained test shard",
+        )
+        == retained_identity
+    )
+    with pytest.raises(StorageIntegrityError, match="generation changed"):
+        store.put_bytes(payload)
+    assert list(shard.iterdir()) == []
+    store.close()
+    _assert_bad_descriptor(retained)
 
 
 @pytest.mark.parametrize("layer", ["root", "sha256", "shard"])

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -4,13 +4,11 @@
 
 from __future__ import annotations
 
-import dis
 import errno
 import hashlib
 import multiprocessing
 import os
 import stat
-import sys
 from pathlib import Path
 from queue import Empty
 
@@ -41,47 +39,6 @@ def _exception_notes(error: BaseException) -> tuple[str, ...]:
         *tuple(getattr(error, "__notes__", ())),
         *tuple(getattr(error, "_codenib_cleanup_notes", ())),
     )
-
-
-def _interrupt_before_store_attr(
-    function: object,
-    attribute: str,
-    callback: object,
-    *,
-    error: BaseException,
-) -> None:
-    """Raise before one constructor attribute handoff opcode executes."""
-
-    assert callable(function)
-    assert callable(callback)
-    code = function.__code__
-    store_offsets = {
-        instruction.offset
-        for instruction in dis.get_instructions(function)
-        if instruction.opname == "STORE_ATTR" and instruction.argval == attribute
-    }
-    assert store_offsets
-    previous_trace = sys.gettrace()
-
-    def trace(frame: object, event: str, _arg: object) -> object:
-        if event == "call" and frame.f_code is code:
-            frame.f_trace_opcodes = True
-            return trace
-        if (
-            event == "opcode"
-            and frame.f_code is code
-            and frame.f_lasti in store_offsets
-        ):
-            assert len(frame.f_locals["strict_shard_descriptors"]) == 256
-            sys.settrace(None)
-            raise error
-        return trace
-
-    sys.settrace(trace)
-    try:
-        callback()
-    finally:
-        sys.settrace(previous_trace)
 
 
 def _put_bytes_in_process(
@@ -659,15 +616,22 @@ def test_strict_constructor_cancellation_during_resource_handoff_closes_all(
 
     monkeypatch.setattr(cas_module, "_retain_directory_descriptor", retain)
     interruption = KeyboardInterrupt("strict resource handoff cancellation")
+
+    def interrupt_handoff(store, **state) -> None:
+        assert store.root == root
+        assert state["require_preprovisioned"] is True
+        assert state["strict_root_descriptor"] is not None
+        assert state["strict_sha256_descriptor"] is not None
+        assert len(state["strict_shard_identities"]) == 256
+        assert len(state["strict_shard_descriptors"]) == 256
+        assert not state["strict_resources"].closed
+        raise interruption
+
+    monkeypatch.setattr(cas_module, "_install_strict_state", interrupt_handoff)
     before = _descriptor_count()
 
     with pytest.raises(KeyboardInterrupt) as caught:
-        _interrupt_before_store_attr(
-            LocalCAS.__init__,
-            "_strict_root_identity",
-            lambda: LocalCAS(root, require_preprovisioned=True),
-            error=interruption,
-        )
+        LocalCAS(root, require_preprovisioned=True)
 
     assert caught.value is interruption
     assert len(retained) == 258

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import dis
 import errno
 import hashlib
 import multiprocessing
 import os
 import stat
+import sys
 from pathlib import Path
 from queue import Empty
 
@@ -39,6 +41,47 @@ def _exception_notes(error: BaseException) -> tuple[str, ...]:
         *tuple(getattr(error, "__notes__", ())),
         *tuple(getattr(error, "_codenib_cleanup_notes", ())),
     )
+
+
+def _interrupt_before_store_attr(
+    function: object,
+    attribute: str,
+    callback: object,
+    *,
+    error: BaseException,
+) -> None:
+    """Raise before one constructor attribute handoff opcode executes."""
+
+    assert callable(function)
+    assert callable(callback)
+    code = function.__code__
+    store_offsets = {
+        instruction.offset
+        for instruction in dis.get_instructions(function)
+        if instruction.opname == "STORE_ATTR" and instruction.argval == attribute
+    }
+    assert store_offsets
+    previous_trace = sys.gettrace()
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            event == "opcode"
+            and frame.f_code is code
+            and frame.f_lasti in store_offsets
+        ):
+            assert len(frame.f_locals["strict_shard_descriptors"]) == 256
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
 
 
 def _put_bytes_in_process(
@@ -597,6 +640,41 @@ def test_provision_builds_complete_strict_layout_and_put_never_mkdirs(
     info = store.put_bytes(b"strict preprovisioned object")
 
     assert store.read_bytes(info.digest) == b"strict preprovisioned object"
+
+
+def test_strict_constructor_cancellation_during_resource_handoff_closes_all(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "objects"
+    provisioned = LocalCAS.provision(root)
+    provisioned.close()
+    retained: list[int] = []
+    real_retain = cas_module._retain_directory_descriptor
+
+    def retain(resources, descriptor):
+        retained_descriptor = real_retain(resources, descriptor)
+        retained.append(retained_descriptor)
+        return retained_descriptor
+
+    monkeypatch.setattr(cas_module, "_retain_directory_descriptor", retain)
+    interruption = KeyboardInterrupt("strict resource handoff cancellation")
+    before = _descriptor_count()
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_before_store_attr(
+            LocalCAS.__init__,
+            "_strict_root_identity",
+            lambda: LocalCAS(root, require_preprovisioned=True),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert len(retained) == 258
+    assert len(set(retained)) == len(retained)
+    for descriptor in retained:
+        _assert_bad_descriptor(descriptor)
+    assert _descriptor_count() <= before
 
 
 def test_strict_put_rejects_preprovisioned_shard_generation_replacement(

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -696,6 +696,128 @@ def test_strict_put_retains_unlinked_shard_generation_authority(
     _assert_bad_descriptor(retained)
 
 
+def test_strict_operations_skip_owner_wide_closed_scans_but_validate_anchors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"strict lifecycle scan accounting"
+    info = store.put_bytes(payload)
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"strict file publication")
+    materialized = tmp_path / "materialized.bin"
+    resources = store._strict_resources
+    assert resources is not None
+    retained_descriptors = {
+        store._strict_root_descriptor,
+        store._strict_sha256_descriptor,
+        *store._strict_shard_descriptors.values(),
+    }
+    owner_wide_scans = 0
+    retained_anchor_checks = 0
+    real_closed = atomic_module._PosixResourceOwner.closed.fget
+    real_require_generation = cas_module._require_directory_generation
+    assert real_closed is not None
+
+    def counted_closed(owner) -> bool:
+        nonlocal owner_wide_scans
+        if owner is resources:
+            owner_wide_scans += 1
+        return real_closed(owner)
+
+    def counted_require_generation(
+        descriptor,
+        expected,
+        *,
+        path,
+        label,
+    ) -> None:
+        nonlocal retained_anchor_checks
+        if descriptor in retained_descriptors:
+            retained_anchor_checks += 1
+        real_require_generation(
+            descriptor,
+            expected,
+            path=path,
+            label=label,
+        )
+
+    def open_and_read() -> None:
+        with store.open(info.digest) as handle:
+            assert handle.read() == payload
+
+    operations = (
+        lambda: store.put_bytes(b"second strict object"),
+        lambda: store.put_file(source),
+        lambda: store.has(info.digest),
+        open_and_read,
+        lambda: store.read_bytes(info.digest),
+        lambda: store.verify(info.digest),
+        lambda: store.materialize(info.digest, materialized),
+    )
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            atomic_module._PosixResourceOwner,
+            "closed",
+            property(counted_closed),
+        )
+        patch.setattr(
+            cas_module,
+            "_require_directory_generation",
+            counted_require_generation,
+        )
+        for operation in operations:
+            owner_wide_scans = 0
+            retained_anchor_checks = 0
+
+            operation()
+
+            assert owner_wide_scans == 0
+            assert retained_anchor_checks == 3
+
+    assert materialized.read_bytes() == payload
+    store.close()
+
+
+def test_strict_failed_close_blocks_operations_until_cleanup_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    info = store.put_bytes(b"close retry object")
+    resources = store._strict_resources
+    retained = store._strict_root_descriptor
+    assert resources is not None
+    assert retained is not None
+    real_close_resources = cas_module._close_posix_resources
+    failure = OSError(errno.EIO, "injected strict close failure")
+    failed = False
+
+    def fail_once(candidate, *, primary_error=None) -> None:
+        nonlocal failed
+        if candidate is resources and not failed:
+            failed = True
+            raise failure
+        real_close_resources(candidate, primary_error=primary_error)
+
+    monkeypatch.setattr(cas_module, "_close_posix_resources", fail_once)
+
+    with pytest.raises(OSError) as caught:
+        store.close()
+
+    assert caught.value is failure
+    assert store._strict_lifecycle_state == cas_module._STRICT_STATE_CLOSING
+    os.fstat(retained)
+    with pytest.raises(StorageIntegrityError, match="authority is closed"):
+        store.read_bytes(info.digest)
+
+    store.close()
+
+    assert store._strict_lifecycle_state == cas_module._STRICT_STATE_CLOSED
+    assert store._strict_resources is None
+    _assert_bad_descriptor(retained)
+
+
 def test_strict_concurrent_close_traverses_retained_anchors_once(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -6,15 +6,52 @@ from __future__ import annotations
 
 import errno
 import hashlib
+import multiprocessing
 import os
-import threading
+import stat
 from pathlib import Path
+from queue import Empty
 
 import pytest
 
+import codenib._atomic_directory as atomic_module
+import codenib._owned_file_publication as owned_file_module
 import codenib.storage.cas as cas_module
 from codenib.storage.cas import LocalCAS
 from codenib.storage.models import StorageIntegrityError, StorageValidationError
+
+
+def _descriptor_count() -> int:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting requires procfs")
+    return len(os.listdir(descriptor_root))
+
+
+def _assert_bad_descriptor(descriptor: int) -> None:
+    with pytest.raises(OSError) as caught:
+        os.fstat(descriptor)
+    assert caught.value.errno == errno.EBADF
+
+
+def _exception_notes(error: BaseException) -> tuple[str, ...]:
+    return (
+        *tuple(getattr(error, "__notes__", ())),
+        *tuple(getattr(error, "_codenib_cleanup_notes", ())),
+    )
+
+
+def _put_bytes_in_process(
+    root: str,
+    payload: bytes,
+    ready: multiprocessing.Queue,
+    start: multiprocessing.Event,
+) -> None:
+    store = LocalCAS(Path(root), require_preprovisioned=True)
+    ready.put(os.getpid())
+    if not start.wait(timeout=30):
+        raise TimeoutError("CAS publication start was not released")
+    store.put_bytes(payload)
 
 
 def test_put_bytes_uses_canonical_key_and_deduplicates(tmp_path: Path) -> None:
@@ -32,6 +69,11 @@ def test_put_bytes_uses_canonical_key_and_deduplicates(tmp_path: Path) -> None:
     assert first.byte_size == len(payload)
     assert first.storage_key == f"sha256/{digest[:2]}/{digest[2:]}"
     assert stored.stat().st_ino == first_metadata.st_ino
+    assert stat.S_IMODE(stored.stat().st_mode) == 0o600
+    assert stored.stat().st_nlink == 1
+    orphans = list(stored.parent.glob(".codenib-file-*"))
+    assert len(orphans) == 1
+    assert orphans[0].read_bytes() == payload
     assert store.has(digest)
     assert store.verify(digest) == first
     assert store.read_bytes(digest) == payload
@@ -106,11 +148,11 @@ def test_existing_special_object_is_rejected(tmp_path: Path) -> None:
 
     with pytest.raises(StorageIntegrityError, match="not a regular file"):
         store.has(digest)
-    with pytest.raises(StorageIntegrityError, match="not a regular file"):
+    with pytest.raises(StorageIntegrityError, match="failed integrity"):
         store.put_bytes(payload)
 
 
-def test_failed_put_cleans_temporary_without_publishing(
+def test_failed_file_fsync_leaves_owned_stage_without_publishing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -119,16 +161,22 @@ def test_failed_put_cleans_temporary_without_publishing(
     digest = hashlib.sha256(payload).hexdigest()
     destination = store.root / "sha256" / digest[:2] / digest[2:]
 
-    def fail_link(*_args, **_kwargs):
-        raise OSError("injected publish failure")
+    real_fsync = owned_file_module.os.fsync
 
-    monkeypatch.setattr("codenib.storage.cas._link_at", fail_link)
+    def fail_file_fsync(descriptor: int) -> None:
+        if stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError(errno.EIO, "injected file fsync failure")
+        real_fsync(descriptor)
 
-    with pytest.raises(OSError, match="injected publish failure"):
+    monkeypatch.setattr(owned_file_module.os, "fsync", fail_file_fsync)
+
+    with pytest.raises(OSError, match="injected file fsync failure"):
         store.put_bytes(payload)
 
     assert not destination.exists()
-    assert list(destination.parent.glob("*.tmp")) == []
+    stages = list(destination.parent.glob(".codenib-file-*"))
+    assert len(stages) == 1
+    assert stages[0].read_bytes() == payload
 
 
 def test_materialize_atomically_replaces_regular_file(tmp_path: Path) -> None:
@@ -189,22 +237,51 @@ def test_put_file_rejects_source_changed_between_passes(
 ) -> None:
     store = LocalCAS(tmp_path / "objects")
     source = tmp_path / "source.bin"
-    source.write_bytes(b"first version")
-    real_create_temporary = cas_module._create_temporary_file
+    original = b"first version"
+    source.write_bytes(original)
+    original_digest = hashlib.sha256(original).hexdigest()
+    real_publish = LocalCAS._publish_object
 
-    def mutate_then_create(*args, **kwargs):
+    def mutate_then_publish(self, *args, **kwargs):
         source.write_bytes(b"second version with a different size")
-        return real_create_temporary(*args, **kwargs)
+        return real_publish(self, *args, **kwargs)
 
     monkeypatch.setattr(
-        "codenib.storage.cas._create_temporary_file",
-        mutate_then_create,
+        LocalCAS,
+        "_publish_object",
+        mutate_then_publish,
     )
 
     with pytest.raises(OSError, match="source changed"):
         store.put_file(source)
 
-    assert list((store.root / "sha256").rglob("*.tmp")) == []
+    destination = store.root / "sha256" / original_digest[:2] / original_digest[2:]
+    assert not destination.exists()
+    stages = list(destination.parent.glob(".codenib-file-*"))
+    assert len(stages) == 1
+
+
+def test_second_file_pass_checks_same_size_mutation_before_stop_iteration(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.bin"
+    original = b"same-size-original"
+    replacement = b"same-size-mutated!"
+    assert len(replacement) == len(original)
+    source.write_bytes(original)
+    digest, byte_size, signature = cas_module._hash_stable_file(source)
+    chunks = cas_module._stable_file_chunks(
+        source,
+        expected_signature=signature,
+        expected_digest=digest,
+        expected_size=byte_size,
+    )
+
+    assert next(chunks) == original
+    source.write_bytes(replacement)
+
+    with pytest.raises(OSError, match="source changed"):
+        next(chunks)
 
 
 @pytest.mark.parametrize("swapped_component", ["sha256", "shard"])
@@ -275,39 +352,200 @@ def test_relative_root_remains_stable_after_working_directory_change(
 
     monkeypatch.chdir(elsewhere)
 
-    assert store.root == (tmp_path / "relative-objects").resolve()
+    assert store.root == Path(os.path.abspath(tmp_path / "relative-objects"))
     assert store.read_bytes(info.digest) == b"stable root"
     assert store.put_bytes(b"another object").byte_size == len(b"another object")
 
 
-def test_new_root_fsyncs_each_created_parent_directory(
+def test_constructor_never_resolves_or_follows_a_lexical_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    existing = tmp_path / "existing"
-    existing.mkdir()
-    root = existing / "level-one" / "level-two" / "objects"
-    fsynced: list[Path] = []
+    root = tmp_path / "objects"
+    resolved = False
 
-    monkeypatch.setattr(
-        cas_module,
-        "_fsync_directory",
-        lambda path: fsynced.append(path),
-    )
-    monkeypatch.setattr(
-        cas_module,
-        "_fsync_directory_handle",
-        lambda _descriptor, _path: None,
-    )
+    def forbidden_resolve(*_args, **_kwargs):
+        nonlocal resolved
+        resolved = True
+        raise AssertionError("CAS root used Path.resolve")
 
+    monkeypatch.setattr(Path, "resolve", forbidden_resolve)
     store = LocalCAS(root)
 
     assert store.root == root
-    assert fsynced == [
-        existing,
-        existing / "level-one",
-        existing / "level-one" / "level-two",
-    ]
+    assert not resolved
+
+
+def test_constructor_rejects_symlinked_ancestor_without_foreign_mutation(
+    tmp_path: Path,
+) -> None:
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(foreign, target_is_directory=True)
+
+    for require_preprovisioned in (False, True):
+        with pytest.raises(StorageValidationError, match="not a real directory"):
+            LocalCAS(
+                alias / "objects",
+                require_preprovisioned=require_preprovisioned,
+            )
+
+    assert list(foreign.iterdir()) == []
+
+
+def test_provision_rejects_filesystem_anchor_before_mkdir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mkdir_calls: list[tuple[object, ...]] = []
+
+    def forbidden_mkdir(*args, **_kwargs) -> None:
+        mkdir_calls.append(args)
+        raise AssertionError("provision attempted mkdir before rejecting root")
+
+    monkeypatch.setattr(cas_module.os, "mkdir", forbidden_mkdir)
+
+    with pytest.raises(StorageValidationError, match="lexical parent"):
+        LocalCAS.provision(Path(os.path.sep))
+
+    assert mkdir_calls == []
+
+
+def test_provision_requires_preexisting_parent_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing_parent = tmp_path / "missing-parent"
+    root = missing_parent / "objects"
+    mkdir_calls: list[tuple[object, ...]] = []
+
+    def forbidden_mkdir(*args, **_kwargs) -> None:
+        mkdir_calls.append(args)
+        raise AssertionError("provision attempted to create a missing ancestor")
+
+    monkeypatch.setattr(cas_module.os, "mkdir", forbidden_mkdir)
+
+    with pytest.raises(StorageValidationError, match="parent must already exist"):
+        LocalCAS.provision(root)
+
+    assert mkdir_calls == []
+    assert not missing_parent.exists()
+
+
+def test_provision_rejects_symlinked_parent_without_foreign_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(foreign, target_is_directory=True)
+    mkdir_calls: list[tuple[object, ...]] = []
+
+    def forbidden_mkdir(*args, **_kwargs) -> None:
+        mkdir_calls.append(args)
+        raise AssertionError("provision followed a symlinked root parent")
+
+    monkeypatch.setattr(cas_module.os, "mkdir", forbidden_mkdir)
+
+    with pytest.raises(StorageValidationError, match="real directory"):
+        LocalCAS.provision(alias / "objects")
+
+    assert mkdir_calls == []
+    assert list(foreign.iterdir()) == []
+
+
+@pytest.mark.parametrize("entry", ["root", "sha256", "last-shard"])
+@pytest.mark.parametrize("phase", ["before", "after"])
+def test_provision_retry_unconditionally_replays_complete_fsync_chain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    entry: str,
+    phase: str,
+) -> None:
+    root = tmp_path / "objects"
+    sha256_root = root / "sha256"
+    real_fsync = cas_module.os.fsync
+    injected = False
+
+    def matches_target(descriptor: int) -> bool:
+        observed = os.fstat(descriptor)
+        if entry == "root":
+            target = root.parent
+        elif entry == "sha256":
+            target = root
+        else:
+            if not (sha256_root / "ff").is_dir():
+                return False
+            target = sha256_root
+        metadata = target.stat()
+        return (observed.st_dev, observed.st_ino) == (
+            metadata.st_dev,
+            metadata.st_ino,
+        )
+
+    def fail_target_fsync(descriptor: int) -> None:
+        nonlocal injected
+        if not injected and matches_target(descriptor):
+            injected = True
+            if phase == "after":
+                real_fsync(descriptor)
+            raise OSError(errno.EIO, f"injected {entry} {phase} fsync failure")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(cas_module.os, "fsync", fail_target_fsync)
+    with pytest.raises(OSError, match=f"injected {entry} {phase}"):
+        LocalCAS.provision(root)
+    assert injected
+
+    replayed_after_complete_layout = False
+
+    def record_retry_fsync(descriptor: int) -> None:
+        nonlocal replayed_after_complete_layout
+        real_fsync(descriptor)
+        if (
+            sha256_root.is_dir()
+            and len([path for path in sha256_root.iterdir() if path.is_dir()]) == 256
+            and matches_target(descriptor)
+        ):
+            replayed_after_complete_layout = True
+
+    monkeypatch.setattr(cas_module.os, "fsync", record_retry_fsync)
+    store = LocalCAS.provision(root)
+
+    assert replayed_after_complete_layout
+    assert store.put_bytes(b"durable retry").byte_size == len(b"durable retry")
+
+
+def test_provision_replays_durability_chain_in_child_to_parent_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "objects"
+    LocalCAS.provision(root)
+    targets = {
+        (metadata.st_dev, metadata.st_ino): label
+        for label, metadata in (
+            ("sha256", (root / "sha256").stat()),
+            ("root", root.stat()),
+            ("root-parent", root.parent.stat()),
+        )
+    }
+    events: list[str] = []
+    real_fsync = cas_module.os.fsync
+
+    def record_fsync(descriptor: int) -> None:
+        metadata = os.fstat(descriptor)
+        label = targets.get((metadata.st_dev, metadata.st_ino))
+        if label is not None:
+            events.append(label)
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(cas_module.os, "fsync", record_fsync)
+
+    LocalCAS.provision(root)
+
+    assert events == ["sha256", "root", "root-parent"]
 
 
 def test_constructor_rejects_symlink_and_special_root(tmp_path: Path) -> None:
@@ -318,138 +556,720 @@ def test_constructor_rejects_symlink_and_special_root(tmp_path: Path) -> None:
     file_root = tmp_path / "file-root"
     file_root.write_text("not a directory", encoding="utf-8")
 
-    with pytest.raises(StorageValidationError, match="not a real directory"):
-        LocalCAS(symlink_root)
-    with pytest.raises(StorageValidationError, match="not a real directory"):
-        LocalCAS(file_root)
+    for require_preprovisioned in (False, True):
+        with pytest.raises(StorageValidationError, match="not a real directory"):
+            LocalCAS(
+                symlink_root,
+                require_preprovisioned=require_preprovisioned,
+            )
+        with pytest.raises(StorageValidationError, match="not a real directory"):
+            LocalCAS(
+                file_root,
+                require_preprovisioned=require_preprovisioned,
+            )
+    assert list(real_root.iterdir()) == []
 
 
-def test_concurrent_same_digest_put_publishes_without_overwrite(
+def test_provision_builds_complete_strict_layout_and_put_never_mkdirs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    store = LocalCAS(tmp_path / "objects")
-    payload = b"concurrent immutable object"
+    root = tmp_path / "objects"
+    LocalCAS.provision(root)
+    sha256_root = root / "sha256"
+
+    assert {entry.name for entry in sha256_root.iterdir()} == {
+        f"{value:02x}" for value in range(256)
+    }
+    store = LocalCAS(root, require_preprovisioned=True)
+    assert store._strict_root_identity is not None
+    assert store._strict_sha256_identity is not None
+    assert len(store._strict_shard_identities) == 256
+
+    def forbidden_mkdir(*_args, **_kwargs) -> None:
+        raise AssertionError("strict CAS put attempted to create a directory")
+
+    monkeypatch.setattr(cas_module.os, "mkdir", forbidden_mkdir)
+    info = store.put_bytes(b"strict preprovisioned object")
+
+    assert store.read_bytes(info.digest) == b"strict preprovisioned object"
+
+
+def test_strict_put_rejects_preprovisioned_shard_generation_replacement(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = b"generation-bound object"
+    digest = hashlib.sha256(payload).hexdigest()
+    shard = root / "sha256" / digest[:2]
+    previous = root / "sha256" / f"{digest[:2]}-previous"
+    shard.rename(previous)
+    shard.mkdir()
+
+    with pytest.raises(StorageIntegrityError, match="generation changed"):
+        store.put_bytes(payload)
+
+    assert list(shard.iterdir()) == []
+    assert list(previous.iterdir()) == []
+
+
+@pytest.mark.parametrize("layer", ["root", "sha256", "shard"])
+@pytest.mark.parametrize("phase", ["before", "after"])
+@pytest.mark.parametrize("exception_type", [OSError, KeyboardInterrupt, SystemExit])
+def test_directory_owner_close_fault_cleans_all_and_preserves_primary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    layer: str,
+    phase: str,
+    exception_type: type[BaseException],
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = f"{layer}-{phase}-{exception_type.__name__}".encode()
+    digest = hashlib.sha256(payload).hexdigest()
+    paths = {
+        "root": root,
+        "sha256": root / "sha256",
+        "shard": root / "sha256" / digest[:2],
+    }
+    target_metadata = paths[layer].stat()
+    target_identity = (target_metadata.st_dev, target_metadata.st_ino)
+    captured: list[int] = []
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = cas_module.os.close
+    error = (
+        OSError(errno.EIO, f"{phase} {layer} close failure")
+        if exception_type is OSError
+        else exception_type(f"{phase} {layer} close interruption")
+    )
+    injected = False
+
+    def capture_target_open(
+        owner,
+        path,
+        flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        metadata = os.fstat(descriptor)
+        if not captured and (metadata.st_dev, metadata.st_ino) == target_identity:
+            captured.append(descriptor)
+        return descriptor
+
+    def fail_target_close(descriptor: int) -> None:
+        nonlocal injected
+        if captured and descriptor == captured[0] and not injected:
+            injected = True
+            if phase == "after":
+                real_close(descriptor)
+            raise error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        capture_target_open,
+    )
+    monkeypatch.setattr(cas_module.os, "close", fail_target_close)
+    before = _descriptor_count()
+
+    with pytest.raises(exception_type) as caught:
+        store.put_bytes(payload)
+
+    assert caught.value is error
+    assert injected
+    assert len(captured) == 1
+    _assert_bad_descriptor(captured[0])
+    assert _descriptor_count() <= before
+    destination = root / "sha256" / digest[:2] / digest[2:]
+    committed_inode = destination.stat().st_ino
+
+    monkeypatch.setattr(cas_module.os, "close", real_close)
+    assert store.put_bytes(payload).digest == digest
+    assert destination.stat().st_ino == committed_inode
+
+
+@pytest.mark.parametrize("layer", ["root", "sha256", "shard"])
+def test_directory_owner_retries_repeated_eio(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    layer: str,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = f"persistent-{layer}".encode()
+    digest = hashlib.sha256(payload).hexdigest()
+    paths = {
+        "root": root,
+        "sha256": root / "sha256",
+        "shard": root / "sha256" / digest[:2],
+    }
+    metadata = paths[layer].stat()
+    target_identity = (metadata.st_dev, metadata.st_ino)
+    captured: list[int] = []
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = cas_module.os.close
+    error = OSError(errno.EIO, f"repeated {layer} close failure")
+    failures_remaining = 5
+
+    def capture_target_open(
+        owner,
+        path,
+        flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        opened = os.fstat(descriptor)
+        if not captured and (opened.st_dev, opened.st_ino) == target_identity:
+            captured.append(descriptor)
+        return descriptor
+
+    def fail_repeatedly(descriptor: int) -> None:
+        nonlocal failures_remaining
+        if captured and descriptor == captured[0] and failures_remaining:
+            failures_remaining -= 1
+            raise error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        capture_target_open,
+    )
+    monkeypatch.setattr(cas_module.os, "close", fail_repeatedly)
+    before = _descriptor_count()
+
+    with pytest.raises(OSError) as caught:
+        store.put_bytes(payload)
+
+    assert caught.value is error
+    assert failures_remaining == 0
+    _assert_bad_descriptor(captured[0])
+    assert _descriptor_count() <= before
+
+
+def test_nested_directory_cleanup_keeps_first_error_and_attempts_every_layer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = b"nested cleanup first primary"
+    digest = hashlib.sha256(payload).hexdigest()
+    target_paths = [root / "sha256" / digest[:2], root / "sha256"]
+    target_identities = {
+        (path.stat().st_dev, path.stat().st_ino): index
+        for index, path in enumerate(target_paths)
+    }
+    descriptors: dict[int, int] = {}
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = cas_module.os.close
+    primary = KeyboardInterrupt("shard close interruption")
+    secondary = SystemExit("sha256 close interruption")
+    injected: set[int] = set()
+
+    def capture_target_open(
+        owner,
+        path,
+        flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        metadata = os.fstat(descriptor)
+        index = target_identities.get((metadata.st_dev, metadata.st_ino))
+        if index is not None and index not in descriptors:
+            descriptors[index] = descriptor
+        return descriptor
+
+    def fail_two_layers(descriptor: int) -> None:
+        for index, error in ((0, primary), (1, secondary)):
+            if descriptors.get(index) == descriptor and index not in injected:
+                injected.add(index)
+                raise error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        capture_target_open,
+    )
+    monkeypatch.setattr(cas_module.os, "close", fail_two_layers)
+    before = _descriptor_count()
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        store.put_bytes(payload)
+
+    assert caught.value is primary
+    assert injected == {0, 1}
+    assert any(
+        "sha256 close interruption" in note for note in _exception_notes(primary)
+    )
+    assert all(descriptor >= 0 for descriptor in descriptors.values())
+    for descriptor in descriptors.values():
+        _assert_bad_descriptor(descriptor)
+    assert _descriptor_count() <= before
+
+
+@pytest.mark.parametrize("layer", ["root", "sha256", "shard"])
+def test_directory_owner_does_not_close_observably_reused_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    layer: str,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = f"reuse-{layer}".encode()
+    digest = hashlib.sha256(payload).hexdigest()
+    paths = {
+        "root": root,
+        "sha256": root / "sha256",
+        "shard": root / "sha256" / digest[:2],
+    }
+    metadata = paths[layer].stat()
+    target_identity = (metadata.st_dev, metadata.st_ino)
+    foreign = tmp_path / f"foreign-{layer}.bin"
+    foreign.write_bytes(b"foreign")
+    foreign_source = os.open(foreign, os.O_RDONLY)
+    captured: list[int] = []
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = cas_module.os.close
+    interruption = KeyboardInterrupt(f"{layer} close reused fd")
+    reused = False
+
+    def capture_target_open(
+        owner,
+        path,
+        flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        opened = os.fstat(descriptor)
+        if not captured and (opened.st_dev, opened.st_ino) == target_identity:
+            captured.append(descriptor)
+        return descriptor
+
+    def close_then_reuse(descriptor: int) -> None:
+        nonlocal reused
+        real_close(descriptor)
+        if captured and descriptor == captured[0] and not reused:
+            os.dup2(foreign_source, descriptor)
+            reused = True
+            raise interruption
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        capture_target_open,
+    )
+    monkeypatch.setattr(cas_module.os, "close", close_then_reuse)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            store.put_bytes(payload)
+
+        assert caught.value is interruption
+        assert reused
+        assert os.pread(captured[0], len(b"foreign"), 0) == b"foreign"
+        assert store.put_bytes(payload).digest == digest
+        assert os.pread(captured[0], len(b"foreign"), 0) == b"foreign"
+    finally:
+        monkeypatch.setattr(cas_module.os, "close", real_close)
+        if captured:
+            real_close(captured[0])
+        real_close(foreign_source)
+
+
+def test_strict_constructor_rejects_incomplete_layout_without_mutation(
+    tmp_path: Path,
+) -> None:
+    missing_root = tmp_path / "missing"
+
+    with pytest.raises(StorageValidationError, match="does not exist"):
+        LocalCAS(missing_root, require_preprovisioned=True)
+    assert not missing_root.exists()
+
+    incomplete = tmp_path / "incomplete"
+    (incomplete / "sha256").mkdir(parents=True)
+    marker = incomplete / "sha256" / "keep"
+    marker.write_bytes(b"unchanged")
+    before = sorted(path.relative_to(incomplete) for path in incomplete.rglob("*"))
+
+    with pytest.raises(StorageValidationError, match="all 256 digest shards"):
+        LocalCAS(incomplete, require_preprovisioned=True)
+
+    after = sorted(path.relative_to(incomplete) for path in incomplete.rglob("*"))
+    assert after == before
+    assert marker.read_bytes() == b"unchanged"
+
+
+def test_capability_gate_fails_before_lazy_layout_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "objects"
+    monkeypatch.setattr(cas_module, "_SAFE_DIRECTORY_FDS", False)
+
+    with pytest.raises(RuntimeError, match="directory-fd support"):
+        LocalCAS(root)
+
+    assert not root.exists()
+
+
+def test_windows_gate_fails_before_constructor_or_provision_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(owned_file_module.sys, "platform", "win32")
+    lazy_root = tmp_path / "lazy"
+    provisioned_root = tmp_path / "provisioned"
+
+    with pytest.raises(RuntimeError, match="unsupported on Windows"):
+        LocalCAS(lazy_root)
+    with pytest.raises(RuntimeError, match="unsupported on Windows"):
+        LocalCAS.provision(provisioned_root)
+
+    assert not lazy_root.exists()
+    assert not provisioned_root.exists()
+
+
+def test_real_multiprocess_same_digest_publishes_one_canonical_inode(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = b"multiprocess immutable object"
+    digest = hashlib.sha256(payload).hexdigest()
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    start = context.Event()
+    processes = [
+        context.Process(
+            target=_put_bytes_in_process,
+            args=(str(root), payload, ready, start),
+        )
+        for _index in range(4)
+    ]
+    for process in processes:
+        process.start()
+    try:
+        for _process in processes:
+            try:
+                ready.get(timeout=30)
+            except Empty as exc:  # pragma: no cover - failure diagnostic
+                raise AssertionError("CAS worker did not reach the race") from exc
+    finally:
+        start.set()
+    for process in processes:
+        process.join(timeout=30)
+    try:
+        assert all(not process.is_alive() for process in processes)
+        assert [process.exitcode for process in processes] == [0, 0, 0, 0]
+    finally:
+        for process in processes:
+            if process.is_alive():  # pragma: no cover - failure cleanup
+                process.terminate()
+                process.join(timeout=10)
+        ready.close()
+        ready.join_thread()
+
+    destination = root / "sha256" / digest[:2] / digest[2:]
+    assert destination.read_bytes() == payload
+    assert destination.stat().st_nlink == 1
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o600
+    stages = list(destination.parent.glob(".codenib-file-*"))
+    assert len(stages) == len(processes) - 1
+    assert all(stage.read_bytes() == payload for stage in stages)
+    assert store.verify(digest).byte_size == len(payload)
+
+
+def test_destination_appearing_during_rename_is_never_overwritten(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"requested object"
+    competing = b"competing object"
     digest = hashlib.sha256(payload).hexdigest()
     destination = store.root / "sha256" / digest[:2] / digest[2:]
-    gate = threading.Barrier(2)
-    local = threading.local()
-    real_verify = LocalCAS._verify_existing_at
+    real_rename = atomic_module._rename_noreplace_at
+    raced = False
 
-    def synchronize_publish_check(self, *args, **kwargs):
-        result = real_verify(self, *args, **kwargs)
-        count = getattr(local, "count", 0) + 1
-        local.count = count
-        if count == 2 and result is None:
-            gate.wait(timeout=5)
-        return result
+    def publish_competitor_then_rename(
+        source: str,
+        target: str,
+        source_parent: int,
+        target_parent: int,
+    ) -> None:
+        nonlocal raced
+        if not raced:
+            raced = True
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            descriptor = os.open(target, flags, 0o600, dir_fd=target_parent)
+            try:
+                os.write(descriptor, competing)
+                os.fchmod(descriptor, 0o600)
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+        real_rename(source, target, source_parent, target_parent)
 
-    successful_inodes: list[int] = []
-    real_link = cas_module._link_at
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        publish_competitor_then_rename,
+    )
 
-    def record_link(*args, **kwargs):
-        real_link(*args, **kwargs)
-        successful_inodes.append(destination.stat().st_ino)
+    with pytest.raises(StorageIntegrityError) as caught:
+        store.put_bytes(payload)
 
-    monkeypatch.setattr(LocalCAS, "_verify_existing_at", synchronize_publish_check)
-    monkeypatch.setattr(cas_module, "_link_at", record_link)
-
-    errors: list[BaseException] = []
-
-    def put() -> None:
-        try:
-            store.put_bytes(payload)
-        except Exception as exc:  # pragma: no cover - asserted below
-            errors.append(exc)
-
-    threads = [threading.Thread(target=put) for _ in range(2)]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join(timeout=10)
-
-    assert all(not thread.is_alive() for thread in threads)
-    assert errors == []
-    assert len(successful_inodes) == 1
-    assert destination.stat().st_ino == successful_inodes[0]
-    assert store.read_bytes(digest) == payload
+    assert isinstance(caught.value.__cause__, owned_file_module.OwnedFileConflictError)
+    assert destination.read_bytes() == competing
+    assert len(list(destination.parent.glob(".codenib-file-*"))) == 1
 
 
-def test_deduplicated_put_flushes_concurrent_publish_before_return(
+@pytest.mark.parametrize("defect", ["mode", "link-count"])
+def test_existing_object_metadata_conflict_is_not_healed(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    defect: str,
 ) -> None:
-    store = LocalCAS(tmp_path / "objects")
-    payload = b"concurrent durability receipt"
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"canonical payload"
     digest = hashlib.sha256(payload).hexdigest()
-    shard = store.root / "sha256" / digest[:2]
-    linked = threading.Event()
-    release_first_writer = threading.Event()
-    dedupe_flushed = threading.Event()
-    real_link = cas_module._link_at
-    real_fsync = cas_module._fsync_directory_handle
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    destination.write_bytes(payload)
+    destination.chmod(0o600)
+    sibling = destination.parent / "extra-link"
+    if defect == "mode":
+        destination.chmod(0o644)
+    else:
+        os.link(destination, sibling)
+    before = destination.stat()
 
-    def link_then_pause(*args, **kwargs) -> None:
-        real_link(*args, **kwargs)
-        linked.set()
-        if not release_first_writer.wait(timeout=5):
-            raise TimeoutError("first CAS publisher was not released")
+    with pytest.raises(StorageIntegrityError) as caught:
+        store.put_bytes(payload)
 
-    def record_fsync(descriptor: int | None, path: Path) -> None:
-        if linked.is_set() and path == shard:
-            dedupe_flushed.set()
-        real_fsync(descriptor, path)
-
-    monkeypatch.setattr(cas_module, "_link_at", link_then_pause)
-    monkeypatch.setattr(cas_module, "_fsync_directory_handle", record_fsync)
-    errors: list[BaseException] = []
-
-    def put() -> None:
-        try:
-            store.put_bytes(payload)
-        except Exception as exc:  # pragma: no cover - asserted below
-            errors.append(exc)
-
-    first = threading.Thread(target=put)
-    first.start()
-    assert linked.wait(timeout=5)
-    second = threading.Thread(target=put)
-    second.start()
-    second.join(timeout=5)
-
-    try:
-        assert not second.is_alive()
-        assert dedupe_flushed.is_set()
-        assert errors == []
-    finally:
-        release_first_writer.set()
-        first.join(timeout=5)
-
-    assert not first.is_alive()
-    assert errors == []
-    assert store.read_bytes(digest) == payload
+    after = destination.stat()
+    assert isinstance(caught.value.__cause__, owned_file_module.OwnedFileConflictError)
+    assert after.st_ino == before.st_ino
+    assert after.st_nlink == before.st_nlink
+    assert stat.S_IMODE(after.st_mode) == stat.S_IMODE(before.st_mode)
+    assert destination.read_bytes() == payload
+    if defect == "link-count":
+        assert sibling.stat().st_ino == before.st_ino
 
 
-def test_put_falls_back_to_atomic_replace_without_hard_link_support(
+def test_rename_failure_before_commit_leaves_stage_and_fresh_retry_inode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    store = LocalCAS(tmp_path / "objects")
-    replacements: list[str] = []
-    real_replace = cas_module._replace_at
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"retry before rename"
+    digest = hashlib.sha256(payload).hexdigest()
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    real_rename = atomic_module._rename_noreplace_at
 
-    def unsupported_link(*_args, **_kwargs) -> None:
-        raise OSError(errno.EOPNOTSUPP, "hard links unavailable")
+    def fail_before_rename(*_args, **_kwargs) -> None:
+        raise OSError(errno.EIO, "injected before rename")
 
-    def record_replace(*args, **kwargs) -> None:
-        real_replace(*args, **kwargs)
-        replacements.append("replaced")
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", fail_before_rename)
+    with pytest.raises(OSError, match="injected before rename"):
+        store.put_bytes(payload)
 
-    monkeypatch.setattr(cas_module, "_link_at", unsupported_link)
-    monkeypatch.setattr(cas_module, "_replace_at", record_replace)
+    assert not destination.exists()
+    stages = list(destination.parent.glob(".codenib-file-*"))
+    assert len(stages) == 1
+    failed_inode = stages[0].stat().st_ino
 
-    info = store.put_bytes(b"fallback publication")
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", real_rename)
+    info = store.put_bytes(payload)
 
-    assert replacements == ["replaced"]
-    assert store.read_bytes(info.digest) == b"fallback publication"
-    assert list((store.root / "sha256").rglob("*.tmp")) == []
+    assert info.digest == digest
+    assert destination.read_bytes() == payload
+    assert destination.stat().st_ino != failed_inode
+    assert stages[0].exists()
+
+
+def test_rename_failure_after_commit_reuses_same_inode_on_fresh_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"retry after rename"
+    digest = hashlib.sha256(payload).hexdigest()
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    real_rename = atomic_module._rename_noreplace_at
+
+    def rename_then_fail(*args, **kwargs) -> None:
+        real_rename(*args, **kwargs)
+        raise OSError(errno.EIO, "injected after rename")
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", rename_then_fail)
+    with pytest.raises(OSError, match="injected after rename"):
+        store.put_bytes(payload)
+
+    committed_inode = destination.stat().st_ino
+    assert list(destination.parent.glob(".codenib-file-*")) == []
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", real_rename)
+    info = store.put_bytes(payload)
+
+    assert info.digest == digest
+    assert destination.stat().st_ino == committed_inode
+    assert len(list(destination.parent.glob(".codenib-file-*"))) == 1
+
+
+def test_parent_fsync_failure_returns_no_blob_and_retry_reuses_inode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"retry after parent fsync"
+    digest = hashlib.sha256(payload).hexdigest()
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    real_fsync = owned_file_module.os.fsync
+    failed = False
+
+    def fail_first_directory_fsync(descriptor: int) -> None:
+        nonlocal failed
+        if not failed and stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            failed = True
+            raise OSError(errno.EIO, "injected parent fsync failure")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(owned_file_module.os, "fsync", fail_first_directory_fsync)
+    with pytest.raises(OSError, match="injected parent fsync failure"):
+        store.put_bytes(payload)
+
+    assert failed
+    committed_inode = destination.stat().st_ino
+
+    monkeypatch.setattr(owned_file_module.os, "fsync", real_fsync)
+    info = store.put_bytes(payload)
+
+    assert info.digest == digest
+    assert destination.stat().st_ino == committed_inode
+    assert len(list(destination.parent.glob(".codenib-file-*"))) == 1
+
+
+def test_blob_info_is_created_only_after_durable_receipt_consumption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    events: list[str] = []
+    real_fsync = owned_file_module.os.fsync
+    real_rename = atomic_module._rename_noreplace_at
+    real_consume = owned_file_module.PublishedFileReceiptOwner.consume
+    real_receipt_close = owned_file_module.PublishedFileReceipt._close_from_owner
+    real_owner_close = owned_file_module.PublishedFileReceiptOwner.close
+    real_blob_info = LocalCAS._blob_info
+
+    def record_fsync(descriptor: int) -> None:
+        metadata = os.fstat(descriptor)
+        real_fsync(descriptor)
+        events.append(
+            "parent-fsync" if stat.S_ISDIR(metadata.st_mode) else "file-fsync"
+        )
+
+    def record_rename(*args, **kwargs) -> None:
+        real_rename(*args, **kwargs)
+        events.append("rename")
+
+    def record_consume(self, callback) -> None:
+        events.append("consume-enter")
+        real_consume(self, callback)
+        events.append("consume-return")
+
+    def record_receipt_close(self, authority) -> None:
+        events.append("receipt-close-enter")
+        real_receipt_close(self, authority)
+        events.append("receipt-close-return")
+
+    def record_owner_close(self) -> None:
+        events.append("owner-close-enter")
+        real_owner_close(self)
+        assert self.closed
+        events.append("owner-terminal")
+
+    def record_blob_info(digest: str, byte_size: int):
+        events.append("blob-info")
+        return real_blob_info(digest, byte_size)
+
+    monkeypatch.setattr(owned_file_module.os, "fsync", record_fsync)
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", record_rename)
+    monkeypatch.setattr(
+        owned_file_module.PublishedFileReceiptOwner,
+        "consume",
+        record_consume,
+    )
+    monkeypatch.setattr(
+        owned_file_module.PublishedFileReceipt,
+        "_close_from_owner",
+        record_receipt_close,
+    )
+    monkeypatch.setattr(
+        owned_file_module.PublishedFileReceiptOwner,
+        "close",
+        record_owner_close,
+    )
+    monkeypatch.setattr(LocalCAS, "_blob_info", staticmethod(record_blob_info))
+
+    store.put_bytes(b"ordered publication")
+
+    assert events == [
+        "file-fsync",
+        "rename",
+        "parent-fsync",
+        "consume-enter",
+        "consume-return",
+        "owner-close-enter",
+        "receipt-close-enter",
+        "receipt-close-return",
+        "owner-terminal",
+        "blob-info",
+    ]
+
+
+def test_unsupported_no_replace_never_uses_legacy_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"no fallback publication"
+    digest = hashlib.sha256(payload).hexdigest()
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    replaced = False
+
+    def unsupported_rename(*_args, **_kwargs) -> None:
+        raise RuntimeError("filesystem no-replace unsupported")
+
+    def forbidden_replace(*_args, **_kwargs) -> None:
+        nonlocal replaced
+        replaced = True
+        raise AssertionError("legacy replace fallback was used")
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", unsupported_rename)
+    monkeypatch.setattr(cas_module.os, "replace", forbidden_replace)
+
+    with pytest.raises(RuntimeError, match="no-replace unsupported"):
+        store.put_bytes(payload)
+
+    assert not replaced
+    assert not destination.exists()
+    assert len(list(destination.parent.glob(".codenib-file-*"))) == 1
+    for symbol in (
+        "_create_temporary_file",
+        "_link_at",
+        "_replace_at",
+        "_unlink_at",
+    ):
+        assert not hasattr(cas_module, symbol)

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -8,7 +8,9 @@ import errno
 import hashlib
 import multiprocessing
 import os
+import signal
 import stat
+import threading
 from pathlib import Path
 from queue import Empty
 
@@ -692,6 +694,229 @@ def test_strict_put_retains_unlinked_shard_generation_authority(
     assert list(shard.iterdir()) == []
     store.close()
     _assert_bad_descriptor(retained)
+
+
+def test_strict_concurrent_close_traverses_retained_anchors_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ObservedCAS(LocalCAS):
+        def __init__(self, *args, **kwargs) -> None:
+            self.second_attempted = threading.Event()
+            super().__init__(*args, **kwargs)
+
+        def _run_lifecycle(self, callback):
+            if threading.current_thread().name == "second-close":
+                self.second_attempted.set()
+            return super()._run_lifecycle(callback)
+
+    store = ObservedCAS.provision(tmp_path / "objects")
+    resources = store._strict_resources
+    assert resources is not None
+    close_entered = threading.Event()
+    release_close = threading.Event()
+    finished: list[str] = []
+    errors: list[BaseException] = []
+    close_calls = 0
+    real_close_resources = cas_module._close_posix_resources
+
+    def blocking_close(candidate, *, primary_error=None) -> None:
+        nonlocal close_calls
+        if candidate is resources:
+            close_calls += 1
+            close_entered.set()
+            assert release_close.wait(timeout=30)
+        real_close_resources(candidate, primary_error=primary_error)
+
+    def close_store(label: str) -> None:
+        try:
+            store.close()
+        except BaseException as exc:  # noqa: B036 - report thread failure
+            errors.append(exc)
+        else:
+            finished.append(label)
+
+    monkeypatch.setattr(cas_module, "_close_posix_resources", blocking_close)
+    first = threading.Thread(target=close_store, args=("first",), name="first-close")
+    second = threading.Thread(
+        target=close_store,
+        args=("second",),
+        name="second-close",
+    )
+    first.start()
+    assert close_entered.wait(timeout=30)
+    second.start()
+    assert store.second_attempted.wait(timeout=30)
+
+    assert close_calls == 1
+    assert finished == []
+    release_close.set()
+    first.join(timeout=30)
+    second.join(timeout=30)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert sorted(finished) == ["first", "second"]
+    assert close_calls == 1
+    assert store._strict_resources is None
+    with pytest.raises(StorageIntegrityError, match="authority is closed"):
+        store.put_bytes(b"after close")
+
+
+@pytest.mark.parametrize("operation", ["put", "read"])
+def test_strict_close_waits_for_active_put_and_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    class ObservedCAS(LocalCAS):
+        def __init__(self, *args, **kwargs) -> None:
+            self.close_attempted = threading.Event()
+            super().__init__(*args, **kwargs)
+
+        def _run_lifecycle(self, callback):
+            if getattr(callback, "__name__", "") == "_close_strict_resources_locked":
+                self.close_attempted.set()
+            return super()._run_lifecycle(callback)
+
+    store = ObservedCAS.provision(tmp_path / "objects")
+    initial = store.put_bytes(b"existing object")
+    strict_resources = store._strict_resources
+    assert strict_resources is not None
+    operation_entered = threading.Event()
+    release_operation = threading.Event()
+    cleanup_entered = threading.Event()
+    results: list[object] = []
+    errors: list[BaseException] = []
+    real_close_resources = cas_module._close_posix_resources
+
+    if operation == "put":
+        real_operation = cas_module.publish_owned_file
+
+        def blocked_publish(*args, **kwargs):
+            operation_entered.set()
+            assert release_operation.wait(timeout=30)
+            return real_operation(*args, **kwargs)
+
+        monkeypatch.setattr(cas_module, "publish_owned_file", blocked_publish)
+
+        def perform() -> object:
+            return store.put_bytes(b"concurrent object")
+
+    else:
+        real_operation = LocalCAS._consume_object
+
+        def blocked_consume(self, *args, **kwargs):
+            operation_entered.set()
+            assert release_operation.wait(timeout=30)
+            return real_operation(self, *args, **kwargs)
+
+        monkeypatch.setattr(LocalCAS, "_consume_object", blocked_consume)
+
+        def perform() -> object:
+            return store.read_bytes(initial.digest)
+
+    def observe_cleanup(resources, *, primary_error=None) -> None:
+        if resources is strict_resources:
+            cleanup_entered.set()
+        real_close_resources(resources, primary_error=primary_error)
+
+    def run_operation() -> None:
+        try:
+            results.append(perform())
+        except BaseException as exc:  # noqa: B036 - report thread failure
+            errors.append(exc)
+
+    def close_store() -> None:
+        try:
+            store.close()
+        except BaseException as exc:  # noqa: B036 - report thread failure
+            errors.append(exc)
+
+    monkeypatch.setattr(cas_module, "_close_posix_resources", observe_cleanup)
+    worker = threading.Thread(target=run_operation)
+    closer = threading.Thread(target=close_store)
+    worker.start()
+    assert operation_entered.wait(timeout=30)
+    closer.start()
+    assert store.close_attempted.wait(timeout=30)
+
+    assert not cleanup_entered.is_set()
+    release_operation.set()
+    worker.join(timeout=30)
+    closer.join(timeout=30)
+
+    assert not worker.is_alive()
+    assert not closer.is_alive()
+    assert errors == []
+    assert len(results) == 1
+    if operation == "read":
+        assert results == [b"existing object"]
+    assert cleanup_entered.is_set()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_strict_child_rejects_operations_and_closes_without_inherited_lock(
+    tmp_path: Path,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    retained = store._strict_root_descriptor
+    assert retained is not None
+    lock_entered = threading.Event()
+    release_lock = threading.Event()
+
+    def hold_lock() -> None:
+        def hold() -> None:
+            lock_entered.set()
+            assert release_lock.wait(timeout=30)
+
+        store._lifecycle_lock.run(hold)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert lock_entered.wait(timeout=30)
+    child = os.fork()
+    if child == 0:  # pragma: no cover - assertions reported through exit status
+        signal.alarm(10)
+        try:
+            try:
+                store.put_bytes(b"child operation")
+            except StorageIntegrityError as exc:
+                if "PID boundary" not in str(exc):
+                    os._exit(81)
+            else:
+                os._exit(82)
+            try:
+                store.close()
+            except StorageIntegrityError as exc:
+                if "PID boundary" not in str(exc):
+                    os._exit(83)
+            else:
+                os._exit(84)
+            try:
+                os.fstat(retained)
+            except OSError as exc:
+                if exc.errno != errno.EBADF:
+                    os._exit(85)
+            else:
+                os._exit(86)
+            os._exit(0)
+        except Exception:
+            os._exit(87)
+
+    try:
+        _pid, status = os.waitpid(child, 0)
+        assert os.WIFEXITED(status)
+        assert os.WEXITSTATUS(status) == 0
+    finally:
+        release_lock.set()
+        holder.join(timeout=30)
+
+    assert not holder.is_alive()
+    os.fstat(retained)
+    assert store.put_bytes(b"parent operation").byte_size == len(b"parent operation")
+    store.close()
 
 
 @pytest.mark.parametrize("layer", ["root", "sha256", "shard"])

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -1026,33 +1026,98 @@ def test_strict_constructor_rejects_incomplete_layout_without_mutation(
     assert marker.read_bytes() == b"unchanged"
 
 
-def test_capability_gate_fails_before_lazy_layout_mutation(
+def test_supported_posix_lazy_path_never_calls_portable_helpers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    try:
+        cas_module._require_local_cas_support()
+    except RuntimeError:
+        pytest.skip("host does not support hardened LocalCAS publication")
+
+    def forbidden_portable_helper(*_args, **_kwargs) -> None:
+        raise AssertionError("supported POSIX CAS called a portable helper")
+
+    for helper_name in (
+        "_open_portable_directory_path",
+        "_open_portable_child_directory",
+        "_open_or_create_portable_child_directory",
+        "_create_portable_temporary_file",
+        "_unlink_portable",
+    ):
+        monkeypatch.setattr(cas_module, helper_name, forbidden_portable_helper)
+    for method_name in (
+        "_publish_portable_object",
+        "_verify_portable_existing",
+        "_publish_portable_temporary",
+    ):
+        monkeypatch.setattr(LocalCAS, method_name, forbidden_portable_helper)
+
+    store = LocalCAS(tmp_path / "objects")
+    info = store.put_bytes(b"hardened POSIX lazy object")
+
+    assert not store._portable_lazy
+    assert store.read_bytes(info.digest) == b"hardened POSIX lazy object"
+
+
+def test_missing_directory_fds_use_portable_lazy_backend(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = tmp_path / "objects"
     monkeypatch.setattr(cas_module, "_SAFE_DIRECTORY_FDS", False)
 
+    def forbidden_owned_publication(*_args, **_kwargs) -> None:
+        raise AssertionError("portable lazy CAS used owned publication")
+
+    monkeypatch.setattr(cas_module, "publish_owned_file", forbidden_owned_publication)
+    store = LocalCAS(root)
+    info = store.put_bytes(b"portable directory-fd fallback")
+    destination = tmp_path / "view.bin"
+
+    assert store._portable_lazy
+    assert store.read_bytes(info.digest) == b"portable directory-fd fallback"
+    assert store.materialize(info.digest, destination) == destination
+    assert destination.read_bytes() == b"portable directory-fd fallback"
+
+    strict_root = tmp_path / "strict"
     with pytest.raises(RuntimeError, match="directory-fd support"):
-        LocalCAS(root)
+        LocalCAS(strict_root, require_preprovisioned=True)
+    assert not strict_root.exists()
 
-    assert not root.exists()
 
-
-def test_windows_gate_fails_before_constructor_or_provision_mutation(
+def test_windows_uses_portable_lazy_backend_but_strict_fails_before_io(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(owned_file_module.sys, "platform", "win32")
     lazy_root = tmp_path / "lazy"
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"portable Windows source")
+    destination = tmp_path / "materialized.bin"
+    strict_root = tmp_path / "strict"
     provisioned_root = tmp_path / "provisioned"
 
+    def forbidden_owned_publication(*_args, **_kwargs) -> None:
+        raise AssertionError("portable Windows CAS used owned publication")
+
+    monkeypatch.setattr(cas_module, "publish_owned_file", forbidden_owned_publication)
+    store = LocalCAS(lazy_root)
+    bytes_info = store.put_bytes(b"portable Windows bytes")
+    file_info = store.put_file(source)
+
+    assert store._portable_lazy
+    assert store.read_bytes(bytes_info.digest) == b"portable Windows bytes"
+    assert store.read_bytes(file_info.digest) == source.read_bytes()
+    assert store.materialize(bytes_info.digest, destination) == destination
+    assert destination.read_bytes() == b"portable Windows bytes"
+
     with pytest.raises(RuntimeError, match="unsupported on Windows"):
-        LocalCAS(lazy_root)
+        LocalCAS(strict_root, require_preprovisioned=True)
     with pytest.raises(RuntimeError, match="unsupported on Windows"):
         LocalCAS.provision(provisioned_root)
 
-    assert not lazy_root.exists()
+    assert not strict_root.exists()
     assert not provisioned_root.exists()
 
 

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import dis
 import errno
 import os
 import signal
@@ -14,7 +13,7 @@ import threading
 from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
-from typing import Callable, Iterator
+from typing import Iterator
 
 import pytest
 
@@ -72,80 +71,6 @@ def _preopened_workspace(
             os.close(descriptor)
         os.close(root_descriptor)
         os.close(parent_descriptor)
-
-
-def _interrupt_before_store(
-    callback: Callable[[], object],
-    *,
-    local_name: str,
-    error: BaseException,
-) -> None:
-    target_code = callback.__code__
-    instructions = {
-        instruction.offset: instruction
-        for instruction in dis.get_instructions(target_code)
-    }
-    previous_trace = sys.gettrace()
-
-    def trace(frame, event, _arg):
-        if event == "call" and frame.f_code is target_code:
-            frame.f_trace_opcodes = True
-            return trace
-        if event == "opcode" and frame.f_code is target_code:
-            instruction = instructions.get(frame.f_lasti)
-            if (
-                instruction is not None
-                and instruction.opname == "STORE_FAST"
-                and instruction.argval == local_name
-            ):
-                sys.settrace(None)
-                raise error
-        return trace
-
-    sys.settrace(trace)
-    try:
-        callback()
-    finally:
-        sys.settrace(previous_trace)
-
-
-def _interrupt_after_store_attr(
-    callback: Callable[[], object],
-    *,
-    target_code: object,
-    attribute: str,
-    error: BaseException,
-) -> None:
-    instructions = {
-        instruction.offset: instruction
-        for instruction in dis.get_instructions(target_code)
-    }
-    previous_trace = sys.gettrace()
-    armed = False
-
-    def trace(frame, event, _arg):
-        nonlocal armed
-        if event == "call" and frame.f_code is target_code:
-            frame.f_trace_opcodes = True
-            return trace
-        if event == "opcode" and frame.f_code is target_code:
-            if armed:
-                sys.settrace(None)
-                raise error
-            instruction = instructions.get(frame.f_lasti)
-            if (
-                instruction is not None
-                and instruction.opname == "STORE_ATTR"
-                and instruction.argval == attribute
-            ):
-                armed = True
-        return trace
-
-    sys.settrace(trace)
-    try:
-        callback()
-    finally:
-        sys.settrace(previous_trace)
 
 
 def _as_windows_ownership(ownership: object) -> object:
@@ -814,6 +739,133 @@ def test_authenticated_snapshot_has_bounded_immutable_bytes_fallback(
         reader.close()
 
 
+@pytest.mark.parametrize("blocked_errno", [errno.ENOSYS, errno.EPERM])
+def test_authenticated_snapshot_falls_back_when_memfd_syscall_is_blocked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    blocked_errno: int,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    payload = b"portable snapshot"
+    (root / "payload").write_bytes(payload)
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+
+    def blocked(*_args, **_kwargs) -> int:
+        raise OSError(blocked_errno, "memfd blocked")
+
+    monkeypatch.setattr(captured_directory.os, "memfd_create", blocked, raising=False)
+    try:
+        with reader.authenticated_snapshot("payload") as (snapshot, _record):
+            assert snapshot.read() == payload
+            with pytest.raises(RuntimeError, match="no sealed descriptor"):
+                _ = snapshot.descriptor
+    finally:
+        reader.close()
+
+
+def test_authenticated_snapshot_does_not_hide_memfd_resource_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_bytes(b"payload")
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+
+    def exhausted(*_args, **_kwargs) -> int:
+        raise OSError(errno.EMFILE, "descriptor limit")
+
+    monkeypatch.setattr(
+        captured_directory.os,
+        "memfd_create",
+        exhausted,
+        raising=False,
+    )
+    try:
+        with pytest.raises(ValueError, match="copied immutably") as caught:
+            with reader.authenticated_snapshot("payload"):
+                pass
+        assert isinstance(caught.value.__cause__, OSError)
+        assert caught.value.__cause__.errno == errno.EMFILE
+    finally:
+        reader.close()
+
+
+def test_authenticated_snapshot_falls_back_when_sealing_is_blocked_and_closes_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    payload = b"seal fallback"
+    (root / "payload").write_bytes(payload)
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+    created: list[int] = []
+
+    def create_stage() -> int:
+        descriptor = os.open(
+            tmp_path / "snapshot-stage",
+            os.O_RDWR | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        created.append(descriptor)
+        return descriptor
+
+    def blocked_seal(
+        _descriptor: int,
+        command: int,
+        *_args: object,
+    ) -> int:
+        assert command == captured_directory._F_ADD_SEALS
+        raise OSError(errno.EPERM, "sealing blocked")
+
+    monkeypatch.setattr(captured_directory, "_create_sealable_memfd", create_stage)
+    assert captured_directory._fcntl is not None
+    monkeypatch.setattr(captured_directory._fcntl, "fcntl", blocked_seal)
+    try:
+        with reader.authenticated_snapshot("payload") as (snapshot, _record):
+            assert snapshot.read() == payload
+    finally:
+        reader.close()
+
+    assert len(created) == 1
+    with pytest.raises(OSError) as caught:
+        os.fstat(created[0])
+    assert caught.value.errno == errno.EBADF
+
+
+def test_authenticated_snapshot_blocked_memfd_obeys_memory_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_bytes(b"oversized")
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+    source = reader.open_file("payload")
+
+    def blocked(*_args, **_kwargs) -> int:
+        raise OSError(errno.EPERM, "memfd blocked")
+
+    def forbidden_copy(*_args, **_kwargs) -> None:
+        raise AssertionError("oversized fallback copied bytes into memory")
+
+    monkeypatch.setattr(captured_directory.os, "memfd_create", blocked, raising=False)
+    monkeypatch.setattr(captured_directory, "_MAX_IN_MEMORY_SNAPSHOT_BYTES", 1)
+    monkeypatch.setattr(
+        captured_directory.AuthenticatedFile,
+        "_copy_authenticated_from_start",
+        forbidden_copy,
+    )
+    try:
+        with pytest.raises(ValueError, match="fallback limit"):
+            source.immutable_snapshot()
+    finally:
+        source.close()
+        reader.close()
+
+
 @pytest.mark.parametrize("force_memory_fallback", [False, True])
 def test_authenticated_snapshot_rewinds_after_partial_source_read(
     tmp_path: Path,
@@ -1401,6 +1453,56 @@ def test_strict_workspace_create_fails_before_filesystem_mutation(
         OwnedWorkspaceAuthority.create()
 
 
+def test_preopened_workspace_rejects_darwin_before_state_or_resource_acquisition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="4" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+
+        def forbidden(*_args, **_kwargs) -> None:
+            raise AssertionError("Darwin adoption acquired a lifecycle resource")
+
+        with monkeypatch.context() as patch:
+            patch.setattr(captured_directory.sys, "platform", "darwin")
+            patch.setattr(
+                captured_directory,
+                "_open_publication_authority",
+                forbidden,
+            )
+            patch.setattr(
+                captured_directory._CancellationSafeRLock,
+                "run",
+                forbidden,
+            )
+            with pytest.raises(UnsupportedWorkspaceCreation, match="requires Linux"):
+                workspace.adopt(
+                    destination=destination,
+                    stage_name=stage.name,
+                    parent_descriptor=parent_fd,
+                    root_descriptor=root_fd,
+                    directory_descriptors=directories,
+                    plan=plan,
+                    expected_destination=None,
+                )
+
+        assert workspace.state == "empty"
+        assert workspace._destination is None
+        assert workspace._stage_path is None
+        assert workspace._plan is None
+        assert workspace._parent_owner.authority is None
+        assert workspace._resources.closed
+        assert workspace._root_descriptor == -1
+        assert workspace._directory_descriptors == {}
+        os.fstat(parent_fd)
+        os.fstat(root_fd)
+
+
 def test_preopened_workspace_seal_rejects_external_hardlink(
     tmp_path: Path,
 ) -> None:
@@ -1456,6 +1558,7 @@ def test_preopened_workspace_seal_is_idempotently_recoverable(
 
 def test_preopened_workspace_seal_return_interruption_keeps_token_recoverable(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     plan = WorkspacePlan(
         subject_digest="8" * 64,
@@ -1475,16 +1578,22 @@ def test_preopened_workspace_seal_return_interruption_keeps_token_recoverable(
         )
         workspace.write_file("payload", [b"safe"])
 
-        def seal_and_store() -> object:
-            ownership = workspace.seal()
+        real_seal = workspace.seal
+        interruption = KeyboardInterrupt("seal return")
+        interrupted = False
+
+        def seal_then_interrupt() -> object:
+            nonlocal interrupted
+            ownership = real_seal()
+            if not interrupted:
+                interrupted = True
+                raise interruption
             return ownership
 
+        monkeypatch.setattr(workspace, "seal", seal_then_interrupt)
+
         with pytest.raises(KeyboardInterrupt, match="seal return"):
-            _interrupt_before_store(
-                seal_and_store,
-                local_name="ownership",
-                error=KeyboardInterrupt("seal return"),
-            )
+            workspace.seal()
 
         ownership = workspace.seal()
         assert directory_ownership_file_records(ownership)[0].path == "payload"
@@ -1938,6 +2047,104 @@ def test_owned_workspace_publish_installs_fresh_durable_receipt(
         receipt_owner.close()
         assert receipt_owner.closed
         assert receipt.closed
+
+
+def test_owned_workspace_detaches_caller_and_public_plan_mutation(
+    tmp_path: Path,
+) -> None:
+    source_directory = WorkspaceDirectory("nested")
+    source_file = WorkspaceFile("nested/payload", max_bytes=8)
+    plan = WorkspacePlan(
+        subject_digest="3" * 64,
+        directories=(source_directory,),
+        files=(source_file,),
+    )
+    alternate = WorkspacePlan(
+        subject_digest="4" * 64,
+        files=(WorkspaceFile("alternate", max_bytes=8),),
+    )
+    original_digest = plan.digest
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+
+        object.__setattr__(source_directory, "path", PurePosixPath("rebound"))
+        object.__setattr__(source_file, "path", PurePosixPath("rebound/payload"))
+        object.__setattr__(source_file, "max_bytes", 1)
+        object.__setattr__(plan, "subject_digest", alternate.subject_digest)
+        object.__setattr__(plan, "directories", alternate.directories)
+        object.__setattr__(plan, "files", alternate.files)
+        object.__setattr__(plan, "digest", alternate.digest)
+        authority_projection = workspace.plan
+        assert authority_projection.digest == original_digest
+        assert authority_projection.files[0].path.as_posix() == "nested/payload"
+        assert authority_projection.files[0].max_bytes == 8
+
+        object.__setattr__(authority_projection.files[0], "path", PurePosixPath("evil"))
+        object.__setattr__(authority_projection, "files", alternate.files)
+        object.__setattr__(authority_projection, "digest", alternate.digest)
+        assert workspace.plan.digest == original_digest
+        assert workspace.plan.files[0].path.as_posix() == "nested/payload"
+        assert workspace.plan.files[0].max_bytes == 8
+
+        workspace.write_file("nested/payload", [b"durable"])
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+        receipt = receipt_owner.receipt
+        assert receipt.plan_digest == original_digest
+
+        receipt_projection = receipt.plan
+        object.__setattr__(receipt_projection.files[0], "path", PurePosixPath("evil"))
+        object.__setattr__(receipt_projection.files[0], "max_bytes", 1)
+        object.__setattr__(receipt_projection, "directories", ())
+        object.__setattr__(receipt_projection, "digest", alternate.digest)
+        assert receipt.plan_digest == original_digest
+        assert receipt.plan.files[0].path.as_posix() == "nested/payload"
+        assert receipt.plan.files[0].max_bytes == 8
+        assert (
+            receipt_owner.consume(lambda borrowed, _reader: borrowed.plan_digest)
+            == original_digest
+        )
+        receipt_owner.close()
+
+
+def test_owned_workspace_rejects_polluted_plan_before_resource_acquisition(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(subject_digest="5" * 64)
+    object.__setattr__(plan, "files", [])
+    with _preopened_workspace(
+        tmp_path, WorkspacePlan(subject_digest="5" * 64)
+    ) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+
+        with pytest.raises(TypeError, match="exact types"):
+            workspace.adopt(
+                destination=destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_fd,
+                root_descriptor=root_fd,
+                directory_descriptors=directories,
+                plan=plan,
+                expected_destination=None,
+            )
+
+        assert workspace.state == "empty"
+        assert workspace._parent_owner.authority is None
+        assert workspace._resources.closed
+        os.fstat(parent_fd)
+        os.fstat(root_fd)
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
@@ -2462,6 +2669,7 @@ def test_owned_workspace_child_closes_reserved_publication_resources(
 
 def test_owned_workspace_first_transfer_store_interruption_is_reconciled(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     plan = WorkspacePlan(subject_digest="e" * 64)
     with _preopened_workspace(tmp_path, plan) as opened:
@@ -2479,13 +2687,22 @@ def test_owned_workspace_first_transfer_store_interruption_is_reconciled(
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()
 
-        with pytest.raises(SystemExit, match="first transfer store"):
-            _interrupt_after_store_attr(
-                lambda: workspace.publish_into(receipt_owner),
-                target_code=OwnedWorkspaceAuthority._publish_into_locked.__code__,
-                attribute="_publication_transfer",
-                error=SystemExit("first transfer store interruption"),
-            )
+        real_store = OwnedWorkspaceAuthority._store_publication_transfer_locked
+        interruption = SystemExit("first transfer store interruption")
+
+        def store_then_interrupt(self, transfer) -> None:
+            real_store(self, transfer)
+            raise interruption
+
+        monkeypatch.setattr(
+            OwnedWorkspaceAuthority,
+            "_store_publication_transfer_locked",
+            store_then_interrupt,
+        )
+        with pytest.raises(SystemExit, match="first transfer store") as caught:
+            workspace.publish_into(receipt_owner)
+
+        assert caught.value is interruption
 
         assert workspace.state == "closed"
         assert receipt_owner.state == "empty"

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -759,11 +759,13 @@ def test_owned_stage_rejects_root_replacement_before_publish(tmp_path: Path) -> 
 
 def test_authenticated_descriptor_exposes_only_a_sealed_good_snapshot(
     tmp_path: Path,
+    filesystem_ctime_tick,
 ) -> None:
     root = tmp_path / "root"
     root.mkdir()
     source = root / "payload"
     source.write_bytes(b"GOOD")
+    captured_ctime_ns = source.stat().st_ctime_ns
     reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
     observed = b""
 
@@ -774,6 +776,7 @@ def test_authenticated_descriptor_exposes_only_a_sealed_good_snapshot(
                 record,
             ):
                 assert record.size == 4
+                filesystem_ctime_tick(captured_ctime_ns)
                 source.write_bytes(b"EVIL")
                 os.lseek(descriptor, 0, os.SEEK_SET)
                 observed = os.read(descriptor, 4)
@@ -808,6 +811,41 @@ def test_authenticated_snapshot_has_bounded_immutable_bytes_fallback(
             with pytest.raises(RuntimeError, match="no sealed descriptor"):
                 _ = snapshot.descriptor
     finally:
+        reader.close()
+
+
+@pytest.mark.parametrize("force_memory_fallback", [False, True])
+def test_authenticated_snapshot_rewinds_after_partial_source_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    force_memory_fallback: bool,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    payload = b"abcdef"
+    (root / "payload").write_bytes(payload)
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+    source = reader.open_file("payload", max_bytes=len(payload))
+
+    if force_memory_fallback:
+
+        def unavailable() -> int:
+            raise captured_directory._SnapshotUnavailable("unsupported host")
+
+        monkeypatch.setattr(
+            captured_directory,
+            "_create_sealable_memfd",
+            unavailable,
+        )
+
+    try:
+        assert source.read(2) == b"ab"
+        with source.immutable_snapshot() as snapshot:
+            assert snapshot.record.size == len(payload)
+            assert snapshot.read() == payload
+        source.verify_unchanged()
+    finally:
+        source.close()
         reader.close()
 
 
@@ -1058,6 +1096,72 @@ def test_workspace_plan_is_canonical_and_bound_to_its_subject() -> None:
         ).digest
         != first.digest
     )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX surrogateescape")
+def test_workspace_plan_and_publication_preserve_raw_filesystem_paths(
+    tmp_path: Path,
+) -> None:
+    raw_name = os.fsdecode(b"payload-\xff.bin")
+    plan = WorkspacePlan(
+        subject_digest="c" * 64,
+        files=(WorkspaceFile(raw_name, max_bytes=3),),
+    )
+    same_plan = WorkspacePlan(
+        subject_digest="c" * 64,
+        files=(WorkspaceFile(PurePosixPath(raw_name), max_bytes=3),),
+    )
+
+    assert plan.digest == same_plan.digest
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file(raw_name, [b"raw"])
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+
+        assert os.fsencode(next(destination.iterdir()).name) == os.fsencode(raw_name)
+        assert (
+            receipt_owner.consume(
+                lambda _receipt, reader: reader.read_bytes(raw_name, max_bytes=3)
+            )
+            == b"raw"
+        )
+        receipt_owner.close()
+
+
+@pytest.mark.parametrize(
+    ("limit_name", "limit"),
+    [
+        ("_MAX_OWNERSHIP_ENTRIES", 1),
+        ("_MAX_OWNERSHIP_METADATA_BYTES", 1),
+    ],
+)
+def test_workspace_plan_uses_exact_ownership_scanner_budgets(
+    monkeypatch: pytest.MonkeyPatch,
+    limit_name: str,
+    limit: int,
+) -> None:
+    monkeypatch.setattr(atomic_directory, limit_name, limit)
+
+    with pytest.raises(ValueError, match="ownership scanner budget"):
+        WorkspacePlan(
+            subject_digest="d" * 64,
+            files=(
+                WorkspaceFile("first", max_bytes=1),
+                WorkspaceFile("second", max_bytes=1),
+            ),
+        )
 
 
 @pytest.mark.parametrize(

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -4,10 +4,17 @@
 
 from __future__ import annotations
 
+import dis
+import errno
+import os
+import signal
 import stat
 import sys
+import threading
+from contextlib import contextmanager
 from dataclasses import replace
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from typing import Callable, Iterator
 
 import pytest
 
@@ -18,7 +25,127 @@ from codenib._atomic_directory import (
     capture_directory_ownership,
     directory_ownership_file_records,
 )
-from codenib._captured_directory import CapturedDirectoryReader, OwnedDirectoryStage
+from codenib._captured_directory import (
+    AuthenticatedSnapshotReader,
+    CapturedDirectoryReader,
+    OwnedDirectoryStage,
+    OwnedWorkspaceAuthority,
+    PublishedWorkspaceReceipt,
+    PublishedWorkspaceReceiptOwner,
+    UnsupportedWorkspaceCreation,
+    WorkspaceDirectory,
+    WorkspaceFile,
+    WorkspacePlan,
+)
+
+
+@contextmanager
+def _preopened_workspace(
+    tmp_path: Path,
+    plan: WorkspacePlan,
+) -> Iterator[tuple[Path, Path, int, int, dict[str, int]]]:
+    parent = tmp_path / "workspace-parent"
+    parent.mkdir(mode=0o700)
+    destination = parent / "destination"
+    stage = parent / "trusted-stage"
+    stage.mkdir(mode=plan.root_mode)
+    for item in plan.directories:
+        (stage / item.path.as_posix()).mkdir(mode=item.mode)
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_descriptor = os.open(parent, flags)
+    root_descriptor = os.open(stage, flags)
+    directories = {
+        item.path.as_posix(): os.open(stage / item.path.as_posix(), flags)
+        for item in plan.directories
+    }
+    try:
+        yield (
+            destination,
+            stage,
+            parent_descriptor,
+            root_descriptor,
+            directories,
+        )
+    finally:
+        for descriptor in directories.values():
+            os.close(descriptor)
+        os.close(root_descriptor)
+        os.close(parent_descriptor)
+
+
+def _interrupt_before_store(
+    callback: Callable[[], object],
+    *,
+    local_name: str,
+    error: BaseException,
+) -> None:
+    target_code = callback.__code__
+    instructions = {
+        instruction.offset: instruction
+        for instruction in dis.get_instructions(target_code)
+    }
+    previous_trace = sys.gettrace()
+
+    def trace(frame, event, _arg):
+        if event == "call" and frame.f_code is target_code:
+            frame.f_trace_opcodes = True
+            return trace
+        if event == "opcode" and frame.f_code is target_code:
+            instruction = instructions.get(frame.f_lasti)
+            if (
+                instruction is not None
+                and instruction.opname == "STORE_FAST"
+                and instruction.argval == local_name
+            ):
+                sys.settrace(None)
+                raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+
+
+def _interrupt_after_store_attr(
+    callback: Callable[[], object],
+    *,
+    target_code: object,
+    attribute: str,
+    error: BaseException,
+) -> None:
+    instructions = {
+        instruction.offset: instruction
+        for instruction in dis.get_instructions(target_code)
+    }
+    previous_trace = sys.gettrace()
+    armed = False
+
+    def trace(frame, event, _arg):
+        nonlocal armed
+        if event == "call" and frame.f_code is target_code:
+            frame.f_trace_opcodes = True
+            return trace
+        if event == "opcode" and frame.f_code is target_code:
+            if armed:
+                sys.settrace(None)
+                raise error
+            instruction = instructions.get(frame.f_lasti)
+            if (
+                instruction is not None
+                and instruction.opname == "STORE_ATTR"
+                and instruction.argval == attribute
+            ):
+                armed = True
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
 
 
 def _as_windows_ownership(ownership: object) -> object:
@@ -628,3 +755,1776 @@ def test_owned_stage_rejects_root_replacement_before_publish(tmp_path: Path) -> 
     assert not destination.exists()
     assert (stolen / "payload").read_bytes() == b"owned bytes"
     assert (stage.path / "foreign").read_bytes() == b"foreign"
+
+
+def test_authenticated_descriptor_exposes_only_a_sealed_good_snapshot(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / "payload"
+    source.write_bytes(b"GOOD")
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+    observed = b""
+
+    try:
+        with pytest.raises(ValueError, match="changed after authentication"):
+            with reader.authenticated_descriptor("payload", max_bytes=4) as (
+                descriptor,
+                record,
+            ):
+                assert record.size == 4
+                source.write_bytes(b"EVIL")
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                observed = os.read(descriptor, 4)
+                with pytest.raises(OSError):
+                    os.write(descriptor, b"FAIL")
+    finally:
+        reader.close()
+
+    assert observed == b"GOOD"
+
+
+def test_authenticated_snapshot_has_bounded_immutable_bytes_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._captured_directory as captured_directory
+
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_bytes(b"first\nsecond")
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+
+    def unavailable() -> int:
+        raise captured_directory._SnapshotUnavailable("unsupported host")
+
+    monkeypatch.setattr(captured_directory, "_create_sealable_memfd", unavailable)
+    try:
+        with reader.authenticated_snapshot("payload") as (snapshot, record):
+            assert record.size == 12
+            assert snapshot.readline() == b"first\n"
+            assert snapshot.read() == b"second"
+            with pytest.raises(RuntimeError, match="no sealed descriptor"):
+                _ = snapshot.descriptor
+    finally:
+        reader.close()
+
+
+def test_authenticated_snapshot_reader_caps_oversized_requests(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    payload = b"x" * (8 * 1024 * 1024 + 17)
+    (root / "payload").write_bytes(payload)
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+
+    try:
+        with reader.authenticated_snapshot("payload") as (snapshot, _record):
+            source = AuthenticatedSnapshotReader(snapshot)
+            first = source.read(1 << 60)
+            second = source.read(1 << 60)
+            assert len(first) == 8 * 1024 * 1024
+            assert first + second == payload
+            assert source.read(1 << 60) == b""
+        with reader.authenticated_snapshot("payload") as (snapshot, _record):
+            source = AuthenticatedSnapshotReader(snapshot)
+            assert len(source.readline(1 << 60)) == 8 * 1024 * 1024
+    finally:
+        reader.close()
+
+
+def test_owned_stage_noreplace_never_overwrites_raced_foreign_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stage = OwnedDirectoryStage(tmp_path / "destination")
+    valuable = tmp_path / "valuable"
+    valuable.write_bytes(b"foreign")
+    real_rename = captured_directory._rename_noreplace_at
+
+    def race_rename(source, destination, src_dir_fd, dst_dir_fd) -> None:
+        valuable.rename(stage.path / destination)
+        real_rename(
+            source,
+            destination,
+            src_dir_fd,
+            dst_dir_fd,
+        )
+
+    monkeypatch.setattr(captured_directory, "_rename_noreplace_at", race_rename)
+    try:
+        with pytest.raises(ValueError, match="already exists"):
+            stage.write_file("payload", [b"new"])
+        assert (stage.path / "payload").read_bytes() == b"foreign"
+    finally:
+        stage.close()
+
+
+def test_owned_stage_does_not_reacquire_foreign_nested_directory(
+    tmp_path: Path,
+) -> None:
+    stage = OwnedDirectoryStage(tmp_path / "destination")
+    foreign = stage.path / "nested"
+    foreign.mkdir()
+    try:
+        with pytest.raises(ValueError, match="was not created here"):
+            stage.write_file("nested/payload", [b"new"])
+        assert not (foreign / "payload").exists()
+    finally:
+        stage.close()
+
+
+def test_owned_stage_rejects_preexisting_ancestor_symlink(tmp_path: Path) -> None:
+    foreign = tmp_path / "foreign"
+    parent = foreign / "parent"
+    parent.mkdir(parents=True)
+    valuable = parent / "valuable.txt"
+    valuable.write_text("preserve", encoding="utf-8")
+    trusted = tmp_path / "trusted"
+    trusted.mkdir()
+    (trusted / "alias").symlink_to(foreign, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="real directory"):
+        OwnedDirectoryStage(trusted / "alias" / "parent" / "published")
+
+    assert valuable.read_text(encoding="utf-8") == "preserve"
+    assert not list(parent.glob(".*.normalize-*"))
+
+
+def test_owned_stage_prepare_creates_nested_parent_and_publishes(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "new" / "nested" / "published"
+    stage = OwnedDirectoryStage.prepare(
+        destination,
+        required_destination_file="marker.txt",
+        allow_empty_destination=True,
+    )
+    stage.write_file("marker.txt", [b"owned"])
+
+    stage.publish()
+
+    assert (destination / "marker.txt").read_bytes() == b"owned"
+
+
+def test_owned_stage_prepare_rejects_parent_replacement_before_write(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "parent" / "published"
+    stage = OwnedDirectoryStage.prepare(destination)
+    saved = tmp_path / "saved-parent"
+    destination.parent.rename(saved)
+    destination.parent.mkdir()
+    valuable = destination.parent / "valuable.txt"
+    valuable.write_text("preserve", encoding="utf-8")
+    try:
+        with pytest.raises(RuntimeError, match="parent path changed"):
+            stage.write_file("marker.txt", [b"owned"])
+        assert valuable.read_text(encoding="utf-8") == "preserve"
+        assert not (destination.parent / "marker.txt").exists()
+    finally:
+        stage.close()
+
+
+def test_owned_stage_prepare_keeps_pinned_parent_across_reversible_swap(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "parent" / "published"
+    stage = OwnedDirectoryStage.prepare(destination)
+    saved = tmp_path / "saved-parent"
+    destination.parent.rename(saved)
+    destination.parent.mkdir()
+    valuable = destination.parent / "valuable.txt"
+    valuable.write_text("preserve", encoding="utf-8")
+    foreign = tmp_path / "foreign-parent"
+    destination.parent.rename(foreign)
+    saved.rename(destination.parent)
+    try:
+        stage.write_file("marker.txt", [b"owned"])
+        stage.publish()
+        assert (destination / "marker.txt").read_bytes() == b"owned"
+        assert (foreign / "valuable.txt").read_text(encoding="utf-8") == "preserve"
+    finally:
+        stage.close()
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs")
+def test_owned_stage_closes_parent_fd_when_iterator_creation_fails(
+    tmp_path: Path,
+) -> None:
+    class RaisingIterable:
+        def __iter__(self):
+            raise RuntimeError("iterator creation failed")
+
+    stage = OwnedDirectoryStage(tmp_path / "destination")
+    baseline = len(list(Path("/proc/self/fd").iterdir()))
+    try:
+        with pytest.raises(RuntimeError, match="iterator creation failed"):
+            stage.write_file("payload", RaisingIterable())
+        assert len(list(Path("/proc/self/fd").iterdir())) == baseline
+    finally:
+        stage.close()
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs")
+def test_owned_stage_closes_all_fds_when_iterator_close_fails(tmp_path: Path) -> None:
+    class RaisingCloseIterator:
+        yielded = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            if self.yielded:
+                raise StopIteration
+            self.yielded = True
+            return b"new"
+
+        def close(self) -> None:
+            raise RuntimeError("iterator close failed")
+
+    stage = OwnedDirectoryStage(tmp_path / "destination")
+    baseline = len(list(Path("/proc/self/fd").iterdir()))
+    try:
+        with pytest.raises(RuntimeError, match="iterator close failed"):
+            stage.write_file("payload", RaisingCloseIterator())
+        assert len(list(Path("/proc/self/fd").iterdir())) == baseline
+        assert (stage.path / "payload").read_bytes() == b"new"
+    finally:
+        stage.close()
+
+
+def test_owned_stage_rejects_root_swap_between_capture_and_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_open = captured_directory.os.open
+    swapped: dict[str, str] = {}
+
+    def race_open(path, flags, mode=0o777, *, dir_fd=None):
+        if (
+            not swapped
+            and dir_fd is not None
+            and isinstance(path, str)
+            and ".normalize-" in path
+            and flags & os.O_DIRECTORY
+        ):
+            stolen = f"{path}.stolen"
+            os.rename(path, stolen, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+            os.mkdir(path, mode=0o700, dir_fd=dir_fd)
+            swapped.update(active=path, stolen=stolen)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(captured_directory.os, "open", race_open)
+    with pytest.raises(RuntimeError, match="root changed"):
+        OwnedDirectoryStage(tmp_path / "destination")
+
+    assert swapped
+    assert (tmp_path / swapped["active"]).is_dir()
+    assert (tmp_path / swapped["stolen"]).is_dir()
+
+
+def test_workspace_plan_is_canonical_and_bound_to_its_subject() -> None:
+    first = WorkspacePlan(
+        subject_digest="a" * 64,
+        directories=(
+            WorkspaceDirectory("nested/deeper"),
+            WorkspaceDirectory("nested"),
+        ),
+        files=(
+            WorkspaceFile("root.bin", max_bytes=8),
+            WorkspaceFile("nested/deeper/payload.bin", mode=0o644, max_bytes=16),
+        ),
+    )
+    second = WorkspacePlan(
+        subject_digest="a" * 64,
+        directories=(
+            WorkspaceDirectory("nested"),
+            WorkspaceDirectory("nested/deeper"),
+        ),
+        files=tuple(reversed(first.files)),
+    )
+
+    assert first == second
+    assert first.digest == second.digest
+    assert len(first.digest) == 64
+    assert (
+        WorkspacePlan(
+            subject_digest="b" * 64,
+            directories=first.directories,
+            files=first.files,
+        ).digest
+        != first.digest
+    )
+
+
+@pytest.mark.parametrize(
+    ("directories", "files", "message"),
+    [
+        ((), (WorkspaceFile("nested/payload", max_bytes=1),), "ancestor"),
+        (
+            (WorkspaceDirectory("A"), WorkspaceDirectory("a")),
+            (),
+            "portable path collision",
+        ),
+        (
+            (WorkspaceDirectory("entry"),),
+            (WorkspaceFile("entry", max_bytes=1),),
+            "both file and directory",
+        ),
+    ],
+)
+def test_workspace_plan_rejects_ambiguous_skeletons(
+    directories: tuple[WorkspaceDirectory, ...],
+    files: tuple[WorkspaceFile, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        WorkspacePlan(
+            subject_digest="c" * 64,
+            directories=directories,
+            files=files,
+        )
+
+
+def test_preopened_workspace_writes_only_planned_files_without_mkdir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="d" * 64,
+        directories=(WorkspaceDirectory("nested"),),
+        files=(
+            WorkspaceFile("root.bin", max_bytes=4),
+            WorkspaceFile("nested/payload.bin", mode=0o644, max_bytes=8),
+        ),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        os.lseek(parent_fd, 37, os.SEEK_SET)
+        os.lseek(root_fd, 37, os.SEEK_SET)
+        workspace = OwnedWorkspaceAuthority()
+
+        def forbidden_mkdir(*_args, **_kwargs) -> None:
+            raise AssertionError("strict workspace runtime must not create directories")
+
+        monkeypatch.setattr(captured_directory.os, "mkdir", forbidden_mkdir)
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("root.bin", [b"root"])
+        workspace.write_file("nested/payload.bin", [b"payload"])
+        ownership = workspace.seal()
+
+        assert directory_ownership_file_records(ownership) == (
+            atomic_directory.TreeFileRecord(
+                path="nested/payload.bin",
+                mode=0o644,
+                size=7,
+                sha256=(
+                    "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5"
+                ),
+            ),
+            atomic_directory.TreeFileRecord(
+                path="root.bin",
+                mode=0o600,
+                size=4,
+                sha256=(
+                    "4813494d137e1631bba301d5acab6e7bb7aa74ce1185d456565ef51d737677b2"
+                ),
+            ),
+        )
+        assert os.lseek(parent_fd, 0, os.SEEK_CUR) == 37
+        assert os.lseek(root_fd, 0, os.SEEK_CUR) == 37
+        assert (stage / "nested" / "payload.bin").read_bytes() == b"payload"
+        workspace.close()
+        os.fstat(parent_fd)
+        os.fstat(root_fd)
+
+
+def test_preopened_workspace_rejects_root_name_replacement(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="e" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        saved = stage.with_name("saved-stage")
+        stage.rename(saved)
+        stage.mkdir(mode=0o700)
+        workspace = OwnedWorkspaceAuthority()
+
+        with pytest.raises(RuntimeError, match="root handle"):
+            workspace.adopt(
+                destination=destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_fd,
+                root_descriptor=root_fd,
+                directory_descriptors=directories,
+                plan=plan,
+                expected_destination=None,
+            )
+
+        assert not (stage / "payload").exists()
+        os.fstat(root_fd)
+
+
+def test_preopened_workspace_rejects_nested_handle_replacement(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="f" * 64,
+        directories=(WorkspaceDirectory("nested"),),
+        files=(WorkspaceFile("nested/payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        nested = stage / "nested"
+        saved = tmp_path / "saved-nested"
+        nested.rename(saved)
+        nested.mkdir(mode=0o700)
+        workspace = OwnedWorkspaceAuthority()
+
+        with pytest.raises(RuntimeError, match="directory handle differs"):
+            workspace.adopt(
+                destination=destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_fd,
+                root_descriptor=root_fd,
+                directory_descriptors=directories,
+                plan=plan,
+                expected_destination=None,
+            )
+
+        assert not (nested / "payload").exists()
+
+
+def test_preopened_workspace_rejects_any_unplanned_skeleton_file(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="1" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        (stage / "foreign").write_bytes(b"preserve")
+        workspace = OwnedWorkspaceAuthority()
+
+        with pytest.raises(ValueError, match="contain no files"):
+            workspace.adopt(
+                destination=destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_fd,
+                root_descriptor=root_fd,
+                directory_descriptors=directories,
+                plan=plan,
+                expected_destination=None,
+            )
+
+        assert (stage / "foreign").read_bytes() == b"preserve"
+
+
+def test_preopened_workspace_rejects_existing_destination_when_missing_expected(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="2" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        destination.mkdir(mode=0o700)
+        workspace = OwnedWorkspaceAuthority()
+
+        with pytest.raises(RuntimeError, match="expected missing"):
+            workspace.adopt(
+                destination=destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_fd,
+                root_descriptor=root_fd,
+                directory_descriptors=directories,
+                plan=plan,
+                expected_destination=None,
+            )
+
+
+def test_preopened_workspace_noreplace_refuses_foreign_planned_leaf(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="3" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        (stage / "payload").write_bytes(b"evil")
+
+        with pytest.raises(RuntimeError, match="unplanned file"):
+            workspace.write_file("payload", [b"good"])
+
+        assert (stage / "payload").read_bytes() == b"evil"
+
+
+def test_strict_workspace_create_fails_before_filesystem_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden_mkdir(*_args, **_kwargs) -> None:
+        raise AssertionError("strict create must fail before mutation")
+
+    monkeypatch.setattr(captured_directory.os, "mkdir", forbidden_mkdir)
+    with pytest.raises(UnsupportedWorkspaceCreation, match="pre-opened skeleton"):
+        OwnedWorkspaceAuthority.create()
+
+
+def test_preopened_workspace_seal_rejects_external_hardlink(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="4" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"safe"])
+        os.link(stage / "payload", tmp_path / "external-alias")
+
+        with pytest.raises(RuntimeError, match="file changed"):
+            workspace.seal()
+
+
+def test_preopened_workspace_seal_is_idempotently_recoverable(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="5" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"safe"])
+
+        ownership = workspace.seal()
+
+        assert workspace.seal() is ownership
+        workspace.close()
+
+
+def test_preopened_workspace_seal_return_interruption_keeps_token_recoverable(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="8" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"safe"])
+
+        def seal_and_store() -> object:
+            ownership = workspace.seal()
+            return ownership
+
+        with pytest.raises(KeyboardInterrupt, match="seal return"):
+            _interrupt_before_store(
+                seal_and_store,
+                local_name="ownership",
+                error=KeyboardInterrupt("seal return"),
+            )
+
+        ownership = workspace.seal()
+        assert directory_ownership_file_records(ownership)[0].path == "payload"
+        workspace.close()
+
+
+def test_preopened_workspace_rejects_producer_reentrant_close(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="6" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+
+        def chunks() -> Iterator[bytes]:
+            with pytest.raises(RuntimeError, match="close is reentrant"):
+                workspace.close()
+            yield b"safe"
+
+        workspace.write_file("payload", chunks())
+        workspace.seal()
+        assert (stage / "payload").read_bytes() == b"safe"
+        workspace.close()
+
+
+def test_preopened_workspace_retains_file_owner_after_persistent_close_eio(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="7" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        real_close = os.close
+        retained: set[int] = set()
+
+        def persistent_file_eio(descriptor: int) -> None:
+            metadata = os.fstat(descriptor)
+            if stat.S_ISREG(metadata.st_mode):
+                retained.add(descriptor)
+                raise OSError(errno.EIO, "persistent file close failure")
+            real_close(descriptor)
+
+        monkeypatch.setattr(captured_directory.os, "close", persistent_file_eio)
+        with pytest.raises(OSError, match="persistent file close failure"):
+            workspace.write_file("payload", [b"safe"])
+
+        assert retained
+        descriptor = next(iter(retained))
+        os.fstat(descriptor)
+        assert workspace.state == "failed"
+
+        monkeypatch.setattr(captured_directory.os, "close", real_close)
+        workspace.close()
+        with pytest.raises(OSError):
+            os.fstat(descriptor)
+
+
+def test_preopened_workspace_close_reconciliation_preserves_first_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="9" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        real_close = os.close
+        armed = [False]
+
+        def persistent_file_eio(descriptor: int) -> None:
+            if stat.S_ISREG(os.fstat(descriptor).st_mode):
+                armed[0] = True
+                raise OSError(errno.EIO, "first file close failure")
+            real_close(descriptor)
+
+        owner_type = type(workspace._resources)
+        real_closed = owner_type.closed
+
+        def interrupted_reconciliation(owner) -> bool:
+            if armed[0] and owner is workspace._resources:
+                raise SystemExit("secondary close-state interruption")
+            return real_closed.fget(owner)
+
+        monkeypatch.setattr(captured_directory.os, "close", persistent_file_eio)
+        monkeypatch.setattr(
+            owner_type,
+            "closed",
+            property(interrupted_reconciliation),
+        )
+        with pytest.raises(OSError, match="first file close failure") as caught:
+            workspace.write_file("payload", [b"safe"])
+
+        assert not isinstance(caught.value, SystemExit)
+        assert workspace.state == "failed"
+
+        monkeypatch.setattr(owner_type, "closed", real_closed)
+        monkeypatch.setattr(captured_directory.os, "close", real_close)
+        workspace.close()
+
+
+def test_preopened_workspace_iterator_close_lookup_preserves_primary_and_fds(
+    tmp_path: Path,
+) -> None:
+    class RaisingCloseLookup:
+        yielded = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            if not self.yielded:
+                self.yielded = True
+                return b"x"
+            raise RuntimeError("producer primary")
+
+        @property
+        def close(self):
+            raise SystemExit("close lookup cancellation")
+
+    plan = WorkspacePlan(
+        subject_digest="0" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        with pytest.raises(RuntimeError, match="producer primary") as caught:
+            workspace.write_file("payload", RaisingCloseLookup())
+
+        assert any(
+            "close lookup cancellation" in note
+            for note in tuple(getattr(caught.value, "__notes__", ()))
+            + tuple(getattr(caught.value, "_codenib_cleanup_notes", ()))
+        )
+        assert all(record.owner.descriptor < 0 for record in workspace._file_owners)
+        assert workspace.state == "closed"
+        assert (stage / "payload").read_bytes() == b"x"
+
+
+def test_preopened_workspace_record_install_interruption_terminally_fails(
+    tmp_path: Path,
+) -> None:
+    class InterruptingRecords(dict):
+        def __setitem__(self, key, value) -> None:
+            super().__setitem__(key, value)
+            raise KeyboardInterrupt("record install interruption")
+
+    plan = WorkspacePlan(
+        subject_digest="a" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace._written_files = InterruptingRecords()
+
+        with pytest.raises(KeyboardInterrupt, match="record install interruption"):
+            workspace.write_file("payload", [b"safe"])
+
+        assert workspace.state == "closed"
+        assert (stage / "payload").read_bytes() == b"safe"
+        with pytest.raises(RuntimeError, match="cannot seal while closed"):
+            workspace.seal()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_owned_workspace_child_closes_inherited_resources_without_parent_effect(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="f" * 64,
+        directories=(WorkspaceDirectory("nested"),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        authority = workspace._parent_owner.authority
+        assert authority is not None
+        workspace_descriptors = {
+            authority._resource,
+            *(record.descriptor for record in workspace._resources._records),
+        }
+        workspace_descriptors.discard(-1)
+
+        lock_acquired = threading.Event()
+        release_lock = threading.Event()
+
+        def hold_lifecycle_lock() -> None:
+            def wait_for_release() -> None:
+                lock_acquired.set()
+                assert release_lock.wait(timeout=5)
+
+            workspace._lock.run(wait_for_release)
+
+        holder = threading.Thread(target=hold_lifecycle_lock)
+        holder.start()
+        assert lock_acquired.wait(timeout=5)
+        child = os.fork()
+        if child == 0:  # pragma: no branch - assertions report through exit code
+            signal.signal(signal.SIGALRM, lambda *_args: os._exit(90))
+            signal.alarm(3)
+            real_close = os.close
+            target_descriptor = workspace._root_descriptor
+            target_barrier = threading.Barrier(2)
+            target_close_calls: list[int] = []
+            close_errors: list[BaseException] = []
+
+            def counted_close(descriptor: int) -> None:
+                if descriptor == target_descriptor:
+                    try:
+                        target_barrier.wait(timeout=0.25)
+                    except threading.BrokenBarrierError:
+                        pass
+                    target_close_calls.append(descriptor)
+                real_close(descriptor)
+
+            captured_directory.os.close = counted_close
+
+            def close_in_child() -> None:
+                try:
+                    workspace.close()
+                except RuntimeError as exc:
+                    if "PID boundary" not in str(exc):
+                        close_errors.append(exc)
+                except BaseException as exc:  # noqa: B036 - child reports failure
+                    close_errors.append(exc)
+                else:
+                    close_errors.append(AssertionError("PID boundary was accepted"))
+
+            closers = [threading.Thread(target=close_in_child) for _ in range(2)]
+            for closer in closers:
+                closer.start()
+            for closer in closers:
+                closer.join(timeout=2)
+            if any(closer.is_alive() for closer in closers):
+                os._exit(91)
+            if close_errors:
+                os._exit(92)
+            if target_close_calls != [target_descriptor]:
+                os._exit(95)
+            try:
+                for descriptor in workspace_descriptors:
+                    try:
+                        os.fstat(descriptor)
+                    except OSError as exc:
+                        if exc.errno != errno.EBADF:
+                            os._exit(93)
+                    else:
+                        os._exit(94)
+            except BaseException:  # noqa: B036 - child reports exact failure
+                os._exit(96)
+            os._exit(0)
+
+        release_lock.set()
+        holder.join(timeout=5)
+        assert not holder.is_alive()
+        _pid, status = os.waitpid(child, 0)
+        assert os.WIFEXITED(status)
+        assert os.WEXITSTATUS(status) == 0
+        for descriptor in workspace_descriptors:
+            os.fstat(descriptor)
+        workspace.close()
+
+
+def test_owned_workspace_adopt_skeleton_validation_is_linear(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    count = 64
+    plan = WorkspacePlan(
+        subject_digest="1" * 64,
+        directories=tuple(
+            WorkspaceDirectory(f"directory-{index:03d}") for index in range(count)
+        ),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        calls = 0
+        real_as_posix = PurePosixPath.as_posix
+
+        def counted_as_posix(path: PurePosixPath) -> str:
+            nonlocal calls
+            calls += 1
+            return real_as_posix(path)
+
+        monkeypatch.setattr(PurePosixPath, "as_posix", counted_as_posix)
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+
+        assert count <= calls < count * 20
+        workspace.close()
+
+
+def test_owned_workspace_seal_flushes_directories_bottom_up(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="2" * 64,
+        directories=(
+            WorkspaceDirectory("nested"),
+            WorkspaceDirectory("nested/deeper"),
+        ),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        descriptor_paths = {
+            descriptor: path
+            for path, descriptor in workspace._directory_descriptors.items()
+        }
+        observed: list[str] = []
+        real_fsync = captured_directory.os.fsync
+
+        def record_fsync(descriptor: int) -> None:
+            path = descriptor_paths.get(descriptor)
+            if path is not None:
+                observed.append(path)
+            real_fsync(descriptor)
+
+        monkeypatch.setattr(captured_directory.os, "fsync", record_fsync)
+
+        workspace.seal()
+
+        assert observed == ["nested/deeper", "nested", ""]
+        workspace.close()
+
+
+def test_owned_workspace_publish_installs_fresh_durable_receipt(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="3" * 64,
+        files=(WorkspaceFile("payload", max_bytes=8),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"durable"])
+        sealed = workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        workspace.publish_into(receipt_owner)
+
+        receipt = receipt_owner.receipt
+        assert isinstance(receipt, PublishedWorkspaceReceipt)
+        assert receipt.durable is True
+        assert receipt.plan_digest == plan.digest
+        assert receipt.sealed_ownership == sealed
+        assert receipt.ownership == capture_directory_ownership(destination)
+        assert receipt.ownership != sealed
+        assert not stage.exists()
+        assert (destination / "payload").read_bytes() == b"durable"
+        assert receipt_owner.consume(
+            lambda borrowed, reader: (
+                borrowed.plan_digest,
+                reader.read_bytes("payload", max_bytes=8),
+            )
+        ) == (plan.digest, b"durable")
+        with pytest.raises(RuntimeError, match="ReceiptOwner"):
+            workspace.close()
+        receipt_owner.close()
+        assert receipt_owner.closed
+        assert receipt.closed
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_published_workspace_child_closes_transfer_without_parent_effect(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(subject_digest="3" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+        authority = workspace._parent_owner.authority
+        assert authority is not None
+        internal_descriptors = {
+            authority.resource,
+            *(record.descriptor for record in workspace._resources._records),
+        }
+        internal_descriptors.discard(-1)
+
+        child = os.fork()
+        if child == 0:  # pragma: no branch - exact child result via exit
+            signal.signal(signal.SIGALRM, lambda *_signal_args: os._exit(70))
+            signal.alarm(3)
+            failures: list[BaseException] = []
+            target_descriptor = workspace._root_descriptor
+            target_barrier = threading.Barrier(2)
+            target_close_calls: list[int] = []
+            real_close = os.close
+
+            def counted_close(descriptor: int) -> None:
+                if descriptor == target_descriptor:
+                    try:
+                        target_barrier.wait(timeout=0.25)
+                    except threading.BrokenBarrierError:
+                        pass
+                    target_close_calls.append(descriptor)
+                real_close(descriptor)
+
+            captured_directory.os.close = counted_close
+
+            def close_in_child() -> None:
+                try:
+                    receipt_owner.close()
+                except RuntimeError as exc:
+                    if "PID boundary" not in str(exc):
+                        failures.append(exc)
+                except BaseException as exc:  # noqa: B036 - child report
+                    failures.append(exc)
+                else:
+                    failures.append(AssertionError("PID boundary was accepted"))
+
+            closers = [threading.Thread(target=close_in_child) for _ in range(2)]
+            for closer in closers:
+                closer.start()
+            for closer in closers:
+                closer.join(timeout=2)
+            if any(closer.is_alive() for closer in closers):
+                os._exit(71)
+            if failures:
+                os._exit(72)
+            if target_close_calls != [target_descriptor]:
+                os._exit(75)
+            for descriptor in internal_descriptors:
+                try:
+                    os.fstat(descriptor)
+                except OSError as exc:
+                    if exc.errno != errno.EBADF:
+                        os._exit(73)
+                else:
+                    os._exit(74)
+            os._exit(0)
+
+        _pid, status = os.waitpid(child, 0)
+        assert os.WIFEXITED(status)
+        assert os.WEXITSTATUS(status) == 0
+        for descriptor in internal_descriptors:
+            os.fstat(descriptor)
+        assert receipt_owner.active
+        receipt_owner.close()
+
+
+def test_owned_workspace_publish_reserves_transfer_before_atomic_helper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="4" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        real_publish = captured_directory._publish_staged_directory_with_authority
+        observed: list[tuple[str, bool]] = []
+
+        def inspect_reservation(*args, **kwargs):
+            observed.append((receipt_owner.state, workspace._resources_transferred))
+            return real_publish(*args, **kwargs)
+
+        monkeypatch.setattr(
+            captured_directory,
+            "_publish_staged_directory_with_authority",
+            inspect_reservation,
+        )
+
+        workspace.publish_into(receipt_owner)
+
+        assert observed == [("reserved", True)]
+        receipt_owner.close()
+
+
+def test_owned_workspace_install_after_store_interruption_keeps_active_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="5" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"safe"])
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        real_install = PublishedWorkspaceReceiptOwner._install
+
+        def install_then_interrupt(self, reservation, receipt) -> None:
+            real_install(self, reservation, receipt)
+            raise KeyboardInterrupt("receipt install return interruption")
+
+        monkeypatch.setattr(
+            PublishedWorkspaceReceiptOwner,
+            "_install",
+            install_then_interrupt,
+        )
+
+        with pytest.raises(KeyboardInterrupt, match="install return"):
+            workspace.publish_into(receipt_owner)
+
+        assert receipt_owner.active
+        assert workspace.state == "published"
+        assert (
+            receipt_owner.consume(
+                lambda _receipt, reader: reader.read_bytes("payload", max_bytes=4)
+            )
+            == b"safe"
+        )
+        receipt_owner.close()
+
+
+def test_owned_workspace_parent_fsync_failure_installs_no_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="6" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        authority = workspace._parent_owner.authority
+        assert authority is not None
+        target = authority.resource
+        real_fsync = captured_directory.os.fsync
+
+        def fail_parent_fsync(descriptor: int) -> None:
+            if descriptor == target:
+                raise OSError(errno.EIO, "parent fsync failed")
+            real_fsync(descriptor)
+
+        monkeypatch.setattr(captured_directory.os, "fsync", fail_parent_fsync)
+
+        with pytest.raises(OSError, match="parent fsync failed"):
+            workspace.publish_into(receipt_owner)
+
+        assert receipt_owner.state == "cleanup"
+        assert workspace.state == "failed"
+        assert destination.is_dir()
+        assert not stage.exists()
+        with pytest.raises(RuntimeError, match="expected active"):
+            _ = receipt_owner.receipt
+        receipt_owner.close()
+        assert receipt_owner.closed
+
+
+def test_owned_workspace_receipt_rejects_suppressed_authentication_failure(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="7" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"safe"])
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+
+        def suppress_failure(
+            _receipt: PublishedWorkspaceReceipt,
+            reader: atomic_directory.PublicationDirectoryReader,
+        ) -> None:
+            with pytest.raises(ValueError, match="absent"):
+                reader.read_bytes("missing", max_bytes=1)
+
+        with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+            receipt_owner.consume(suppress_failure)
+        assert receipt_owner.active
+        receipt_owner.close()
+
+
+def test_owned_workspace_receipt_rejects_post_publish_root_change(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(subject_digest="8" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+        destination.chmod(0o500)
+
+        with pytest.raises(RuntimeError, match="root handle changed"):
+            receipt_owner.consume(lambda _receipt, _reader: None)
+        receipt_owner.close()
+
+
+def test_owned_workspace_receipt_close_persistent_eio_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="9" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+        target = workspace._root_descriptor
+        real_close = captured_directory.os.close
+        injected = False
+
+        def fail_once(descriptor: int) -> None:
+            nonlocal injected
+            if descriptor == target and not injected:
+                injected = True
+                raise OSError(errno.EIO, "persistent workspace close")
+            real_close(descriptor)
+
+        monkeypatch.setattr(captured_directory.os, "close", fail_once)
+
+        with pytest.raises(OSError, match="persistent workspace close"):
+            receipt_owner.close()
+        assert receipt_owner.state == "close-failed"
+        os.fstat(target)
+        receipt_owner.close()
+        assert receipt_owner.closed
+
+
+def test_owned_workspace_existing_destination_receipt_retains_exact_orphan(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="a" * 64,
+        files=(WorkspaceFile("new", max_bytes=3),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        destination.mkdir(mode=0o700)
+        (destination / "old").write_bytes(b"old")
+        expected_destination = capture_directory_ownership(destination)
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=expected_destination,
+        )
+        workspace.write_file("new", [b"new"])
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        workspace.publish_into(receipt_owner)
+
+        orphan = receipt_owner.receipt.orphan
+        assert orphan is not None
+        assert (
+            orphan.reopen(lambda reader: reader.read_bytes("old", max_bytes=3))
+            == b"old"
+        )
+        assert (
+            receipt_owner.consume(
+                lambda _receipt, reader: reader.read_bytes("new", max_bytes=3)
+            )
+            == b"new"
+        )
+        receipt_owner.close()
+
+
+def test_owned_workspace_receipt_constructor_interruption_keeps_cleanup_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="b" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        def interrupt_constructor(self, **kwargs) -> None:
+            self._transfer = kwargs["transfer"]
+            raise SystemExit("workspace receipt constructor interruption")
+
+        monkeypatch.setattr(
+            PublishedWorkspaceReceipt,
+            "__init__",
+            interrupt_constructor,
+        )
+
+        with pytest.raises(SystemExit, match="constructor interruption"):
+            workspace.publish_into(receipt_owner)
+
+        assert destination.is_dir()
+        assert receipt_owner.state == "cleanup"
+        with pytest.raises(RuntimeError, match="ReceiptOwner"):
+            workspace.close()
+        receipt_owner.close()
+        assert receipt_owner.closed
+
+
+def test_owned_workspace_reservation_after_store_interruption_is_cleanup_owned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="c" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        real_reserve = PublishedWorkspaceReceiptOwner._reserve
+
+        def reserve_then_interrupt(self, reservation) -> None:
+            real_reserve(self, reservation)
+            raise KeyboardInterrupt("reservation return interruption")
+
+        monkeypatch.setattr(
+            PublishedWorkspaceReceiptOwner,
+            "_reserve",
+            reserve_then_interrupt,
+        )
+
+        with pytest.raises(KeyboardInterrupt, match="reservation return"):
+            workspace.publish_into(receipt_owner)
+
+        assert stage.is_dir()
+        assert not destination.exists()
+        assert receipt_owner.state == "cleanup"
+        receipt_owner.close()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_owned_workspace_child_closes_reserved_publication_resources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="c" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        def fork_while_reserved(*_args, **_kwargs) -> None:
+            authority = workspace._parent_owner.authority
+            assert authority is not None
+            internal_descriptors = {
+                authority.resource,
+                *(record.descriptor for record in workspace._resources._records),
+            }
+            internal_descriptors.discard(-1)
+            child = os.fork()
+            if child == 0:  # pragma: no branch - exact child result via exit
+                signal.signal(signal.SIGALRM, lambda *_signal_args: os._exit(80))
+                signal.alarm(3)
+                try:
+                    receipt_owner.close()
+                except RuntimeError as exc:
+                    if "PID boundary" not in str(exc):
+                        os._exit(81)
+                except BaseException:  # noqa: B036 - child reports by status
+                    os._exit(82)
+                else:
+                    os._exit(83)
+                for descriptor in internal_descriptors:
+                    try:
+                        os.fstat(descriptor)
+                    except OSError as exc:
+                        if exc.errno != errno.EBADF:
+                            os._exit(84)
+                    else:
+                        os._exit(85)
+                os._exit(0)
+            _pid, status = os.waitpid(child, 0)
+            assert os.WIFEXITED(status)
+            assert os.WEXITSTATUS(status) == 0
+            for descriptor in internal_descriptors:
+                os.fstat(descriptor)
+            raise RuntimeError("stop after reserved child cleanup")
+
+        monkeypatch.setattr(
+            captured_directory,
+            "_publish_staged_directory_with_authority",
+            fork_while_reserved,
+        )
+
+        with pytest.raises(RuntimeError, match="reserved child cleanup"):
+            workspace.publish_into(receipt_owner)
+
+        assert receipt_owner.state == "cleanup"
+        receipt_owner.close()
+
+
+def test_owned_workspace_first_transfer_store_interruption_is_reconciled(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(subject_digest="e" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        with pytest.raises(SystemExit, match="first transfer store"):
+            _interrupt_after_store_attr(
+                lambda: workspace.publish_into(receipt_owner),
+                target_code=OwnedWorkspaceAuthority._publish_into_locked.__code__,
+                attribute="_publication_transfer",
+                error=SystemExit("first transfer store interruption"),
+            )
+
+        assert workspace.state == "closed"
+        assert receipt_owner.state == "empty"
+        assert stage.is_dir()
+        assert not destination.exists()
+        receipt_owner.close()
+
+
+def test_owned_workspace_post_install_failure_does_not_deadlock_owner_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="f" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        installed = threading.Event()
+        observer_entered_workspace = threading.Event()
+        observed_states: list[str] = []
+        failures: list[BaseException] = []
+        real_install = PublishedWorkspaceReceiptOwner._install
+        real_closed = OwnedWorkspaceAuthority._publication_transfer_closed
+
+        def install_then_interrupt(self, reservation, receipt) -> None:
+            real_install(self, reservation, receipt)
+            installed.set()
+            assert observer_entered_workspace.wait(timeout=5)
+            raise KeyboardInterrupt("post-install publication interruption")
+
+        def observe_workspace_close(self, transfer) -> bool:
+            observer_entered_workspace.set()
+            return real_closed(self, transfer)
+
+        monkeypatch.setattr(
+            PublishedWorkspaceReceiptOwner,
+            "_install",
+            install_then_interrupt,
+        )
+        monkeypatch.setattr(
+            OwnedWorkspaceAuthority,
+            "_publication_transfer_closed",
+            observe_workspace_close,
+        )
+
+        def observe_owner() -> None:
+            try:
+                assert installed.wait(timeout=5)
+                observed_states.append(receipt_owner.state)
+            except BaseException as exc:  # noqa: B036 - report worker failure
+                failures.append(exc)
+
+        observer = threading.Thread(target=observe_owner, daemon=True)
+        publisher_errors: list[BaseException] = []
+
+        def publish() -> None:
+            try:
+                workspace.publish_into(receipt_owner)
+            except BaseException as exc:  # noqa: B036 - report worker failure
+                publisher_errors.append(exc)
+
+        publisher = threading.Thread(target=publish, daemon=True)
+        observer.start()
+        publisher.start()
+        publisher.join(timeout=5)
+        observer.join(timeout=5)
+
+        assert not publisher.is_alive()
+        assert not observer.is_alive()
+        assert not failures
+        assert len(publisher_errors) == 1
+        assert isinstance(publisher_errors[0], KeyboardInterrupt)
+        assert "post-install publication" in str(publisher_errors[0])
+        assert observed_states == ["active"]
+        assert receipt_owner.active
+        receipt_owner.close()
+
+
+def test_owned_workspace_consume_and_close_are_linear(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(subject_digest="d" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+        consuming = threading.Event()
+        release_consumer = threading.Event()
+        consumer_done = threading.Event()
+        close_done = threading.Event()
+        failures: list[BaseException] = []
+
+        def consume() -> None:
+            try:
+
+                def hold_reader(_receipt, _reader) -> None:
+                    consuming.set()
+                    assert release_consumer.wait(timeout=5)
+
+                receipt_owner.consume(hold_reader)
+                consumer_done.set()
+            except BaseException as exc:  # noqa: B036 - report from worker
+                failures.append(exc)
+
+        def close() -> None:
+            try:
+                receipt_owner.close()
+                close_done.set()
+            except BaseException as exc:  # noqa: B036 - report from worker
+                failures.append(exc)
+
+        consumer = threading.Thread(target=consume)
+        closer = threading.Thread(target=close)
+        consumer.start()
+        assert consuming.wait(timeout=5)
+        closer.start()
+        assert not close_done.wait(timeout=0.1)
+        release_consumer.set()
+        consumer.join(timeout=5)
+        closer.join(timeout=5)
+
+        assert not failures
+        assert consumer_done.is_set()
+        assert close_done.is_set()
+        assert receipt_owner.closed

--- a/test/test_owned_file_publication.py
+++ b/test/test_owned_file_publication.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import dis
 import errno
 import hashlib
 import multiprocessing
@@ -54,46 +53,6 @@ def _set_nonzero_directory_offset(descriptor: int) -> int:
     return offset
 
 
-def _call_with_interrupt_before_store(
-    function: object,
-    local_name: str,
-    callback: object,
-    *,
-    error: BaseException,
-) -> None:
-    """Raise while a call result is on-stack before its first STORE_FAST."""
-
-    assert callable(function)
-    assert callable(callback)
-    code = function.__code__
-    store_offsets = {
-        instruction.offset
-        for instruction in dis.get_instructions(function)
-        if instruction.opname == "STORE_FAST" and instruction.argval == local_name
-    }
-    assert store_offsets
-    previous_trace = sys.gettrace()
-
-    def trace(frame: object, event: str, _arg: object) -> object:
-        if event == "call" and frame.f_code is code:
-            frame.f_trace_opcodes = True
-            return trace
-        if (
-            event == "opcode"
-            and frame.f_code is code
-            and frame.f_lasti in store_offsets
-        ):
-            sys.settrace(None)
-            raise error
-        return trace
-
-    sys.settrace(trace)
-    try:
-        callback()
-    finally:
-        sys.settrace(previous_trace)
-
-
 def _store_publish_result(
     publication: OwnedFilePublicationAuthority,
     receipt_owner: PublishedFileReceiptOwner,
@@ -106,7 +65,7 @@ def _store_helper_result(
     destination: Path,
     receipt_owner: PublishedFileReceiptOwner,
 ) -> None:
-    result = publish_owned_file(
+    result = publication_module.publish_owned_file(
         destination,
         [b"x"],
         max_bytes=1,
@@ -471,6 +430,7 @@ def test_borrowed_parent_bridge_retries_repeated_eio_without_touching_caller(
 @pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
 def test_publish_into_caller_store_cancellation_keeps_owner_and_leaks_no_fd(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     exception_type: type[BaseException],
 ) -> None:
     before = _descriptor_count()
@@ -478,15 +438,25 @@ def test_publish_into_caller_store_cancellation_keeps_owner_and_leaks_no_fd(
     publication.write([b"x"])
     receipt_owner = PublishedFileReceiptOwner()
     interruption = exception_type("injected before caller receipt-result store")
+    real_publish = OwnedFilePublicationAuthority.publish_into
+
+    def publish_then_interrupt(
+        candidate: OwnedFilePublicationAuthority,
+        owner: PublishedFileReceiptOwner,
+    ) -> None:
+        real_publish(candidate, owner)
+        if candidate is publication:
+            raise interruption
+
+    monkeypatch.setattr(
+        OwnedFilePublicationAuthority,
+        "publish_into",
+        publish_then_interrupt,
+    )
 
     try:
         with pytest.raises(exception_type) as caught:
-            _call_with_interrupt_before_store(
-                _store_publish_result,
-                "result",
-                lambda: _store_publish_result(publication, receipt_owner),
-                error=interruption,
-            )
+            _store_publish_result(publication, receipt_owner)
         assert caught.value is interruption
         assert publication.state == "published"
         assert receipt_owner.active
@@ -502,21 +472,28 @@ def test_publish_into_caller_store_cancellation_keeps_owner_and_leaks_no_fd(
 @pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
 def test_helper_caller_store_cancellation_keeps_owner_and_leaks_no_fd(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     exception_type: type[BaseException],
 ) -> None:
     before = _descriptor_count()
     destination = tmp_path / "object"
     receipt_owner = PublishedFileReceiptOwner()
     interruption = exception_type("injected before caller helper-result store")
+    real_helper = publication_module.publish_owned_file
+
+    def helper_then_interrupt(*args, **kwargs) -> None:
+        real_helper(*args, **kwargs)
+        raise interruption
+
+    monkeypatch.setattr(
+        publication_module,
+        "publish_owned_file",
+        helper_then_interrupt,
+    )
 
     try:
         with pytest.raises(exception_type) as caught:
-            _call_with_interrupt_before_store(
-                _store_helper_result,
-                "result",
-                lambda: _store_helper_result(destination, receipt_owner),
-                error=interruption,
-            )
+            _store_helper_result(destination, receipt_owner)
         assert caught.value is interruption
         assert receipt_owner.active
         assert receipt_owner.receipt.read_bytes(max_bytes=1) == b"x"
@@ -726,6 +703,7 @@ def test_different_existing_file_is_a_non_destructive_conflict(
 ) -> None:
     destination = tmp_path / "object"
     destination.write_bytes(b"old")
+    destination.chmod(0o644)
 
     with PublishedFileReceiptOwner() as receipt_owner:
         with pytest.raises(OwnedFileConflictError) as caught:
@@ -2632,6 +2610,7 @@ def test_failure_and_receipt_close_do_not_leak_descriptors(tmp_path: Path) -> No
     before = len(list(Path("/proc/self/fd").iterdir()))
     destination = tmp_path / "object"
     destination.write_bytes(b"old")
+    destination.chmod(0o644)
     for index in range(12):
         with PublishedFileReceiptOwner() as failed_owner:
             with pytest.raises(OwnedFileConflictError):

--- a/test/test_owned_file_publication.py
+++ b/test/test_owned_file_publication.py
@@ -9,6 +9,7 @@ import errno
 import hashlib
 import multiprocessing
 import os
+import signal
 import stat
 import sys
 import threading
@@ -2465,6 +2466,110 @@ def test_linear_state_and_pid_binding(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(publication_module.os, "getpid", lambda: owner_pid)
     assert receipt_owner.closed
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_receipt_child_close_uses_process_local_lifecycle_lock(
+    tmp_path: Path,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"payload"],
+        max_bytes=7,
+        receipt_owner=receipt_owner,
+    )
+    receipt_descriptor = receipt_owner.receipt._descriptor
+    consuming = threading.Event()
+    release = threading.Event()
+
+    def hold_receipt() -> None:
+        receipt_owner.consume(
+            lambda _receipt: (
+                consuming.set(),
+                release.wait(timeout=10),
+            )
+        )
+
+    holder = threading.Thread(target=hold_receipt)
+    holder.start()
+    assert consuming.wait(timeout=5)
+
+    child = os.fork()
+    if child == 0:  # pragma: no branch - child reports exact outcome by status
+        signal.signal(signal.SIGALRM, lambda *_args: os._exit(70))
+        signal.alarm(3)
+        try:
+            receipt_owner.close()
+        except RuntimeError as exc:
+            if "PID boundary" not in str(exc):
+                os._exit(71)
+        except BaseException:  # noqa: B036 - child reports by status
+            os._exit(72)
+        else:
+            os._exit(73)
+        try:
+            os.fstat(receipt_descriptor)
+        except OSError as exc:
+            if exc.errno != errno.EBADF:
+                os._exit(74)
+        else:
+            os._exit(75)
+        os._exit(0)
+
+    _pid, status = os.waitpid(child, 0)
+    release.set()
+    holder.join(timeout=5)
+    assert not holder.is_alive()
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+    assert receipt_owner.receipt.read_bytes(max_bytes=7) == b"payload"
+    receipt_owner.close()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_publication_child_close_does_not_seek_parent_stage(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=6)
+    stage_descriptor = publication._descriptor
+
+    def chunks():
+        yield b"abc"
+        assert os.lseek(stage_descriptor, 0, os.SEEK_CUR) == 3
+        child = os.fork()
+        if child == 0:  # pragma: no branch - child reports exact outcome by status
+            signal.signal(signal.SIGALRM, lambda *_args: os._exit(80))
+            signal.alarm(3)
+            try:
+                publication.close()
+            except RuntimeError as exc:
+                if "PID boundary" not in str(exc):
+                    os._exit(81)
+            except BaseException:  # noqa: B036 - child reports by status
+                os._exit(82)
+            else:
+                os._exit(83)
+            try:
+                os.fstat(stage_descriptor)
+            except OSError as exc:
+                if exc.errno != errno.EBADF:
+                    os._exit(84)
+            else:
+                os._exit(85)
+            os._exit(0)
+        _pid, status = os.waitpid(child, 0)
+        assert os.WIFEXITED(status)
+        assert os.WEXITSTATUS(status) == 0
+        assert os.lseek(stage_descriptor, 0, os.SEEK_CUR) == 3
+        yield b"def"
+
+    record = publication.write(chunks())
+    assert record.size == 6
+    receipt_owner = PublishedFileReceiptOwner()
+    publication.publish_into(receipt_owner)
+    assert receipt_owner.receipt.read_bytes(max_bytes=6) == b"abcdef"
+    receipt_owner.close()
 
 
 def test_missing_parent_and_noncanonical_leaf_do_not_create_paths(

--- a/test/test_owned_file_publication.py
+++ b/test/test_owned_file_publication.py
@@ -1,0 +1,2660 @@
+# SPDX-FileCopyrightText: 2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import dis
+import errno
+import hashlib
+import multiprocessing
+import os
+import stat
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+import codenib._atomic_directory as atomic_module
+import codenib._owned_file_publication as publication_module
+from codenib._owned_file_publication import (
+    OwnedFileConflictError,
+    OwnedFilePublicationAuthority,
+    PublishedFileReceiptOwner,
+    publish_owned_file,
+    require_owned_file_publication_support,
+)
+
+
+def _descriptor_count() -> int:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting requires procfs")
+    return len(os.listdir(descriptor_root))
+
+
+def _assert_bad_descriptor(descriptor: int) -> None:
+    with pytest.raises(OSError) as caught:
+        os.fstat(descriptor)
+    assert caught.value.errno == errno.EBADF
+
+
+def _exception_notes(error: BaseException) -> tuple[str, ...]:
+    return (
+        *tuple(getattr(error, "__notes__", ())),
+        *tuple(getattr(error, "_codenib_cleanup_notes", ())),
+    )
+
+
+def _set_nonzero_directory_offset(descriptor: int) -> int:
+    offset = os.lseek(descriptor, 37, os.SEEK_SET)
+    assert offset != 0
+    return offset
+
+
+def _call_with_interrupt_before_store(
+    function: object,
+    local_name: str,
+    callback: object,
+    *,
+    error: BaseException,
+) -> None:
+    """Raise while a call result is on-stack before its first STORE_FAST."""
+
+    assert callable(function)
+    assert callable(callback)
+    code = function.__code__
+    store_offsets = {
+        instruction.offset
+        for instruction in dis.get_instructions(function)
+        if instruction.opname == "STORE_FAST" and instruction.argval == local_name
+    }
+    assert store_offsets
+    previous_trace = sys.gettrace()
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            event == "opcode"
+            and frame.f_code is code
+            and frame.f_lasti in store_offsets
+        ):
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+
+
+def _store_publish_result(
+    publication: OwnedFilePublicationAuthority,
+    receipt_owner: PublishedFileReceiptOwner,
+) -> None:
+    result = publication.publish_into(receipt_owner)
+    assert result is None
+
+
+def _store_helper_result(
+    destination: Path,
+    receipt_owner: PublishedFileReceiptOwner,
+) -> None:
+    result = publish_owned_file(
+        destination,
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    assert result is None
+
+
+def _publish_in_process(destination: str, payload: bytes) -> None:
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publish_owned_file(
+            Path(destination),
+            [payload],
+            max_bytes=len(payload),
+            receipt_owner=receipt_owner,
+        )
+        receipt = receipt_owner.receipt
+        assert receipt.read_bytes(max_bytes=len(payload)) == payload
+
+
+def test_publish_returns_handle_bound_receipt(tmp_path: Path) -> None:
+    destination = tmp_path / "object"
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        assert (
+            publish_owned_file(
+                destination,
+                [b"abc", b"def"],
+                max_bytes=6,
+                mode=0o640,
+                receipt_owner=receipt_owner,
+            )
+            is None
+        )
+        receipt = receipt_owner.receipt
+        assert not receipt.reused
+        assert receipt.orphan is None
+        assert receipt.record.size == 6
+        assert receipt.record.sha256 == hashlib.sha256(b"abcdef").hexdigest()
+        assert receipt.record.mode == 0o640
+        assert receipt.read_bytes(max_bytes=6) == b"abcdef"
+        with pytest.raises(RuntimeError, match="ReceiptOwner"):
+            receipt.close()
+        assert receipt_owner.active
+        assert destination.read_bytes() == b"abcdef"
+        assert stat.S_IMODE(destination.stat().st_mode) == 0o640
+    assert receipt_owner.closed
+
+
+def test_identical_existing_file_is_authenticated_and_reused(tmp_path: Path) -> None:
+    destination = tmp_path / "object"
+    destination.write_bytes(b"same")
+    destination.chmod(0o640)
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publish_owned_file(
+            destination,
+            b"same",
+            max_bytes=4,
+            mode=0o640,
+            receipt_owner=receipt_owner,
+        )
+        receipt = receipt_owner.receipt
+        orphan = receipt.orphan
+        assert receipt.reused
+        assert receipt.record.mode == 0o640
+        assert receipt.read_bytes(max_bytes=4) == b"same"
+        assert orphan is not None
+        assert orphan.path.exists()
+        assert orphan.path.read_bytes() == b"same"
+
+
+def test_borrowed_parent_resource_is_never_closed(tmp_path: Path) -> None:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    expected_identity = atomic_module.publication_parent_identity(parent_resource)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    try:
+        with PublishedFileReceiptOwner() as receipt_owner:
+            publish_owned_file(
+                tmp_path / "object",
+                b"same-parent",
+                max_bytes=len(b"same-parent"),
+                parent_resource=parent_resource,
+                receipt_owner=receipt_owner,
+            )
+            receipt = receipt_owner.receipt
+            assert receipt.parent_identity == expected_identity
+            assert receipt.read_bytes(max_bytes=len(b"same-parent")) == b"same-parent"
+
+        assert atomic_module.publication_parent_identity(parent_resource) == (
+            expected_identity
+        )
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+    finally:
+        os.close(parent_resource)
+
+
+def test_borrowed_parent_mismatch_fails_before_stage_or_destination(
+    tmp_path: Path,
+) -> None:
+    destination_parent = tmp_path / "destination-parent"
+    borrowed_parent = tmp_path / "borrowed-parent"
+    destination_parent.mkdir()
+    borrowed_parent.mkdir()
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(borrowed_parent, flags)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    try:
+        with pytest.raises(RuntimeError, match="parent path changed"):
+            OwnedFilePublicationAuthority(
+                destination_parent / "object",
+                max_bytes=1,
+                parent_resource=parent_resource,
+            )
+
+        assert list(destination_parent.iterdir()) == []
+        assert list(borrowed_parent.iterdir()) == []
+        os.fstat(parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+    finally:
+        os.close(parent_resource)
+
+
+def test_borrowed_parent_conflict_does_not_change_caller_offset(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "object"
+    destination.write_bytes(b"old")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    try:
+        with pytest.raises(OwnedFileConflictError):
+            publish_owned_file(
+                destination,
+                b"new",
+                max_bytes=3,
+                parent_resource=parent_resource,
+                consume=lambda _receipt: None,
+            )
+
+        os.fstat(parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+        assert destination.read_bytes() == b"old"
+    finally:
+        os.close(parent_resource)
+
+
+def test_borrowed_parent_bridge_rejects_fd_replacement_before_openat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    original_alias = os.dup(parent_resource)
+    foreign_resource = os.open(foreign, flags)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    real_open = atomic_module._PosixResourceOwner.open
+    replaced = False
+
+    def replace_then_open(
+        owner,
+        path,
+        open_flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        nonlocal replaced
+        if path == "." and dir_fd == parent_resource and not replaced:
+            os.dup2(foreign_resource, parent_resource)
+            replaced = True
+        return real_open(
+            owner,
+            path,
+            open_flags,
+            mode,
+            dir_fd=dir_fd,
+        )
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        replace_then_open,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="changed while opened"):
+            OwnedFilePublicationAuthority(
+                tmp_path / "object",
+                max_bytes=1,
+                parent_resource=parent_resource,
+            )
+
+        assert replaced
+        assert atomic_module.publication_parent_identity(parent_resource) == (
+            atomic_module.publication_parent_identity(foreign_resource)
+        )
+        assert not (tmp_path / "object").exists()
+        assert not list(tmp_path.glob(".codenib-file-*"))
+    finally:
+        os.dup2(original_alias, parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+        os.close(foreign_resource)
+        os.close(original_alias)
+        os.close(parent_resource)
+
+
+@pytest.mark.parametrize("phase", ["before", "after"])
+@pytest.mark.parametrize("exception_type", [OSError, KeyboardInterrupt, SystemExit])
+def test_borrowed_parent_bridge_close_failure_preserves_caller_ofd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+    exception_type: type[BaseException],
+) -> None:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    before = _descriptor_count()
+    bridge_descriptors: list[int] = []
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = publication_module.os.close
+    error = (
+        OSError(errno.EIO, f"{phase} bridge close failure")
+        if exception_type is OSError
+        else exception_type(f"{phase} bridge close interruption")
+    )
+    injected = False
+
+    def record_bridge_open(
+        owner,
+        path,
+        open_flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(
+            owner,
+            path,
+            open_flags,
+            mode,
+            dir_fd=dir_fd,
+        )
+        if path == "." and dir_fd == parent_resource:
+            bridge_descriptors.append(descriptor)
+        return descriptor
+
+    def fail_bridge_close(descriptor: int) -> None:
+        nonlocal injected
+        if bridge_descriptors and descriptor == bridge_descriptors[0] and not injected:
+            injected = True
+            if phase == "after":
+                real_close(descriptor)
+            raise error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        record_bridge_open,
+    )
+    monkeypatch.setattr(publication_module.os, "close", fail_bridge_close)
+    try:
+        with pytest.raises(exception_type) as caught:
+            OwnedFilePublicationAuthority(
+                tmp_path / "object",
+                max_bytes=1,
+                parent_resource=parent_resource,
+            )
+
+        assert caught.value is error
+        assert injected
+        assert len(bridge_descriptors) == 1
+        _assert_bad_descriptor(bridge_descriptors[0])
+        os.fstat(parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+        assert _descriptor_count() <= before
+        assert not (tmp_path / "object").exists()
+        assert not list(tmp_path.glob(".codenib-file-*"))
+    finally:
+        os.close(parent_resource)
+
+
+def test_borrowed_parent_bridge_retries_repeated_eio_without_touching_caller(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    before = _descriptor_count()
+    bridge_descriptors: list[int] = []
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = publication_module.os.close
+    error = OSError(errno.EIO, "repeated bridge close failure")
+    failures_remaining = 4
+
+    def record_bridge_open(
+        owner,
+        path,
+        open_flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(
+            owner,
+            path,
+            open_flags,
+            mode,
+            dir_fd=dir_fd,
+        )
+        if path == "." and dir_fd == parent_resource:
+            bridge_descriptors.append(descriptor)
+        return descriptor
+
+    def fail_repeatedly(descriptor: int) -> None:
+        nonlocal failures_remaining
+        if (
+            bridge_descriptors
+            and descriptor == bridge_descriptors[0]
+            and failures_remaining
+        ):
+            failures_remaining -= 1
+            raise error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        record_bridge_open,
+    )
+    monkeypatch.setattr(publication_module.os, "close", fail_repeatedly)
+    try:
+        with pytest.raises(OSError) as caught:
+            OwnedFilePublicationAuthority(
+                tmp_path / "object",
+                max_bytes=1,
+                parent_resource=parent_resource,
+            )
+
+        assert caught.value is error
+        assert failures_remaining == 0
+        _assert_bad_descriptor(bridge_descriptors[0])
+        os.fstat(parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+        assert _descriptor_count() <= before
+    finally:
+        os.close(parent_resource)
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_publish_into_caller_store_cancellation_keeps_owner_and_leaks_no_fd(
+    tmp_path: Path,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    interruption = exception_type("injected before caller receipt-result store")
+
+    try:
+        with pytest.raises(exception_type) as caught:
+            _call_with_interrupt_before_store(
+                _store_publish_result,
+                "result",
+                lambda: _store_publish_result(publication, receipt_owner),
+                error=interruption,
+            )
+        assert caught.value is interruption
+        assert publication.state == "published"
+        assert receipt_owner.active
+        assert receipt_owner.receipt.read_bytes(max_bytes=1) == b"x"
+    finally:
+        receipt_owner.close()
+        publication.close()
+
+    assert receipt_owner.closed
+    assert _descriptor_count() <= before
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_helper_caller_store_cancellation_keeps_owner_and_leaks_no_fd(
+    tmp_path: Path,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    destination = tmp_path / "object"
+    receipt_owner = PublishedFileReceiptOwner()
+    interruption = exception_type("injected before caller helper-result store")
+
+    try:
+        with pytest.raises(exception_type) as caught:
+            _call_with_interrupt_before_store(
+                _store_helper_result,
+                "result",
+                lambda: _store_helper_result(destination, receipt_owner),
+                error=interruption,
+            )
+        assert caught.value is interruption
+        assert receipt_owner.active
+        assert receipt_owner.receipt.read_bytes(max_bytes=1) == b"x"
+    finally:
+        receipt_owner.close()
+
+    assert receipt_owner.closed
+    assert _descriptor_count() <= before
+
+
+def test_publication_requires_precreated_owner_before_any_rename(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=1)
+    publication.write([b"x"])
+    try:
+        with pytest.raises(TypeError, match="receipt_owner"):
+            publication.publish()
+        assert publication.state == "written"
+        assert not destination.exists()
+    finally:
+        publication.close()
+
+    with pytest.raises(TypeError, match="exactly one"):
+        publish_owned_file(tmp_path / "other", [b"x"], max_bytes=1)
+    assert not (tmp_path / "other").exists()
+
+
+def test_helper_consumer_gets_borrowed_receipt_and_closes_it_on_return(
+    tmp_path: Path,
+) -> None:
+    observed: list[publication_module.PublishedFileReceipt] = []
+
+    def consume(receipt: publication_module.PublishedFileReceipt) -> None:
+        observed.append(receipt)
+        assert receipt.read_bytes(max_bytes=1) == b"x"
+
+    assert (
+        publish_owned_file(
+            tmp_path / "object",
+            [b"x"],
+            max_bytes=1,
+            consume=consume,
+        )
+        is None
+    )
+    assert len(observed) == 1
+    assert observed[0].closed
+
+
+def test_helper_consumer_primary_wins_persistent_close_and_leaks_no_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = _descriptor_count()
+    primary = KeyboardInterrupt("consumer cancellation")
+    cleanup = OSError(errno.EIO, "persistent helper receipt close failure")
+    captured: list[publication_module.PublishedFileReceipt] = []
+    captured_descriptors: list[int] = []
+    real_close = publication_module.os.close
+
+    def fail_receipt_close(candidate: int) -> None:
+        if captured_descriptors and candidate == captured_descriptors[0]:
+            raise cleanup
+        real_close(candidate)
+
+    def consume(receipt: publication_module.PublishedFileReceipt) -> None:
+        captured.append(receipt)
+        captured_descriptors.append(receipt._descriptor)
+        raise primary
+
+    monkeypatch.setattr(publication_module.os, "close", fail_receipt_close)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        publish_owned_file(
+            tmp_path / "object",
+            [b"x"],
+            max_bytes=1,
+            consume=consume,
+        )
+
+    assert caught.value is primary
+    assert len(captured) == 1
+    assert captured[0].closed
+    assert any(
+        "descriptor cleanup also failed" in note
+        and "persistent helper receipt close failure" in note
+        for note in _exception_notes(primary)
+    )
+    assert _descriptor_count() <= before
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_existing_open_cancellation_invalidates_owner_without_fd_leak(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    destination = tmp_path / "object"
+    destination.write_bytes(b"same")
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=4)
+    publication.write([b"same"])
+    interruption = exception_type("injected after existing descriptor ownership")
+    real_open = publication_module._DescriptorOwner.open
+
+    def open_then_interrupt(owner, path, flags, mode=0o777, *, dir_fd=None):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        if path == destination.name:
+            raise interruption
+        return descriptor
+
+    monkeypatch.setattr(
+        publication_module._DescriptorOwner,
+        "open",
+        open_then_interrupt,
+    )
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(exception_type) as caught:
+                publication.publish_into(receipt_owner)
+            assert caught.value is interruption
+        finally:
+            publication.close()
+
+    assert destination.read_bytes() == b"same"
+    assert _descriptor_count() <= before
+
+
+def test_receipt_constructor_cancellation_invalidates_every_fd_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = _descriptor_count()
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    interruption = SystemExit("injected after receipt construction")
+    real_receipt_type = publication_module.PublishedFileReceipt
+    captured_receipts = []
+    captured_descriptors: list[int] = []
+
+    class InterruptingReceipt(real_receipt_type):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            captured_receipts.append(self)
+            captured_descriptors.append(self._descriptor)
+            raise interruption
+
+    monkeypatch.setattr(
+        publication_module,
+        "PublishedFileReceipt",
+        InterruptingReceipt,
+    )
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(SystemExit) as caught:
+                publication.publish_into(receipt_owner)
+            assert caught.value is interruption
+        finally:
+            publication.close()
+
+    assert len(captured_receipts) == 1
+    assert captured_receipts[0].closed
+    stale_descriptor = captured_descriptors[0]
+    _assert_bad_descriptor(stale_descriptor)
+
+    foreign = tmp_path / "foreign"
+    foreign.write_bytes(b"foreign")
+    opened = os.open(foreign, os.O_RDONLY)
+    replacement = stale_descriptor
+    if opened != replacement:
+        os.dup2(opened, replacement)
+        os.close(opened)
+    try:
+        with pytest.raises(RuntimeError, match="ReceiptOwner"):
+            captured_receipts[0].close()
+        assert os.pread(replacement, 7, 0) == b"foreign"
+    finally:
+        os.close(replacement)
+    assert _descriptor_count() <= before
+
+
+@pytest.mark.parametrize("existing_mode", [0o600, 0o666])
+def test_existing_mode_mismatch_or_unsafe_mode_is_a_conflict(
+    tmp_path: Path,
+    existing_mode: int,
+) -> None:
+    destination = tmp_path / "object"
+    destination.write_bytes(b"same")
+    destination.chmod(existing_mode)
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        with pytest.raises(OwnedFileConflictError):
+            publish_owned_file(
+                destination,
+                b"same",
+                max_bytes=4,
+                mode=0o640,
+                receipt_owner=receipt_owner,
+            )
+
+    assert stat.S_IMODE(destination.stat().st_mode) == existing_mode
+
+
+def test_different_existing_file_is_a_non_destructive_conflict(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "object"
+    destination.write_bytes(b"old")
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        with pytest.raises(OwnedFileConflictError) as caught:
+            publish_owned_file(
+                destination,
+                [b"new"],
+                max_bytes=3,
+                receipt_owner=receipt_owner,
+            )
+
+    assert destination.read_bytes() == b"old"
+    assert caught.value.observed is not None
+    assert caught.value.orphan.path.read_bytes() == b"new"
+
+
+@pytest.mark.parametrize("kind", ["fifo", "symlink", "directory"])
+def test_existing_non_regular_destination_is_a_conflict(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    destination = tmp_path / "object"
+    if kind == "fifo":
+        os.mkfifo(destination)
+    elif kind == "symlink":
+        destination.symlink_to("missing-target")
+    else:
+        destination.mkdir()
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        with pytest.raises(OwnedFileConflictError) as caught:
+            publish_owned_file(
+                destination,
+                [b"new"],
+                max_bytes=3,
+                receipt_owner=receipt_owner,
+            )
+
+    assert destination.lstat()
+    assert caught.value.observed is None
+    assert caught.value.orphan.path.read_bytes() == b"new"
+
+
+def test_destination_appearing_at_rename_is_never_replaced(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=3)
+    publication.write([b"new"])
+    assert publication._authority is not None
+    original = publication._authority._rename_callback
+
+    def race(source: str, final: str) -> None:
+        assert publication._authority is not None
+        descriptor = os.open(
+            final,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o644,
+            dir_fd=publication._authority.resource,
+        )
+        try:
+            os.write(descriptor, b"old")
+        finally:
+            os.close(descriptor)
+        original(source, final)
+
+    publication._authority._rename_callback = race
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(OwnedFileConflictError):
+                publication.publish_into(receipt_owner)
+        finally:
+            publication.close()
+
+    assert destination.read_bytes() == b"old"
+
+
+def test_stage_create_uses_exclusive_nofollow_cloexec_and_exact_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_flags: list[int] = []
+    real_open = publication_module.os.open
+
+    def record_open(path, flags, mode=0o777, *, dir_fd=None):
+        if isinstance(path, str) and path.startswith(".codenib-file-"):
+            observed_flags.append(flags)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(publication_module.os, "open", record_open)
+    publication = OwnedFilePublicationAuthority(
+        tmp_path / "object",
+        max_bytes=1,
+        mode=0o640,
+    )
+    try:
+        metadata = os.fstat(publication._descriptor)
+        assert stat.S_ISREG(metadata.st_mode)
+        assert metadata.st_nlink == 1
+        assert stat.S_IMODE(metadata.st_mode) == 0o640
+        assert observed_flags
+        assert observed_flags[0] & os.O_CREAT
+        assert observed_flags[0] & os.O_EXCL
+        assert observed_flags[0] & os.O_NOFOLLOW
+        assert observed_flags[0] & os.O_CLOEXEC
+    finally:
+        publication.close()
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_constructor_cancellation_after_authority_acquire_closes_all_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    interruption = exception_type("injected after authority acquisition")
+    real_acquire = publication_module._PublicationAuthorityOwner.acquire
+
+    def acquire_then_interrupt(owner, path: Path) -> None:
+        real_acquire(owner, path)
+        raise interruption
+
+    monkeypatch.setattr(
+        publication_module._PublicationAuthorityOwner,
+        "acquire",
+        acquire_then_interrupt,
+    )
+
+    with pytest.raises(exception_type) as caught:
+        OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+
+    assert caught.value is interruption
+    assert _descriptor_count() <= before
+    assert not list(tmp_path.glob(".codenib-file-*"))
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_borrowed_parent_authority_cancellation_closes_only_owned_duplicates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    before = _descriptor_count()
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    interruption = exception_type("injected after borrowed authority acquisition")
+    real_acquire = publication_module._PublicationAuthorityOwner.acquire
+
+    def acquire_then_interrupt(
+        owner,
+        path: Path,
+        *,
+        parent_resource: int | None = None,
+    ) -> None:
+        real_acquire(owner, path, parent_resource=parent_resource)
+        raise interruption
+
+    monkeypatch.setattr(
+        publication_module._PublicationAuthorityOwner,
+        "acquire",
+        acquire_then_interrupt,
+    )
+    try:
+        with pytest.raises(exception_type) as caught:
+            OwnedFilePublicationAuthority(
+                tmp_path / "object",
+                max_bytes=1,
+                parent_resource=parent_resource,
+            )
+
+        assert caught.value is interruption
+        os.fstat(parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+        assert _descriptor_count() <= before
+        assert not list(tmp_path.glob(".codenib-file-*"))
+    finally:
+        os.close(parent_resource)
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_authority_factory_return_cancellation_uses_preinstalled_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    interruption = exception_type("injected before authority factory handoff")
+    real_open = atomic_module._open_publication_authority
+    installed_owners: list[publication_module._PublicationAuthorityOwner] = []
+
+    def open_then_interrupt(*args, **kwargs):
+        owner = kwargs.get("authority_owner")
+        assert isinstance(owner, publication_module._PublicationAuthorityOwner)
+        authority = real_open(*args, **kwargs)
+        assert owner.authority is authority
+        installed_owners.append(owner)
+        raise interruption
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_open_publication_authority",
+        open_then_interrupt,
+    )
+
+    with pytest.raises(exception_type) as caught:
+        OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+
+    assert caught.value is interruption
+    assert installed_owners
+    assert installed_owners[0].authority is None
+    assert _descriptor_count() <= before
+    assert not list(tmp_path.glob(".codenib-file-*"))
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_constructor_cancellation_after_stage_open_closes_all_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    interruption = exception_type("injected after stage descriptor ownership")
+    real_open = publication_module._DescriptorOwner.open
+
+    def open_then_interrupt(owner, path, flags, mode=0o777, *, dir_fd=None):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        if isinstance(path, str) and path.startswith(".codenib-file-"):
+            raise interruption
+        return descriptor
+
+    monkeypatch.setattr(
+        publication_module._DescriptorOwner,
+        "open",
+        open_then_interrupt,
+    )
+
+    with pytest.raises(exception_type) as caught:
+        OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+
+    assert caught.value is interruption
+    assert _descriptor_count() <= before
+    stages = list(tmp_path.glob(".codenib-file-*"))
+    assert len(stages) == 1
+    assert stages[0].read_bytes() == b""
+
+
+def test_stage_with_a_second_link_is_rejected(tmp_path: Path) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+
+    class LinkingProducer:
+        def __iter__(self):
+            yield b"x"
+            assert publication._authority is not None
+            os.link(
+                publication._stage_name,
+                "foreign-link",
+                src_dir_fd=publication._authority.resource,
+                dst_dir_fd=publication._authority.resource,
+                follow_symlinks=False,
+            )
+
+    try:
+        with pytest.raises(RuntimeError, match="identity changed"):
+            publication.write(LinkingProducer())
+    finally:
+        publication.close()
+
+    assert not (tmp_path / "object").exists()
+    assert (tmp_path / "foreign-link").read_bytes() == b"x"
+
+
+def test_same_size_stage_mutation_is_caught_by_pre_publish_rehash(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=3)
+    publication.write([b"abc"])
+    os.pwrite(publication._descriptor, b"x", 0)
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(RuntimeError, match="producer digest"):
+                publication.publish_into(receipt_owner)
+        finally:
+            publication.close()
+
+    assert not (tmp_path / "object").exists()
+
+
+def test_same_size_mutation_after_rename_is_caught_before_receipt(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=3)
+    publication.write([b"abc"])
+    assert publication._authority is not None
+    original = publication._authority._rename_callback
+
+    def rename_then_mutate(source: str, final: str) -> None:
+        original(source, final)
+        os.pwrite(publication._descriptor, b"x", 0)
+
+    publication._authority._rename_callback = rename_then_mutate
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(RuntimeError, match="producer digest"):
+                publication.publish_into(receipt_owner)
+        finally:
+            publication.close()
+
+    assert destination.read_bytes() == b"xbc"
+
+
+def test_first_receipt_is_duplicated_from_held_stage_not_reopened_by_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+
+    def forbidden_reopen(*_args, **_kwargs):
+        raise AssertionError("first publication reopened the final path")
+
+    monkeypatch.setattr(
+        OwnedFilePublicationAuthority,
+        "_open_regular",
+        forbidden_reopen,
+    )
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publication.publish_into(receipt_owner)
+        receipt = receipt_owner.receipt
+        assert receipt.read_bytes(max_bytes=1) == b"x"
+    try:
+        assert receipt_owner.closed
+    finally:
+        publication.close()
+
+
+@pytest.mark.parametrize("swap", ["parent", "ancestor"])
+def test_parent_path_aba_fails_before_publication(
+    tmp_path: Path,
+    swap: str,
+) -> None:
+    ancestor = tmp_path / "ancestor"
+    parent = ancestor / "parent"
+    parent.mkdir(parents=True)
+    publication = OwnedFilePublicationAuthority(parent / "object", max_bytes=1)
+    publication.write([b"x"])
+
+    if swap == "parent":
+        moved = ancestor / "moved-parent"
+        parent.rename(moved)
+        parent.mkdir()
+        replacement_parent = parent
+    else:
+        moved = tmp_path / "moved-ancestor"
+        ancestor.rename(moved)
+        ancestor.mkdir()
+        replacement_parent = ancestor / "parent"
+        replacement_parent.mkdir()
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(RuntimeError, match="parent path changed"):
+                publication.publish_into(receipt_owner)
+        finally:
+            publication.close()
+
+    assert not (replacement_parent / "object").exists()
+
+
+def test_producer_error_closes_iterator_and_preserves_owned_orphan(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=2)
+
+    class BrokenProducer:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.closed = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            self.calls += 1
+            if self.calls == 1:
+                return b"x"
+            raise LookupError("producer failed")
+
+        def close(self) -> None:
+            self.closed = True
+
+    producer = BrokenProducer()
+    try:
+        with pytest.raises(LookupError, match="producer failed"):
+            publication.write(producer)
+        assert producer.closed
+        assert publication.state == "failed"
+        assert publication.orphan is not None
+        assert publication.orphan.path.read_bytes() == b"x"
+    finally:
+        publication.close()
+
+
+def test_iterator_close_error_prevents_publication(tmp_path: Path) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+
+    def fail_close() -> None:
+        raise OSError(errno.EIO, "close failed")
+
+    class CloseableIterator:
+        def __init__(self) -> None:
+            self.done = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            if self.done:
+                raise StopIteration
+            self.done = True
+            return b"x"
+
+        close = staticmethod(fail_close)
+
+    try:
+        with pytest.raises(OSError, match="close failed"):
+            publication.write(CloseableIterator())
+        assert publication.state == "failed"
+        assert publication.orphan is not None
+        assert publication.orphan.path.read_bytes() == b"x"
+    finally:
+        publication.close()
+
+
+def test_iterator_primary_cancellation_wins_and_close_cancellation_is_noted(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    primary = KeyboardInterrupt("producer interrupted")
+    secondary = SystemExit("iterator close cancelled")
+
+    class DoublyInterruptedIterator:
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            raise primary
+
+        def close(self) -> None:
+            raise secondary
+
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            publication.write(DoublyInterruptedIterator())
+        assert caught.value is primary
+        assert any(
+            "publication iterator cleanup also failed" in note
+            and "iterator close cancelled" in note
+            for note in _exception_notes(primary)
+        )
+        assert publication.state == "failed"
+    finally:
+        publication.close()
+
+
+def test_file_fsync_error_leaves_only_an_owned_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    stage_descriptor = publication._descriptor
+    real_fsync = publication_module.os.fsync
+
+    def fail_file_fsync(descriptor: int) -> None:
+        if descriptor == stage_descriptor:
+            raise OSError(errno.EIO, "file fsync failed")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(publication_module.os, "fsync", fail_file_fsync)
+    try:
+        with pytest.raises(OSError, match="file fsync failed"):
+            publication.write([b"x"])
+        assert publication.orphan is not None
+        assert not (tmp_path / "object").exists()
+    finally:
+        publication.close()
+
+
+def test_parent_fsync_error_returns_no_receipt_after_committed_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    assert publication._authority is not None
+    parent_descriptor = publication._authority.resource
+    real_fsync = publication_module.os.fsync
+
+    def fail_parent_fsync(descriptor: int) -> None:
+        if descriptor == parent_descriptor:
+            raise OSError(errno.EIO, "parent fsync failed")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(publication_module.os, "fsync", fail_parent_fsync)
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(OSError, match="parent fsync failed"):
+                publication.publish_into(receipt_owner)
+            assert publication.state == "failed"
+        finally:
+            publication.close()
+
+    assert (tmp_path / "object").read_bytes() == b"x"
+
+
+def test_rename_error_before_mutation_preserves_stage(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    assert publication._authority is not None
+
+    def fail_rename(_source: str, _destination: str) -> None:
+        raise OSError(errno.EIO, "rename failed")
+
+    publication._authority._rename_callback = fail_rename
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(OSError, match="rename failed"):
+                publication.publish_into(receipt_owner)
+            assert publication.orphan is not None
+            assert publication.orphan.path.read_bytes() == b"x"
+        finally:
+            publication.close()
+
+
+def test_rename_error_after_mutation_returns_no_receipt_and_retry_reuses(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    assert publication._authority is not None
+    original = publication._authority._rename_callback
+
+    def rename_then_fail(source: str, destination: str) -> None:
+        original(source, destination)
+        raise OSError(errno.EIO, "injected after rename")
+
+    publication._authority._rename_callback = rename_then_fail
+    with PublishedFileReceiptOwner() as failed_owner:
+        try:
+            with pytest.raises(OSError, match="injected after rename"):
+                publication.publish_into(failed_owner)
+            assert publication.orphan is None
+        finally:
+            publication.close()
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publish_owned_file(
+            tmp_path / "object",
+            [b"x"],
+            max_bytes=1,
+            receipt_owner=receipt_owner,
+        )
+        receipt = receipt_owner.receipt
+        assert receipt.reused
+        assert receipt.read_bytes(max_bytes=1) == b"x"
+
+
+def test_rename_reconciliation_cancellation_is_secondary_and_conservative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    assert publication._authority is not None
+    primary = KeyboardInterrupt("rename interrupted")
+    secondary = SystemExit("rename reconciliation cancelled")
+    orphan = publication.orphan
+    assert orphan is not None
+    stage_path = orphan.path
+
+    def interrupt_rename(_source: str, _destination: str) -> None:
+        raise primary
+
+    def interrupt_reconciliation() -> bool:
+        raise secondary
+
+    publication._authority._rename_callback = interrupt_rename
+    monkeypatch.setattr(
+        OwnedFilePublicationAuthority,
+        "_rename_committed",
+        lambda _publication: interrupt_reconciliation(),
+    )
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(KeyboardInterrupt) as caught:
+                publication.publish_into(receipt_owner)
+            assert caught.value is primary
+            assert any(
+                "rename outcome reconciliation also failed" in note
+                and "rename reconciliation cancelled" in note
+                for note in _exception_notes(primary)
+            )
+            # A cancelled reconciliation cannot safely advertise either
+            # namespace name as an owned orphan, even though this injected
+            # pre-rename case leaves the diagnostic path visible.
+            assert publication.orphan is None
+            assert stage_path.read_bytes() == b"x"
+        finally:
+            publication.close()
+
+
+def test_stage_close_error_prevents_a_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    stage_descriptor = publication._descriptor
+    real_close = publication_module.os.close
+
+    def fail_stage_close(descriptor: int) -> None:
+        if descriptor == stage_descriptor:
+            raise OSError(errno.EIO, "stage close failed")
+        real_close(descriptor)
+
+    monkeypatch.setattr(publication_module.os, "close", fail_stage_close)
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(OSError, match="stage close failed"):
+                publication.publish_into(receipt_owner)
+            with pytest.raises(OSError) as caught:
+                os.fstat(stage_descriptor)
+            assert caught.value.errno == errno.EBADF
+        finally:
+            monkeypatch.setattr(publication_module.os, "close", real_close)
+            publication.close()
+
+
+@pytest.mark.parametrize(
+    ("phase", "interruption"),
+    [
+        pytest.param(
+            "before",
+            OSError(errno.EIO, "before close failure"),
+            id="oserror-before",
+        ),
+        pytest.param(
+            "after",
+            OSError(errno.EIO, "after close failure"),
+            id="oserror-after",
+        ),
+        pytest.param(
+            "before",
+            KeyboardInterrupt("before close interrupt"),
+            id="keyboardinterrupt-before",
+        ),
+        pytest.param(
+            "after",
+            SystemExit("after close cancellation"),
+            id="systemexit-after",
+        ),
+    ],
+)
+def test_receipt_owner_close_reconciles_before_and_after_real_close_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+    interruption: BaseException,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    receipt = receipt_owner.receipt
+    descriptor = receipt._descriptor
+    real_close = publication_module.os.close
+
+    def injected_close(candidate: int) -> None:
+        if candidate != descriptor:
+            real_close(candidate)
+            return
+        if phase == "after":
+            real_close(candidate)
+        raise interruption
+
+    monkeypatch.setattr(publication_module.os, "close", injected_close)
+    with pytest.raises(type(interruption)) as caught:
+        receipt_owner.close()
+
+    assert caught.value is interruption
+    if phase == "before":
+        assert receipt_owner.active
+        assert not receipt.closed
+        assert os.fstat(descriptor)
+        monkeypatch.setattr(publication_module.os, "close", real_close)
+        receipt_owner.close()
+    else:
+        assert receipt_owner.closed
+    assert receipt.closed
+    _assert_bad_descriptor(descriptor)
+
+
+def test_receipt_owner_close_interrupted_while_arming_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    receipt = receipt_owner.receipt
+    descriptor = receipt._descriptor
+    interruption = SystemExit("injected during close ownership arming")
+    real_arm = publication_module._arm_descriptor_for_close
+    injected = False
+
+    def interrupt_first_arm(candidate: int, **kwargs) -> int:
+        nonlocal injected
+        if candidate == descriptor and not injected:
+            injected = True
+            raise interruption
+        return real_arm(candidate, **kwargs)
+
+    monkeypatch.setattr(
+        publication_module,
+        "_arm_descriptor_for_close",
+        interrupt_first_arm,
+    )
+    with pytest.raises(SystemExit) as caught:
+        receipt_owner.close()
+
+    assert caught.value is interruption
+    assert injected
+    assert receipt_owner.active
+    assert not receipt.closed
+    monkeypatch.setattr(
+        publication_module,
+        "_arm_descriptor_for_close",
+        real_arm,
+    )
+    receipt_owner.close()
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+@pytest.mark.parametrize("replacement_kind", ["different-inode", "same-inode-new-ofd"])
+def test_receipt_close_preserves_observable_fd_reuse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement_kind: str,
+) -> None:
+    destination = tmp_path / "object"
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        destination,
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    receipt = receipt_owner.receipt
+    descriptor = receipt._descriptor
+    replacement_path = destination
+    if replacement_kind == "different-inode":
+        replacement_path = tmp_path / "foreign"
+        replacement_path.write_bytes(b"foreign")
+    expected = replacement_path.read_bytes()
+    real_close = publication_module.os.close
+    real_open = publication_module.os.open
+    interruption = SystemExit("injected after close and observable fd reuse")
+
+    def close_then_reuse(candidate: int) -> None:
+        if candidate != descriptor:
+            real_close(candidate)
+            return
+        real_close(candidate)
+        opened = real_open(replacement_path, os.O_RDONLY)
+        if opened != candidate:
+            os.dup2(opened, candidate)
+            real_close(opened)
+        raise interruption
+
+    monkeypatch.setattr(publication_module.os, "close", close_then_reuse)
+    try:
+        with pytest.raises(SystemExit) as caught:
+            receipt_owner.close()
+        assert caught.value is interruption
+        assert receipt_owner.closed
+        assert receipt.closed
+        assert os.pread(descriptor, len(expected), 0) == expected
+
+        # The invalidated owner must not touch the replacement on a retry.
+        receipt_owner.close()
+        assert os.pread(descriptor, len(expected), 0) == expected
+    finally:
+        real_close(descriptor)
+
+
+def test_exact_same_ofd_aba_is_retained_but_foreign_reuse_is_not_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    receipt = receipt_owner.receipt
+    descriptor = receipt._descriptor
+    alias = os.dup(descriptor)
+    real_close = publication_module.os.close
+    interruption = KeyboardInterrupt("injected exact same-OFD dup2 ABA")
+
+    def close_then_restore_exact_alias(candidate: int) -> None:
+        if candidate != descriptor:
+            real_close(candidate)
+            return
+        real_close(candidate)
+        os.dup2(alias, candidate)
+        raise interruption
+
+    monkeypatch.setattr(
+        publication_module.os,
+        "close",
+        close_then_restore_exact_alias,
+    )
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            receipt_owner.close()
+        assert caught.value is interruption
+        assert receipt_owner.active
+        assert not receipt.closed
+
+        # Identity plus the shared offset cookie cannot distinguish this ABA,
+        # so the retryable owner conservatively retains it.  A later observable
+        # reuse is rejected before another close syscall touches that number.
+        assert os.fstat(descriptor)
+        assert os.fstat(alias)
+
+        monkeypatch.setattr(publication_module.os, "close", real_close)
+        foreign = tmp_path / "foreign-after-aba"
+        foreign.write_bytes(b"foreign")
+        opened = os.open(foreign, os.O_RDONLY)
+        if opened != descriptor:
+            os.dup2(opened, descriptor)
+            real_close(opened)
+        with pytest.raises(RuntimeError, match="changed before close retry"):
+            receipt_owner.close()
+        assert receipt_owner.closed
+        assert os.pread(descriptor, 7, 0) == b"foreign"
+        real_close(descriptor)
+    finally:
+        real_close(alias)
+
+
+def test_receipt_owner_persistent_close_eio_retains_owner_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    real_close = publication_module.os.close
+    error = OSError(errno.EIO, "persistent receipt close failure")
+    close_calls = 0
+
+    def fail_receipt_close(candidate: int) -> None:
+        nonlocal close_calls
+        if candidate == descriptor:
+            close_calls += 1
+            raise error
+        real_close(candidate)
+
+    try:
+        monkeypatch.setattr(publication_module.os, "close", fail_receipt_close)
+        for _attempt in range(2):
+            with pytest.raises(OSError) as caught:
+                receipt_owner.close()
+            assert caught.value is error
+            assert receipt_owner.active
+            assert os.fstat(descriptor)
+    finally:
+        monkeypatch.setattr(publication_module.os, "close", real_close)
+        receipt_owner.close()
+
+    assert close_calls == 2
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+def test_receipt_owner_close_after_error_preserves_primary_and_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    real_close = publication_module.os.close
+    primary = KeyboardInterrupt("primary cancellation")
+    cleanup = OSError(errno.EIO, "persistent receipt cleanup failure")
+
+    def fail_receipt_close(candidate: int) -> None:
+        if candidate == descriptor:
+            raise cleanup
+        real_close(candidate)
+
+    try:
+        monkeypatch.setattr(publication_module.os, "close", fail_receipt_close)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            try:
+                raise primary
+            except BaseException as body_error:
+                receipt_owner.close_after_error(body_error)
+                raise
+        assert caught.value is primary
+        assert any(
+            "published receipt owner cleanup also failed" in note
+            and "persistent receipt cleanup failure" in note
+            for note in _exception_notes(primary)
+        )
+        assert receipt_owner.active
+        assert os.fstat(descriptor)
+    finally:
+        monkeypatch.setattr(publication_module.os, "close", real_close)
+        receipt_owner.close()
+
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+def test_publish_error_after_install_preserves_primary_and_installed_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    primary = SystemExit("injected after receipt owner install")
+    cleanup = OSError(errno.EIO, "installed receipt close failure")
+    installed_descriptor = -1
+    real_install = PublishedFileReceiptOwner._install
+    real_close = publication_module.os.close
+
+    def install_then_interrupt(owner, reservation, receipt) -> None:
+        nonlocal installed_descriptor
+        real_install(owner, reservation, receipt)
+        installed_descriptor = receipt._descriptor
+        raise primary
+
+    def fail_installed_close(candidate: int) -> None:
+        if candidate == installed_descriptor:
+            raise cleanup
+        real_close(candidate)
+
+    monkeypatch.setattr(PublishedFileReceiptOwner, "_install", install_then_interrupt)
+    monkeypatch.setattr(publication_module.os, "close", fail_installed_close)
+    try:
+        with pytest.raises(SystemExit) as caught:
+            publication.publish_into(receipt_owner)
+        assert caught.value is primary
+        assert installed_descriptor >= 0
+        assert receipt_owner.active
+        assert os.fstat(installed_descriptor)
+        assert any(
+            "published receipt owner cleanup also failed" in note
+            and "installed receipt close failure" in note
+            for note in _exception_notes(primary)
+        )
+    finally:
+        monkeypatch.setattr(publication_module.os, "close", real_close)
+        receipt_owner.close()
+        publication.close()
+
+    assert destination.read_bytes() == b"x"
+    assert receipt_owner.closed
+    _assert_bad_descriptor(installed_descriptor)
+
+
+def test_receipt_install_reentry_is_rejected_without_double_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    real_install = PublishedFileReceiptOwner._install
+    reentry_errors: list[BaseException] = []
+
+    def install_with_reentry(owner, reservation, receipt) -> None:
+        try:
+            publication.publish_into(owner)
+        except RuntimeError as error:
+            reentry_errors.append(error)
+        real_install(owner, reservation, receipt)
+
+    monkeypatch.setattr(PublishedFileReceiptOwner, "_install", install_with_reentry)
+    try:
+        publication.publish_into(receipt_owner)
+        assert len(reentry_errors) == 1
+        assert isinstance(reentry_errors[0], RuntimeError)
+        assert "publishing, expected written" in str(reentry_errors[0])
+        assert receipt_owner.receipt.read_bytes(max_bytes=1) == b"x"
+    finally:
+        receipt_owner.close()
+        publication.close()
+
+    assert receipt_owner.closed
+
+
+def test_owner_lifecycle_lock_recovers_acquire_success_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    real_acquire = publication_module._CancellationSafeRLock._acquire
+    interruption = KeyboardInterrupt("after lifecycle lock acquire")
+    injected = False
+
+    def acquire_then_interrupt(lock) -> None:
+        nonlocal injected
+        real_acquire(lock)
+        if lock is receipt_owner._lock and not injected:
+            injected = True
+            raise interruption
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_acquire",
+        acquire_then_interrupt,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _ = receipt_owner.state
+    assert caught.value is interruption
+    assert injected
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_acquire",
+        real_acquire,
+    )
+    observed: list[str] = []
+    observer = threading.Thread(target=lambda: observed.append(receipt_owner.state))
+    observer.start()
+    observer.join(timeout=2)
+    assert not observer.is_alive()
+    assert observed == ["empty"]
+
+
+def test_owner_lifecycle_lock_release_cancellation_keeps_closed_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    real_release = publication_module._CancellationSafeRLock._release
+    interruption = SystemExit("after lifecycle lock release")
+    injected = False
+
+    def release_then_interrupt(lock) -> None:
+        nonlocal injected
+        real_release(lock)
+        if lock is receipt_owner._lock and not injected:
+            injected = True
+            raise interruption
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_release",
+        release_then_interrupt,
+    )
+    with pytest.raises(SystemExit) as caught:
+        receipt_owner.close()
+    assert caught.value is interruption
+    assert injected
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_release",
+        real_release,
+    )
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+    receipt_owner.close()
+
+
+def test_owner_lifecycle_release_failure_is_secondary_to_callback_primary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    real_release = publication_module._CancellationSafeRLock._release
+    primary = KeyboardInterrupt("lifecycle callback primary")
+    secondary = SystemExit("before lifecycle lock release")
+    injected = False
+
+    def release_interrupt_once(lock) -> None:
+        nonlocal injected
+        if lock is receipt_owner._lock and not injected:
+            injected = True
+            raise secondary
+        real_release(lock)
+
+    def fail_callback() -> None:
+        raise primary
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_release",
+        release_interrupt_once,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        receipt_owner._lock.run(fail_callback)
+    assert caught.value is primary
+    assert injected
+    assert any(
+        "receipt lifecycle lock release was interrupted" in note
+        and "before lifecycle lock release" in note
+        for note in _exception_notes(primary)
+    )
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_release",
+        real_release,
+    )
+    observed: list[str] = []
+    observer = threading.Thread(target=lambda: observed.append(receipt_owner.state))
+    observer.start()
+    observer.join(timeout=2)
+    assert not observer.is_alive()
+    assert observed == ["empty"]
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_consume_return_cleanup_cancellation_does_not_strand_reentrancy_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    callback_returned = False
+    injected = False
+    interruption = exception_type("after consume callback return")
+    real_normalize = PublishedFileReceiptOwner._normalize_closed_locked
+
+    def normalize_after_callback(owner) -> None:
+        nonlocal injected
+        if owner is receipt_owner and callback_returned and not injected:
+            injected = True
+            raise interruption
+        real_normalize(owner)
+
+    def consume(receipt: publication_module.PublishedFileReceipt) -> None:
+        nonlocal callback_returned
+        assert receipt.read_bytes(max_bytes=1) == b"x"
+        callback_returned = True
+
+    monkeypatch.setattr(
+        PublishedFileReceiptOwner,
+        "_normalize_closed_locked",
+        normalize_after_callback,
+    )
+    with pytest.raises(exception_type) as caught:
+        receipt_owner.consume(consume)
+    assert caught.value is interruption
+    assert callback_returned
+    assert injected
+
+    monkeypatch.setattr(
+        PublishedFileReceiptOwner,
+        "_normalize_closed_locked",
+        real_normalize,
+    )
+    receipt_owner.close()
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_persistent_close_error_wins_state_cleanup_cancellation_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    receipt = receipt_owner.receipt
+    descriptor = receipt._descriptor
+    real_close = publication_module.os.close
+    real_closed = publication_module.PublishedFileReceipt.closed.fget
+    assert real_closed is not None
+    close_error = OSError(errno.EIO, "persistent close before real syscall")
+    interruption = exception_type("receipt close-state observation cancelled")
+    close_attempted = False
+    injected = False
+
+    def fail_close(candidate: int) -> None:
+        nonlocal close_attempted
+        if candidate == descriptor:
+            close_attempted = True
+            raise close_error
+        real_close(candidate)
+
+    def interrupt_closed(candidate) -> bool:
+        nonlocal injected
+        if candidate is receipt and close_attempted and not injected:
+            injected = True
+            raise interruption
+        return real_closed(candidate)
+
+    monkeypatch.setattr(publication_module.os, "close", fail_close)
+    monkeypatch.setattr(
+        publication_module.PublishedFileReceipt,
+        "closed",
+        property(interrupt_closed),
+    )
+    with pytest.raises(OSError) as caught:
+        receipt_owner.close()
+
+    assert caught.value is close_error
+    assert close_attempted
+    assert injected
+    assert any(
+        "receipt owner close-state cleanup also failed" in note
+        and "close-state observation cancelled" in note
+        for note in _exception_notes(close_error)
+    )
+    assert receipt_owner.active
+    assert os.fstat(descriptor)
+
+    monkeypatch.setattr(publication_module.os, "close", real_close)
+    monkeypatch.setattr(
+        publication_module.PublishedFileReceipt,
+        "closed",
+        property(real_closed),
+    )
+    receipt_owner.close()
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+@pytest.mark.parametrize("phase", ["before", "after"])
+def test_after_real_close_state_transition_cancellation_converges_by_observation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    interruption = SystemExit(f"{phase} receipt close-state transition")
+    real_settle = PublishedFileReceiptOwner._settle_receipt_locked
+    injected = False
+
+    def settle_then_interrupt(owner, receipt):
+        nonlocal injected
+        if owner is receipt_owner and not injected:
+            injected = True
+            if phase == "after":
+                real_settle(owner, receipt)
+            raise interruption
+        return real_settle(owner, receipt)
+
+    monkeypatch.setattr(
+        PublishedFileReceiptOwner,
+        "_settle_receipt_locked",
+        settle_then_interrupt,
+    )
+    with pytest.raises(SystemExit) as caught:
+        receipt_owner.close()
+
+    assert caught.value is interruption
+    assert injected
+    _assert_bad_descriptor(descriptor)
+    assert receipt_owner.closed
+    receipt_owner.close()
+
+
+@pytest.mark.parametrize(
+    ("phase", "exception_type"),
+    [
+        pytest.param("before", KeyboardInterrupt, id="before-keyboardinterrupt"),
+        pytest.param("after", SystemExit, id="after-systemexit"),
+    ],
+)
+def test_publication_primary_wins_cancel_reservation_transition_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+    exception_type: type[BaseException],
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    primary = LookupError("publication authentication primary")
+    interruption = exception_type(f"{phase} terminal reservation slot store")
+    real_bind = OwnedFilePublicationAuthority._bind_stage
+    real_cancel = PublishedFileReceiptOwner._cancel_reservation_locked
+    injected = False
+
+    def fail_publish_bind(candidate, record) -> None:
+        if candidate is publication:
+            raise primary
+        real_bind(candidate, record)
+
+    def cancel_then_interrupt(owner, reservation) -> bool:
+        nonlocal injected
+        if owner is receipt_owner and not injected:
+            injected = True
+            if phase == "after":
+                real_cancel(owner, reservation)
+            raise interruption
+        return real_cancel(owner, reservation)
+
+    monkeypatch.setattr(OwnedFilePublicationAuthority, "_bind_stage", fail_publish_bind)
+    monkeypatch.setattr(
+        PublishedFileReceiptOwner,
+        "_cancel_reservation_locked",
+        cancel_then_interrupt,
+    )
+    try:
+        with pytest.raises(LookupError) as caught:
+            publication.publish_into(receipt_owner)
+        assert caught.value is primary
+        assert injected
+        assert any(
+            "receipt reservation cleanup also failed" in note
+            and "terminal reservation slot store" in note
+            for note in _exception_notes(primary)
+        )
+        assert receipt_owner.closed
+        receipt_owner.close()
+        assert not destination.exists()
+    finally:
+        publication.close()
+
+
+def test_helper_consumer_primary_wins_terminal_close_cancellation_and_no_fd_leak(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = _descriptor_count()
+    primary = KeyboardInterrupt("helper consumer primary")
+    interruption = SystemExit("before terminal descriptor close")
+    captured: list[publication_module.PublishedFileReceipt] = []
+    descriptors: list[int] = []
+    real_close = publication_module.os.close
+    injected = False
+    close_calls = 0
+
+    def interrupt_first_close(candidate: int) -> None:
+        nonlocal close_calls, injected
+        if descriptors and candidate == descriptors[0]:
+            close_calls += 1
+            if not injected:
+                injected = True
+                raise interruption
+        real_close(candidate)
+
+    def consume(receipt: publication_module.PublishedFileReceipt) -> None:
+        captured.append(receipt)
+        descriptors.append(receipt._descriptor)
+        raise primary
+
+    monkeypatch.setattr(publication_module.os, "close", interrupt_first_close)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        publish_owned_file(
+            tmp_path / "object",
+            [b"x"],
+            max_bytes=1,
+            consume=consume,
+        )
+
+    assert caught.value is primary
+    assert injected
+    assert close_calls == 2
+    assert len(captured) == 1
+    assert captured[0].closed
+    _assert_bad_descriptor(descriptors[0])
+    assert any(
+        "descriptor terminal cleanup was interrupted" in note
+        and "before terminal descriptor close" in note
+        for note in _exception_notes(primary)
+    )
+    assert _descriptor_count() <= before
+
+
+def test_concurrent_owner_close_calls_are_linear_after_one_close_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    real_close = publication_module.os.close
+    interruption = OSError(errno.EIO, "first concurrent close failure")
+    start = threading.Barrier(3)
+    outcomes: list[BaseException | None] = []
+    close_calls = 0
+
+    def fail_first_close(candidate: int) -> None:
+        nonlocal close_calls
+        if candidate == descriptor:
+            close_calls += 1
+            if close_calls == 1:
+                raise interruption
+        real_close(candidate)
+
+    def close() -> None:
+        start.wait()
+        try:
+            receipt_owner.close()
+        except BaseException as error:  # noqa: B036 - report thread outcome
+            outcomes.append(error)
+        else:
+            outcomes.append(None)
+
+    monkeypatch.setattr(publication_module.os, "close", fail_first_close)
+    workers = [threading.Thread(target=close) for _index in range(2)]
+    for worker in workers:
+        worker.start()
+    start.wait()
+    for worker in workers:
+        worker.join(timeout=3)
+        assert not worker.is_alive()
+
+    assert len(outcomes) == 2
+    assert sum(error is interruption for error in outcomes) == 1
+    assert sum(error is None for error in outcomes) == 1
+    assert close_calls == 2
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+def test_one_owner_concurrent_reservations_allow_exactly_one_publication(
+    tmp_path: Path,
+) -> None:
+    before = _descriptor_count()
+    receipt_owner = PublishedFileReceiptOwner()
+    publications = [
+        OwnedFilePublicationAuthority(tmp_path / f"object-{index}", max_bytes=1)
+        for index in range(2)
+    ]
+    for index, publication in enumerate(publications):
+        publication.write([bytes([ord("a") + index])])
+    start = threading.Barrier(3)
+    outcomes: list[tuple[int, str, BaseException | None]] = []
+
+    def publish(index: int) -> None:
+        publication = publications[index]
+        start.wait()
+        try:
+            publication.publish_into(receipt_owner)
+        except RuntimeError as error:
+            outcomes.append((index, "error", error))
+        else:
+            outcomes.append((index, "published", None))
+        finally:
+            publication.close()
+
+    workers = [threading.Thread(target=publish, args=(index,)) for index in range(2)]
+    for worker in workers:
+        worker.start()
+    start.wait()
+    for worker in workers:
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+
+    published = [entry for entry in outcomes if entry[1] == "published"]
+    rejected = [entry for entry in outcomes if entry[1] == "error"]
+    assert len(published) == 1
+    assert len(rejected) == 1
+    assert isinstance(rejected[0][2], RuntimeError)
+    assert receipt_owner.active
+    winning_index = published[0][0]
+    assert receipt_owner.receipt.path == tmp_path / f"object-{winning_index}"
+    assert sum((tmp_path / f"object-{index}").exists() for index in range(2)) == 1
+
+    receipt_owner.close()
+    assert receipt_owner.closed
+    assert _descriptor_count() <= before
+
+
+def test_owner_close_cannot_cancel_a_reserved_publication_before_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    reserved = threading.Event()
+    continue_publication = threading.Event()
+    errors: list[Exception] = []
+    real_reserve = PublishedFileReceiptOwner._reserve
+
+    def reserve_then_wait(owner, reservation) -> None:
+        real_reserve(owner, reservation)
+        if owner is receipt_owner:
+            reserved.set()
+            assert continue_publication.wait(timeout=2)
+
+    def publish() -> None:
+        try:
+            publication.publish_into(receipt_owner)
+        except Exception as error:
+            errors.append(error)
+
+    monkeypatch.setattr(PublishedFileReceiptOwner, "_reserve", reserve_then_wait)
+    worker = threading.Thread(target=publish)
+    worker.start()
+    assert reserved.wait(timeout=2)
+    assert receipt_owner.state == "reserved"
+    assert not destination.exists()
+    with pytest.raises(RuntimeError, match="publication is in progress"):
+        receipt_owner.close()
+    assert receipt_owner.state == "reserved"
+    assert not destination.exists()
+
+    continue_publication.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    try:
+        assert errors == []
+        assert receipt_owner.active
+        assert destination.read_bytes() == b"x"
+    finally:
+        receipt_owner.close()
+        publication.close()
+
+
+def test_owner_consume_and_close_are_linear_across_threads(tmp_path: Path) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    consume_started = threading.Event()
+    allow_consume_return = threading.Event()
+    close_started = threading.Event()
+    close_finished = threading.Event()
+    consumed: list[bytes] = []
+    errors: list[BaseException] = []
+
+    def consume(receipt: publication_module.PublishedFileReceipt) -> None:
+        try:
+            consume_started.set()
+            consumed.append(receipt.read_bytes(max_bytes=1))
+            assert allow_consume_return.wait(timeout=2)
+            consumed.append(receipt.read_bytes(max_bytes=1))
+        except Exception as error:
+            errors.append(error)
+
+    def close() -> None:
+        try:
+            close_started.set()
+            receipt_owner.close()
+        except Exception as error:
+            errors.append(error)
+        finally:
+            close_finished.set()
+
+    consumer = threading.Thread(target=lambda: receipt_owner.consume(consume))
+    consumer.start()
+    assert consume_started.wait(timeout=2)
+    closer = threading.Thread(target=close)
+    closer.start()
+    assert close_started.wait(timeout=2)
+    assert not close_finished.wait(timeout=0.05)
+    allow_consume_return.set()
+    consumer.join(timeout=2)
+    closer.join(timeout=2)
+
+    assert not consumer.is_alive()
+    assert not closer.is_alive()
+    assert errors == []
+    assert consumed == [b"x", b"x"]
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+@pytest.mark.parametrize(
+    ("phase", "exception_type"),
+    [
+        pytest.param("before", KeyboardInterrupt, id="keyboardinterrupt-before"),
+        pytest.param("after", SystemExit, id="systemexit-after"),
+    ],
+)
+def test_parent_authority_close_defers_interrupt_and_closes_all_resources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+    exception_type: type[BaseException],
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    assert publication._authority is not None
+    parent_descriptor = publication._authority.resource
+    real_close = publication_module.os.close
+    interruption = exception_type(f"{phase} parent close interrupt")
+
+    def interrupt_parent_close(descriptor: int) -> None:
+        if descriptor != parent_descriptor:
+            real_close(descriptor)
+            return
+        if phase == "after":
+            real_close(descriptor)
+        raise interruption
+
+    monkeypatch.setattr(publication_module.os, "close", interrupt_parent_close)
+    with PublishedFileReceiptOwner() as receipt_owner:
+        with pytest.raises(exception_type) as caught:
+            publication.publish_into(receipt_owner)
+
+        assert caught.value is interruption
+        _assert_bad_descriptor(parent_descriptor)
+        publication.close()
+
+
+def test_body_error_wins_while_close_visits_stage_and_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = _descriptor_count()
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    stage_descriptor = publication._descriptor
+    assert publication._authority is not None
+    parent_descriptor = publication._authority.resource
+    real_close = publication_module.os.close
+    stage_interruption = KeyboardInterrupt("stage cleanup interrupted")
+    parent_cancellation = SystemExit("parent cleanup cancelled")
+    stage_injected = False
+    parent_injected = False
+
+    def interrupt_two_closes(descriptor: int) -> None:
+        nonlocal stage_injected, parent_injected
+        if descriptor == stage_descriptor and not stage_injected:
+            stage_injected = True
+            raise stage_interruption
+        if descriptor == parent_descriptor and not parent_injected:
+            parent_injected = True
+            real_close(descriptor)
+            raise parent_cancellation
+        real_close(descriptor)
+
+    monkeypatch.setattr(publication_module.os, "close", interrupt_two_closes)
+
+    class BrokenProducer:
+        def __iter__(self):
+            raise LookupError("primary producer failure")
+
+    with pytest.raises(LookupError, match="primary producer failure") as caught:
+        with publication:
+            publication.write(BrokenProducer())
+
+    assert stage_injected
+    assert parent_injected
+    assert publication.state == "closed"
+    _assert_bad_descriptor(stage_descriptor)
+    _assert_bad_descriptor(parent_descriptor)
+    assert any(
+        "publication cleanup also failed" in note
+        and "stage cleanup interrupted" in note
+        for note in _exception_notes(caught.value)
+    )
+    assert _descriptor_count() <= before
+
+
+def test_linear_state_and_pid_binding(tmp_path: Path, monkeypatch) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    with pytest.raises(RuntimeError, match="expected staged"):
+        publication.write([b"x"])
+
+    owner_pid = os.getpid()
+    monkeypatch.setattr(publication_module.os, "getpid", lambda: owner_pid + 1)
+    with pytest.raises(RuntimeError, match="PID boundary"):
+        publication.publish_into(receipt_owner)
+    with pytest.raises(RuntimeError, match="PID boundary"):
+        publication.close()
+    with pytest.raises(RuntimeError, match="PID boundary"):
+        _ = receipt_owner.state
+    with pytest.raises(RuntimeError, match="PID boundary"):
+        receipt_owner.close()
+
+    monkeypatch.setattr(publication_module.os, "getpid", lambda: owner_pid)
+    assert receipt_owner.closed
+
+
+def test_missing_parent_and_noncanonical_leaf_do_not_create_paths(
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing"
+    with pytest.raises(FileNotFoundError):
+        OwnedFilePublicationAuthority(missing / "object", max_bytes=1)
+    assert not missing.exists()
+
+    with pytest.raises(ValueError, match="safe final component"):
+        OwnedFilePublicationAuthority(tmp_path / "..", max_bytes=1)
+
+
+def test_publication_uses_no_destructive_or_resolving_path_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("destructive or resolving path call")
+
+    for name in ("resolve", "mkdir", "unlink", "rmdir"):
+        monkeypatch.setattr(Path, name, forbidden)
+    for name in ("unlink", "remove", "rmdir"):
+        monkeypatch.setattr(publication_module.os, name, forbidden)
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publish_owned_file(
+            tmp_path / "object",
+            [b"x"],
+            max_bytes=1,
+            receipt_owner=receipt_owner,
+        )
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux process gate")
+def test_concurrent_processes_publish_identical_bytes(tmp_path: Path) -> None:
+    destination = tmp_path / "object"
+    payload = b"shared bytes"
+    context = multiprocessing.get_context("fork")
+    processes = [
+        context.Process(
+            target=_publish_in_process,
+            args=(os.fspath(destination), payload),
+        )
+        for _index in range(4)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=20)
+        assert process.exitcode == 0
+
+    assert destination.read_bytes() == payload
+    assert len(list(tmp_path.glob(".codenib-file-*"))) == 3
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs")
+def test_failure_and_receipt_close_do_not_leak_descriptors(tmp_path: Path) -> None:
+    before = len(list(Path("/proc/self/fd").iterdir()))
+    destination = tmp_path / "object"
+    destination.write_bytes(b"old")
+    for index in range(12):
+        with PublishedFileReceiptOwner() as failed_owner:
+            with pytest.raises(OwnedFileConflictError):
+                publish_owned_file(
+                    destination,
+                    [f"new-{index}".encode()],
+                    max_bytes=16,
+                    receipt_owner=failed_owner,
+                )
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publish_owned_file(
+            destination,
+            [b"old"],
+            max_bytes=3,
+            receipt_owner=receipt_owner,
+        )
+    after = len(list(Path("/proc/self/fd").iterdir()))
+    assert after <= before + 1
+
+
+def test_darwin_rename_dispatch_uses_existing_renameatx_np(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[object, ...]] = []
+
+    class Rename:
+        argtypes = None
+        restype = None
+
+        def __call__(self, *args):
+            calls.append(args)
+            return 0
+
+    class Libc:
+        renameatx_np = Rename()
+
+    monkeypatch.setattr(atomic_module.sys, "platform", "darwin")
+    monkeypatch.setattr(atomic_module.ctypes, "CDLL", lambda *_args, **_kwargs: Libc())
+
+    atomic_module._rename_noreplace_at("stage", "final", 10, 11)
+
+    assert calls == [(10, b"stage", 11, b"final", atomic_module._RENAME_EXCL)]
+
+
+def test_windows_fails_before_opening_or_mutating_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    opened = False
+
+    def forbidden_open(*_args, **_kwargs):
+        nonlocal opened
+        opened = True
+        raise AssertionError("Windows publication authority was opened")
+
+    monkeypatch.setattr(publication_module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        publication_module._atomic,
+        "_open_publication_authority",
+        forbidden_open,
+    )
+
+    with pytest.raises(RuntimeError, match="unsupported on Windows"):
+        OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    assert not opened
+    assert not (tmp_path / "object").exists()
+
+
+@pytest.mark.parametrize(
+    ("platform", "message"),
+    (("win32", "unsupported on Windows"), ("freebsd", "unsupported on this host")),
+)
+def test_support_gate_fails_before_opening_or_mutating_any_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+    message: str,
+) -> None:
+    touched = False
+
+    def forbidden(*_args, **_kwargs):
+        nonlocal touched
+        touched = True
+        raise AssertionError("support gate touched filesystem publication state")
+
+    monkeypatch.setattr(publication_module.sys, "platform", platform)
+    monkeypatch.setattr(
+        publication_module._atomic,
+        "_require_rename_noreplace_platform",
+        forbidden,
+    )
+    monkeypatch.setattr(
+        publication_module._atomic,
+        "_open_publication_authority",
+        forbidden,
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        require_owned_file_publication_support()
+
+    assert not touched
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_support_gate_covers_atomic_directory_fd_prerequisites(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend_checked = False
+
+    def forbidden_backend_check() -> None:
+        nonlocal backend_checked
+        backend_checked = True
+        raise AssertionError("rename backend was checked after a failed fd gate")
+
+    monkeypatch.setattr(
+        publication_module._atomic,
+        "_SAFE_OWNERSHIP_DIRECTORY_FDS",
+        False,
+    )
+    monkeypatch.setattr(
+        publication_module._atomic,
+        "_require_rename_noreplace_platform",
+        forbidden_backend_check,
+    )
+
+    with pytest.raises(RuntimeError, match="anchored directory-fd support"):
+        require_owned_file_publication_support()
+
+    assert not backend_checked
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary

Add the owned publication primitives needed to publish local CAS objects and preopened workspaces without reopening ambient paths.

The stack has been restacked onto current `main`; its former #584/#585 history is no longer part of this PR. #585 is merged.

## Changes

- add owned file publication authority with no-replace installation, authenticated receipts, cancellation-safe cleanup, and fork-safe descriptor ownership
- publish strict `LocalCAS` objects through retained root/hash/shard generation authorities
- keep strict CAS acquisition, handoff, operations, and cleanup in one process-local cancellation-safe lifecycle
- preserve exact root, SHA-256, and selected-shard generation validation without owner-wide scans on each operation
- preserve the portable lazy `LocalCAS` backend where owned publication is unsupported, while strict mode fails before filesystem I/O
- add preopened captured-workspace publication with exact scanner-bounded ownership validation
- detach adopted workspace plans and receipt projections from caller-mutable dataclass objects
- authenticate immutable snapshots from byte zero, including after partial reads
- fall back to bounded memory when memfd/sealing is unavailable, while retaining resource/I/O failures
- reject unsupported Darwin workspace adoption before resource or state acquisition
- preserve POSIX surrogate-escaped filesystem paths in workspace receipts
- document the strict publication and compatibility-mode boundary in the storage roadmap
- cover publication races, PID boundaries, descriptor offsets, generation replacement, cleanup, and resource lifecycle failures

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Python 3.11 publication/CAS focus: 402 passed, 10 skipped
- full `test/storage`: 281 passed
- `test/storage/test_cas.py`: 83 passed
- Python 3.12 focused lifecycle/cancellation coverage: passed
- repeated concurrent close/read/put/fork and FD-reuse/cancellation probes: passed
- independent final audit: 0 blocker, 0 high, 0 medium
- `pre-commit run --from-ref origin/main --to-ref HEAD`: passed
- `git diff --check origin/main...HEAD`: passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of the code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] The changes generate no new warnings
- [x] Any dependent changes have been merged and published