### PR TITLE
fix(runtime): retain authenticated source authorities

### DIFF
--- a/codenib/_contained_source.py
+++ b/codenib/_contained_source.py
@@ -6,12 +6,50 @@
 
 from __future__ import annotations
 
+import errno
+import ntpath
 import os
 import stat
+import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
-from typing import Iterator
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Iterator, Sequence
+
+from ._windows_fs_authority import (
+    FILE_ATTRIBUTE_DIRECTORY as _WINDOWS_FILE_ATTRIBUTE_DIRECTORY,
+)
+from ._windows_fs_authority import (
+    FILE_ATTRIBUTE_REPARSE_POINT as _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT,
+)
+from ._windows_fs_authority import FILE_LIST_DIRECTORY as _WINDOWS_FILE_LIST_DIRECTORY
+from ._windows_fs_authority import FILE_READ_ATTRIBUTES as _WINDOWS_FILE_READ_ATTRIBUTES
+from ._windows_fs_authority import FILE_READ_DATA as _WINDOWS_FILE_READ_DATA
+from ._windows_fs_authority import (
+    IO_REPARSE_TAG_SYMLINK as _WINDOWS_IO_REPARSE_TAG_SYMLINK,
+)
+from ._windows_fs_authority import (
+    SYMLINK_FLAG_RELATIVE as _WINDOWS_SYMLINK_FLAG_RELATIVE,
+)
+from ._windows_fs_authority import SYNCHRONIZE as _WINDOWS_SYNCHRONIZE
+from ._windows_fs_authority import (
+    WindowsDirectoryAuthority as _WindowsDirectoryAuthority,
+)
+from ._windows_fs_authority import WindowsDirectoryEntry as _WindowsDirectoryEntry
+from ._windows_fs_authority import WindowsHandleMetadata as _WindowsHandleMetadata
+from ._windows_fs_authority import WindowsKernelApi as _WindowsKernelApi
+from ._windows_fs_authority import WindowsReparsePoint as _WindowsReparsePoint
+from ._windows_fs_authority import _close_windows_handles, _WindowsHandleCleanup
+from ._windows_fs_authority import (
+    open_lexical_directory_authority as _open_lexical_windows_authority,
+)
+from ._windows_fs_authority import (
+    windows_file_id_is_reliable as _windows_file_id_is_reliable,
+)
+from ._windows_fs_authority import windows_kernel_api as _shared_windows_kernel_api
+from ._windows_fs_authority import (
+    windows_require_source_api as _shared_windows_require_source_api,
+)
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _MAX_COMPONENTS = 256
@@ -32,6 +70,266 @@ SECURE_CONTAINED_SYMLINKS = (
 
 class ContainedSourceMissingError(ValueError):
     """A lexically present source link has no resolvable regular target."""
+
+
+class _SourceCleanupSlot:
+    """Stable, retryable owner across raw-resource and binding handoffs."""
+
+    __slots__ = ("_resource",)
+
+    def __init__(self) -> None:
+        self._resource: object | None = None
+
+    def own(self, resource: object) -> None:
+        if resource is None:
+            raise TypeError("source cleanup resource must not be null")
+        self._resource = resource
+
+    @property
+    def pending_sources(self) -> tuple[object, ...]:
+        resource = self._resource
+        if resource is None or self.closed:
+            return ()
+        nested = getattr(resource, "pending_sources", None)
+        if nested is not None:
+            return tuple(nested)
+        return (resource,)
+
+    @property
+    def closed(self) -> bool:
+        resource = self._resource
+        if resource is None:
+            return True
+        try:
+            return bool(resource.closed)  # type: ignore[attr-defined]
+        except BaseException:  # noqa: B036 - uncertain ownership stays retained
+            return False
+
+    def close(self) -> None:
+        resource = self._resource
+        if resource is None:
+            return
+        close = getattr(resource, "close", None)
+        if not callable(close):
+            raise TypeError("source cleanup resource has no close method")
+        close()
+        if self.closed:
+            self._resource = None
+
+
+class _PosixDescriptorCleanup:
+    """Retryable owner for descriptors acquired during contained resolution."""
+
+    __slots__ = ("descriptors", "expected_identities")
+
+    def __init__(self) -> None:
+        self.descriptors: list[int] = []
+        self.expected_identities: dict[int, tuple[int, ...]] = {}
+
+    @property
+    def closed(self) -> bool:
+        return not self.descriptors
+
+    def retain(self, descriptor: int) -> int:
+        if descriptor not in self.descriptors:
+            self.descriptors.append(descriptor)
+        return descriptor
+
+    def remember_identity(self, descriptor: int, metadata: os.stat_result) -> None:
+        self.expected_identities[descriptor] = _binding_identity(metadata)
+
+    def open(self, path: str | Path, flags: int, *, dir_fd: int | None = None) -> int:
+        descriptor = -1
+        try:
+            if dir_fd is None:
+                descriptor = os.open(path, flags)
+            else:
+                descriptor = os.open(path, flags, dir_fd=dir_fd)
+            return self.retain(descriptor)
+        except BaseException:  # noqa: B036 - commit native return ownership
+            if descriptor >= 0:
+                try:
+                    self.retain(descriptor)
+                except BaseException:  # noqa: B036 - preserve acquisition failure
+                    pass
+            raise
+
+    def dup(self, descriptor: int) -> int:
+        duplicate = -1
+        try:
+            duplicate = os.dup(descriptor)
+            return self.retain(duplicate)
+        except BaseException:  # noqa: B036 - commit native return ownership
+            if duplicate >= 0:
+                try:
+                    self.retain(duplicate)
+                except BaseException:  # noqa: B036 - preserve acquisition failure
+                    pass
+            raise
+
+    def _close_selected(self, selected: tuple[int, ...]) -> BaseException | None:
+        deferred: BaseException | None = None
+        for descriptor in reversed(selected):
+            if descriptor not in self.descriptors:
+                continue
+            closed = False
+            try:
+                before = os.fstat(descriptor)
+                expected = self.expected_identities.get(descriptor)
+                if expected is not None and _binding_identity(before) != expected:
+                    deferred = deferred or RuntimeError(
+                        "source descriptor ownership changed"
+                    )
+                    closed = True
+                else:
+                    try:
+                        os.close(descriptor)
+                        closed = True
+                    except BaseException as exc:  # noqa: B036 - probe close result
+                        deferred = deferred or exc
+                        try:
+                            visible = os.fstat(descriptor)
+                        except OSError as probe:
+                            if probe.errno == errno.EBADF:
+                                closed = True
+                            else:
+                                deferred = deferred or probe
+                        except BaseException as probe:  # noqa: B036
+                            deferred = deferred or probe
+                        else:
+                            if _binding_identity(visible) != _binding_identity(before):
+                                closed = True
+            except OSError as exc:
+                if exc.errno == errno.EBADF:
+                    closed = True
+                else:
+                    deferred = deferred or exc
+            except BaseException as exc:  # noqa: B036 - visit remaining fds
+                deferred = deferred or exc
+            if closed:
+                while descriptor in self.descriptors:
+                    self.descriptors.remove(descriptor)
+                self.expected_identities.pop(descriptor, None)
+        return deferred
+
+    def close_descriptor(self, descriptor: int) -> None:
+        failure = self._close_selected((descriptor,))
+        if failure is not None:
+            raise failure
+
+    def close(self) -> None:
+        failure = self._close_selected(tuple(self.descriptors))
+        if failure is not None:
+            raise failure
+
+
+class _SourceCleanupGroup:
+    """Retryable cleanup-all owner for independently pending authorities."""
+
+    __slots__ = ("owners",)
+
+    def __init__(self, *owners: object) -> None:
+        self.owners: list[object] = []
+        for owner in owners:
+            self.add(owner)
+
+    def add(self, owner: object) -> None:
+        if owner is self:
+            return
+        if isinstance(owner, _SourceCleanupGroup):
+            for nested in owner.owners:
+                self.add(nested)
+            return
+        if not any(candidate is owner for candidate in self.owners):
+            self.owners.append(owner)
+
+    @property
+    def closed(self) -> bool:
+        for owner in self.owners:
+            try:
+                if not bool(owner.closed):  # type: ignore[attr-defined]
+                    return False
+            except BaseException:  # noqa: B036 - uncertain ownership is pending
+                return False
+        return True
+
+    @property
+    def pending_sources(self) -> tuple[object, ...]:
+        pending: list[object] = []
+        for owner in self.owners:
+            try:
+                if bool(owner.closed):  # type: ignore[attr-defined]
+                    continue
+            except BaseException:  # noqa: B036 - retain uncertain owner
+                pass
+            nested = getattr(owner, "pending_sources", None)
+            if nested is None:
+                pending.append(owner)
+            else:
+                pending.extend(nested)
+        return tuple(pending)
+
+    def close(self) -> None:
+        first_failure: BaseException | None = None
+        for owner in tuple(self.owners):
+            try:
+                owner.close()  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - cleanup every owner
+                first_failure = first_failure or exc
+        if first_failure is not None:
+            raise first_failure
+
+
+def _attach_source_cleanup_owner(failure: BaseException, owner: object) -> None:
+    """Attach all still-live cleanup owners to the propagated exception."""
+
+    try:
+        if bool(owner.closed):  # type: ignore[attr-defined]
+            return
+    except BaseException:  # noqa: B036 - uncertain ownership must stay reachable
+        pass
+    existing = getattr(failure, "source_cleanup_owner", None)
+    if existing is owner:
+        return
+    if existing is None:
+        attached = owner
+    elif isinstance(existing, _SourceCleanupGroup):
+        existing.add(owner)
+        attached = existing
+    else:
+        attached = _SourceCleanupGroup(existing, owner)
+    try:
+        failure.source_cleanup_owner = attached  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - the current frame still retains *owner*
+        pass
+
+
+def _inherit_source_cleanup_owner(
+    failure: BaseException,
+    prior: BaseException,
+) -> None:
+    """Keep a nested retry owner reachable from a translated primary error."""
+
+    owner = getattr(prior, "source_cleanup_owner", None)
+    if owner is not None:
+        _attach_source_cleanup_owner(failure, owner)
+
+
+def _raise_with_cleanup(
+    primary: BaseException,
+    owner: object,
+) -> None:
+    """Prefer *primary* while retaining any failed cleanup for explicit retry."""
+
+    cleanup_failure: BaseException | None = None
+    try:
+        owner.close()  # type: ignore[attr-defined]
+    except BaseException as exc:  # noqa: B036 - primary remains authoritative
+        cleanup_failure = exc
+    _attach_source_cleanup_owner(primary, owner)
+    if cleanup_failure is not None:
+        raise primary from cleanup_failure
+    raise primary
 
 
 def _is_link_or_reparse(metadata: os.stat_result) -> bool:
@@ -116,8 +414,6 @@ def _normalize_link_target(
         resolved.append(part)
         if len(resolved) > _MAX_COMPONENTS:
             raise ValueError("resolved source path exceeds its component limit")
-    if not resolved:
-        raise ValueError("source symlink does not resolve to a file")
     return tuple(resolved)
 
 
@@ -137,7 +433,13 @@ class _BoundRepositoryFile:
     root_descriptor: int
     root_identity: tuple[int, ...]
     observations: list[_PathObservation]
+    cleanup: _PosixDescriptorCleanup
     is_regular = True
+    is_directory = False
+
+    @property
+    def closed(self) -> bool:
+        return self.cleanup.closed
 
     def update_hash(self, hasher: object) -> None:
         update = getattr(hasher, "update", None)
@@ -200,16 +502,17 @@ class _BoundRepositoryFile:
             raise ValueError("source file changed while it was being read")
 
     def close(self) -> None:
-        descriptors = [
-            self.descriptor,
-            self.root_descriptor,
-            *(item.parent_descriptor for item in self.observations),
-        ]
-        for descriptor in descriptors:
-            try:
-                os.close(descriptor)
-            except OSError:
-                pass
+        try:
+            self.cleanup.close()
+        finally:
+            pending = set(self.cleanup.descriptors)
+            if self.descriptor not in pending:
+                self.descriptor = -1
+            if self.root_descriptor not in pending:
+                self.root_descriptor = -1
+            for item in self.observations:
+                if item.parent_descriptor not in pending:
+                    item.parent_descriptor = -1
 
 
 @dataclass(slots=True)
@@ -222,7 +525,13 @@ class _StableUnresolvedRepositoryFile:
     parent_identity: tuple[int, ...]
     name: str
     expected: tuple[int, ...] | None
+    cleanup: _PosixDescriptorCleanup
     is_regular = False
+    is_directory = False
+
+    @property
+    def closed(self) -> bool:
+        return self.cleanup.closed
 
     def verify(self) -> None:
         _verify_stable_unresolved(
@@ -237,16 +546,63 @@ class _StableUnresolvedRepositoryFile:
         )
 
     def close(self) -> None:
-        descriptors = [
+        try:
+            self.cleanup.close()
+        finally:
+            pending = set(self.cleanup.descriptors)
+            if self.root_descriptor not in pending:
+                self.root_descriptor = -1
+            if self.parent_descriptor not in pending:
+                self.parent_descriptor = -1
+            for item in self.observations:
+                if item.parent_descriptor not in pending:
+                    item.parent_descriptor = -1
+
+
+@dataclass(slots=True)
+class _BoundRepositoryDirectory:
+    """Pinned directory outcome for a lexical repository symlink."""
+
+    descriptor: int
+    opened_identity: tuple[int, ...]
+    root: Path
+    root_descriptor: int
+    root_identity: tuple[int, ...]
+    observations: list[_PathObservation]
+    cleanup: _PosixDescriptorCleanup
+    is_regular = False
+    is_directory = True
+
+    @property
+    def closed(self) -> bool:
+        return self.cleanup.closed
+
+    def verify(self) -> None:
+        _verify_resolution_state(
+            self.root,
             self.root_descriptor,
-            self.parent_descriptor,
-            *(item.parent_descriptor for item in self.observations),
-        ]
-        for descriptor in descriptors:
-            try:
-                os.close(descriptor)
-            except OSError:
-                pass
+            self.root_identity,
+            self.observations,
+        )
+        opened = os.fstat(self.descriptor)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or _version_identity(opened) != self.opened_identity
+        ):
+            raise ValueError("source directory changed during contained resolution")
+
+    def close(self) -> None:
+        try:
+            self.cleanup.close()
+        finally:
+            pending = set(self.cleanup.descriptors)
+            if self.descriptor not in pending:
+                self.descriptor = -1
+            if self.root_descriptor not in pending:
+                self.root_descriptor = -1
+            for item in self.observations:
+                if item.parent_descriptor not in pending:
+                    item.parent_descriptor = -1
 
 
 def _directory_flags() -> int:
@@ -340,16 +696,61 @@ def _open_secure(
     expected_final_identity: tuple[int, ...] | None = None,
     allow_stable_unresolved: bool = False,
     allow_absolute_symlinks: bool = False,
-) -> _BoundRepositoryFile | _StableUnresolvedRepositoryFile:
-    try:
-        root_before = root.lstat()
-    except FileNotFoundError as exc:
-        raise ContainedSourceMissingError("repository root does not exist") from exc
+    pinned_root_descriptor: int | None = None,
+    expected_root_identity: tuple[int, ...] | None = None,
+    cleanup_slot: _SourceCleanupSlot | None = None,
+) -> _BoundRepositoryFile | _BoundRepositoryDirectory | _StableUnresolvedRepositoryFile:
+    cleanup = _PosixDescriptorCleanup()
+    if cleanup_slot is not None:
+        cleanup_slot.own(cleanup)
+    if pinned_root_descriptor is None:
+        try:
+            root_before = root.lstat()
+        except FileNotFoundError as exc:
+            raise ContainedSourceMissingError("repository root does not exist") from exc
+        try:
+            root_descriptor = cleanup.open(root, _directory_flags())
+        except BaseException as primary:  # noqa: B036 - retain partial open
+            _raise_with_cleanup(primary, cleanup_slot or cleanup)
+    else:
+        if (
+            isinstance(pinned_root_descriptor, bool)
+            or not isinstance(pinned_root_descriptor, int)
+            or pinned_root_descriptor < 0
+        ):
+            raise ValueError("pinned repository root descriptor is invalid")
+        try:
+            root_descriptor = cleanup.dup(pinned_root_descriptor)
+        except BaseException as primary:  # noqa: B036 - retain partial dup
+            _raise_with_cleanup(primary, cleanup_slot or cleanup)
+        try:
+            root_before = os.fstat(root_descriptor)
+            path_before = root.lstat()
+        except BaseException as primary:  # noqa: B036 - preserve acquisition
+            _raise_with_cleanup(primary, cleanup_slot or cleanup)
+        if _binding_identity(path_before) != _binding_identity(root_before):
+            _raise_with_cleanup(
+                ValueError("repository root changed during source resolution"),
+                cleanup_slot or cleanup,
+            )
     if _is_link_or_reparse(root_before) or not stat.S_ISDIR(root_before.st_mode):
-        raise ValueError("repository root must be a real directory")
+        _raise_with_cleanup(
+            ValueError("repository root must be a real directory"),
+            cleanup_slot or cleanup,
+        )
     if not _identity_is_reliable(root_before):
-        raise ValueError("repository root has no reliable filesystem identity")
-    root_descriptor = os.open(root, _directory_flags())
+        _raise_with_cleanup(
+            ValueError("repository root has no reliable filesystem identity"),
+            cleanup_slot or cleanup,
+        )
+    if (
+        expected_root_identity is not None
+        and _version_identity(root_before) != expected_root_identity
+    ):
+        _raise_with_cleanup(
+            ValueError("repository root changed during source resolution"),
+            cleanup_slot or cleanup,
+        )
     current_descriptor = -1
     source_descriptor = -1
     observations: list[_PathObservation] = []
@@ -382,16 +783,53 @@ def _open_secure(
                 root_descriptor=root_descriptor,
                 root_identity=_version_identity(root_opened),
                 observations=observations,
-                parent_descriptor=os.dup(parent_descriptor),
+                parent_descriptor=cleanup.dup(parent_descriptor),
                 parent_identity=parent_identity,
                 name=name,
                 expected=expected,
+                cleanup=cleanup,
             )
             root_descriptor = -1
             observations = []
+            if cleanup_slot is not None:
+                cleanup_slot.own(retained)
             return retained
 
-        current_descriptor = os.dup(root_descriptor)
+        def retain_directory(
+            directory_descriptor: int,
+            *,
+            expected_binding: tuple[int, ...] | None = None,
+        ) -> _BoundRepositoryDirectory:
+            nonlocal root_descriptor, observations
+            try:
+                opened = os.fstat(directory_descriptor)
+                if (
+                    expected_binding is not None
+                    and _binding_identity(opened) != expected_binding
+                ):
+                    raise ValueError("source directory changed while opening")
+                binding = _BoundRepositoryDirectory(
+                    descriptor=directory_descriptor,
+                    opened_identity=_version_identity(opened),
+                    root=root,
+                    root_descriptor=root_descriptor,
+                    root_identity=_version_identity(root_opened),
+                    observations=observations,
+                    cleanup=cleanup,
+                )
+            except BaseException as primary:  # noqa: B036 - preserve construction
+                _raise_with_cleanup(primary, cleanup_slot or cleanup)
+            root_descriptor = -1
+            observations = []
+            try:
+                binding.verify()
+            except BaseException as primary:  # noqa: B036 - preserve validation
+                _raise_with_cleanup(primary, cleanup_slot or binding)
+            if cleanup_slot is not None:
+                cleanup_slot.own(binding)
+            return binding
+
+        current_descriptor = cleanup.dup(root_descriptor)
         pending = [(name, index == len(parts) - 1) for index, name in enumerate(parts)]
         resolved_prefix: tuple[str, ...] = ()
         symlink_count = 0
@@ -445,7 +883,7 @@ def _open_secure(
                     )
                 observations.append(
                     _PathObservation(
-                        parent_descriptor=os.dup(current_descriptor),
+                        parent_descriptor=cleanup.dup(current_descriptor),
                         name=name,
                         identity=_version_identity(before),
                         link_target=target,
@@ -473,15 +911,28 @@ def _open_secure(
                 )
                 if len(target_parts) + len(pending) > _MAX_COMPONENTS:
                     raise ValueError("resolved source path exceeds its component limit")
+                if not target_parts and not pending:
+                    expected_is_link = (
+                        expected_final_identity is not None
+                        and stat.S_ISLNK(expected_final_identity[2])
+                    )
+                    if not allow_stable_unresolved or not expected_is_link:
+                        raise ValueError(
+                            "source path resolves to the repository directory"
+                        )
+                    return retain_directory(
+                        cleanup.dup(root_descriptor),
+                        expected_binding=_binding_identity(root_opened),
+                    )
                 pending = [*((part, False) for part in target_parts), *pending]
                 resolved_prefix = ()
-                os.close(current_descriptor)
-                current_descriptor = os.dup(root_descriptor)
+                cleanup.close_descriptor(current_descriptor)
+                current_descriptor = cleanup.dup(root_descriptor)
                 continue
 
             observations.append(
                 _PathObservation(
-                    parent_descriptor=os.dup(current_descriptor),
+                    parent_descriptor=cleanup.dup(current_descriptor),
                     name=name,
                     identity=_version_identity(before),
                 )
@@ -491,7 +942,7 @@ def _open_secure(
                     raise ValueError("source path has a non-directory component")
                 child_descriptor = -1
                 try:
-                    child_descriptor = os.open(
+                    child_descriptor = cleanup.open(
                         name,
                         _directory_flags(),
                         dir_fd=current_descriptor,
@@ -499,11 +950,9 @@ def _open_secure(
                     opened = os.fstat(child_descriptor)
                     if _binding_identity(opened) != _binding_identity(before):
                         raise ValueError("source directory changed while opening")
-                except BaseException:
-                    if child_descriptor >= 0:
-                        os.close(child_descriptor)
-                    raise
-                os.close(current_descriptor)
+                except BaseException as primary:  # noqa: B036 - preserve open error
+                    _raise_with_cleanup(primary, cleanup_slot or cleanup)
+                cleanup.close_descriptor(current_descriptor)
                 current_descriptor = child_descriptor
                 resolved_prefix = (*resolved_prefix, name)
                 continue
@@ -512,6 +961,27 @@ def _open_secure(
                 expected_is_link = expected_final_identity is not None and stat.S_ISLNK(
                     expected_final_identity[2]
                 )
+                if (
+                    allow_stable_unresolved
+                    and expected_is_link
+                    and stat.S_ISDIR(before.st_mode)
+                ):
+                    directory_descriptor = -1
+                    try:
+                        directory_descriptor = cleanup.open(
+                            name,
+                            _directory_flags(),
+                            dir_fd=current_descriptor,
+                        )
+                        retained_descriptor = directory_descriptor
+                        directory_descriptor = -1
+                        return retain_directory(
+                            retained_descriptor,
+                            expected_binding=_binding_identity(before),
+                        )
+                    finally:
+                        if directory_descriptor >= 0:
+                            cleanup.close_descriptor(directory_descriptor)
                 if (
                     allow_stable_unresolved
                     and expected_is_link
@@ -524,7 +994,7 @@ def _open_secure(
                         expected=_version_identity(before),
                     )
                 raise ValueError("source path is not a regular repository file")
-            source_descriptor = os.open(
+            source_descriptor = cleanup.open(
                 name,
                 _regular_flags(),
                 dir_fd=current_descriptor,
@@ -539,14 +1009,16 @@ def _open_secure(
                 root_descriptor=root_descriptor,
                 root_identity=_version_identity(root_opened),
                 observations=observations,
+                cleanup=cleanup,
             )
             source_descriptor = -1
             root_descriptor = -1
             try:
                 binding.verify()
-            except BaseException:
-                binding.close()
-                raise
+            except BaseException as primary:  # noqa: B036 - preserve validation
+                _raise_with_cleanup(primary, cleanup_slot or binding)
+            if cleanup_slot is not None:
+                cleanup_slot.own(binding)
             return binding
         raise ValueError("source path does not resolve to a file")
     except FileNotFoundError as exc:
@@ -556,18 +1028,834 @@ def _open_secure(
     except OSError as exc:
         raise ValueError("source path could not be resolved safely") from exc
     finally:
-        if source_descriptor >= 0:
-            os.close(source_descriptor)
-        if current_descriptor >= 0:
-            os.close(current_descriptor)
-        if root_descriptor >= 0:
-            os.close(root_descriptor)
-        if root_descriptor >= 0 or source_descriptor >= 0:
-            for observation in observations:
-                try:
-                    os.close(observation.parent_descriptor)
-                except OSError:
-                    pass
+        active_failure = sys.exc_info()[1]
+        cleanup_failure: BaseException | None = None
+        try:
+            if root_descriptor < 0 and source_descriptor < 0:
+                if current_descriptor >= 0:
+                    cleanup.close_descriptor(current_descriptor)
+            else:
+                cleanup.close()
+        except BaseException as exc:  # noqa: B036 - preserve primary + owner
+            cleanup_failure = exc
+        owner = cleanup_slot or cleanup
+        if active_failure is not None:
+            _attach_source_cleanup_owner(active_failure, owner)
+            if cleanup_failure is not None:
+                raise active_failure from cleanup_failure
+        elif cleanup_failure is not None:
+            _attach_source_cleanup_owner(cleanup_failure, owner)
+            raise cleanup_failure
+
+
+def _windows_kernel_api() -> _WindowsKernelApi:
+    return _shared_windows_kernel_api()
+
+
+def _windows_lexical_repository_path(value: str | Path) -> Path:
+    expanded = os.path.expanduser(os.fspath(value))
+    return Path(ntpath.abspath(expanded))
+
+
+def _windows_binding_identity(metadata: _WindowsHandleMetadata) -> tuple[object, ...]:
+    return (
+        metadata.st_dev,
+        metadata.file_id_128,
+        metadata.st_mode,
+        metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0,
+        metadata.st_file_attributes,
+        metadata.reparse_tag,
+    )
+
+
+def _windows_version_identity(metadata: _WindowsHandleMetadata) -> tuple[object, ...]:
+    return (
+        *_windows_binding_identity(metadata),
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        metadata.delete_pending,
+    )
+
+
+def _windows_identity_is_reliable(metadata: _WindowsHandleMetadata) -> bool:
+    return (
+        bool(metadata.st_dev)
+        and _windows_file_id_is_reliable(metadata.file_id_128)
+        and not metadata.delete_pending
+    )
+
+
+def _windows_entry_is_reparse(entry: _WindowsDirectoryEntry) -> bool:
+    return bool(entry.attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def _windows_metadata_is_reparse(metadata: _WindowsHandleMetadata) -> bool:
+    return bool(metadata.st_file_attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def _windows_simple_child_name(name: str) -> None:
+    if (
+        not isinstance(name, str)
+        or not name
+        or name in {".", ".."}
+        or "/" in name
+        or "\\" in name
+        or "\x00" in name
+        or len(name.encode("utf-8", errors="strict")) > _MAX_RELATIVE_PATH_BYTES
+    ):
+        raise ValueError("Windows source entry has an invalid child name")
+
+
+def _windows_find_child(
+    api: _WindowsKernelApi,
+    parent_handle: int,
+    name: str,
+) -> _WindowsDirectoryEntry | None:
+    """Find one exact child without imposing unsafe case-folding semantics."""
+
+    _windows_simple_child_name(name)
+    matches = [
+        entry for entry in api.enumerate_directory(parent_handle) if entry.name == name
+    ]
+    if len(matches) > 1:
+        raise ValueError("Windows source directory has duplicate exact child names")
+    return matches[0] if matches else None
+
+
+def _windows_open_child(
+    api: _WindowsKernelApi,
+    parent_handle: int,
+    entry: _WindowsDirectoryEntry,
+    *,
+    cleanup: _WindowsHandleCleanup | None = None,
+) -> tuple[int, _WindowsHandleMetadata]:
+    """Open the enumerated child no-follow and rebind its exact FILE_ID."""
+
+    if not _windows_file_id_is_reliable(entry.file_id_128):
+        raise ValueError("Windows source entry has no reliable 128-bit FILE_ID")
+    is_reparse = _windows_entry_is_reparse(entry)
+    is_directory = bool(entry.attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+    desired_access = _WINDOWS_FILE_READ_ATTRIBUTES | _WINDOWS_SYNCHRONIZE
+    if not is_reparse:
+        desired_access |= (
+            _WINDOWS_FILE_LIST_DIRECTORY if is_directory else _WINDOWS_FILE_READ_DATA
+        )
+    selected_cleanup = cleanup or _WindowsHandleCleanup(api)
+    handle = 0
+    try:
+        handle = api.open_relative(
+            parent_handle,
+            entry.name,
+            desired_access=desired_access,
+            is_directory=is_directory,
+            allow_reparse=is_reparse,
+        )
+        selected_cleanup.retain(handle)
+        opened = api.metadata(handle)
+        selected_cleanup.retain(handle, opened)
+        if (
+            not _windows_identity_is_reliable(opened)
+            or opened.file_id_128 != entry.file_id_128
+            or opened.st_dev != api.metadata(parent_handle).st_dev
+            or bool(opened.st_file_attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+            != is_directory
+            or _windows_metadata_is_reparse(opened) != is_reparse
+            or (is_reparse and opened.reparse_tag != entry.reparse_tag)
+        ):
+            raise ValueError("Windows source entry changed while it was opened")
+        return handle, opened
+    except BaseException as primary:  # noqa: B036 - preserve construction failure
+        _raise_with_cleanup(primary, selected_cleanup)
+
+
+def _strip_windows_namespace(path: str) -> str:
+    if path.startswith("\\??\\UNC\\"):
+        return "\\\\" + path[8:]
+    if path.startswith("\\??\\"):
+        return path[4:]
+    if path.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + path[8:]
+    if path.startswith("\\\\?\\"):
+        return path[4:]
+    return path
+
+
+def _windows_path_parts(path: str) -> tuple[str, ...]:
+    return tuple(PureWindowsPath(ntpath.normpath(path)).parts)
+
+
+def _normalize_windows_link_target(
+    root: Path,
+    prefix: tuple[str, ...],
+    point: _WindowsReparsePoint,
+) -> tuple[str, ...]:
+    """Normalize one Windows SYMLINK payload into pinned-root components."""
+
+    target = point.substitute_name
+    if not isinstance(target, str) or not target or "\x00" in target:
+        raise ValueError("Windows source symlink target must be non-empty")
+    if len(target.encode("utf-8", errors="strict")) > _MAX_SYMLINK_TARGET_BYTES:
+        raise ValueError("Windows source symlink target exceeds its byte limit")
+    relative = bool(point.flags & _WINDOWS_SYMLINK_FLAG_RELATIVE)
+    if point.flags & ~_WINDOWS_SYMLINK_FLAG_RELATIVE:
+        raise ValueError("Windows source symlink has unsupported flags")
+
+    if relative:
+        if ntpath.isabs(target) or ntpath.splitdrive(target)[0]:
+            raise ValueError("Windows relative symlink contains an absolute target")
+        resolved: list[str] = list(prefix)
+        target_parts = target.replace("\\", "/").split("/")
+    else:
+        target = _strip_windows_namespace(target)
+        if not ntpath.isabs(target):
+            raise ValueError("Windows absolute symlink has a relative target")
+        root_parts = _windows_path_parts(str(root))
+        target_parts_absolute = _windows_path_parts(target)
+        if len(target_parts_absolute) < len(root_parts) or any(
+            observed.casefold() != expected.casefold()
+            for observed, expected in zip(
+                target_parts_absolute,
+                root_parts,
+                strict=False,
+            )
+        ):
+            raise ValueError("Windows source symlink resolves outside the repository")
+        resolved = []
+        target_parts = list(target_parts_absolute[len(root_parts) :])
+
+    for part in target_parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if not resolved:
+                raise ValueError(
+                    "Windows source symlink resolves outside the repository"
+                )
+            resolved.pop()
+            continue
+        if ":" in part:
+            raise ValueError("Windows source symlink contains a stream component")
+        _windows_simple_child_name(part)
+        resolved.append(part)
+        if len(resolved) > _MAX_COMPONENTS:
+            raise ValueError("resolved Windows source path exceeds its component limit")
+    return tuple(resolved)
+
+
+def _windows_link_target_text(point: _WindowsReparsePoint) -> str:
+    target = point.print_name or point.substitute_name
+    if not isinstance(target, str) or not target or "\x00" in target:
+        raise ValueError("Windows source symlink has no canonical text target")
+    if len(target.encode("utf-8", errors="strict")) > _MAX_SYMLINK_TARGET_BYTES:
+        raise ValueError("Windows source symlink target exceeds its byte limit")
+    return target
+
+
+@dataclass(slots=True)
+class _WindowsPathObservation:
+    parent_handle: int
+    parent_identity: tuple[object, ...]
+    name: str
+    file_id_128: bytes
+    handle: int
+    identity: tuple[object, ...]
+    reparse_point: _WindowsReparsePoint | None = None
+
+
+def _verify_windows_root_path(
+    api: _WindowsKernelApi,
+    authority: _WindowsDirectoryAuthority,
+    root_handle: int,
+    root_identity: tuple[object, ...],
+) -> None:
+    authority.verify()
+    opened = api.metadata(root_handle)
+    if _windows_version_identity(opened) != root_identity:
+        raise ValueError("Windows repository root changed during source resolution")
+
+
+def _verify_windows_resolution_state(
+    api: _WindowsKernelApi,
+    authority: _WindowsDirectoryAuthority,
+    root_handle: int,
+    root_identity: tuple[object, ...],
+    observations: Sequence[_WindowsPathObservation],
+) -> None:
+    _verify_windows_root_path(api, authority, root_handle, root_identity)
+    for observation in observations:
+        if (
+            _windows_version_identity(api.metadata(observation.parent_handle))
+            != observation.parent_identity
+        ):
+            raise ValueError("Windows source parent changed during resolution")
+        entry = _windows_find_child(api, observation.parent_handle, observation.name)
+        if entry is None or entry.file_id_128 != observation.file_id_128:
+            raise ValueError("Windows source path changed during resolution")
+        if (
+            _windows_version_identity(api.metadata(observation.handle))
+            != observation.identity
+        ):
+            raise ValueError("Windows source object changed during resolution")
+        if observation.reparse_point is not None and (
+            api.query_reparse_point(observation.handle) != observation.reparse_point
+        ):
+            raise ValueError("Windows source symlink changed during resolution")
+    _verify_windows_root_path(api, authority, root_handle, root_identity)
+
+
+class _WindowsResolutionBinding:
+    is_regular = False
+    is_directory = False
+
+    def __init__(
+        self,
+        *,
+        api: _WindowsKernelApi,
+        root: Path,
+        root_authority: _WindowsDirectoryAuthority,
+        owns_root_authority: bool,
+        root_handle: int,
+        root_identity: tuple[object, ...],
+        observations: list[_WindowsPathObservation],
+        handles: list[int],
+        handle_identities: dict[int, tuple[object, ...]],
+    ) -> None:
+        self.api = api
+        self.root = root
+        self.root_authority = root_authority
+        self.owns_root_authority = owns_root_authority
+        self.root_handle = root_handle
+        self.root_identity = root_identity
+        self.observations = observations
+        self.handles = handles
+        self.handle_identities = handle_identities
+        self.closed = False
+        self._cleanup_started = False
+
+    def verify(self) -> None:
+        if self.closed or self._cleanup_started:
+            raise ValueError("Windows source binding is closed")
+        _verify_windows_resolution_state(
+            self.api,
+            self.root_authority,
+            self.root_handle,
+            self.root_identity,
+            self.observations,
+        )
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self._cleanup_started = True
+        failure = _close_windows_handles(
+            self.api,
+            self.handles,
+            self.handle_identities,
+        )
+        if self.root_handle not in self.handles:
+            self.root_handle = 0
+        if self.owns_root_authority:
+            try:
+                self.root_authority.close()
+            except BaseException as exc:  # noqa: B036 - finish all cleanup
+                if failure is None:
+                    failure = exc
+        self.closed = not self.handles and (
+            not self.owns_root_authority or self.root_authority.closed
+        )
+        if failure is not None:
+            raise failure
+
+
+class _WindowsResolutionConstructionCleanup:
+    """Owner spanning partial resolution HANDLEs and an optional root authority."""
+
+    __slots__ = ("handles", "root_authority", "owns_root_authority")
+
+    def __init__(
+        self,
+        api: _WindowsKernelApi,
+        root_authority: _WindowsDirectoryAuthority,
+        *,
+        owns_root_authority: bool,
+    ) -> None:
+        self.handles = _WindowsHandleCleanup(api)
+        self.root_authority = root_authority
+        self.owns_root_authority = owns_root_authority
+
+    @property
+    def closed(self) -> bool:
+        return self.handles.closed and (
+            not self.owns_root_authority or self.root_authority.closed
+        )
+
+    def close(self) -> None:
+        failure: BaseException | None = None
+        try:
+            self.handles.close()
+        except BaseException as exc:  # noqa: B036 - cleanup all authorities
+            failure = exc
+        if self.owns_root_authority:
+            try:
+                self.root_authority.close()
+            except BaseException as exc:  # noqa: B036 - preserve first failure
+                failure = failure or exc
+        if failure is not None:
+            raise failure
+
+
+class _WindowsBoundRepositoryFile(_WindowsResolutionBinding):
+    is_regular = True
+
+    def __init__(
+        self,
+        *,
+        file_handle: int,
+        opened_identity: tuple[object, ...],
+        opened_size: int,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.file_handle = file_handle
+        self.opened_identity = opened_identity
+        self.opened_size = opened_size
+
+    def _opened(self) -> _WindowsHandleMetadata:
+        opened = self.api.metadata(self.file_handle)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or _windows_metadata_is_reparse(opened)
+            or not _windows_identity_is_reliable(opened)
+            or _windows_version_identity(opened) != self.opened_identity
+            or opened.st_size != self.opened_size
+        ):
+            raise ValueError("Windows source file is not a stable regular file")
+        return opened
+
+    def update_hash(self, hasher: object) -> None:
+        update = getattr(hasher, "update", None)
+        if not callable(update):
+            raise TypeError("hasher must provide an update method")
+        opened = self._opened()
+        remaining = opened.st_size
+        while remaining:
+            block = self.api.read(self.file_handle, min(remaining, _READ_CHUNK_BYTES))
+            if not block:
+                raise ValueError("Windows source file was truncated while hashing")
+            update(block)
+            remaining -= len(block)
+        if self.api.read(self.file_handle, 1):
+            raise ValueError("Windows source file grew while hashing")
+        self.verify()
+        self._opened()
+
+    def read_bytes(self, *, max_bytes: int) -> bytes:
+        if (
+            isinstance(max_bytes, bool)
+            or not isinstance(max_bytes, int)
+            or max_bytes <= 0
+        ):
+            raise ValueError("source byte limit must be positive")
+        opened = self._opened()
+        if opened.st_size < 0 or opened.st_size > max_bytes:
+            raise ValueError("Windows source file exceeds its bounded read limit")
+        payload = bytearray()
+        remaining = opened.st_size
+        while remaining:
+            block = self.api.read(self.file_handle, min(remaining, _READ_CHUNK_BYTES))
+            if not block:
+                raise ValueError("Windows source file was truncated while being read")
+            payload.extend(block)
+            remaining -= len(block)
+        if self.api.read(self.file_handle, 1):
+            raise ValueError("Windows source file grew while being read")
+        self.verify()
+        self._opened()
+        return bytes(payload)
+
+
+class _WindowsBoundRepositoryDirectory(_WindowsResolutionBinding):
+    is_directory = True
+
+    def __init__(
+        self,
+        *,
+        directory_handle: int,
+        opened_identity: tuple[object, ...],
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.directory_handle = directory_handle
+        self.opened_identity = opened_identity
+
+    def verify(self) -> None:
+        super().verify()
+        opened = self.api.metadata(self.directory_handle)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or _windows_metadata_is_reparse(opened)
+            or _windows_version_identity(opened) != self.opened_identity
+        ):
+            raise ValueError("Windows source directory changed during resolution")
+
+
+class _WindowsStableUnresolvedRepositoryFile(_WindowsResolutionBinding):
+    def __init__(
+        self,
+        *,
+        parent_handle: int,
+        parent_identity: tuple[object, ...],
+        name: str,
+        expected_file_id: bytes | None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.parent_handle = parent_handle
+        self.parent_identity = parent_identity
+        self.name = name
+        self.expected_file_id = expected_file_id
+
+    def verify(self) -> None:
+        super().verify()
+        if (
+            _windows_version_identity(self.api.metadata(self.parent_handle))
+            != self.parent_identity
+        ):
+            raise ValueError("Windows unresolved source parent changed")
+        entry = _windows_find_child(self.api, self.parent_handle, self.name)
+        observed = None if entry is None else entry.file_id_128
+        if observed != self.expected_file_id:
+            raise ValueError("Windows unresolved source terminal changed")
+
+
+def _open_windows_pinned_repository_root(
+    root: Path,
+    *,
+    api: _WindowsKernelApi | None = None,
+    cleanup_slot: _SourceCleanupSlot | None = None,
+) -> tuple[
+    _WindowsKernelApi,
+    _WindowsDirectoryAuthority,
+    tuple[object, ...],
+]:
+    selected = _windows_kernel_api() if api is None else api
+    if api is None:
+        _shared_windows_require_source_api(selected)
+    authority = _open_lexical_windows_authority(
+        root,
+        api=selected,
+        cleanup_slot=cleanup_slot,
+    )
+    try:
+        opened = selected.metadata(authority.handle)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or _windows_metadata_is_reparse(opened)
+            or not _windows_identity_is_reliable(opened)
+        ):
+            raise ValueError(
+                "Windows repository root must be a real identity-bound directory"
+            )
+        identity = _windows_version_identity(opened)
+        _verify_windows_root_path(selected, authority, authority.handle, identity)
+        return selected, authority, identity
+    except BaseException as primary:  # noqa: B036 - preserve root failure
+        _raise_with_cleanup(primary, cleanup_slot or authority)
+
+
+def _verify_windows_pinned_repository_root(
+    api: _WindowsKernelApi,
+    authority: _WindowsDirectoryAuthority,
+    expected_identity: tuple[object, ...],
+) -> None:
+    _verify_windows_root_path(
+        api,
+        authority,
+        authority.handle,
+        expected_identity,
+    )
+
+
+def _open_windows_resolution_at(
+    root: Path,
+    root_authority: _WindowsDirectoryAuthority,
+    parts: tuple[str, ...],
+    *,
+    expected_root_identity: tuple[object, ...],
+    expected_final_identity: tuple[object, ...] | None,
+    allow_stable_unresolved: bool,
+    api: _WindowsKernelApi,
+    owns_root_authority: bool = False,
+    cleanup_slot: _SourceCleanupSlot | None = None,
+) -> _WindowsResolutionBinding:
+    construction = _WindowsResolutionConstructionCleanup(
+        api,
+        root_authority,
+        owns_root_authority=owns_root_authority,
+    )
+    if cleanup_slot is not None:
+        cleanup_slot.own(construction)
+    cleanup = construction.handles
+    owned_root = 0
+    try:
+        owned_root = api.duplicate_handle(root_authority.handle)
+        cleanup.retain(owned_root)
+    except BaseException as primary:  # noqa: B036 - retain partial duplicate
+        _raise_with_cleanup(primary, cleanup_slot or construction)
+    handles = cleanup.handles
+    handle_identities = cleanup.expected_identities
+    observations: list[_WindowsPathObservation] = []
+    try:
+        root_opened = api.metadata(owned_root)
+        cleanup.retain(owned_root, root_opened)
+        if (
+            _windows_version_identity(root_opened) != expected_root_identity
+            or not stat.S_ISDIR(root_opened.st_mode)
+            or _windows_metadata_is_reparse(root_opened)
+            or not _windows_identity_is_reliable(root_opened)
+        ):
+            raise ValueError("Windows repository root changed before resolution")
+        current_handle = owned_root
+        pending = [(part, index == len(parts) - 1) for index, part in enumerate(parts)]
+        resolved_prefix: tuple[str, ...] = ()
+        seen_links: set[bytes] = set()
+        symlink_count = 0
+        lexical_final_is_link = bool(
+            expected_final_identity is not None
+            and len(expected_final_identity) > 5
+            and expected_final_identity[5] == _WINDOWS_IO_REPARSE_TAG_SYMLINK
+        )
+
+        def common_kwargs() -> dict[str, object]:
+            return {
+                "api": api,
+                "root": root,
+                "root_authority": root_authority,
+                "owns_root_authority": owns_root_authority,
+                "root_handle": owned_root,
+                "root_identity": expected_root_identity,
+                "observations": observations,
+                "handles": handles,
+                "handle_identities": handle_identities,
+            }
+
+        while pending:
+            name, is_lexical_final = pending.pop(0)
+            parent_identity = _windows_version_identity(api.metadata(current_handle))
+            entry = _windows_find_child(api, current_handle, name)
+            if entry is None:
+                if not (allow_stable_unresolved and lexical_final_is_link):
+                    raise FileNotFoundError(name)
+                binding = _WindowsStableUnresolvedRepositoryFile(
+                    parent_handle=current_handle,
+                    parent_identity=parent_identity,
+                    name=name,
+                    expected_file_id=None,
+                    **common_kwargs(),
+                )
+                binding.verify()
+                if cleanup_slot is not None:
+                    cleanup_slot.own(binding)
+                return binding
+            opened_handle, opened = _windows_open_child(
+                api,
+                current_handle,
+                entry,
+                cleanup=cleanup,
+            )
+            opened_identity = _windows_version_identity(opened)
+            if (
+                is_lexical_final
+                and expected_final_identity is not None
+                and opened_identity != expected_final_identity
+            ):
+                raise ValueError("Windows source differs from its initial observation")
+
+            point: _WindowsReparsePoint | None = None
+            if _windows_metadata_is_reparse(opened):
+                if opened.reparse_tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
+                    raise ValueError(
+                        "Windows source contains an unsupported reparse point"
+                    )
+                point = api.query_reparse_point(opened_handle)
+                if point.tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
+                    raise ValueError("Windows source reparse tag changed while opening")
+            observation = _WindowsPathObservation(
+                parent_handle=current_handle,
+                parent_identity=parent_identity,
+                name=name,
+                file_id_128=entry.file_id_128,
+                handle=opened_handle,
+                identity=opened_identity,
+                reparse_point=point,
+            )
+            observations.append(observation)
+
+            if point is not None:
+                symlink_count += 1
+                if symlink_count > _MAX_SYMLINKS:
+                    raise ValueError(
+                        "Windows source symlink resolution exceeds its limit"
+                    )
+                if opened.file_id_128 in seen_links:
+                    if not (allow_stable_unresolved and lexical_final_is_link):
+                        raise ValueError(
+                            "Windows source symlink resolution contains a loop"
+                        )
+                    binding = _WindowsStableUnresolvedRepositoryFile(
+                        parent_handle=current_handle,
+                        parent_identity=parent_identity,
+                        name=name,
+                        expected_file_id=entry.file_id_128,
+                        **common_kwargs(),
+                    )
+                    binding.verify()
+                    if cleanup_slot is not None:
+                        cleanup_slot.own(binding)
+                    return binding
+                seen_links.add(opened.file_id_128)
+                target_parts = _normalize_windows_link_target(
+                    root,
+                    resolved_prefix,
+                    point,
+                )
+                if len(target_parts) + len(pending) > _MAX_COMPONENTS:
+                    raise ValueError(
+                        "resolved Windows source path exceeds its component limit"
+                    )
+                if not target_parts and not pending:
+                    if not (allow_stable_unresolved and lexical_final_is_link):
+                        raise ValueError(
+                            "Windows source path resolves to the repository directory"
+                        )
+                    directory_handle = api.duplicate_handle(owned_root)
+                    cleanup.retain(directory_handle)
+                    directory_metadata = api.metadata(directory_handle)
+                    cleanup.retain(directory_handle, directory_metadata)
+                    binding = _WindowsBoundRepositoryDirectory(
+                        directory_handle=directory_handle,
+                        opened_identity=_windows_version_identity(directory_metadata),
+                        **common_kwargs(),
+                    )
+                    binding.verify()
+                    if cleanup_slot is not None:
+                        cleanup_slot.own(binding)
+                    return binding
+                pending = [*((part, False) for part in target_parts), *pending]
+                resolved_prefix = ()
+                current_handle = owned_root
+                continue
+
+            if pending:
+                if not stat.S_ISDIR(opened.st_mode):
+                    raise ValueError("Windows source has a non-directory component")
+                current_handle = opened_handle
+                resolved_prefix = (*resolved_prefix, name)
+                continue
+
+            if stat.S_ISDIR(opened.st_mode):
+                if not (allow_stable_unresolved and lexical_final_is_link):
+                    raise ValueError("Windows source path is not a regular file")
+                binding = _WindowsBoundRepositoryDirectory(
+                    directory_handle=opened_handle,
+                    opened_identity=opened_identity,
+                    **common_kwargs(),
+                )
+                binding.verify()
+                if cleanup_slot is not None:
+                    cleanup_slot.own(binding)
+                return binding
+            if not stat.S_ISREG(opened.st_mode):
+                if not (allow_stable_unresolved and lexical_final_is_link):
+                    raise ValueError("Windows source path is not a regular file")
+                binding = _WindowsStableUnresolvedRepositoryFile(
+                    parent_handle=current_handle,
+                    parent_identity=parent_identity,
+                    name=name,
+                    expected_file_id=entry.file_id_128,
+                    **common_kwargs(),
+                )
+                binding.verify()
+                if cleanup_slot is not None:
+                    cleanup_slot.own(binding)
+                return binding
+            binding = _WindowsBoundRepositoryFile(
+                file_handle=opened_handle,
+                opened_identity=opened_identity,
+                opened_size=opened.st_size,
+                **common_kwargs(),
+            )
+            binding.verify()
+            if cleanup_slot is not None:
+                cleanup_slot.own(binding)
+            return binding
+        raise ValueError("Windows source path does not resolve to a file")
+    except BaseException as primary:  # noqa: B036 - preserve resolution failure
+        _raise_with_cleanup(primary, cleanup_slot or construction)
+
+
+@contextmanager
+def _resolved_windows_repository_file_at(
+    root: str | Path,
+    root_authority: _WindowsDirectoryAuthority,
+    relative: str,
+    *,
+    expected_root_identity: tuple[object, ...],
+    expected_final_identity: tuple[object, ...],
+    api: _WindowsKernelApi | None = None,
+) -> Iterator[_WindowsResolutionBinding]:
+    """Resolve one source entry through a caller-owned pinned Windows root."""
+
+    selected = _windows_kernel_api() if api is None else api
+    parts = _relative_parts(relative)
+    cleanup_slot = _SourceCleanupSlot()
+    binding = _open_windows_resolution_at(
+        Path(root),
+        root_authority,
+        parts,
+        expected_root_identity=expected_root_identity,
+        expected_final_identity=expected_final_identity,
+        allow_stable_unresolved=True,
+        api=selected,
+        cleanup_slot=cleanup_slot,
+    )
+    try:
+        yield binding
+        binding.verify()
+    except BaseException as primary:  # noqa: B036 - preserve body failure
+        _raise_with_cleanup(primary, cleanup_slot)
+    else:
+        try:
+            cleanup_slot.close()
+        except BaseException as cleanup_failure:  # noqa: B036
+            _attach_source_cleanup_owner(cleanup_failure, cleanup_slot)
+            raise
+
+
+def _open_windows_repository_file(
+    root: Path,
+    parts: tuple[str, ...],
+    *,
+    expected_final_identity: tuple[object, ...] | None = None,
+    allow_stable_unresolved: bool = False,
+) -> _WindowsResolutionBinding:
+    cleanup_slot = _SourceCleanupSlot()
+    api, root_authority, root_identity = _open_windows_pinned_repository_root(
+        root,
+        cleanup_slot=cleanup_slot,
+    )
+    return _open_windows_resolution_at(
+        root,
+        root_authority,
+        parts,
+        expected_root_identity=root_identity,
+        expected_final_identity=expected_final_identity,
+        allow_stable_unresolved=allow_stable_unresolved,
+        api=api,
+        owns_root_authority=True,
+        cleanup_slot=cleanup_slot,
+    )
 
 
 def _static_components(
@@ -633,6 +1921,19 @@ def validate_repository_file(root: str | Path, relative: str) -> None:
     """Require one stable regular source file resolving beneath *root*."""
 
     try:
+        if sys.platform == "win32":
+            repository = _windows_lexical_repository_path(root)
+            binding = _open_windows_repository_file(
+                repository,
+                _relative_parts(relative),
+            )
+            try:
+                if not binding.is_regular:
+                    raise ValueError("source path is not a regular repository file")
+                binding.verify()
+            finally:
+                binding.close()
+            return
         repository = Path(root).expanduser().resolve()
         parts = _relative_parts(relative)
         if SECURE_CONTAINED_SYMLINKS:
@@ -665,6 +1966,18 @@ def read_repository_file(
     if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes <= 0:
         raise ValueError("source byte limit must be positive")
     try:
+        if sys.platform == "win32":
+            repository = _windows_lexical_repository_path(root)
+            binding = _open_windows_repository_file(
+                repository,
+                _relative_parts(relative),
+            )
+            try:
+                if not isinstance(binding, _WindowsBoundRepositoryFile):
+                    raise ValueError("source path is not a regular repository file")
+                return binding.read_bytes(max_bytes=max_bytes)
+            finally:
+                binding.close()
         repository = Path(root).expanduser().resolve()
         parts = _relative_parts(relative)
         if SECURE_CONTAINED_SYMLINKS:
@@ -688,9 +2001,25 @@ def resolved_repository_file(
     relative: str,
     *,
     expected_final_identity: tuple[int, ...],
-) -> Iterator[_BoundRepositoryFile | _StableUnresolvedRepositoryFile]:
+) -> Iterator[
+    _BoundRepositoryFile | _BoundRepositoryDirectory | _StableUnresolvedRepositoryFile
+]:
     """Yield a pinned regular file or a retained stable link-only outcome."""
 
+    if sys.platform == "win32":
+        repository = _windows_lexical_repository_path(root)
+        binding = _open_windows_repository_file(
+            repository,
+            _relative_parts(relative),
+            expected_final_identity=expected_final_identity,
+            allow_stable_unresolved=True,
+        )
+        try:
+            yield binding
+            binding.verify()
+        finally:
+            binding.close()
+        return
     if not SECURE_CONTAINED_SYMLINKS:
         raise ValueError("stable link-only resolution requires directory-fd support")
     repository = Path(root).expanduser().resolve()
@@ -712,6 +2041,48 @@ def resolved_repository_file(
         binding.close()
 
 
+@contextmanager
+def _resolved_repository_file_at(
+    root: str | Path,
+    root_descriptor: int,
+    relative: str,
+    *,
+    expected_root_identity: tuple[int, ...],
+    expected_final_identity: tuple[int, ...],
+) -> Iterator[
+    _BoundRepositoryFile | _BoundRepositoryDirectory | _StableUnresolvedRepositoryFile
+]:
+    """Resolve one entry through a caller-owned, already-pinned root fd."""
+
+    if not SECURE_CONTAINED_SYMLINKS:
+        raise ValueError("pinned source resolution requires directory-fd support")
+    repository = Path(root)
+    if not repository.is_absolute():
+        raise ValueError("pinned repository root must be absolute")
+    parts = _relative_parts(relative)
+    cleanup_slot = _SourceCleanupSlot()
+    binding = _open_secure(
+        repository,
+        parts,
+        expected_final_identity=expected_final_identity,
+        allow_stable_unresolved=True,
+        pinned_root_descriptor=root_descriptor,
+        expected_root_identity=expected_root_identity,
+        cleanup_slot=cleanup_slot,
+    )
+    try:
+        yield binding
+        binding.verify()
+    except BaseException as primary:  # noqa: B036 - preserve body failure
+        _raise_with_cleanup(primary, cleanup_slot)
+    else:
+        try:
+            cleanup_slot.close()
+        except BaseException as cleanup_failure:  # noqa: B036
+            _attach_source_cleanup_owner(cleanup_failure, cleanup_slot)
+            raise
+
+
 def update_repository_file_hash(
     root: str | Path,
     relative: str,
@@ -724,6 +2095,20 @@ def update_repository_file_hash(
     update = getattr(hasher, "update", None)
     if not callable(update):
         raise TypeError("hasher must provide an update method")
+    if sys.platform == "win32":
+        repository = _windows_lexical_repository_path(root)
+        binding = _open_windows_repository_file(
+            repository,
+            _relative_parts(relative),
+            expected_final_identity=expected_final_identity,
+        )
+        try:
+            if not isinstance(binding, _WindowsBoundRepositoryFile):
+                raise ValueError("source path is not a regular repository file")
+            binding.update_hash(hasher)
+        finally:
+            binding.close()
+        return
     repository = Path(root).expanduser().resolve()
     parts = _relative_parts(relative)
     if not SECURE_CONTAINED_SYMLINKS:

--- a/codenib/_contained_source.py
+++ b/codenib/_contained_source.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 import errno
 import ntpath
 import os
+import secrets
 import stat
 import sys
+import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import Iterator, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Iterator, Sequence
 
 from ._windows_fs_authority import (
     FILE_ATTRIBUTE_DIRECTORY as _WINDOWS_FILE_ATTRIBUTE_DIRECTORY,
@@ -57,6 +59,19 @@ _MAX_RELATIVE_PATH_BYTES = 4_096
 _MAX_SYMLINKS = 40
 _MAX_SYMLINK_TARGET_BYTES = 4_096
 _READ_CHUNK_BYTES = 1024 * 1024
+_CLOSE_COOKIE_FLOOR = 1 << 20
+_CLOSE_COOKIE_SPAN = 1 << 30
+_CLOSE_COOKIE_LOCK = threading.Lock()
+_CLOSE_COOKIE_COUNTS: dict[int, int] = {}
+
+
+def _reset_close_cookie_lock_after_fork() -> None:
+    global _CLOSE_COOKIE_LOCK
+    _CLOSE_COOKIE_LOCK = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_close_cookie_lock_after_fork)
 SECURE_CONTAINED_SYMLINKS = (
     os.name == "posix"
     and hasattr(os, "O_DIRECTORY")
@@ -120,23 +135,39 @@ class _SourceCleanupSlot:
 class _PosixDescriptorCleanup:
     """Retryable owner for descriptors acquired during contained resolution."""
 
-    __slots__ = ("descriptors", "expected_identities")
+    __slots__ = ("descriptors", "expected_identities", "close_cookies")
 
     def __init__(self) -> None:
         self.descriptors: list[int] = []
         self.expected_identities: dict[int, tuple[int, ...]] = {}
+        self.close_cookies: dict[int, int] = {}
 
     @property
     def closed(self) -> bool:
         return not self.descriptors
 
-    def retain(self, descriptor: int) -> int:
+    def retain(
+        self,
+        descriptor: int,
+        metadata: os.stat_result | None = None,
+    ) -> int:
+        if (
+            isinstance(descriptor, bool)
+            or not isinstance(descriptor, int)
+            or descriptor < 0
+        ):
+            raise ValueError("source cleanup descriptor is invalid")
         if descriptor not in self.descriptors:
             self.descriptors.append(descriptor)
+        if descriptor not in self.expected_identities:
+            opened = os.fstat(descriptor) if metadata is None else metadata
+            self.expected_identities[descriptor] = _descriptor_ownership_identity(
+                opened
+            )
         return descriptor
 
     def remember_identity(self, descriptor: int, metadata: os.stat_result) -> None:
-        self.expected_identities[descriptor] = _binding_identity(metadata)
+        self.expected_identities[descriptor] = _descriptor_ownership_identity(metadata)
 
     def open(self, path: str | Path, flags: int, *, dir_fd: int | None = None) -> int:
         descriptor = -1
@@ -176,13 +207,32 @@ class _PosixDescriptorCleanup:
             try:
                 before = os.fstat(descriptor)
                 expected = self.expected_identities.get(descriptor)
-                if expected is not None and _binding_identity(before) != expected:
+                close_cookie = self.close_cookies.get(descriptor)
+                if (
+                    expected is not None
+                    and _descriptor_ownership_identity(before) != expected
+                ):
+                    deferred = deferred or RuntimeError(
+                        "source descriptor ownership changed"
+                    )
+                    closed = True
+                elif close_cookie is not None and not _descriptor_has_close_cookie(
+                    descriptor,
+                    close_cookie,
+                ):
                     deferred = deferred or RuntimeError(
                         "source descriptor ownership changed"
                     )
                     closed = True
                 else:
                     try:
+                        if close_cookie is None:
+                            close_cookie = _arm_or_reuse_descriptor_close_cookie(
+                                descriptor,
+                                self.close_cookies.values(),
+                            )
+                            if close_cookie is not None:
+                                self.close_cookies[descriptor] = close_cookie
                         os.close(descriptor)
                         closed = True
                     except BaseException as exc:  # noqa: B036 - probe close result
@@ -197,7 +247,15 @@ class _PosixDescriptorCleanup:
                         except BaseException as probe:  # noqa: B036
                             deferred = deferred or probe
                         else:
-                            if _binding_identity(visible) != _binding_identity(before):
+                            if _descriptor_ownership_identity(
+                                visible
+                            ) != _descriptor_ownership_identity(before) or (
+                                close_cookie is not None
+                                and not _descriptor_has_close_cookie(
+                                    descriptor,
+                                    close_cookie,
+                                )
+                            ):
                                 closed = True
             except OSError as exc:
                 if exc.errno == errno.EBADF:
@@ -210,6 +268,7 @@ class _PosixDescriptorCleanup:
                 while descriptor in self.descriptors:
                     self.descriptors.remove(descriptor)
                 self.expected_identities.pop(descriptor, None)
+                _discard_descriptor_close_cookie(self.close_cookies, descriptor)
         return deferred
 
     def close_descriptor(self, descriptor: int) -> None:
@@ -346,6 +405,87 @@ def _binding_identity(metadata: os.stat_result) -> tuple[int, ...]:
         metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0,
         getattr(metadata, "st_file_attributes", 0),
     )
+
+
+def _descriptor_ownership_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    """Stable identity for deciding whether an fd number is still ours."""
+
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT,
+    )
+
+
+def _arm_descriptor_close_cookie(descriptor: int) -> int | None:
+    """Bind a retryable close to this exact open-file description."""
+
+    cookie = _CLOSE_COOKIE_FLOOR + secrets.randbelow(_CLOSE_COOKIE_SPAN)
+    try:
+        observed = os.lseek(descriptor, cookie, os.SEEK_SET)
+    except OSError as exc:
+        if exc.errno in {errno.EINVAL, errno.ESPIPE, getattr(errno, "ENOTSUP", -1)}:
+            return None
+        raise
+    if observed != cookie or os.lseek(descriptor, 0, os.SEEK_CUR) != cookie:
+        raise RuntimeError("could not arm source descriptor close ownership")
+    return cookie
+
+
+def _arm_or_reuse_descriptor_close_cookie(
+    descriptor: int,
+    active_cookies: Iterable[int],
+) -> int | None:
+    """Reuse a process-wide cookie shared by dup aliases, or arm one."""
+
+    with _CLOSE_COOKIE_LOCK:
+        try:
+            position = os.lseek(descriptor, 0, os.SEEK_CUR)
+        except OSError as exc:
+            if exc.errno in {
+                errno.EINVAL,
+                errno.ESPIPE,
+                getattr(errno, "ENOTSUP", -1),
+            }:
+                return None
+            raise
+        candidates = set(active_cookies).union(_CLOSE_COOKIE_COUNTS)
+        for cookie in candidates:
+            if type(cookie) is int and position == cookie:
+                _CLOSE_COOKIE_COUNTS[cookie] = _CLOSE_COOKIE_COUNTS.get(cookie, 0) + 1
+                return cookie
+        cookie = _arm_descriptor_close_cookie(descriptor)
+        if cookie is not None:
+            _CLOSE_COOKIE_COUNTS[cookie] = _CLOSE_COOKIE_COUNTS.get(cookie, 0) + 1
+        return cookie
+
+
+def _release_descriptor_close_cookie(cookie: int) -> None:
+    with _CLOSE_COOKIE_LOCK:
+        count = _CLOSE_COOKIE_COUNTS.get(cookie, 0)
+        if count <= 1:
+            _CLOSE_COOKIE_COUNTS.pop(cookie, None)
+        else:
+            _CLOSE_COOKIE_COUNTS[cookie] = count - 1
+
+
+def _discard_descriptor_close_cookie(
+    close_cookies: dict[int, int],
+    descriptor: int,
+) -> None:
+    cookie = close_cookies.pop(descriptor, None)
+    if cookie is not None:
+        _release_descriptor_close_cookie(cookie)
+
+
+def _descriptor_has_close_cookie(descriptor: int, cookie: int) -> bool:
+    try:
+        return os.lseek(descriptor, 0, os.SEEK_CUR) == cookie
+    except OSError as exc:
+        if exc.errno == errno.EBADF:
+            return False
+        raise
 
 
 def _version_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -694,6 +834,7 @@ def _open_secure(
     parts: tuple[str, ...],
     *,
     expected_final_identity: tuple[int, ...] | None = None,
+    expected_final_link_target: str | None = None,
     allow_stable_unresolved: bool = False,
     allow_absolute_symlinks: bool = False,
     pinned_root_descriptor: int | None = None,
@@ -872,6 +1013,14 @@ def _open_secure(
                     raise ValueError("source symlink resolution exceeds its limit")
                 link_identity = (before.st_dev, before.st_ino)
                 target = os.readlink(name, dir_fd=current_descriptor)
+                if (
+                    is_lexical_final
+                    and expected_final_link_target is not None
+                    and target != expected_final_link_target
+                ):
+                    raise ValueError(
+                        "source symlink target differs from its initial observation"
+                    )
                 after = os.stat(
                     name,
                     dir_fd=current_descriptor,
@@ -1169,22 +1318,6 @@ def _windows_open_child(
         _raise_with_cleanup(primary, selected_cleanup)
 
 
-def _strip_windows_namespace(path: str) -> str:
-    if path.startswith("\\??\\UNC\\"):
-        return "\\\\" + path[8:]
-    if path.startswith("\\??\\"):
-        return path[4:]
-    if path.startswith("\\\\?\\UNC\\"):
-        return "\\\\" + path[8:]
-    if path.startswith("\\\\?\\"):
-        return path[4:]
-    return path
-
-
-def _windows_path_parts(path: str) -> tuple[str, ...]:
-    return tuple(PureWindowsPath(ntpath.normpath(path)).parts)
-
-
 def _normalize_windows_link_target(
     root: Path,
     prefix: tuple[str, ...],
@@ -1207,22 +1340,7 @@ def _normalize_windows_link_target(
         resolved: list[str] = list(prefix)
         target_parts = target.replace("\\", "/").split("/")
     else:
-        target = _strip_windows_namespace(target)
-        if not ntpath.isabs(target):
-            raise ValueError("Windows absolute symlink has a relative target")
-        root_parts = _windows_path_parts(str(root))
-        target_parts_absolute = _windows_path_parts(target)
-        if len(target_parts_absolute) < len(root_parts) or any(
-            observed.casefold() != expected.casefold()
-            for observed, expected in zip(
-                target_parts_absolute,
-                root_parts,
-                strict=False,
-            )
-        ):
-            raise ValueError("Windows source symlink resolves outside the repository")
-        resolved = []
-        target_parts = list(target_parts_absolute[len(root_parts) :])
+        raise ValueError("Windows source symlink target must be relative")
 
     for part in target_parts:
         if part in {"", "."}:
@@ -1584,6 +1702,7 @@ def _open_windows_resolution_at(
     *,
     expected_root_identity: tuple[object, ...],
     expected_final_identity: tuple[object, ...] | None,
+    expected_final_link_target: str | None = None,
     allow_stable_unresolved: bool,
     api: _WindowsKernelApi,
     owns_root_authority: bool = False,
@@ -1681,6 +1800,14 @@ def _open_windows_resolution_at(
                 point = api.query_reparse_point(opened_handle)
                 if point.tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
                     raise ValueError("Windows source reparse tag changed while opening")
+                if (
+                    is_lexical_final
+                    and expected_final_link_target is not None
+                    and _windows_link_target_text(point) != expected_final_link_target
+                ):
+                    raise ValueError(
+                        "Windows source symlink target differs from its initial observation"
+                    )
             observation = _WindowsPathObservation(
                 parent_handle=current_handle,
                 parent_identity=parent_identity,
@@ -1803,6 +1930,7 @@ def _resolved_windows_repository_file_at(
     *,
     expected_root_identity: tuple[object, ...],
     expected_final_identity: tuple[object, ...],
+    expected_final_link_target: str | None = None,
     api: _WindowsKernelApi | None = None,
 ) -> Iterator[_WindowsResolutionBinding]:
     """Resolve one source entry through a caller-owned pinned Windows root."""
@@ -1816,6 +1944,7 @@ def _resolved_windows_repository_file_at(
         parts,
         expected_root_identity=expected_root_identity,
         expected_final_identity=expected_final_identity,
+        expected_final_link_target=expected_final_link_target,
         allow_stable_unresolved=True,
         api=selected,
         cleanup_slot=cleanup_slot,
@@ -1838,6 +1967,7 @@ def _open_windows_repository_file(
     parts: tuple[str, ...],
     *,
     expected_final_identity: tuple[object, ...] | None = None,
+    expected_final_link_target: str | None = None,
     allow_stable_unresolved: bool = False,
 ) -> _WindowsResolutionBinding:
     cleanup_slot = _SourceCleanupSlot()
@@ -1851,6 +1981,7 @@ def _open_windows_repository_file(
         parts,
         expected_root_identity=root_identity,
         expected_final_identity=expected_final_identity,
+        expected_final_link_target=expected_final_link_target,
         allow_stable_unresolved=allow_stable_unresolved,
         api=api,
         owns_root_authority=True,
@@ -2049,6 +2180,7 @@ def _resolved_repository_file_at(
     *,
     expected_root_identity: tuple[int, ...],
     expected_final_identity: tuple[int, ...],
+    expected_final_link_target: str | None = None,
 ) -> Iterator[
     _BoundRepositoryFile | _BoundRepositoryDirectory | _StableUnresolvedRepositoryFile
 ]:
@@ -2065,6 +2197,7 @@ def _resolved_repository_file_at(
         repository,
         parts,
         expected_final_identity=expected_final_identity,
+        expected_final_link_target=expected_final_link_target,
         allow_stable_unresolved=True,
         pinned_root_descriptor=root_descriptor,
         expected_root_identity=expected_root_identity,

--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -28,6 +28,7 @@ from .runtime import (
     ContextArtifactBinding,
     VerifiedContextArtifact,
     bind_context_artifact,
+    query_context_artifact,
     verify_context_artifact,
 )
 
@@ -46,6 +47,7 @@ __all__ = [
     "extract_context_artifact_archive",
     "fetch_github_context_artifact",
     "normalize_owned_query_view",
+    "query_context_artifact",
     "validate_portable_query_view",
     "resolve_github_context_artifact",
     "render_artifact_mcp_config",

--- a/codenib/artifacts/archive.py
+++ b/codenib/artifacts/archive.py
@@ -6,29 +6,233 @@
 
 from __future__ import annotations
 
-import json
+import os
 import stat
-import tempfile
 import zipfile
+from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
+from typing import BinaryIO, Iterator
 
-from .._atomic_directory import (
-    PublicationDirectoryReader,
-    _annotate_secondary_error,
-    capture_directory_ownership,
-    directory_ownership_root_identity,
-    discard_owned_directory,
-    lexical_directory_path,
-    publish_staged_directory,
+from .._atomic_directory import PublicationDirectoryReader, lexical_directory_path
+from .._captured_directory import (
+    OwnedDirectoryStage,
+    _create_sealable_memfd,
+    _seal_snapshot_descriptor,
+    _SnapshotUnavailable,
+    _write_all,
 )
 from .context import CONTEXT_ARTIFACT_MANIFEST
-from .runtime import VerifiedContextArtifact, verify_context_artifact
+from .runtime import VerifiedContextArtifact, verify_context_artifact_reader
 
 DEFAULT_MAX_ARCHIVE_FILES = 100_000
 DEFAULT_MAX_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
 _COPY_CHUNK_BYTES = 1024 * 1024
-_MAX_CONTEXT_METADATA_BYTES = 16 * 1024 * 1024
+_MAX_ARCHIVE_PATH_BYTES = 4_096
+_MAX_ARCHIVE_PATH_COMPONENTS = 256
+_MAX_ARCHIVE_ENVELOPE_BYTES = 16 * 1024 * 1024
+_MAX_ARCHIVE_MEMBER_OVERHEAD = 4_096
+
+
+def _read_archive(descriptor: int, size: int) -> bytes:
+    return os.read(descriptor, size)
+
+
+def _create_archive_snapshot() -> int:
+    try:
+        return _create_sealable_memfd()
+    except _SnapshotUnavailable as exc:
+        raise ValueError(
+            "secure context archive parsing requires immutable sealed snapshots"
+        ) from exc
+
+
+def _write_snapshot(descriptor: int, block: bytes) -> None:
+    _write_all(descriptor, block)
+
+
+def _seal_archive_snapshot(descriptor: int) -> None:
+    try:
+        _seal_snapshot_descriptor(descriptor)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(
+            "context artifact archive snapshot could not be sealed"
+        ) from exc
+
+
+def _stable_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _directory_binding_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    """Identify one retained lexical ancestor without mutable directory times."""
+
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0) & 0x400,
+    )
+
+
+@contextmanager
+def _authenticated_archive_snapshot(
+    value: str | Path,
+    *,
+    max_files: int,
+    max_bytes: int,
+) -> Iterator[tuple[Path, BinaryIO]]:
+    """Copy one lexical no-follow regular file into a verified snapshot."""
+
+    if os.name != "posix" or not (
+        hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and os.open in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.stat in os.supports_follow_symlinks
+    ):
+        raise ValueError(
+            "secure context archive reads require no-follow directory handles"
+        )
+    candidate = Path(value).expanduser()
+    lexical = Path(os.path.abspath(os.fspath(candidate)))
+    encoded = os.fsencode(lexical)
+    if (
+        lexical.name in {"", ".", ".."}
+        or len(encoded) > _MAX_ARCHIVE_PATH_BYTES
+        or len(lexical.parts) > _MAX_ARCHIVE_PATH_COMPONENTS
+    ):
+        raise ValueError("context artifact archive path is invalid or too long")
+    physical_limit = (
+        max_bytes
+        + max_files * _MAX_ARCHIVE_MEMBER_OVERHEAD
+        + _MAX_ARCHIVE_ENVELOPE_BYTES
+    )
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    directory_flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+    file_flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    file_flags |= getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_BINARY", 0)
+    descriptors: list[int] = []
+    bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
+    source = -1
+    snapshot_descriptor = -1
+    snapshot: BinaryIO | None = None
+    try:
+        descriptor = os.open(lexical.anchor, directory_flags)
+        descriptors.append(descriptor)
+        root = os.fstat(descriptor)
+        if not root.st_dev or not root.st_ino or not stat.S_ISDIR(root.st_mode):
+            raise ValueError("context artifact archive root has no stable identity")
+        for part in lexical.parts[1:-1]:
+            before = os.stat(part, dir_fd=descriptor, follow_symlinks=False)
+            if (
+                not stat.S_ISDIR(before.st_mode)
+                or stat.S_ISLNK(before.st_mode)
+                or not before.st_dev
+                or not before.st_ino
+            ):
+                raise ValueError(
+                    "context artifact archive parent is not a real directory"
+                )
+            child = os.open(part, directory_flags, dir_fd=descriptor)
+            opened = os.fstat(child)
+            if _directory_binding_identity(opened) != _directory_binding_identity(
+                before
+            ):
+                os.close(child)
+                raise ValueError("context artifact archive parent changed")
+            bindings.append(
+                (descriptor, part, child, _directory_binding_identity(opened))
+            )
+            descriptors.append(child)
+            descriptor = child
+
+        before = os.stat(
+            lexical.name,
+            dir_fd=descriptor,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or stat.S_ISLNK(before.st_mode)
+            or not before.st_dev
+            or not before.st_ino
+            or before.st_size < 0
+            or before.st_size > physical_limit
+        ):
+            raise ValueError(
+                f"context artifact archive is not a bounded regular file: {lexical}"
+            )
+        source = os.open(lexical.name, file_flags, dir_fd=descriptor)
+        opened = os.fstat(source)
+        expected = _stable_identity(before)
+        if _stable_identity(opened) != expected:
+            raise ValueError("context artifact archive changed while opening")
+
+        snapshot_descriptor = _create_archive_snapshot()
+        remaining = opened.st_size
+        while remaining:
+            block = _read_archive(source, min(remaining, _COPY_CHUNK_BYTES))
+            if not block:
+                raise ValueError("context artifact archive was truncated")
+            _write_snapshot(snapshot_descriptor, block)
+            remaining -= len(block)
+        if _read_archive(source, 1):
+            raise ValueError("context artifact archive grew while reading")
+
+        def verify_binding() -> None:
+            if (
+                _stable_identity(os.fstat(source)) != expected
+                or _stable_identity(
+                    os.stat(
+                        lexical.name,
+                        dir_fd=descriptor,
+                        follow_symlinks=False,
+                    )
+                )
+                != expected
+            ):
+                raise ValueError("context artifact archive changed while reading")
+            for parent, name, child, identity in bindings:
+                if (
+                    _directory_binding_identity(os.fstat(child)) != identity
+                    or _directory_binding_identity(
+                        os.stat(name, dir_fd=parent, follow_symlinks=False)
+                    )
+                    != identity
+                ):
+                    raise ValueError("context artifact archive parent changed")
+
+        verify_binding()
+        _seal_archive_snapshot(snapshot_descriptor)
+        snapshot = os.fdopen(snapshot_descriptor, "rb")
+        snapshot_descriptor = -1
+        yield lexical, snapshot
+        verify_binding()
+    except FileNotFoundError as exc:
+        raise ValueError(f"context artifact archive does not exist: {lexical}") from exc
+    except OSError as exc:
+        raise ValueError(
+            f"context artifact archive could not be opened safely: {lexical}"
+        ) from exc
+    finally:
+        if snapshot is not None:
+            snapshot.close()
+        if snapshot_descriptor >= 0:
+            os.close(snapshot_descriptor)
+        if source >= 0:
+            os.close(source)
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
 
 
 def _member_path(value: str) -> PurePosixPath:
@@ -121,24 +325,28 @@ def _extract_member(
     archive: zipfile.ZipFile,
     info: zipfile.ZipInfo,
     relative: PurePosixPath,
-    root: Path,
+    stage: OwnedDirectoryStage,
 ) -> None:
-    output = root.joinpath(*relative.parts)
     if info.is_dir():
-        output.mkdir(parents=True, exist_ok=True)
         return
-    output.parent.mkdir(parents=True, exist_ok=True)
-    written = 0
-    with archive.open(info, "r") as source, output.open("xb") as destination:
-        while chunk := source.read(_COPY_CHUNK_BYTES):
-            written += len(chunk)
-            if written > info.file_size:
-                raise ValueError(
-                    f"context artifact archive member exceeded declared size: {relative}"
-                )
-            destination.write(chunk)
-    if written != info.file_size:
-        raise ValueError(f"context artifact archive member size mismatch: {relative}")
+
+    def chunks():
+        written = 0
+        with archive.open(info, "r") as source:
+            while chunk := source.read(_COPY_CHUNK_BYTES):
+                written += len(chunk)
+                if written > info.file_size:
+                    raise ValueError(
+                        "context artifact archive member exceeded declared size: "
+                        f"{relative}"
+                    )
+                yield chunk
+        if written != info.file_size:
+            raise ValueError(
+                f"context artifact archive member size mismatch: {relative}"
+            )
+
+    stage.write_file(relative, chunks(), max_bytes=info.file_size)
 
 
 def extract_context_artifact_archive(
@@ -152,174 +360,88 @@ def extract_context_artifact_archive(
 ) -> VerifiedContextArtifact:
     """Extract and verify an artifact ZIP before publishing it."""
 
-    archive_candidate = Path(archive_path).expanduser()
-    if archive_candidate.is_symlink():
-        raise ValueError(
-            f"context artifact archive must not be a symbolic link: {archive_candidate}"
-        )
-    archive_path = archive_candidate.resolve()
-    if not archive_path.is_file():
-        raise ValueError(f"context artifact archive does not exist: {archive_path}")
+    if (
+        isinstance(max_files, bool)
+        or not isinstance(max_files, int)
+        or max_files <= 0
+        or isinstance(max_bytes, bool)
+        or not isinstance(max_bytes, int)
+        or max_bytes <= 0
+    ):
+        raise ValueError("context artifact archive limits must be positive integers")
     output = lexical_directory_path(Path(output_dir))
-    if output.is_symlink():
-        raise ValueError(
-            f"context artifact output must not be a symbolic link: {output}"
-        )
-    if output.exists() and not output.is_dir():
-        raise ValueError(f"context artifact output is not a directory: {output}")
     try:
-        expected_output_ownership = (
-            capture_directory_ownership(
-                output,
-                required_root_file=CONTEXT_ARTIFACT_MANIFEST,
-                allow_empty_root=True,
-            )
-            if output.exists()
-            else None
+        stage = OwnedDirectoryStage.prepare(
+            output,
+            required_destination_file=CONTEXT_ARTIFACT_MANIFEST,
+            allow_empty_destination=True,
         )
-    except RuntimeError as exc:
+    except (OSError, RuntimeError) as exc:
         raise ValueError(
             "refusing to replace a non-empty directory that is not a "
             f"CodeNib context artifact: {output}"
         ) from exc
 
-    output.parent.mkdir(parents=True, exist_ok=True)
-    stage = lexical_directory_path(
-        Path(
-            tempfile.mkdtemp(
-                prefix=f".{output.name}.extract-",
-                dir=str(output.parent),
-            )
-        )
-    )
-    stage_root_ownership = capture_directory_ownership(stage)
-    initial_stage_root_identity = directory_ownership_root_identity(
-        stage_root_ownership
-    )
+    published: list[VerifiedContextArtifact] = []
     try:
-        with zipfile.ZipFile(archive_path) as archive:
-            members = _validated_members(
-                archive,
+        with _authenticated_archive_snapshot(
+            archive_path,
+            max_files=max_files,
+            max_bytes=max_bytes,
+        ) as (archive_display, snapshot):
+            with zipfile.ZipFile(snapshot) as archive:
+                members = _validated_members(
+                    archive,
+                    max_files=max_files,
+                    max_bytes=max_bytes,
+                )
+                for info, relative in members:
+                    _extract_member(archive, info, relative, stage)
+
+        def validate_staged_artifact(candidate: PublicationDirectoryReader) -> None:
+            verify_context_artifact_reader(
+                candidate,
+                expected_repository=expected_repository,
+                expected_commit=expected_commit,
                 max_files=max_files,
                 max_bytes=max_bytes,
             )
-            for info, relative in members:
-                _extract_member(archive, info, relative, stage)
 
-        verified = verify_context_artifact(
-            stage,
-            expected_repository=expected_repository,
-            expected_commit=expected_commit,
-            max_files=max_files,
-            max_bytes=max_bytes,
-        )
-        publication_ownership = capture_directory_ownership(stage)
-        if (
-            directory_ownership_root_identity(publication_ownership)
-            != initial_stage_root_identity
-        ):
-            raise RuntimeError("context artifact stage root changed during extraction")
-        stage_root_ownership = publication_ownership
-        expected_files = {
-            item["path"]: (item["bytes"], item["sha256"])
-            for item in verified.metadata["files"]
-        }
+        def validate_published_artifact(
+            candidate: PublicationDirectoryReader,
+        ) -> None:
+            verified = verify_context_artifact_reader(
+                candidate,
+                expected_repository=expected_repository,
+                expected_commit=expected_commit,
+                max_files=max_files,
+                max_bytes=max_bytes,
+            )
+            published.append(
+                replace(
+                    verified,
+                    root=output,
+                    metadata_path=output / CONTEXT_ARTIFACT_MANIFEST,
+                    manifest_path=output / verified.manifest_path.name,
+                )
+            )
 
-        def validate_artifact(candidate: PublicationDirectoryReader) -> None:
-            records = {record.path: record for record in candidate.file_records()}
-            metadata_record = records.pop(CONTEXT_ARTIFACT_MANIFEST, None)
-            if (
-                metadata_record is None
-                or metadata_record.size > _MAX_CONTEXT_METADATA_BYTES
-                or set(records) != set(expected_files)
-                or any(
-                    (record.size, record.sha256) != expected_files[path]
-                    for path, record in records.items()
-                )
-            ):
-                raise ValueError(
-                    "published context artifact differs from its verified identity"
-                )
-            try:
-                metadata = json.loads(
-                    candidate.read_bytes(
-                        CONTEXT_ARTIFACT_MANIFEST,
-                        max_bytes=_MAX_CONTEXT_METADATA_BYTES,
-                    ).decode("utf-8", errors="strict")
-                )
-            except (UnicodeError, json.JSONDecodeError) as exc:
-                raise ValueError(
-                    "published context artifact metadata is invalid"
-                ) from exc
-            if metadata != verified.metadata:
-                raise ValueError(
-                    "published context artifact metadata changed after verification"
-                )
-
-        publish_staged_directory(
-            stage,
-            output,
-            expected_stage_root_ownership=stage_root_ownership,
-            expected_destination_ownership=expected_output_ownership,
-            validate_staged_directory=validate_artifact,
-            validate_published_destination=validate_artifact,
+        stage.publish(
+            validate_staged_directory=validate_staged_artifact,
+            validate_published_destination=validate_published_artifact,
         )
     except zipfile.BadZipFile as exc:
-        primary_error = ValueError(
-            f"context artifact archive is not a valid ZIP: {archive_path}"
-        )
-        try:
-            observed_stage_ownership = capture_directory_ownership(stage)
-            if (
-                directory_ownership_root_identity(observed_stage_ownership)
-                == initial_stage_root_identity
-            ):
-                stage_root_ownership = observed_stage_ownership
-        except BaseException as capture_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "context archive stage cleanup capture also failed",
-                capture_error,
-            )
-        try:
-            discard_owned_directory(stage, stage_root_ownership)
-        except BaseException as discard_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "context archive stage discard also failed",
-                discard_error,
-            )
-        raise primary_error from exc
-    except BaseException as primary_error:
-        try:
-            observed_stage_ownership = capture_directory_ownership(stage)
-            if (
-                directory_ownership_root_identity(observed_stage_ownership)
-                == initial_stage_root_identity
-            ):
-                stage_root_ownership = observed_stage_ownership
-        except BaseException as capture_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "context archive stage cleanup capture also failed",
-                capture_error,
-            )
-        try:
-            discard_owned_directory(stage, stage_root_ownership)
-        except BaseException as discard_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "context archive stage discard also failed",
-                discard_error,
-            )
+        stage.discard()
+        raise ValueError(
+            f"context artifact archive is not a valid ZIP: {archive_display}"
+        ) from exc
+    except BaseException:
+        stage.discard()
         raise
 
-    return replace(
-        verified,
-        root=output,
-        metadata_path=output / CONTEXT_ARTIFACT_MANIFEST,
-        manifest_path=output / verified.manifest_path.relative_to(stage),
-    )
+    if len(published) != 1:
+        raise RuntimeError("published context artifact was not authority-verified")
+    return published[0]
 
 
 __all__ = [

--- a/codenib/artifacts/archive.py
+++ b/codenib/artifacts/archive.py
@@ -6,15 +6,23 @@
 
 from __future__ import annotations
 
+import io
 import os
 import stat
+import struct
+import sys
 import zipfile
 from contextlib import contextmanager
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO, Iterator
 
-from .._atomic_directory import PublicationDirectoryReader, lexical_directory_path
+from .. import _windows_fs_authority as _windows_fs
+from .._atomic_directory import (
+    PublicationDirectoryReader,
+    _annotate_secondary_error,
+    lexical_directory_path,
+)
 from .._captured_directory import (
     OwnedDirectoryStage,
     _create_sealable_memfd,
@@ -22,20 +30,196 @@ from .._captured_directory import (
     _SnapshotUnavailable,
     _write_all,
 )
+from .._contained_source import _PosixDescriptorCleanup
 from .context import CONTEXT_ARTIFACT_MANIFEST
 from .runtime import VerifiedContextArtifact, verify_context_artifact_reader
 
 DEFAULT_MAX_ARCHIVE_FILES = 100_000
 DEFAULT_MAX_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
+DEFAULT_MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
 _COPY_CHUNK_BYTES = 1024 * 1024
 _MAX_ARCHIVE_PATH_BYTES = 4_096
 _MAX_ARCHIVE_PATH_COMPONENTS = 256
 _MAX_ARCHIVE_ENVELOPE_BYTES = 16 * 1024 * 1024
 _MAX_ARCHIVE_MEMBER_OVERHEAD = 4_096
+_MAX_ZIP_COMMENT_BYTES = (1 << 16) - 1
+
+
+@dataclass(slots=True)
+class _ArchiveCleanupRecord:
+    resource: object
+    closed: bool = False
+
+
+class _ArchiveCleanupOwner:
+    """Retryable owner spanning Windows authority and child HANDLE handoffs."""
+
+    def __init__(self) -> None:
+        self._records: list[_ArchiveCleanupRecord] = []
+
+    def own(self, resource: object) -> None:
+        if resource is None:
+            raise TypeError("archive cleanup resource must not be null")
+        if any(record.resource is resource for record in self._records):
+            return
+        record: _ArchiveCleanupRecord | None = None
+        try:
+            record = _ArchiveCleanupRecord(resource)
+            self._records.append(record)
+        except BaseException:  # noqa: B036 - commit resource ownership
+            if record is not None and not any(
+                candidate is record for candidate in self._records
+            ):
+                try:
+                    self._records.append(record)
+                except BaseException:  # noqa: B036 - preserve primary failure
+                    pass
+            raise
+
+    @staticmethod
+    def _reports_closed(resource: object) -> bool:
+        try:
+            return bool(resource.closed)  # type: ignore[attr-defined]
+        except BaseException:  # noqa: B036 - uncertain ownership stays retained
+            return False
+
+    @property
+    def closed(self) -> bool:
+        for record in self._records:
+            if not record.closed and self._reports_closed(record.resource):
+                record.closed = True
+        return all(record.closed for record in self._records)
+
+    def close(self) -> None:
+        deferred: BaseException | None = None
+        for record in reversed(tuple(self._records)):
+            if record.closed or self._reports_closed(record.resource):
+                record.closed = True
+                continue
+            close = getattr(record.resource, "close", None)
+            if not callable(close):
+                failure = TypeError("archive cleanup resource has no close method")
+                if deferred is None:
+                    deferred = failure
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "additional archive cleanup also failed",
+                        failure,
+                    )
+                continue
+            try:
+                close()
+                record.closed = True
+            except BaseException as failure:  # noqa: B036 - visit every owner
+                if self._reports_closed(record.resource):
+                    record.closed = True
+                if deferred is None:
+                    deferred = failure
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "additional archive cleanup also failed",
+                        failure,
+                    )
+        if deferred is not None:
+            raise deferred
+        if not self.closed:
+            raise RuntimeError("Windows archive cleanup remains pending")
+
+
+def _attach_archive_cleanup_owner(
+    failure: BaseException,
+    owner: _ArchiveCleanupOwner,
+) -> None:
+    if owner.closed:
+        return
+    try:
+        failure.archive_cleanup_owner = owner  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - local owner remains authoritative
+        pass
+
+
+class _ImmutableArchiveSnapshot(io.RawIOBase):
+    """Seekable read-only chunks for platforms without sealed descriptors."""
+
+    def __init__(self, chunks: tuple[bytes, ...]) -> None:
+        super().__init__()
+        self._chunks = chunks
+        self._size = sum(len(chunk) for chunk in chunks)
+        self._offset = 0
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
+
+    def write(self, _payload: bytes) -> int:
+        raise io.UnsupportedOperation("archive snapshot is read-only")
+
+    def read(self, size: int = -1) -> bytes:
+        self._checkClosed()
+        if size is None or size < 0:
+            end = self._size
+        else:
+            end = min(self._size, self._offset + size)
+        if end <= self._offset:
+            return b""
+        output = bytearray(end - self._offset)
+        output_offset = 0
+        chunk_start = 0
+        for chunk in self._chunks:
+            chunk_end = chunk_start + len(chunk)
+            if chunk_end <= self._offset:
+                chunk_start = chunk_end
+                continue
+            if chunk_start >= end:
+                break
+            source_start = max(self._offset, chunk_start) - chunk_start
+            source_end = min(end, chunk_end) - chunk_start
+            segment = chunk[source_start:source_end]
+            output[output_offset : output_offset + len(segment)] = segment
+            output_offset += len(segment)
+            chunk_start = chunk_end
+        self._offset = end
+        return bytes(output)
+
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        self._checkClosed()
+        if whence == os.SEEK_SET:
+            position = offset
+        elif whence == os.SEEK_CUR:
+            position = self._offset + offset
+        elif whence == os.SEEK_END:
+            position = self._size + offset
+        else:
+            raise ValueError("invalid archive snapshot seek mode")
+        if position < 0:
+            raise ValueError("negative archive snapshot seek position")
+        self._offset = position
+        return position
+
+    def tell(self) -> int:
+        self._checkClosed()
+        return self._offset
+
+    def close(self) -> None:
+        self._chunks = ()
+        self._size = 0
+        self._offset = 0
+        super().close()
 
 
 def _read_archive(descriptor: int, size: int) -> bytes:
     return os.read(descriptor, size)
+
+
+def _archive_os_name() -> str:
+    return os.name
 
 
 def _create_archive_snapshot() -> int:
@@ -84,25 +268,139 @@ def _directory_binding_identity(metadata: os.stat_result) -> tuple[int, ...]:
     )
 
 
+def _windows_archive_entry(
+    authority: _windows_fs.WindowsDirectoryAuthority,
+    name: str,
+) -> _windows_fs.WindowsDirectoryEntry:
+    iterator = getattr(authority.api, "iter_directory", None)
+    entries = (
+        iterator(authority.handle)
+        if callable(iterator)
+        else authority.api.enumerate_directory(authority.handle)
+    )
+    matches = [entry for entry in entries if entry.name == name]
+    if len(matches) != 1:
+        raise ValueError("context artifact archive path is missing or ambiguous")
+    return matches[0]
+
+
+@contextmanager
+def _authenticated_windows_archive_snapshot(
+    lexical: Path,
+    *,
+    physical_limit: int,
+) -> Iterator[BinaryIO]:
+    """Read one exact Windows file generation through retained HANDLEs."""
+
+    owner = _ArchiveCleanupOwner()
+    snapshot: _ImmutableArchiveSnapshot | None = None
+    try:
+        authority = _windows_fs.open_lexical_directory_authority(
+            lexical.parent,
+            cleanup_slot=owner,
+        )
+        api = authority.api
+        cleanup = _windows_fs._WindowsHandleCleanup(api)
+        owner.own(cleanup)
+        entry = _windows_archive_entry(authority, lexical.name)
+        if entry.attributes & (
+            _windows_fs.FILE_ATTRIBUTE_DIRECTORY
+            | _windows_fs.FILE_ATTRIBUTE_REPARSE_POINT
+        ):
+            raise ValueError(
+                f"context artifact archive is not a bounded regular file: {lexical}"
+            )
+        handle = _windows_fs._open_owned_windows_handle(
+            lambda: api.open_relative(
+                authority.handle,
+                entry.name,
+                desired_access=(
+                    _windows_fs.FILE_READ_DATA
+                    | _windows_fs.FILE_READ_ATTRIBUTES
+                    | _windows_fs.SYNCHRONIZE
+                ),
+                is_directory=False,
+                allow_reparse=False,
+            ),
+            cleanup.handles,
+        )
+        opened = api.metadata(handle)
+        cleanup.retain(handle, opened)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_file_attributes & _windows_fs.FILE_ATTRIBUTE_REPARSE_POINT
+            or not opened.st_dev
+            or not _windows_fs.windows_file_id_is_reliable(opened.file_id_128)
+            or entry.file_id_128 != opened.file_id_128
+            or opened.delete_pending
+            or opened.st_size < 0
+            or opened.st_size > physical_limit
+        ):
+            raise ValueError(
+                f"context artifact archive is not a bounded regular file: {lexical}"
+            )
+        expected = _windows_fs.windows_metadata_identity(opened)
+        chunks: list[bytes] = []
+        remaining = opened.st_size
+        while remaining:
+            block = api.read(handle, min(remaining, _COPY_CHUNK_BYTES))
+            if not block:
+                raise ValueError("context artifact archive was truncated")
+            chunks.append(block)
+            remaining -= len(block)
+        if api.read(handle, 1):
+            raise ValueError("context artifact archive grew while reading")
+
+        def verify_binding() -> None:
+            observed = api.metadata(handle)
+            rebound = _windows_archive_entry(authority, lexical.name)
+            if (
+                _windows_fs.windows_metadata_identity(observed) != expected
+                or rebound.file_id_128 != opened.file_id_128
+            ):
+                raise ValueError("context artifact archive changed while reading")
+            authority.verify()
+
+        verify_binding()
+        snapshot = _ImmutableArchiveSnapshot(tuple(chunks))
+        chunks.clear()
+        yield snapshot
+        verify_binding()
+    finally:
+        active_failure = sys.exc_info()[1]
+        cleanup_failure: BaseException | None = None
+        if snapshot is not None:
+            try:
+                snapshot.close()
+            except BaseException as exc:  # noqa: B036 - visit every authority
+                cleanup_failure = exc
+        try:
+            owner.close()
+        except BaseException as exc:  # noqa: B036 - retain retryable owner
+            cleanup_failure = cleanup_failure or exc
+        if cleanup_failure is not None:
+            if active_failure is not None:
+                _annotate_secondary_error(
+                    active_failure,
+                    "Windows archive authority cleanup also failed",
+                    cleanup_failure,
+                )
+                _attach_archive_cleanup_owner(active_failure, owner)
+            else:
+                _attach_archive_cleanup_owner(cleanup_failure, owner)
+                raise cleanup_failure
+
+
 @contextmanager
 def _authenticated_archive_snapshot(
     value: str | Path,
     *,
     max_files: int,
     max_bytes: int,
+    max_archive_bytes: int = DEFAULT_MAX_ARCHIVE_BYTES,
 ) -> Iterator[tuple[Path, BinaryIO]]:
     """Copy one lexical no-follow regular file into a verified snapshot."""
 
-    if os.name != "posix" or not (
-        hasattr(os, "O_DIRECTORY")
-        and hasattr(os, "O_NOFOLLOW")
-        and os.open in os.supports_dir_fd
-        and os.stat in os.supports_dir_fd
-        and os.stat in os.supports_follow_symlinks
-    ):
-        raise ValueError(
-            "secure context archive reads require no-follow directory handles"
-        )
     candidate = Path(value).expanduser()
     lexical = Path(os.path.abspath(os.fspath(candidate)))
     encoded = os.fsencode(lexical)
@@ -112,23 +410,43 @@ def _authenticated_archive_snapshot(
         or len(lexical.parts) > _MAX_ARCHIVE_PATH_COMPONENTS
     ):
         raise ValueError("context artifact archive path is invalid or too long")
-    physical_limit = (
+    physical_limit = min(
+        max_archive_bytes,
         max_bytes
         + max_files * _MAX_ARCHIVE_MEMBER_OVERHEAD
-        + _MAX_ARCHIVE_ENVELOPE_BYTES
+        + _MAX_ARCHIVE_ENVELOPE_BYTES,
     )
+    platform_name = _archive_os_name()
+    if platform_name == "nt":
+        with _authenticated_windows_archive_snapshot(
+            lexical,
+            physical_limit=physical_limit,
+        ) as snapshot:
+            yield lexical, snapshot
+        return
+    if platform_name != "posix" or not (
+        hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and os.open in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.stat in os.supports_follow_symlinks
+    ):
+        raise ValueError(
+            "secure context archive reads require no-follow directory handles"
+        )
     directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     directory_flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
     file_flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
     file_flags |= getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_BINARY", 0)
-    descriptors: list[int] = []
+    owner = _ArchiveCleanupOwner()
+    descriptor_cleanup = _PosixDescriptorCleanup()
+    owner.own(descriptor_cleanup)
     bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
     source = -1
     snapshot_descriptor = -1
     snapshot: BinaryIO | None = None
     try:
-        descriptor = os.open(lexical.anchor, directory_flags)
-        descriptors.append(descriptor)
+        descriptor = descriptor_cleanup.open(lexical.anchor, directory_flags)
         root = os.fstat(descriptor)
         if not root.st_dev or not root.st_ino or not stat.S_ISDIR(root.st_mode):
             raise ValueError("context artifact archive root has no stable identity")
@@ -143,17 +461,19 @@ def _authenticated_archive_snapshot(
                 raise ValueError(
                     "context artifact archive parent is not a real directory"
                 )
-            child = os.open(part, directory_flags, dir_fd=descriptor)
+            child = descriptor_cleanup.open(
+                part,
+                directory_flags,
+                dir_fd=descriptor,
+            )
             opened = os.fstat(child)
             if _directory_binding_identity(opened) != _directory_binding_identity(
                 before
             ):
-                os.close(child)
                 raise ValueError("context artifact archive parent changed")
             bindings.append(
                 (descriptor, part, child, _directory_binding_identity(opened))
             )
-            descriptors.append(child)
             descriptor = child
 
         before = os.stat(
@@ -172,13 +492,18 @@ def _authenticated_archive_snapshot(
             raise ValueError(
                 f"context artifact archive is not a bounded regular file: {lexical}"
             )
-        source = os.open(lexical.name, file_flags, dir_fd=descriptor)
+        source = descriptor_cleanup.open(
+            lexical.name,
+            file_flags,
+            dir_fd=descriptor,
+        )
         opened = os.fstat(source)
         expected = _stable_identity(before)
         if _stable_identity(opened) != expected:
             raise ValueError("context artifact archive changed while opening")
 
         snapshot_descriptor = _create_archive_snapshot()
+        descriptor_cleanup.retain(snapshot_descriptor)
         remaining = opened.st_size
         while remaining:
             block = _read_archive(source, min(remaining, _COPY_CHUNK_BYTES))
@@ -214,7 +539,11 @@ def _authenticated_archive_snapshot(
 
         verify_binding()
         _seal_archive_snapshot(snapshot_descriptor)
-        snapshot = os.fdopen(snapshot_descriptor, "rb")
+        # The descriptor cleanup remains the sole native-fd owner.  The file
+        # wrapper is separately closeable but must never close a reused raw fd
+        # if its own close is interrupted and later retried.
+        snapshot = os.fdopen(snapshot_descriptor, "rb", closefd=False)
+        owner.own(snapshot)
         snapshot_descriptor = -1
         yield lexical, snapshot
         verify_binding()
@@ -225,14 +554,20 @@ def _authenticated_archive_snapshot(
             f"context artifact archive could not be opened safely: {lexical}"
         ) from exc
     finally:
-        if snapshot is not None:
-            snapshot.close()
-        if snapshot_descriptor >= 0:
-            os.close(snapshot_descriptor)
-        if source >= 0:
-            os.close(source)
-        for descriptor in reversed(descriptors):
-            os.close(descriptor)
+        active_failure = sys.exc_info()[1]
+        try:
+            owner.close()
+        except BaseException as cleanup_failure:  # noqa: B036 - retain owner
+            if active_failure is not None:
+                _annotate_secondary_error(
+                    active_failure,
+                    "POSIX archive authority cleanup also failed",
+                    cleanup_failure,
+                )
+                _attach_archive_cleanup_owner(active_failure, owner)
+            else:
+                _attach_archive_cleanup_owner(cleanup_failure, owner)
+                raise
 
 
 def _member_path(value: str) -> PurePosixPath:
@@ -252,6 +587,144 @@ def _member_path(value: str) -> PurePosixPath:
 
 def _member_kind(info: zipfile.ZipInfo) -> int:
     return stat.S_IFMT(info.external_attr >> 16)
+
+
+def _preflight_zip_envelope(
+    snapshot: BinaryIO,
+    *,
+    max_files: int,
+) -> None:
+    """Bound the ZIP directory before ``ZipFile`` allocates ``ZipInfo`` objects."""
+
+    snapshot.seek(0, os.SEEK_END)
+    archive_size = snapshot.tell()
+    tail_size = min(archive_size, 22 + _MAX_ZIP_COMMENT_BYTES)
+    snapshot.seek(archive_size - tail_size)
+    tail = snapshot.read(tail_size)
+    end_index = tail.rfind(b"PK\x05\x06")
+    if end_index < 0 or len(tail) - end_index < 22:
+        raise zipfile.BadZipFile("missing ZIP end record")
+    end_offset = archive_size - tail_size + end_index
+    try:
+        (
+            signature,
+            disk_number,
+            central_disk,
+            disk_members,
+            member_count,
+            central_size,
+            central_offset,
+            comment_size,
+        ) = struct.unpack_from("<4s4H2LH", tail, end_index)
+    except struct.error as exc:
+        raise zipfile.BadZipFile("truncated ZIP end record") from exc
+    if (
+        signature != b"PK\x05\x06"
+        or disk_number != 0
+        or central_disk != 0
+        or end_offset + 22 + comment_size != archive_size
+    ):
+        raise zipfile.BadZipFile("invalid or multi-disk ZIP envelope")
+
+    if (
+        disk_members == 0xFFFF
+        or member_count == 0xFFFF
+        or central_size == 0xFFFFFFFF
+        or central_offset == 0xFFFFFFFF
+    ):
+        locator_offset = end_offset - 20
+        if locator_offset < 0:
+            raise zipfile.BadZipFile("missing ZIP64 locator")
+        snapshot.seek(locator_offset)
+        locator = snapshot.read(20)
+        try:
+            locator_signature, locator_disk, zip64_offset, total_disks = struct.unpack(
+                "<4sLQL", locator
+            )
+        except struct.error as exc:
+            raise zipfile.BadZipFile("truncated ZIP64 locator") from exc
+        if (
+            locator_signature != b"PK\x06\x07"
+            or locator_disk != 0
+            or total_disks != 1
+            or zip64_offset < 0
+            or zip64_offset + 56 > locator_offset
+        ):
+            raise zipfile.BadZipFile("invalid ZIP64 locator")
+        snapshot.seek(zip64_offset)
+        record = snapshot.read(56)
+        try:
+            (
+                zip64_signature,
+                record_size,
+                _create_version,
+                _extract_version,
+                zip64_disk,
+                zip64_central_disk,
+                zip64_disk_members,
+                zip64_members,
+                zip64_central_size,
+                zip64_central_offset,
+            ) = struct.unpack("<4sQ2H2L4Q", record)
+        except struct.error as exc:
+            raise zipfile.BadZipFile("truncated ZIP64 end record") from exc
+        if (
+            zip64_signature != b"PK\x06\x06"
+            or record_size < 44
+            or zip64_disk != 0
+            or zip64_central_disk != 0
+            or zip64_disk_members != zip64_members
+        ):
+            raise zipfile.BadZipFile("invalid or multi-disk ZIP64 envelope")
+        member_count = zip64_members
+        central_size = zip64_central_size
+        central_offset = zip64_central_offset
+        central_end = zip64_offset
+    else:
+        if disk_members != member_count:
+            raise zipfile.BadZipFile("invalid multi-disk ZIP member count")
+        central_end = end_offset
+
+    max_entries = max_files * 2 + 64
+    if member_count > max_entries:
+        raise ValueError(f"context artifact archive exceeds {max_entries} entries")
+    maximum_central_size = _MAX_ARCHIVE_ENVELOPE_BYTES + max_entries * (
+        _MAX_ARCHIVE_PATH_BYTES + _MAX_ARCHIVE_MEMBER_OVERHEAD
+    )
+    if central_size > maximum_central_size:
+        raise ValueError(
+            "context artifact archive central directory exceeds its budget"
+        )
+    if central_offset > central_end or central_size > central_end - central_offset:
+        raise zipfile.BadZipFile("ZIP central directory lies outside its envelope")
+    # EOCD counts are attacker-controlled. Walk only the fixed central headers
+    # and their bounded variable sections to prove the real count before
+    # ``ZipFile`` creates one Python object per member.
+    central_limit = central_offset + central_size
+    snapshot.seek(central_offset)
+    actual_members = 0
+    while snapshot.tell() < central_limit:
+        header = snapshot.read(46)
+        if len(header) != 46 or header[:4] != b"PK\x01\x02":
+            raise zipfile.BadZipFile("invalid ZIP central directory header")
+        try:
+            name_size, extra_size, member_comment_size = struct.unpack_from(
+                "<3H", header, 28
+            )
+        except struct.error as exc:
+            raise zipfile.BadZipFile("truncated ZIP central directory header") from exc
+        variable_size = name_size + extra_size + member_comment_size
+        if variable_size > central_limit - snapshot.tell():
+            raise zipfile.BadZipFile("ZIP central directory entry exceeds its envelope")
+        snapshot.seek(variable_size, os.SEEK_CUR)
+        actual_members += 1
+        if actual_members > max_entries:
+            raise ValueError(f"context artifact archive exceeds {max_entries} entries")
+    if snapshot.tell() != central_limit or actual_members != member_count:
+        raise zipfile.BadZipFile(
+            "ZIP central directory count does not match its envelope"
+        )
+    snapshot.seek(0)
 
 
 def _validated_members(
@@ -357,6 +830,7 @@ def extract_context_artifact_archive(
     expected_commit: str | None = None,
     max_files: int = DEFAULT_MAX_ARCHIVE_FILES,
     max_bytes: int = DEFAULT_MAX_EXPANDED_BYTES,
+    max_archive_bytes: int = DEFAULT_MAX_ARCHIVE_BYTES,
 ) -> VerifiedContextArtifact:
     """Extract and verify an artifact ZIP before publishing it."""
 
@@ -367,6 +841,9 @@ def extract_context_artifact_archive(
         or isinstance(max_bytes, bool)
         or not isinstance(max_bytes, int)
         or max_bytes <= 0
+        or isinstance(max_archive_bytes, bool)
+        or not isinstance(max_archive_bytes, int)
+        or max_archive_bytes <= 0
     ):
         raise ValueError("context artifact archive limits must be positive integers")
     output = lexical_directory_path(Path(output_dir))
@@ -388,7 +865,9 @@ def extract_context_artifact_archive(
             archive_path,
             max_files=max_files,
             max_bytes=max_bytes,
+            max_archive_bytes=max_archive_bytes,
         ) as (archive_display, snapshot):
+            _preflight_zip_envelope(snapshot, max_files=max_files)
             with zipfile.ZipFile(snapshot) as archive:
                 members = _validated_members(
                     archive,
@@ -432,9 +911,16 @@ def extract_context_artifact_archive(
         )
     except zipfile.BadZipFile as exc:
         stage.discard()
-        raise ValueError(
+        failure = ValueError(
             f"context artifact archive is not a valid ZIP: {archive_display}"
-        ) from exc
+        )
+        cleanup_owner = getattr(exc, "archive_cleanup_owner", None)
+        if cleanup_owner is not None:
+            try:
+                failure.archive_cleanup_owner = cleanup_owner  # type: ignore[attr-defined]
+            except BaseException:  # noqa: B036 - chained error still retains owner
+                pass
+        raise failure from exc
     except BaseException:
         stage.discard()
         raise
@@ -445,6 +931,7 @@ def extract_context_artifact_archive(
 
 
 __all__ = [
+    "DEFAULT_MAX_ARCHIVE_BYTES",
     "DEFAULT_MAX_ARCHIVE_FILES",
     "DEFAULT_MAX_EXPANDED_BYTES",
     "extract_context_artifact_archive",

--- a/codenib/artifacts/mcp_config.py
+++ b/codenib/artifacts/mcp_config.py
@@ -40,20 +40,20 @@ def render_artifact_mcp_config(
     if claude_scope not in {"local", "project", "user"}:
         raise ValueError("Claude MCP scope must be local, project, or user")
 
-    binding = bind_context_artifact(
+    with bind_context_artifact(
         artifact_path,
         repo_path,
         expected_repository=expected_repository,
-    )
-    args = [
-        "mcp",
-        "--artifact",
-        str(binding.artifact.root),
-        "--repo",
-        str(binding.repo_path),
-        "--repository",
-        binding.artifact.repository,
-    ]
+    ) as binding:
+        args = [
+            "mcp",
+            "--artifact",
+            str(binding.artifact.root),
+            "--repo",
+            str(binding.repo_path),
+            "--repository",
+            binding.artifact.repository,
+        ]
     server = {
         "type": "stdio",
         "command": command,

--- a/codenib/artifacts/runtime.py
+++ b/codenib/artifacts/runtime.py
@@ -7,26 +7,45 @@
 from __future__ import annotations
 
 import json
+import math
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from pathlib import Path, PurePosixPath
-from typing import Any, Mapping
+from typing import Any, Callable, Iterator, Mapping, NoReturn
 
-from .._contained_source import validate_repository_file
+from .._atomic_directory import (
+    PublicationAuthenticatedFile,
+    PublicationDirectoryReader,
+    TreeFileRecord,
+    capture_directory_ownership,
+    directory_ownership_file_records,
+    lexical_directory_path,
+    reopen_authenticated_directory,
+)
+from .._bounded_json import iter_bounded_json_array
+from .._contained_source import _attach_source_cleanup_owner
 from ..compiler.checkout_identity import checkout_commit
 from ..compiler.manifest import MANIFEST_FILENAME, MANIFEST_VERSION, RepoManifest
 from ..compiler.snapshot_store import normalize_repo
-from ..source_fingerprint import fingerprint_repository
+from ..source_fingerprint import (
+    RepositorySourceBinding,
+    _SourceLifecycleRLock,
+    _SourceLockLease,
+    capture_repository_source,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
+)
 from .context import (
     CONTEXT_ARTIFACT_MANIFEST,
     CONTEXT_ARTIFACT_SCHEMA,
     PORTABLE_CONTEXT_VIEWS,
 )
-from .security import file_sha256
 
 _COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 _DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
-_SOURCE_FINGERPRINT_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_SOURCE_FINGERPRINT_RE = re.compile(r"^(?:sha256|sha256-v2):[0-9a-f]{64}$")
 _REPOSITORY_RE = re.compile(r"^[a-z0-9_.-]+(?:/[a-z0-9_.-]+)*$")
 _DEFAULT_MAX_FILES = 100_000
 _DEFAULT_MAX_BYTES = 64 * 1024 * 1024 * 1024
@@ -34,11 +53,40 @@ _MAX_METADATA_BYTES = 16 * 1024 * 1024
 _MAX_DOCUMENTS_BYTES = 256 * 1024 * 1024
 
 
+def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate context artifact JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _bounded_json_int(value: str) -> int:
+    if len(value) > 1_024:
+        raise ValueError("context artifact JSON integer is too large")
+    return int(value)
+
+
+def _bounded_json_float(value: str) -> float:
+    if len(value) > 1_024:
+        raise ValueError("context artifact JSON number is too large")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("context artifact JSON number is not finite")
+    return parsed
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"context artifact JSON constant is not finite: {value}")
+
+
 @dataclass(frozen=True, slots=True)
 class VerifiedContextArtifact:
     """Integrity-checked, still-unbound portable context artifact."""
 
     root: Path
+    ownership: object = dataclass_field(repr=False, compare=False)
     metadata_path: Path
     manifest_path: Path
     metadata: Mapping[str, Any]
@@ -52,28 +100,356 @@ class VerifiedContextArtifact:
     byte_count: int
 
 
-@dataclass(frozen=True, slots=True)
+class SourceBindingCleanupOwner:
+    """Explicit, retryable owner for source bindings awaiting cleanup."""
+
+    def __init__(self) -> None:
+        self._sources: list[object] = []
+
+    def retain(self, source: object) -> None:
+        close = getattr(source, "close", None)
+        if not callable(close):
+            raise TypeError("source cleanup resource must provide close()")
+        if not any(candidate is source for candidate in self._sources):
+            self._sources.append(source)
+
+    @property
+    def pending_sources(self) -> tuple[RepositorySourceBinding, ...]:
+        pending: list[RepositorySourceBinding] = []
+        for source in self._sources:
+            nested = getattr(source, "pending_sources", None)
+            if nested is None:
+                pending.append(source)  # type: ignore[arg-type]
+            else:
+                pending.extend(nested)
+        return tuple(pending)
+
+    @property
+    def closed(self) -> bool:
+        return not self._sources
+
+    def close(self) -> None:
+        """Visit every source and retain only authorities that remain open."""
+
+        first_failure: BaseException | None = None
+        pending: list[object] = []
+        for source in tuple(self._sources):
+            try:
+                source.close()  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - cleanup all sources
+                if first_failure is None:
+                    first_failure = exc
+            try:
+                fully_closed = bool(source.closed)  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - retain uncertain owner
+                fully_closed = False
+                if first_failure is None:
+                    first_failure = exc
+            if not fully_closed:
+                pending.append(source)
+        self._sources[:] = pending
+        if first_failure is not None:
+            raise first_failure
+
+
+def _source_cleanup_owner_is_pending(owner: object | None) -> bool:
+    """Treat uncertain cleanup ownership as pending and therefore non-degradable."""
+
+    if owner is None:
+        return False
+    try:
+        return not bool(owner.closed)  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - uncertain ownership is pending
+        return True
+
+
+def _raise_source_cleanup_failure(
+    primary: BaseException,
+    cleanup_failure: BaseException | None,
+    pending_owner: object | None,
+) -> NoReturn:
+    """Apply source cleanup priority and retain every still-pending owner."""
+
+    actual = primary
+    if (
+        cleanup_failure is not None
+        and isinstance(primary, Exception)
+        and not isinstance(cleanup_failure, Exception)
+    ):
+        actual = cleanup_failure
+
+    prior_owner = getattr(primary, "source_cleanup_owner", None)
+    if _source_cleanup_owner_is_pending(prior_owner):
+        _attach_source_cleanup_owner(actual, prior_owner)
+    if _source_cleanup_owner_is_pending(pending_owner):
+        _attach_source_cleanup_owner(actual, pending_owner)
+
+    if actual is cleanup_failure:
+        raise actual from primary
+    if cleanup_failure is not None:
+        raise actual from cleanup_failure
+    raise actual
+
+
+_SOURCE_BINDING_AVAILABLE = object()
+_SOURCE_BINDING_CLEANUP_PENDING = object()
+_SOURCE_BINDING_CONSUMED = object()
+
+
+@dataclass(slots=True)
 class ContextArtifactBinding:
-    """Verified artifact rebound in memory to one exact source checkout."""
+    """Verified artifact rebound to exact source bytes, not mutable Git state."""
 
     artifact: VerifiedContextArtifact
-    repo_path: Path
+    repo_path: Path | None
     manifest: RepoManifest
+    checkout_commit_observed: str | None = None
+    _source_binding: RepositorySourceBinding | None = dataclass_field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _transfer_lock: _SourceLifecycleRLock = dataclass_field(
+        default_factory=_SourceLifecycleRLock,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _source_state: tuple[object, RepositorySourceBinding | None] = dataclass_field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        self._source_state = (_SOURCE_BINDING_AVAILABLE, self._source_binding)
+        self._source_binding = None
+
+    @property
+    def source_binding(self) -> RepositorySourceBinding | None:
+        """Return a non-owning snapshot for diagnostics only."""
+
+        with self._transfer_lease():
+            state, source = self._source_state
+            return source if state is _SOURCE_BINDING_AVAILABLE else None
+
+    @property
+    def source_bound(self) -> bool:
+        with self._transfer_lease():
+            state, source = self._source_state
+            return state is _SOURCE_BINDING_AVAILABLE and source is not None
+
+    @contextmanager
+    def _transfer_lease(self) -> Iterator[None]:
+        with _SourceLockLease(self._transfer_lock) as acquisition_failure:
+            if acquisition_failure is not None:
+                raise acquisition_failure
+            yield
+
+    @property
+    def source_verification_scope(self) -> str | None:
+        """Describe the authority retained for later source reads."""
+
+        return "content-bytes" if self.source_bound else None
+
+    @property
+    def commit_verified(self) -> bool:
+        """Mutable Git HEAD is not attested by an M1 content binding."""
+
+        return False
+
+    def install_source_binding(
+        self,
+        install: Callable[[RepositorySourceBinding | None], None],
+        *,
+        expected: RepositorySourceBinding | None = None,
+        require_expected: bool = False,
+    ) -> None:
+        """Install the one-shot source into an already-stable runtime owner.
+
+        The callback must publish its argument in the destination owner before
+        returning.  Unlike returning the capability, this keeps the destination
+        reachable if cancellation lands between this method's return and the
+        caller's next bytecode.
+        """
+
+        source: RepositorySourceBinding | None = None
+        try:
+            with self._transfer_lease():
+                state, candidate = self._source_state
+                if state is not _SOURCE_BINDING_AVAILABLE:
+                    raise RuntimeError(
+                        "context artifact source authority was already transferred"
+                    )
+                if require_expected and candidate is not expected:
+                    raise ValueError(
+                        "artifact source authority does not match its binding"
+                    )
+                source = candidate
+                # Retain an explicit cleanup owner while the callback installs
+                # the source. A failed or interrupted installation remains
+                # retryable through close().
+                self._source_state = (_SOURCE_BINDING_CLEANUP_PENDING, source)
+                install(source)
+                self._source_state = (_SOURCE_BINDING_CONSUMED, None)
+        except BaseException:  # noqa: B036 - close unreturned capability
+            self._recover_source_install(source)
+            raise
+
+    def _recover_source_install(
+        self,
+        source: RepositorySourceBinding | None,
+    ) -> None:
+        """Close or retain a source whose destination install did not finish."""
+
+        try:
+            with _SourceLockLease(self._transfer_lock):
+                state, owned = self._source_state
+                if state is not _SOURCE_BINDING_CLEANUP_PENDING or owned is not source:
+                    return
+                if source is not None:
+                    try:
+                        source.close()
+                    except BaseException:  # noqa: B036 - preserve primary
+                        pass
+                self._source_state = (
+                    (_SOURCE_BINDING_CONSUMED, None)
+                    if source is None or source.closed
+                    else (_SOURCE_BINDING_CLEANUP_PENDING, source)
+                )
+        except BaseException:  # noqa: B036 - binding still retains pending owner
+            return
+
+    def close(self) -> None:
+        """Close an unconsumed live-source authority; query bindings are no-op."""
+
+        deferred: BaseException | None = None
+        try:
+            with _SourceLockLease(self._transfer_lock) as acquisition_failure:
+                if acquisition_failure is not None:
+                    deferred = acquisition_failure
+                state, source = self._source_state
+                if state in {
+                    _SOURCE_BINDING_AVAILABLE,
+                    _SOURCE_BINDING_CLEANUP_PENDING,
+                }:
+                    if source is None:
+                        self._source_state = (_SOURCE_BINDING_CONSUMED, None)
+                    else:
+                        try:
+                            source.close()
+                        except BaseException as exc:  # noqa: B036 - retain owner
+                            if deferred is None:
+                                deferred = exc
+                        self._source_state = (
+                            (_SOURCE_BINDING_CONSUMED, None)
+                            if source.closed
+                            else (_SOURCE_BINDING_CLEANUP_PENDING, source)
+                        )
+        except BaseException as exc:  # noqa: B036 - state retains retry owner
+            if deferred is None:
+                deferred = exc
+        if deferred is not None:
+            raise deferred
+
+    def __enter__(self) -> ContextArtifactBinding:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
 
 
-def _load_json_object(path: Path, *, label: str, max_bytes: int) -> dict[str, Any]:
+class _PublicationContextReader:
+    """Context-artifact facade over an authority-bound publication reader."""
+
+    def __init__(
+        self,
+        publication: PublicationDirectoryReader,
+        ownership: object,
+        *,
+        entry_policy_factory: Callable[[], Callable[[str, str, int, int], None]],
+    ) -> None:
+        self._publication = publication
+        self._ownership = ownership
+        self._entry_policy_factory = entry_policy_factory
+        self._records = {
+            record.path: record
+            for record in directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+        }
+
+    def _record(self, relative: str | PurePosixPath) -> TreeFileRecord:
+        normalized = PurePosixPath(relative) if isinstance(relative, str) else relative
+        try:
+            return self._records[normalized.as_posix()]
+        except KeyError as exc:
+            raise ValueError(
+                f"context artifact has no initial file record: {normalized}"
+            ) from exc
+
+    @contextmanager
+    def open_file(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> Iterator[PublicationAuthenticatedFile]:
+        normalized = PurePosixPath(relative) if isinstance(relative, str) else relative
+        expected = self._record(normalized)
+        with self._publication.open_authenticated_file(
+            normalized,
+            max_bytes=max_bytes,
+        ) as source:
+            yield source
+        if source.record != expected:
+            raise ValueError(
+                f"context artifact file differs from its initial record: {normalized}"
+            )
+
+    def read_bytes(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        payload = bytearray()
+        with self.open_file(relative, max_bytes=max_bytes) as source:
+            for chunk in source.iter_bytes():
+                payload.extend(chunk)
+        return bytes(payload)
+
+    def verify_root(self) -> None:
+        observed = self._publication.capture_ownership(
+            entry_policy=self._entry_policy_factory(),
+        )
+        if observed != self._ownership:
+            raise ValueError("context artifact changed during verification")
+
+    def close(self) -> None:
+        return None
+
+
+_ContextReader = _PublicationContextReader
+
+
+def _load_json_object(
+    reader: _ContextReader,
+    relative: str | PurePosixPath,
+    *,
+    label: str,
+    max_bytes: int,
+) -> dict[str, Any]:
     try:
-        size = path.stat().st_size
-    except OSError as exc:
-        raise ValueError(f"{label} is not readable: {path}") from exc
-    if size > max_bytes:
-        raise ValueError(f"{label} exceeds {max_bytes} bytes: {path}")
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-        raise ValueError(f"{label} is not valid UTF-8 JSON: {path}") from exc
+        value = json.loads(
+            reader.read_bytes(relative, max_bytes=max_bytes),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_json_constant,
+            parse_int=_bounded_json_int,
+            parse_float=_bounded_json_float,
+        )
+    except ValueError as exc:
+        raise ValueError(f"{label} is not valid UTF-8 JSON: {relative}") from exc
     if not isinstance(value, dict):
-        raise ValueError(f"{label} must be a JSON object: {path}")
+        raise ValueError(f"{label} must be a JSON object: {relative}")
     return value
 
 
@@ -92,29 +468,7 @@ def _relative_path(value: object, *, label: str) -> PurePosixPath:
 
 def _artifact_path(root: Path, value: object, *, label: str) -> Path:
     relative = _relative_path(value, label=label)
-    path = root.joinpath(*relative.parts)
-    resolved = path.resolve()
-    if root != resolved and root not in resolved.parents:
-        raise ValueError(f"{label} escapes the context artifact")
-    return resolved
-
-
-def _actual_files(root: Path, *, max_files: int) -> set[str]:
-    files: set[str] = set()
-    for path in sorted(root.rglob("*")):
-        relative = path.relative_to(root).as_posix()
-        if path.is_symlink():
-            raise ValueError(f"context artifact contains a symbolic link: {relative}")
-        if path.is_file():
-            files.add(relative)
-            # The metadata file is intentionally outside its own inventory.
-            if len(files) > max_files + 1:
-                raise ValueError(
-                    f"context artifact contains more than {max_files} inventoried files"
-                )
-        elif not path.is_dir():
-            raise ValueError(f"context artifact contains a special file: {relative}")
-    return files
+    return root.joinpath(*relative.parts)
 
 
 def _inventory(
@@ -204,64 +558,60 @@ def _artifact_views(metadata: Mapping[str, Any]) -> tuple[str, ...]:
 def _source_path(value: object, *, label: str) -> str:
     if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
         raise ValueError(f"{label} must be a repository-relative POSIX path")
+    try:
+        encoded = value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{label} must be a repository-relative POSIX path") from exc
     path = PurePosixPath(value)
     if (
         path.is_absolute()
         or value != path.as_posix()
         or any(part in {"", ".", ".."} for part in path.parts)
+        or len(path.parts) > 256
+        or len(encoded) > 4_096
     ):
         raise ValueError(f"{label} must be a repository-relative POSIX path")
     return path.as_posix()
 
 
 def _document_source_paths(
-    path: Path,
+    reader: _ContextReader,
+    relative: str | PurePosixPath,
     *,
     label: str,
     max_bytes: int,
 ) -> set[str]:
-    try:
-        size = path.stat().st_size
-    except OSError as exc:
-        raise ValueError(f"{label} is not readable: {path}") from exc
-    if size > max_bytes:
-        raise ValueError(f"{label} exceeds {max_bytes} bytes: {path}")
-    try:
-        documents = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-        raise ValueError(f"{label} is not valid UTF-8 JSON: {path}") from exc
-    if not isinstance(documents, list):
-        raise ValueError(f"{label} must be a JSON list: {path}")
-
     result: set[str] = set()
-    for index, document in enumerate(documents):
-        if not isinstance(document, dict):
-            raise ValueError(f"{label} document {index} must be an object")
-        page_content = document.get("page_content")
-        metadata = document.get("metadata")
-        if not isinstance(page_content, str) or not isinstance(metadata, dict):
-            raise ValueError(
-                f"{label} document {index} has invalid content or metadata"
-            )
-        raw_file = metadata.get("file")
-        if raw_file is not None and raw_file != "":
-            result.add(
-                _source_path(
-                    raw_file,
-                    label=f"{label} document {index} file",
+    with reader.open_file(relative, max_bytes=max_bytes) as source:
+        for index, document in enumerate(iter_bounded_json_array(source, label=label)):
+            if not isinstance(document, dict):
+                raise ValueError(f"{label} document {index} must be an object")
+            page_content = document.get("page_content")
+            metadata = document.get("metadata")
+            if not isinstance(page_content, str) or not isinstance(metadata, dict):
+                raise ValueError(
+                    f"{label} document {index} has invalid content or metadata"
                 )
-            )
-        for field in ("start_line", "end_line"):
-            value = metadata.get(field)
-            if value is not None and (
-                not isinstance(value, int) or isinstance(value, bool) or value < 0
-            ):
-                raise ValueError(f"{label} document {index} has invalid {field}")
+            raw_file = metadata.get("file")
+            if raw_file is not None and raw_file != "":
+                result.add(
+                    _source_path(
+                        raw_file,
+                        label=f"{label} document {index} file",
+                    )
+                )
+            for field in ("start_line", "end_line"):
+                value = metadata.get(field)
+                if value is not None and (
+                    not isinstance(value, int) or isinstance(value, bool) or value < 0
+                ):
+                    raise ValueError(f"{label} document {index} has invalid {field}")
     return result
 
 
 def _validate_view_payloads(
     root: Path,
+    reader: _ContextReader,
     inventory: Mapping[str, tuple[int, str]],
     *,
     views: tuple[str, ...],
@@ -276,7 +626,8 @@ def _validate_view_payloads(
         if not required <= inventory_paths:
             raise ValueError("portable BM25 view is missing its serving files")
         metadata = _load_json_object(
-            root / metadata_relative,
+            reader,
+            metadata_relative,
             label="portable BM25 metadata",
             max_bytes=_MAX_METADATA_BYTES,
         )
@@ -284,7 +635,8 @@ def _validate_view_payloads(
             raise ValueError("portable BM25 project root must be 'source'")
         source_paths.update(
             _document_source_paths(
-                root / documents_relative,
+                reader,
+                documents_relative,
                 label="portable BM25 documents",
                 max_bytes=_MAX_DOCUMENTS_BYTES,
             )
@@ -311,7 +663,8 @@ def _validate_view_payloads(
                 )
             source_paths.update(
                 _document_source_paths(
-                    root.joinpath(*path.parts),
+                    reader,
+                    path,
                     label=f"portable vector documents {relative}",
                     max_bytes=_MAX_DOCUMENTS_BYTES,
                 )
@@ -321,6 +674,7 @@ def _validate_view_payloads(
 
 def _validate_manifest(
     root: Path,
+    reader: _ContextReader,
     metadata: Mapping[str, Any],
     *,
     commit: str,
@@ -346,8 +700,14 @@ def _validate_manifest(
     if manifest_relative not in inventoried_paths:
         raise ValueError("context artifact manifest is absent from its inventory")
     try:
-        manifest = RepoManifest.load(manifest_path)
-    except (KeyError, OSError, TypeError, ValueError) as exc:
+        manifest_payload = _load_json_object(
+            reader,
+            manifest_relative,
+            label="context artifact repository manifest",
+            max_bytes=_MAX_METADATA_BYTES,
+        )
+        manifest = RepoManifest.from_dict(manifest_payload)
+    except (KeyError, TypeError, ValueError) as exc:
         raise ValueError("context artifact repository manifest is invalid") from exc
     if manifest.version != MANIFEST_VERSION:
         raise ValueError(
@@ -418,8 +778,6 @@ def _validate_manifest(
             entry.path,
             label=f"context artifact {view} view path",
         )
-        if not view_path.is_dir():
-            raise ValueError(f"context artifact view is missing: {view}")
         view_relative = view_path.relative_to(root).as_posix()
         if not any(
             relative == view_relative or relative.startswith(f"{view_relative}/")
@@ -433,96 +791,146 @@ def _validate_manifest(
     return manifest_path, manifest
 
 
-def verify_context_artifact(
-    root: str | Path,
+def _validate_context_limits(max_files: int, max_bytes: int) -> None:
+    if (
+        isinstance(max_files, bool)
+        or not isinstance(max_files, int)
+        or max_files <= 0
+        or isinstance(max_bytes, bool)
+        or not isinstance(max_bytes, int)
+        or max_bytes <= 0
+    ):
+        raise ValueError("context artifact limits must be positive integers")
+
+
+def _context_entry_policy(
     *,
-    expected_repository: str | None = None,
-    expected_commit: str | None = None,
-    max_files: int = _DEFAULT_MAX_FILES,
-    max_bytes: int = _DEFAULT_MAX_BYTES,
+    max_files: int,
+    max_bytes: int,
+) -> Callable[[str, str, int, int], None]:
+    file_count = [0]
+    captured_bytes = [0]
+
+    def policy(relative: str, kind: str, mode: int, size: int) -> None:
+        del mode
+        if kind != "file":
+            return
+        file_count[0] += 1
+        if file_count[0] > max_files + 1:
+            raise ValueError(
+                f"context artifact contains more than {max_files} inventoried files"
+            )
+        name = PurePosixPath(relative).name
+        if name.startswith("documents") and name.endswith(".json"):
+            per_file_limit = _MAX_DOCUMENTS_BYTES
+        elif relative == CONTEXT_ARTIFACT_MANIFEST or name.endswith(".json"):
+            per_file_limit = _MAX_METADATA_BYTES
+        else:
+            per_file_limit = max_bytes
+        if size < 0 or size > per_file_limit:
+            raise ValueError(
+                f"context artifact file exceeds its {per_file_limit}-byte limit: "
+                f"{relative}"
+            )
+        captured_bytes[0] += size
+        if captured_bytes[0] > max_bytes + _MAX_METADATA_BYTES:
+            raise ValueError("context artifact exceeds its captured byte limit")
+
+    return policy
+
+
+def _verify_context_artifact_reader(
+    root: Path,
+    ownership: object,
+    reader: _ContextReader,
+    *,
+    expected_repository: str | None,
+    expected_commit: str | None,
+    max_files: int,
+    max_bytes: int,
+    capture_final: Callable[[], object],
 ) -> VerifiedContextArtifact:
-    """Verify an artifact completely without opening any persisted index."""
-
-    candidate = Path(root).expanduser()
-    if candidate.is_symlink():
-        raise ValueError(
-            f"context artifact root must not be a symbolic link: {candidate}"
+    metadata_path = root / CONTEXT_ARTIFACT_MANIFEST
+    try:
+        metadata = _load_json_object(
+            reader,
+            CONTEXT_ARTIFACT_MANIFEST,
+            label="context artifact metadata",
+            max_bytes=_MAX_METADATA_BYTES,
         )
-    resolved = candidate.resolve()
-    if not resolved.is_dir():
-        raise ValueError(f"context artifact directory does not exist: {resolved}")
-    metadata_path = resolved / CONTEXT_ARTIFACT_MANIFEST
-    if metadata_path.is_symlink() or not metadata_path.is_file():
-        raise ValueError(f"context artifact metadata is missing: {metadata_path}")
-    metadata = _load_json_object(
-        metadata_path,
-        label="context artifact metadata",
-        max_bytes=_MAX_METADATA_BYTES,
-    )
-    if metadata.get("schema") != CONTEXT_ARTIFACT_SCHEMA:
-        raise ValueError(
-            "context artifact schema is incompatible: "
-            f"expected {CONTEXT_ARTIFACT_SCHEMA}, found {metadata.get('schema')!r}"
-        )
-    repository, commit, source_fingerprint = _repository_identity(metadata)
-    views = _artifact_views(metadata)
-    inventory, byte_count = _inventory(
-        metadata,
-        max_files=max_files,
-        max_bytes=max_bytes,
-    )
-
-    expected_files = set(inventory) | {CONTEXT_ARTIFACT_MANIFEST}
-    actual_files = _actual_files(resolved, max_files=max_files)
-    if actual_files != expected_files:
-        missing = sorted(expected_files - actual_files)
-        extra = sorted(actual_files - expected_files)
-        raise ValueError(
-            "context artifact file set differs from its inventory: "
-            f"missing={missing}, extra={extra}"
-        )
-    for relative, (expected_size, expected_digest) in inventory.items():
-        path = _artifact_path(
-            resolved,
-            relative,
-            label=f"context artifact inventory path {relative!r}",
-        )
-        size, digest = file_sha256(path)
-        if size != expected_size or digest != expected_digest:
-            raise ValueError(f"context artifact file digest mismatch: {relative}")
-
-    manifest_path, manifest = _validate_manifest(
-        resolved,
-        metadata,
-        commit=commit,
-        source_fingerprint=source_fingerprint,
-        views=views,
-        inventoried_paths=set(inventory),
-    )
-    source_paths = _validate_view_payloads(
-        resolved,
-        inventory,
-        views=views,
-    )
-    if expected_repository is not None:
-        expected = normalize_repo(expected_repository)
-        if repository != expected:
+        if metadata.get("schema") != CONTEXT_ARTIFACT_SCHEMA:
             raise ValueError(
-                "context artifact repository mismatch: "
-                f"expected {expected}, found {repository}"
+                "context artifact schema is incompatible: "
+                f"expected {CONTEXT_ARTIFACT_SCHEMA}, "
+                f"found {metadata.get('schema')!r}"
             )
-    if expected_commit is not None:
-        expected = expected_commit.strip().lower()
-        if not _COMMIT_RE.fullmatch(expected):
-            raise ValueError("expected context artifact commit must be a full Git SHA")
-        if commit != expected:
+        repository, commit, source_fingerprint = _repository_identity(metadata)
+        views = _artifact_views(metadata)
+        inventory, byte_count = _inventory(
+            metadata,
+            max_files=max_files,
+            max_bytes=max_bytes,
+        )
+        records = {
+            record.path: record
+            for record in directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+        }
+        expected_files = set(inventory) | {CONTEXT_ARTIFACT_MANIFEST}
+        actual_files = set(records)
+        if actual_files != expected_files:
+            missing = sorted(expected_files - actual_files)
+            extra = sorted(actual_files - expected_files)
             raise ValueError(
-                "context artifact commit mismatch: "
-                f"expected {expected[:12]}, found {commit[:12]}"
+                "context artifact file set differs from its inventory: "
+                f"missing={missing}, extra={extra}"
             )
+        for relative, (expected_size, expected_digest) in inventory.items():
+            record = records[relative]
+            if record.size != expected_size or record.sha256 != expected_digest:
+                raise ValueError(f"context artifact file digest mismatch: {relative}")
+
+        manifest_path, manifest = _validate_manifest(
+            root,
+            reader,
+            metadata,
+            commit=commit,
+            source_fingerprint=source_fingerprint,
+            views=views,
+            inventoried_paths=set(inventory),
+        )
+        source_paths = _validate_view_payloads(
+            root,
+            reader,
+            inventory,
+            views=views,
+        )
+        if expected_repository is not None:
+            expected = normalize_repo(expected_repository)
+            if repository != expected:
+                raise ValueError(
+                    "context artifact repository mismatch: "
+                    f"expected {expected}, found {repository}"
+                )
+        if expected_commit is not None:
+            expected = expected_commit.strip().lower()
+            if not _COMMIT_RE.fullmatch(expected):
+                raise ValueError(
+                    "expected context artifact commit must be a full Git SHA"
+                )
+            if commit != expected:
+                raise ValueError(
+                    "context artifact commit mismatch: "
+                    f"expected {expected[:12]}, found {commit[:12]}"
+                )
+        reader.verify_root()
+        if capture_final() != ownership:
+            raise ValueError("context artifact changed during verification")
+    finally:
+        reader.close()
 
     return VerifiedContextArtifact(
-        root=resolved,
+        root=root,
+        ownership=ownership,
         metadata_path=metadata_path,
         manifest_path=manifest_path,
         metadata=metadata,
@@ -537,6 +945,101 @@ def verify_context_artifact(
     )
 
 
+def verify_context_artifact_reader(
+    publication: PublicationDirectoryReader,
+    *,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+    max_files: int = _DEFAULT_MAX_FILES,
+    max_bytes: int = _DEFAULT_MAX_BYTES,
+) -> VerifiedContextArtifact:
+    """Verify an artifact through a publication authority without a path reopen."""
+
+    _validate_context_limits(max_files, max_bytes)
+    policy_factory = lambda: _context_entry_policy(  # noqa: E731
+        max_files=max_files,
+        max_bytes=max_bytes,
+    )
+    ownership = publication.capture_ownership(entry_policy=policy_factory())
+    reader = _PublicationContextReader(
+        publication,
+        ownership,
+        entry_policy_factory=policy_factory,
+    )
+    return _verify_context_artifact_reader(
+        Path("/__codenib_context_artifact__"),
+        ownership,
+        reader,
+        expected_repository=expected_repository,
+        expected_commit=expected_commit,
+        max_files=max_files,
+        max_bytes=max_bytes,
+        capture_final=lambda: publication.capture_ownership(
+            entry_policy=policy_factory(),
+        ),
+    )
+
+
+def verify_context_artifact(
+    root: str | Path,
+    *,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+    max_files: int = _DEFAULT_MAX_FILES,
+    max_bytes: int = _DEFAULT_MAX_BYTES,
+) -> VerifiedContextArtifact:
+    """Verify an artifact completely without opening any persisted index."""
+
+    _validate_context_limits(max_files, max_bytes)
+    resolved = lexical_directory_path(Path(root))
+    policy_factory = lambda: _context_entry_policy(  # noqa: E731
+        max_files=max_files,
+        max_bytes=max_bytes,
+    )
+
+    try:
+        ownership = capture_directory_ownership(
+            resolved,
+            entry_policy=policy_factory(),
+        )
+    except ValueError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(
+            "context artifact directory could not be captured safely; it may "
+            f"contain a symbolic link or unstable content: {resolved}"
+        ) from exc
+
+    def verify(publication: PublicationDirectoryReader) -> VerifiedContextArtifact:
+        reader = _PublicationContextReader(
+            publication,
+            ownership,
+            entry_policy_factory=policy_factory,
+        )
+        return _verify_context_artifact_reader(
+            resolved,
+            ownership,
+            reader,
+            expected_repository=expected_repository,
+            expected_commit=expected_commit,
+            max_files=max_files,
+            max_bytes=max_bytes,
+            capture_final=lambda: publication.capture_ownership(
+                entry_policy=policy_factory(),
+            ),
+        )
+
+    try:
+        return reopen_authenticated_directory(resolved, ownership, verify)
+    except ValueError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(
+            "context artifact directory could not be reopened safely; it may "
+            f"contain a symbolic link or unstable content: {resolved}"
+        ) from exc
+
+
 def bind_context_artifact(
     root: str | Path,
     repo_path: str | Path,
@@ -544,65 +1047,117 @@ def bind_context_artifact(
     expected_repository: str | None = None,
     expected_commit: str | None = None,
 ) -> ContextArtifactBinding:
-    """Verify an artifact and bind it to an exact, unchanged checkout."""
+    """Bind an artifact to retained, v2-authenticated repository content."""
 
     artifact = verify_context_artifact(
         root,
         expected_repository=expected_repository,
         expected_commit=expected_commit,
     )
-    repo = Path(repo_path).expanduser().resolve()
-    if not repo.is_dir():
-        raise ValueError(f"repository checkout does not exist: {repo}")
-    actual_commit = checkout_commit(repo)
-    if actual_commit != artifact.commit:
-        actual_label = actual_commit[:12] if actual_commit else "not-a-git-checkout"
-        raise ValueError(
-            "repository checkout commit does not match the context artifact: "
-            f"checkout={actual_label}, artifact={artifact.commit[:12]}"
-        )
-    source = fingerprint_repository(
-        repo,
-        exclude_roots=(artifact.root,),
-    )
-    if source.value != artifact.source_fingerprint:
-        raise ValueError(
-            "repository source files do not match the context artifact fingerprint"
-        )
-    if source.file_count != artifact.manifest.file_count:
-        raise ValueError(
-            "repository file count does not match the context artifact manifest"
-        )
-    for relative in artifact.source_paths:
-        try:
-            validate_repository_file(repo, relative)
-        except ValueError as exc:
-            raise ValueError(
-                "context artifact source path is not a stable file inside "
-                f"the repository checkout: {relative}"
-            ) from exc
+    cleanup_owner = SourceBindingCleanupOwner()
 
-    manifest_data = artifact.manifest.to_dict()
-    manifest_data["repo"]["path"] = str(repo)
-    for view, entry in manifest_data["indexes"].items():
-        entry["path"] = str(
-            _artifact_path(
-                artifact.root,
-                entry["path"],
-                label=f"context artifact {view} view path",
+    def bind(_publication: PublicationDirectoryReader) -> ContextArtifactBinding:
+        if not is_secure_source_fingerprint_v2(artifact.source_fingerprint):
+            raise ValueError(
+                "legacy context artifact source fingerprints are query-only; "
+                "rebuild with source fingerprint v2 before binding a live checkout"
             )
+        repo = lexical_repository_path(repo_path)
+        source = capture_repository_source(
+            repo,
+            exclude_roots=(artifact.root,),
+            _source_owner=cleanup_owner.retain,
         )
-    manifest = RepoManifest.from_dict(manifest_data)
+        # This is diagnostic provenance only. A mutable Git HEAD cannot be
+        # attested by any finite sequence of path reads, so it never gates the
+        # retained content authority or native trust.
+        actual_commit = checkout_commit(repo)
+        source.verify_snapshot()
+        if source.fingerprint != artifact.source_fingerprint:
+            raise ValueError(
+                "repository source files do not match the context artifact fingerprint"
+            )
+        if source.file_count != artifact.manifest.file_count:
+            raise ValueError(
+                "repository file count does not match the context artifact manifest"
+            )
+        source_records = {record.path for record in source.file_records}
+        missing_source_paths = sorted(set(artifact.source_paths) - source_records)
+        if missing_source_paths:
+            raise ValueError(
+                "context artifact source paths are absent from the authenticated "
+                "repository: " + ", ".join(missing_source_paths)
+            )
+
+        manifest_data = artifact.manifest.to_dict()
+        manifest_data["repo"]["path"] = str(repo)
+        for view, entry in manifest_data["indexes"].items():
+            entry["path"] = str(
+                _artifact_path(
+                    artifact.root,
+                    entry["path"],
+                    label=f"context artifact {view} view path",
+                )
+            )
+        manifest = RepoManifest.from_dict(manifest_data)
+        return ContextArtifactBinding(
+            artifact=artifact,
+            repo_path=repo,
+            manifest=manifest,
+            checkout_commit_observed=actual_commit or None,
+            _source_binding=source,
+        )
+
+    try:
+        return reopen_authenticated_directory(
+            artifact.root,
+            artifact.ownership,  # type: ignore[arg-type]
+            bind,
+        )
+    except BaseException as exc:  # noqa: B036 - cleanup before propagation
+        try:
+            cleanup_owner.close()
+        except BaseException:  # noqa: B036 - preserve primary, retain owner
+            _attach_source_cleanup_owner(exc, cleanup_owner)
+        if isinstance(exc, ValueError):
+            raise
+        if not isinstance(exc, (OSError, RuntimeError)):
+            raise
+        translated = ValueError(
+            "context artifact changed between verification and source binding"
+        )
+        _attach_source_cleanup_owner(translated, cleanup_owner)
+        raise translated from exc
+
+
+def query_context_artifact(
+    root: str | Path,
+    *,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+) -> ContextArtifactBinding:
+    """Create an authority-bound, source-disabled portable query binding."""
+
+    artifact = verify_context_artifact(
+        root,
+        expected_repository=expected_repository,
+        expected_commit=expected_commit,
+    )
     return ContextArtifactBinding(
         artifact=artifact,
-        repo_path=repo,
-        manifest=manifest,
+        repo_path=None,
+        manifest=artifact.manifest,
+        checkout_commit_observed=None,
+        _source_binding=None,
     )
 
 
 __all__ = [
     "ContextArtifactBinding",
+    "SourceBindingCleanupOwner",
     "VerifiedContextArtifact",
     "bind_context_artifact",
+    "query_context_artifact",
     "verify_context_artifact",
+    "verify_context_artifact_reader",
 ]

--- a/codenib/artifacts/runtime.py
+++ b/codenib/artifacts/runtime.py
@@ -1072,16 +1072,17 @@ def bind_context_artifact(
         # attested by any finite sequence of path reads, so it never gates the
         # retained content authority or native trust.
         actual_commit = checkout_commit(repo)
-        source.verify_snapshot()
-        if source.fingerprint != artifact.source_fingerprint:
+        source_identity = source.authenticated_identity_snapshot()
+        authenticated_repo = source_identity.root
+        if source_identity.fingerprint != artifact.source_fingerprint:
             raise ValueError(
                 "repository source files do not match the context artifact fingerprint"
             )
-        if source.file_count != artifact.manifest.file_count:
+        if source_identity.file_count != artifact.manifest.file_count:
             raise ValueError(
                 "repository file count does not match the context artifact manifest"
             )
-        source_records = {record.path for record in source.file_records}
+        source_records = {record.path for record in source_identity.file_records}
         missing_source_paths = sorted(set(artifact.source_paths) - source_records)
         if missing_source_paths:
             raise ValueError(
@@ -1090,7 +1091,7 @@ def bind_context_artifact(
             )
 
         manifest_data = artifact.manifest.to_dict()
-        manifest_data["repo"]["path"] = str(repo)
+        manifest_data["repo"]["path"] = str(authenticated_repo)
         for view, entry in manifest_data["indexes"].items():
             entry["path"] = str(
                 _artifact_path(
@@ -1102,7 +1103,7 @@ def bind_context_artifact(
         manifest = RepoManifest.from_dict(manifest_data)
         return ContextArtifactBinding(
             artifact=artifact,
-            repo_path=repo,
+            repo_path=authenticated_repo,
             manifest=manifest,
             checkout_commit_observed=actual_commit or None,
             _source_binding=source,
@@ -1115,18 +1116,39 @@ def bind_context_artifact(
             bind,
         )
     except BaseException as exc:  # noqa: B036 - cleanup before propagation
+        cleanup_failure: BaseException | None = None
         try:
             cleanup_owner.close()
-        except BaseException:  # noqa: B036 - preserve primary, retain owner
-            _attach_source_cleanup_owner(exc, cleanup_owner)
+        except BaseException as failure:  # noqa: B036 - shared priority below
+            cleanup_failure = failure
+        pending_owner = (
+            cleanup_owner if _source_cleanup_owner_is_pending(cleanup_owner) else None
+        )
         if isinstance(exc, ValueError):
+            if cleanup_failure is not None or pending_owner is not None:
+                _raise_source_cleanup_failure(
+                    exc,
+                    cleanup_failure,
+                    pending_owner,
+                )
             raise
         if not isinstance(exc, (OSError, RuntimeError)):
+            if cleanup_failure is not None or pending_owner is not None:
+                _raise_source_cleanup_failure(
+                    exc,
+                    cleanup_failure,
+                    pending_owner,
+                )
             raise
         translated = ValueError(
             "context artifact changed between verification and source binding"
         )
-        _attach_source_cleanup_owner(translated, cleanup_owner)
+        if cleanup_failure is not None or pending_owner is not None:
+            _raise_source_cleanup_failure(
+                translated,
+                cleanup_failure,
+                pending_owner,
+            )
         raise translated from exc
 
 

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -660,30 +660,48 @@ def _run_artifact_verify(args: argparse.Namespace) -> int:
 
     try:
         if args.repo:
-            binding = bind_context_artifact(
+            with bind_context_artifact(
                 args.path,
                 resolve_repo_path(args.repo),
                 expected_repository=args.repository,
                 expected_commit=args.commit,
-            )
-            artifact = binding.artifact
-            checkout = binding.repo_path
+            ) as binding:
+                artifact = binding.artifact
+                checkout = binding.repo_path
+                summary = (
+                    artifact.root,
+                    artifact.repository,
+                    artifact.commit,
+                    tuple(artifact.views),
+                    artifact.file_count,
+                    artifact.byte_count,
+                    checkout,
+                )
         else:
             artifact = verify_context_artifact(
                 args.path,
                 expected_repository=args.repository,
                 expected_commit=args.commit,
             )
-            checkout = None
+            summary = (
+                artifact.root,
+                artifact.repository,
+                artifact.commit,
+                tuple(artifact.views),
+                artifact.file_count,
+                artifact.byte_count,
+                None,
+            )
     except (OSError, RuntimeError, ValueError) as exc:
         raise CLIError(str(exc)) from exc
 
-    print(f"Context artifact: {artifact.root}")
-    print(f"Repository:       {artifact.repository}")
-    print(f"Commit:           {artifact.commit}")
-    print(f"Views:            {', '.join(artifact.views)}")
-    print(f"Files:            {artifact.file_count}")
-    print(f"Bytes:            {artifact.byte_count}")
+    root, repository, commit, views, file_count, byte_count, checkout = summary
+    print(f"Context artifact: {root}")
+    print(f"Repository:       {repository}")
+    print(f"Commit:           {commit}")
+    print(f"Views:            {', '.join(views)}")
+    print(f"Files:            {file_count}")
+    print(f"Bytes:            {byte_count}")
     print(f"Checkout:         {checkout or 'not checked'}")
     return 0
 
@@ -703,20 +721,27 @@ def _run_artifact_fetch(args: argparse.Namespace) -> int:
             api_url=args.github_api_url,
             force=args.force,
         )
-        binding = bind_context_artifact(
+        with bind_context_artifact(
             result.artifact.root,
             repo_path,
             expected_repository=args.repository,
             expected_commit=commit,
-        )
+        ) as binding:
+            artifact_summary = (
+                binding.artifact.root,
+                binding.artifact.repository,
+                binding.artifact.commit,
+                tuple(binding.artifact.views),
+            )
     except (OSError, RuntimeError, ValueError) as exc:
         raise CLIError(str(exc)) from exc
 
     state = "downloaded" if result.downloaded else "cached"
-    print(f"Context artifact: {binding.artifact.root}")
-    print(f"Repository:       {binding.artifact.repository}")
-    print(f"Commit:           {binding.artifact.commit}")
-    print(f"Views:            {', '.join(binding.artifact.views)}")
+    artifact_root, repository, artifact_commit, views = artifact_summary
+    print(f"Context artifact: {artifact_root}")
+    print(f"Repository:       {repository}")
+    print(f"Commit:           {artifact_commit}")
+    print(f"Views:            {', '.join(views)}")
     print(f"State:            {state}")
     if result.record is not None:
         print(f"GitHub artifact:  {result.record.artifact_id}")

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -469,7 +469,9 @@ class VectorIndexBuilder:
         output_dir: str = kwargs["output_dir"]
         last_commit: str = kwargs.get("last_commit", "")
 
+        from ..index.embedding._lifecycle import close_vector_after_failure
         from ..index.embedding.artifact_integrity import (
+            _mint_trusted_local_vector_authorization,
             begin_vector_view_update,
             finish_vector_view_update,
             require_complete_vector_view,
@@ -525,6 +527,11 @@ class VectorIndexBuilder:
             if previous_artifact is not None
             else artifact_identity
         )
+        native_authorization = _mint_trusted_local_vector_authorization(
+            output_dir,
+            load_identity,
+            evidence=("compiler-incremental-vector-view",),
+        )
         vector_store = CodeVectorStore(
             embedding_model=artifact_identity["embedding_model"],
             embedding_provider=artifact_identity["embedding_provider"],
@@ -534,8 +541,15 @@ class VectorIndexBuilder:
             artifact_metadata=load_identity,
             **self._embedding_call_kwargs(),
         )
-        self._validate_vector_dimension(vector_store)
-        vector_store.load(output_dir)
+        try:
+            self._validate_vector_dimension(vector_store)
+            vector_store.load(
+                output_dir,
+                native_index_authorization=native_authorization,
+            )
+        except BaseException as primary:  # noqa: B036 - close partial native state
+            close_vector_after_failure(vector_store, primary)
+            raise
 
         chunk_store = IncrementalChunkStore.load(chunk_store_path)
         embeddings_cache = EmbeddingsCache.load(embeddings_cache_path)

--- a/codenib/compiler/skill_context.py
+++ b/codenib/compiler/skill_context.py
@@ -308,6 +308,10 @@ def _load_vector(
     default_batch_size: Optional[int] = None,
 ):
     """Load a FAISS vector store from an arbitrary directory path."""
+    from ..index.embedding._lifecycle import close_vector_after_failure
+    from ..index.embedding.artifact_integrity import (
+        _mint_trusted_local_vector_authorization,
+    )
     from ..index.embedding.vector_store import CodeVectorStore
 
     kwargs = dict(embedding_kwargs or {})
@@ -316,17 +320,30 @@ def _load_vector(
     if default_batch_size is not None:
         kwargs["default_batch_size"] = default_batch_size
 
+    artifact_contract = dict(artifact_metadata or {})
+    native_authorization = _mint_trusted_local_vector_authorization(
+        index_path,
+        artifact_contract,
+        evidence=("compiler-skill-context-vector-view",),
+    )
     store = CodeVectorStore(
         embedding_model=embedding_model,
         embedding_provider=embedding_provider,
         dimension=embedding_dimension,
         index_metric=index_metric,
-        artifact_metadata=artifact_metadata,
+        artifact_metadata=artifact_contract,
         trust_remote_code=trust_remote_code,
         **kwargs,
     )
-    store.load(index_path)
-    return store
+    try:
+        store.load(
+            index_path,
+            native_index_authorization=native_authorization,
+        )
+        return store
+    except BaseException as primary:  # noqa: B036 - close partial native state
+        close_vector_after_failure(store, primary)
+        raise
 
 
 def _load_symbol_graph(index_path: str):

--- a/codenib/index/embedding/_lifecycle.py
+++ b/codenib/index/embedding/_lifecycle.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Failure-safe ownership helpers for vector-store consumers."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..._atomic_directory import _annotate_secondary_error
+
+
+class _ClosableVectorStore(Protocol):
+    def close(self) -> None: ...
+
+
+def close_vector_after_failure(
+    vector_store: _ClosableVectorStore,
+    primary: BaseException,
+) -> None:
+    """Close an unpublished store with cancellation-safe failure priority.
+
+    ``CodeVectorStore.close`` retains native indices that fail to reset, so the
+    store itself is the retryable cleanup owner.  Keep it reachable from the
+    original failure whenever cleanup does not complete, including when close
+    is interrupted by ``KeyboardInterrupt`` or another ``BaseException``.
+    """
+
+    try:
+        vector_store.close()
+    except BaseException as cleanup_error:  # noqa: B036 - preserve primary
+        try:
+            _annotate_secondary_error(
+                primary,
+                "vector store cleanup also failed",
+                cleanup_error,
+            )
+        except BaseException:  # noqa: B036 - notes must not replace primary
+            pass
+        preferred = (
+            cleanup_error
+            if isinstance(primary, Exception)
+            and not isinstance(cleanup_error, Exception)
+            else primary
+        )
+        try:
+            preferred.vector_cleanup_owner = vector_store  # type: ignore[attr-defined]
+        except BaseException:  # noqa: B036 - traceback still retains the owner
+            pass
+        if preferred is cleanup_error:
+            raise cleanup_error from primary
+        raise primary from cleanup_error
+
+
+__all__ = ["close_vector_after_failure"]

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -16,6 +16,7 @@ from typing import Any, Mapping
 
 from ..._atomic_directory import (
     TreeFileRecord,
+    _annotate_secondary_error,
     capture_directory_ownership,
     directory_ownership_file_records,
     directory_ownership_inventory,
@@ -23,6 +24,11 @@ from ..._atomic_directory import (
 )
 from ..._bounded_json import iter_bounded_json_array
 from ..._captured_directory import AuthenticatedFile, CapturedDirectoryReader
+from ...native_index_authorization import (
+    NativeIndexAuthorization,
+    require_native_index_authorization,
+    require_native_index_authorization_preflight,
+)
 
 VECTOR_PERSISTENCE_SCHEMA = 1
 VECTOR_VIEW_UPDATE_MARKER = ".vector-view.update-in-progress"
@@ -255,6 +261,46 @@ def capture_authenticated_vector_view(root: str | Path) -> AuthenticatedVectorVi
         return AuthenticatedVectorView.capture(root)
     except (OSError, RuntimeError, ValueError) as exc:
         raise ValueError(f"vector view could not be captured safely: {root}") from exc
+
+
+def require_authorized_vector_view(
+    root: str | Path,
+    authorization: NativeIndexAuthorization | None,
+    semantic_contract: Mapping[str, Any],
+) -> None:
+    """Require exact authority for a vector tree without loading its model.
+
+    This gate is intended for callers whose vector-store constructor may load
+    an embedding model or initialize a remote client. It binds the supplied
+    capability to one freshly captured tree and semantic contract, verifies
+    that the tree remained stable, and closes the captured view before the
+    caller performs any expensive initialization.
+    """
+
+    require_native_index_authorization_preflight(
+        authorization,
+        view_type="vector",
+    )
+    view = capture_authenticated_vector_view(root)
+    try:
+        require_native_index_authorization(
+            authorization,
+            view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+        )
+        view.verify_final()
+    except BaseException as primary_error:  # noqa: B036 - preserve first failure
+        try:
+            view.close()
+        except BaseException as cleanup_error:  # noqa: B036 - preserve first failure
+            _annotate_secondary_error(
+                primary_error,
+                "authenticated vector view cleanup also failed",
+                cleanup_error,
+            )
+        raise
+    view.close()
 
 
 def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -577,6 +623,7 @@ __all__ = [
     "begin_vector_view_update",
     "capture_authenticated_vector_view",
     "finish_vector_view_update",
+    "require_authorized_vector_view",
     "require_complete_vector_view",
     "validate_vector_config_artifact",
     "validate_vector_generation_artifacts",

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -10,15 +10,251 @@ import hashlib
 import json
 import os
 import stat
-from pathlib import Path
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
+
+from ..._atomic_directory import (
+    TreeFileRecord,
+    capture_directory_ownership,
+    directory_ownership_file_records,
+    directory_ownership_inventory,
+    lexical_directory_path,
+)
+from ..._bounded_json import iter_bounded_json_array
+from ..._captured_directory import AuthenticatedFile, CapturedDirectoryReader
 
 VECTOR_PERSISTENCE_SCHEMA = 1
 VECTOR_VIEW_UPDATE_MARKER = ".vector-view.update-in-progress"
 _DIGEST_BYTES = 1024 * 1024
 _MAX_CONFIG_BYTES = 16 * 1024 * 1024
+_MAX_DOCUMENT_BYTES = 256 * 1024 * 1024
+_MAX_FAISS_BYTES = 8 * 1024 * 1024 * 1024
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _UPDATE_MARKER_PAYLOAD = b'{"schema":"codenib.vector-view-update.v1"}\n'
+_VECTOR_LEVELS = frozenset({"l0", "l2"})
+_MUTABLE_ROOT_FILES = frozenset(
+    {
+        "chunk_store.json",
+        "chunk_store.pkl",
+        "embeddings_cache.json",
+        "embeddings_cache.npz",
+        "embeddings_cache.pkl",
+        "incremental_state.json",
+    }
+)
+
+
+def _vector_entry_policy(relative: str, kind: str, mode: int, size: int) -> None:
+    del mode
+    path = PurePosixPath(relative)
+    if kind == "directory":
+        if len(path.parts) != 1 or path.name not in _VECTOR_LEVELS:
+            raise ValueError(f"vector view has an invalid directory: {relative}")
+        return
+    if len(path.parts) == 1:
+        name = path.name
+        if name.startswith("config_") and name.endswith(".json"):
+            limit = _MAX_CONFIG_BYTES
+        elif name == "config.json":
+            limit = _MAX_CONFIG_BYTES
+        elif name == VECTOR_VIEW_UPDATE_MARKER or (
+            name.startswith(".config_") and name.endswith(".save-in-progress")
+        ):
+            limit = _MAX_CONFIG_BYTES
+        elif name in _MUTABLE_ROOT_FILES:
+            limit = _MAX_DOCUMENT_BYTES
+        else:
+            raise ValueError(f"vector view has an invalid file: {relative}")
+    elif len(path.parts) == 2 and path.parts[0] in _VECTOR_LEVELS:
+        name = path.name
+        suffix = path.suffix.casefold()
+        if name.startswith("config_") and suffix == ".json":
+            limit = _MAX_CONFIG_BYTES
+        elif name.startswith("documents_") and suffix in {
+            ".json",
+            ".pkl",
+            ".pickle",
+        }:
+            limit = _MAX_DOCUMENT_BYTES
+        elif name.startswith("index_") and suffix == ".faiss":
+            limit = _MAX_FAISS_BYTES
+        elif name.startswith("index_") and suffix in {".pkl", ".pickle"}:
+            limit = _MAX_DOCUMENT_BYTES
+        else:
+            raise ValueError(f"vector view has an invalid file: {relative}")
+    else:
+        raise ValueError(f"vector view has an invalid entry: {relative}")
+    if size < 0 or size > limit:
+        raise ValueError(f"vector artifact exceeds its {limit}-byte limit: {relative}")
+
+
+class _WrappedValueReader:
+    """Expose one bytes payload as a synthetic one-item JSON array."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._parts = iter((b"[", payload, b"]"))
+        self._pending = b""
+
+    def read(self, size: int = -1) -> bytes:
+        if not self._pending:
+            self._pending = next(self._parts, b"")
+        if size is None or size < 0 or len(self._pending) <= size:
+            block = self._pending
+            self._pending = b""
+            return block
+        block = self._pending[:size]
+        self._pending = self._pending[size:]
+        return block
+
+
+@dataclass(slots=True)
+class AuthenticatedVectorView:
+    """One captured vector tree whose consumers never reopen trusted paths."""
+
+    root: Path
+    ownership: object
+    reader: CapturedDirectoryReader
+    records: dict[str, TreeFileRecord]
+    inventory: tuple[tuple[str, str], ...]
+
+    @classmethod
+    def capture(cls, root: str | Path) -> AuthenticatedVectorView:
+        lexical = lexical_directory_path(Path(root))
+        ownership = capture_directory_ownership(
+            lexical,
+            entry_policy=_vector_entry_policy,
+        )
+        try:
+            reader = CapturedDirectoryReader(lexical, ownership)
+        except BaseException:
+            raise
+        return cls(
+            root=lexical,
+            ownership=ownership,
+            reader=reader,
+            records={
+                record.path: record
+                for record in directory_ownership_file_records(ownership)
+            },
+            inventory=directory_ownership_inventory(ownership),
+        )
+
+    def close(self) -> None:
+        self.reader.close()
+
+    def __enter__(self) -> AuthenticatedVectorView:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def has_file(self, relative: str | PurePosixPath) -> bool:
+        value = relative.as_posix() if isinstance(relative, PurePosixPath) else relative
+        return value in self.records
+
+    def record(self, relative: str | PurePosixPath) -> TreeFileRecord:
+        value = relative.as_posix() if isinstance(relative, PurePosixPath) else relative
+        try:
+            return self.records[value]
+        except KeyError as exc:
+            raise ValueError(f"vector artifact file is missing: {value}") from exc
+
+    def open_file(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> AuthenticatedFile:
+        return self.reader.open_file(relative, max_bytes=max_bytes)
+
+    def authenticated_descriptor(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ):
+        """Return a context manager yielding an immutable authenticated fd."""
+
+        return self.reader.authenticated_descriptor(relative, max_bytes=max_bytes)
+
+    def authenticated_snapshot(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ):
+        """Return a context manager yielding immutable authenticated bytes."""
+
+        return self.reader.authenticated_snapshot(relative, max_bytes=max_bytes)
+
+    def load_json_object(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        label: str,
+        max_bytes: int = _MAX_CONFIG_BYTES,
+    ) -> dict[str, Any]:
+        payload = self.reader.read_bytes(relative, max_bytes=max_bytes)
+        values = iter_bounded_json_array(
+            _WrappedValueReader(payload),
+            label=label,
+            max_items=1,
+            max_element_bytes=max_bytes,
+        )
+        try:
+            value = next(values)
+        except StopIteration as exc:
+            raise ValueError(f"{label} is empty") from exc
+        try:
+            next(values)
+        except StopIteration:
+            pass
+        else:  # pragma: no cover - the synthetic wrapper has exactly one item
+            raise ValueError(f"{label} contains multiple JSON values")
+        if not isinstance(value, dict):
+            raise ValueError(f"{label} must be a JSON object")
+        return value
+
+    def require_record(
+        self,
+        relative: str | PurePosixPath,
+        expected: object,
+    ) -> TreeFileRecord:
+        record = self.record(relative)
+        if not isinstance(expected, Mapping) or set(expected) != {
+            "file",
+            "size",
+            "sha256",
+        }:
+            raise ValueError("invalid vector artifact fingerprint")
+        if dict(expected) != {
+            "file": PurePosixPath(record.path).name,
+            "size": record.size,
+            "sha256": record.sha256,
+        }:
+            raise ValueError(
+                f"vector artifact does not match its fingerprint: {record.path}"
+            )
+        return record
+
+    def verify_final(self) -> None:
+        self.reader.verify_root()
+        observed = capture_directory_ownership(
+            self.root,
+            entry_policy=_vector_entry_policy,
+        )
+        if observed != self.ownership:
+            raise ValueError("vector view changed during authenticated loading")
+
+
+def capture_authenticated_vector_view(root: str | Path) -> AuthenticatedVectorView:
+    """Capture a bounded no-follow vector tree before native authorization."""
+
+    try:
+        return AuthenticatedVectorView.capture(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError(f"vector view could not be captured safely: {root}") from exc
 
 
 def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -335,9 +571,11 @@ def validate_vector_generation_artifacts(
 
 
 __all__ = [
+    "AuthenticatedVectorView",
     "VECTOR_PERSISTENCE_SCHEMA",
     "VECTOR_VIEW_UPDATE_MARKER",
     "begin_vector_view_update",
+    "capture_authenticated_vector_view",
     "finish_vector_view_update",
     "require_complete_vector_view",
     "validate_vector_config_artifact",

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -12,7 +12,7 @@ import os
 import stat
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from ..._atomic_directory import (
     TreeFileRecord,
@@ -26,6 +26,7 @@ from ..._bounded_json import iter_bounded_json_array
 from ..._captured_directory import AuthenticatedFile, CapturedDirectoryReader
 from ...native_index_authorization import (
     NativeIndexAuthorization,
+    _mint_trusted_local_admin_authorization,
     require_native_index_authorization,
     require_native_index_authorization_preflight,
 )
@@ -263,6 +264,54 @@ def capture_authenticated_vector_view(root: str | Path) -> AuthenticatedVectorVi
         raise ValueError(f"vector view could not be captured safely: {root}") from exc
 
 
+def _attach_vector_view_cleanup_owner(
+    primary: BaseException,
+    view: AuthenticatedVectorView,
+    cleanup_error: BaseException,
+) -> None:
+    """Keep a pending captured-tree owner reachable from the primary failure."""
+
+    owner = getattr(cleanup_error, "captured_directory_cleanup_owner", None)
+    if owner is None:
+        owner = view.reader
+    try:
+        primary.captured_directory_cleanup_owner = owner  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - traceback still retains local view
+        pass
+
+
+def _mint_trusted_local_vector_authorization(
+    root: str | Path,
+    semantic_contract: Mapping[str, Any],
+    *,
+    evidence: Sequence[str],
+) -> NativeIndexAuthorization:
+    """Capture and authorize one stable local vector view before model setup."""
+
+    view = capture_authenticated_vector_view(root)
+    try:
+        authorization = _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=evidence,
+        )
+        view.verify_final()
+    except BaseException as primary_error:  # noqa: B036 - preserve first failure
+        try:
+            view.close()
+        except BaseException as cleanup_error:  # noqa: B036 - preserve first failure
+            _attach_vector_view_cleanup_owner(primary_error, view, cleanup_error)
+            _annotate_secondary_error(
+                primary_error,
+                "authenticated vector view cleanup also failed",
+                cleanup_error,
+            )
+        raise
+    view.close()
+    return authorization
+
+
 def require_authorized_vector_view(
     root: str | Path,
     authorization: NativeIndexAuthorization | None,
@@ -294,6 +343,7 @@ def require_authorized_vector_view(
         try:
             view.close()
         except BaseException as cleanup_error:  # noqa: B036 - preserve first failure
+            _attach_vector_view_cleanup_owner(primary_error, view, cleanup_error)
             _annotate_secondary_error(
                 primary_error,
                 "authenticated vector view cleanup also failed",

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional
 from ...code_chunker import CodeChunker, RepoChunkingConfig
 from ...log_utils import get_logger
 from ...profiler import Profiler
+from ._lifecycle import close_vector_after_failure
+from .artifact_integrity import _mint_trusted_local_vector_authorization
 from .vector_store import CodeVectorStore
 
 logger = get_logger(__name__)
@@ -99,6 +101,12 @@ def build_hierarchical_vector_store(
                 "(pass force_rebuild=True to override).",
                 store_path,
             )
+            artifact_contract = dict(artifact_metadata or {})
+            native_authorization = _mint_trusted_local_vector_authorization(
+                store_path,
+                artifact_contract,
+                evidence=("hierarchical-vector-builder-cache",),
+            )
             vector_store = CodeVectorStore(
                 embedding_model=embedding_model,
                 embedding_provider=embedding_provider,
@@ -110,11 +118,18 @@ def build_hierarchical_vector_store(
                 store_path=str(store_path),
                 profiler=profiler,
                 embedding=embedding,
-                artifact_metadata=artifact_metadata,
+                artifact_metadata=artifact_contract,
                 **(embedding_kwargs or {}),
             )
-            vector_store.load(str(store_path))
-            return vector_store
+            try:
+                vector_store.load(
+                    str(store_path),
+                    native_index_authorization=native_authorization,
+                )
+                return vector_store
+            except BaseException as primary:  # noqa: B036 - close partial state
+                close_vector_after_failure(vector_store, primary)
+                raise
 
     languages = languages or ["python"]
     build_levels = normalized_levels

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -16,22 +16,29 @@ import pickle
 import tempfile
 from collections.abc import Mapping
 from contextlib import contextmanager, nullcontext
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 
 import faiss
 import numpy as np
 
 from ... import compat_pickle
+from ..._bounded_json import iter_bounded_json_array
+from ..._captured_directory import AuthenticatedSnapshotReader
 from ...log_utils import get_logger
+from ...native_index_authorization import (
+    NativeIndexAuthorization,
+    require_native_index_authorization,
+    require_native_index_authorization_preflight,
+)
 from ...profiler import Profiler
 from ...provider_routes import normalize_provider
 from ...types import NodeInfo
 from .artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
-    require_complete_vector_view,
-    validate_vector_config_artifact,
-    validate_vector_level_artifacts,
+    VECTOR_VIEW_UPDATE_MARKER,
+    AuthenticatedVectorView,
+    capture_authenticated_vector_view,
     vector_level_artifact_records,
 )
 from .model_policy import (
@@ -57,6 +64,28 @@ _HUGGINGFACE_ONLY_OPTIONS = frozenset(
         "trust_remote_code",
     }
 )
+
+
+@contextmanager
+def _authenticated_binary_file(
+    view: AuthenticatedVectorView,
+    relative: str,
+):
+    """Yield a file object backed only by an immutable authenticated snapshot."""
+
+    with view.authenticated_snapshot(relative) as (snapshot, _record):
+        yield AuthenticatedSnapshotReader(snapshot)
+
+
+def _read_authenticated_faiss(
+    view: AuthenticatedVectorView,
+    relative: str,
+) -> Any:
+    """Give FAISS only a fixed-chunk reader over an authenticated snapshot."""
+
+    with view.authenticated_snapshot(relative) as (snapshot, _record):
+        source = AuthenticatedSnapshotReader(snapshot)
+        return faiss.read_index(faiss.PyCallbackIOReader(source.read))
 
 
 def _pop_compatible_model_option(
@@ -785,14 +814,22 @@ class CodeVectorStore:
                 results.append((documents[idx], float(dist)))
         return results
 
-    def swap_index(self, path: str) -> None:
+    def swap_index(
+        self,
+        path: str,
+        *,
+        native_index_authorization: NativeIndexAuthorization | None = None,
+    ) -> None:
         """Hot-swap the FAISS index without reloading the embedding model.
 
         The replacement is fully loaded and validated before the current
         L0/L2 state is released. The embedding model is left intact so the
         caller can reuse the same model across many instances.
         """
-        self.load(path)
+        self.load(
+            path,
+            native_index_authorization=native_index_authorization,
+        )
 
     def close(self) -> None:
         """Release embeddings and FAISS resources to free memory."""
@@ -1321,32 +1358,60 @@ class CodeVectorStore:
         logger.info(f"Saved {level.upper()} store with {len(documents)} documents")
         return artifacts
 
-    def load(self, path: Optional[str] = None) -> None:
+    def load(
+        self,
+        path: Optional[str] = None,
+        *,
+        native_index_authorization: NativeIndexAuthorization | None = None,
+    ) -> None:
         """
         Load the vector store from disk.
 
         Args:
             path: Path to load the store from (uses self.store_path if not provided)
+            native_index_authorization: Process-local authorization bound to the
+                exact captured tree and semantic view contract. Artifact fields
+                cannot provide this capability.
         """
         load_path = Path(path) if path else self.store_path
         if load_path is None:
             raise ValueError("No load path provided")
+        require_native_index_authorization_preflight(
+            native_index_authorization,
+            view_type="vector",
+        )
+        view = capture_authenticated_vector_view(load_path)
+        try:
+            require_native_index_authorization(
+                native_index_authorization,
+                view.ownership,
+                view_type="vector",
+                semantic_contract=self.artifact_metadata,
+            )
+            self._load_captured(view)
+            view.verify_final()
+        finally:
+            view.close()
 
-        load_path = Path(load_path)
-        if not load_path.exists():
-            raise FileNotFoundError(f"Vector store not found at {load_path}")
+    def _load_captured(self, view: AuthenticatedVectorView) -> None:
+        """Load native state only through one already-authorized captured tree."""
 
-        logger.info(f"Loading vector store from {load_path}")
-        require_complete_vector_view(load_path)
+        load_path = view.root
+        logger.info("Loading authenticated vector store from %s", load_path)
+        if view.has_file(VECTOR_VIEW_UPDATE_MARKER):
+            raise ValueError(
+                "vector view has an incomplete update marker: "
+                f"{VECTOR_VIEW_UPDATE_MARKER}"
+            )
 
         model_suffix = self.embedding_model.replace("/", "__")
 
         # Load top-level configuration
-        config_path = load_path / f"config_{model_suffix}.json"
-        if not config_path.exists():
-            config_path = load_path / "config.json"
-        save_marker = load_path / f".config_{model_suffix}.json.save-in-progress"
-        if save_marker.exists():
+        config_relative = f"config_{model_suffix}.json"
+        if not view.has_file(config_relative):
+            config_relative = "config.json"
+        save_marker = f".config_{model_suffix}.json.save-in-progress"
+        if view.has_file(save_marker):
             raise ValueError(
                 f"Vector store has an interrupted save marker: {save_marker}"
             )
@@ -1354,17 +1419,19 @@ class CodeVectorStore:
         expected_artifact = dict(self.artifact_metadata)
         expected_config = expected_artifact.get("persistence_config_fingerprint")
         if expected_config is not None:
-            config_path = validate_vector_config_artifact(
-                load_path,
-                model_suffix,
+            config_relative = f"config_{model_suffix}.json"
+            view.require_record(
+                config_relative,
                 expected_config,
             )
         loaded_artifact = expected_artifact
         expected_counts: Dict[str, Optional[int]] = {"l0": None, "l2": None}
         committed_levels: Optional[dict[str, object]] = None
-        if config_path.exists():
-            with open(config_path, "r") as f:
-                config = json.load(f)
+        if view.has_file(config_relative):
+            config = view.load_json_object(
+                config_relative,
+                label="vector generation config",
+            )
 
             saved_model = config.get("embedding_model")
             if saved_model is not None and saved_model != self.embedding_model:
@@ -1453,8 +1520,7 @@ class CodeVectorStore:
         loaded_levels = {}
         for level in ("l0", "l2"):
             expected_count = expected_counts[level]
-            level_path = load_path / level
-            faiss_path = level_path / f"index_{model_suffix}.faiss"
+            faiss_relative = f"{level}/index_{model_suffix}.faiss"
             committed_artifacts = (
                 committed_levels.get(level) if committed_levels is not None else None
             )
@@ -1479,16 +1545,17 @@ class CodeVectorStore:
                     f"Vector config is missing committed artifacts for {level}"
                 )
 
-            if committed_artifacts is not None or faiss_path.exists():
+            if committed_artifacts is not None or view.has_file(faiss_relative):
                 index, documents = self._load_level(
-                    level_path,
+                    view,
+                    level,
                     model_suffix,
                     committed_artifacts=committed_artifacts,
                 )
             elif expected_count is not None and expected_count > 0:
                 raise FileNotFoundError(
                     f"Vector config expects {expected_count} {level} documents, "
-                    f"but {faiss_path} is missing"
+                    f"but {faiss_relative} is missing"
                 )
             else:
                 index, documents = self._build_faiss_index(), []
@@ -1536,7 +1603,8 @@ class CodeVectorStore:
 
     def _load_level(
         self,
-        level_path: Path,
+        view: AuthenticatedVectorView,
+        level: str,
         model_suffix: str,
         *,
         committed_artifacts: object = None,
@@ -1546,72 +1614,96 @@ class CodeVectorStore:
         Handles both the new format (raw FAISS + _Document list) and the
         legacy LangChain format (FAISS + docstore pkl) transparently.
         """
+        level_path = view.root / level
         index_name = f"index_{model_suffix}"
-        committed_documents_path = None
+        faiss_relative = f"{level}/{index_name}.faiss"
+        committed_documents_relative = None
         if committed_artifacts is not None:
-            faiss_path, committed_documents_path = validate_vector_level_artifacts(
-                level_path,
-                model_suffix,
-                committed_artifacts,
+            if not isinstance(committed_artifacts, Mapping) or set(
+                committed_artifacts
+            ) != {"index", "documents"}:
+                raise ValueError(f"invalid committed vector artifacts for {level_path}")
+            view.require_record(faiss_relative, committed_artifacts["index"])
+            documents_record = committed_artifacts["documents"]
+            if not isinstance(documents_record, Mapping):
+                raise ValueError(
+                    f"invalid documents vector artifact record for {level_path}"
+                )
+            documents_name = documents_record.get("file")
+            if documents_name not in {
+                f"documents_{model_suffix}.json",
+                f"documents_{model_suffix}.pkl",
+            }:
+                raise ValueError(
+                    f"invalid documents vector artifact filename for {level_path}"
+                )
+            committed_documents_relative = f"{level}/{documents_name}"
+            view.require_record(
+                committed_documents_relative,
+                documents_record,
             )
-        else:
-            faiss_path = level_path / f"{index_name}.faiss"
 
-        if not faiss_path.exists():
-            raise FileNotFoundError(f"FAISS index not found at {faiss_path}")
+        if not view.has_file(faiss_relative):
+            raise FileNotFoundError(f"FAISS index not found at {faiss_relative}")
 
         try:
-            index = faiss.read_index(str(faiss_path))
+            index = _read_authenticated_faiss(view, faiss_relative)
         except Exception as e:
             raise ValueError(
-                f"Could not load FAISS index from {faiss_path}: {e}"
+                f"Could not load FAISS index from {faiss_relative}: {e}"
             ) from e
         if int(index.d) != self.dimension:
             raise ValueError(
-                f"FAISS dimension mismatch at {faiss_path}: "
+                f"FAISS dimension mismatch at {faiss_relative}: "
                 f"expected {self.dimension}, found {int(index.d)}"
             )
 
         # Portable artifacts use inert JSON so a downloaded document store is
         # never unpickled. Local indexes retain the pickle fallback for
         # compatibility with previously built artifacts.
-        json_path = level_path / f"documents_{model_suffix}.json"
-        if committed_documents_path is not None:
-            if committed_documents_path.suffix == ".json":
-                documents = self._load_documents_json(committed_documents_path)
+        json_relative = f"{level}/documents_{model_suffix}.json"
+        if committed_documents_relative is not None:
+            if PurePosixPath(committed_documents_relative).suffix == ".json":
+                documents = self._load_documents_json(
+                    view,
+                    committed_documents_relative,
+                )
             else:
                 try:
-                    with committed_documents_path.open("rb") as handle:
+                    with _authenticated_binary_file(
+                        view,
+                        committed_documents_relative,
+                    ) as handle:
                         raw_docs = compat_pickle.load(handle)
                     documents = [_to_document(document) for document in raw_docs]
                 except Exception as exc:
                     raise ValueError(
                         "Could not load committed vector documents from "
-                        f"{committed_documents_path}: {exc}"
+                        f"{committed_documents_relative}: {exc}"
                     ) from exc
-        elif json_path.exists():
-            documents = self._load_documents_json(json_path)
+        elif view.has_file(json_relative):
+            documents = self._load_documents_json(view, json_relative)
         else:
             documents = None
 
             # Try loading the local documents pickle (works for both new
             # _Document and legacy LangChain Document objects).
-            docs_path = level_path / f"documents_{model_suffix}.pkl"
-            if docs_path.exists():
+            docs_relative = f"{level}/documents_{model_suffix}.pkl"
+            if view.has_file(docs_relative):
                 try:
-                    with open(docs_path, "rb") as f:
-                        raw_docs = compat_pickle.load(f)
+                    with _authenticated_binary_file(view, docs_relative) as source:
+                        raw_docs = compat_pickle.load(source)
                     documents = [_to_document(d) for d in raw_docs]
                 except Exception as exc:
                     logger.warning(
-                        "Could not load documents from %s: %s", docs_path, exc
+                        "Could not load documents from %s: %s", docs_relative, exc
                     )
 
             # Fallback: LangChain stores use index_name.pkl for their docstore.
-            lc_pkl_path = level_path / f"{index_name}.pkl"
-            if documents is None and lc_pkl_path.exists():
+            lc_pkl_relative = f"{level}/{index_name}.pkl"
+            if documents is None and view.has_file(lc_pkl_relative):
                 try:
-                    documents = self._load_langchain_pkl(lc_pkl_path)
+                    documents = self._load_langchain_pkl(view, lc_pkl_relative)
                     logger.info(
                         "Loaded %d documents from legacy LangChain format",
                         len(documents),
@@ -1619,7 +1711,7 @@ class CodeVectorStore:
                 except Exception as exc:
                     logger.warning(
                         "Could not load legacy LangChain pkl from %s: %s",
-                        lc_pkl_path,
+                        lc_pkl_relative,
                         exc,
                     )
 
@@ -1636,44 +1728,107 @@ class CodeVectorStore:
                 f"Misaligned vector level {level_path}: {int(index.ntotal)} vectors "
                 f"for {len(documents)} documents"
             )
+        self._validate_loaded_faiss_index(
+            index,
+            relative=faiss_relative,
+            document_count=len(documents),
+        )
+        level_config_relative = f"{level}/config_{model_suffix}.json"
+        if view.has_file(level_config_relative):
+            level_config = view.load_json_object(
+                level_config_relative,
+                label=f"vector {level} config",
+            )
+            expected_level_config = {
+                "embedding_model": self.embedding_model,
+                "embedding_provider": self.embedding_provider,
+                "embedding_revision": self.embedding_revision,
+                "dimension": self.dimension,
+                "index_type": self.index_type,
+                "index_metric": self.index_metric,
+                "level": level,
+                "num_documents": len(documents),
+            }
+            for field, expected in expected_level_config.items():
+                if level_config.get(field) != expected:
+                    raise ValueError(
+                        f"vector {level} config {field} mismatch: "
+                        f"expected {expected!r}, found {level_config.get(field)!r}"
+                    )
         return index, documents
 
+    def _validate_loaded_faiss_index(
+        self,
+        index: faiss.Index,
+        *,
+        relative: str,
+        document_count: int,
+    ) -> None:
+        expected_metric = self._faiss_metric()
+        if int(index.metric_type) != int(expected_metric):
+            raise ValueError(
+                f"FAISS metric mismatch at {relative}: expected "
+                f"{self.index_metric}, found {int(index.metric_type)}"
+            )
+        if self.index_type == "flat":
+            valid_type = isinstance(index, faiss.IndexFlat)
+        else:
+            valid_type = isinstance(index, faiss.IndexIVF)
+        if not valid_type:
+            raise ValueError(
+                f"FAISS index type mismatch at {relative}: expected {self.index_type}"
+            )
+        if document_count > 0 and not bool(index.is_trained):
+            raise ValueError(f"FAISS index is not trained at {relative}")
+
     @staticmethod
-    def _load_documents_json(path: Path) -> List[_Document]:
+    def _load_documents_json(
+        view: AuthenticatedVectorView,
+        relative: str,
+    ) -> List[_Document]:
         """Load the non-executable portable vector document format."""
 
-        with path.open(encoding="utf-8") as handle:
-            payload = json.load(handle)
-        if not isinstance(payload, list):
-            raise ValueError(f"vector documents must be a JSON list: {path}")
-
         documents: List[_Document] = []
-        for index, item in enumerate(payload):
-            if not isinstance(item, dict):
-                raise ValueError(
-                    f"vector document {index} must be a JSON object: {path}"
+        with view.open_file(relative) as source:
+            for index, item in enumerate(
+                iter_bounded_json_array(
+                    source,
+                    label=f"vector documents {relative}",
                 )
-            page_content = item.get("page_content")
-            metadata = item.get("metadata")
-            if not isinstance(page_content, str) or not isinstance(metadata, dict):
-                raise ValueError(
-                    f"vector document {index} has invalid content or metadata: {path}"
+            ):
+                if not isinstance(item, dict) or set(item) != {
+                    "page_content",
+                    "metadata",
+                }:
+                    raise ValueError(
+                        f"vector document {index} must have canonical shape: "
+                        f"{relative}"
+                    )
+                page_content = item.get("page_content")
+                metadata = item.get("metadata")
+                if not isinstance(page_content, str) or not isinstance(metadata, dict):
+                    raise ValueError(
+                        f"vector document {index} has invalid content or metadata: "
+                        f"{relative}"
+                    )
+                documents.append(
+                    _Document(page_content=page_content, metadata=dict(metadata))
                 )
-            documents.append(
-                _Document(page_content=page_content, metadata=dict(metadata))
-            )
         return documents
 
     @staticmethod
-    def _load_langchain_pkl(pkl_path: Path) -> List[_Document]:
+    def _load_langchain_pkl(
+        view: AuthenticatedVectorView,
+        relative: str,
+    ) -> List[_Document]:
         """Extract documents from a LangChain FAISS pkl file.
 
         The pkl file contains ``(InMemoryDocstore, index_to_docstore_id)``
         where ``index_to_docstore_id`` maps integer FAISS indices to
         docstore string IDs.
         """
-        with open(pkl_path, "rb") as f:
-            docstore, index_to_docstore_id = compat_pickle.load(f)
+        with _authenticated_binary_file(view, relative) as source:
+            docstore, index_to_docstore_id = compat_pickle.load(source)
 
         documents: List[_Document] = []
         for i in sorted(index_to_docstore_id.keys()):

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -13,9 +13,11 @@ import inspect
 import json
 import os
 import pickle
+import sys
 import tempfile
 from collections.abc import Mapping
 from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 
@@ -23,6 +25,7 @@ import faiss
 import numpy as np
 
 from ... import compat_pickle
+from ..._atomic_directory import _annotate_secondary_error
 from ..._bounded_json import iter_bounded_json_array
 from ..._captured_directory import AuthenticatedSnapshotReader
 from ...log_utils import get_logger
@@ -38,6 +41,7 @@ from .artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
     VECTOR_VIEW_UPDATE_MARKER,
     AuthenticatedVectorView,
+    _attach_vector_view_cleanup_owner,
     capture_authenticated_vector_view,
     vector_level_artifact_records,
 )
@@ -228,6 +232,77 @@ class _Document:
     def __repr__(self) -> str:
         name = self.metadata.get("name", "")
         return f"_Document(name={name!r}, len={len(self.page_content)})"
+
+
+@dataclass(slots=True)
+class _LoadedVectorState:
+    """Temporary replacement state committed only after final authentication."""
+
+    l0_index: Any
+    l0_documents: List[_Document]
+    l2_index: Any
+    l2_documents: List[_Document]
+    artifact_metadata: Dict[str, Any]
+    store_path: Path | None
+
+
+class _VectorIndexCleanupOwner:
+    """Retryable aggregate owner for unpublished or superseded FAISS indices."""
+
+    __slots__ = ("indices",)
+
+    def __init__(self, indices: tuple[Any, ...]) -> None:
+        seen: set[int] = set()
+        self.indices: list[Any] = []
+        for index in indices:
+            if index is None or id(index) in seen:
+                continue
+            seen.add(id(index))
+            self.indices.append(index)
+
+    @property
+    def closed(self) -> bool:
+        return not self.indices
+
+    def close(self) -> None:
+        pending: list[Any] = []
+        failure: BaseException | None = None
+        for index in self.indices:
+            reset = getattr(index, "reset", None)
+            if not callable(reset):
+                continue
+            try:
+                reset()
+            except BaseException as exc:  # noqa: B036 - visit every index
+                pending.append(index)
+                if failure is None:
+                    failure = exc
+                else:
+                    _annotate_secondary_error(
+                        failure,
+                        "additional FAISS index cleanup also failed",
+                        exc,
+                    )
+        self.indices = pending
+        if failure is not None:
+            try:
+                failure.vector_index_cleanup_owner = self  # type: ignore[attr-defined]
+            except BaseException:  # noqa: B036 - traceback still retains owner
+                pass
+            raise failure
+
+
+def _attach_vector_index_cleanup_owner(
+    primary: BaseException,
+    cleanup_error: BaseException,
+) -> None:
+    owner = getattr(cleanup_error, "vector_index_cleanup_owner", None)
+    if owner is None:
+        return
+    try:
+        primary.vector_index_cleanup_owner = owner  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - traceback still retains cleanup error
+        pass
 
 
 class _HuggingFaceEmbeddingWrapper:
@@ -519,6 +594,63 @@ class CodeVectorStore:
     - L2: Function/method-level chunks for fine-grained retrieval (default)
     """
 
+    def _state_for_update(self) -> _LoadedVectorState:
+        """Return the current state, lazily supporting lightweight test stores."""
+
+        state = getattr(self, "_loaded_state", None)
+        if state is None:
+            state = _LoadedVectorState(None, [], None, [], {}, None)
+            self._loaded_state = state
+        return state
+
+    @property
+    def l0_index(self) -> Any:
+        return self._loaded_state.l0_index
+
+    @l0_index.setter
+    def l0_index(self, value: Any) -> None:
+        self._state_for_update().l0_index = value
+
+    @property
+    def l0_documents(self) -> List[_Document]:
+        return self._loaded_state.l0_documents
+
+    @l0_documents.setter
+    def l0_documents(self, value: List[_Document]) -> None:
+        self._state_for_update().l0_documents = value
+
+    @property
+    def l2_index(self) -> Any:
+        return self._loaded_state.l2_index
+
+    @l2_index.setter
+    def l2_index(self, value: Any) -> None:
+        self._state_for_update().l2_index = value
+
+    @property
+    def l2_documents(self) -> List[_Document]:
+        return self._loaded_state.l2_documents
+
+    @l2_documents.setter
+    def l2_documents(self, value: List[_Document]) -> None:
+        self._state_for_update().l2_documents = value
+
+    @property
+    def artifact_metadata(self) -> Dict[str, Any]:
+        return self._loaded_state.artifact_metadata
+
+    @artifact_metadata.setter
+    def artifact_metadata(self, value: Dict[str, Any]) -> None:
+        self._state_for_update().artifact_metadata = value
+
+    @property
+    def store_path(self) -> Path | None:
+        return self._loaded_state.store_path
+
+    @store_path.setter
+    def store_path(self, value: Path | None) -> None:
+        self._state_for_update().store_path = value
+
     def __init__(
         self,
         embedding_model: str = "text-embedding-ada-002",
@@ -591,9 +723,9 @@ class CodeVectorStore:
             )
         self.ivf_nlist = max(1, int(ivf_nlist))
         self.ivf_nprobe = max(1, int(ivf_nprobe))
-        self.store_path = Path(store_path) if store_path else None
+        initial_store_path = Path(store_path) if store_path else None
         self.profiler = profiler
-        self.artifact_metadata = dict(artifact_metadata or {})
+        initial_artifact_metadata = dict(artifact_metadata or {})
 
         # Initialize the embedding model — or reuse a shared one so the same
         # model isn't loaded onto the GPU once per store.
@@ -608,12 +740,18 @@ class CodeVectorStore:
         self.dimension = self._infer_embedding_dimension(dimension)
 
         # Initialize L0 (file-level skeletons)
-        self.l0_index = self._build_faiss_index()
-        self.l0_documents: List[_Document] = []
+        l0_index = self._build_faiss_index()
 
         # Initialize L2 (function/method-level) - default
-        self.l2_index = self._build_faiss_index()
-        self.l2_documents: List[_Document] = []
+        l2_index = self._build_faiss_index()
+        self._loaded_state = _LoadedVectorState(
+            l0_index=l0_index,
+            l0_documents=[],
+            l2_index=l2_index,
+            l2_documents=[],
+            artifact_metadata=initial_artifact_metadata,
+            store_path=initial_store_path,
+        )
 
         logger.info(
             f"Initialized CodeVectorStore with {embedding_provider}:{embedding_model}"
@@ -621,10 +759,11 @@ class CodeVectorStore:
 
     def _get_index_and_docs(self, level: Level) -> tuple[faiss.Index, List[_Document]]:
         """Get the FAISS index and documents list for the specified level."""
+        state = self._loaded_state
         if level == "l0":
-            return self.l0_index, self.l0_documents
+            return state.l0_index, state.l0_documents
         elif level == "l2":
-            return self.l2_index, self.l2_documents
+            return state.l2_index, state.l2_documents
         else:
             raise ValueError(f"Invalid level: {level}. Must be 'l0' or 'l2'.")
 
@@ -833,17 +972,43 @@ class CodeVectorStore:
 
     def close(self) -> None:
         """Release embeddings and FAISS resources to free memory."""
-        for index in (self.l0_index, self.l2_index):
-            if index is None:
+
+        state = self._loaded_state
+        released: dict[int, bool] = {}
+        deferred: BaseException | None = None
+        for index in (state.l0_index, state.l2_index):
+            if index is None or id(index) in released:
                 continue
             reset = getattr(index, "reset", None)
-            if callable(reset):
+            if not callable(reset):
+                released[id(index)] = True
+                continue
+            try:
                 reset()
+                released[id(index)] = True
+            except BaseException as exc:  # noqa: B036 - visit both native indices
+                released[id(index)] = False
+                if deferred is None:
+                    deferred = exc
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "additional FAISS index cleanup also failed",
+                        exc,
+                    )
 
-        self.l0_documents.clear()
-        self.l2_documents.clear()
-        self.l0_index = None
-        self.l2_index = None
+        l0_released = state.l0_index is None or released.get(id(state.l0_index), False)
+        l2_released = state.l2_index is None or released.get(id(state.l2_index), False)
+        self._loaded_state = _LoadedVectorState(
+            l0_index=None if l0_released else state.l0_index,
+            l0_documents=[] if l0_released else state.l0_documents,
+            l2_index=None if l2_released else state.l2_index,
+            l2_documents=[] if l2_released else state.l2_documents,
+            artifact_metadata=state.artifact_metadata,
+            store_path=state.store_path,
+        )
+        if deferred is not None:
+            raise deferred
 
         self.embedding = None
         self._query_cache_depth = 0
@@ -1381,6 +1546,9 @@ class CodeVectorStore:
             view_type="vector",
         )
         view = capture_authenticated_vector_view(load_path)
+        loaded_state: _LoadedVectorState | None = None
+        previous_state: _LoadedVectorState | None = None
+        view_closed = False
         try:
             require_native_index_authorization(
                 native_index_authorization,
@@ -1388,12 +1556,71 @@ class CodeVectorStore:
                 view_type="vector",
                 semantic_contract=self.artifact_metadata,
             )
-            self._load_captured(view)
+            loaded_state = self._load_captured(view)
             view.verify_final()
-        finally:
+            # A close failure is still a failed replacement. Finish the
+            # captured-view lifecycle before exposing any newly parsed state.
             view.close()
+            view_closed = True
+            previous_state = self._loaded_state
+            self._replace_loaded_state(loaded_state)
+        finally:
+            primary_error = sys.exc_info()[1]
+            cleanup_error: BaseException | None = None
+            if not view_closed:
+                try:
+                    view.close()
+                    view_closed = True
+                except BaseException as exc:  # noqa: B036 - preserve primary
+                    cleanup_error = exc
+            if loaded_state is not None:
+                release_state = (
+                    previous_state
+                    if self._loaded_state is loaded_state
+                    else loaded_state
+                )
+                if release_state is not None:
+                    try:
+                        self._release_vector_indices(
+                            tuple(
+                                index
+                                for index in (
+                                    release_state.l0_index,
+                                    release_state.l2_index,
+                                )
+                                if index is not self.l0_index
+                                and index is not self.l2_index
+                            )
+                        )
+                    except BaseException as exc:  # noqa: B036 - visit all cleanup
+                        if primary_error is not None:
+                            _attach_vector_index_cleanup_owner(primary_error, exc)
+                        if cleanup_error is None:
+                            cleanup_error = exc
+                        else:
+                            _attach_vector_index_cleanup_owner(cleanup_error, exc)
+                            _annotate_secondary_error(
+                                cleanup_error,
+                                "vector index cleanup also failed",
+                                exc,
+                            )
+            if cleanup_error is not None:
+                if primary_error is not None:
+                    if not view_closed:
+                        _attach_vector_view_cleanup_owner(
+                            primary_error,
+                            view,
+                            cleanup_error,
+                        )
+                    _annotate_secondary_error(
+                        primary_error,
+                        "vector load cleanup also failed",
+                        cleanup_error,
+                    )
+                else:
+                    raise cleanup_error
 
-    def _load_captured(self, view: AuthenticatedVectorView) -> None:
+    def _load_captured(self, view: AuthenticatedVectorView) -> _LoadedVectorState:
         """Load native state only through one already-authorized captured tree."""
 
         load_path = view.root
@@ -1517,75 +1744,71 @@ class CodeVectorStore:
         elif expected_artifact.get("embedding_fingerprint") is not None:
             raise ValueError("Vector store is missing its top-level configuration")
 
-        loaded_levels = {}
-        for level in ("l0", "l2"):
-            expected_count = expected_counts[level]
-            faiss_relative = f"{level}/index_{model_suffix}.faiss"
-            committed_artifacts = (
-                committed_levels.get(level) if committed_levels is not None else None
-            )
+        loaded_levels: dict[str, tuple[Any, List[_Document]]] = {}
+        try:
+            for level in ("l0", "l2"):
+                expected_count = expected_counts[level]
+                faiss_relative = f"{level}/index_{model_suffix}.faiss"
+                committed_artifacts = (
+                    committed_levels.get(level)
+                    if committed_levels is not None
+                    else None
+                )
 
-            # A zero count in the top-level config is authoritative. Older
-            # writers could leave stale level files behind after deletions.
-            if expected_count == 0:
-                if committed_artifacts is not None:
+                # A zero count in the top-level config is authoritative. Older
+                # writers could leave stale level files behind after deletions.
+                if expected_count == 0:
+                    if committed_artifacts is not None:
+                        raise ValueError(
+                            f"Vector config commits artifacts for empty {level} level"
+                        )
+                    loaded_levels[level] = (self._build_faiss_index(), [])
+                    continue
+
+                if (
+                    committed_levels is not None
+                    and expected_count is not None
+                    and expected_count > 0
+                    and committed_artifacts is None
+                ):
                     raise ValueError(
-                        f"Vector config commits artifacts for empty {level} level"
+                        f"Vector config is missing committed artifacts for {level}"
                     )
-                loaded_levels[level] = (self._build_faiss_index(), [])
-                continue
 
-            if (
-                committed_levels is not None
-                and expected_count is not None
-                and expected_count > 0
-                and committed_artifacts is None
-            ):
-                raise ValueError(
-                    f"Vector config is missing committed artifacts for {level}"
+                if committed_artifacts is not None or view.has_file(faiss_relative):
+                    index, documents = self._load_level(
+                        view,
+                        level,
+                        model_suffix,
+                        committed_artifacts=committed_artifacts,
+                    )
+                elif expected_count is not None and expected_count > 0:
+                    raise FileNotFoundError(
+                        f"Vector config expects {expected_count} {level} documents, "
+                        f"but {faiss_relative} is missing"
+                    )
+                else:
+                    index, documents = self._build_faiss_index(), []
+
+                loaded_levels[level] = (index, documents)
+                if expected_count is not None and len(documents) != expected_count:
+                    raise ValueError(
+                        f"{level} config expects {expected_count} documents, "
+                        f"loaded {len(documents)}"
+                    )
+        except BaseException as primary_error:
+            try:
+                self._release_vector_indices(
+                    tuple(index for index, _documents in loaded_levels.values())
                 )
-
-            if committed_artifacts is not None or view.has_file(faiss_relative):
-                index, documents = self._load_level(
-                    view,
-                    level,
-                    model_suffix,
-                    committed_artifacts=committed_artifacts,
+            except BaseException as cleanup_error:  # noqa: B036 - preserve primary
+                _attach_vector_index_cleanup_owner(primary_error, cleanup_error)
+                _annotate_secondary_error(
+                    primary_error,
+                    "partially loaded vector levels cleanup also failed",
+                    cleanup_error,
                 )
-            elif expected_count is not None and expected_count > 0:
-                raise FileNotFoundError(
-                    f"Vector config expects {expected_count} {level} documents, "
-                    f"but {faiss_relative} is missing"
-                )
-            else:
-                index, documents = self._build_faiss_index(), []
-
-            if expected_count is not None and len(documents) != expected_count:
-                raise ValueError(
-                    f"{level} config expects {expected_count} documents, "
-                    f"loaded {len(documents)}"
-                )
-            loaded_levels[level] = (index, documents)
-
-        old_indices = (self.l0_index, self.l2_index)
-        self.l0_index, self.l0_documents = loaded_levels["l0"]
-        self.l2_index, self.l2_documents = loaded_levels["l2"]
-        self.artifact_metadata = loaded_artifact
-        self.store_path = load_path
-
-        for old_index in old_indices:
-            if (
-                old_index is None
-                or old_index is self.l0_index
-                or old_index is self.l2_index
-            ):
-                continue
-            reset = getattr(old_index, "reset", None)
-            if callable(reset):
-                try:
-                    reset()
-                except Exception as exc:
-                    logger.debug("Could not release replaced FAISS index: %s", exc)
+            raise
 
         for level, (_index, documents) in loaded_levels.items():
             if documents:
@@ -1595,11 +1818,29 @@ class CodeVectorStore:
                     len(documents),
                 )
 
-        total_docs = len(self.l0_documents) + len(self.l2_documents)
+        total_docs = sum(len(documents) for _index, documents in loaded_levels.values())
         logger.info(
             f"Vector store loaded successfully with {total_docs} total documents "
-            f"(L0: {len(self.l0_documents)}, L2: {len(self.l2_documents)})"
+            f"(L0: {len(loaded_levels['l0'][1])}, "
+            f"L2: {len(loaded_levels['l2'][1])})"
         )
+        return _LoadedVectorState(
+            l0_index=loaded_levels["l0"][0],
+            l0_documents=loaded_levels["l0"][1],
+            l2_index=loaded_levels["l2"][0],
+            l2_documents=loaded_levels["l2"][1],
+            artifact_metadata=loaded_artifact,
+            store_path=load_path,
+        )
+
+    @staticmethod
+    def _release_vector_indices(indices: tuple[Any, ...]) -> None:
+        _VectorIndexCleanupOwner(indices).close()
+
+    def _replace_loaded_state(self, state: _LoadedVectorState) -> None:
+        """Commit one fully verified replacement with a single reference store."""
+
+        self._loaded_state = state
 
     def _load_level(
         self,
@@ -1646,12 +1887,52 @@ class CodeVectorStore:
         if not view.has_file(faiss_relative):
             raise FileNotFoundError(f"FAISS index not found at {faiss_relative}")
 
+        index: faiss.Index | None = None
         try:
-            index = _read_authenticated_faiss(view, faiss_relative)
-        except Exception as e:
-            raise ValueError(
-                f"Could not load FAISS index from {faiss_relative}: {e}"
-            ) from e
+            try:
+                index = _read_authenticated_faiss(view, faiss_relative)
+            except Exception as e:
+                raise ValueError(
+                    f"Could not load FAISS index from {faiss_relative}: {e}"
+                ) from e
+            return self._finish_loaded_level(
+                view,
+                level,
+                model_suffix,
+                level_path=level_path,
+                faiss_relative=faiss_relative,
+                committed_documents_relative=committed_documents_relative,
+                index=index,
+            )
+        except BaseException as primary_error:
+            # FAISS has already allocated native state, but the caller cannot
+            # assume ownership until this method returns successfully.
+            if index is not None:
+                try:
+                    self._release_vector_indices((index,))
+                except BaseException as cleanup_error:  # noqa: B036 - preserve primary
+                    _attach_vector_index_cleanup_owner(primary_error, cleanup_error)
+                    _annotate_secondary_error(
+                        primary_error,
+                        "partially loaded FAISS index cleanup also failed",
+                        cleanup_error,
+                    )
+            raise
+
+    def _finish_loaded_level(
+        self,
+        view: AuthenticatedVectorView,
+        level: str,
+        model_suffix: str,
+        *,
+        level_path: Path,
+        faiss_relative: str,
+        committed_documents_relative: str | None,
+        index: faiss.Index,
+    ) -> tuple[faiss.Index, List[_Document]]:
+        """Validate documents and metadata for one already-acquired index."""
+
+        index_name = f"index_{model_suffix}"
         if int(index.d) != self.dimension:
             raise ValueError(
                 f"FAISS dimension mismatch at {faiss_relative}: "

--- a/codenib/index/sparse_idx/bm25_index.py
+++ b/codenib/index/sparse_idx/bm25_index.py
@@ -9,7 +9,7 @@ import os
 import re
 import stat
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional
 
 from rank_bm25 import BM25Okapi
 
@@ -21,11 +21,20 @@ from ...utils import is_test_file, wrap_code_snippet
 
 if TYPE_CHECKING:
     from ...graph.code_graph import CodeGraph
+    from ...source_fingerprint import RepositorySourceBinding
 
 logger = get_logger(__name__)
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _MAX_RUNTIME_SOURCE_BYTES = 64 * 1024 * 1024
+SOURCE_MODE_LEGACY_DIRECT = "legacy-direct"
+SOURCE_MODE_BOUND_REPOSITORY = "bound-repository"
+SOURCE_MODE_PERSISTED_ONLY = "persisted-only"
+_SOURCE_MODES = {
+    SOURCE_MODE_LEGACY_DIRECT,
+    SOURCE_MODE_BOUND_REPOSITORY,
+    SOURCE_MODE_PERSISTED_ONLY,
+}
 _SECURE_SOURCE_DIRECTORY_FDS = (
     os.name == "posix"
     and hasattr(os, "O_DIRECTORY")
@@ -427,6 +436,8 @@ class BM25CodeIndexer:
         self.retriever = None
         self.code_graph: CodeGraph = None
         self.project_root = project_root
+        self.source_mode = SOURCE_MODE_LEGACY_DIRECT
+        self._source_binding: RepositorySourceBinding | None = None
         self.nodes: List[str] = []
 
         # Build the index immediately if a code_graph is provided
@@ -447,6 +458,8 @@ class BM25CodeIndexer:
         self.nodes = []
         self.code_graph = code_graph
         self.project_root = code_graph.project_root
+        self.source_mode = SOURCE_MODE_LEGACY_DIRECT
+        self._source_binding = None
 
         # Convert graph nodes to documents
         for vertex in code_graph.graph.vs:
@@ -483,6 +496,8 @@ class BM25CodeIndexer:
         self.nodes = []
         self.code_graph = None
         self.project_root = project_root
+        self.source_mode = SOURCE_MODE_LEGACY_DIRECT
+        self._source_binding = None
 
         # Keep each bounded source span independently searchable. Overloads and
         # split large definitions can share a node_id, but merging them widens
@@ -715,6 +730,33 @@ class BM25CodeIndexer:
         wrap_with_ln: bool = True,
         filter_test: bool = False,
     ) -> List[NodeInfo]:
+        if self.source_mode == SOURCE_MODE_BOUND_REPOSITORY:
+            if self._source_binding is None:  # pragma: no cover - invariant
+                raise RuntimeError("BM25 bound source mode has no source authority")
+            with self._source_binding.read_session():
+                return self._search(
+                    query,
+                    top_k=top_k,
+                    return_code_content=return_code_content,
+                    wrap_with_ln=wrap_with_ln,
+                    filter_test=filter_test,
+                )
+        return self._search(
+            query,
+            top_k=top_k,
+            return_code_content=return_code_content,
+            wrap_with_ln=wrap_with_ln,
+            filter_test=filter_test,
+        )
+
+    def _search(
+        self,
+        query: str,
+        top_k: Optional[int] = None,
+        return_code_content: bool = False,
+        wrap_with_ln: bool = True,
+        filter_test: bool = False,
+    ) -> List[NodeInfo]:
         """
         Search the index for nodes matching the query.
 
@@ -747,6 +789,7 @@ class BM25CodeIndexer:
 
         # Convert results to NodeInfo objects and apply filtering
         processed_results = []
+        source_cache: dict[str, Optional[str]] = {}
         for doc in results:
             # Extract all metadata directly from the document
             metadata = doc.metadata
@@ -765,7 +808,18 @@ class BM25CodeIndexer:
             # Handle code content if requested
             content = None
             if return_code_content and file_path:
-                source_text = _read_source_text(self.project_root, file_path)
+                source_text = None
+                if self.source_mode != SOURCE_MODE_PERSISTED_ONLY:
+                    try:
+                        source_key = os.fspath(file_path)
+                    except TypeError:
+                        source_key = None
+                    if isinstance(source_key, str):
+                        if source_key not in source_cache:
+                            source_cache[source_key] = self._read_result_source(
+                                source_key
+                            )
+                        source_text = source_cache[source_key]
                 if source_text is not None:
                     if node_type == NODE_TYPE_FILE:
                         # For file nodes, return entire file content.
@@ -823,6 +877,34 @@ class BM25CodeIndexer:
         return processed_results
 
     def search_identifier_occurrences(
+        self,
+        identifier: str,
+        *,
+        context_query: Optional[str] = None,
+        top_k: int = 20,
+        wrap_with_ln: bool = True,
+        filter_test: bool = False,
+    ) -> List[NodeInfo]:
+        if self.source_mode == SOURCE_MODE_BOUND_REPOSITORY:
+            if self._source_binding is None:  # pragma: no cover - invariant
+                raise RuntimeError("BM25 bound source mode has no source authority")
+            with self._source_binding.read_session():
+                return self._search_identifier_occurrences(
+                    identifier,
+                    context_query=context_query,
+                    top_k=top_k,
+                    wrap_with_ln=wrap_with_ln,
+                    filter_test=filter_test,
+                )
+        return self._search_identifier_occurrences(
+            identifier,
+            context_query=context_query,
+            top_k=top_k,
+            wrap_with_ln=wrap_with_ln,
+            filter_test=filter_test,
+        )
+
+    def _search_identifier_occurrences(
         self,
         identifier: str,
         *,
@@ -891,18 +973,23 @@ class BM25CodeIndexer:
                 continue
             if not isinstance(source_key, str):
                 continue
-            if source_key not in files:
-                source_text = _read_source_text(self.project_root, source_key)
-                files[source_key] = (
-                    _split_source_lines(source_text) if source_text is not None else []
-                )
-            lines = files[source_key]
-            if not lines:
-                continue
-
-            start_idx = max(0, start_line)
-            end_idx = min(len(lines), end_line + 1)
-            selected = lines[start_idx:end_idx]
+            if self.source_mode == SOURCE_MODE_PERSISTED_ONLY:
+                selected = _split_source_lines(doc.page_content)
+                start_idx = max(0, start_line)
+            else:
+                if source_key not in files:
+                    source_text = self._read_result_source(source_key)
+                    files[source_key] = (
+                        _split_source_lines(source_text)
+                        if source_text is not None
+                        else []
+                    )
+                lines = files[source_key]
+                if not lines:
+                    continue
+                start_idx = max(0, start_line)
+                end_idx = min(len(lines), end_line + 1)
+                selected = lines[start_idx:end_idx]
             code_content = "".join(selected)
             if not occurrence.search(code_content):
                 continue
@@ -941,6 +1028,40 @@ class BM25CodeIndexer:
 
         matches.sort(key=lambda item: (item[0], item[1], item[2]))
         return [node for _, _, _, node in matches[:top_k]]
+
+    def bind_repository_source(self, binding: RepositorySourceBinding) -> None:
+        """Attach a retained source authority chosen by the runtime caller."""
+
+        if binding.fingerprint is None:  # pragma: no cover - structural contract
+            raise TypeError("repository source binding is invalid")
+        binding.verify_snapshot()
+        self._source_binding = binding
+        self.project_root = str(binding.root)
+        self.source_mode = SOURCE_MODE_BOUND_REPOSITORY
+
+    def _read_result_source(self, file_path: object) -> Optional[str]:
+        if self.source_mode == SOURCE_MODE_BOUND_REPOSITORY:
+            if self._source_binding is None:  # pragma: no cover - invariant
+                raise RuntimeError("BM25 bound source mode has no source authority")
+            try:
+                relative = os.fspath(file_path)
+            except TypeError:
+                return None
+            if not isinstance(relative, str):
+                return None
+            try:
+                payload = self._source_binding.read_bytes(
+                    relative,
+                    max_bytes=_MAX_RUNTIME_SOURCE_BYTES,
+                )
+            except ValueError:
+                return None
+            return (
+                payload.decode("utf-8", errors="replace")
+                .replace("\r\n", "\n")
+                .replace("\r", "\n")
+            )
+        return _read_source_text(self.project_root, file_path)
 
     def save_index(self, directory_path: str):
         """
@@ -998,13 +1119,70 @@ class BM25CodeIndexer:
         with open(documents_file, "r", encoding="utf-8") as f:
             documents_data = json.load(f)
 
-        # Reconstruct Document objects
+        metadata_file = os.path.join(directory_path, "bm25_metadata.json")
+        if os.path.exists(metadata_file):
+            with open(metadata_file, "r", encoding="utf-8") as f:
+                metadata = json.load(f)
+        else:
+            metadata = {
+                "project_root": None,
+                "max_k": self.max_k,
+                "language": self.language,
+            }
+        self.load_index_values(documents_data, metadata)
+
+    def load_index_values(
+        self,
+        documents_data: Iterable[object],
+        metadata: Mapping[str, Any] | None,
+        *,
+        source_mode: str = SOURCE_MODE_LEGACY_DIRECT,
+    ) -> None:
+        """Load already-decoded BM25 values from an authenticated reader.
+
+        Artifact runtimes use this entry point so persisted bytes can be read
+        through a pinned directory authority instead of being reopened by path.
+        """
+
+        if metadata is not None and not isinstance(metadata, Mapping):
+            raise ValueError("BM25 metadata must be an object")
+        metadata = {} if metadata is None else metadata
+        max_k = metadata.get("max_k", 10)
+        language = metadata.get("language", "english")
+        project_root = metadata.get("project_root")
+        if isinstance(max_k, bool) or not isinstance(max_k, int) or max_k <= 0:
+            raise ValueError("BM25 max_k must be a positive integer")
+        if not isinstance(language, str) or not language:
+            raise ValueError("BM25 language must be a non-empty string")
+        if project_root is not None and not isinstance(project_root, str):
+            raise ValueError("BM25 project_root must be a string or null")
+        if source_mode not in _SOURCE_MODES:
+            raise ValueError(f"unsupported BM25 source mode: {source_mode!r}")
+
+        # Restore serving configuration before creating the retriever.  Its k
+        # value is fixed at construction time.
+        self.project_root = project_root
+        self.source_mode = source_mode
+        self._source_binding = None
+        self.max_k = max_k
+        self.language = language
+
+        # Reconstruct Document objects one decoded element at a time.
         self.documents = []
         self.nodes = []
         seen_nodes = set()
         for doc_data in documents_data:
+            if not isinstance(doc_data, Mapping):
+                raise ValueError("BM25 document must be an object")
+            page_content = doc_data.get("page_content")
+            document_metadata = doc_data.get("metadata")
+            if not isinstance(page_content, str) or not isinstance(
+                document_metadata, Mapping
+            ):
+                raise ValueError("BM25 document content or metadata is invalid")
             doc = Document(
-                page_content=doc_data["page_content"], metadata=doc_data["metadata"]
+                page_content=page_content,
+                metadata=dict(document_metadata),
             )
             self.documents.append(doc)
             node_name = doc.metadata.get("node_id") or doc.metadata.get("name")
@@ -1012,19 +1190,4 @@ class BM25CodeIndexer:
                 self.nodes.append(node_name)
                 seen_nodes.add(node_name)
 
-        # Load additional metadata including project_root
-        metadata_file = os.path.join(directory_path, "bm25_metadata.json")
-        if os.path.exists(metadata_file):
-            with open(metadata_file, "r", encoding="utf-8") as f:
-                metadata = json.load(f)
-                self.project_root = metadata.get("project_root")
-                self.max_k = metadata.get("max_k", 10)
-                self.language = metadata.get("language", "english")
-        else:
-            # For backward compatibility with indices saved without metadata
-            self.project_root = None
-
-        # Recreate only after restoring ``max_k``. Reversing this order silently
-        # capped loaded artifacts at the constructor default (15), even when
-        # the persisted compiler contract requested 128 candidates.
         self.retriever = BM25Retriever.from_documents(self.documents, k=self.max_k)

--- a/codenib/index/sparse_idx/bm25_index.py
+++ b/codenib/index/sparse_idx/bm25_index.py
@@ -1032,11 +1032,9 @@ class BM25CodeIndexer:
     def bind_repository_source(self, binding: RepositorySourceBinding) -> None:
         """Attach a retained source authority chosen by the runtime caller."""
 
-        if binding.fingerprint is None:  # pragma: no cover - structural contract
-            raise TypeError("repository source binding is invalid")
-        binding.verify_snapshot()
+        source_identity = binding.authenticated_identity_snapshot()
         self._source_binding = binding
-        self.project_root = str(binding.root)
+        self.project_root = str(source_identity.root)
         self.source_mode = SOURCE_MODE_BOUND_REPOSITORY
 
     def _read_result_source(self, file_path: object) -> Optional[str]:

--- a/codenib/index/trigram/zoekt_searcher.py
+++ b/codenib/index/trigram/zoekt_searcher.py
@@ -33,6 +33,7 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from ..._atomic_directory import _annotate_secondary_error
 from ...types import NodeInfo
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,33 @@ DEFAULT_SEARCH_TIMEOUT = 10.0  # per-request HTTP timeout
 
 class ZoektUnavailableError(RuntimeError):
     """Raised when the Zoekt binary or shard directory is unavailable."""
+
+
+class _ZoektProcessOwner:
+    """Preinstalled owner spanning Popen construction and caller handoff."""
+
+    __slots__ = ("process",)
+
+    def __init__(self) -> None:
+        self.process: Optional[subprocess.Popen[bytes]] = None
+
+    def retain(self, process: subprocess.Popen[bytes]) -> None:
+        if self.process is not None and self.process is not process:
+            raise RuntimeError("zoekt process ownership changed")
+        self.process = process
+
+    def release(self, process: subprocess.Popen[bytes]) -> None:
+        if self.process is not process:
+            raise RuntimeError("zoekt process ownership changed")
+        self.process = None
+
+
+class _OwnedZoektProcess(subprocess.Popen):
+    """Register the Python process object before native process creation."""
+
+    def __init__(self, owner: _ZoektProcessOwner, *args, **kwargs) -> None:
+        owner.retain(self)
+        super().__init__(*args, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -141,34 +169,116 @@ class ZoektSearcher:
             self.index_dir,
         ]
         logger.info("Starting zoekt-webserver: %s", " ".join(cmd))
-        self._proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-        )
+        owner = _ZoektProcessOwner()
+        try:
+            # The owner is installed into the Popen subclass before its native
+            # constructor runs. An interruption at the CALL-return/POP_TOP
+            # bytecode boundary therefore cannot orphan the spawned child.
+            _OwnedZoektProcess(
+                owner,
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+            if owner.process is None:
+                raise RuntimeError("zoekt process constructor lost ownership")
+            self._proc = owner.process
+            owner.release(self._proc)
 
-        if not self._cleanup_registered:
-            atexit.register(self.stop)
-            self._cleanup_registered = True
+            if not self._cleanup_registered:
+                atexit.register(self.stop)
+                self._cleanup_registered = True
 
-        self._wait_until_ready()
+            self._wait_until_ready()
+        except BaseException as primary:  # noqa: B036 - retain spawned child
+            if owner.process is not None and self._proc is None:
+                self._proc = owner.process
+            if self._proc is not None:
+                try:
+                    self.stop()
+                except BaseException as cleanup_error:  # noqa: B036
+                    _annotate_secondary_error(
+                        primary,
+                        "zoekt startup cleanup also failed",
+                        cleanup_error,
+                    )
+                    preferred = (
+                        cleanup_error
+                        if isinstance(primary, Exception)
+                        and not isinstance(cleanup_error, Exception)
+                        else primary
+                    )
+                    if self._proc is not None:
+                        try:
+                            preferred.zoekt_cleanup_owner = self  # type: ignore[attr-defined]
+                        except BaseException:  # noqa: B036 - traceback owns self
+                            pass
+                    if preferred is cleanup_error:
+                        raise cleanup_error from primary
+                    raise primary from cleanup_error
+            raise
 
     def stop(self) -> None:
         """Terminate the webserver subprocess if it is still running."""
         proc = self._proc
         if proc is None:
             return
-        if proc.poll() is None:
+        failure: BaseException | None = None
+
+        def retain_failure(exc: BaseException) -> None:
+            nonlocal failure
+            if failure is None:
+                failure = exc
+            else:
+                _annotate_secondary_error(
+                    failure,
+                    "additional zoekt-webserver cleanup failed",
+                    exc,
+                )
+
+        exited = False
+        try:
+            exited = proc.poll() is not None
+        except BaseException as exc:  # noqa: B036 - owner remains pending
+            retain_failure(exc)
+        if not exited:
             try:
                 proc.terminate()
+            except BaseException as exc:  # noqa: B036 - still try kill
+                retain_failure(exc)
+            try:
+                proc.wait(timeout=5)
+                exited = True
+            except subprocess.TimeoutExpired:
+                pass
+            except BaseException as exc:  # noqa: B036 - still try kill
+                retain_failure(exc)
+            if not exited:
+                try:
+                    proc.kill()
+                except BaseException as exc:  # noqa: B036 - retain child
+                    retain_failure(exc)
                 try:
                     proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait(timeout=5)
-            except Exception as exc:
-                logger.warning("Error stopping zoekt-webserver: %s", exc)
-        self._proc = None
+                    exited = True
+                except BaseException as exc:  # noqa: B036 - retain child
+                    retain_failure(exc)
+        if not exited:
+            try:
+                exited = proc.poll() is not None
+            except BaseException as exc:  # noqa: B036 - retain child
+                retain_failure(exc)
+        if exited:
+            self._proc = None
+        elif failure is None:
+            failure = RuntimeError("zoekt-webserver cleanup remains pending")
+        if failure is not None:
+            if self._proc is not None:
+                try:
+                    failure.zoekt_cleanup_owner = self  # type: ignore[attr-defined]
+                except BaseException:  # noqa: B036 - traceback owns self
+                    pass
+            raise failure
 
     def _wait_until_ready(self) -> None:
         """Poll until the webserver returns any HTTP response or we time out."""

--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -93,7 +93,7 @@ discovery.
 | `lsp_definition` | runtime LSP provider or `symbol_graph` | location | static graph analogue of go-to-definition |
 | `lsp_references` | runtime LSP provider or `symbol_graph` | locations | static graph analogue of find-references |
 | `lsp_route` | runtime LSP provider or `symbol_graph` | locations | compact route anchors for related symbols |
-| `read_source` | verified checkout | source window | bounded source inspection after retrieval/navigation |
+| `read_source` | content-authenticated source binding | source window | bounded source inspection after retrieval/navigation |
 | `get_manifest` | — | — | repo metadata: path, commit, languages, capabilities |
 
 All source locations returned by MCP use 1-based line numbers. Internal indexes
@@ -232,8 +232,10 @@ Static LSP-shaped navigation through the server's selected runtime provider.
 A source-verified local C/C++-only checkout can reuse an existing project-local
 clangd index for symbol definition and reference queries without generating a
 new index. Position and route calls lazily load the compatible complete graph
-once. Portable artifacts, mixed-language repositories, unverified checkouts,
-and disabled or unavailable native support use the persisted `symbol_graph`.
+once. Portable artifacts expose only their supported portable views and never
+attach a project-local native provider. Mixed-language repositories, unverified
+checkouts, and disabled or unavailable native support use the persisted
+`symbol_graph` when that view is eligible and loaded.
 Result rows expose provider backend, fallback, capability, and snapshot metadata
 when available; `get_manifest.runtime.lsp_provider` exposes the selection before
 the first result. These tools return compact locations only; clients should read
@@ -256,8 +258,9 @@ entry budget before normalization.
   matches and 512 expanded candidates, and stops after 100 milliseconds.
 
 ### `read_source`
-Reads source only when server startup verified the checkout against the direct
-manifest or a rebound portable artifact.
+Reads source only while a retained repository authority authenticates the live
+bytes against the v2 content fingerprint and per-file records from a direct
+manifest or rebound portable artifact.
 
 - `file_path` (str): canonical repository-relative POSIX path; absolute paths,
   traversal, symlinks, and special files are rejected.
@@ -268,8 +271,10 @@ manifest or a rebound portable artifact.
 The response includes at most 16,000 content characters plus the indexed
 commit/source fingerprint. `content_projection` reports whether the requested
 window was shortened and, when truncation ended on a complete line, the next
-`start_line`. Source identity is checked at startup under the server's
-quiescent-checkout assumption; restart or rebind after modifying the checkout.
+`start_line`. Each read session revalidates the retained whole-tree authority
+and exact file record. The commit is display provenance only: mutable Git HEAD
+is not attested by this content binding. Any source drift permanently disables
+the binding until the server is restarted or rebound.
 
 ### `get_manifest`
 Returns the manifest version; a nested `repo` object containing path, commit,

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import logging
 import math
+import sys
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -127,17 +128,99 @@ class _DimensionProbeEmbedding:
 
 
 def _close_vector(vector: CodeVectorStore) -> None:
+    vector.close()
+
+
+def _close_vector_after_failure(
+    vector: CodeVectorStore,
+    primary: BaseException,
+) -> None:
+    """Release an unpublished vector without replacing its load failure."""
+
     try:
         vector.close()
-    except Exception as exc:
-        logger.warning("Failed to release vector resources: %s", exc)
+    except BaseException as cleanup_error:  # noqa: B036 - preserve primary
+        try:
+            primary.add_note(f"vector cleanup also failed: {cleanup_error!r}")
+        except (AttributeError, TypeError):  # pragma: no cover - Python < 3.11
+            pass
+        actual = (
+            cleanup_error
+            if isinstance(primary, Exception)
+            and not isinstance(cleanup_error, Exception)
+            else primary
+        )
+        try:
+            actual.vector_cleanup_owner = vector  # type: ignore[attr-defined]
+        except BaseException:  # noqa: B036 - traceback still retains local owner
+            pass
+        if actual is cleanup_error:
+            raise cleanup_error from primary
+        raise primary from cleanup_error
 
 
 def _stop_zoekt(searcher: ZoektSearcher) -> None:
+    searcher.stop()
+
+
+def _stop_zoekt_after_failure(
+    context: ServerContext,
+    searcher: ZoektSearcher,
+    primary: BaseException,
+) -> None:
+    """Release an unpublished searcher or expose one retryable context owner."""
+
+    # Publish the cleanup owner before stop: an interruption during stop must
+    # remain reachable after this loader's local frame disappears.
+    context.zoekt = searcher
     try:
-        searcher.stop()
-    except Exception as exc:
-        logger.warning("Failed to stop Zoekt runtime: %s", exc)
+        _stop_zoekt(searcher)
+    except BaseException as cleanup_error:  # noqa: B036 - preserve priority
+        actual = _retain_context_cleanup_failure(
+            primary,
+            "Zoekt cleanup also failed",
+            cleanup_error,
+        )
+        _attach_context_cleanup_owner(actual, context)
+        if actual is cleanup_error:
+            raise cleanup_error from primary
+        raise primary from cleanup_error
+    context.zoekt = None
+
+
+def _retain_context_cleanup_failure(
+    deferred: BaseException | None,
+    label: str,
+    failure: BaseException,
+) -> BaseException:
+    if deferred is None:
+        return failure
+    if isinstance(deferred, Exception) and not isinstance(failure, Exception):
+        _annotate_context_cleanup_failure(failure, label, deferred)
+        return failure
+    _annotate_context_cleanup_failure(deferred, label, failure)
+    return deferred
+
+
+def _annotate_context_cleanup_failure(
+    primary: BaseException,
+    label: str,
+    secondary: BaseException,
+) -> None:
+    try:
+        primary.add_note(f"{label}: {secondary!r}")
+    except (AttributeError, TypeError):  # pragma: no cover - Python < 3.11
+        pass
+
+
+def _attach_context_cleanup_owner(
+    failure: BaseException,
+    context: ServerContext,
+) -> None:
+    try:
+        failure.context_cleanup_owner = context  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - traceback still retains local owner
+        pass
 
 
 def _resolve_views(views: Iterable[str] | None) -> frozenset[str]:
@@ -264,7 +347,7 @@ class ServerContext:
         if self._source_binding is None:
             return False
         try:
-            self._source_binding.verify_snapshot()
+            self._source_binding.authenticated_identity_snapshot()
         except Exception as exc:
             self.source_error = self._source_binding.failure_reason or str(exc)
             return False
@@ -344,17 +427,18 @@ class ServerContext:
                     lexical_repository_path,
                 )
 
+                source_identity = owned_source.authenticated_identity_snapshot()
                 if (
                     not owned_source.usable
                     or not is_secure_source_fingerprint_v2(manifest.source_fingerprint)
-                    or owned_source.fingerprint != manifest.source_fingerprint
-                    or owned_source.file_count != manifest.file_count
-                    or owned_source.root != lexical_repository_path(manifest.repo_path)
+                    or source_identity.fingerprint != manifest.source_fingerprint
+                    or source_identity.file_count != manifest.file_count
+                    or source_identity.root
+                    != lexical_repository_path(manifest.repo_path)
                 ):
                     raise ValueError(
                         "repository source authority does not match the manifest"
                     )
-                owned_source.verify_snapshot()
 
             ctx.source_error = (
                 None
@@ -395,17 +479,34 @@ class ServerContext:
                 _source_cleanup_owner_is_pending,
             )
 
+            runtime_cleanup_failure: BaseException | None = None
+            if ctx is not None:
+                try:
+                    ctx.close()
+                except BaseException as exc:  # noqa: B036 - retain source priority
+                    _attach_context_cleanup_owner(exc, ctx)
+                    _attach_context_cleanup_owner(primary, ctx)
+                    runtime_cleanup_failure = exc
             cleanup_source = (
                 ctx._source_binding
                 if ctx is not None and ctx._source_binding is not None
-                else source_binding if artifact_binding is None else None
+                else (
+                    source_binding
+                    if artifact_binding is None
+                    and _source_cleanup_owner_is_pending(source_binding)
+                    else None
+                )
             )
-            cleanup_failure: BaseException | None = None
+            cleanup_failure = runtime_cleanup_failure
             if cleanup_source is not None:
                 try:
                     cleanup_source.close()
                 except BaseException as exc:  # noqa: B036 - apply shared priority
-                    cleanup_failure = exc
+                    cleanup_failure = _retain_context_cleanup_failure(
+                        cleanup_failure,
+                        "source cleanup retry also failed",
+                        exc,
+                    )
             pending_owner = (
                 cleanup_source
                 if _source_cleanup_owner_is_pending(cleanup_source)
@@ -483,18 +584,49 @@ class ServerContext:
         """Release runtime resources owned by this context."""
 
         with self._view_lock:
-            self.end_explore_session()
+            deferred: BaseException | None = None
+            try:
+                self.end_explore_session()
+            except BaseException as exc:  # noqa: B036 - visit every runtime owner
+                deferred = exc
             self.lsp_provider = None
             if self.zoekt is not None:
-                _stop_zoekt(self.zoekt)
-                self.zoekt = None
+                try:
+                    _stop_zoekt(self.zoekt)
+                except BaseException as exc:  # noqa: B036 - continue cleanup
+                    deferred = _retain_context_cleanup_failure(
+                        deferred,
+                        "Zoekt cleanup also failed",
+                        exc,
+                    )
+                else:
+                    self.zoekt = None
             if self.vector is not None:
-                _close_vector(self.vector)
-                self.vector = None
+                try:
+                    _close_vector(self.vector)
+                except BaseException as exc:  # noqa: B036 - continue cleanup
+                    deferred = _retain_context_cleanup_failure(
+                        deferred,
+                        "vector cleanup also failed",
+                        exc,
+                    )
+                else:
+                    self.vector = None
             if self._source_binding is not None:
-                self._source_binding.close()
-                self._source_binding = None
-                self.source_error = "source binding is closed"
+                try:
+                    self._source_binding.close()
+                except BaseException as exc:  # noqa: B036 - preserve retry owner
+                    deferred = _retain_context_cleanup_failure(
+                        deferred,
+                        "source cleanup also failed",
+                        exc,
+                    )
+                if self._source_binding.closed:
+                    self._source_binding = None
+                    self.source_error = "source binding is closed"
+            if deferred is not None:
+                _attach_context_cleanup_owner(deferred, self)
+                raise deferred
 
     def begin_explore_session(self) -> ExploreSessionRuntime:
         """Create fresh state for one stdio connection.
@@ -542,9 +674,9 @@ class ServerContext:
             current = self.explore_runtime
             if current is None or (runtime is not None and current is not runtime):
                 return
+            current.close()
             self.explore_runtime = None
             self._explore_loop = None
-            current.close()
 
     def configure_lsp_provider(
         self,
@@ -613,12 +745,20 @@ class ServerContext:
                 if view not in available
             }
         finally:
-            if ctx.zoekt is not None:
-                _stop_zoekt(ctx.zoekt)
-                ctx.zoekt = None
-            if ctx.vector is not None:
-                _close_vector(ctx.vector)
-                ctx.vector = None
+            active_failure = sys.exc_info()[1]
+            try:
+                ctx.close()
+            except BaseException as cleanup_failure:  # noqa: B036 - keep priority
+                if active_failure is None:
+                    raise
+                preferred = _retain_context_cleanup_failure(
+                    active_failure,
+                    "view validation cleanup also failed",
+                    cleanup_failure,
+                )
+                _attach_context_cleanup_owner(preferred, ctx)
+                if preferred is cleanup_failure:
+                    raise cleanup_failure from active_failure
 
     # ------------------------------------------------------------------
     # Private loaders
@@ -731,22 +871,26 @@ class ServerContext:
         try:
             searcher = ZoektSearcher(index_dir=entry.path)
             searcher.start()
-            self.zoekt = searcher
             logger.info(
                 "Started zoekt-webserver  shards=%s  port=%d",
                 entry.path,
                 searcher.port,
             )
+            self.zoekt = searcher
         except ZoektUnavailableError as exc:
             if searcher is not None:
-                _stop_zoekt(searcher)
+                _stop_zoekt_after_failure(self, searcher, exc)
             self.errors["zoekt"] = str(exc)
             logger.warning("Zoekt unavailable: %s", exc)
         except Exception as exc:
             if searcher is not None:
-                _stop_zoekt(searcher)
+                _stop_zoekt_after_failure(self, searcher, exc)
             self.errors["zoekt"] = str(exc)
             logger.warning("Failed to start zoekt-webserver: %s", exc)
+        except BaseException as exc:  # noqa: B036 - cleanup then propagate
+            if searcher is not None:
+                _stop_zoekt_after_failure(self, searcher, exc)
+            raise
 
     def _load_vector(self, *, probe: bool = False) -> None:
         """Load vector embedding index if available."""
@@ -819,9 +963,11 @@ class ServerContext:
                 stats["total_documents"],
                 route.model,
             )
-        except Exception as exc:
+        except BaseException as exc:  # noqa: B036 - release unpublished native state
             if vector is not None:
-                _close_vector(vector)
+                _close_vector_after_failure(vector, exc)
             self.vector = None
+            if not isinstance(exc, Exception):
+                raise
             self.errors["vector"] = str(exc)
             logger.warning("Failed to load vector index: %s", exc)

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -13,23 +13,33 @@ call time rather than blocking server startup.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import math
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import RLock
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
 
+from .._atomic_directory import (
+    PublicationDirectoryReader,
+    reopen_authenticated_directory,
+)
+from .._bounded_json import iter_bounded_json_array
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
 from ..provider_routes import resolve_embedding_artifact_route
 
 if TYPE_CHECKING:
+    from ..artifacts.runtime import ContextArtifactBinding
     from ..graph.code_graph import CodeGraph
     from ..index.embedding.vector_store import CodeVectorStore
     from ..index.regex_idx import RegexNodeIndex
     from ..index.sparse_idx import BM25CodeIndexer
     from ..index.trigram import ZoektSearcher
+    from ..native_index_authorization import NativeIndexAuthorization
+    from ..source_fingerprint import RepositorySourceBinding
     from .explore_session import ExploreSessionRuntime
 
 logger = logging.getLogger(__name__)
@@ -42,6 +52,9 @@ _VIEW_LOADERS = (
     ("vector", "_load_vector"),
 )
 RUNTIME_VIEW_NAMES = frozenset(name for name, _ in _VIEW_LOADERS)
+_PORTABLE_ARTIFACT_RUNTIME_VIEWS = frozenset({"bm25", "vector"})
+_MAX_ARTIFACT_METADATA_BYTES = 16 * 1024 * 1024
+_MAX_ARTIFACT_DOCUMENTS_BYTES = 256 * 1024 * 1024
 _VIEW_DEPENDENCIES = {
     "regex_index": frozenset({"symbol_graph"}),
 }
@@ -54,6 +67,49 @@ def _running_event_loop() -> asyncio.AbstractEventLoop | None:
         return asyncio.get_running_loop()
     except RuntimeError:
         return None
+
+
+def _reject_duplicate_json_object(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate artifact BM25 JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _bounded_json_int(value: str) -> int:
+    if len(value) > 1_024:
+        raise ValueError("artifact BM25 JSON integer is too large")
+    return int(value)
+
+
+def _bounded_json_float(value: str) -> float:
+    if len(value) > 1_024:
+        raise ValueError("artifact BM25 JSON number is too large")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError("artifact BM25 JSON number is not finite")
+    return result
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"artifact BM25 JSON constant is not finite: {value}")
+
+
+def _load_artifact_bm25_metadata(payload: bytes) -> Mapping[str, Any]:
+    value = json.loads(
+        payload,
+        object_pairs_hook=_reject_duplicate_json_object,
+        parse_int=_bounded_json_int,
+        parse_float=_bounded_json_float,
+        parse_constant=_reject_json_constant,
+    )
+    if not isinstance(value, dict):
+        raise ValueError("artifact BM25 metadata must be a JSON object")
+    return value
 
 
 class _DimensionProbeEmbedding:
@@ -137,7 +193,6 @@ class ServerContext:
     lsp_provider_selection: Dict[str, Any] = field(default_factory=dict)
     errors: Dict[str, str] = field(default_factory=dict)
     artifact: Optional[Mapping[str, Any]] = None
-    source_verified: bool = False
     source_error: Optional[str] = "source binding has not been verified"
     explore_runtime: Optional[ExploreSessionRuntime] = field(
         default=None, init=False, repr=False
@@ -150,6 +205,70 @@ class ServerContext:
         default="local_source_not_verified", init=False, repr=False
     )
     _view_lock: RLock = field(default_factory=RLock, init=False, repr=False)
+    _native_index_authorization: Optional[NativeIndexAuthorization] = field(
+        default=None,
+        repr=False,
+    )
+    _artifact_binding: Optional[ContextArtifactBinding] = field(
+        default=None,
+        repr=False,
+    )
+    _source_binding: Optional[RepositorySourceBinding] = field(
+        default=None,
+        repr=False,
+    )
+
+    @property
+    def source_verified(self) -> bool:
+        """Return whether live reads retain exact content-byte authority."""
+
+        return self._source_binding is not None and self._source_binding.usable
+
+    @property
+    def source_verification_scope(self) -> str | None:
+        """M1 authenticates v2 content bytes, never mutable Git HEAD state."""
+
+        return "content-bytes" if self.source_verified else None
+
+    @property
+    def commit_verified(self) -> bool:
+        """Mutable checkout commit provenance requires an M2 source snapshot."""
+
+        return False
+
+    def _install_repository_source(
+        self,
+        source: RepositorySourceBinding | None,
+    ) -> None:
+        """Publish a transferred source in this already-reachable owner."""
+
+        self._source_binding = source
+
+    def read_source_bytes(self, relative: str, *, max_bytes: int) -> bytes:
+        """Read one repository file through the retained source authority."""
+
+        if self._source_binding is None:
+            raise RuntimeError(
+                f"source reads are unavailable: {self.source_error or 'unverified'}"
+            )
+        try:
+            return self._source_binding.read_bytes(relative, max_bytes=max_bytes)
+        except Exception as exc:
+            self.source_error = str(exc)
+            raise
+
+    def verify_source_status(self) -> bool:
+        """Refresh whole-tree source truth before publishing verified status."""
+
+        if self._source_binding is None:
+            return False
+        try:
+            self._source_binding.verify_snapshot()
+        except Exception as exc:
+            self.source_error = self._source_binding.failure_reason or str(exc)
+            return False
+        self.source_error = None
+        return True
 
     @classmethod
     def load(
@@ -158,6 +277,9 @@ class ServerContext:
         *,
         views: Iterable[str] | None = None,
         artifact: Mapping[str, Any] | None = None,
+        artifact_binding: ContextArtifactBinding | None = None,
+        native_index_authorization: NativeIndexAuthorization | None = None,
+        source_binding: RepositorySourceBinding | None = None,
     ) -> ServerContext:
         """Load a manifest and the selected runtime views.
 
@@ -166,39 +288,133 @@ class ServerContext:
         selected view is loaded independently; a failure in one does not block
         the others. Failed views are recorded in ``errors``.
         """
-        selected = _resolve_views(views)
-        manifest = (
-            manifest_path
-            if isinstance(manifest_path, RepoManifest)
-            else RepoManifest.load(manifest_path)
-        )
-        ctx = cls(manifest=manifest, artifact=dict(artifact) if artifact else None)
+        ctx: ServerContext | None = None
+        try:
+            selected = _resolve_views(views)
+            if artifact_binding is not None and native_index_authorization is not None:
+                raise ValueError(
+                    "portable artifact bindings cannot authorize native vector parsing"
+                )
+            artifact_origin = artifact is not None or artifact_binding is not None
+            if artifact_origin:
+                disallowed = selected - _PORTABLE_ARTIFACT_RUNTIME_VIEWS
+                if views is not None and disallowed:
+                    raise ValueError(
+                        "portable artifact contexts cannot load native views: "
+                        + ", ".join(sorted(disallowed))
+                    )
+                selected &= _PORTABLE_ARTIFACT_RUNTIME_VIEWS
+            if artifact_binding is not None:
+                if (
+                    not isinstance(manifest_path, RepoManifest)
+                    or manifest_path.to_dict() != artifact_binding.manifest.to_dict()
+                ):
+                    raise ValueError(
+                        "artifact runtime manifest must come from its verified binding"
+                    )
+                manifest = artifact_binding.manifest
+            else:
+                manifest = (
+                    manifest_path
+                    if isinstance(manifest_path, RepoManifest)
+                    else RepoManifest.load(manifest_path)
+                )
 
-        ctx.load_views(selected)
-        ctx.configure_lsp_provider(
-            allow_native=False,
-            native_disabled_reason=(
-                "portable_artifact_uses_persisted_graph"
-                if ctx.artifact is not None
-                else "local_source_not_verified"
-            ),
-        )
+            ctx = cls(
+                manifest=manifest,
+                artifact=dict(artifact) if artifact is not None else None,
+                _native_index_authorization=native_index_authorization,
+                _artifact_binding=artifact_binding,
+                _source_binding=None,
+            )
+            if artifact_binding is not None:
+                artifact_binding.install_source_binding(
+                    ctx._install_repository_source,
+                    expected=source_binding,
+                    require_expected=source_binding is not None,
+                )
+            else:
+                ctx._install_repository_source(source_binding)
+            owned_source = ctx._source_binding
 
-        cap_summary = {k: v for k, v in manifest.capabilities.items() if v}
-        loaded = [
-            view for view, _ in _VIEW_LOADERS if getattr(ctx, view, None) is not None
-        ]
-        logger.info(
-            "ServerContext ready  repo=%s  commit=%s  requested=%s  loaded=%s  "
-            "capabilities=%s  errors=%s",
-            manifest.repo_path,
-            manifest.commit[:8] if manifest.commit else "N/A",
-            sorted(selected),
-            loaded or "none",
-            cap_summary or "none",
-            list(ctx.errors) or "none",
-        )
-        return ctx
+            if owned_source is not None:
+                from ..source_fingerprint import (
+                    is_secure_source_fingerprint_v2,
+                    lexical_repository_path,
+                )
+
+                if (
+                    not owned_source.usable
+                    or not is_secure_source_fingerprint_v2(manifest.source_fingerprint)
+                    or owned_source.fingerprint != manifest.source_fingerprint
+                    or owned_source.file_count != manifest.file_count
+                    or owned_source.root != lexical_repository_path(manifest.repo_path)
+                ):
+                    raise ValueError(
+                        "repository source authority does not match the manifest"
+                    )
+                owned_source.verify_snapshot()
+
+            ctx.source_error = (
+                None
+                if owned_source is not None
+                else "source binding has not been verified"
+            )
+
+            ctx.load_views(selected)
+            ctx.configure_lsp_provider(
+                allow_native=False,
+                native_disabled_reason=(
+                    "portable_artifact_uses_persisted_graph"
+                    if artifact_origin
+                    else "local_source_not_verified"
+                ),
+            )
+
+            cap_summary = {k: v for k, v in manifest.capabilities.items() if v}
+            loaded = [
+                view
+                for view, _ in _VIEW_LOADERS
+                if getattr(ctx, view, None) is not None
+            ]
+            logger.info(
+                "ServerContext ready  repo=%s  commit=%s  requested=%s  loaded=%s  "
+                "capabilities=%s  errors=%s",
+                manifest.repo_path,
+                manifest.commit[:8] if manifest.commit else "N/A",
+                sorted(selected),
+                loaded or "none",
+                cap_summary or "none",
+                list(ctx.errors) or "none",
+            )
+            return ctx
+        except BaseException as primary:  # noqa: B036 - preserve primary
+            from ..artifacts.runtime import (
+                _raise_source_cleanup_failure,
+                _source_cleanup_owner_is_pending,
+            )
+
+            cleanup_source = (
+                ctx._source_binding
+                if ctx is not None and ctx._source_binding is not None
+                else source_binding if artifact_binding is None else None
+            )
+            cleanup_failure: BaseException | None = None
+            if cleanup_source is not None:
+                try:
+                    cleanup_source.close()
+                except BaseException as exc:  # noqa: B036 - apply shared priority
+                    cleanup_failure = exc
+            pending_owner = (
+                cleanup_source
+                if _source_cleanup_owner_is_pending(cleanup_source)
+                else None
+            )
+            _raise_source_cleanup_failure(
+                primary,
+                cleanup_failure,
+                pending_owner,
+            )
 
     @property
     def loaded_views(self) -> frozenset[str]:
@@ -210,7 +426,12 @@ class ServerContext:
             if getattr(self, view, None) is not None
         )
 
-    def load_views(self, views: Iterable[str]) -> Dict[str, str]:
+    def load_views(
+        self,
+        views: Iterable[str],
+        *,
+        native_index_authorization: NativeIndexAuthorization | None = None,
+    ) -> Dict[str, str]:
         """Load additional manifest views without disturbing loaded resources.
 
         View dependencies are resolved in the same way as :meth:`load`. The
@@ -221,6 +442,19 @@ class ServerContext:
 
         selected = _resolve_views(views)
         with self._view_lock:
+            if self.artifact is not None or self._artifact_binding is not None:
+                disallowed = selected - _PORTABLE_ARTIFACT_RUNTIME_VIEWS
+                if disallowed:
+                    raise ValueError(
+                        "portable artifact contexts cannot load native views: "
+                        + ", ".join(sorted(disallowed))
+                    )
+            if native_index_authorization is not None:
+                if self._artifact_binding is not None:
+                    raise ValueError(
+                        "portable artifact bindings cannot authorize native parsing"
+                    )
+                self._native_index_authorization = native_index_authorization
             for view, loader_name in _VIEW_LOADERS:
                 if view not in selected or getattr(self, view, None) is not None:
                     continue
@@ -250,6 +484,10 @@ class ServerContext:
             if self.vector is not None:
                 _close_vector(self.vector)
                 self.vector = None
+            if self._source_binding is not None:
+                self._source_binding.close()
+                self._source_binding = None
+                self.source_error = "source binding is closed"
 
     def begin_explore_session(self) -> ExploreSessionRuntime:
         """Create fresh state for one stdio connection.
@@ -330,6 +568,7 @@ class ServerContext:
         manifest: RepoManifest | str | Path,
         *,
         views: Iterable[str],
+        native_index_authorization: NativeIndexAuthorization | None = None,
     ) -> Dict[str, str]:
         """Open selected artifacts without initializing a vector query model.
 
@@ -345,7 +584,10 @@ class ServerContext:
             if isinstance(manifest, RepoManifest)
             else RepoManifest.load(manifest)
         )
-        ctx = cls(manifest=resolved_manifest)
+        ctx = cls(
+            manifest=resolved_manifest,
+            _native_index_authorization=native_index_authorization,
+        )
         available: set[str] = set()
         try:
             for view, loader_name in _VIEW_LOADERS:
@@ -396,12 +638,51 @@ class ServerContext:
             return
         try:
             from ..index.sparse_idx import BM25CodeIndexer
+            from ..index.sparse_idx.bm25_index import SOURCE_MODE_PERSISTED_ONLY
 
-            require_bm25_manifest_artifact(entry)
             indexer = BM25CodeIndexer()
-            indexer.load_index(entry.path)
-            if indexer.project_root == "source":
-                indexer.project_root = self.manifest.repo_path
+            if self._artifact_binding is None:
+                if self.artifact is not None:
+                    raise ValueError(
+                        "portable BM25 loading requires a verified artifact binding"
+                    )
+                require_bm25_manifest_artifact(entry)
+                indexer.load_index(entry.path)
+            else:
+                artifact = self._artifact_binding.artifact
+
+                def load_portable_bm25(
+                    reader: PublicationDirectoryReader,
+                ) -> None:
+                    metadata = _load_artifact_bm25_metadata(
+                        reader.read_bytes(
+                            "views/bm25/bm25_metadata.json",
+                            max_bytes=_MAX_ARTIFACT_METADATA_BYTES,
+                        )
+                    )
+                    with reader.open_authenticated_file(
+                        "views/bm25/documents.json",
+                        max_bytes=_MAX_ARTIFACT_DOCUMENTS_BYTES,
+                    ) as documents:
+                        indexer.load_index_values(
+                            iter_bounded_json_array(
+                                documents,
+                                label="portable artifact BM25 documents",
+                            ),
+                            metadata,
+                            source_mode=SOURCE_MODE_PERSISTED_ONLY,
+                        )
+
+                reopen_authenticated_directory(
+                    artifact.root,
+                    artifact.ownership,  # type: ignore[arg-type]
+                    load_portable_bm25,
+                )
+            if self._source_binding is not None:
+                indexer.bind_repository_source(self._source_binding)
+            else:
+                indexer.project_root = None
+                indexer.source_mode = SOURCE_MODE_PERSISTED_ONLY
             self.bm25 = indexer
             logger.info("Loaded BM25 index from %s", entry.path)
         except Exception as exc:
@@ -465,6 +746,13 @@ class ServerContext:
         entry = self.manifest.indexes.get("vector")
         if not entry or not self.manifest.index_is_current("vector"):
             return
+        if self._native_index_authorization is None:
+            self.errors["vector"] = (
+                "native vector parsing requires external authorization; "
+                "portable artifacts remain inert by default"
+            )
+            logger.warning("Vector view is inert without external authorization")
+            return
 
         vector = None
         try:
@@ -489,7 +777,9 @@ class ServerContext:
             )
 
             # Load FAISS index from disk
-            vector.load()
+            vector.load(
+                native_index_authorization=self._native_index_authorization,
+            )
 
             # Validate model consistency
             loaded_model = vector.embedding_model

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -29,6 +29,7 @@ from .._atomic_directory import (
 from .._bounded_json import iter_bounded_json_array
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
+from ..index.embedding.artifact_integrity import require_authorized_vector_view
 from ..provider_routes import resolve_embedding_artifact_route
 
 if TYPE_CHECKING:
@@ -291,11 +292,11 @@ class ServerContext:
         ctx: ServerContext | None = None
         try:
             selected = _resolve_views(views)
-            if artifact_binding is not None and native_index_authorization is not None:
-                raise ValueError(
-                    "portable artifact bindings cannot authorize native vector parsing"
-                )
             artifact_origin = artifact is not None or artifact_binding is not None
+            if artifact_origin and native_index_authorization is not None:
+                raise ValueError(
+                    "portable artifact contexts cannot authorize native vector parsing"
+                )
             if artifact_origin:
                 disallowed = selected - _PORTABLE_ARTIFACT_RUNTIME_VIEWS
                 if views is not None and disallowed:
@@ -442,18 +443,24 @@ class ServerContext:
 
         selected = _resolve_views(views)
         with self._view_lock:
-            if self.artifact is not None or self._artifact_binding is not None:
+            artifact_origin = (
+                self.artifact is not None or self._artifact_binding is not None
+            )
+            if artifact_origin:
                 disallowed = selected - _PORTABLE_ARTIFACT_RUNTIME_VIEWS
                 if disallowed:
                     raise ValueError(
                         "portable artifact contexts cannot load native views: "
                         + ", ".join(sorted(disallowed))
                     )
-            if native_index_authorization is not None:
-                if self._artifact_binding is not None:
+                if (
+                    native_index_authorization is not None
+                    or self._native_index_authorization is not None
+                ):
                     raise ValueError(
-                        "portable artifact bindings cannot authorize native parsing"
+                        "portable artifact contexts cannot authorize native parsing"
                     )
+            if native_index_authorization is not None:
                 self._native_index_authorization = native_index_authorization
             for view, loader_name in _VIEW_LOADERS:
                 if view not in selected or getattr(self, view, None) is not None:
@@ -746,6 +753,13 @@ class ServerContext:
         entry = self.manifest.indexes.get("vector")
         if not entry or not self.manifest.index_is_current("vector"):
             return
+        if self.artifact is not None or self._artifact_binding is not None:
+            self.errors["vector"] = (
+                "portable artifact contexts cannot use external authorization "
+                "for native vector parsing"
+            )
+            logger.warning("Portable vector view remains native-parser inert")
+            return
         if self._native_index_authorization is None:
             self.errors["vector"] = (
                 "native vector parsing requires external authorization; "
@@ -759,6 +773,11 @@ class ServerContext:
             from ..index.embedding.vector_store import CodeVectorStore
 
             cfg = entry.config
+            require_authorized_vector_view(
+                entry.path,
+                self._native_index_authorization,
+                cfg,
+            )
             route = resolve_embedding_artifact_route(cfg)
             kwargs = route.embedding_backend_kwargs()
             if probe:

--- a/codenib/mcp/prompts.py
+++ b/codenib/mcp/prompts.py
@@ -45,7 +45,8 @@ response. Use the lower-level tools when you need to force one operation.
 Search responses keep every ranked location but may project large source bodies
 under a shared content budget. A truncated hit includes ``content_projection``
 metadata; use ``read_source`` with its file and 1-based line range to inspect
-the exact checkout before finalizing an answer.
+content authenticated against the indexed v2 source fingerprint before
+finalizing an answer. The displayed commit is not a mutable-HEAD attestation.
 
 ## When to use each tool
 
@@ -106,9 +107,11 @@ Examples:
 ### read_source
 Use after search or static navigation identifies a source location. It accepts
 only a repository-relative POSIX path and at most 200 lines per call. The
-server enables reads only when the checkout matched the manifest or a verified
-portable-artifact binding at startup, and each response carries that commit and
-source fingerprint.
+server enables reads only while a retained source authority matches the v2
+content fingerprint and per-file records from a manifest or portable-artifact
+binding. Each response carries the indexed commit as display provenance and the
+content fingerprint used by that authority; it does not claim that mutable Git
+HEAD is attested.
 
 ### Choosing between them
 | Scenario | Tool |

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -808,9 +808,19 @@ def init_server(
                 if artifact_binding is not None
                 else source_binding
             )
-            verified = retained_source is not None and is_secure_source_fingerprint_v2(
+            verified = False
+            if retained_source is not None and is_secure_source_fingerprint_v2(
                 manifest.source_fingerprint
-            )
+            ):
+                retained_identity = retained_source.authenticated_identity_snapshot()
+                if (
+                    retained_identity.fingerprint != manifest.source_fingerprint
+                    or retained_identity.file_count != manifest.file_count
+                ):
+                    raise ValueError(
+                        "repository source bytes do not match the indexed content"
+                    )
+                verified = True
             native_authorization = None
             if verified:
                 source_error = None
@@ -830,9 +840,12 @@ def init_server(
                             exclude_roots=(resolved_manifest_path.parent,),
                             _source_owner=capture_cleanup_owner.retain,
                         )
+                        retained_identity = (
+                            retained_source.authenticated_identity_snapshot()
+                        )
                         if (
-                            retained_source.fingerprint != manifest.source_fingerprint
-                            or retained_source.file_count != manifest.file_count
+                            retained_identity.fingerprint != manifest.source_fingerprint
+                            or retained_identity.file_count != manifest.file_count
                         ):
                             raise ValueError(
                                 "repository source bytes do not match the indexed "

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -23,9 +23,9 @@ import asyncio
 import logging
 import sys
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, nullcontext
 from pathlib import Path
-from typing import Annotated, Any, Literal, Optional
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional
 
 from pydantic import Field
 
@@ -66,6 +66,10 @@ from .tools.search import search_bm25_impl, search_context_impl, search_regex_im
 from .tools.search import search_semantic as _search_semantic_impl
 from .tools.search import search_zoekt_impl
 from .tools.source import read_source_impl
+
+if TYPE_CHECKING:
+    from ..artifacts.runtime import ContextArtifactBinding
+    from ..source_fingerprint import RepositorySourceBinding
 
 logger = logging.getLogger(__name__)
 
@@ -517,9 +521,10 @@ async def lsp_route(
 @mcp.tool(
     name="read_source",
     description=(
-        "Read up to 200 lines from the verified repository checkout using a "
+        "Read up to 200 lines authenticated by the retained source-content "
+        "binding using a "
         "repository-relative POSIX path and 1-based inclusive line range. "
-        "Responses are bounded and retain commit/source provenance."
+        "Responses are bounded; commit is display provenance, not attested."
     ),
 )
 async def read_source(
@@ -527,7 +532,7 @@ async def read_source(
     start_line: _PositiveLine = 1,
     end_line: _PositiveLine | None = None,
 ) -> dict[str, Any]:
-    """Return one bounded source window from the verified checkout."""
+    """Return one bounded window from content-authenticated source bytes."""
     if _ctx is None:
         raise RuntimeError("Server not initialized")
     return await asyncio.to_thread(
@@ -550,6 +555,7 @@ async def get_manifest() -> dict[str, Any]:
     """Return the repo manifest as a dict."""
     if _ctx is None:
         raise RuntimeError("Server not initialized")
+    source_verified = _ctx.verify_source_status()
     result = _ctx.manifest.to_dict()
     explore_runtime = getattr(_ctx, "explore_runtime", None)
     explore_session = (
@@ -563,8 +569,11 @@ async def get_manifest() -> dict[str, Any]:
         "tool_surface": mcp.tool_surface,
         "explore_session": explore_session,
         "source_read": {
-            "verified": _ctx.source_verified,
+            "verified": source_verified,
             "error": _ctx.source_error,
+            "verification_scope": _ctx.source_verification_scope,
+            "commit_verified": False,
+            "checkout_state": "not-attested",
         },
         "lsp_provider": dict(_ctx.lsp_provider_selection),
     }
@@ -636,8 +645,11 @@ def server_status() -> str:
         else:
             lines.append("  ✗ zoekt: not_loaded")
 
+        source_verified = ctx.verify_source_status()
         source_status = (
-            "verified" if ctx.source_verified else (ctx.source_error or "unverified")
+            "verified(content-bytes; commit=not-attested)"
+            if source_verified
+            else (ctx.source_error or "unverified")
         )
         lines.append(f"  source_read: {source_status}")
 
@@ -717,7 +729,8 @@ def init_server(
     manifest_path: RepoManifest | str | Path,
     *,
     artifact: dict[str, Any] | None = None,
-    source_verified: bool = False,
+    artifact_binding: ContextArtifactBinding | None = None,
+    source_binding: RepositorySourceBinding | None = None,
 ) -> None:
     """Initialize the global ServerContext from a manifest file.
 
@@ -737,49 +750,186 @@ def init_server(
             manifest.repo_path,
             (manifest.commit or "")[:12],
         )
+        compiler_lock = nullcontext()
     else:
         resolved = Path(manifest_path).resolve()
         if not resolved.exists():
             raise FileNotFoundError(f"Manifest not found: {resolved}")
         logger.info("Loading manifest from %s", resolved)
-        manifest = RepoManifest.load(resolved)
         resolved_manifest_path = resolved
-    if _ctx is not None:
-        _ctx.close()
-    _ctx = ServerContext.load(manifest, artifact=artifact)
-    if source_verified:
-        _ctx.source_verified = True
-        _ctx.source_error = None
-    elif resolved_manifest_path is not None:
-        from ..compiler.checkout_identity import validate_checkout_identity
+        # A local manifest is an explicit administrator boundary. Serialize
+        # capture and native loading with the same cache lock as IndexCompiler.
+        # Artifact bindings intentionally skip this branch and remain inert.
+        from filelock import FileLock
 
-        repo_path = Path(manifest.repo_path).expanduser().resolve()
-        if not manifest.source_fingerprint:
-            _ctx.source_error = "manifest has no source fingerprint"
-        elif not repo_path.is_dir():
-            _ctx.source_error = "manifest repository checkout does not exist"
-        else:
+        compiler_lock = FileLock(str(resolved.parent / ".index-compiler.lock"))
+
+    from ..artifacts.runtime import (
+        SourceBindingCleanupOwner,
+        _raise_source_cleanup_failure,
+        _source_cleanup_owner_is_pending,
+    )
+
+    capture_cleanup_owner: SourceBindingCleanupOwner | None = None
+    new_context: ServerContext | None = None
+
+    def close_capture_owner(
+        primary: BaseException,
+    ) -> tuple[BaseException | None, object | None]:
+        """Close the preinstalled owner and identify any retry authority."""
+
+        cleanup_failure: BaseException | None = None
+        if capture_cleanup_owner is not None:
             try:
-                validate_checkout_identity(
-                    repo_path,
-                    manifest,
-                    artifact_root=resolved_manifest_path.parent,
-                )
-            except (OSError, ValueError) as exc:
-                _ctx.source_error = str(exc)
-            else:
-                _ctx.source_verified = True
-                _ctx.source_error = None
+                capture_cleanup_owner.close()
+            except BaseException as exc:  # noqa: B036 - caller selects priority
+                cleanup_failure = exc
+        pending_owner: object | None = None
+        if _source_cleanup_owner_is_pending(capture_cleanup_owner):
+            pending_owner = capture_cleanup_owner
+        nested_owner = getattr(primary, "source_cleanup_owner", None)
+        if pending_owner is None and _source_cleanup_owner_is_pending(nested_owner):
+            pending_owner = nested_owner
+        return cleanup_failure, pending_owner
+
+    try:
+        with compiler_lock:
+            if resolved_manifest_path is not None:
+                manifest = RepoManifest.load(resolved_manifest_path)
+
+            from ..source_fingerprint import (
+                capture_repository_source,
+                is_secure_source_fingerprint_v2,
+            )
+
+            source_error: str | None = "source binding has not been verified"
+            retained_source = (
+                artifact_binding.source_binding
+                if artifact_binding is not None
+                else source_binding
+            )
+            verified = retained_source is not None and is_secure_source_fingerprint_v2(
+                manifest.source_fingerprint
+            )
+            native_authorization = None
+            if verified:
+                source_error = None
+            elif resolved_manifest_path is not None:
+                from ..source_fingerprint import lexical_repository_path
+
+                repo_path = lexical_repository_path(manifest.repo_path)
+                if not is_secure_source_fingerprint_v2(manifest.source_fingerprint):
+                    source_error = (
+                        "manifest has no trust-eligible source fingerprint v2"
+                    )
+                else:
+                    capture_cleanup_owner = SourceBindingCleanupOwner()
+                    try:
+                        retained_source = capture_repository_source(
+                            repo_path,
+                            exclude_roots=(resolved_manifest_path.parent,),
+                            _source_owner=capture_cleanup_owner.retain,
+                        )
+                        if (
+                            retained_source.fingerprint != manifest.source_fingerprint
+                            or retained_source.file_count != manifest.file_count
+                        ):
+                            raise ValueError(
+                                "repository source bytes do not match the indexed "
+                                "content"
+                            )
+                    except BaseException as exc:  # noqa: B036 - preserve primary
+                        cleanup_failure, pending_owner = close_capture_owner(exc)
+                        retained_source = None
+                        if (
+                            not isinstance(exc, Exception)
+                            or cleanup_failure is not None
+                            or pending_owner is not None
+                        ):
+                            _raise_source_cleanup_failure(
+                                exc,
+                                cleanup_failure,
+                                pending_owner,
+                            )
+                        source_error = str(exc)
+                    else:
+                        verified = True
+                        source_error = None
+
+                if verified and manifest.index_is_current("vector"):
+                    from ..index.embedding.artifact_integrity import (
+                        capture_authenticated_vector_view,
+                    )
+                    from ..native_index_authorization import (
+                        _mint_trusted_local_admin_authorization,
+                    )
+
+                    entry = manifest.indexes["vector"]
+                    with capture_authenticated_vector_view(entry.path) as vector_view:
+                        native_authorization = _mint_trusted_local_admin_authorization(
+                            vector_view.ownership,
+                            view_type="vector",
+                            semantic_contract=entry.config,
+                            evidence=(
+                                "local-admin-cli-intent",
+                                "source-content-fingerprint-v2-bound",
+                                "captured-vector-tree-subject",
+                            ),
+                        )
+
+            new_context = ServerContext.load(
+                manifest,
+                artifact=artifact,
+                artifact_binding=artifact_binding,
+                native_index_authorization=native_authorization,
+                source_binding=retained_source,
+            )
+            new_context.source_error = source_error
+            portable_artifact = artifact is not None or artifact_binding is not None
+            new_context.configure_lsp_provider(
+                allow_native=new_context.source_verified and not portable_artifact,
+                native_disabled_reason=(
+                    "portable_artifact_uses_persisted_graph"
+                    if portable_artifact
+                    else "local_source_not_verified"
+                ),
+            )
+
+        if _ctx is not None:
+            _ctx.close()
+        _ctx = new_context
         if not _ctx.source_verified:
             logger.warning("Source reads disabled: %s", _ctx.source_error)
-    _ctx.configure_lsp_provider(
-        allow_native=_ctx.source_verified and _ctx.artifact is None,
-        native_disabled_reason=(
-            "portable_artifact_uses_persisted_graph"
-            if _ctx.artifact is not None
-            else "local_source_not_verified"
-        ),
-    )
+    except BaseException as primary:  # noqa: B036 - retain capture owner
+        # Once the new context is globally reachable it is the stable owner.
+        # Before that point, the preinstalled capture owner must close or retain
+        # the source across any return-handoff or startup cancellation.
+        if not (new_context is not None and _ctx is new_context):
+            cleanup_failure: BaseException | None = None
+            pending_owner: object | None = None
+            context_source = (
+                new_context._source_binding if new_context is not None else None
+            )
+            if new_context is not None:
+                try:
+                    new_context.close()
+                except BaseException as exc:  # noqa: B036 - apply shared priority
+                    cleanup_failure = exc
+            if _source_cleanup_owner_is_pending(context_source):
+                pending_owner = context_source
+            if capture_cleanup_owner is not None:
+                owner_failure, owner_pending = close_capture_owner(primary)
+                if cleanup_failure is None:
+                    cleanup_failure = owner_failure
+                if pending_owner is None:
+                    pending_owner = owner_pending
+            if cleanup_failure is not None or pending_owner is not None:
+                _raise_source_cleanup_failure(
+                    primary,
+                    cleanup_failure,
+                    pending_owner,
+                )
+        raise
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -792,37 +942,51 @@ def main(argv: list[str] | None = None) -> None:
     if args.artifact and manifest_path:
         logger.error("Choose either a manifest or --artifact, not both")
         sys.exit(1)
-    if args.artifact and not args.repo:
-        logger.error("--artifact requires --repo with the exact checkout")
-        sys.exit(1)
     if not args.artifact and not manifest_path:
         logger.error(
-            "No context provided. Use: %s <manifest> or --artifact <dir> --repo <dir>",
+            "No context provided. Use: %s <manifest> or --artifact <dir> "
+            "[--repo <dir>]",
             program_name,
         )
         sys.exit(1)
 
     try:
         if args.artifact:
-            from ..artifacts import bind_context_artifact
+            if args.repo:
+                from ..artifacts import bind_context_artifact
 
-            binding = bind_context_artifact(
-                args.artifact,
-                args.repo,
-                expected_repository=args.repository,
-            )
+                binding = bind_context_artifact(
+                    args.artifact,
+                    args.repo,
+                    expected_repository=args.repository,
+                )
+            else:
+                from ..artifacts import query_context_artifact
+
+                binding = query_context_artifact(
+                    args.artifact,
+                    expected_repository=args.repository,
+                )
             artifact = binding.artifact
-            init_server(
-                binding.manifest,
-                artifact={
-                    "verified": True,
-                    "schema": artifact.metadata["schema"],
-                    "repository": artifact.repository,
-                    "commit": artifact.commit,
-                    "views": list(artifact.views),
-                },
-                source_verified=True,
-            )
+            try:
+                init_server(
+                    binding.manifest,
+                    artifact={
+                        "verified": True,
+                        "schema": artifact.metadata["schema"],
+                        "repository": artifact.repository,
+                        "commit": artifact.commit,
+                        "views": list(artifact.views),
+                    },
+                    artifact_binding=binding,
+                )
+            except BaseException:  # noqa: B036 - preserve startup failure
+                try:
+                    binding.close()
+                except BaseException:  # noqa: B036 - preserve primary failure
+                    pass
+                raise
+            binding.close()
         else:
             init_server(manifest_path)
         logger.info("Starting MCP server on stdio...")

--- a/codenib/mcp/tools/source.py
+++ b/codenib/mcp/tools/source.py
@@ -7,10 +7,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import Any
 
-from ...web.repository_files import live_source_slice, safe_repo_relative_path
 from ..context import ServerContext
 from ._validation import (
     MAX_LSP_POSITION,
@@ -20,6 +19,8 @@ from ._validation import (
     bounded_integer,
     required_text,
 )
+
+_MAX_SOURCE_FILE_BYTES = 64 * 1024 * 1024
 
 
 def _repository_relative_source(ctx: ServerContext, value: str) -> str:
@@ -38,11 +39,7 @@ def _repository_relative_source(ctx: ServerContext, value: str) -> str:
     ):
         raise ValueError("file_path must be a repository-relative POSIX path.")
 
-    root = Path(ctx.manifest.repo_path).expanduser().resolve()
-    relative = safe_repo_relative_path(str(root), path_text)
-    if relative != path_text:
-        raise ValueError("file_path must resolve inside the repository checkout.")
-    return relative
+    return path_text
 
 
 def _bounded_source_content(payload: dict[str, Any]) -> dict[str, Any]:
@@ -99,7 +96,7 @@ def read_source_impl(
     start_line: int = 1,
     end_line: int | None = None,
 ) -> dict[str, Any]:
-    """Read one verified repository-relative source window."""
+    """Read one content-authenticated repository-relative source window."""
 
     if getattr(ctx, "source_verified", False) is not True:
         detail = getattr(ctx, "source_error", None) or "source binding is unverified"
@@ -126,14 +123,23 @@ def read_source_impl(
             f"source windows may contain at most {MAX_SOURCE_WINDOW_LINES} lines."
         )
 
-    payload = live_source_slice(
-        ctx.manifest.repo_path,
-        relative,
-        first,
-        last,
-    )
-    if payload is None:
-        raise ValueError("file_path is not a readable regular repository file.")
+    try:
+        source_bytes = ctx.read_source_bytes(
+            relative,
+            max_bytes=_MAX_SOURCE_FILE_BYTES,
+        )
+    except ValueError as exc:
+        raise ValueError(
+            "file_path is not a readable regular repository file."
+        ) from exc
+    all_lines = source_bytes.decode("utf-8", errors="replace").splitlines(keepends=True)
+    selected = all_lines[first - 1 : last]
+    payload = {
+        "file": relative,
+        "start_line": first,
+        "end_line": first + len(selected) - 1,
+        "content": "".join(selected),
+    }
     if int(payload["end_line"]) < first:
         raise ValueError("start_line exceeds the source file length.")
     payload = _bounded_source_content(payload)
@@ -143,6 +149,9 @@ def read_source_impl(
         "commit": ctx.manifest.commit,
         "source_fingerprint": ctx.manifest.source_fingerprint,
         "verified": True,
+        "verification_scope": "content-bytes",
+        "commit_verified": False,
+        "checkout_state": "not-attested",
     }
     return payload
 

--- a/codenib/model/embedding_retrieve_pipeline.py
+++ b/codenib/model/embedding_retrieve_pipeline.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 from typing import List, Optional
 
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
+from ..index.embedding.artifact_integrity import (
+    _mint_trusted_local_vector_authorization,
+)
 from ..log_utils import get_logger
 from ..types import QueriedNode
 
@@ -131,7 +134,15 @@ class EmbeddingRetrievePipeline:
         faster than creating a new :class:`EmbeddingRetrievePipeline` for each
         instance, and a failed replacement leaves the current index available.
         """
-        self.vector_store.swap_index(index_path)
+        native_authorization = _mint_trusted_local_vector_authorization(
+            index_path,
+            self.vector_store.artifact_metadata,
+            evidence=("embedding-retrieval-vector-swap",),
+        )
+        self.vector_store.swap_index(
+            index_path,
+            native_index_authorization=native_authorization,
+        )
 
     def query(self, query: str, top_k: Optional[int] = None) -> List[QueriedNode]:
         """Retrieve top-K nodes using embedding similarity search.

--- a/codenib/model/retrieve_rerank_pipeline.py
+++ b/codenib/model/retrieve_rerank_pipeline.py
@@ -12,6 +12,10 @@ from typing import Dict, List, Optional, Sequence, Set
 from ..code_chunker import CodeChunker, RepoChunkingConfig
 from ..graph.code_graph import CodeGraph
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
+from ..index.embedding._lifecycle import close_vector_after_failure
+from ..index.embedding.artifact_integrity import (
+    _mint_trusted_local_vector_authorization,
+)
 from ..index.embedding.model_policy import resolve_embedding_load_policy_from_options
 from ..index.rerank.cross_encoder import build_reranker
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
@@ -804,6 +808,19 @@ class RetrieveRerankPipeline:
         embedding_dimension: int,
         embedding_kwargs: Dict[str, object],
     ) -> CodeVectorStore:
+        model_suffix = embedding_model.replace("/", "__")
+        config_file = self.index_path / f"config_{model_suffix}.json"
+        l0_path = self.index_path / "l0"
+        l2_path = self.index_path / "l2"
+
+        cache_exists = config_file.exists() or (l0_path.exists() and l2_path.exists())
+        native_authorization = None
+        if cache_exists:
+            native_authorization = _mint_trusted_local_vector_authorization(
+                self.index_path,
+                {},
+                evidence=("retrieve-rerank-local-vector-cache",),
+            )
         vector_store = CodeVectorStore(
             embedding_model=embedding_model,
             embedding_provider=embedding_provider,
@@ -811,33 +828,34 @@ class RetrieveRerankPipeline:
             store_path=str(self.index_path),
             **embedding_kwargs,
         )
-        model_suffix = embedding_model.replace("/", "__")
-        config_file = self.index_path / f"config_{model_suffix}.json"
-        l0_path = self.index_path / "l0"
-        l2_path = self.index_path / "l2"
-
-        cache_exists = config_file.exists() or (l0_path.exists() and l2_path.exists())
         if cache_exists:
             logger.info(
                 "Loading hierarchical vector store from cache.",
                 extra={"index_path": str(self.index_path)},
             )
-            vector_store.load(str(self.index_path))
-            missing_levels = []
-            if not vector_store.l0_documents:
-                missing_levels.append("l0")
-            if self.retrieval_level == "l2" and not vector_store.l2_documents:
-                missing_levels.append("l2")
+            try:
+                vector_store.load(
+                    str(self.index_path),
+                    native_index_authorization=native_authorization,
+                )
+                missing_levels = []
+                if not vector_store.l0_documents:
+                    missing_levels.append("l0")
+                if self.retrieval_level == "l2" and not vector_store.l2_documents:
+                    missing_levels.append("l2")
 
-            if not missing_levels:
-                return vector_store
+                if not missing_levels:
+                    return vector_store
 
-            logger.info(
-                "Cached vector store missing required levels %s; rebuilding.",
-                missing_levels,
-                extra={"index_path": str(self.index_path)},
-            )
-            vector_store.clear()
+                logger.info(
+                    "Cached vector store missing required levels %s; rebuilding.",
+                    missing_levels,
+                    extra={"index_path": str(self.index_path)},
+                )
+                vector_store.clear()
+            except BaseException as primary:  # noqa: B036 - close partial state
+                close_vector_after_failure(vector_store, primary)
+                raise
 
         logger.info("Building hierarchical vector store index.")
         vector_store = build_hierarchical_vector_store(

--- a/codenib/native_index_authorization.py
+++ b/codenib/native_index_authorization.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping, Sequence
@@ -80,14 +81,7 @@ class NativeIndexSubject:
 class NativeIndexAuthorization:
     """Non-serializable, process-local capability for one native subject."""
 
-    __slots__ = (
-        "_seal",
-        "trust_class",
-        "view_type",
-        "subject_digest",
-        "root_identity",
-        "evidence",
-    )
+    __slots__ = ("_state",)
 
     def __init__(
         self,
@@ -98,15 +92,55 @@ class NativeIndexAuthorization:
         subject_digest: str,
         root_identity: tuple[int, ...] | None,
         evidence: tuple[str, ...],
+        process_id: int,
     ) -> None:
         if seal is not _TOKEN_SEAL:
             raise TypeError("native index authorization cannot be constructed directly")
-        self._seal = seal
-        self.trust_class = trust_class
-        self.view_type = view_type
-        self.subject_digest = subject_digest
-        self.root_identity = root_identity
-        self.evidence = evidence
+        object.__setattr__(
+            self,
+            "_state",
+            (
+                seal,
+                trust_class,
+                view_type,
+                subject_digest,
+                root_identity,
+                evidence,
+                process_id,
+            ),
+        )
+
+    def __setattr__(self, name: str, value: object) -> None:
+        del name, value
+        raise AttributeError("native index authorization is immutable")
+
+    @property
+    def _seal(self) -> object:
+        return self._state[0]
+
+    @property
+    def trust_class(self) -> NativeTrustClass:
+        return self._state[1]
+
+    @property
+    def view_type(self) -> str:
+        return self._state[2]
+
+    @property
+    def subject_digest(self) -> str:
+        return self._state[3]
+
+    @property
+    def root_identity(self) -> tuple[int, ...] | None:
+        return self._state[4]
+
+    @property
+    def evidence(self) -> tuple[str, ...]:
+        return self._state[5]
+
+    @property
+    def process_id(self) -> int:
+        return self._state[6]
 
     def __reduce__(self):
         raise TypeError(
@@ -144,14 +178,18 @@ def native_index_subject(
     )
 
 
-def mint_trusted_local_authorization(
+def _mint_trusted_local_admin_authorization(
     ownership: object,
     *,
     view_type: str,
     semantic_contract: Mapping[str, Any],
-    evidence: Sequence[str] = (),
+    evidence: Sequence[str],
 ) -> NativeIndexAuthorization:
-    """Mint after the caller's local lock/source/config checks have succeeded."""
+    """Issue only after the caller's local lock/source/config checks succeed.
+
+    The module seal prevents artifact self-authorization and accidental direct
+    construction. It is not a sandbox against malicious in-process Python.
+    """
 
     subject = native_index_subject(
         ownership,
@@ -159,7 +197,9 @@ def mint_trusted_local_authorization(
         semantic_contract=semantic_contract,
     )
     normalized_evidence = tuple(evidence)
-    if any(not isinstance(item, str) or not item for item in normalized_evidence):
+    if not normalized_evidence or any(
+        not isinstance(item, str) or not item for item in normalized_evidence
+    ):
         raise ValueError(
             "native index authorization evidence must be non-empty strings"
         )
@@ -170,6 +210,7 @@ def mint_trusted_local_authorization(
         subject_digest=subject.digest,
         root_identity=directory_ownership_root_identity(ownership),  # type: ignore[arg-type]
         evidence=normalized_evidence,
+        process_id=os.getpid(),
     )
 
 
@@ -185,6 +226,8 @@ def require_native_index_authorization(
         or authorization._seal is not _TOKEN_SEAL
     ):
         raise ValueError("native index parsing requires external authorization")
+    if authorization.process_id != os.getpid():
+        raise ValueError("native index authorization belongs to another process")
     subject = native_index_subject(
         ownership,
         view_type=view_type,
@@ -207,12 +250,35 @@ def require_native_index_authorization(
     return subject
 
 
+def require_native_index_authorization_preflight(
+    authorization: NativeIndexAuthorization | None,
+    *,
+    view_type: str,
+) -> None:
+    """Reject malformed or foreign-process tokens before expensive capture."""
+
+    if (
+        not isinstance(authorization, NativeIndexAuthorization)
+        or authorization._seal is not _TOKEN_SEAL
+    ):
+        raise ValueError("native index parsing requires external authorization")
+    if authorization.process_id != os.getpid():
+        raise ValueError("native index authorization belongs to another process")
+    if (
+        authorization.trust_class != "trusted-local"
+        or authorization.view_type != view_type
+        or not _DIGEST_RE.fullmatch(authorization.subject_digest)
+        or authorization.root_identity is None
+    ):
+        raise ValueError("native index authorization has an invalid preliminary scope")
+
+
 __all__ = [
     "FAISS_PARSER_CONTRACT",
     "NATIVE_INDEX_SUBJECT_SCHEMA",
     "NativeIndexAuthorization",
     "NativeIndexSubject",
-    "mint_trusted_local_authorization",
     "native_index_subject",
     "require_native_index_authorization",
+    "require_native_index_authorization_preflight",
 ]

--- a/codenib/sandbox/docker.py
+++ b/codenib/sandbox/docker.py
@@ -138,14 +138,7 @@ def normalize_target(prefix, target):
     if not target or '\0' in target or len(os.fsencode(target)) > 4096:
         raise SystemExit('source symlink target is invalid')
     if os.path.isabs(target):
-        try:
-            relative_target = pathlib.Path(os.path.normpath(target)).relative_to(
-                source_root
-            )
-        except ValueError:
-            raise SystemExit('source symlink resolves outside the repository')
-        target = relative_target.as_posix()
-        resolved = []
+        raise SystemExit('source symlink target must be relative')
     else:
         resolved = list(prefix)
     for part in target.split('/'):

--- a/codenib/sandbox/docker.py
+++ b/codenib/sandbox/docker.py
@@ -108,50 +108,147 @@ root = pathlib.Path('/workspace')
 ignored = set(json.loads(sys.argv[1]))
 fingerprint_version = int(sys.argv[2])
 filter_version = int(sys.argv[3])
+source_root = pathlib.Path(sys.argv[4])
+if fingerprint_version != 2:
+    raise SystemExit('unsupported source fingerprint version')
 hasher = hashlib.sha256()
-hasher.update(
-    (
-        f'codenib-source-fingerprint:{fingerprint_version}:'
-        f'{filter_version}\0'
-    ).encode('ascii')
-)
+hasher.update(b'codenib-source-fingerprint\0\x02')
+def frame_header(domain, payload_size):
+    if not domain or len(domain) > 0xffff or not 0 <= payload_size < 1 << 64:
+        raise SystemExit('source fingerprint frame exceeds its limits')
+    hasher.update(len(domain).to_bytes(2, 'big'))
+    hasher.update(domain)
+    hasher.update(payload_size.to_bytes(8, 'big'))
+def frame(domain, payload):
+    frame_header(domain, len(payload))
+    hasher.update(payload)
+def hash_content(path, metadata, domain):
+    frame_header(domain, metadata.st_size)
+    with path.open('rb') as handle:
+        remaining = metadata.st_size
+        while remaining:
+            block = handle.read(min(remaining, 1024 * 1024))
+            if not block:
+                raise SystemExit('source file was truncated while hashing')
+            hasher.update(block)
+            remaining -= len(block)
+        if handle.read(1):
+            raise SystemExit('source file grew while hashing')
+def normalize_target(prefix, target):
+    if not target or '\0' in target or len(os.fsencode(target)) > 4096:
+        raise SystemExit('source symlink target is invalid')
+    if os.path.isabs(target):
+        try:
+            relative_target = pathlib.Path(os.path.normpath(target)).relative_to(
+                source_root
+            )
+        except ValueError:
+            raise SystemExit('source symlink resolves outside the repository')
+        target = relative_target.as_posix()
+        resolved = []
+    else:
+        resolved = list(prefix)
+    for part in target.split('/'):
+        if part in {'', '.'}:
+            continue
+        if part == '..':
+            if not resolved:
+                raise SystemExit('source symlink resolves outside the repository')
+            resolved.pop()
+        else:
+            resolved.append(part)
+        if len(resolved) > 256:
+            raise SystemExit('resolved source path is too deep')
+    return tuple(resolved)
+def resolve_link(relative_parts):
+    pending = list(relative_parts)
+    resolved = []
+    seen_links = set()
+    symlink_count = 0
+    while pending:
+        name = pending.pop(0)
+        candidate = root.joinpath(*resolved, name)
+        try:
+            metadata = candidate.lstat()
+        except FileNotFoundError:
+            return 'unresolved', None, None
+        if stat.S_ISLNK(metadata.st_mode):
+            symlink_count += 1
+            if symlink_count > 40:
+                return 'unresolved', None, None
+            identity = (metadata.st_dev, metadata.st_ino)
+            if identity in seen_links:
+                return 'unresolved', None, None
+            seen_links.add(identity)
+            target_parts = normalize_target(tuple(resolved), os.readlink(candidate))
+            pending = [*target_parts, *pending]
+            resolved = []
+            continue
+        if pending:
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise SystemExit('source path has a non-directory component')
+            resolved.append(name)
+            continue
+        if stat.S_ISREG(metadata.st_mode):
+            return 'regular', candidate, metadata
+        if stat.S_ISDIR(metadata.st_mode):
+            return 'directory', candidate, metadata
+        return 'unresolved', None, None
+    root_metadata = root.lstat()
+    if not stat.S_ISDIR(root_metadata.st_mode):
+        raise SystemExit('source root is not a directory')
+    return 'directory', root, root_metadata
+frame(b'filter-policy-version', str(filter_version).encode('ascii'))
 file_count = 0
-for current_root, directories, files in os.walk(root):
-    directories[:] = sorted(
-        name for name in directories
-        if name not in ignored and not name.startswith('.codenib')
-    )
-    current = pathlib.Path(current_root)
-    for filename in sorted(files):
-        path = current / filename
-        relative_path = path.relative_to(root)
-        if any(
-            part in ignored or part.startswith('.codenib')
-            for part in relative_path.parts
-        ):
+def scan_directory(current, prefix):
+    global file_count
+    with os.scandir(current) as iterator:
+        names = sorted(child.name for child in iterator)
+    child_directories = []
+    for name in names:
+        if name in ignored or name.startswith('.codenib'):
             continue
-        mode = path.lstat().st_mode
+        relative_parts = (*prefix, name)
+        path = current / name
+        metadata = path.lstat()
+        mode = metadata.st_mode
+        relative = os.fsencode('/'.join(relative_parts))
         if stat.S_ISLNK(mode):
-            raise SystemExit('source fingerprint does not permit symlinks')
-        if not stat.S_ISREG(mode):
+            target = os.readlink(path)
+            target_state, target_path, target_metadata = resolve_link(
+                relative_parts
+            )
+            if target_state == 'directory':
+                continue
+            frame(b'entry-kind', b'link')
+            frame(b'entry-path', relative)
+            frame(b'link-target', os.fsencode(target))
+            if target_state == 'unresolved':
+                frame(b'link-target-state', b'unresolved')
+            else:
+                frame(b'link-target-state', b'regular')
+                hash_content(
+                    target_path,
+                    target_metadata,
+                    b'link-target-content',
+                )
+        elif stat.S_ISREG(mode):
+            frame(b'entry-kind', b'file')
+            frame(b'entry-path', relative)
+            hash_content(path, metadata, b'file-content')
+        elif stat.S_ISDIR(mode):
+            child_directories.append((path, relative_parts))
             continue
-        relative = relative_path.as_posix().encode(
-            'utf-8', errors='surrogateescape'
-        )
-        hasher.update(b'F\0')
-        hasher.update(relative)
-        hasher.update(b'\0')
-        with path.open('rb') as handle:
-            while True:
-                block = handle.read(1024 * 1024)
-                if not block:
-                    break
-                hasher.update(block)
-        hasher.update(b'\0')
+        else:
+            continue
         file_count += 1
+    for child, child_parts in child_directories:
+        scan_directory(child, child_parts)
+scan_directory(root, ())
+frame(b'entry-count', file_count.to_bytes(8, 'big'))
 print(json.dumps({
     'file_count': file_count,
-    'source_fingerprint': 'sha256:' + hasher.hexdigest(),
+    'source_fingerprint': 'sha256-v2:' + hasher.hexdigest(),
 }, sort_keys=True, separators=(',', ':')))
 """.strip()
 
@@ -970,6 +1067,7 @@ class DockerSandboxProvider:
                 json.dumps(sorted(DEFAULT_IGNORED_DIRS), separators=(",", ":")),
                 str(SOURCE_FINGERPRINT_VERSION),
                 str(REPOSITORY_FILTER_POLICY_VERSION),
+                os.path.abspath(os.path.expanduser(os.fspath(spec.source_dir))),
             ]
         )
         completed = self._run_control_container(name, args)
@@ -981,7 +1079,7 @@ class DockerSandboxProvider:
             raise SandboxUnavailableError(
                 "sandbox source fingerprint helper returned invalid output"
             ) from exc
-        if not re.fullmatch(r"sha256:[0-9a-f]{64}", fingerprint) or file_count < 0:
+        if not re.fullmatch(r"sha256-v2:[0-9a-f]{64}", fingerprint) or file_count < 0:
             raise SandboxUnavailableError(
                 "sandbox source fingerprint helper returned invalid identity"
             )

--- a/codenib/scip_interface/scip_query.py
+++ b/codenib/scip_interface/scip_query.py
@@ -56,7 +56,7 @@ FACT_QUERY_FILTER_PROOF_SCHEMA_VERSION = 1
 SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION = 4
 
 _HEX_DIGEST = re.compile(r"[0-9a-f]{64}")
-_SOURCE_FINGERPRINT = re.compile(r"sha256:[0-9a-f]{64}")
+_SOURCE_FINGERPRINT = re.compile(r"(?:sha256|sha256-v2):[0-9a-f]{64}")
 _GIT_COMMIT = re.compile(r"[0-9a-f]{40}")
 _INPUT_RECEIPT_KEYS = frozenset({"schema_version", "index", "metadata"})
 _INPUT_INDEX_KEYS = frozenset({"path", "size_bytes", "sha256"})

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -18,12 +18,16 @@ import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable, Iterator
+from typing import Any, Callable, Iterable, Iterator, Mapping
 
 from ._contained_source import (
     SECURE_CONTAINED_SYMLINKS,
+    _arm_or_reuse_descriptor_close_cookie,
     _attach_source_cleanup_owner,
     _binding_identity,
+    _descriptor_has_close_cookie,
+    _descriptor_ownership_identity,
+    _discard_descriptor_close_cookie,
     _identity_is_reliable,
     _inherit_source_cleanup_owner,
     _open_windows_pinned_repository_root,
@@ -82,14 +86,35 @@ class _SourceLifecycleRLock:
     def __init__(self) -> None:
         self._lock = threading.RLock()
         self._depth = threading.local()
+        self._pid = os.getpid()
+        self._process_states = {self._pid: (self._lock, self._depth)}
+
+    def _refresh_after_fork(self) -> None:
+        """Discard an inherited native lock whose owning thread no longer exists."""
+
+        process_id = os.getpid()
+        if process_id == self._pid:
+            return
+        # The child may start several threads before this inherited object is
+        # first touched. CPython's single dict.setdefault call installs one
+        # process-local state before its return can be interrupted, so every
+        # child thread converges on the same non-inherited native lock.
+        child_state = self._process_states.setdefault(
+            process_id,
+            (threading.RLock(), threading.local()),
+        )
+        self._lock, self._depth = child_state
+        self._pid = process_id
 
     def depth(self) -> int:
+        self._refresh_after_fork()
         return int(getattr(self._depth, "value", 0))
 
     def _set_depth(self, depth: int) -> None:
         self._depth.value = depth
 
     def _native_is_owned(self) -> bool:
+        self._refresh_after_fork()
         runtime: Any = self._lock
         ownership_check = getattr(runtime, "_is_owned", None)
         if not callable(ownership_check):
@@ -302,6 +327,27 @@ class RepositorySourceFileRecord:
     size: int
     sha256: str
     lexical_identity: tuple[object, ...]
+    link_target: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _RepositorySourceLinkRecord:
+    """Captured state reached through one visible lexical source link."""
+
+    path: str
+    lexical_identity: tuple[object, ...]
+    link_target: str
+    target_state: str
+
+
+@dataclass(frozen=True, slots=True)
+class RepositorySourceIdentitySnapshot:
+    """Detached public identity rebuilt from one retained private authority."""
+
+    root: Path
+    fingerprint: str
+    file_count: int
+    file_records: tuple[RepositorySourceFileRecord, ...]
 
 
 class _HashFanout:
@@ -315,6 +361,155 @@ class _HashFanout:
             target.update(payload)
 
 
+def _snapshot_source_identity_value(value: object) -> object:
+    if type(value) is tuple:
+        return tuple(_snapshot_source_identity_value(item) for item in value)
+    if value is None or type(value) in {bool, int, str, bytes}:
+        return value
+    raise TypeError("repository source identity contains a non-exact value")
+
+
+def _same_source_identity_value(left: object, right: object) -> bool:
+    if type(left) is not type(right):
+        return False
+    if type(left) is tuple:
+        return len(left) == len(right) and all(  # type: ignore[arg-type]
+            _same_source_identity_value(left_item, right_item)
+            for left_item, right_item in zip(  # type: ignore[arg-type]
+                left,
+                right,
+                strict=True,
+            )
+        )
+    return left == right
+
+
+def _same_source_file_record(
+    left: RepositorySourceFileRecord,
+    right: RepositorySourceFileRecord,
+) -> bool:
+    return (
+        type(left) is RepositorySourceFileRecord
+        and type(right) is RepositorySourceFileRecord
+        and type(left.path) is type(right.path) is str
+        and left.path == right.path
+        and type(left.size) is type(right.size) is int
+        and left.size == right.size
+        and type(left.sha256) is type(right.sha256) is str
+        and left.sha256 == right.sha256
+        and type(left.link_target) is type(right.link_target)
+        and left.link_target == right.link_target
+        and _same_source_identity_value(
+            left.lexical_identity,
+            right.lexical_identity,
+        )
+    )
+
+
+def _snapshot_source_file_record(record: object) -> RepositorySourceFileRecord:
+    if type(record) is not RepositorySourceFileRecord:
+        raise TypeError("repository source records must use the exact record type")
+    if (
+        type(record.path) is not str
+        or type(record.size) is not int
+        or type(record.sha256) is not str
+        or type(record.lexical_identity) is not tuple
+        or (record.link_target is not None and type(record.link_target) is not str)
+    ):
+        raise TypeError("repository source record fields must use exact types")
+    if (
+        not record.path
+        or record.size < 0
+        or not re.fullmatch(r"[0-9a-f]{64}", record.sha256, re.ASCII)
+    ):
+        raise ValueError("repository source record identity is invalid")
+    return RepositorySourceFileRecord(
+        path=record.path,
+        size=record.size,
+        sha256=record.sha256,
+        lexical_identity=_snapshot_source_identity_value(
+            record.lexical_identity
+        ),  # type: ignore[arg-type]
+        link_target=record.link_target,
+    )
+
+
+def _verify_resolved_repository_link(
+    source: object,
+    link: _RepositorySourceLinkRecord,
+    records: Mapping[str, RepositorySourceFileRecord],
+) -> None:
+    observed_state = (
+        "regular"
+        if source.is_regular  # type: ignore[attr-defined]
+        else (
+            "directory" if source.is_directory else "unresolved"
+        )  # type: ignore[attr-defined]
+    )
+    if observed_state != link.target_state:
+        raise RepositoryChangedError(
+            "repository source link target state changed after authentication"
+        )
+    if observed_state != "regular":
+        return
+    record = records.get(link.path)
+    if record is None or record.link_target != link.link_target:
+        raise RepositoryChangedError(
+            "repository source link record changed after authentication"
+        )
+    content_digest = hashlib.sha256()
+    source.update_hash(content_digest)  # type: ignore[attr-defined]
+    opened_size = getattr(source, "opened_size", None)
+    if opened_size is None:
+        descriptor = getattr(source, "descriptor", -1)
+        opened_size = os.fstat(descriptor).st_size
+    if opened_size != record.size or content_digest.hexdigest() != record.sha256:
+        raise RepositoryChangedError(
+            "repository source link target differs from its authenticated record"
+        )
+
+
+def _verify_posix_repository_links(
+    root: Path,
+    root_descriptor: int,
+    root_identity: tuple[int, ...],
+    links: tuple[_RepositorySourceLinkRecord, ...],
+    records: Mapping[str, RepositorySourceFileRecord],
+) -> None:
+    for link in links:
+        with _resolved_repository_file_at(
+            root,
+            root_descriptor,
+            link.path,
+            expected_root_identity=root_identity,
+            expected_final_identity=link.lexical_identity,  # type: ignore[arg-type]
+            expected_final_link_target=link.link_target,
+        ) as source:
+            _verify_resolved_repository_link(source, link, records)
+
+
+def _verify_windows_repository_links(
+    root: Path,
+    root_authority: object,
+    root_identity: tuple[object, ...],
+    links: tuple[_RepositorySourceLinkRecord, ...],
+    records: Mapping[str, RepositorySourceFileRecord],
+    *,
+    api: _WindowsKernelApi,
+) -> None:
+    for link in links:
+        with _resolved_windows_repository_file_at(
+            root,
+            root_authority,
+            link.path,
+            expected_root_identity=root_identity,
+            expected_final_identity=link.lexical_identity,
+            expected_final_link_target=link.link_target,
+            api=api,
+        ) as source:
+            _verify_resolved_repository_link(source, link, records)
+
+
 class RepositorySourceBinding:
     """Retained root authority and exact records for verified live reads."""
 
@@ -323,6 +518,11 @@ class RepositorySourceBinding:
         "fingerprint",
         "file_count",
         "file_records",
+        "_authenticated_root",
+        "_authenticated_fingerprint",
+        "_authenticated_file_count",
+        "_authenticated_file_records",
+        "_authenticated_link_records",
         "_records",
         "_inventory_digest",
         "_inventory_entries",
@@ -346,6 +546,7 @@ class RepositorySourceBinding:
         root: Path,
         fingerprint: SourceFingerprint,
         file_records: Iterable[RepositorySourceFileRecord],
+        link_records: Iterable[_RepositorySourceLinkRecord],
         inventory_digest: str,
         inventory_entries: int,
         excluded: tuple[tuple[str, ...], ...],
@@ -355,13 +556,53 @@ class RepositorySourceBinding:
         windows_api: _WindowsKernelApi | None = None,
         windows_authority: object | None = None,
     ) -> None:
-        records = tuple(file_records)
-        self.root = root
+        if type(root) is not type(Path()) or type(fingerprint) is not SourceFingerprint:
+            raise TypeError("repository source identity fields must use exact types")
+        if (
+            type(fingerprint.value) is not str
+            or type(fingerprint.file_count) is not int
+            or fingerprint.file_count < 0
+            or not _SOURCE_FINGERPRINT_V2_RE.fullmatch(fingerprint.value)
+        ):
+            raise ValueError("repository source identity is invalid")
+        records = tuple(_snapshot_source_file_record(record) for record in file_records)
+        authenticated_records = tuple(
+            _snapshot_source_file_record(record) for record in records
+        )
+        root_snapshot = type(root)(os.fspath(root))
+        self.root = type(root)(os.fspath(root))
         self.fingerprint = fingerprint.value
         self.file_count = fingerprint.file_count
         self.file_records = records
-        self._records = {record.path: record for record in records}
-        if len(self._records) != len(records):
+        self._authenticated_root = root_snapshot
+        self._authenticated_fingerprint = fingerprint.value
+        self._authenticated_file_count = fingerprint.file_count
+        self._authenticated_file_records = authenticated_records
+        authenticated_links: list[_RepositorySourceLinkRecord] = []
+        for record in link_records:
+            if (
+                type(record) is not _RepositorySourceLinkRecord
+                or type(record.path) is not str
+                or type(record.lexical_identity) is not tuple
+                or type(record.link_target) is not str
+                or record.target_state not in {"regular", "directory", "unresolved"}
+            ):
+                raise ValueError(
+                    "repository source binding contains invalid link records"
+                )
+            authenticated_links.append(
+                _RepositorySourceLinkRecord(
+                    path=record.path,
+                    lexical_identity=_snapshot_source_identity_value(
+                        record.lexical_identity
+                    ),  # type: ignore[arg-type]
+                    link_target=record.link_target,
+                    target_state=record.target_state,
+                )
+            )
+        self._authenticated_link_records = tuple(authenticated_links)
+        self._records = {record.path: record for record in authenticated_records}
+        if len(self._records) != len(authenticated_records):
             raise ValueError("repository source binding contains duplicate records")
         self._inventory_digest = inventory_digest
         self._inventory_entries = inventory_entries
@@ -453,6 +694,7 @@ class RepositorySourceBinding:
 
     def _verify_inventory(self) -> None:
         self._require_open()
+        self._verify_public_projection()
         if self._windows_authority is not None:
             api = self._windows_api
             if api is None:  # pragma: no cover - constructor invariant
@@ -474,6 +716,7 @@ class RepositorySourceBinding:
                 authority,
                 self._root_identity,
             )
+            self._verify_retained_link_targets()
             return
         scan = _scan_pinned_repository(
             self._root_descriptor,
@@ -492,6 +735,72 @@ class RepositorySourceBinding:
             authority,
             self._root_identity,  # type: ignore[arg-type]
         )
+        self._verify_retained_link_targets()
+
+    def _verify_public_projection(self) -> None:
+        if (
+            type(self.root) is not type(self._authenticated_root)
+            or self.root != self._authenticated_root
+            or type(self.fingerprint) is not str
+            or self.fingerprint != self._authenticated_fingerprint
+            or type(self.file_count) is not int
+            or self.file_count != self._authenticated_file_count
+            or type(self.file_records) is not tuple
+            or len(self.file_records) != len(self._authenticated_file_records)
+        ):
+            raise RepositoryChangedError(
+                "repository source public identity changed after authentication"
+            )
+        for observed, expected in zip(
+            self.file_records,
+            self._authenticated_file_records,
+            strict=True,
+        ):
+            try:
+                detached = _snapshot_source_file_record(observed)
+            except (TypeError, ValueError) as exc:
+                raise RepositoryChangedError(
+                    "repository source public records changed after authentication"
+                ) from exc
+            if not _same_source_file_record(detached, expected):
+                raise RepositoryChangedError(
+                    "repository source public records changed after authentication"
+                )
+        if len(self._records) != len(self._authenticated_file_records) or any(
+            (
+                not _same_source_file_record(self._records[expected.path], expected)
+                if expected.path in self._records
+                else True
+            )
+            for expected in self._authenticated_file_records
+        ):
+            raise RepositoryChangedError(
+                "repository source retained records changed after authentication"
+            )
+
+    def _verify_retained_link_targets(self) -> None:
+        """Rebind every link target state, including excluded or missing targets."""
+
+        if self._windows_authority is not None:
+            api = self._windows_api
+            if api is None:  # pragma: no cover - constructor invariant
+                raise AssertionError("Windows repository binding has no API")
+            _verify_windows_repository_links(
+                self._authenticated_root,
+                self._windows_authority,
+                self._root_identity,
+                self._authenticated_link_records,
+                self._records,
+                api=api,
+            )
+            return
+        _verify_posix_repository_links(
+            self._authenticated_root,
+            self._root_descriptor,
+            self._root_identity,  # type: ignore[arg-type]
+            self._authenticated_link_records,
+            self._records,
+        )
 
     def verify_snapshot(self) -> None:
         """Revalidate the whole retained v2 inventory or poison this binding."""
@@ -508,6 +817,33 @@ class RepositorySourceBinding:
                 raise RepositoryChangedError(
                     "repository source changed after it was authenticated"
                 ) from exc
+
+    def authenticated_identity_snapshot(self) -> RepositorySourceIdentitySnapshot:
+        """Verify and return identity values caller mutation cannot replace."""
+
+        with self._authentication_lease():
+            try:
+                self._verify_inventory()
+            except BaseException as exc:  # noqa: B036 - preserve body failure
+                self._poison(exc)
+                if isinstance(exc, RepositoryChangedError):
+                    raise
+                if not isinstance(exc, (OSError, RuntimeError, ValueError)):
+                    raise
+                raise RepositoryChangedError(
+                    "repository source changed after it was authenticated"
+                ) from exc
+            return RepositorySourceIdentitySnapshot(
+                root=type(self._authenticated_root)(
+                    os.fspath(self._authenticated_root)
+                ),
+                fingerprint=self._authenticated_fingerprint,
+                file_count=self._authenticated_file_count,
+                file_records=tuple(
+                    _snapshot_source_file_record(record)
+                    for record in self._authenticated_file_records
+                ),
+            )
 
     @contextmanager
     def read_session(self) -> Iterator[RepositorySourceBinding]:
@@ -576,20 +912,22 @@ class RepositorySourceBinding:
             if api is None:  # pragma: no cover - constructor invariant
                 raise AssertionError("Windows repository binding has no API")
             resolver = _resolved_windows_repository_file_at(
-                self.root,
+                self._authenticated_root,
                 self._windows_authority,
                 relative,
                 expected_root_identity=self._root_identity,
                 expected_final_identity=record.lexical_identity,
+                expected_final_link_target=record.link_target,
                 api=api,
             )
         else:
             resolver = _resolved_repository_file_at(
-                self.root,
+                self._authenticated_root,
                 self._root_descriptor,
                 relative,
                 expected_root_identity=self._root_identity,  # type: ignore[arg-type]
                 expected_final_identity=record.lexical_identity,  # type: ignore[arg-type]
+                expected_final_link_target=record.link_target,
             )
         with resolver as source:
             if not source.is_regular:
@@ -1176,6 +1514,7 @@ class _PosixRepositoryRootAuthority:
         "root_identity",
         "_resources",
         "_resource_identities",
+        "_resource_close_cookies",
         "_anchor_identity",
         "_bindings",
         "_closed",
@@ -1197,6 +1536,7 @@ class _PosixRepositoryRootAuthority:
         self.root_identity = root_identity
         self._resources = resources
         self._resource_identities = resource_identities
+        self._resource_close_cookies: dict[int, int] = {}
         self._anchor_identity = anchor_identity
         self._bindings = bindings
         self._closed = False
@@ -1230,6 +1570,7 @@ class _PosixRepositoryRootAuthority:
         failure = _close_posix_descriptors(
             self._resources,
             self._resource_identities,
+            self._resource_close_cookies,
         )
         self._closed = not self._resources
         self.descriptor = -1
@@ -1240,6 +1581,7 @@ class _PosixRepositoryRootAuthority:
 def _close_posix_descriptors(
     descriptors: list[int],
     expected_identities: dict[int, tuple[int, ...]],
+    close_cookies: dict[int, int],
 ) -> BaseException | None:
     """Visit every descriptor and retain the first delayed close failure."""
 
@@ -1250,7 +1592,21 @@ def _close_posix_descriptors(
             try:
                 observed = os.fstat(descriptor)
                 expected = expected_identities.get(descriptor)
-                if expected is not None and _binding_identity(observed) != expected:
+                close_cookie = close_cookies.get(descriptor)
+                if (
+                    expected is not None
+                    and _descriptor_ownership_identity(observed) != expected
+                ):
+                    deferred = _remember_interruption(
+                        deferred,
+                        RuntimeError("repository descriptor ownership changed"),
+                    )
+                    closed = True
+                    break
+                if close_cookie is not None and not _descriptor_has_close_cookie(
+                    descriptor,
+                    close_cookie,
+                ):
                     deferred = _remember_interruption(
                         deferred,
                         RuntimeError("repository descriptor ownership changed"),
@@ -1270,8 +1626,15 @@ def _close_posix_descriptors(
                 deferred = _remember_interruption(deferred, exc)
                 continue
 
-            expected_at_close = _binding_identity(observed)
+            expected_at_close = _descriptor_ownership_identity(observed)
             try:
+                if close_cookie is None:
+                    close_cookie = _arm_or_reuse_descriptor_close_cookie(
+                        descriptor,
+                        close_cookies.values(),
+                    )
+                    if close_cookie is not None:
+                        close_cookies[descriptor] = close_cookie
                 os.close(descriptor)
                 closed = True
             except BaseException as exc:  # noqa: B036 - confirm close result
@@ -1297,7 +1660,13 @@ def _close_posix_descriptors(
                             break
                         deferred = _remember_interruption(deferred, probe_error)
                         continue
-                    if _binding_identity(visible) != expected_at_close:
+                    if _descriptor_ownership_identity(visible) != expected_at_close or (
+                        close_cookie is not None
+                        and not _descriptor_has_close_cookie(
+                            descriptor,
+                            close_cookie,
+                        )
+                    ):
                         # The owned fd closed and its number was reused. Never
                         # close the replacement descriptor.
                         closed = True
@@ -1322,17 +1691,19 @@ def _close_posix_descriptors(
                     if isinstance(exc, Exception):
                         raise
                     deferred = _remember_interruption(deferred, exc)
+            _discard_descriptor_close_cookie(close_cookies, descriptor)
     return deferred
 
 
 class _PosixPartialCleanup:
     """Retryable owner installed before temporary descriptor acquisition."""
 
-    __slots__ = ("descriptors", "expected_identities")
+    __slots__ = ("descriptors", "expected_identities", "close_cookies")
 
     def __init__(self) -> None:
         self.descriptors: list[int] = []
         self.expected_identities: dict[int, tuple[int, ...]] = {}
+        self.close_cookies: dict[int, int] = {}
 
     @property
     def closed(self) -> bool:
@@ -1343,7 +1714,9 @@ class _PosixPartialCleanup:
         if deferred is not None:
             raise deferred
         if metadata is not None:
-            self.expected_identities[descriptor] = _binding_identity(metadata)
+            self.expected_identities[descriptor] = _descriptor_ownership_identity(
+                metadata
+            )
         return descriptor
 
     def close_descriptor(self, descriptor: int) -> None:
@@ -1353,11 +1726,21 @@ class _PosixPartialCleanup:
             for descriptor in selected
             if descriptor in self.expected_identities
         }
-        failure = _close_posix_descriptors(selected, identities)
+        cookies = {
+            descriptor: self.close_cookies[descriptor]
+            for descriptor in selected
+            if descriptor in self.close_cookies
+        }
+        failure = _close_posix_descriptors(selected, identities, cookies)
         if descriptor not in selected:
             while descriptor in self.descriptors:
                 self.descriptors.remove(descriptor)
             self.expected_identities.pop(descriptor, None)
+            self.close_cookies.pop(descriptor, None)
+        elif descriptor not in cookies:
+            self.close_cookies.pop(descriptor, None)
+        else:
+            self.close_cookies[descriptor] = cookies[descriptor]
         if failure is not None:
             raise failure
 
@@ -1365,6 +1748,7 @@ class _PosixPartialCleanup:
         failure = _close_posix_descriptors(
             self.descriptors,
             self.expected_identities,
+            self.close_cookies,
         )
         if failure is not None:
             raise failure
@@ -1554,7 +1938,7 @@ def _open_pinned_repository_root(
         if not _identity_is_reliable(anchor_metadata):
             raise ValueError("repository root anchor has no reliable identity")
         anchor_identity = _binding_identity(anchor_metadata)
-        resource_identities[anchor] = anchor_identity
+        resource_identities[anchor] = _descriptor_ownership_identity(anchor_metadata)
         bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
         descriptor = anchor
         for part in root.parts[1:]:
@@ -1576,7 +1960,7 @@ def _open_pinned_repository_root(
             expected_binding = _binding_identity(before)
             if _binding_identity(opened) != expected_binding:
                 raise ValueError("repository root changed while it was being pinned")
-            resource_identities[child] = expected_binding
+            resource_identities[child] = _descriptor_ownership_identity(opened)
             bindings.append((descriptor, part, child, expected_binding))
             descriptor = child
         root_identity = _version_identity(os.fstat(descriptor))
@@ -1647,6 +2031,7 @@ def _fingerprint_windows_repository(
     excluded = _excluded_windows_relative_roots(root_path, exclude_roots)
     file_count = 0
     file_records: list[RepositorySourceFileRecord] = []
+    link_records: list[_RepositorySourceLinkRecord] = []
     root_authority = None
     selected: _WindowsKernelApi | None = None
     completed = False
@@ -1682,8 +2067,22 @@ def _fingerprint_windows_repository(
                         relative_text,
                         expected_root_identity=root_identity,
                         expected_final_identity=_windows_version_identity(metadata),
+                        expected_final_link_target=raw_target,
                         api=selected,
                     ) as binding:
+                        target_state = (
+                            "regular"
+                            if binding.is_regular
+                            else "directory" if binding.is_directory else "unresolved"
+                        )
+                        link_records.append(
+                            _RepositorySourceLinkRecord(
+                                path=relative_text,
+                                lexical_identity=_windows_version_identity(metadata),
+                                link_target=raw_target,
+                                target_state=target_state,
+                            )
+                        )
                         if binding.is_directory:
                             continue
                         if version == 1:
@@ -1725,6 +2124,7 @@ def _fingerprint_windows_repository(
                                     lexical_identity=_windows_version_identity(
                                         metadata
                                     ),
+                                    link_target=raw_target,
                                 )
                             )
                         elif version != 1:
@@ -1800,6 +2200,14 @@ def _fingerprint_windows_repository(
             root_authority,
             root_identity,
         )
+        _verify_windows_repository_links(
+            root_path,
+            root_authority,
+            root_identity,
+            tuple(link_records),
+            {record.path: record for record in file_records},
+            api=selected,
+        )
         completed = True
     except RepositoryChangedError as exc:
         if isinstance(exc.__cause__, BaseException):
@@ -1846,6 +2254,7 @@ def _fingerprint_windows_repository(
                 root=root_path,
                 fingerprint=fingerprint,
                 file_records=file_records,
+                link_records=link_records,
                 inventory_digest=initial_scan.inventory_digest,
                 inventory_entries=initial_scan.inventory_entries,
                 excluded=excluded,
@@ -1919,6 +2328,7 @@ def _fingerprint_repository(
         )
     file_count = 0
     file_records: list[RepositorySourceFileRecord] = []
+    link_records: list[_RepositorySourceLinkRecord] = []
     excluded = _excluded_relative_roots(root_path, exclude_roots)
     root_descriptor = -1
     root_authority: _PosixRepositoryRootAuthority | None = None
@@ -1955,7 +2365,21 @@ def _fingerprint_repository(
                         relative_text,
                         expected_root_identity=root_identity,
                         expected_final_identity=_version_identity(initial_metadata),
+                        expected_final_link_target=raw_target,
                     ) as binding:
+                        target_state = (
+                            "regular"
+                            if binding.is_regular
+                            else "directory" if binding.is_directory else "unresolved"
+                        )
+                        link_records.append(
+                            _RepositorySourceLinkRecord(
+                                path=relative_text,
+                                lexical_identity=_version_identity(initial_metadata),
+                                link_target=raw_target,
+                                target_state=target_state,
+                            )
+                        )
                         if binding.is_directory:
                             # Preserve v1's directory-link exclusion and keep
                             # v2 host/container identities byte-for-byte equal.
@@ -1997,6 +2421,7 @@ def _fingerprint_repository(
                                     lexical_identity=_version_identity(
                                         initial_metadata
                                     ),
+                                    link_target=raw_target,
                                 )
                             )
                         elif version != 1:
@@ -2071,6 +2496,13 @@ def _fingerprint_repository(
                 "repository entries changed while they were being fingerprinted"
             )
         _verify_pinned_repository_root(root_authority, root_identity)
+        _verify_posix_repository_links(
+            root_path,
+            root_descriptor,
+            root_identity,
+            tuple(link_records),
+            {record.path: record for record in file_records},
+        )
         completed = True
     except RepositoryChangedError as exc:
         if isinstance(exc.__cause__, BaseException):
@@ -2122,6 +2554,7 @@ def _fingerprint_repository(
                 root=root_path,
                 fingerprint=fingerprint,
                 file_records=file_records,
+                link_records=link_records,
                 inventory_digest=initial_scan.inventory_digest,
                 inventory_entries=initial_scan.inventory_entries,
                 excluded=excluded,
@@ -2274,6 +2707,7 @@ __all__ = [
     "RepositoryChangedError",
     "RepositorySourceBinding",
     "RepositorySourceFileRecord",
+    "RepositorySourceIdentitySnapshot",
     "SOURCE_FINGERPRINT_VERSION",
     "SourceFingerprint",
     "capture_repository_source",

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -6,30 +6,264 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
+import ntpath
 import os
+import re
 import stat
 import subprocess
+import sys
+import threading
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Callable, Iterable, Iterator
 
 from ._contained_source import (
+    SECURE_CONTAINED_SYMLINKS,
+    _attach_source_cleanup_owner,
+    _binding_identity,
+    _identity_is_reliable,
+    _inherit_source_cleanup_owner,
+    _open_windows_pinned_repository_root,
+    _resolved_repository_file_at,
+    _resolved_windows_repository_file_at,
+    _SourceCleanupSlot,
+    _verify_windows_pinned_repository_root,
     _version_identity,
-    resolved_repository_file,
-    update_repository_file_hash,
+    _windows_entry_is_reparse,
+    _windows_find_child,
+    _windows_identity_is_reliable,
+    _windows_link_target_text,
+    _windows_metadata_is_reparse,
+    _windows_open_child,
+    _windows_version_identity,
 )
+from ._windows_fs_authority import (
+    IO_REPARSE_TAG_SYMLINK as _WINDOWS_IO_REPARSE_TAG_SYMLINK,
+)
+from ._windows_fs_authority import WindowsDirectoryEntry as _WindowsDirectoryEntry
+from ._windows_fs_authority import WindowsHandleMetadata as _WindowsHandleMetadata
+from ._windows_fs_authority import WindowsKernelApi as _WindowsKernelApi
+from ._windows_fs_authority import _WindowsHandleCleanup
 from .repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     repository_path_is_visible,
-    walk_repository_files,
 )
 
-SOURCE_FINGERPRINT_VERSION = 1
+SOURCE_FINGERPRINT_VERSION = 2
+
+_SOURCE_FINGERPRINT_V1_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_SOURCE_FINGERPRINT_V2_RE = re.compile(r"^sha256-v2:[0-9a-f]{64}$")
+_V2_MAGIC = b"codenib-source-fingerprint\x00\x02"
+_MAX_FRAME_BYTES = (1 << 64) - 1
+_MAX_SOURCE_COMPONENTS = 256
+_MAX_SOURCE_PATH_BYTES = 4_096
+_MAX_SOURCE_ENTRIES = 500_000
+_MAX_SOURCE_METADATA_BYTES = 128 * 1024 * 1024
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 
 
 class RepositoryChangedError(RuntimeError):
     """Raised when repository contents change while they are being inspected."""
+
+
+def _remember_interruption(
+    deferred: BaseException | None,
+    interruption: BaseException,
+) -> BaseException:
+    return deferred if deferred is not None else interruption
+
+
+class _SourceLifecycleRLock:
+    """RLock with an owner-depth token visible after interrupted acquisition."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._depth = threading.local()
+
+    def depth(self) -> int:
+        return int(getattr(self._depth, "value", 0))
+
+    def _set_depth(self, depth: int) -> None:
+        self._depth.value = depth
+
+    def _native_is_owned(self) -> bool:
+        runtime: Any = self._lock
+        ownership_check = getattr(runtime, "_is_owned", None)
+        if not callable(ownership_check):
+            raise RuntimeError("source lifecycle lock lacks owner tracking")
+        return bool(ownership_check())
+
+    def acquire(self) -> bool:
+        depth = self.depth()
+        if depth:
+            self._set_depth(depth + 1)
+            return True
+        acquired = self._lock.acquire()
+        if acquired:
+            self._set_depth(1)
+        return acquired
+
+    def release(self) -> None:
+        depth = self.depth()
+        if depth < 1 or not self._native_is_owned():
+            raise RuntimeError("cannot release an unowned source lifecycle lock")
+        if depth > 1:
+            self._set_depth(depth - 1)
+            return
+        self._lock.release()
+        self._set_depth(0)
+
+
+_SOURCE_LOCK_RECOVERY_LIMIT = 64
+
+
+def _defer_source_lock_failure(
+    deferred: BaseException | None,
+    failure: BaseException,
+) -> BaseException:
+    """Retain the first lock interruption while reconciliation completes."""
+
+    return _remember_interruption(deferred, failure)
+
+
+def _acquire_source_lock(
+    lock: _SourceLifecycleRLock,
+    baseline: int,
+    deferred: BaseException | None = None,
+) -> BaseException | None:
+    """Acquire exactly one logical lease without repeating a native acquire.
+
+    Once a native acquire may have run, ownership is reconciled before another
+    acquire is attempted.  This prevents a second cancellation in the recovery
+    probe from adding an untracked native RLock recursion level.
+    """
+
+    for _attempt in range(_SOURCE_LOCK_RECOVERY_LIMIT):
+        try:
+            depth = lock.depth()
+            native_owned = lock._native_is_owned()
+        except BaseException as exc:  # noqa: B036 - bounded reconciliation
+            deferred = _defer_source_lock_failure(deferred, exc)
+            continue
+
+        if native_owned:
+            if depth > baseline:
+                return deferred
+            try:
+                # Native ownership already proves that a zero-depth acquire
+                # completed, or that this is a reentrant logical acquisition.
+                # Publish the one logical level without touching the RLock.
+                lock._set_depth(baseline + 1)
+            except BaseException as exc:  # noqa: B036 - confirm publication
+                deferred = _defer_source_lock_failure(deferred, exc)
+                continue
+            return deferred
+
+        if depth > baseline:
+            try:
+                # A prior attempt changed only the logical token.  Roll that
+                # unowned token back before attempting the native lock.
+                lock._set_depth(baseline)
+            except BaseException as exc:  # noqa: B036 - confirm rollback
+                deferred = _defer_source_lock_failure(deferred, exc)
+                continue
+
+        try:
+            if lock.acquire():
+                return deferred
+        except BaseException as exc:  # noqa: B036 - reconcile before retry
+            deferred = _defer_source_lock_failure(deferred, exc)
+
+    if deferred is not None:
+        raise deferred
+    raise RuntimeError("source lifecycle lock acquisition recovery did not converge")
+
+
+def _release_source_lock(
+    lock: _SourceLifecycleRLock,
+    baseline: int,
+    deferred: BaseException | None = None,
+) -> BaseException | None:
+    """Restore the lease baseline without repeating a completed native release."""
+
+    for _attempt in range(_SOURCE_LOCK_RECOVERY_LIMIT):
+        try:
+            depth = lock.depth()
+            native_owned = lock._native_is_owned()
+        except BaseException as exc:  # noqa: B036 - bounded reconciliation
+            deferred = _defer_source_lock_failure(deferred, exc)
+            continue
+
+        if baseline:
+            if not native_owned:
+                # An outer logical lease must retain the collapsed native lock.
+                # Reacquiring here could block behind a replacement owner, so
+                # fail explicitly after making the lost-ownership state visible.
+                try:
+                    lock._set_depth(0)
+                except BaseException as exc:  # noqa: B036 - confirm publication
+                    deferred = _defer_source_lock_failure(deferred, exc)
+                    continue
+                return _defer_source_lock_failure(
+                    deferred,
+                    RuntimeError("source lifecycle lock lost its outer native owner"),
+                )
+            if depth != baseline:
+                try:
+                    lock._set_depth(baseline)
+                except BaseException as exc:  # noqa: B036 - confirm publication
+                    deferred = _defer_source_lock_failure(deferred, exc)
+                    continue
+            return deferred
+
+        if not native_owned:
+            if depth:
+                try:
+                    lock._set_depth(0)
+                except BaseException as exc:  # noqa: B036 - confirm publication
+                    deferred = _defer_source_lock_failure(deferred, exc)
+                    continue
+            return deferred
+
+        if depth != 1:
+            try:
+                lock._set_depth(1)
+            except BaseException as exc:  # noqa: B036 - confirm publication
+                deferred = _defer_source_lock_failure(deferred, exc)
+                continue
+
+        try:
+            lock.release()
+        except BaseException as exc:  # noqa: B036 - probe before another release
+            deferred = _defer_source_lock_failure(deferred, exc)
+
+    if deferred is not None:
+        raise deferred
+    raise RuntimeError("source lifecycle lock release recovery did not converge")
+
+
+class _SourceLockLease:
+    """Pair one cancellation-safe lock acquisition with one release."""
+
+    def __init__(self, lock: _SourceLifecycleRLock) -> None:
+        self._lock = lock
+        self._baseline = lock.depth()
+
+    def __enter__(self) -> BaseException | None:
+        return _acquire_source_lock(self._lock, self._baseline)
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        exc_value: object,
+        _traceback: object,
+    ) -> None:
+        deferred = _release_source_lock(self._lock, self._baseline)
+        if deferred is not None and exc_value is None:
+            raise deferred
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,20 +274,1878 @@ class SourceFingerprint:
     file_count: int
 
 
-def _link_matches(
-    path: Path,
-    *,
-    initial: os.stat_result,
-    target: str,
-) -> bool:
-    try:
-        observed = path.lstat()
-        observed_target = os.readlink(path)
-    except OSError:
-        return False
-    return _version_identity(observed) == _version_identity(initial) and (
-        observed_target == target
+@dataclass(frozen=True, slots=True)
+class _RepositoryEntry:
+    relative: str
+    metadata: os.stat_result | _WindowsHandleMetadata
+    link_target: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _RepositoryScan:
+    entries: tuple[_RepositoryEntry, ...]
+    inventory_digest: str
+    inventory_entries: int
+
+
+@dataclass(slots=True)
+class _RepositoryScanBudget:
+    entries: int = 0
+    metadata_bytes: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class RepositorySourceFileRecord:
+    """One regular source payload authenticated by a repository binding."""
+
+    path: str
+    size: int
+    sha256: str
+    lexical_identity: tuple[object, ...]
+
+
+class _HashFanout:
+    __slots__ = ("_targets",)
+
+    def __init__(self, *targets: object) -> None:
+        self._targets = targets
+
+    def update(self, payload: bytes) -> None:
+        for target in self._targets:
+            target.update(payload)
+
+
+class RepositorySourceBinding:
+    """Retained root authority and exact records for verified live reads."""
+
+    __slots__ = (
+        "root",
+        "fingerprint",
+        "file_count",
+        "file_records",
+        "_records",
+        "_inventory_digest",
+        "_inventory_entries",
+        "_excluded",
+        "_root_descriptor",
+        "_posix_authority",
+        "_root_identity",
+        "_windows_api",
+        "_windows_authority",
+        "_pid",
+        "_lock",
+        "_closed",
+        "_poisoned",
+        "_session_depth",
+        "_failure_reason",
     )
+
+    def __init__(
+        self,
+        *,
+        root: Path,
+        fingerprint: SourceFingerprint,
+        file_records: Iterable[RepositorySourceFileRecord],
+        inventory_digest: str,
+        inventory_entries: int,
+        excluded: tuple[tuple[str, ...], ...],
+        root_identity: tuple[object, ...],
+        root_descriptor: int = -1,
+        posix_authority: object | None = None,
+        windows_api: _WindowsKernelApi | None = None,
+        windows_authority: object | None = None,
+    ) -> None:
+        records = tuple(file_records)
+        self.root = root
+        self.fingerprint = fingerprint.value
+        self.file_count = fingerprint.file_count
+        self.file_records = records
+        self._records = {record.path: record for record in records}
+        if len(self._records) != len(records):
+            raise ValueError("repository source binding contains duplicate records")
+        self._inventory_digest = inventory_digest
+        self._inventory_entries = inventory_entries
+        self._excluded = excluded
+        self._root_descriptor = root_descriptor
+        self._posix_authority = posix_authority
+        self._root_identity = root_identity
+        self._windows_api = windows_api
+        self._windows_authority = windows_authority
+        self._pid = os.getpid()
+        self._lock = _SourceLifecycleRLock()
+        self._closed = False
+        self._poisoned = False
+        self._session_depth = 0
+        self._failure_reason: str | None = None
+
+    def __enter__(self) -> RepositorySourceBinding:
+        self._require_open()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    @property
+    def usable(self) -> bool:
+        """Return whether this process may still attempt authenticated reads."""
+
+        with self._state_lease():
+            return not self._closed and not self._poisoned and self._pid == os.getpid()
+
+    @property
+    def closed(self) -> bool:
+        """Return whether every retained filesystem authority is closed."""
+
+        with self._state_lease():
+            return self._closed
+
+    @property
+    def failure_reason(self) -> str | None:
+        """Return the first authentication failure retained for diagnostics."""
+
+        with self._state_lease():
+            return self._failure_reason
+
+    @contextmanager
+    def _state_lease(self) -> Iterator[None]:
+        with _SourceLockLease(self._lock) as acquisition_failure:
+            if acquisition_failure is not None:
+                raise acquisition_failure
+            yield
+
+    def _poison(self, reason: object) -> None:
+        try:
+            with _SourceLockLease(self._lock) as deferred:
+                if self._failure_reason is None:
+                    self._failure_reason = str(reason) or "repository source changed"
+                self._poisoned = True
+                try:
+                    self.close()
+                except BaseException as exc:  # noqa: B036 - defer cleanup
+                    deferred = _remember_interruption(deferred, exc)
+                if deferred is not None:
+                    raise deferred
+        except BaseException:  # noqa: B036 - preserve auth failure
+            # Authentication failures retain the operation's original
+            # exception after cleanup has visited every authority.
+            pass
+
+    def _require_open(self) -> None:
+        if self._poisoned:
+            raise RepositoryChangedError("repository source binding is poisoned")
+        if self._closed:
+            raise RuntimeError("repository source binding is closed")
+        if self._pid != os.getpid():
+            raise RuntimeError("repository source binding cannot cross processes")
+
+    @contextmanager
+    def _authentication_lease(self) -> Iterator[None]:
+        """Hold the reentrant lock and poison on every interrupted operation."""
+
+        try:
+            with _SourceLockLease(self._lock) as acquisition_failure:
+                if acquisition_failure is not None:
+                    raise acquisition_failure
+                yield
+        except BaseException as exc:
+            self._poison(exc)
+            raise
+
+    def _verify_inventory(self) -> None:
+        self._require_open()
+        if self._windows_authority is not None:
+            api = self._windows_api
+            if api is None:  # pragma: no cover - constructor invariant
+                raise AssertionError("Windows repository binding has no API")
+            authority = self._windows_authority
+            scan = _scan_pinned_windows_repository(
+                api,
+                authority.handle,
+                excluded=self._excluded,
+                collect_entries=False,
+            )
+            if (
+                scan.inventory_digest != self._inventory_digest
+                or scan.inventory_entries != self._inventory_entries
+            ):
+                raise RepositoryChangedError("repository source inventory changed")
+            _verify_windows_pinned_repository_root(
+                api,
+                authority,
+                self._root_identity,
+            )
+            return
+        scan = _scan_pinned_repository(
+            self._root_descriptor,
+            excluded=self._excluded,
+            collect_entries=False,
+        )
+        if (
+            scan.inventory_digest != self._inventory_digest
+            or scan.inventory_entries != self._inventory_entries
+        ):
+            raise RepositoryChangedError("repository source inventory changed")
+        authority = self._posix_authority
+        if authority is None:  # pragma: no cover - constructor invariant
+            raise AssertionError("POSIX repository binding has no root authority")
+        _verify_pinned_repository_root(
+            authority,
+            self._root_identity,  # type: ignore[arg-type]
+        )
+
+    def verify_snapshot(self) -> None:
+        """Revalidate the whole retained v2 inventory or poison this binding."""
+
+        with self._authentication_lease():
+            try:
+                self._verify_inventory()
+            except BaseException as exc:  # noqa: B036 - preserve body failure
+                self._poison(exc)
+                if isinstance(exc, RepositoryChangedError):
+                    raise
+                if not isinstance(exc, (OSError, RuntimeError, ValueError)):
+                    raise
+                raise RepositoryChangedError(
+                    "repository source changed after it was authenticated"
+                ) from exc
+
+    @contextmanager
+    def read_session(self) -> Iterator[RepositorySourceBinding]:
+        """Gate exact reads with one whole-tree check per side.
+
+        Cancellation is recovered once execution is inside this generator. The
+        outer ``contextlib`` yield/enter handoff remains Python's context-manager
+        protocol boundary; security-sensitive callers must use the temporary
+        form ``with binding.read_session():`` and must not retain or manually
+        enter the returned generator manager.
+        """
+
+        with self._authentication_lease():
+            if self._session_depth == 0:
+                try:
+                    self._verify_inventory()
+                except BaseException as exc:
+                    self._poison(exc)
+                    if isinstance(exc, RepositoryChangedError):
+                        raise
+                    if not isinstance(exc, (OSError, RuntimeError, ValueError)):
+                        raise
+                    raise RepositoryChangedError(
+                        "repository source changed before a read session"
+                    ) from exc
+            self._session_depth += 1
+            primary_failure: BaseException | None = None
+            try:
+                yield self
+            except BaseException as exc:  # noqa: B036 - preserve body failure
+                primary_failure = exc
+            finally:
+                self._session_depth -= 1
+                exit_failure: BaseException | None = None
+                if self._session_depth == 0 and not self._closed and not self._poisoned:
+                    try:
+                        self._verify_inventory()
+                    except BaseException as exc:  # noqa: B036 - defer exit fault
+                        self._poison(exc)
+                        exit_failure = exc
+                if primary_failure is not None:
+                    if exit_failure is not None:
+                        raise primary_failure from exit_failure
+                    raise primary_failure
+                if exit_failure is not None:
+                    if isinstance(exit_failure, RepositoryChangedError):
+                        raise exit_failure
+                    if not isinstance(
+                        exit_failure,
+                        (OSError, RuntimeError, ValueError),
+                    ):
+                        raise exit_failure
+                    raise RepositoryChangedError(
+                        "repository source changed during a read session"
+                    ) from exit_failure
+
+    def _read_record(
+        self,
+        relative: str,
+        record: RepositorySourceFileRecord,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        if self._windows_authority is not None:
+            api = self._windows_api
+            if api is None:  # pragma: no cover - constructor invariant
+                raise AssertionError("Windows repository binding has no API")
+            resolver = _resolved_windows_repository_file_at(
+                self.root,
+                self._windows_authority,
+                relative,
+                expected_root_identity=self._root_identity,
+                expected_final_identity=record.lexical_identity,
+                api=api,
+            )
+        else:
+            resolver = _resolved_repository_file_at(
+                self.root,
+                self._root_descriptor,
+                relative,
+                expected_root_identity=self._root_identity,  # type: ignore[arg-type]
+                expected_final_identity=record.lexical_identity,  # type: ignore[arg-type]
+            )
+        with resolver as source:
+            if not source.is_regular:
+                raise ValueError("source path is no longer a regular file")
+            payload = source.read_bytes(max_bytes=max_bytes)
+        if (
+            len(payload) != record.size
+            or hashlib.sha256(payload).hexdigest() != record.sha256
+        ):
+            raise RepositoryChangedError(
+                "repository source file differs from its authenticated record"
+            )
+        return payload
+
+    def read_bytes(self, relative: str, *, max_bytes: int) -> bytes:
+        """Read one exact captured regular file and rebind the whole inventory."""
+
+        if (
+            isinstance(max_bytes, bool)
+            or not isinstance(max_bytes, int)
+            or max_bytes <= 0
+        ):
+            raise ValueError("source byte limit must be positive")
+        if not isinstance(relative, str):
+            raise TypeError("repository source path must be text")
+        record = self._records.get(relative)
+        if record is None:
+            raise ValueError("source path is not in the authenticated repository")
+        if record.size > max_bytes:
+            raise ValueError("source file exceeds its bounded read limit")
+
+        with self._authentication_lease():
+            try:
+                if self._session_depth == 0:
+                    self._verify_inventory()
+                payload = self._read_record(
+                    relative,
+                    record,
+                    max_bytes=max_bytes,
+                )
+                if self._session_depth == 0:
+                    self._verify_inventory()
+                return payload
+            except BaseException as exc:
+                self._poison(exc)
+                if isinstance(exc, RepositoryChangedError):
+                    raise
+                if not isinstance(exc, (OSError, RuntimeError, ValueError)):
+                    raise
+                raise RepositoryChangedError(
+                    "repository source changed while it was being read"
+                ) from exc
+
+    def close(self) -> None:
+        with _SourceLockLease(self._lock) as first_failure:
+            if not self._closed:
+                # Closing may finish only part of an authority chain before an
+                # operational error. Never permit reads through that partially
+                # dismantled authority; a later close call may still retry the
+                # retained resource owners.
+                self._poisoned = True
+                posix_authority = self._posix_authority
+                if posix_authority is not None:
+                    try:
+                        posix_authority.close()
+                    except BaseException as exc:  # noqa: B036 - finish cleanup
+                        first_failure = _remember_interruption(first_failure, exc)
+                    if posix_authority.closed:
+                        self._posix_authority = None
+                        self._root_descriptor = -1
+                authority = self._windows_authority
+                if authority is not None:
+                    try:
+                        authority.close()
+                    except BaseException as exc:  # noqa: B036 - finish cleanup
+                        first_failure = _remember_interruption(first_failure, exc)
+                    if authority.closed:
+                        self._windows_authority = None
+                self._closed = (
+                    self._posix_authority is None and self._windows_authority is None
+                )
+            if first_failure is not None:
+                raise first_failure
+
+
+def source_fingerprint_version(value: object) -> int | None:
+    """Return the recognized canonical source-fingerprint version."""
+
+    if not isinstance(value, str):
+        return None
+    if _SOURCE_FINGERPRINT_V2_RE.fullmatch(value):
+        return 2
+    if _SOURCE_FINGERPRINT_V1_RE.fullmatch(value):
+        return 1
+    return None
+
+
+def is_secure_source_fingerprint_v2(value: object) -> bool:
+    """Return whether *value* is a canonical, trust-eligible v2 identity."""
+
+    return source_fingerprint_version(value) == SOURCE_FINGERPRINT_VERSION
+
+
+def is_legacy_source_fingerprint_v1(value: object) -> bool:
+    """Return whether *value* is a canonical legacy diagnostic identity."""
+
+    return source_fingerprint_version(value) == 1
+
+
+def lexical_repository_path(value: str | Path) -> Path:
+    """Return an absolute repository path without following replaceable links."""
+
+    return Path(os.path.abspath(os.path.expanduser(os.fspath(value))))
+
+
+def _lexical_windows_repository_path(value: str | Path) -> Path:
+    """Return Windows lexical absolute syntax even in platform-neutral fakes."""
+
+    expanded = os.path.expanduser(os.fspath(value))
+    return Path(ntpath.abspath(expanded))
+
+
+def _entry_version_identity(
+    metadata: os.stat_result | _WindowsHandleMetadata,
+) -> tuple[object, ...]:
+    if isinstance(metadata, _WindowsHandleMetadata):
+        return _windows_version_identity(metadata)
+    return _version_identity(metadata)
+
+
+def _update_frame_header(hasher: object, domain: bytes, payload_size: int) -> None:
+    """Write one unambiguous v2 frame header before a buffered or streamed value."""
+
+    if (
+        not domain
+        or len(domain) > 0xFFFF
+        or payload_size < 0
+        or payload_size > _MAX_FRAME_BYTES
+    ):
+        raise ValueError("source fingerprint frame is outside its encoding limits")
+    update = getattr(hasher, "update", None)
+    if not callable(update):  # pragma: no cover - internal hashlib contract
+        raise TypeError("hasher must provide an update method")
+    update(len(domain).to_bytes(2, "big"))
+    update(domain)
+    update(payload_size.to_bytes(8, "big"))
+
+
+def _update_frame(hasher: object, domain: bytes, payload: bytes) -> None:
+    _update_frame_header(hasher, domain, len(payload))
+    hasher.update(payload)
+
+
+def _directory_flags() -> int:
+    return (
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | os.O_NOFOLLOW
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+
+def _is_link_or_reparse(metadata: os.stat_result) -> bool:
+    return stat.S_ISLNK(metadata.st_mode) or bool(
+        getattr(metadata, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def _excluded_relative_roots(
+    root: Path,
+    exclude_roots: Iterable[str | Path],
+) -> tuple[tuple[str, ...], ...]:
+    excluded: list[tuple[str, ...]] = []
+    for value in exclude_roots:
+        candidate = lexical_repository_path(value)
+        try:
+            relative = candidate.relative_to(root)
+        except ValueError:
+            continue
+        excluded.append(relative.parts)
+    return tuple(excluded)
+
+
+def _excluded_windows_relative_roots(
+    root: Path,
+    exclude_roots: Iterable[str | Path],
+) -> tuple[tuple[str, ...], ...]:
+    root_parts = tuple(
+        part.casefold() for part in ntpath.normpath(str(root)).split("\\")
+    )
+    excluded: list[tuple[str, ...]] = []
+    for value in exclude_roots:
+        candidate = ntpath.normpath(str(_lexical_windows_repository_path(value)))
+        candidate_parts = tuple(candidate.split("\\"))
+        if len(candidate_parts) < len(root_parts) or any(
+            observed.casefold() != expected
+            for observed, expected in zip(
+                candidate_parts,
+                root_parts,
+                strict=False,
+            )
+        ):
+            continue
+        excluded.append(candidate_parts[len(root_parts) :])
+    return tuple(excluded)
+
+
+def _relative_is_excluded(
+    parts: tuple[str, ...],
+    excluded: tuple[tuple[str, ...], ...],
+) -> bool:
+    return any(parts[: len(prefix)] == prefix for prefix in excluded)
+
+
+def _reserve_scan_entry(
+    budget: _RepositoryScanBudget,
+    relative: str,
+) -> None:
+    encoded = os.fsencode(relative)
+    if (
+        len(relative.split("/")) > _MAX_SOURCE_COMPONENTS
+        or len(encoded) > _MAX_SOURCE_PATH_BYTES
+    ):
+        raise ValueError("repository source path exceeds its structural limit")
+    budget.entries += 1
+    budget.metadata_bytes += 256 + len(encoded)
+    if budget.entries > _MAX_SOURCE_ENTRIES:
+        raise ValueError("repository source scan exceeds its entry limit")
+    if budget.metadata_bytes > _MAX_SOURCE_METADATA_BYTES:
+        raise ValueError("repository source scan exceeds its metadata limit")
+
+
+def _reserve_link_target(
+    budget: _RepositoryScanBudget,
+    link_target: str,
+) -> None:
+    budget.metadata_bytes += len(os.fsencode(link_target))
+    if budget.metadata_bytes > _MAX_SOURCE_METADATA_BYTES:
+        raise ValueError("repository source scan exceeds its metadata limit")
+
+
+def _update_inventory_record(
+    hasher: object,
+    *,
+    relative: str,
+    kind: bytes,
+    metadata: os.stat_result | _WindowsHandleMetadata,
+    link_target: str | None,
+) -> None:
+    _update_frame(hasher, b"inventory-kind", kind)
+    _update_frame(hasher, b"inventory-path", os.fsencode(relative))
+    identity = b",".join(
+        repr(value).encode("ascii") for value in _entry_version_identity(metadata)
+    )
+    _update_frame(hasher, b"inventory-identity", identity)
+    if link_target is not None:
+        _update_frame(hasher, b"inventory-link-target", os.fsencode(link_target))
+
+
+def _scan_pinned_repository(
+    root_descriptor: int,
+    *,
+    excluded: tuple[tuple[str, ...], ...],
+    collect_entries: bool,
+) -> _RepositoryScan:
+    """Enumerate one stable view through an already-open repository root."""
+
+    inventory = hashlib.sha256()
+    entries: list[_RepositoryEntry] = []
+    budget = _RepositoryScanBudget()
+    cleanup = _PosixPartialCleanup()
+
+    def scan_directory(
+        descriptor: int,
+        parts: tuple[str, ...],
+    ) -> None:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISDIR(before.st_mode)
+            or _is_link_or_reparse(before)
+            or not _identity_is_reliable(before)
+        ):
+            raise ValueError("repository source directory is not stably bound")
+
+        names: list[str] = []
+        with _owned_scan_descriptor(
+            cleanup,
+            lambda: os.open(".", _directory_flags(), dir_fd=descriptor),
+        ) as scan_descriptor:
+            with os.scandir(scan_descriptor) as children:
+                for child in children:
+                    child_parts = (*parts, child.name)
+                    relative = "/".join(child_parts)
+                    if _relative_is_excluded(child_parts, excluded) or not (
+                        repository_path_is_visible(relative)
+                    ):
+                        continue
+                    # Charge the name before retaining it. A hostile wide
+                    # directory therefore stops at the first over-budget
+                    # entry rather than being materialized before limits run.
+                    _reserve_scan_entry(budget, relative)
+                    names.append(child.name)
+        names.sort()
+
+        directories: list[tuple[str, os.stat_result, tuple[str, ...]]] = []
+        for name in names:
+            child_parts = (*parts, name)
+            relative = "/".join(child_parts)
+            metadata = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+            if not _identity_is_reliable(metadata):
+                raise ValueError(
+                    f"repository source entry has no reliable identity: {relative}"
+                )
+
+            link_target: str | None = None
+            mode = metadata.st_mode
+            if _is_link_or_reparse(metadata):
+                if not stat.S_ISLNK(mode):
+                    raise ValueError(
+                        f"repository source contains a reparse point: {relative}"
+                    )
+                link_target = os.readlink(name, dir_fd=descriptor)
+                _reserve_link_target(budget, link_target)
+                link_after = os.stat(
+                    name,
+                    dir_fd=descriptor,
+                    follow_symlinks=False,
+                )
+                if _version_identity(link_after) != _version_identity(metadata):
+                    raise ValueError(
+                        f"repository source link changed while scanning: {relative}"
+                    )
+                # Never follow a source link from the inventory pass.  Safe
+                # regular/unresolved/directory classification happens through
+                # the pinned contained resolver in the content pass.
+                kind = b"link"
+            elif stat.S_ISDIR(mode):
+                kind = b"directory"
+            elif stat.S_ISREG(mode):
+                kind = b"file"
+            else:
+                kind = f"special-{stat.S_IFMT(mode):o}".encode("ascii")
+
+            _update_inventory_record(
+                inventory,
+                relative=relative,
+                kind=kind,
+                metadata=metadata,
+                link_target=link_target,
+            )
+            if kind == b"directory":
+                directories.append((name, metadata, child_parts))
+            elif collect_entries and kind in {b"file", b"link"}:
+                entries.append(
+                    _RepositoryEntry(
+                        relative=relative,
+                        metadata=metadata,
+                        link_target=link_target,
+                    )
+                )
+
+        del names
+
+        for name, metadata, child_parts in directories:
+            with _owned_scan_descriptor(
+                cleanup,
+                lambda name=name, descriptor=descriptor: os.open(
+                    name,
+                    _directory_flags(),
+                    dir_fd=descriptor,
+                ),
+            ) as child_descriptor:
+                opened = os.fstat(child_descriptor)
+                if _binding_identity(opened) != _binding_identity(metadata):
+                    raise ValueError(
+                        "repository source directory changed while opening: "
+                        + "/".join(child_parts)
+                    )
+                scan_directory(child_descriptor, child_parts)
+                after = os.fstat(child_descriptor)
+                rebound = os.stat(
+                    name,
+                    dir_fd=descriptor,
+                    follow_symlinks=False,
+                )
+                if _version_identity(after) != _version_identity(
+                    opened
+                ) or _version_identity(rebound) != _version_identity(metadata):
+                    raise ValueError(
+                        "repository source directory changed while scanning: "
+                        + "/".join(child_parts)
+                    )
+
+        after = os.fstat(descriptor)
+        if _version_identity(after) != _version_identity(before):
+            label = "/".join(parts) or "."
+            raise ValueError(
+                f"repository source directory changed while scanning: {label}"
+            )
+
+    scan_directory(root_descriptor, ())
+    return _RepositoryScan(
+        entries=tuple(entries),
+        inventory_digest=inventory.hexdigest(),
+        inventory_entries=budget.entries,
+    )
+
+
+def _windows_relative_is_excluded(
+    parts: tuple[str, ...],
+    excluded: tuple[tuple[str, ...], ...],
+) -> bool:
+    folded = tuple(part.casefold() for part in parts)
+    return any(
+        folded[: len(prefix)] == tuple(part.casefold() for part in prefix)
+        for prefix in excluded
+    )
+
+
+def _iter_windows_directory(
+    api: _WindowsKernelApi,
+    handle: int,
+) -> Iterable[_WindowsDirectoryEntry]:
+    iterator = getattr(api, "iter_directory", None)
+    if callable(iterator):
+        return iterator(handle)
+    return api.enumerate_directory(handle)
+
+
+def _scan_pinned_windows_repository(
+    api: _WindowsKernelApi,
+    root_handle: int,
+    *,
+    excluded: tuple[tuple[str, ...], ...],
+    collect_entries: bool,
+) -> _RepositoryScan:
+    """Enumerate through one retained Windows root without following reparses."""
+
+    inventory = hashlib.sha256()
+    entries: list[_RepositoryEntry] = []
+    budget = _RepositoryScanBudget()
+    cleanup = _WindowsHandleCleanup(api)
+
+    def scan_directory(handle: int, parts: tuple[str, ...]) -> None:
+        before = api.metadata(handle)
+        if (
+            not stat.S_ISDIR(before.st_mode)
+            or _windows_metadata_is_reparse(before)
+            or not _windows_identity_is_reliable(before)
+        ):
+            raise ValueError("Windows repository directory is not stably bound")
+
+        children: list[tuple[str, _WindowsDirectoryEntry]] = []
+        for child in _iter_windows_directory(api, handle):
+            child_parts = (*parts, child.name)
+            relative = "/".join(child_parts)
+            if _windows_relative_is_excluded(child_parts, excluded) or not (
+                repository_path_is_visible(relative)
+            ):
+                continue
+            _reserve_scan_entry(budget, relative)
+            children.append((child.name, child))
+        children.sort(key=lambda item: item[0])
+
+        directories: list[
+            tuple[_WindowsDirectoryEntry, tuple[object, ...], tuple[str, ...]]
+        ] = []
+        for name, child in children:
+            child_parts = (*parts, name)
+            relative = "/".join(child_parts)
+            with _owned_scan_handle(
+                cleanup,
+                lambda handle=handle, child=child: _windows_open_child(
+                    api,
+                    handle,
+                    child,
+                    cleanup=cleanup,
+                ),
+            ) as (child_handle, metadata):
+                if metadata.st_dev != before.st_dev:
+                    raise ValueError("Windows repository scan crosses a volume")
+                link_target: str | None = None
+                if _windows_entry_is_reparse(child):
+                    if metadata.reparse_tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
+                        raise ValueError(
+                            f"Windows repository contains unsupported reparse: {relative}"
+                        )
+                    point = api.query_reparse_point(child_handle)
+                    if point.tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
+                        raise ValueError(
+                            f"Windows repository reparse tag changed: {relative}"
+                        )
+                    link_target = _windows_link_target_text(point)
+                    _reserve_link_target(budget, link_target)
+                    kind = b"link"
+                elif stat.S_ISDIR(metadata.st_mode):
+                    kind = b"directory"
+                elif stat.S_ISREG(metadata.st_mode):
+                    kind = b"file"
+                else:
+                    kind = f"special-{stat.S_IFMT(metadata.st_mode):o}".encode("ascii")
+
+                after = api.metadata(child_handle)
+                if _windows_version_identity(after) != _windows_version_identity(
+                    metadata
+                ):
+                    raise ValueError(
+                        f"Windows repository entry changed while scanning: {relative}"
+                    )
+                rebound = _windows_find_child(api, handle, name)
+                if rebound is None or rebound.file_id_128 != child.file_id_128:
+                    raise ValueError(
+                        f"Windows repository entry changed while scanning: {relative}"
+                    )
+                _update_inventory_record(
+                    inventory,
+                    relative=relative,
+                    kind=kind,
+                    metadata=metadata,
+                    link_target=link_target,
+                )
+                if kind == b"directory":
+                    directories.append(
+                        (child, _windows_version_identity(metadata), child_parts)
+                    )
+                elif collect_entries and kind in {b"file", b"link"}:
+                    entries.append(
+                        _RepositoryEntry(
+                            relative=relative,
+                            metadata=metadata,
+                            link_target=link_target,
+                        )
+                    )
+
+        del children
+        for child, expected_identity, child_parts in directories:
+            with _owned_scan_handle(
+                cleanup,
+                lambda handle=handle, child=child: _windows_open_child(
+                    api,
+                    handle,
+                    child,
+                    cleanup=cleanup,
+                ),
+            ) as (child_handle, opened):
+                if _windows_version_identity(opened) != expected_identity:
+                    raise ValueError(
+                        "Windows repository directory changed while reopening: "
+                        + "/".join(child_parts)
+                    )
+                scan_directory(child_handle, child_parts)
+                after = api.metadata(child_handle)
+                rebound = _windows_find_child(api, handle, child.name)
+                if (
+                    _windows_version_identity(after) != expected_identity
+                    or rebound is None
+                    or rebound.file_id_128 != child.file_id_128
+                ):
+                    raise ValueError(
+                        "Windows repository directory changed while scanning: "
+                        + "/".join(child_parts)
+                    )
+
+        after = api.metadata(handle)
+        if _windows_version_identity(after) != _windows_version_identity(before):
+            label = "/".join(parts) or "."
+            raise ValueError(
+                f"Windows repository directory changed while scanning: {label}"
+            )
+
+    scan_directory(root_handle, ())
+    return _RepositoryScan(
+        entries=tuple(entries),
+        inventory_digest=inventory.hexdigest(),
+        inventory_entries=budget.entries,
+    )
+
+
+class _PosixRepositoryRootAuthority:
+    __slots__ = (
+        "root",
+        "descriptor",
+        "root_identity",
+        "_resources",
+        "_resource_identities",
+        "_anchor_identity",
+        "_bindings",
+        "_closed",
+    )
+
+    def __init__(
+        self,
+        *,
+        root: Path,
+        descriptor: int,
+        root_identity: tuple[int, ...],
+        resources: list[int],
+        resource_identities: dict[int, tuple[int, ...]],
+        anchor_identity: tuple[int, ...],
+        bindings: list[tuple[int, str, int, tuple[int, ...]]],
+    ) -> None:
+        self.root = root
+        self.descriptor = descriptor
+        self.root_identity = root_identity
+        self._resources = resources
+        self._resource_identities = resource_identities
+        self._anchor_identity = anchor_identity
+        self._bindings = bindings
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def verify(self, expected_root_identity: tuple[int, ...]) -> None:
+        if self._closed:
+            raise ValueError("repository root authority is closed")
+        anchor = self._resources[0]
+        if _binding_identity(os.fstat(anchor)) != self._anchor_identity:
+            raise ValueError("repository root anchor changed")
+        for parent, name, child, expected_binding in self._bindings:
+            observed = os.stat(name, dir_fd=parent, follow_symlinks=False)
+            opened = os.fstat(child)
+            if (
+                _is_link_or_reparse(observed)
+                or not stat.S_ISDIR(observed.st_mode)
+                or _binding_identity(observed) != expected_binding
+                or _binding_identity(opened) != expected_binding
+            ):
+                raise ValueError("repository root path changed")
+        if _version_identity(os.fstat(self.descriptor)) != expected_root_identity:
+            raise ValueError("repository root changed while it was retained")
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        failure = _close_posix_descriptors(
+            self._resources,
+            self._resource_identities,
+        )
+        self._closed = not self._resources
+        self.descriptor = -1
+        if failure is not None:
+            raise failure
+
+
+def _close_posix_descriptors(
+    descriptors: list[int],
+    expected_identities: dict[int, tuple[int, ...]],
+) -> BaseException | None:
+    """Visit every descriptor and retain the first delayed close failure."""
+
+    deferred: BaseException | None = None
+    for descriptor in reversed(tuple(descriptors)):
+        closed = False
+        while True:
+            try:
+                observed = os.fstat(descriptor)
+                expected = expected_identities.get(descriptor)
+                if expected is not None and _binding_identity(observed) != expected:
+                    deferred = _remember_interruption(
+                        deferred,
+                        RuntimeError("repository descriptor ownership changed"),
+                    )
+                    closed = True
+                    break
+            except OSError as exc:
+                if exc.errno == errno.EBADF:
+                    closed = True
+                    break
+                deferred = _remember_interruption(deferred, exc)
+                break
+            except BaseException as exc:  # noqa: B036 - defer cancellation
+                if isinstance(exc, Exception):
+                    deferred = _remember_interruption(deferred, exc)
+                    break
+                deferred = _remember_interruption(deferred, exc)
+                continue
+
+            expected_at_close = _binding_identity(observed)
+            try:
+                os.close(descriptor)
+                closed = True
+            except BaseException as exc:  # noqa: B036 - confirm close result
+                deferred = _remember_interruption(deferred, exc)
+                while True:
+                    try:
+                        visible = os.fstat(descriptor)
+                    except OSError as probe_error:
+                        if probe_error.errno == errno.EBADF:
+                            closed = True
+                        else:
+                            deferred = _remember_interruption(
+                                deferred,
+                                probe_error,
+                            )
+                        break
+                    except BaseException as probe_error:  # noqa: B036
+                        if isinstance(probe_error, Exception):
+                            deferred = _remember_interruption(
+                                deferred,
+                                probe_error,
+                            )
+                            break
+                        deferred = _remember_interruption(deferred, probe_error)
+                        continue
+                    if _binding_identity(visible) != expected_at_close:
+                        # The owned fd closed and its number was reused. Never
+                        # close the replacement descriptor.
+                        closed = True
+                    break
+                if closed or isinstance(exc, Exception):
+                    break
+                continue
+            break
+
+        if closed:
+            while descriptor in descriptors:
+                try:
+                    descriptors.pop(descriptors.index(descriptor))
+                except BaseException as exc:
+                    if isinstance(exc, Exception):
+                        raise
+                    deferred = _remember_interruption(deferred, exc)
+            while descriptor in expected_identities:
+                try:
+                    expected_identities.pop(descriptor, None)
+                except BaseException as exc:
+                    if isinstance(exc, Exception):
+                        raise
+                    deferred = _remember_interruption(deferred, exc)
+    return deferred
+
+
+class _PosixPartialCleanup:
+    """Retryable owner installed before temporary descriptor acquisition."""
+
+    __slots__ = ("descriptors", "expected_identities")
+
+    def __init__(self) -> None:
+        self.descriptors: list[int] = []
+        self.expected_identities: dict[int, tuple[int, ...]] = {}
+
+    @property
+    def closed(self) -> bool:
+        return not self.descriptors
+
+    def retain(self, descriptor: int, metadata: os.stat_result | None = None) -> int:
+        deferred = _append_owned_descriptor(self.descriptors, descriptor)
+        if deferred is not None:
+            raise deferred
+        if metadata is not None:
+            self.expected_identities[descriptor] = _binding_identity(metadata)
+        return descriptor
+
+    def close_descriptor(self, descriptor: int) -> None:
+        selected = [descriptor] if descriptor in self.descriptors else []
+        identities = {
+            descriptor: self.expected_identities[descriptor]
+            for descriptor in selected
+            if descriptor in self.expected_identities
+        }
+        failure = _close_posix_descriptors(selected, identities)
+        if descriptor not in selected:
+            while descriptor in self.descriptors:
+                self.descriptors.remove(descriptor)
+            self.expected_identities.pop(descriptor, None)
+        if failure is not None:
+            raise failure
+
+    def close(self) -> None:
+        failure = _close_posix_descriptors(
+            self.descriptors,
+            self.expected_identities,
+        )
+        if failure is not None:
+            raise failure
+
+
+@contextmanager
+def _owned_scan_descriptor(
+    cleanup: _PosixPartialCleanup,
+    operation: Callable[[], int],
+) -> Iterator[int]:
+    """Acquire one scan fd and preserve a primary across failed cleanup."""
+
+    descriptor = -1
+    try:
+        descriptor = operation()
+        cleanup.retain(descriptor)
+    except BaseException as primary:  # noqa: B036 - retain partial native return
+        if descriptor >= 0:
+            try:
+                cleanup.retain(descriptor)
+            except BaseException:  # noqa: B036 - preserve acquisition primary
+                pass
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup.close()
+        except BaseException as exc:  # noqa: B036
+            cleanup_failure = exc
+        _attach_source_cleanup_owner(primary, cleanup)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+    try:
+        yield descriptor
+    except BaseException as primary:  # noqa: B036 - preserve scan primary
+        cleanup_failure = None
+        try:
+            cleanup.close_descriptor(descriptor)
+        except BaseException as exc:  # noqa: B036
+            cleanup_failure = exc
+        _attach_source_cleanup_owner(primary, cleanup)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+    else:
+        try:
+            cleanup.close_descriptor(descriptor)
+        except BaseException as cleanup_failure:  # noqa: B036
+            _attach_source_cleanup_owner(cleanup_failure, cleanup)
+            raise
+
+
+@contextmanager
+def _owned_scan_handle(
+    cleanup: _WindowsHandleCleanup,
+    operation: Callable[[], tuple[int, _WindowsHandleMetadata]],
+) -> Iterator[tuple[int, _WindowsHandleMetadata]]:
+    """Retain one scan HANDLE and preserve primary/cleanup priority."""
+
+    try:
+        handle, metadata = operation()
+        cleanup.retain(handle, metadata)
+    except BaseException as primary:  # noqa: B036 - helper may carry an owner
+        nested = getattr(primary, "source_cleanup_owner", None)
+        if nested is not None:
+            _attach_source_cleanup_owner(primary, nested)
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup.close()
+        except BaseException as exc:  # noqa: B036
+            cleanup_failure = exc
+        _attach_source_cleanup_owner(primary, cleanup)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+    try:
+        yield handle, metadata
+    except BaseException as primary:  # noqa: B036 - preserve scan primary
+        selected = _WindowsHandleCleanup(cleanup.api)
+        if handle in cleanup.handles:
+            selected.handles.append(handle)
+            if handle in cleanup.expected_identities:
+                selected.expected_identities[handle] = cleanup.expected_identities[
+                    handle
+                ]
+        cleanup_failure = None
+        try:
+            selected.close()
+        except BaseException as exc:  # noqa: B036
+            cleanup_failure = exc
+        if selected.closed:
+            while handle in cleanup.handles:
+                cleanup.handles.remove(handle)
+            cleanup.expected_identities.pop(handle, None)
+        _attach_source_cleanup_owner(primary, cleanup)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+    else:
+        selected = _WindowsHandleCleanup(cleanup.api)
+        if handle in cleanup.handles:
+            selected.handles.append(handle)
+            if handle in cleanup.expected_identities:
+                selected.expected_identities[handle] = cleanup.expected_identities[
+                    handle
+                ]
+        try:
+            selected.close()
+        except BaseException as cleanup_failure:  # noqa: B036
+            _attach_source_cleanup_owner(cleanup_failure, cleanup)
+            raise
+        finally:
+            if selected.closed:
+                while handle in cleanup.handles:
+                    cleanup.handles.remove(handle)
+                cleanup.expected_identities.pop(handle, None)
+
+
+def _append_owned_descriptor(
+    descriptors: list[int],
+    descriptor: int,
+    deferred: BaseException | None = None,
+) -> BaseException | None:
+    while descriptor not in descriptors:
+        try:
+            descriptors.append(descriptor)
+        except BaseException as exc:
+            if isinstance(exc, Exception):
+                raise
+            deferred = _remember_interruption(deferred, exc)
+    return deferred
+
+
+def _open_owned_posix_directory(
+    path: str,
+    *,
+    descriptors: list[int],
+    dir_fd: int | None = None,
+) -> int:
+    """Open and register a directory fd at the first Python-owned opportunity.
+
+    A raw integer can still be lost if arbitrary opcode injection lands between
+    the native ``os.open`` return and Python's result store. Covering that
+    interpreter boundary requires a native helper that returns an owning object.
+    """
+
+    descriptor = -1
+    try:
+        if dir_fd is None:
+            descriptor = os.open(path, _directory_flags())
+        else:
+            descriptor = os.open(path, _directory_flags(), dir_fd=dir_fd)
+        deferred = _append_owned_descriptor(descriptors, descriptor)
+        if deferred is not None:
+            raise deferred
+        return descriptor
+    except BaseException:  # noqa: B036 - commit descriptor ownership
+        if descriptor >= 0:
+            try:
+                _append_owned_descriptor(descriptors, descriptor)
+            except BaseException:  # noqa: B036 - preserve primary failure
+                pass
+        raise
+
+
+def _open_pinned_repository_root(
+    root: Path,
+    *,
+    cleanup_slot: _SourceCleanupSlot | None = None,
+) -> _PosixRepositoryRootAuthority:
+    if not (SECURE_CONTAINED_SYMLINKS and os.scandir in getattr(os, "supports_fd", ())):
+        raise ValueError(
+            "secure source fingerprints require directory-fd traversal support"
+        )
+    if not root.is_absolute() or root.anchor != os.path.sep:
+        raise ValueError("repository root must be an absolute lexical path")
+    cleanup = _PosixPartialCleanup()
+    if cleanup_slot is not None:
+        cleanup_slot.own(cleanup)
+    resources = cleanup.descriptors
+    resource_identities = cleanup.expected_identities
+    try:
+        anchor = _open_owned_posix_directory(
+            root.anchor,
+            descriptors=resources,
+        )
+        anchor_metadata = os.fstat(anchor)
+        if not _identity_is_reliable(anchor_metadata):
+            raise ValueError("repository root anchor has no reliable identity")
+        anchor_identity = _binding_identity(anchor_metadata)
+        resource_identities[anchor] = anchor_identity
+        bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
+        descriptor = anchor
+        for part in root.parts[1:]:
+            before = os.stat(part, dir_fd=descriptor, follow_symlinks=False)
+            if (
+                _is_link_or_reparse(before)
+                or not stat.S_ISDIR(before.st_mode)
+                or not _identity_is_reliable(before)
+            ):
+                raise ValueError(
+                    "repository root ancestors must be real directories with identity"
+                )
+            child = _open_owned_posix_directory(
+                part,
+                descriptors=resources,
+                dir_fd=descriptor,
+            )
+            opened = os.fstat(child)
+            expected_binding = _binding_identity(before)
+            if _binding_identity(opened) != expected_binding:
+                raise ValueError("repository root changed while it was being pinned")
+            resource_identities[child] = expected_binding
+            bindings.append((descriptor, part, child, expected_binding))
+            descriptor = child
+        root_identity = _version_identity(os.fstat(descriptor))
+        authority = _PosixRepositoryRootAuthority(
+            root=root,
+            descriptor=descriptor,
+            root_identity=root_identity,
+            resources=resources,
+            resource_identities=resource_identities,
+            anchor_identity=anchor_identity,
+            bindings=bindings,
+        )
+        authority.verify(root_identity)
+        if cleanup_slot is not None:
+            cleanup_slot.own(authority)
+        return authority
+    except BaseException as primary:  # noqa: B036 - preserve root failure
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup.close()
+        except BaseException as exc:  # noqa: B036 - retain retry owner
+            cleanup_failure = exc
+        owner = cleanup_slot or cleanup
+        _attach_source_cleanup_owner(primary, owner)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+
+
+def _verify_pinned_repository_root(
+    authority: _PosixRepositoryRootAuthority,
+    expected_identity: tuple[int, ...],
+) -> None:
+    authority.verify(expected_identity)
+
+
+def _fingerprint_windows_repository(
+    root: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path],
+    version: int,
+    api: _WindowsKernelApi | None = None,
+    retain_binding: bool = False,
+    source_owner: Callable[[object], None] | None = None,
+    cleanup_slot: _SourceCleanupSlot | None = None,
+) -> SourceFingerprint | RepositorySourceBinding:
+    """Hash a Windows repository through one retained HANDLE authority."""
+
+    if retain_binding and cleanup_slot is None:
+        cleanup_slot = _SourceCleanupSlot()
+        if source_owner is not None:
+            source_owner(cleanup_slot)
+    root_path = _lexical_windows_repository_path(root)
+    hasher = hashlib.sha256()
+    if version == 1:
+        hasher.update(
+            (
+                "codenib-source-fingerprint:1:" f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
+            ).encode("ascii")
+        )
+    else:
+        hasher.update(_V2_MAGIC)
+        _update_frame(
+            hasher,
+            b"filter-policy-version",
+            str(REPOSITORY_FILTER_POLICY_VERSION).encode("ascii"),
+        )
+    excluded = _excluded_windows_relative_roots(root_path, exclude_roots)
+    file_count = 0
+    file_records: list[RepositorySourceFileRecord] = []
+    root_authority = None
+    selected: _WindowsKernelApi | None = None
+    completed = False
+    try:
+        selected, root_authority, root_identity = _open_windows_pinned_repository_root(
+            root_path,
+            api=api,
+            cleanup_slot=cleanup_slot,
+        )
+        initial_scan = _scan_pinned_windows_repository(
+            selected,
+            root_authority.handle,
+            excluded=excluded,
+            collect_entries=True,
+        )
+        for entry in initial_scan.entries:
+            metadata = entry.metadata
+            if not isinstance(metadata, _WindowsHandleMetadata):
+                raise AssertionError("Windows source scan returned POSIX metadata")
+            relative_text = entry.relative
+            relative = relative_text.encode("utf-8", errors="strict")
+            path = root_path.joinpath(*relative_text.split("/"))
+
+            if _windows_metadata_is_reparse(metadata):
+                raw_target = entry.link_target
+                if raw_target is None:
+                    raise AssertionError("Windows source link has no captured target")
+                target = raw_target.encode("utf-8", errors="strict")
+                try:
+                    with _resolved_windows_repository_file_at(
+                        root_path,
+                        root_authority,
+                        relative_text,
+                        expected_root_identity=root_identity,
+                        expected_final_identity=_windows_version_identity(metadata),
+                        api=selected,
+                    ) as binding:
+                        if binding.is_directory:
+                            continue
+                        if version == 1:
+                            hasher.update(b"L\0")
+                            hasher.update(relative)
+                            hasher.update(b"\0")
+                            hasher.update(target)
+                            hasher.update(b"\0")
+                        else:
+                            _update_frame(hasher, b"entry-kind", b"link")
+                            _update_frame(hasher, b"entry-path", relative)
+                            _update_frame(hasher, b"link-target", target)
+                        link_is_regular = binding.is_regular
+                        if link_is_regular:
+                            if not hasattr(binding, "opened_size"):
+                                raise AssertionError(
+                                    "Windows regular binding has no opened size"
+                                )
+                            if version == 1:
+                                hasher.update(b"C\0")
+                            else:
+                                _update_frame(
+                                    hasher,
+                                    b"link-target-state",
+                                    b"regular",
+                                )
+                                _update_frame_header(
+                                    hasher,
+                                    b"link-target-content",
+                                    binding.opened_size,
+                                )
+                            content_digest = hashlib.sha256()
+                            binding.update_hash(_HashFanout(hasher, content_digest))
+                            file_records.append(
+                                RepositorySourceFileRecord(
+                                    path=relative_text,
+                                    size=binding.opened_size,
+                                    sha256=content_digest.hexdigest(),
+                                    lexical_identity=_windows_version_identity(
+                                        metadata
+                                    ),
+                                )
+                            )
+                        elif version != 1:
+                            _update_frame(
+                                hasher,
+                                b"link-target-state",
+                                b"unresolved",
+                            )
+                except (OSError, ValueError) as exc:
+                    raise RepositoryChangedError(
+                        "repository link target could not be read consistently: "
+                        f"{path}"
+                    ) from exc
+                if version == 1 and link_is_regular:
+                    hasher.update(b"\0")
+                file_count += 1
+                continue
+
+            if not stat.S_ISREG(metadata.st_mode):
+                continue
+            if version == 1:
+                hasher.update(b"F\0")
+                hasher.update(relative)
+                hasher.update(b"\0")
+            else:
+                _update_frame(hasher, b"entry-kind", b"file")
+                _update_frame(hasher, b"entry-path", relative)
+                _update_frame_header(hasher, b"file-content", metadata.st_size)
+            try:
+                with _resolved_windows_repository_file_at(
+                    root_path,
+                    root_authority,
+                    relative_text,
+                    expected_root_identity=root_identity,
+                    expected_final_identity=_windows_version_identity(metadata),
+                    api=selected,
+                ) as binding:
+                    if not binding.is_regular:
+                        raise ValueError("Windows repository file became nonregular")
+                    content_digest = hashlib.sha256()
+                    binding.update_hash(_HashFanout(hasher, content_digest))
+                    file_records.append(
+                        RepositorySourceFileRecord(
+                            path=relative_text,
+                            size=metadata.st_size,
+                            sha256=content_digest.hexdigest(),
+                            lexical_identity=_windows_version_identity(metadata),
+                        )
+                    )
+            except (OSError, ValueError) as exc:
+                raise RepositoryChangedError(
+                    f"repository file could not be read consistently: {path}"
+                ) from exc
+            if version == 1:
+                hasher.update(b"\0")
+            file_count += 1
+
+        final_scan = _scan_pinned_windows_repository(
+            selected,
+            root_authority.handle,
+            excluded=excluded,
+            collect_entries=False,
+        )
+        if (
+            final_scan.inventory_digest != initial_scan.inventory_digest
+            or final_scan.inventory_entries != initial_scan.inventory_entries
+        ):
+            raise RepositoryChangedError(
+                "repository entries changed while they were being fingerprinted"
+            )
+        _verify_windows_pinned_repository_root(
+            selected,
+            root_authority,
+            root_identity,
+        )
+        completed = True
+    except RepositoryChangedError as exc:
+        if isinstance(exc.__cause__, BaseException):
+            _inherit_source_cleanup_owner(exc, exc.__cause__)
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        failure = RepositoryChangedError(
+            "repository changed while it was being fingerprinted"
+        )
+        _inherit_source_cleanup_owner(failure, exc)
+        raise failure from exc
+    finally:
+        if root_authority is not None and (not retain_binding or not completed):
+            active_failure = sys.exc_info()[1]
+            owner = cleanup_slot or root_authority
+            try:
+                owner.close()  # type: ignore[attr-defined]
+            except BaseException as cleanup_failure:  # noqa: B036
+                if active_failure is not None:
+                    _attach_source_cleanup_owner(active_failure, owner)
+                    raise active_failure from cleanup_failure
+                _attach_source_cleanup_owner(cleanup_failure, owner)
+                raise
+
+    if version != 1:
+        _update_frame(hasher, b"entry-count", file_count.to_bytes(8, "big"))
+    fingerprint = SourceFingerprint(
+        value=(
+            f"sha256:{hasher.hexdigest()}"
+            if version == 1
+            else f"sha256-v2:{hasher.hexdigest()}"
+        ),
+        file_count=file_count,
+    )
+    if retain_binding:
+        if version != SOURCE_FINGERPRINT_VERSION:
+            raise ValueError("only source fingerprint v2 can retain read authority")
+        if selected is None or root_authority is None:  # pragma: no cover - invariant
+            raise AssertionError("Windows source authority was not retained")
+        retained = root_authority
+        binding: RepositorySourceBinding | None = None
+        try:
+            binding = RepositorySourceBinding(
+                root=root_path,
+                fingerprint=fingerprint,
+                file_records=file_records,
+                inventory_digest=initial_scan.inventory_digest,
+                inventory_entries=initial_scan.inventory_entries,
+                excluded=excluded,
+                root_identity=root_identity,
+                windows_api=selected,
+                windows_authority=retained,
+            )
+            if cleanup_slot is not None:
+                cleanup_slot.own(binding)
+            root_authority = None
+            return binding
+        except BaseException as primary:  # noqa: B036 - preserve construction
+            owner = cleanup_slot or binding or retained
+            cleanup_failure: BaseException | None = None
+            try:
+                owner.close()  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - expose retry owner
+                cleanup_failure = exc
+            _attach_source_cleanup_owner(primary, owner)
+            if cleanup_failure is not None:
+                raise primary from cleanup_failure
+            raise
+    return fingerprint
+
+
+def _fingerprint_repository(
+    root: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path],
+    version: int,
+    retain_binding: bool = False,
+    source_owner: Callable[[object], None] | None = None,
+) -> SourceFingerprint | RepositorySourceBinding:
+    """Hash visible repository contents with v2 or the diagnostic v1 format."""
+
+    if version not in {1, SOURCE_FINGERPRINT_VERSION}:
+        raise ValueError(f"unsupported source fingerprint version: {version}")
+    cleanup_slot: _SourceCleanupSlot | None = None
+    if retain_binding:
+        cleanup_slot = _SourceCleanupSlot()
+        if source_owner is not None:
+            source_owner(cleanup_slot)
+    if sys.platform == "win32":
+        return _fingerprint_windows_repository(
+            root,
+            exclude_roots=exclude_roots,
+            version=version,
+            retain_binding=retain_binding,
+            cleanup_slot=cleanup_slot,
+        )
+
+    # Do not call Path.resolve() here. A reversible root-to-symlink swap during
+    # resolution could permanently redirect the rest of this operation to a
+    # foreign tree. The lexical path remains the rebind target for the pinned
+    # no-follow descriptor throughout the operation.
+    root_path = lexical_repository_path(root)
+
+    hasher = hashlib.sha256()
+    if version == 1:
+        hasher.update(
+            (
+                "codenib-source-fingerprint:1:" f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
+            ).encode("ascii")
+        )
+    else:
+        hasher.update(_V2_MAGIC)
+        _update_frame(
+            hasher,
+            b"filter-policy-version",
+            str(REPOSITORY_FILTER_POLICY_VERSION).encode("ascii"),
+        )
+    file_count = 0
+    file_records: list[RepositorySourceFileRecord] = []
+    excluded = _excluded_relative_roots(root_path, exclude_roots)
+    root_descriptor = -1
+    root_authority: _PosixRepositoryRootAuthority | None = None
+    completed = False
+    try:
+        root_authority = _open_pinned_repository_root(
+            root_path,
+            cleanup_slot=cleanup_slot,
+        )
+        root_descriptor = root_authority.descriptor
+        root_identity = root_authority.root_identity
+        initial_scan = _scan_pinned_repository(
+            root_descriptor,
+            excluded=excluded,
+            collect_entries=True,
+        )
+
+        for entry in initial_scan.entries:
+            relative_text = entry.relative
+            relative = os.fsencode(relative_text)
+            initial_metadata = entry.metadata
+            path = root_path.joinpath(*relative_text.split("/"))
+
+            mode = initial_metadata.st_mode
+            if stat.S_ISLNK(mode):
+                raw_target = entry.link_target
+                if raw_target is None:  # pragma: no cover - scan invariant
+                    raise AssertionError("source link has no captured target")
+                target = os.fsencode(raw_target)
+                try:
+                    with _resolved_repository_file_at(
+                        root_path,
+                        root_descriptor,
+                        relative_text,
+                        expected_root_identity=root_identity,
+                        expected_final_identity=_version_identity(initial_metadata),
+                    ) as binding:
+                        if binding.is_directory:
+                            # Preserve v1's directory-link exclusion and keep
+                            # v2 host/container identities byte-for-byte equal.
+                            continue
+                        if version == 1:
+                            hasher.update(b"L\0")
+                            hasher.update(relative)
+                            hasher.update(b"\0")
+                            hasher.update(target)
+                            hasher.update(b"\0")
+                        else:
+                            _update_frame(hasher, b"entry-kind", b"link")
+                            _update_frame(hasher, b"entry-path", relative)
+                            _update_frame(hasher, b"link-target", target)
+                        link_is_regular = binding.is_regular
+                        if link_is_regular:
+                            if version == 1:
+                                hasher.update(b"C\0")
+                            else:
+                                opened = os.fstat(binding.descriptor)
+                                _update_frame(
+                                    hasher,
+                                    b"link-target-state",
+                                    b"regular",
+                                )
+                                _update_frame_header(
+                                    hasher,
+                                    b"link-target-content",
+                                    opened.st_size,
+                                )
+                            opened = os.fstat(binding.descriptor)
+                            content_digest = hashlib.sha256()
+                            binding.update_hash(_HashFanout(hasher, content_digest))
+                            file_records.append(
+                                RepositorySourceFileRecord(
+                                    path=relative_text,
+                                    size=opened.st_size,
+                                    sha256=content_digest.hexdigest(),
+                                    lexical_identity=_version_identity(
+                                        initial_metadata
+                                    ),
+                                )
+                            )
+                        elif version != 1:
+                            _update_frame(
+                                hasher,
+                                b"link-target-state",
+                                b"unresolved",
+                            )
+                except (OSError, ValueError) as exc:
+                    raise RepositoryChangedError(
+                        "repository link target could not be read consistently: "
+                        f"{path}"
+                    ) from exc
+                if version == 1 and link_is_regular:
+                    hasher.update(b"\0")
+                file_count += 1
+                continue
+
+            if not stat.S_ISREG(mode):  # pragma: no cover - scan invariant
+                continue
+
+            if version == 1:
+                hasher.update(b"F\0")
+                hasher.update(relative)
+                hasher.update(b"\0")
+            else:
+                _update_frame(hasher, b"entry-kind", b"file")
+                _update_frame(hasher, b"entry-path", relative)
+                _update_frame_header(
+                    hasher,
+                    b"file-content",
+                    initial_metadata.st_size,
+                )
+            try:
+                with _resolved_repository_file_at(
+                    root_path,
+                    root_descriptor,
+                    relative_text,
+                    expected_root_identity=root_identity,
+                    expected_final_identity=_version_identity(initial_metadata),
+                ) as binding:
+                    if not binding.is_regular:  # pragma: no cover - expected regular
+                        raise ValueError("repository file became nonregular")
+                    content_digest = hashlib.sha256()
+                    binding.update_hash(_HashFanout(hasher, content_digest))
+                    file_records.append(
+                        RepositorySourceFileRecord(
+                            path=relative_text,
+                            size=initial_metadata.st_size,
+                            sha256=content_digest.hexdigest(),
+                            lexical_identity=_version_identity(initial_metadata),
+                        )
+                    )
+            except (OSError, ValueError) as exc:
+                raise RepositoryChangedError(
+                    f"repository file could not be read consistently: {path}"
+                ) from exc
+            if version == 1:
+                hasher.update(b"\0")
+            file_count += 1
+
+        final_scan = _scan_pinned_repository(
+            root_descriptor,
+            excluded=excluded,
+            collect_entries=False,
+        )
+        if (
+            final_scan.inventory_digest != initial_scan.inventory_digest
+            or final_scan.inventory_entries != initial_scan.inventory_entries
+        ):
+            raise RepositoryChangedError(
+                "repository entries changed while they were being fingerprinted"
+            )
+        _verify_pinned_repository_root(root_authority, root_identity)
+        completed = True
+    except RepositoryChangedError as exc:
+        if isinstance(exc.__cause__, BaseException):
+            _inherit_source_cleanup_owner(exc, exc.__cause__)
+        raise
+    except (OSError, ValueError) as exc:
+        failure = RepositoryChangedError(
+            "repository changed while it was being fingerprinted"
+        )
+        _inherit_source_cleanup_owner(failure, exc)
+        raise failure from exc
+    finally:
+        if root_authority is not None and (not retain_binding or not completed):
+            active_failure = sys.exc_info()[1]
+            owner = cleanup_slot or root_authority
+            try:
+                owner.close()  # type: ignore[attr-defined]
+            except BaseException as cleanup_failure:  # noqa: B036
+                if active_failure is not None:
+                    _attach_source_cleanup_owner(active_failure, owner)
+                    raise active_failure from cleanup_failure
+                _attach_source_cleanup_owner(cleanup_failure, owner)
+                raise
+
+    if version != 1:
+        _update_frame(
+            hasher,
+            b"entry-count",
+            file_count.to_bytes(8, "big"),
+        )
+    fingerprint = SourceFingerprint(
+        value=(
+            f"sha256:{hasher.hexdigest()}"
+            if version == 1
+            else f"sha256-v2:{hasher.hexdigest()}"
+        ),
+        file_count=file_count,
+    )
+    if retain_binding:
+        if version != SOURCE_FINGERPRINT_VERSION:
+            raise ValueError("only source fingerprint v2 can retain read authority")
+        if root_authority is None:  # pragma: no cover - invariant
+            raise AssertionError("POSIX source authority was not retained")
+        retained_authority = root_authority
+        retained_descriptor = retained_authority.descriptor
+        binding: RepositorySourceBinding | None = None
+        try:
+            binding = RepositorySourceBinding(
+                root=root_path,
+                fingerprint=fingerprint,
+                file_records=file_records,
+                inventory_digest=initial_scan.inventory_digest,
+                inventory_entries=initial_scan.inventory_entries,
+                excluded=excluded,
+                root_identity=root_identity,
+                root_descriptor=retained_descriptor,
+                posix_authority=retained_authority,
+            )
+            if cleanup_slot is not None:
+                cleanup_slot.own(binding)
+            root_authority = None
+            root_descriptor = -1
+            return binding
+        except BaseException as primary:  # noqa: B036 - preserve construction
+            owner = cleanup_slot or binding or retained_authority
+            cleanup_failure: BaseException | None = None
+            try:
+                owner.close()  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - expose retry owner
+                cleanup_failure = exc
+            _attach_source_cleanup_owner(primary, owner)
+            if cleanup_failure is not None:
+                raise primary from cleanup_failure
+            raise
+    return fingerprint
 
 
 def fingerprint_repository(
@@ -61,91 +2153,60 @@ def fingerprint_repository(
     *,
     exclude_roots: Iterable[str | Path] = (),
 ) -> SourceFingerprint:
-    """Hash the paths and contents exposed by the shared repository filter."""
+    """Hash visible paths and contents with the canonical v2 framing."""
 
-    root_path = Path(root).expanduser().resolve()
-    if not root_path.is_dir():
-        raise ValueError(f"repository path is not a directory: {root_path}")
-
-    hasher = hashlib.sha256()
-    hasher.update(
-        (
-            f"codenib-source-fingerprint:{SOURCE_FINGERPRINT_VERSION}:"
-            f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
-        ).encode("ascii")
+    result = _fingerprint_repository(
+        root,
+        exclude_roots=exclude_roots,
+        version=SOURCE_FINGERPRINT_VERSION,
     )
-    file_count = 0
+    if not isinstance(result, SourceFingerprint):  # pragma: no cover - invariant
+        result.close()
+        raise AssertionError("fingerprint unexpectedly retained source authority")
+    return result
 
-    for path in walk_repository_files(root_path, exclude_roots=exclude_roots):
-        relative_text = path.relative_to(root_path).as_posix()
-        relative = relative_text.encode("utf-8", errors="surrogateescape")
-        try:
-            initial_metadata = path.lstat()
-        except OSError as exc:
-            raise RepositoryChangedError(
-                f"repository file disappeared while it was being inspected: {path}"
-            ) from exc
 
-        mode = initial_metadata.st_mode
-        if stat.S_ISLNK(mode):
-            try:
-                raw_target = os.readlink(path)
-                target = raw_target.encode("utf-8", errors="surrogateescape")
-            except OSError as exc:
-                raise RepositoryChangedError(
-                    f"repository link changed while it was being inspected: {path}"
-                ) from exc
-            hasher.update(b"L\0")
-            hasher.update(relative)
-            hasher.update(b"\0")
-            hasher.update(target)
-            hasher.update(b"\0")
-            try:
-                with resolved_repository_file(
-                    root_path,
-                    relative_text,
-                    expected_final_identity=_version_identity(initial_metadata),
-                ) as binding:
-                    if binding.is_regular:
-                        hasher.update(b"C\0")
-                        binding.update_hash(hasher)
-            except (OSError, ValueError) as exc:
-                raise RepositoryChangedError(
-                    "repository link target could not be read consistently: " f"{path}"
-                ) from exc
-            if not _link_matches(path, initial=initial_metadata, target=raw_target):
-                raise RepositoryChangedError(
-                    f"repository link changed while it was being read: {path}"
-                )
-            if binding.is_regular:
-                hasher.update(b"\0")
-            file_count += 1
-            continue
+def capture_repository_source(
+    root: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path] = (),
+    _source_owner: Callable[[object], None] | None = None,
+) -> RepositorySourceBinding:
+    """Capture source fingerprint v2 and retain its exact read authority.
 
-        if not stat.S_ISREG(mode):
-            continue
+    ``_source_owner`` is an internal handoff sink used by callers that must own
+    a stable cleanup slot before acquisition and the completed binding before
+    this Python frame returns.
+    """
 
-        hasher.update(b"F\0")
-        hasher.update(relative)
-        hasher.update(b"\0")
-        try:
-            update_repository_file_hash(
-                root_path,
-                relative_text,
-                hasher,
-                expected_final_identity=_version_identity(initial_metadata),
-            )
-        except (OSError, ValueError) as exc:
-            raise RepositoryChangedError(
-                f"repository file could not be read consistently: {path}"
-            ) from exc
-        hasher.update(b"\0")
-        file_count += 1
-
-    return SourceFingerprint(
-        value=f"sha256:{hasher.hexdigest()}",
-        file_count=file_count,
+    result = _fingerprint_repository(
+        root,
+        exclude_roots=exclude_roots,
+        version=SOURCE_FINGERPRINT_VERSION,
+        retain_binding=True,
+        source_owner=_source_owner,
     )
+    if not isinstance(result, RepositorySourceBinding):  # pragma: no cover
+        raise AssertionError("source capture did not retain repository authority")
+    return result
+
+
+def fingerprint_repository_v1_for_diagnostics(
+    root: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path] = (),
+) -> SourceFingerprint:
+    """Reproduce legacy v1 solely for migration diagnostics.
+
+    V1 used delimiter concatenation and is structurally ambiguous.  Its result
+    must never authorize source reads, native indexes, or artifact reuse.
+    """
+
+    result = _fingerprint_repository(root, exclude_roots=exclude_roots, version=1)
+    if not isinstance(result, SourceFingerprint):  # pragma: no cover - invariant
+        result.close()
+        raise AssertionError("diagnostic fingerprint retained source authority")
+    return result
 
 
 def repository_source_is_dirty(
@@ -159,8 +2220,11 @@ def repository_source_is_dirty(
     Git-based incremental update paths.
     """
 
-    root_path = Path(root).expanduser().resolve()
-    excluded = tuple(Path(path).expanduser().resolve() for path in exclude_roots)
+    # Keep the same lexical-root contract as fingerprint_repository().  A
+    # resolve() here would let a reversible root swap redirect Git's status
+    # query and incorrectly authorize an incremental update for another tree.
+    root_path = lexical_repository_path(root)
+    excluded = tuple(lexical_repository_path(path) for path in exclude_roots)
     try:
         result = subprocess.run(
             [
@@ -208,8 +2272,16 @@ def repository_source_is_dirty(
 
 __all__ = [
     "RepositoryChangedError",
+    "RepositorySourceBinding",
+    "RepositorySourceFileRecord",
     "SOURCE_FINGERPRINT_VERSION",
     "SourceFingerprint",
+    "capture_repository_source",
     "fingerprint_repository",
+    "fingerprint_repository_v1_for_diagnostics",
+    "is_legacy_source_fingerprint_v1",
+    "is_secure_source_fingerprint_v2",
+    "lexical_repository_path",
     "repository_source_is_dirty",
+    "source_fingerprint_version",
 ]

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -21,6 +21,10 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
+from ..index.embedding._lifecycle import close_vector_after_failure
+from ..index.embedding.artifact_integrity import (
+    _mint_trusted_local_vector_authorization,
+)
 from ..log_utils import get_logger
 from ..provider_routes import normalize_endpoint, resolve_embedding_artifact_route
 from ..repository_summary import read_repository_summary
@@ -448,6 +452,13 @@ class RepoRegistry:
             client_kwargs = route.client_kwargs()
         embedding_kwargs.update(client_kwargs)
 
+        native_authorization = _mint_trusted_local_vector_authorization(
+            vec_entry.path,
+            artifact_config,
+            evidence=("web-repository-local-vector-view",),
+        )
+        missing_embedding = object()
+        previous_embedding = self._embeddings.get(cache_key, missing_embedding)
         vector_store = _vector_store_type()(
             embedding_model=route.model,
             embedding_provider=route.provider,
@@ -458,9 +469,30 @@ class RepoRegistry:
             artifact_metadata=artifact_config,
             **embedding_kwargs,
         )
-        self._embeddings[cache_key] = vector_store.embedding
-        vector_store.load(vec_entry.path)
-        return vector_store
+        candidate_embedding = missing_embedding
+        try:
+            candidate_embedding = vector_store.embedding
+            vector_store.load(
+                vec_entry.path,
+                native_index_authorization=native_authorization,
+            )
+            # Publish the reusable client only after the authenticated vector
+            # view loaded successfully.  The exception handler below rolls
+            # this handoff back if cancellation lands before the return.
+            self._embeddings[cache_key] = candidate_embedding
+            return vector_store
+        except BaseException as primary:  # noqa: B036 - close partial state
+            if (
+                candidate_embedding is not missing_embedding
+                and self._embeddings.get(cache_key, missing_embedding)
+                is candidate_embedding
+            ):
+                if previous_embedding is missing_embedding:
+                    self._embeddings.pop(cache_key, None)
+                else:
+                    self._embeddings[cache_key] = previous_embedding
+            close_vector_after_failure(vector_store, primary)
+            raise
 
     def _create_ask_llm(self) -> "LiteLLMChat":
         """Create the interactive model without mutating process-wide config."""

--- a/examples/eval_synthesized_queries.py
+++ b/examples/eval_synthesized_queries.py
@@ -54,6 +54,7 @@ import subprocess
 import sys
 import time
 from collections import Counter, defaultdict
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -372,8 +373,14 @@ def _make_agent(
     from codenib.compiler.manifest import RepoManifest
     from codenib.compiler.params import SessionContext
     from codenib.index.embedding import CodeVectorStore
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
     from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
     from codenib.llm.litellm_chat import LiteLLMChat
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
     from codenib.ops.rerank import RerankContext
     from codenib.ops.retrieve import RetrieveContext
 
@@ -405,59 +412,88 @@ def _make_agent(
     )
     compiler.compile_repo(repo_path, cache_dir=cache_dir)
 
-    # Phase 2: load indexes, skills, build runner
-    manifest = RepoManifest.load(os.path.join(cache_dir, "repo_manifest.json"))
-    bm25_index, vector_store = None, None
+    # Phase 2: load indexes, skills, build runner.  Keep the vector store
+    # registered before loading so any partial native state is also released.
+    with ExitStack() as resources:
+        manifest = RepoManifest.load(os.path.join(cache_dir, "repo_manifest.json"))
+        bm25_index, vector_store = None, None
 
-    if "bm25" in manifest.indexes and manifest.indexes["bm25"].status == "fresh":
-        bm25_index = BM25CodeIndexer()
-        bm25_index.load_index(manifest.indexes["bm25"].path)
+        if "bm25" in manifest.indexes and manifest.indexes["bm25"].status == "fresh":
+            bm25_index = BM25CodeIndexer()
+            bm25_index.load_index(manifest.indexes["bm25"].path)
 
-    if "vector" in manifest.indexes and manifest.indexes["vector"].status == "fresh":
-        cfg = manifest.indexes["vector"].config
-        vector_store = CodeVectorStore(
-            embedding_model=cfg.get("embedding_model", args.embedding_model),
-            embedding_provider="huggingface",
-            dimension=cfg.get("embedding_dimension", args.embedding_dimension),
-            store_path=manifest.indexes["vector"].path,
+        if (
+            "vector" in manifest.indexes
+            and manifest.indexes["vector"].status == "fresh"
+        ):
+            entry = manifest.indexes["vector"]
+            artifact_contract = dict(entry.config)
+            with capture_authenticated_vector_view(entry.path) as vector_view:
+                native_authorization = _mint_trusted_local_admin_authorization(
+                    vector_view.ownership,
+                    view_type="vector",
+                    semantic_contract=artifact_contract,
+                    evidence=(
+                        "synthesized-eval-local-vector-view",
+                        "captured-vector-tree-subject",
+                    ),
+                )
+            vector_store = CodeVectorStore(
+                embedding_model=artifact_contract.get(
+                    "embedding_model", args.embedding_model
+                ),
+                embedding_provider="huggingface",
+                dimension=artifact_contract.get(
+                    "embedding_dimension", args.embedding_dimension
+                ),
+                store_path=entry.path,
+                artifact_metadata=artifact_contract,
+            )
+            resources.callback(vector_store.close)
+            vector_store.load(
+                entry.path,
+                native_index_authorization=native_authorization,
+            )
+
+        ctx: Dict[str, Any] = {
+            "retrieve": RetrieveContext(
+                bm25=bm25_index,
+                vector_store=vector_store,
+                default_top_k=args.topk,
+                default_level="l2",
+            ),
+        }
+        if vector_store:
+            ctx["rerank"] = RerankContext(embedding_store=vector_store)
+
+        skills_dir = os.path.join(_PROJECT_ROOT, "codenib", "agent", "skills")
+        SkillLoader().load_all(skills_dir, contexts=ctx)
+
+        runner = AgentRunner(
+            llm=LiteLLMChat(model=args.model, temperature=0.0, max_tokens=1024),
+            registry=SkillRegistry(),
+            max_turns=args.max_turns,
+            manifest=manifest,
+            session_ctx=SessionContext(
+                repo_path=repo_path,
+                repo_size=manifest.file_count,
+                primary_language=(
+                    manifest.languages[0] if manifest.languages else language
+                ),
+            ),
         )
-        vector_store.load(manifest.indexes["vector"].path)
 
-    ctx: Dict[str, Any] = {
-        "retrieve": RetrieveContext(
-            bm25=bm25_index,
-            vector_store=vector_store,
-            default_top_k=args.topk,
-            default_level="l2",
-        ),
-    }
-    if vector_store:
-        ctx["rerank"] = RerankContext(embedding_store=vector_store)
+        def query_fn(q: str, **_kw) -> List[QueriedNode]:
+            result = runner.run(q)
+            nodes: List[QueriedNode] = []
+            for tc in result.tool_calls:
+                if isinstance(tc.result, list):
+                    nodes.extend(n for n in tc.result if isinstance(n, QueriedNode))
+            return nodes
 
-    skills_dir = os.path.join(_PROJECT_ROOT, "codenib", "agent", "skills")
-    SkillLoader().load_all(skills_dir, contexts=ctx)
+        retained_resources = resources.pop_all()
 
-    runner = AgentRunner(
-        llm=LiteLLMChat(model=args.model, temperature=0.0, max_tokens=1024),
-        registry=SkillRegistry(),
-        max_turns=args.max_turns,
-        manifest=manifest,
-        session_ctx=SessionContext(
-            repo_path=repo_path,
-            repo_size=manifest.file_count,
-            primary_language=manifest.languages[0] if manifest.languages else language,
-        ),
-    )
-
-    def query_fn(q: str, **_kw) -> List[QueriedNode]:
-        result = runner.run(q)
-        nodes: List[QueriedNode] = []
-        for tc in result.tool_calls:
-            if isinstance(tc.result, list):
-                nodes.extend(n for n in tc.result if isinstance(n, QueriedNode))
-        return nodes
-
-    return runner, query_fn, lambda: None
+    return runner, query_fn, retained_resources.close
 
 
 _PIPELINE_FACTORIES = {

--- a/examples/skill_agent.py
+++ b/examples/skill_agent.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -128,6 +129,12 @@ def build_vector_store(
 ):
     """Build (or load) hierarchical embedding index."""
     from codenib.index.embedding import CodeVectorStore, build_hierarchical_vector_store
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
 
     store_path = Path(index_path)
     store_path.mkdir(parents=True, exist_ok=True)
@@ -136,15 +143,33 @@ def build_vector_store(
     l2 = store_path / "l2"
     if l0.exists() and l2.exists():
         print("  Embedding: loading cached index")
-        vs = CodeVectorStore(
-            embedding_model=embedding_model,
-            embedding_provider="huggingface",
-            dimension=embedding_dimension,
-            store_path=str(store_path),
-        )
-        vs.load(str(store_path))
-        if vs.l0_documents and vs.l2_documents:
-            return vs
+        artifact_contract: Dict[str, Any] = {}
+        with capture_authenticated_vector_view(store_path) as vector_view:
+            native_authorization = _mint_trusted_local_admin_authorization(
+                vector_view.ownership,
+                view_type="vector",
+                semantic_contract=artifact_contract,
+                evidence=(
+                    "skill-agent-cached-vector-view",
+                    "captured-vector-tree-subject",
+                ),
+            )
+        with ExitStack() as resources:
+            vs = CodeVectorStore(
+                embedding_model=embedding_model,
+                embedding_provider="huggingface",
+                dimension=embedding_dimension,
+                store_path=str(store_path),
+                artifact_metadata=artifact_contract,
+            )
+            resources.callback(vs.close)
+            vs.load(
+                str(store_path),
+                native_index_authorization=native_authorization,
+            )
+            if vs.l0_documents and vs.l2_documents:
+                resources.pop_all()
+                return vs
         print("  Embedding: cache incomplete, rebuilding")
 
     print("  Embedding: building hierarchical index (may take a minute)...")
@@ -302,7 +327,13 @@ def run_agent(args: argparse.Namespace) -> None:
     from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
     from codenib.compiler.manifest import RepoManifest
     from codenib.index.embedding import CodeVectorStore
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
     from codenib.llm.litellm_chat import LiteLLMChat
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
 
     repo_path = os.path.abspath(args.repo)
     cache_dir = args.index_path or str(repo_index_dir(repo_path))
@@ -364,88 +395,110 @@ def run_agent(args: argparse.Namespace) -> None:
     manifest = RepoManifest.load(manifest_path)
     print(f"  Loaded manifest: {len(manifest.indexes)} indexes")
 
-    # Load actual index objects from manifest paths
-    bm25_index = None
-    vector_store = None
+    # Load actual index objects from manifest paths.  Register native resources
+    # before loading so both partial-load failures and normal completion close.
+    with ExitStack() as resources:
+        bm25_index = None
+        vector_store = None
 
-    if "bm25" in manifest.indexes and manifest.indexes["bm25"].status == "fresh":
-        bm25_index = BM25CodeIndexer()
-        bm25_index.load_index(manifest.indexes["bm25"].path)
-        print(f"  Loaded BM25 from {manifest.indexes['bm25'].path}")
+        if "bm25" in manifest.indexes and manifest.indexes["bm25"].status == "fresh":
+            bm25_index = BM25CodeIndexer()
+            bm25_index.load_index(manifest.indexes["bm25"].path)
+            print(f"  Loaded BM25 from {manifest.indexes['bm25'].path}")
 
-    if "vector" in manifest.indexes and manifest.indexes["vector"].status == "fresh":
-        emb_model = manifest.indexes["vector"].config.get(
-            "embedding_model", args.embedding_model
+        if (
+            "vector" in manifest.indexes
+            and manifest.indexes["vector"].status == "fresh"
+        ):
+            entry = manifest.indexes["vector"]
+            artifact_contract = dict(entry.config)
+            emb_model = artifact_contract.get("embedding_model", args.embedding_model)
+            emb_dim = artifact_contract.get(
+                "embedding_dimension", args.embedding_dimension
+            )
+            with capture_authenticated_vector_view(entry.path) as vector_view:
+                native_authorization = _mint_trusted_local_admin_authorization(
+                    vector_view.ownership,
+                    view_type="vector",
+                    semantic_contract=artifact_contract,
+                    evidence=(
+                        "skill-agent-manifest-vector-view",
+                        "captured-vector-tree-subject",
+                    ),
+                )
+            vector_store = CodeVectorStore(
+                embedding_model=emb_model,
+                embedding_provider="huggingface",
+                dimension=emb_dim,
+                store_path=entry.path,
+                artifact_metadata=artifact_contract,
+            )
+            resources.callback(vector_store.close)
+            vector_store.load(
+                entry.path,
+                native_index_authorization=native_authorization,
+            )
+            print(f"  Loaded vector store from {entry.path}")
+
+        # Create contexts and load skills
+        retrieve_ctx = RetrieveContext(
+            bm25=bm25_index,
+            vector_store=vector_store,
+            default_top_k=args.top_k,
+            default_level="l2",
         )
-        emb_dim = manifest.indexes["vector"].config.get(
-            "embedding_dimension", args.embedding_dimension
+        contexts: Dict[str, Any] = {"retrieve": retrieve_ctx}
+        if vector_store:
+            contexts["rerank"] = RerankContext(embedding_store=vector_store)
+
+        skills_dir = os.path.join(_PROJECT_ROOT, "codenib", "agent", "skills")
+        loader = SkillLoader()
+        loaded = loader.load_all(skills_dir, contexts=contexts)
+        print(f"  Loaded {len(loaded)} skills: {[s.skill_id for s in loaded]}")
+
+        # Session context for parameter scaling
+        session_ctx = SessionContext(
+            repo_path=repo_path,
+            repo_size=manifest.file_count,
+            primary_language=(
+                manifest.languages[0] if manifest.languages else "python"
+            ),
         )
-        vector_store = CodeVectorStore(
-            embedding_model=emb_model,
-            embedding_provider="huggingface",
-            dimension=emb_dim,
-            store_path=manifest.indexes["vector"].path,
+
+        # Create LLM and AgentRunner
+        llm = LiteLLMChat(
+            model=args.model,
+            temperature=0.0,
+            max_tokens=1024,
         )
-        vector_store.load(manifest.indexes["vector"].path)
-        print(f"  Loaded vector store from {manifest.indexes['vector'].path}")
 
-    # Create contexts and load skills
-    retrieve_ctx = RetrieveContext(
-        bm25=bm25_index,
-        vector_store=vector_store,
-        default_top_k=args.top_k,
-        default_level="l2",
-    )
-    contexts: Dict[str, Any] = {"retrieve": retrieve_ctx}
-    if vector_store:
-        contexts["rerank"] = RerankContext(embedding_store=vector_store)
+        runner = AgentRunner(
+            llm=llm,
+            registry=SkillRegistry(),
+            max_turns=5,
+            manifest=manifest,
+            session_ctx=session_ctx,
+        )
 
-    skills_dir = os.path.join(_PROJECT_ROOT, "codenib", "agent", "skills")
-    loader = SkillLoader()
-    loaded = loader.load_all(skills_dir, contexts=contexts)
-    print(f"  Loaded {len(loaded)} skills: {[s.skill_id for s in loaded]}")
+        print("\n--- Running agent (max 5 turns) ---")
+        result = runner.run(args.query)
 
-    # Session context for parameter scaling
-    session_ctx = SessionContext(
-        repo_path=repo_path,
-        repo_size=manifest.file_count,
-        primary_language=manifest.languages[0] if manifest.languages else "python",
-    )
+        print("\n=== Agent Result ===")
+        print(f"  Turns: {result.total_turns}")
+        print(f"  Tool calls: {len(result.tool_calls)}")
+        for tc in result.tool_calls:
+            print(f"    - {tc.skill_id}({tc.arguments})")
 
-    # Create LLM and AgentRunner
-    llm = LiteLLMChat(
-        model=args.model,
-        temperature=0.0,
-        max_tokens=1024,
-    )
+        # Collect results from tool call outputs
+        all_results = []
+        for tc in result.tool_calls:
+            if isinstance(tc.result, list):
+                all_results.extend(tc.result)
 
-    runner = AgentRunner(
-        llm=llm,
-        registry=SkillRegistry(),
-        max_turns=5,
-        manifest=manifest,
-        session_ctx=session_ctx,
-    )
-
-    print(f"\n--- Running agent (max 5 turns) ---")
-    result = runner.run(args.query)
-
-    print(f"\n=== Agent Result ===")
-    print(f"  Turns: {result.total_turns}")
-    print(f"  Tool calls: {len(result.tool_calls)}")
-    for tc in result.tool_calls:
-        print(f"    - {tc.skill_id}({tc.arguments})")
-
-    # Collect results from tool call outputs
-    all_results = []
-    for tc in result.tool_calls:
-        if isinstance(tc.result, list):
-            all_results.extend(tc.result)
-
-    if all_results:
-        print_results(all_results, args.top_k)
-    else:
-        print(f"\nAgent response: {result.final_answer}")
+        if all_results:
+            print_results(all_results, args.top_k)
+        else:
+            print(f"\nAgent response: {result.final_answer}")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/mcp_benchmark_codenib_base.py
+++ b/scripts/mcp_benchmark_codenib_base.py
@@ -17,15 +17,18 @@ import asyncio
 import json
 import time
 from collections import defaultdict
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Dict, List
 
 import datasets
 
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.search import search_semantic
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.paths import prebuilt_data_dir
 
 CODENIB_DATA = prebuilt_data_dir()
@@ -143,87 +146,109 @@ async def benchmark_instance(
         },
     )
 
-    ctx = ServerContext(manifest=manifest)
-    try:
-        ctx.vector = CodeVectorStore(
-            embedding_model=embedding_model,
-            embedding_provider="huggingface",
-            dimension=dimension,
-            index_metric="ip",
-            store_path=str(repo_dir),
-            revision=(
-                DEFAULT_EMBEDDING_REVISION
-                if embedding_model == DEFAULT_EMBEDDING_MODEL
-                else None
-            ),
-            trust_remote_code=(embedding_model == DEFAULT_EMBEDDING_MODEL),
-        )
-        ctx.vector.load()
-    except Exception as e:
+    artifact_contract = dict(manifest.indexes["vector"].config)
+    with ExitStack() as resources:
+        ctx = ServerContext(manifest=manifest)
+        resources.callback(ctx.close)
+        try:
+            with capture_authenticated_vector_view(repo_dir) as vector_view:
+                native_authorization = _mint_trusted_local_admin_authorization(
+                    vector_view.ownership,
+                    view_type="vector",
+                    semantic_contract=artifact_contract,
+                    evidence=(
+                        "mcp-benchmark-local-vector-view",
+                        "captured-vector-tree-subject",
+                    ),
+                )
+
+            ctx.vector = CodeVectorStore(
+                embedding_model=embedding_model,
+                embedding_provider="huggingface",
+                dimension=dimension,
+                index_metric="ip",
+                store_path=str(repo_dir),
+                artifact_metadata=artifact_contract,
+                revision=(
+                    DEFAULT_EMBEDDING_REVISION
+                    if embedding_model == DEFAULT_EMBEDDING_MODEL
+                    else None
+                ),
+                trust_remote_code=(embedding_model == DEFAULT_EMBEDDING_MODEL),
+            )
+            ctx.vector.load(
+                native_index_authorization=native_authorization,
+            )
+        except Exception as e:
+            return {
+                "instance_id": instance_id,
+                "language_group": language_group,
+                "status": "error",
+                "reason": str(e),
+            }
+
+        stats = ctx.vector.get_stats()
+        if stats.get("total_documents", 0) == 0:
+            return {
+                "instance_id": instance_id,
+                "language_group": language_group,
+                "status": "skipped",
+                "reason": "empty_index",
+            }
+
+        query = instance["problem_statement"]
+        start_time = time.time()
+
+        try:
+            results = await search_semantic(
+                ctx=ctx,
+                query=query,
+                top_k=top_k,
+                level="l2",
+            )
+            elapsed = time.time() - start_time
+        except Exception as e:
+            return {
+                "instance_id": instance_id,
+                "language_group": language_group,
+                "status": "error",
+                "reason": f"search_failed: {e}",
+            }
+
+        repo = instance.get("repo", "") or ""
+        retrieved_files: List[str] = []
+        retrieved_symbols: List[str] = []
+        for r in results:
+            rel = _make_relative(r.get("file", "") or "", instance_id, repo)
+            retrieved_files.append(rel)
+            retrieved_symbols.append(_normalize_symbol(r.get("node_id", "") or ""))
+
+        # GT: prefer gt_target_files / gt_code_blocks (codenib-base schema).
+        gt_files = list(instance.get("gt_target_files") or [])
+        gt_symbols: List[str] = []
+        for block in instance.get("gt_code_blocks") or []:
+            if block.get("file_path") and block.get("symbol"):
+                gt_symbols.append(_gt_symbol(block["file_path"], block["symbol"]))
+        # Fallback to gt_symbols_modified if blocks are absent.
+        if not gt_symbols:
+            for s in instance.get("gt_symbols_modified") or []:
+                gt_symbols.append(_normalize_symbol(s))
+
+        k_values = [1, 3, 5, 10]
+        file_metrics = compute_metrics(retrieved_files, gt_files, k_values)
+        symbol_metrics = compute_metrics(retrieved_symbols, gt_symbols, k_values)
+
         return {
             "instance_id": instance_id,
             "language_group": language_group,
-            "status": "error",
-            "reason": str(e),
+            "difficulty_level": instance.get("difficulty_level"),
+            "status": "success",
+            "elapsed_s": elapsed,
+            "num_results": len(results),
+            "retrieved_files": retrieved_files[:top_k],
+            "retrieved_symbols": retrieved_symbols[:top_k],
+            "metrics": {"files": file_metrics, "symbols": symbol_metrics},
         }
-
-    stats = ctx.vector.get_stats()
-    if stats.get("total_documents", 0) == 0:
-        return {
-            "instance_id": instance_id,
-            "language_group": language_group,
-            "status": "skipped",
-            "reason": "empty_index",
-        }
-
-    query = instance["problem_statement"]
-    start_time = time.time()
-
-    try:
-        results = await search_semantic(ctx=ctx, query=query, top_k=top_k, level="l2")
-        elapsed = time.time() - start_time
-    except Exception as e:
-        return {
-            "instance_id": instance_id,
-            "language_group": language_group,
-            "status": "error",
-            "reason": f"search_failed: {e}",
-        }
-
-    repo = instance.get("repo", "") or ""
-    retrieved_files: List[str] = []
-    retrieved_symbols: List[str] = []
-    for r in results:
-        rel = _make_relative(r.get("file", "") or "", instance_id, repo)
-        retrieved_files.append(rel)
-        retrieved_symbols.append(_normalize_symbol(r.get("node_id", "") or ""))
-
-    # GT: prefer gt_target_files / gt_code_blocks (codenib-base schema).
-    gt_files = list(instance.get("gt_target_files") or [])
-    gt_symbols: List[str] = []
-    for block in instance.get("gt_code_blocks") or []:
-        if block.get("file_path") and block.get("symbol"):
-            gt_symbols.append(_gt_symbol(block["file_path"], block["symbol"]))
-    # Fallback to gt_symbols_modified if blocks are absent.
-    if not gt_symbols:
-        for s in instance.get("gt_symbols_modified") or []:
-            gt_symbols.append(_normalize_symbol(s))
-
-    k_values = [1, 3, 5, 10]
-    file_metrics = compute_metrics(retrieved_files, gt_files, k_values)
-    symbol_metrics = compute_metrics(retrieved_symbols, gt_symbols, k_values)
-
-    return {
-        "instance_id": instance_id,
-        "language_group": language_group,
-        "difficulty_level": instance.get("difficulty_level"),
-        "status": "success",
-        "elapsed_s": elapsed,
-        "num_results": len(results),
-        "retrieved_files": retrieved_files[:top_k],
-        "retrieved_symbols": retrieved_symbols[:top_k],
-        "metrics": {"files": file_metrics, "symbols": symbol_metrics},
-    }
 
 
 def _bucket_aggregate(

--- a/test/agent/test_embedding_search_e2e.py
+++ b/test/agent/test_embedding_search_e2e.py
@@ -22,6 +22,7 @@ Environment variable CODENIB_INDEX_PATH can override the cache location:
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 from pathlib import Path
 
 import pytest
@@ -54,54 +55,81 @@ EMBEDDING_INDEX_PATH = "/tmp/embedding_e2e_index"
 def vector_store(httpie_cli_repo):
     """Build or load a CodeVectorStore for the httpie/cli repo."""
     from codenib.index.embedding import CodeVectorStore, build_hierarchical_vector_store
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
 
     repo_path = str(httpie_cli_repo)
     store_root = Path(EMBEDDING_INDEX_PATH)
     l0_dir = store_root / "l0"
     l2_dir = store_root / "l2"
 
-    if l0_dir.exists() and l2_dir.exists():
-        print(f"\n[e2e] Loading cached index from {EMBEDDING_INDEX_PATH}")
-        vs = CodeVectorStore(
-            embedding_model=DEFAULT_EMBEDDING_MODEL,
-            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
-            dimension=DEFAULT_EMBEDDING_DIM,
-            store_path=EMBEDDING_INDEX_PATH,
-            model_kwargs={
-                "trust_remote_code": True,
-                "device": "cuda",
-                "model_kwargs": {"torch_dtype": "float16"},
-            },
-            encode_kwargs={
-                "batch_size": 4,
-                "normalize_embeddings": True,
-            },
-        )
-        vs.load(EMBEDDING_INDEX_PATH)
-    else:
-        print(f"\n[e2e] Building index for {repo_path} into {EMBEDDING_INDEX_PATH}")
-        store_root.mkdir(parents=True, exist_ok=True)
-        vs = build_hierarchical_vector_store(
-            repo_path=repo_path,
-            index_path=EMBEDDING_INDEX_PATH,
-            languages=["python"],
-            embedding_model=DEFAULT_EMBEDDING_MODEL,
-            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
-            embedding_dimension=DEFAULT_EMBEDDING_DIM,
-            embedding_kwargs={
-                "model_kwargs": {
+    with ExitStack() as resources:
+        if l0_dir.exists() and l2_dir.exists():
+            print(f"\n[e2e] Loading cached index from {EMBEDDING_INDEX_PATH}")
+            artifact_contract = {}
+            with capture_authenticated_vector_view(store_root) as vector_view:
+                authorization = _mint_trusted_local_admin_authorization(
+                    vector_view.ownership,
+                    view_type="vector",
+                    semantic_contract=artifact_contract,
+                    evidence=(
+                        "embedding-e2e-local-vector-view",
+                        "captured-vector-tree-subject",
+                    ),
+                )
+            vs = CodeVectorStore(
+                embedding_model=DEFAULT_EMBEDDING_MODEL,
+                embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+                dimension=DEFAULT_EMBEDDING_DIM,
+                store_path=EMBEDDING_INDEX_PATH,
+                artifact_metadata=artifact_contract,
+                model_kwargs={
                     "trust_remote_code": True,
                     "device": "cuda",
                     "model_kwargs": {"torch_dtype": "float16"},
                 },
-                "encode_kwargs": {
+                encode_kwargs={
                     "batch_size": 4,
                     "normalize_embeddings": True,
                 },
-            },
-        )
+            )
+            resources.callback(vs.close)
+            vs.load(
+                EMBEDDING_INDEX_PATH,
+                native_index_authorization=authorization,
+            )
+        else:
+            print(
+                f"\n[e2e] Building index for {repo_path} into "
+                f"{EMBEDDING_INDEX_PATH}"
+            )
+            store_root.mkdir(parents=True, exist_ok=True)
+            vs = build_hierarchical_vector_store(
+                repo_path=repo_path,
+                index_path=EMBEDDING_INDEX_PATH,
+                languages=["python"],
+                embedding_model=DEFAULT_EMBEDDING_MODEL,
+                embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+                embedding_dimension=DEFAULT_EMBEDDING_DIM,
+                embedding_kwargs={
+                    "model_kwargs": {
+                        "trust_remote_code": True,
+                        "device": "cuda",
+                        "model_kwargs": {"torch_dtype": "float16"},
+                    },
+                    "encode_kwargs": {
+                        "batch_size": 4,
+                        "normalize_embeddings": True,
+                    },
+                },
+            )
+            resources.callback(vs.close)
 
-    return vs
+        yield vs
 
 
 @pytest.fixture(scope="session")

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from codenib._atomic_directory import capture_directory_ownership
 from codenib.artifacts import normalize_owned_query_view, validate_portable_query_view
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.index.embedding.artifact_integrity import (
@@ -22,6 +23,7 @@ from codenib.index.embedding.artifact_integrity import (
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.provider_routes import resolve_inference_route
 
 _VECTOR_CONFIG = {
@@ -35,6 +37,15 @@ _VECTOR_CONFIG = {
 }
 _MODEL_SUFFIX = "test__model"
 _REVISION = "a" * 40
+
+
+def _vector_authorization(vector: Path, store):
+    return _mint_trusted_local_admin_authorization(
+        capture_directory_ownership(vector),
+        view_type="vector",
+        semantic_contract=store.artifact_metadata,
+        evidence=("portable-vector-view-test-local-admin",),
+    )
 
 
 def _tree(root: Path) -> dict[str, bytes]:
@@ -1513,7 +1524,7 @@ def test_normalize_schema6_view_loads_with_runtime_contract(
         trust_remote_code=False,
     )
 
-    store.load()
+    store.load(native_index_authorization=_vector_authorization(vector, store))
 
     assert len(store.l2_documents) == 1
     assert int(store.l2_index.ntotal) == 1
@@ -1744,10 +1755,8 @@ def test_normalize_rejects_untrained_active_ivf_before_runtime_first_search(
         revision=_REVISION,
         trust_remote_code=False,
     )
-    store.load()
-    assert store.l2_index.is_trained is False
-    with pytest.raises(RuntimeError, match="is_trained"):
-        store.search("VALUE", top_k=1)
+    with pytest.raises(ValueError, match="FAISS index is not trained"):
+        store.load(native_index_authorization=_vector_authorization(vector, store))
 
     with pytest.raises(ValueError, match="active IVF index is untrained"):
         normalize_owned_query_view(

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -23,7 +23,8 @@ import urllib.request
 import zipfile
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -339,6 +340,40 @@ def test_verify_and_bind_artifact_before_loading_bm25(tmp_path: Path) -> None:
     results = context.bm25.search("value", return_code_content=True)
     assert results[0].file == "sample.py"
     assert "VALUE = 1" in (results[0].content or "")
+
+
+def test_bind_uses_one_detached_repository_identity_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    probe = capture_repository_source(repo, exclude_roots=(artifact,))
+    source_type = type(probe)
+    real_snapshot = source_type.authenticated_identity_snapshot
+    probe.close()
+    substituted_root = tmp_path / "substituted"
+
+    def snapshot_then_replace_public_projection(source):
+        snapshot = real_snapshot(source)
+        source.root = substituted_root
+        source.fingerprint = "sha256-v2:" + ("0" * 64)
+        source.file_count = 0
+        source.file_records = ()
+        return snapshot
+
+    monkeypatch.setattr(
+        source_type,
+        "authenticated_identity_snapshot",
+        snapshot_then_replace_public_projection,
+    )
+
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    try:
+        assert binding.repo_path == repo
+        assert binding.manifest.repo_path == str(repo)
+        assert binding.source_bound
+    finally:
+        binding.close()
 
 
 def test_bound_source_reads_poison_after_checkout_changes(tmp_path: Path) -> None:
@@ -725,6 +760,43 @@ def test_bind_persistent_close_failure_exposes_retryable_source_owner(
     monkeypatch.setattr(source_type, "close", real_close)
     owner.close()
     assert owner.closed
+    assert captured[0].closed
+
+
+def test_bind_promotes_source_cleanup_cancellation_over_value_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    captured = []
+    real_capture = runtime_module.capture_repository_source
+    cleanup_interruption = KeyboardInterrupt("source cleanup interrupted")
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        source.fingerprint = "sha256-v2:" + ("0" * 64)
+        return source
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+    probe = capture_repository_source(repo, exclude_roots=(artifact,))
+    source_type = type(probe)
+    probe.close()
+    real_close = source_type.close
+
+    def interrupt_close(source) -> None:
+        if source in captured:
+            raise cleanup_interruption
+        real_close(source)
+
+    monkeypatch.setattr(source_type, "close", interrupt_close)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        bind_context_artifact(artifact, repo, expected_commit=commit)
+
+    assert caught.value is cleanup_interruption
+    assert caught.value.source_cleanup_owner.pending_sources == (captured[0],)
+    monkeypatch.setattr(source_type, "close", real_close)
+    caught.value.source_cleanup_owner.close()
     assert captured[0].closed
 
 
@@ -1218,6 +1290,341 @@ def test_archive_snapshot_allows_sibling_mutation_but_rejects_parent_rebind(
             held.rename(anchor)
 
 
+def test_archive_snapshot_applies_independent_compressed_input_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.artifacts import archive as archive_module
+
+    archive = tmp_path / "oversized.zip"
+    archive.write_bytes(b"x" * 1025)
+    monkeypatch.setattr(
+        archive_module,
+        "_create_archive_snapshot",
+        lambda: pytest.fail("oversized archive must fail before allocating a memfd"),
+    )
+
+    with pytest.raises(ValueError, match="bounded regular file"):
+        with archive_module._authenticated_archive_snapshot(
+            archive,
+            max_files=100,
+            max_bytes=64 * 1024 * 1024 * 1024,
+            max_archive_bytes=1024,
+        ):
+            pytest.fail("oversized archive snapshot must not be yielded")
+
+
+def test_posix_archive_snapshot_close_retry_does_not_close_reused_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.artifacts import archive as archive_module
+
+    archive = tmp_path / "artifact.zip"
+    archive.write_bytes(b"snapshot")
+    replacement_path = tmp_path / "replacement"
+    replacement_path.write_bytes(b"foreign")
+    real_fdopen = os.fdopen
+    snapshot_descriptor = -1
+    interruption = KeyboardInterrupt("snapshot wrapper close interrupted")
+
+    class InterruptingSnapshot:
+        def __init__(self, wrapped) -> None:
+            self.wrapped = wrapped
+            self.interrupt = True
+
+        @property
+        def closed(self) -> bool:
+            return self.wrapped.closed
+
+        def __getattr__(self, name: str):
+            return getattr(self.wrapped, name)
+
+        def close(self) -> None:
+            if self.interrupt:
+                self.interrupt = False
+                raise interruption
+            self.wrapped.close()
+
+    wrapper: InterruptingSnapshot | None = None
+
+    def interrupting_fdopen(descriptor: int, mode: str, *, closefd: bool):
+        nonlocal snapshot_descriptor, wrapper
+        assert closefd is False
+        snapshot_descriptor = descriptor
+        wrapper = InterruptingSnapshot(real_fdopen(descriptor, mode, closefd=closefd))
+        return wrapper
+
+    monkeypatch.setattr(archive_module.os, "fdopen", interrupting_fdopen)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with archive_module._authenticated_archive_snapshot(
+            archive,
+            max_files=1,
+            max_bytes=1024,
+        ) as (_display, snapshot):
+            assert snapshot.read() == b"snapshot"
+
+    assert caught.value is interruption
+    assert wrapper is not None
+    replacement = os.open(replacement_path, os.O_RDONLY)
+    if replacement != snapshot_descriptor:
+        os.dup2(replacement, snapshot_descriptor)
+        os.close(replacement)
+        replacement = snapshot_descriptor
+    try:
+        caught.value.archive_cleanup_owner.close()
+        assert os.read(replacement, 7) == b"foreign"
+    finally:
+        os.close(replacement)
+
+
+def test_archive_snapshot_routes_windows_through_handle_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.artifacts import archive as archive_module
+
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as archive:
+        archive.writestr(CONTEXT_ARTIFACT_MANIFEST, "{}")
+    observed = {}
+
+    @contextmanager
+    def fake_windows_snapshot(lexical: Path, *, physical_limit: int):
+        observed.update(lexical=lexical, physical_limit=physical_limit)
+        with archive_module._ImmutableArchiveSnapshot((payload.getvalue(),)) as source:
+            yield source
+
+    monkeypatch.setattr(archive_module, "_archive_os_name", lambda: "nt")
+    monkeypatch.setattr(
+        archive_module,
+        "_authenticated_windows_archive_snapshot",
+        fake_windows_snapshot,
+    )
+
+    path = tmp_path / "artifact.zip"
+    with archive_module._authenticated_archive_snapshot(
+        path,
+        max_files=1,
+        max_bytes=1024,
+        max_archive_bytes=2048,
+    ) as (display, snapshot):
+        with zipfile.ZipFile(snapshot) as archive:
+            assert archive.namelist() == [CONTEXT_ARTIFACT_MANIFEST]
+        with pytest.raises(io.UnsupportedOperation):
+            snapshot.write(b"tamper")
+
+    assert display == path
+    assert observed == {"lexical": path, "physical_limit": 2048}
+
+
+def test_windows_archive_snapshot_reads_pinned_handle_and_closes_authorities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib import _windows_fs_authority as windows_fs
+    from codenib.artifacts import archive as archive_module
+
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as archive:
+        archive.writestr(CONTEXT_ARTIFACT_MANIFEST, "{}")
+    archive_bytes = payload.getvalue()
+    file_id = b"f" * 16
+    metadata = windows_fs.WindowsHandleMetadata(
+        st_dev=7,
+        st_ino=1,
+        st_mode=stat.S_IFREG | 0o444,
+        st_size=len(archive_bytes),
+        st_mtime_ns=1,
+        st_ctime_ns=1,
+        st_nlink=1,
+        st_file_attributes=0,
+        file_id_128=file_id,
+    )
+    entry = windows_fs.WindowsDirectoryEntry(
+        name="artifact.zip",
+        file_id=1,
+        attributes=0,
+        file_id_128=file_id,
+    )
+
+    class Api:
+        def __init__(self) -> None:
+            self.offset = 0
+            self.open_handles = {200}
+
+        def enumerate_directory(self, handle):
+            assert handle == 100
+            return (entry,)
+
+        def open_relative(self, parent, name, **kwargs):
+            assert (parent, name) == (100, "artifact.zip")
+            assert kwargs["allow_reparse"] is False
+            self.open_handles.add(200)
+            return 200
+
+        def metadata(self, handle):
+            if handle not in self.open_handles:
+                raise KeyError(handle)
+            return metadata
+
+        def read(self, handle, size):
+            assert handle == 200
+            block = archive_bytes[self.offset : self.offset + size]
+            self.offset += len(block)
+            return block
+
+        def close(self, handle):
+            self.open_handles.remove(handle)
+
+    api = Api()
+    authority = SimpleNamespace(
+        api=api,
+        handle=100,
+        verify=MagicMock(),
+        close=MagicMock(),
+    )
+    monkeypatch.setattr(
+        archive_module._windows_fs,
+        "open_lexical_directory_authority",
+        lambda _parent, *, cleanup_slot: (cleanup_slot.own(authority) or authority),
+    )
+
+    with archive_module._authenticated_windows_archive_snapshot(
+        tmp_path / "artifact.zip",
+        physical_limit=len(archive_bytes),
+    ) as snapshot:
+        with zipfile.ZipFile(snapshot) as archive:
+            assert archive.namelist() == [CONTEXT_ARTIFACT_MANIFEST]
+
+    assert api.open_handles == set()
+    assert authority.verify.call_count == 2
+    authority.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize("interruption_stage", ["authority", "child"])
+def test_windows_archive_snapshot_closes_interrupted_handle_handoffs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interruption_stage: str,
+) -> None:
+    from codenib import _windows_fs_authority as windows_fs
+    from codenib.artifacts import archive as archive_module
+
+    file_id = b"f" * 16
+    metadata = windows_fs.WindowsHandleMetadata(
+        st_dev=7,
+        st_ino=1,
+        st_mode=stat.S_IFREG | 0o444,
+        st_size=1,
+        st_mtime_ns=1,
+        st_ctime_ns=1,
+        st_nlink=1,
+        st_file_attributes=0,
+        file_id_128=file_id,
+    )
+    entry = windows_fs.WindowsDirectoryEntry(
+        name="artifact.zip",
+        file_id=1,
+        attributes=0,
+        file_id_128=file_id,
+    )
+
+    class _Api:
+        def __init__(self) -> None:
+            self.open_handles: set[int] = set()
+
+        def enumerate_directory(self, _handle):
+            return (entry,)
+
+        def open_relative(self, _parent, _name, **_kwargs):
+            self.open_handles.add(200)
+            return 200
+
+        def metadata(self, handle):
+            if handle not in self.open_handles:
+                raise KeyError(handle)
+            return metadata
+
+        def close(self, handle):
+            self.open_handles.remove(handle)
+
+    api = _Api()
+    authority = SimpleNamespace(
+        api=api,
+        handle=100,
+        verify=MagicMock(),
+        close=MagicMock(),
+    )
+    interruption = KeyboardInterrupt(f"injected {interruption_stage} handoff")
+
+    def open_authority(_parent, *, cleanup_slot):
+        cleanup_slot.own(authority)
+        if interruption_stage == "authority":
+            raise interruption
+        return authority
+
+    monkeypatch.setattr(
+        archive_module._windows_fs,
+        "open_lexical_directory_authority",
+        open_authority,
+    )
+    if interruption_stage == "child":
+        real_append = windows_fs._append_owned_windows_handle
+        interrupted = False
+
+        def interrupt_after_append(handles, handle, deferred=None):
+            nonlocal interrupted
+            result = real_append(handles, handle, deferred)
+            if not interrupted:
+                interrupted = True
+                raise interruption
+            return result
+
+        monkeypatch.setattr(
+            archive_module._windows_fs,
+            "_append_owned_windows_handle",
+            interrupt_after_append,
+        )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with archive_module._authenticated_windows_archive_snapshot(
+            tmp_path / "artifact.zip",
+            physical_limit=1,
+        ):
+            pytest.fail("interrupted archive snapshot must not be yielded")
+
+    assert caught.value is interruption
+    assert api.open_handles == set()
+    authority.close.assert_called_once_with()
+
+
+def test_windows_archive_entry_uses_exact_unicode_name() -> None:
+    from codenib import _windows_fs_authority as windows_fs
+    from codenib.artifacts import archive as archive_module
+
+    exact = windows_fs.WindowsDirectoryEntry(
+        name="ss.zip",
+        file_id=1,
+        attributes=0,
+        file_id_128=b"1" * 16,
+    )
+    near = windows_fs.WindowsDirectoryEntry(
+        name="ß.zip",
+        file_id=2,
+        attributes=0,
+        file_id_128=b"2" * 16,
+    )
+    authority = SimpleNamespace(
+        handle=100,
+        api=SimpleNamespace(enumerate_directory=lambda _handle: (near, exact)),
+    )
+
+    assert archive_module._windows_archive_entry(authority, "ss.zip") is exact
+    with pytest.raises(ValueError, match="missing or ambiguous"):
+        archive_module._windows_archive_entry(authority, "SS.zip")
+
+
 def test_extract_archive_reads_one_pinned_generation_during_path_aba(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1238,6 +1645,17 @@ def test_extract_archive_reads_one_pinned_generation_during_path_aba(
         if not swapped:
             swapped = True
             archive.rename(saved)
+            # Some filesystems do not advance ctime for a rapid rename-away/
+            # rename-back cycle. Force a distinct retained-file version so the
+            # version-bound snapshot check remains deterministic there too.
+            saved_metadata = saved.stat()
+            os.utime(
+                saved,
+                ns=(
+                    saved_metadata.st_atime_ns,
+                    saved_metadata.st_mtime_ns + 1_000_000_000,
+                ),
+            )
             foreign.rename(archive)
             try:
                 return real_read(descriptor, size)
@@ -1524,6 +1942,89 @@ def test_extract_archive_limits_directory_entries(tmp_path: Path) -> None:
             tmp_path / "directory-output",
             max_files=1,
         )
+
+
+def test_extract_archive_checks_member_count_before_zipfile_allocates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.artifacts import archive as archive_module
+
+    source = tmp_path / "oversized-envelope.zip"
+    with zipfile.ZipFile(source, "w") as bundle:
+        bundle.writestr(CONTEXT_ARTIFACT_MANIFEST, "{}")
+    payload = bytearray(source.read_bytes())
+    end = payload.rfind(b"PK\x05\x06")
+    assert end >= 0
+    excessive_count = 67  # max_files=1 permits at most 66 raw entries.
+    payload[end + 8 : end + 10] = excessive_count.to_bytes(2, "little")
+    payload[end + 10 : end + 12] = excessive_count.to_bytes(2, "little")
+    source.write_bytes(payload)
+
+    def should_not_parse(*_args, **_kwargs):
+        raise AssertionError("ZipFile allocated entries before envelope validation")
+
+    monkeypatch.setattr(archive_module.zipfile, "ZipFile", should_not_parse)
+    with pytest.raises(ValueError, match="exceeds 66 entries"):
+        extract_context_artifact_archive(
+            source,
+            tmp_path / "output",
+            max_files=1,
+        )
+
+
+def test_extract_archive_rejects_lying_member_count_before_zipfile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.artifacts import archive as archive_module
+
+    source = tmp_path / "lying-count.zip"
+    with zipfile.ZipFile(source, "w") as bundle:
+        bundle.writestr(CONTEXT_ARTIFACT_MANIFEST, "{}")
+        bundle.writestr("one.txt", "one")
+        bundle.writestr("two.txt", "two")
+    payload = bytearray(source.read_bytes())
+    end = payload.rfind(b"PK\x05\x06")
+    assert end >= 0
+    payload[end + 8 : end + 10] = (1).to_bytes(2, "little")
+    payload[end + 10 : end + 12] = (1).to_bytes(2, "little")
+    source.write_bytes(payload)
+
+    def should_not_parse(*_args, **_kwargs):
+        raise AssertionError("ZipFile parsed a lying central-directory count")
+
+    monkeypatch.setattr(archive_module.zipfile, "ZipFile", should_not_parse)
+    with pytest.raises(ValueError, match="not a valid ZIP"):
+        extract_context_artifact_archive(
+            source,
+            tmp_path / "output",
+            max_files=1,
+        )
+
+
+def test_extract_archive_transfers_pending_owner_from_bad_zip_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.artifacts import archive as archive_module
+
+    source = tmp_path / "malformed.zip"
+    with zipfile.ZipFile(source, "w") as bundle:
+        bundle.writestr(CONTEXT_ARTIFACT_MANIFEST, "{}")
+    owner = object()
+    malformed = zipfile.BadZipFile("injected malformed central directory")
+    malformed.archive_cleanup_owner = owner
+
+    def fail_parse(*_args, **_kwargs):
+        raise malformed
+
+    monkeypatch.setattr(archive_module.zipfile, "ZipFile", fail_parse)
+    with pytest.raises(ValueError, match="not a valid ZIP") as caught:
+        extract_context_artifact_archive(source, tmp_path / "output")
+
+    assert caught.value.archive_cleanup_owner is owner
+    assert caught.value.__cause__ is malformed
 
 
 def _github_record(
@@ -1872,6 +2373,19 @@ def test_render_artifact_mcp_host_commands_are_shell_safe(tmp_path: Path) -> Non
             separators=(",", ":"),
         ),
     ]
+
+
+def test_render_artifact_mcp_config_closes_source_authority(tmp_path: Path) -> None:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting needs /proc/self/fd")
+    repo, artifact, _commit = _bm25_artifact(tmp_path)
+    before = len(tuple(descriptor_root.iterdir()))
+
+    for _ in range(20):
+        render_artifact_mcp_config(artifact, repo, host="json")
+
+    assert len(tuple(descriptor_root.iterdir())) <= before + 1
 
 
 def test_mcp_server_starts_from_verified_artifact(tmp_path: Path) -> None:

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -5,29 +5,42 @@
 from __future__ import annotations
 
 import asyncio
+import dis
 import hashlib
+import inspect
 import io
 import json
 import math
+import os
 import shlex
 import shutil
 import stat
 import subprocess
+import sys
+import threading
 import urllib.error
 import urllib.request
 import zipfile
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 import codenib.artifacts.github as github_artifacts
+import codenib.artifacts.runtime as runtime_module
+import codenib.index.sparse_idx.bm25_index as bm25_module
 import codenib.mcp.server as server_module
+from codenib._atomic_directory import (
+    PublicationDirectoryReader,
+    reopen_authenticated_directory,
+)
 from codenib.artifacts import (
     CONTEXT_ARTIFACT_MANIFEST,
     bind_context_artifact,
     extract_context_artifact_archive,
     fetch_github_context_artifact,
+    query_context_artifact,
     render_artifact_mcp_config,
     resolve_github_context_artifact,
     stage_context_artifact,
@@ -39,7 +52,11 @@ from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.source import read_source_impl
-from codenib.source_fingerprint import RepositoryChangedError, fingerprint_repository
+from codenib.source_fingerprint import (
+    RepositoryChangedError,
+    capture_repository_source,
+    fingerprint_repository,
+)
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -271,6 +288,21 @@ def _refresh_inventory_file(artifact: Path, metadata: dict, relative: str) -> No
     record["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _rewrite_artifact_source_fingerprint(artifact: Path, fingerprint: str) -> None:
+    metadata = _metadata(artifact)
+    metadata["repository"]["source_fingerprint"] = fingerprint
+    manifest_relative = metadata["manifest"]["path"]
+    manifest_path = artifact / manifest_relative
+    manifest = RepoManifest.load(manifest_path)
+    manifest.source_fingerprint = fingerprint
+    manifest.last_indexed_source_fingerprint = fingerprint
+    for entry in manifest.indexes.values():
+        entry.source_fingerprint = fingerprint
+    manifest.save(manifest_path)
+    _refresh_inventory_file(artifact, metadata, manifest_relative)
+    _write_metadata(artifact, metadata)
+
+
 def _zip_tree(source: Path, output: Path, *, prefix: str = "") -> None:
     with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for path in sorted(source.rglob("*")):
@@ -297,12 +329,547 @@ def test_verify_and_bind_artifact_before_loading_bm25(tmp_path: Path) -> None:
     assert verified.views == ("bm25",)
     assert binding.manifest.repo_path == str(repo)
     assert binding.manifest.indexes["bm25"].path == str(artifact / "views" / "bm25")
-    context = ServerContext.load(binding.manifest, views=["bm25"])
+    context = ServerContext.load(
+        binding.manifest,
+        views=["bm25"],
+        artifact_binding=binding,
+    )
     assert context.bm25 is not None
     assert context.bm25.project_root == str(repo)
     results = context.bm25.search("value", return_code_content=True)
     assert results[0].file == "sample.py"
     assert "VALUE = 1" in (results[0].content or "")
+
+
+def test_bound_source_reads_poison_after_checkout_changes(tmp_path: Path) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(
+        artifact,
+        repo,
+        expected_repository="example/project",
+        expected_commit=commit,
+    )
+    context = ServerContext.load(
+        binding.manifest,
+        views=["bm25"],
+        artifact_binding=binding,
+    )
+    assert context.source_verified is True
+    (repo / "sample.py").write_text("VALUE = 999\n", encoding="utf-8")
+
+    with pytest.raises(RepositoryChangedError):
+        read_source_impl(context, "sample.py", 1, 1)
+    assert context.source_verified is False
+    with pytest.raises(RepositoryChangedError, match="poisoned"):
+        context.bm25.search("value", return_code_content=True)
+
+
+def test_artifact_binding_close_releases_unconsumed_source_authority(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    source = binding.source_binding
+    assert source is not None and source.usable
+
+    binding.close()
+    binding.close()
+
+    assert binding.source_bound is False
+    assert not source.usable
+
+
+@pytest.mark.parametrize(
+    ("timing", "interruption"),
+    [
+        pytest.param(
+            "before",
+            KeyboardInterrupt("context binding close interrupted before source close"),
+            id="before-close",
+        ),
+        pytest.param(
+            "after",
+            SystemExit("context binding close interrupted after source close"),
+            id="after-close",
+        ),
+    ],
+)
+def test_artifact_binding_close_retains_cleanup_owner_through_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    timing: str,
+    interruption: BaseException,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    source = binding.source_binding
+    assert source is not None
+    source_type = type(source)
+    real_close = source_type.close
+    injected = False
+
+    def interrupt_source_close(instance) -> None:
+        nonlocal injected
+        if instance is source and not injected:
+            injected = True
+            if timing == "before":
+                raise interruption
+            real_close(instance)
+            raise interruption
+        real_close(instance)
+
+    monkeypatch.setattr(source_type, "close", interrupt_source_close)
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert injected
+    assert binding.source_bound is False
+    monkeypatch.setattr(source_type, "close", real_close)
+    binding.close()
+    assert source.closed
+
+
+def test_artifact_binding_source_authority_install_is_linear_one_shot(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    barrier = threading.Barrier(3)
+    installed = []
+    failures: list[BaseException] = []
+
+    def install() -> None:
+        target = []
+        barrier.wait()
+        try:
+            binding.install_source_binding(target.append)
+            installed.extend(target)
+        except BaseException as exc:  # noqa: B036 - record thread result
+            failures.append(exc)
+
+    threads = [threading.Thread(target=install) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(installed) == 1
+    assert installed[0] is not None
+    assert len(failures) == 1
+    assert isinstance(failures[0], RuntimeError)
+    assert "already transferred" in str(failures[0])
+    installed[0].close()
+
+
+def test_artifact_binding_rejected_expected_source_retains_original_owner(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    source = binding.source_binding
+    assert source is not None
+    other = capture_repository_source(repo, exclude_roots=(artifact,))
+
+    with pytest.raises(ValueError, match="does not match"):
+        binding.install_source_binding(
+            lambda _source: pytest.fail("mismatched source must not be installed"),
+            expected=other,
+            require_expected=True,
+        )
+
+    assert binding.source_binding is source
+    assert source.usable
+    installed = []
+    binding.install_source_binding(installed.append)
+    assert installed == [source]
+    source.close()
+    other.close()
+
+
+def test_server_context_losing_install_does_not_close_winners_source(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    winner = []
+    binding.install_source_binding(winner.append)
+    source = winner[0]
+    assert source is not None and source.usable
+
+    with pytest.raises(RuntimeError, match="already transferred"):
+        ServerContext.load(
+            binding.manifest,
+            views=[],
+            artifact_binding=binding,
+            source_binding=source,
+        )
+
+    assert source.usable
+    source.close()
+
+
+def test_server_context_expected_witness_mismatch_does_not_close_witness(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = query_context_artifact(artifact, expected_commit=commit)
+    witness = capture_repository_source(repo, exclude_roots=(artifact,))
+
+    with pytest.raises(ValueError, match="does not match"):
+        ServerContext.load(
+            binding.manifest,
+            views=[],
+            artifact_binding=binding,
+            source_binding=witness,
+        )
+
+    assert witness.usable
+    witness.close()
+    binding.close()
+
+
+def test_artifact_binding_install_cancellation_closes_claimed_authority(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    source = binding.source_binding
+    assert source is not None
+    method = type(binding).install_source_binding
+    lines, first_line = inspect.getsourcelines(method)
+    target_line = first_line + next(
+        index for index, line in enumerate(lines) if "install(source)" in line
+    )
+    interruption = KeyboardInterrupt("injected after source authority claim")
+    injected = False
+
+    def interrupt_after_claim(frame, event, _arg):
+        nonlocal injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "line"
+            and frame.f_lineno == target_line
+        ):
+            injected = True
+            raise interruption
+        return interrupt_after_claim
+
+    sys.settrace(interrupt_after_claim)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            binding.install_source_binding(lambda _source: None)
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected
+    assert source.closed
+    assert binding.source_bound is False
+
+
+def test_server_context_install_handoff_cancellation_closes_source(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    source = binding.source_binding
+    assert source is not None
+    method = ServerContext.load.__func__
+    source_lines, first_line = inspect.getsourcelines(method)
+    call_line = first_line + next(
+        index
+        for index, line in enumerate(source_lines)
+        if "artifact_binding.install_source_binding(" in line
+    )
+    current_line = None
+    target_offset = None
+    for instruction in dis.get_instructions(method):
+        if instruction.starts_line is not None:
+            current_line = instruction.starts_line
+        if instruction.opname == "POP_TOP" and current_line in range(
+            call_line, call_line + 5
+        ):
+            target_offset = instruction.offset
+            break
+    assert target_offset is not None
+    interruption = KeyboardInterrupt("injected after destination install")
+    injected = False
+
+    def interrupt_after_install(frame, event, _arg):
+        nonlocal injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "opcode"
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            raise interruption
+        frame.f_trace_opcodes = True
+        return interrupt_after_install
+
+    sys.settrace(interrupt_after_install)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            ServerContext.load(
+                binding.manifest,
+                views=[],
+                artifact_binding=binding,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected
+    assert source.closed
+    assert binding.source_bound is False
+
+
+def test_bind_checkout_cancellation_closes_captured_source_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    captured = []
+    real_capture = runtime_module.capture_repository_source
+    interruption = KeyboardInterrupt("injected checkout cancellation")
+    descriptor_root = Path("/proc/self/fd")
+    before = len(tuple(descriptor_root.iterdir())) if descriptor_root.is_dir() else None
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        return source
+
+    def interrupt_checkout(_repo: Path) -> str:
+        raise interruption
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+    monkeypatch.setattr(runtime_module, "checkout_commit", interrupt_checkout)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        bind_context_artifact(artifact, repo, expected_commit=commit)
+
+    assert caught.value is interruption
+    assert len(captured) == 1
+    assert captured[0].closed
+    if before is not None:
+        assert len(tuple(descriptor_root.iterdir())) <= before + 1
+
+
+def test_bind_capture_return_cancellation_uses_preinstalled_cleanup_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    captured = []
+    real_capture = runtime_module.capture_repository_source
+    interruption = KeyboardInterrupt("injected after capture returned")
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        raise interruption
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        bind_context_artifact(artifact, repo, expected_commit=commit)
+
+    assert caught.value is interruption
+    assert len(captured) == 1
+    assert captured[0].closed
+
+
+def test_bind_persistent_close_failure_exposes_retryable_source_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    captured = []
+    real_capture = runtime_module.capture_repository_source
+    interruption = KeyboardInterrupt("injected bind cancellation")
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        return source
+
+    def interrupt_checkout(_repo: Path) -> str:
+        raise interruption
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+    monkeypatch.setattr(runtime_module, "checkout_commit", interrupt_checkout)
+    probe = capture_repository_source(repo, exclude_roots=(artifact,))
+    source_type = type(probe)
+    probe.close()
+    real_close = source_type.close
+
+    def persistent_close(source) -> None:
+        if source in captured:
+            raise OSError("injected persistent source close failure")
+        real_close(source)
+
+    monkeypatch.setattr(source_type, "close", persistent_close)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        bind_context_artifact(artifact, repo, expected_commit=commit)
+
+    assert caught.value is interruption
+    assert len(captured) == 1
+    owner = caught.value.source_cleanup_owner
+    assert owner.pending_sources == (captured[0],)
+    assert not captured[0].closed
+
+    monkeypatch.setattr(source_type, "close", real_close)
+    owner.close()
+    assert owner.closed
+    assert captured[0].closed
+
+
+def test_bind_rejects_artifact_root_replaced_after_internal_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    saved = tmp_path / "verified-root"
+    real_verify = runtime_module.verify_context_artifact
+
+    def verify_then_replace(*args: object, **kwargs: object):
+        verified = real_verify(*args, **kwargs)
+        artifact.rename(saved)
+        shutil.copytree(saved, artifact)
+        return verified
+
+    monkeypatch.setattr(
+        runtime_module,
+        "verify_context_artifact",
+        verify_then_replace,
+    )
+    with pytest.raises(ValueError, match="changed between verification"):
+        bind_context_artifact(
+            artifact,
+            repo,
+            expected_commit=commit,
+        )
+
+
+def test_bind_rejects_checkout_replaced_after_source_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    foreign = tmp_path / "foreign-repo"
+    shutil.copytree(repo, foreign, symlinks=True)
+    captured = tmp_path / "captured-repo"
+    real_checkout_commit = runtime_module.checkout_commit
+
+    def replace_before_commit(path: Path) -> str:
+        repo.rename(captured)
+        foreign.rename(repo)
+        return real_checkout_commit(path)
+
+    monkeypatch.setattr(runtime_module, "checkout_commit", replace_before_commit)
+    with pytest.raises(ValueError, match="changed between verification"):
+        bind_context_artifact(
+            artifact,
+            repo,
+            expected_repository="example/project",
+            expected_commit=commit,
+        )
+
+    assert repo.is_dir()
+    assert captured.is_dir()
+
+
+def test_artifact_binding_rejects_root_replaced_before_runtime_load(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    saved = tmp_path / "bound-root"
+    artifact.rename(saved)
+    shutil.copytree(saved, artifact)
+    documents = artifact / "views/bm25/documents.json"
+    documents.write_text(
+        '[{"page_content":"FOREIGN","metadata":{"file":"sample.py"}}]',
+        encoding="utf-8",
+    )
+
+    context = ServerContext.load(
+        binding.manifest,
+        views=["bm25"],
+        artifact_binding=binding,
+    )
+
+    assert context.bm25 is None
+    assert "captured ownership" in context.errors["bm25"]
+
+
+def test_artifact_bm25_reader_never_reads_path_swapped_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    foreign = tmp_path / "foreign-artifact"
+    shutil.copytree(artifact, foreign)
+    (foreign / "views/bm25/documents.json").write_text(
+        '[{"page_content":"FOREIGN","metadata":{"file":"sample.py"}}]',
+        encoding="utf-8",
+    )
+    saved = tmp_path / "authorized-artifact"
+    real_open = PublicationDirectoryReader.open_authenticated_file
+    swapped = False
+    from codenib.index.sparse_idx import BM25CodeIndexer
+
+    real_load_values = BM25CodeIndexer.load_index_values
+    loaded_page_content: list[str] = []
+
+    def record_loaded_values(self, documents, metadata, **kwargs):
+        result = real_load_values(self, documents, metadata, **kwargs)
+        loaded_page_content.extend(document.page_content for document in self.documents)
+        return result
+
+    @contextmanager
+    def open_during_root_aba(self, relative, *, max_bytes=None):
+        nonlocal swapped
+        normalized = Path(relative).as_posix()
+        if normalized != "views/bm25/documents.json":
+            with real_open(self, relative, max_bytes=max_bytes) as source:
+                yield source
+            return
+        swapped = True
+        artifact.rename(saved)
+        foreign.rename(artifact)
+        try:
+            with real_open(self, relative, max_bytes=max_bytes) as source:
+                yield source
+        finally:
+            artifact.rename(foreign)
+            saved.rename(artifact)
+
+    monkeypatch.setattr(
+        PublicationDirectoryReader,
+        "open_authenticated_file",
+        open_during_root_aba,
+    )
+    monkeypatch.setattr(
+        BM25CodeIndexer,
+        "load_index_values",
+        record_loaded_values,
+    )
+    context = ServerContext.load(
+        binding.manifest,
+        views=["bm25"],
+        artifact_binding=binding,
+    )
+
+    assert swapped
+    assert context.bm25 is None
+    assert context.errors["bm25"]
+    assert loaded_page_content == ["sample py value 1"]
 
 
 def test_stage_bind_query_and_mcp_accept_contained_source_symlink(
@@ -322,9 +889,8 @@ def test_stage_bind_query_and_mcp_accept_contained_source_symlink(
         binding.manifest,
         views=["bm25"],
         artifact={"repository": "example/project"},
+        artifact_binding=binding,
     )
-    context.source_verified = True
-    context.source_error = None
 
     assert context.bm25 is not None
     results = context.bm25.search("value", return_code_content=True)
@@ -333,7 +899,7 @@ def test_stage_bind_query_and_mcp_accept_contained_source_symlink(
     assert source["content"] == "VALUE = 1\n"
 
 
-def test_bind_and_query_portable_semantic_artifact_without_pickle(
+def test_bound_portable_semantic_artifact_remains_native_inert_by_default(
     tmp_path: Path,
 ) -> None:
     repo, artifact, commit = _vector_artifact(tmp_path)
@@ -349,13 +915,16 @@ def test_bind_and_query_portable_semantic_artifact_without_pickle(
         CodeVectorStore,
         "_initialize_embedding_model",
         return_value=_PortableEmbedding(),
-    ):
-        context = ServerContext.load(binding.manifest, views=["vector"])
-        assert context.vector is not None
-        results = context.vector.search("locate a symbol", top_k=1)
+    ) as initialize_embedding:
+        context = ServerContext.load(
+            binding.manifest,
+            views=["vector"],
+            artifact_binding=binding,
+        )
+        assert context.vector is None
 
-    assert results[0].node_name == "locate_symbol"
-    assert results[0].file == "search.py"
+    initialize_embedding.assert_not_called()
+    assert "external authorization" in context.errors["vector"]
 
 
 def test_verify_rejects_digest_mismatch(tmp_path: Path) -> None:
@@ -420,6 +989,33 @@ def test_verify_rejects_repository_and_commit_mismatch(tmp_path: Path) -> None:
         )
 
 
+def test_v1_artifact_supports_inert_bm25_query_but_cannot_bind(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, _commit = _bm25_artifact(tmp_path)
+    legacy = f"sha256:{'a' * 64}"
+    _rewrite_artifact_source_fingerprint(artifact, legacy)
+
+    query_binding = query_context_artifact(artifact)
+    verified = query_binding.artifact
+    context = ServerContext.load(
+        query_binding.manifest,
+        views=["bm25"],
+        artifact_binding=query_binding,
+    )
+    try:
+        assert verified.source_fingerprint == legacy
+        assert context.source_verified is False
+        assert context.bm25 is not None
+        assert context.bm25.project_root is None
+        assert context.bm25.search("value", return_code_content=False)
+    finally:
+        context.close()
+
+    with pytest.raises(ValueError, match="query-only"):
+        bind_context_artifact(artifact, repo)
+
+
 def test_verify_rejects_unsafe_bm25_source_contract(tmp_path: Path) -> None:
     _repo, artifact, _commit = _bm25_artifact(tmp_path)
     metadata_path = artifact / "views" / "bm25" / "bm25_metadata.json"
@@ -455,6 +1051,24 @@ def test_verify_rejects_unsafe_bm25_source_contract(tmp_path: Path) -> None:
         verify_context_artifact(artifact)
 
 
+def test_runtime_source_path_budget_has_exact_utf8_and_component_boundaries() -> None:
+    exact_bytes = "a" * 4_096
+    exact_components = "/".join("a" for _ in range(256))
+
+    assert runtime_module._source_path(exact_bytes, label="source") == exact_bytes
+    assert (
+        runtime_module._source_path(exact_components, label="source")
+        == exact_components
+    )
+    for invalid in (
+        "a" * 4_097,
+        "/".join("a" for _ in range(257)),
+        "\ud800.py",
+    ):
+        with pytest.raises(ValueError, match="repository-relative POSIX path"):
+            runtime_module._source_path(invalid, label="source")
+
+
 def test_stage_rejects_source_symlink_outside_checkout(tmp_path: Path) -> None:
     with pytest.raises(
         (ValueError, RepositoryChangedError),
@@ -463,14 +1077,64 @@ def test_stage_rejects_source_symlink_outside_checkout(tmp_path: Path) -> None:
         _bm25_artifact(tmp_path, source_symlink=True)
 
 
-def test_bind_rejects_checkout_commit_drift(tmp_path: Path) -> None:
+def test_bind_rejects_checkout_content_drift_even_after_commit(tmp_path: Path) -> None:
     repo, artifact, _commit = _bm25_artifact(tmp_path)
     (repo / "second.py").write_text("SECOND = 2\n", encoding="utf-8")
     _git(repo, "add", "second.py")
     _git(repo, "commit", "--quiet", "-m", "second")
 
-    with pytest.raises(ValueError, match="checkout commit does not match"):
+    with pytest.raises(ValueError, match="source files do not match"):
         bind_context_artifact(artifact, repo)
+
+
+def test_bind_treats_same_content_new_head_as_unattested_display_provenance(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, indexed_commit = _bm25_artifact(tmp_path)
+    _git(repo, "commit", "--quiet", "--allow-empty", "-m", "same tree, new head")
+    current_commit = _git(repo, "rev-parse", "HEAD")
+    assert current_commit != indexed_commit
+
+    binding = bind_context_artifact(artifact, repo)
+    try:
+        assert binding.source_bound
+        assert binding.source_verification_scope == "content-bytes"
+        assert binding.commit_verified is False
+        assert binding.checkout_commit_observed == current_commit
+        assert binding.manifest.commit == indexed_commit
+    finally:
+        binding.close()
+
+
+def test_bind_never_attests_head_changed_after_diagnostic_observation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, indexed_commit = _bm25_artifact(tmp_path)
+    _git(repo, "commit", "--quiet", "--allow-empty", "-m", "same tree c2")
+    second_commit = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "reset", "--quiet", "--hard", indexed_commit)
+    real_checkout_commit = runtime_module.checkout_commit
+
+    def observe_then_change_head(path: Path) -> str:
+        observed = real_checkout_commit(path)
+        _git(repo, "reset", "--quiet", "--hard", second_commit)
+        return observed
+
+    monkeypatch.setattr(
+        runtime_module,
+        "checkout_commit",
+        observe_then_change_head,
+    )
+    binding = bind_context_artifact(artifact, repo)
+    try:
+        assert binding.source_bound
+        assert binding.checkout_commit_observed == indexed_commit
+        assert _git(repo, "rev-parse", "HEAD") == second_commit
+        assert binding.commit_verified is False
+        assert binding.source_verification_scope == "content-bytes"
+    finally:
+        binding.close()
 
 
 def test_bind_rejects_checkout_source_drift(tmp_path: Path) -> None:
@@ -501,6 +1165,197 @@ def test_extract_archive_verifies_and_removes_single_root_prefix(
     )
 
 
+def test_extract_archive_rejects_final_symlink_and_fifo(tmp_path: Path) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    archive = tmp_path / "artifact.zip"
+    _zip_tree(artifact, archive)
+    linked = tmp_path / "linked.zip"
+    linked.symlink_to(archive)
+    with pytest.raises(ValueError, match="bounded regular file"):
+        extract_context_artifact_archive(linked, tmp_path / "linked-output")
+
+    if not hasattr(os, "mkfifo"):
+        return
+    fifo = tmp_path / "archive.fifo"
+    os.mkfifo(fifo)
+    with pytest.raises(ValueError, match="bounded regular file"):
+        extract_context_artifact_archive(fifo, tmp_path / "fifo-output")
+
+
+def test_archive_snapshot_allows_sibling_mutation_but_rejects_parent_rebind(
+    tmp_path: Path,
+) -> None:
+    from codenib.artifacts import archive as archive_module
+
+    anchor = tmp_path / "anchor"
+    anchor.mkdir()
+    archive = anchor / "artifact.zip"
+    archive.write_bytes(b"snapshot")
+
+    with archive_module._authenticated_archive_snapshot(
+        archive,
+        max_files=1,
+        max_bytes=1024,
+    ):
+        (anchor / "legitimate-sibling").mkdir()
+
+    held = tmp_path / "held-anchor"
+    foreign = tmp_path / "foreign-anchor"
+    foreign.mkdir()
+    try:
+        with pytest.raises(ValueError, match="archive parent changed"):
+            with archive_module._authenticated_archive_snapshot(
+                archive,
+                max_files=1,
+                max_bytes=1024,
+            ):
+                anchor.rename(held)
+                foreign.rename(anchor)
+    finally:
+        if anchor.exists():
+            anchor.rename(foreign)
+        if held.exists():
+            held.rename(anchor)
+
+
+def test_extract_archive_reads_one_pinned_generation_during_path_aba(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    archive = tmp_path / "artifact.zip"
+    _zip_tree(artifact, archive)
+    foreign = tmp_path / "foreign.zip"
+    foreign.write_bytes(b"not the authorized archive")
+    saved = tmp_path / "saved.zip"
+    from codenib.artifacts import archive as archive_module
+
+    real_read = archive_module._read_archive
+    swapped = False
+
+    def read_during_aba(descriptor: int, size: int) -> bytes:
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            archive.rename(saved)
+            foreign.rename(archive)
+            try:
+                return real_read(descriptor, size)
+            finally:
+                archive.rename(foreign)
+                saved.rename(archive)
+        return real_read(descriptor, size)
+
+    monkeypatch.setattr(archive_module, "_read_archive", read_during_aba)
+    with pytest.raises(ValueError, match="changed while reading"):
+        extract_context_artifact_archive(
+            archive,
+            tmp_path / "output",
+        )
+
+    assert swapped
+    assert foreign.read_bytes() == b"not the authorized archive"
+    assert not (tmp_path / "output").exists()
+
+
+def test_extract_archive_native_parser_consumes_only_sealed_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = tmp_path / "fixture"
+    fixture.mkdir()
+    _repo, artifact, _commit = _bm25_artifact(fixture)
+    archive_a = tmp_path / "artifact-a.zip"
+    _zip_tree(artifact, archive_a)
+
+    artifact_b = tmp_path / "artifact-b"
+    shutil.copytree(artifact, artifact_b)
+    documents = artifact_b / "views" / "bm25" / "documents.json"
+    documents.write_text(
+        documents.read_text(encoding="utf-8").replace("value 1", "value 9"),
+        encoding="utf-8",
+    )
+    metadata = _metadata(artifact_b)
+    _refresh_inventory_file(
+        artifact_b,
+        metadata,
+        "views/bm25/documents.json",
+    )
+    _write_metadata(artifact_b, metadata)
+    archive_b = tmp_path / "artifact-b.zip"
+    _zip_tree(artifact_b, archive_b)
+    replacement = archive_b.read_bytes()
+
+    from codenib.artifacts import archive as archive_module
+
+    real_zip_file = archive_module.zipfile.ZipFile
+    attempted = False
+    replaced = False
+
+    def tamper_before_parse(snapshot, *args, **kwargs):
+        nonlocal attempted, replaced
+        attempted = True
+        descriptor = snapshot.fileno()
+        try:
+            os.ftruncate(descriptor, 0)
+            os.write(descriptor, replacement)
+            os.lseek(descriptor, 0, os.SEEK_SET)
+        except OSError:
+            pass
+        else:  # pragma: no cover - vulnerable writable snapshot implementation
+            replaced = True
+        return real_zip_file(snapshot, *args, **kwargs)
+
+    monkeypatch.setattr(archive_module.zipfile, "ZipFile", tamper_before_parse)
+    output = tmp_path / "output"
+    extract_context_artifact_archive(archive_a, output)
+
+    assert attempted
+    assert not replaced
+    assert b"value 1" in (output / "views/bm25/documents.json").read_bytes()
+    assert b"value 9" not in (output / "views/bm25/documents.json").read_bytes()
+
+
+def test_extract_archive_returns_published_authority_not_refreshed_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_a = tmp_path / "a"
+    fixture_b = tmp_path / "b"
+    fixture_a.mkdir()
+    fixture_b.mkdir()
+    _repo, artifact, commit = _bm25_artifact(fixture_a)
+    _other_repo, foreign_artifact, _other_commit = _bm25_artifact(fixture_b)
+    archive = tmp_path / "artifact.zip"
+    _zip_tree(artifact, archive)
+    output = tmp_path / "output"
+    saved = tmp_path / "published-a"
+    from codenib.artifacts import archive as archive_module
+
+    real_publish = archive_module.OwnedDirectoryStage.publish
+
+    def publish_then_replace(self, **kwargs: object):
+        result = real_publish(self, **kwargs)
+        output.rename(saved)
+        shutil.copytree(foreign_artifact, output)
+        return result
+
+    monkeypatch.setattr(
+        archive_module.OwnedDirectoryStage,
+        "publish",
+        publish_then_replace,
+    )
+    verified = extract_context_artifact_archive(archive, output)
+
+    assert verified.commit == commit
+    with pytest.raises((RuntimeError, ValueError), match="captured ownership"):
+        reopen_authenticated_directory(
+            output,
+            verified.ownership,
+            lambda _reader: None,
+        )
+
+
 def test_extract_archive_restores_previous_output_on_publish_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -517,7 +1372,7 @@ def test_extract_archive_restores_previous_output_on_publish_failure(
     real_rename = atomic_directory._rename_noreplace_at
 
     def fail_final_publish(source, target, source_dir_fd, target_dir_fd):
-        if source.startswith(".extracted.extract-") and target == output.name:
+        if source.startswith(".extracted.normalize-") and target == output.name:
             raise OSError("injected archive publish failure")
         return real_rename(source, target, source_dir_fd, target_dir_fd)
 
@@ -530,8 +1385,7 @@ def test_extract_archive_restores_previous_output_on_publish_failure(
         extract_context_artifact_archive(archive, output)
 
     assert marker.read_text(encoding="utf-8") == "preserve"
-    assert not list(output.parent.glob(".extracted.extract-*"))
-    assert not list(output.parent.glob(".extracted.previous-*"))
+    assert not list(output.parent.glob(".extracted.normalize-*"))
 
 
 def test_extract_archive_preserves_output_changed_during_build(
@@ -580,7 +1434,7 @@ def test_extract_archive_rejects_output_symlink(tmp_path: Path) -> None:
     output = tmp_path / "output"
     output.symlink_to(victim, target_is_directory=True)
 
-    with pytest.raises(ValueError, match="symbolic link"):
+    with pytest.raises(ValueError, match="not a directory or is a link"):
         extract_context_artifact_archive(archive, output)
 
     assert output.is_symlink()
@@ -601,20 +1455,21 @@ def test_extract_archive_does_not_follow_swapped_stage_symlink(
 
     from codenib.artifacts import archive as archive_module
 
-    real_mkdtemp = archive_module.tempfile.mkdtemp
+    real_stage = archive_module.OwnedDirectoryStage
     swapped: Path | None = None
 
-    def swap_stage(*args, **kwargs):
-        nonlocal swapped
-        created = Path(real_mkdtemp(*args, **kwargs))
-        created.rename(stolen)
-        created.symlink_to(victim, target_is_directory=True)
-        swapped = created
-        return str(created)
+    class SwappedStage(real_stage):
+        def __init__(self, destination, **kwargs):
+            nonlocal swapped
+            super().__init__(destination, **kwargs)
+            if Path(destination).name == "output" and swapped is None:
+                self.path.rename(stolen)
+                self.path.symlink_to(victim, target_is_directory=True)
+                swapped = self.path
 
-    monkeypatch.setattr(archive_module.tempfile, "mkdtemp", swap_stage)
+    monkeypatch.setattr(archive_module, "OwnedDirectoryStage", SwappedStage)
 
-    with pytest.raises(ValueError, match="link"):
+    with pytest.raises(RuntimeError, match="owned stage root changed"):
         extract_context_artifact_archive(archive, tmp_path / "output")
 
     assert swapped is not None and swapped.is_symlink()
@@ -785,7 +1640,10 @@ def test_fetch_github_artifact_verifies_archive_digest_and_reuses_cache(
     assert second.downloaded is False
     assert second.record is None
     assert calls == {"list": 1, "download": 1}
-    with pytest.raises(ValueError, match="inventory exceeds 2 files"):
+    with pytest.raises(
+        ValueError,
+        match="inventory exceeds 2 files|contains more than 2 inventoried files",
+    ):
         fetch_github_context_artifact(
             "example/project",
             commit,
@@ -1046,3 +1904,94 @@ def test_mcp_server_starts_from_verified_artifact(tmp_path: Path) -> None:
         "views": ["bm25"],
     }
     assert manifest["runtime"]["loaded_views"] == ["bm25"]
+
+
+def test_mcp_server_query_only_v1_artifact_loads_bm25_without_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    _rewrite_artifact_source_fingerprint(artifact, f"sha256:{'a' * 64}")
+
+    with patch.object(server_module.mcp, "run") as run_server:
+        server_module.main(
+            [
+                "--artifact",
+                str(artifact),
+                "--repository",
+                "example/project",
+                "--log-level",
+                "ERROR",
+            ]
+        )
+
+    run_server.assert_called_once_with(transport="stdio")
+    context = server_module.get_context()
+    assert context.source_verified is False
+    assert context.bm25 is not None
+    assert context.bm25.source_mode == bm25_module.SOURCE_MODE_PERSISTED_ONLY
+    cwd_source = tmp_path / "sample.py"
+    cwd_source.write_text("API_KEY = 'QUERY_ONLY_CWD_SECRET'\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        bm25_module,
+        "_read_source_text",
+        lambda *_args: pytest.fail("query-only artifact must not read source paths"),
+    )
+
+    relative = context.bm25.search("value", return_code_content=True)
+    assert relative
+    assert all(result.content is None for result in relative)
+    assert "QUERY_ONLY_CWD_SECRET" not in repr(relative)
+    assert context.bm25.search_identifier_occurrences("value")
+
+    context.bm25.documents[0].metadata["file"] = str(cwd_source)
+    absolute = context.bm25.search("value", return_code_content=True)
+    assert absolute
+    assert all(result.content is None for result in absolute)
+    assert "QUERY_ONLY_CWD_SECRET" not in repr(absolute)
+    assert context.bm25.search_identifier_occurrences("value")
+    with pytest.raises(RuntimeError, match="source binding has not been verified"):
+        read_source_impl(context, "sample.py", 1, 1)
+
+
+def test_mcp_server_query_only_v1_vector_artifact_never_parses_native_bytes(
+    tmp_path: Path,
+) -> None:
+    _repo, artifact, _commit = _vector_artifact(tmp_path)
+    _rewrite_artifact_source_fingerprint(artifact, f"sha256:{'a' * 64}")
+
+    with (
+        patch.object(server_module.mcp, "run") as run_server,
+        patch(
+            "codenib.index.embedding.artifact_integrity."
+            "capture_authenticated_vector_view"
+        ) as capture_vector,
+        patch(
+            "codenib.native_index_authorization."
+            "_mint_trusted_local_admin_authorization"
+        ) as mint_authorization,
+        patch.object(
+            CodeVectorStore,
+            "_initialize_embedding_model",
+        ) as initialize_embedding,
+    ):
+        server_module.main(
+            [
+                "--artifact",
+                str(artifact),
+                "--repository",
+                "example/semantic-project",
+                "--log-level",
+                "ERROR",
+            ]
+        )
+
+    run_server.assert_called_once_with(transport="stdio")
+    capture_vector.assert_not_called()
+    mint_authorization.assert_not_called()
+    initialize_embedding.assert_not_called()
+    context = server_module.get_context()
+    assert context.source_verified is False
+    assert context.vector is None
+    assert "external authorization" in context.errors["vector"]

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import asyncio
-import dis
 import hashlib
 import inspect
 import io
@@ -608,58 +607,29 @@ def test_artifact_binding_install_cancellation_closes_claimed_authority(
 
 def test_server_context_install_handoff_cancellation_closes_source(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo, artifact, commit = _bm25_artifact(tmp_path)
     binding = bind_context_artifact(artifact, repo, expected_commit=commit)
     source = binding.source_binding
     assert source is not None
-    method = ServerContext.load.__func__
-    source_lines, first_line = inspect.getsourcelines(method)
-    call_line = first_line + next(
-        index
-        for index, line in enumerate(source_lines)
-        if "artifact_binding.install_source_binding(" in line
-    )
-    current_line = None
-    target_offset = None
-    for instruction in dis.get_instructions(method):
-        if instruction.starts_line is not None:
-            current_line = instruction.starts_line
-        if instruction.opname == "POP_TOP" and current_line in range(
-            call_line, call_line + 5
-        ):
-            target_offset = instruction.offset
-            break
-    assert target_offset is not None
     interruption = KeyboardInterrupt("injected after destination install")
-    injected = False
+    binding_type = type(binding)
+    real_install = binding_type.install_source_binding
 
-    def interrupt_after_install(frame, event, _arg):
-        nonlocal injected
-        if (
-            not injected
-            and frame.f_code is method.__code__
-            and event == "opcode"
-            and frame.f_lasti == target_offset
-        ):
-            injected = True
-            raise interruption
-        frame.f_trace_opcodes = True
-        return interrupt_after_install
+    def install_then_interrupt(self, install, **kwargs):
+        real_install(self, install, **kwargs)
+        raise interruption
 
-    sys.settrace(interrupt_after_install)
-    try:
-        with pytest.raises(KeyboardInterrupt) as caught:
-            ServerContext.load(
-                binding.manifest,
-                views=[],
-                artifact_binding=binding,
-            )
-    finally:
-        sys.settrace(None)
+    monkeypatch.setattr(binding_type, "install_source_binding", install_then_interrupt)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        ServerContext.load(
+            binding.manifest,
+            views=[],
+            artifact_binding=binding,
+        )
 
     assert caught.value is interruption
-    assert injected
     assert source.closed
     assert binding.source_bound is False
 

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -48,6 +48,7 @@ from codenib.repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     default_exclude_patterns,
 )
+from codenib.source_fingerprint import is_secure_source_fingerprint_v2
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -404,6 +405,7 @@ class TestVectorIndexBuilder:
                 )
 
         assert store_type.call_args.kwargs["artifact_metadata"] == previous
+        vector_store.close.assert_called_once_with()
 
     @pytest.mark.parametrize("missing", ["chunk_json", "embedding_pair"])
     def test_pickle_only_incremental_state_forces_rebuild(self, tmp_path, missing):
@@ -1338,7 +1340,7 @@ class TestIndexCompiler:
             data = json.load(f)
         assert data["version"] == MANIFEST_VERSION
         assert "bm25" in data["indexes"]
-        assert data["repo"]["source_fingerprint"].startswith("sha256:")
+        assert is_secure_source_fingerprint_v2(data["repo"]["source_fingerprint"])
         assert data["indexes"]["bm25"]["source_fingerprint"] == (
             data["repo"]["source_fingerprint"]
         )

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -61,6 +61,47 @@ def _make_meta(
     )
 
 
+def test_vector_loader_closes_partial_store_on_base_exception(monkeypatch):
+    primary = KeyboardInterrupt("cancel vector load")
+    stores = []
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.close_calls = 0
+            stores.append(self)
+
+        def load(self, _path, **_kwargs):
+            raise primary
+
+        def close(self):
+            self.close_calls += 1
+
+    monkeypatch.setattr(
+        "codenib.index.embedding.artifact_integrity."
+        "_mint_trusted_local_vector_authorization",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.CodeVectorStore",
+        FakeStore,
+    )
+
+    observed = None
+    try:
+        skill_context._load_vector(
+            "/tmp/vector",
+            embedding_model="model",
+            embedding_provider="huggingface",
+            embedding_dimension=4,
+        )
+    except BaseException as exc:  # noqa: B036 - assert cancellation identity
+        observed = exc
+
+    assert observed is primary
+    assert len(stores) == 1
+    assert stores[0].close_calls == 1
+
+
 @pytest.fixture(autouse=True)
 def _reset_registry():
     SkillRegistry.reset()

--- a/test/index/sparse_idx/test_bm25_safe_source.py
+++ b/test/index/sparse_idx/test_bm25_safe_source.py
@@ -11,9 +11,14 @@ from pathlib import Path
 import pytest
 
 import codenib._contained_source as contained_source_module
+import codenib.source_fingerprint as source_fingerprint_module
 from codenib.code_chunking.base import CodeChunk
 from codenib.index.sparse_idx import bm25_index as bm25_module
 from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
+from codenib.source_fingerprint import (
+    RepositorySourceBinding,
+    capture_repository_source,
+)
 from codenib.types import NODE_TYPE_FILE
 
 
@@ -152,6 +157,81 @@ def test_regular_file_node_still_returns_the_entire_source(tmp_path: Path) -> No
     assert _content(indexer) == "first\nsecond\n"
 
 
+def test_bound_search_reads_each_source_file_once_per_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "pkg" / "source.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("shared_marker_one()\nshared_marker_two()\n", encoding="utf-8")
+    indexer = BM25CodeIndexer(
+        chunks=[
+            CodeChunk(
+                content="shared_marker first",
+                start_line=0,
+                end_line=0,
+                chunk_type="function",
+                name="shared_marker_one",
+                file="pkg/source.py",
+                node_id="pkg/source.py:shared_marker_one()",
+            ),
+            CodeChunk(
+                content="shared_marker second",
+                start_line=1,
+                end_line=1,
+                chunk_type="function",
+                name="shared_marker_two",
+                file="pkg/source.py",
+                node_id="pkg/source.py:shared_marker_two()",
+            ),
+        ],
+        project_root=str(repo),
+    )
+    binding = capture_repository_source(repo)
+    indexer.bind_repository_source(binding)
+
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    real_read = RepositorySourceBinding._read_record
+    scans = 0
+    reads = 0
+
+    def counted_scan(*args, **kwargs):
+        nonlocal scans
+        scans += 1
+        return real_scan(*args, **kwargs)
+
+    def counted_read(self, *args, **kwargs):
+        nonlocal reads
+        reads += 1
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        counted_scan,
+    )
+    monkeypatch.setattr(RepositorySourceBinding, "_read_record", counted_read)
+
+    try:
+        results = indexer.search(
+            "shared_marker",
+            top_k=2,
+            return_code_content=True,
+            wrap_with_ln=False,
+        )
+
+        assert len(results) == 2
+        assert {result.content for result in results} == {
+            "shared_marker_one()\n",
+            "shared_marker_two()\n",
+        }
+        assert reads == 1
+        assert scans == 2
+    finally:
+        binding.close()
+
+
 def test_absolute_source_beneath_root_is_accepted(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     source = repo / "pkg" / "source.py"
@@ -222,7 +302,7 @@ def test_source_on_a_different_windows_drive_is_rejected(tmp_path: Path) -> None
     )
 
 
-def test_absolute_final_source_symlink_is_rejected(tmp_path: Path) -> None:
+def test_absolute_contained_final_source_symlink_is_accepted(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     target = repo / "real.py"
@@ -231,7 +311,7 @@ def test_absolute_final_source_symlink_is_rejected(tmp_path: Path) -> None:
 
     indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
 
-    assert _content(indexer) is None
+    assert _content(indexer) == "contained alias target\n"
 
 
 def test_relative_final_source_symlink_inside_root_is_accepted(tmp_path: Path) -> None:

--- a/test/index/sparse_idx/test_bm25_safe_source.py
+++ b/test/index/sparse_idx/test_bm25_safe_source.py
@@ -232,6 +232,42 @@ def test_bound_search_reads_each_source_file_once_per_query(
         binding.close()
 
 
+def test_bind_repository_source_uses_one_detached_identity_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("VALUE = 1\n", encoding="utf-8")
+    indexer = _indexer(None, "source.py")
+    binding = capture_repository_source(repo)
+    binding_type = type(binding)
+    real_snapshot = binding_type.authenticated_identity_snapshot
+    substituted_root = tmp_path / "substituted"
+
+    def snapshot_then_replace_public_projection(source):
+        snapshot = real_snapshot(source)
+        source.root = substituted_root
+        source.fingerprint = "sha256-v2:" + ("0" * 64)
+        source.file_count = 0
+        source.file_records = ()
+        return snapshot
+
+    monkeypatch.setattr(
+        binding_type,
+        "authenticated_identity_snapshot",
+        snapshot_then_replace_public_projection,
+    )
+
+    try:
+        indexer.bind_repository_source(binding)
+
+        assert indexer.project_root == str(repo)
+        assert indexer.source_mode == bm25_module.SOURCE_MODE_BOUND_REPOSITORY
+    finally:
+        binding.close()
+
+
 def test_absolute_source_beneath_root_is_accepted(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     source = repo / "pkg" / "source.py"
@@ -302,7 +338,7 @@ def test_source_on_a_different_windows_drive_is_rejected(tmp_path: Path) -> None
     )
 
 
-def test_absolute_contained_final_source_symlink_is_accepted(tmp_path: Path) -> None:
+def test_absolute_contained_final_source_symlink_is_rejected(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     target = repo / "real.py"
@@ -311,7 +347,7 @@ def test_absolute_contained_final_source_symlink_is_accepted(tmp_path: Path) -> 
 
     indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
 
-    assert _content(indexer) == "contained alias target\n"
+    assert _content(indexer) is None
 
 
 def test_relative_final_source_symlink_inside_root_is_accepted(tmp_path: Path) -> None:

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -4,7 +4,48 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from codenib.index.embedding import builders
+
+
+def test_cached_builder_closes_store_when_load_fails(monkeypatch, tmp_path):
+    index_path = tmp_path / "index"
+    index_path.mkdir()
+    (index_path / "config_test-model.json").write_text("{}", encoding="utf-8")
+    primary = RuntimeError("cached load failed")
+    stores = []
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.close_calls = 0
+            stores.append(self)
+
+        def load(self, _path, **_kwargs):
+            raise primary
+
+        def close(self):
+            self.close_calls += 1
+
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+    monkeypatch.setattr(
+        builders,
+        "_mint_trusted_local_vector_authorization",
+        lambda *_args, **_kwargs: object(),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        builders.build_hierarchical_vector_store(
+            repo_path=str(tmp_path),
+            index_path=str(index_path),
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=4,
+        )
+
+    assert exc_info.value is primary
+    assert len(stores) == 1
+    assert stores[0].close_calls == 1
 
 
 def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path):

--- a/test/index/test_vector_artifact_identity.py
+++ b/test/index/test_vector_artifact_identity.py
@@ -4,15 +4,19 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from codenib._atomic_directory import capture_directory_ownership
 from codenib.index.embedding.vector_store import (
     CodeVectorStore,
     _OpenAIEmbeddingWrapper,
+    _read_authenticated_faiss,
 )
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 
 
 class _Embedding:
@@ -24,6 +28,51 @@ class _Embedding:
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         return [[0.0] * self.dimension for _ in texts]
+
+
+def test_faiss_callback_caps_oversized_native_read_requests(monkeypatch) -> None:
+    payload_size = 8 * 1024 * 1024 + 17
+
+    class _Snapshot:
+        def __init__(self) -> None:
+            self.record = SimpleNamespace(size=payload_size)
+            self.offset = 0
+            self.requests: list[int] = []
+
+        def read(self, size: int) -> bytes:
+            self.requests.append(size)
+            remaining = payload_size - self.offset
+            consumed = min(size, remaining)
+            self.offset += consumed
+            return b"x" * consumed
+
+    snapshot = _Snapshot()
+    view = SimpleNamespace(
+        authenticated_snapshot=lambda _relative: nullcontext(
+            (snapshot, snapshot.record)
+        )
+    )
+    observed: list[int] = []
+    sentinel = object()
+
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.faiss.PyCallbackIOReader",
+        lambda callback: callback,
+    )
+
+    def read_index(callback):
+        while block := callback(1 << 60):
+            observed.append(len(block))
+        return sentinel
+
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.faiss.read_index",
+        read_index,
+    )
+
+    assert _read_authenticated_faiss(view, "l2/index.faiss") is sentinel
+    assert observed == [8 * 1024 * 1024, 17]
+    assert max(snapshot.requests) == 8 * 1024 * 1024
 
 
 def _store(
@@ -45,6 +94,51 @@ def _store(
     )
 
 
+def _authorization(path, store):
+    return _mint_trusted_local_admin_authorization(
+        capture_directory_ownership(path),
+        view_type="vector",
+        semantic_contract=store.artifact_metadata,
+        evidence=("vector-artifact-test-local-admin",),
+    )
+
+
+def test_load_denies_missing_authorization_before_tree_capture(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = _store(tmp_path, fingerprint="sha256:expected")
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.capture_authenticated_vector_view",
+        lambda _path: pytest.fail("denied native load must not capture the tree"),
+    )
+
+    with pytest.raises(ValueError, match="requires external authorization"):
+        store.load()
+
+
+def test_load_denies_foreign_pid_authorization_before_tree_capture(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import codenib.native_index_authorization as authorization_module
+
+    store = _store(tmp_path, fingerprint="sha256:expected")
+    authorization = _authorization(tmp_path, store)
+    monkeypatch.setattr(
+        authorization_module.os,
+        "getpid",
+        lambda: authorization.process_id + 1,
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.capture_authenticated_vector_view",
+        lambda _path: pytest.fail("foreign-PID load must not capture the tree"),
+    )
+
+    with pytest.raises(ValueError, match="another process"):
+        store.load(native_index_authorization=authorization)
+
+
 def test_load_rejects_manifest_and_saved_artifact_fingerprint_mismatch(
     tmp_path,
 ) -> None:
@@ -52,7 +146,7 @@ def test_load_rejects_manifest_and_saved_artifact_fingerprint_mismatch(
     reopened = _store(tmp_path, fingerprint="sha256:second")
 
     with pytest.raises(ValueError, match="does not match manifest"):
-        reopened.load()
+        reopened.load(native_index_authorization=_authorization(tmp_path, reopened))
 
 
 def test_load_rejects_provider_substitution(tmp_path) -> None:
@@ -64,7 +158,7 @@ def test_load_rejects_provider_substitution(tmp_path) -> None:
     )
 
     with pytest.raises(ValueError, match="provider mismatch"):
-        reopened.load()
+        reopened.load(native_index_authorization=_authorization(tmp_path, reopened))
 
 
 def test_load_rejects_embedding_revision_substitution(tmp_path) -> None:
@@ -76,7 +170,7 @@ def test_load_rejects_embedding_revision_substitution(tmp_path) -> None:
     )
 
     with pytest.raises(ValueError, match="embedding revision mismatch"):
-        reopened.load()
+        reopened.load(native_index_authorization=_authorization(tmp_path, reopened))
 
 
 @pytest.mark.parametrize("option", ["revision", "trust_remote_code"])
@@ -98,7 +192,7 @@ def test_load_requires_saved_identity_when_manifest_has_a_fingerprint(tmp_path) 
     reopened = _store(tmp_path, fingerprint="sha256:expected")
 
     with pytest.raises(ValueError, match="top-level configuration"):
-        reopened.load()
+        reopened.load(native_index_authorization=_authorization(tmp_path, reopened))
 
 
 def test_openai_wrapper_sends_vector_options_on_embedding_requests() -> None:

--- a/test/index/test_vector_artifact_identity.py
+++ b/test/index/test_vector_artifact_identity.py
@@ -4,15 +4,19 @@
 
 from __future__ import annotations
 
+import inspect
+import sys
 from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import codenib.index.embedding.artifact_integrity as artifact_integrity_module
 from codenib._atomic_directory import capture_directory_ownership
 from codenib.index.embedding.vector_store import (
     CodeVectorStore,
+    _LoadedVectorState,
     _OpenAIEmbeddingWrapper,
     _read_authenticated_faiss,
 )
@@ -101,6 +105,92 @@ def _authorization(path, store):
         semantic_contract=store.artifact_metadata,
         evidence=("vector-artifact-test-local-admin",),
     )
+
+
+def test_load_level_releases_native_index_when_validation_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = _store(tmp_path, fingerprint="sha256:expected")
+
+    class _MismatchedIndex:
+        d = store.dimension + 1
+
+        def __init__(self) -> None:
+            self.reset_calls = 0
+
+        def reset(self) -> None:
+            self.reset_calls += 1
+
+    index = _MismatchedIndex()
+    view = SimpleNamespace(
+        root=tmp_path,
+        has_file=lambda relative: relative.endswith(".faiss"),
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store._read_authenticated_faiss",
+        lambda _view, _relative: index,
+    )
+
+    with pytest.raises(ValueError, match="FAISS dimension mismatch"):
+        store._load_level(view, "l0", "vendor__model")
+
+    assert index.reset_calls == 1
+
+
+def test_load_level_owns_index_at_first_line_after_native_read(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = _store(tmp_path, fingerprint="sha256:expected")
+
+    class _Index:
+        def __init__(self) -> None:
+            self.reset_calls = 0
+
+        def reset(self) -> None:
+            self.reset_calls += 1
+
+    index = _Index()
+    view = SimpleNamespace(
+        root=tmp_path,
+        has_file=lambda relative: relative.endswith(".faiss"),
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store._read_authenticated_faiss",
+        lambda _view, _relative: index,
+    )
+    source, first_line = inspect.getsourcelines(CodeVectorStore._load_level)
+    finish_line = first_line + next(
+        offset
+        for offset, line in enumerate(source)
+        if "return self._finish_loaded_level(" in line
+    )
+    interruption = KeyboardInterrupt("injected after native index read")
+    injected = False
+
+    def trace(frame, event, _arg):
+        nonlocal injected
+        if (
+            not injected
+            and frame.f_code is CodeVectorStore._load_level.__code__
+            and event == "line"
+            and frame.f_lineno == finish_line
+        ):
+            injected = True
+            raise interruption
+        return trace
+
+    sys.settrace(trace)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            store._load_level(view, "l0", "vendor__model")
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected
+    assert index.reset_calls == 1
 
 
 def test_load_denies_missing_authorization_before_tree_capture(
@@ -193,6 +283,363 @@ def test_load_requires_saved_identity_when_manifest_has_a_fingerprint(tmp_path) 
 
     with pytest.raises(ValueError, match="top-level configuration"):
         reopened.load(native_index_authorization=_authorization(tmp_path, reopened))
+
+
+def test_load_keeps_previous_state_when_final_tree_verification_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = _store(tmp_path, fingerprint="sha256:expected")
+    old_l0 = store.l0_index
+    old_l2 = store.l2_index
+    old_metadata = store.artifact_metadata
+    old_path = store.store_path
+    ownership = capture_directory_ownership(tmp_path)
+    authorization = _mint_trusted_local_admin_authorization(
+        ownership,
+        view_type="vector",
+        semantic_contract=store.artifact_metadata,
+        evidence=("vector-final-verification-test",),
+    )
+
+    class ReplacementIndex:
+        def __init__(self) -> None:
+            self.reset_calls = 0
+
+        def reset(self) -> None:
+            self.reset_calls += 1
+
+    replacement_l0 = ReplacementIndex()
+    replacement_l2 = ReplacementIndex()
+    view = SimpleNamespace(
+        ownership=ownership,
+        verify_final=lambda: (_ for _ in ()).throw(
+            ValueError("injected final vector verification failure")
+        ),
+        close=lambda: None,
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.capture_authenticated_vector_view",
+        lambda _path: view,
+    )
+    monkeypatch.setattr(
+        store,
+        "_load_captured",
+        lambda _view: _LoadedVectorState(
+            l0_index=replacement_l0,
+            l0_documents=[object()],
+            l2_index=replacement_l2,
+            l2_documents=[object()],
+            artifact_metadata={"embedding_fingerprint": "sha256:replacement"},
+            store_path=tmp_path / "replacement",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="final vector verification"):
+        store.load(native_index_authorization=authorization)
+
+    assert store.l0_index is old_l0
+    assert store.l2_index is old_l2
+    assert store.artifact_metadata is old_metadata
+    assert store.store_path is old_path
+    assert replacement_l0.reset_calls == 1
+    assert replacement_l2.reset_calls == 1
+
+
+@pytest.mark.parametrize(
+    "cleanup_failure",
+    [RuntimeError("index reset failed"), KeyboardInterrupt("index reset cancelled")],
+)
+def test_load_preserves_primary_and_visits_all_temporary_cleanup(
+    tmp_path,
+    monkeypatch,
+    cleanup_failure: BaseException,
+) -> None:
+    store = _store(tmp_path, fingerprint="sha256:expected")
+    ownership = capture_directory_ownership(tmp_path)
+    authorization = _mint_trusted_local_admin_authorization(
+        ownership,
+        view_type="vector",
+        semantic_contract=store.artifact_metadata,
+        evidence=("vector-failed-load-cleanup-test",),
+    )
+
+    class _Index:
+        def __init__(self, failure=None) -> None:
+            self.failure = failure
+            self.reset_calls = 0
+
+        def reset(self) -> None:
+            self.reset_calls += 1
+            if self.failure is not None:
+                raise self.failure
+
+    primary = ValueError("injected final vector verification failure")
+    replacement_l0 = _Index(cleanup_failure)
+    replacement_l2 = _Index()
+    close_calls = []
+    view = SimpleNamespace(
+        ownership=ownership,
+        verify_final=lambda: (_ for _ in ()).throw(primary),
+        close=lambda: close_calls.append(True),
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.capture_authenticated_vector_view",
+        lambda _path: view,
+    )
+    monkeypatch.setattr(
+        store,
+        "_load_captured",
+        lambda _view: _LoadedVectorState(
+            l0_index=replacement_l0,
+            l0_documents=[object()],
+            l2_index=replacement_l2,
+            l2_documents=[object()],
+            artifact_metadata={"embedding_fingerprint": "sha256:replacement"},
+            store_path=tmp_path / "replacement",
+        ),
+    )
+
+    with pytest.raises(ValueError) as caught:
+        store.load(native_index_authorization=authorization)
+
+    assert caught.value is primary
+    assert close_calls == [True]
+    assert replacement_l0.reset_calls == replacement_l2.reset_calls == 1
+    owner = caught.value.vector_index_cleanup_owner
+    assert owner.indices == [replacement_l0]
+    replacement_l0.failure = None
+    owner.close()
+    assert owner.closed
+    assert replacement_l0.reset_calls == 2
+    assert replacement_l2.reset_calls == 1
+
+
+def test_load_preserves_pending_captured_view_owner_on_cleanup_failure(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = _store(tmp_path, fingerprint="sha256:expected")
+    ownership = capture_directory_ownership(tmp_path)
+    authorization = _mint_trusted_local_admin_authorization(
+        ownership,
+        view_type="vector",
+        semantic_contract=store.artifact_metadata,
+        evidence=("vector-view-cleanup-owner-test",),
+    )
+    primary = ValueError("injected final vector verification failure")
+    cleanup_failure = KeyboardInterrupt("injected captured view cleanup failure")
+
+    class _Owner:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    owner = _Owner()
+
+    def fail_close() -> None:
+        cleanup_failure.captured_directory_cleanup_owner = owner
+        raise cleanup_failure
+
+    view = SimpleNamespace(
+        ownership=ownership,
+        verify_final=lambda: (_ for _ in ()).throw(primary),
+        close=fail_close,
+        reader=object(),
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.capture_authenticated_vector_view",
+        lambda _path: view,
+    )
+    monkeypatch.setattr(
+        store,
+        "_load_captured",
+        lambda _view: (_ for _ in ()).throw(primary),
+    )
+
+    with pytest.raises(ValueError) as caught:
+        store.load(native_index_authorization=authorization)
+
+    assert caught.value is primary
+    assert caught.value.captured_directory_cleanup_owner is owner
+    owner.close()
+    assert owner.close_calls == 1
+
+
+@pytest.mark.parametrize("operation", ["mint", "require"])
+def test_vector_authorization_gate_preserves_pending_view_cleanup_owner(
+    tmp_path,
+    monkeypatch,
+    operation: str,
+) -> None:
+    primary = ValueError("injected vector gate verification failure")
+    cleanup_failure = KeyboardInterrupt("injected vector gate cleanup failure")
+    owner = MagicMock()
+
+    def fail_close() -> None:
+        cleanup_failure.captured_directory_cleanup_owner = owner
+        raise cleanup_failure
+
+    view = SimpleNamespace(
+        ownership=object(),
+        verify_final=lambda: (_ for _ in ()).throw(primary),
+        close=fail_close,
+        reader=object(),
+    )
+    monkeypatch.setattr(
+        artifact_integrity_module,
+        "capture_authenticated_vector_view",
+        lambda _path: view,
+    )
+    monkeypatch.setattr(
+        artifact_integrity_module,
+        "_mint_trusted_local_admin_authorization",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        artifact_integrity_module,
+        "require_native_index_authorization_preflight",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        artifact_integrity_module,
+        "require_native_index_authorization",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        if operation == "mint":
+            artifact_integrity_module._mint_trusted_local_vector_authorization(
+                tmp_path,
+                {},
+                evidence=("test",),
+            )
+        else:
+            artifact_integrity_module.require_authorized_vector_view(
+                tmp_path,
+                object(),
+                {},
+            )
+
+    assert caught.value is primary
+    assert caught.value.captured_directory_cleanup_owner is owner
+
+
+def test_load_keeps_published_state_when_old_index_cleanup_is_cancelled(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = _store(tmp_path, fingerprint="sha256:expected")
+    ownership = capture_directory_ownership(tmp_path)
+    authorization = _mint_trusted_local_admin_authorization(
+        ownership,
+        view_type="vector",
+        semantic_contract=store.artifact_metadata,
+        evidence=("vector-old-index-cleanup-test",),
+    )
+
+    class Index:
+        def __init__(self, failure=None) -> None:
+            self.failure = failure
+            self.reset_calls = 0
+
+        def reset(self) -> None:
+            self.reset_calls += 1
+            if self.failure is not None:
+                raise self.failure
+
+    interruption = KeyboardInterrupt("injected old-index cleanup cancellation")
+    old_l0 = Index(interruption)
+    old_l2 = Index()
+    store.l0_index = old_l0
+    store.l2_index = old_l2
+    replacement_l0 = Index()
+    replacement_l2 = Index()
+    view = SimpleNamespace(
+        ownership=ownership,
+        verify_final=lambda: None,
+        close=lambda: None,
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.capture_authenticated_vector_view",
+        lambda _path: view,
+    )
+    monkeypatch.setattr(
+        store,
+        "_load_captured",
+        lambda _view: _LoadedVectorState(
+            l0_index=replacement_l0,
+            l0_documents=[object()],
+            l2_index=replacement_l2,
+            l2_documents=[object()],
+            artifact_metadata={"embedding_fingerprint": "sha256:replacement"},
+            store_path=tmp_path / "replacement",
+        ),
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        store.load(native_index_authorization=authorization)
+
+    assert caught.value is interruption
+    assert store.l0_index is replacement_l0
+    assert store.l2_index is replacement_l2
+    assert replacement_l0.reset_calls == replacement_l2.reset_calls == 0
+    owner = caught.value.vector_index_cleanup_owner
+    assert owner.indices == [old_l0]
+    old_l0.failure = None
+    owner.close()
+    assert owner.closed
+    assert old_l0.reset_calls == 2
+    assert old_l2.reset_calls == 1
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [RuntimeError("index reset failed"), KeyboardInterrupt("index reset cancelled")],
+)
+def test_close_visits_all_indices_and_retains_failed_index_for_retry(
+    tmp_path,
+    failure: BaseException,
+) -> None:
+    store = _store(tmp_path, fingerprint="sha256:expected")
+
+    class _Index:
+        def __init__(self, reset_failure=None) -> None:
+            self.reset_failure = reset_failure
+            self.reset_calls = 0
+
+        def reset(self) -> None:
+            self.reset_calls += 1
+            if self.reset_failure is not None:
+                raise self.reset_failure
+
+    first = _Index(failure)
+    second = _Index()
+    store.l0_index = first
+    store.l0_documents = [object()]
+    store.l2_index = second
+    store.l2_documents = [object()]
+
+    with pytest.raises(type(failure)) as caught:
+        store.close()
+
+    assert caught.value is failure
+    assert first.reset_calls == second.reset_calls == 1
+    assert store.l0_index is first
+    assert len(store.l0_documents) == 1
+    assert store.l2_index is None
+    assert store.l2_documents == []
+    assert store.embedding is not None
+
+    first.reset_failure = None
+    store.close()
+
+    assert first.reset_calls == 2
+    assert second.reset_calls == 1
+    assert store.l0_index is store.l2_index is None
+    assert store.embedding is None
 
 
 def test_openai_wrapper_sends_vector_options_on_embedding_requests() -> None:

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -452,6 +452,28 @@ def test_zero_top_level_count_does_not_resurrect_stale_level_files(tmp_path):
     assert loaded.l2_documents == []
 
 
+def test_load_supports_legacy_local_pickle_documents(tmp_path):
+    path = tmp_path / "vs"
+    chunks = _chunks(2)
+    store = _make_store(embedding_model="test/model")
+    store.add_code_chunks(chunks)
+    store.save(str(path))
+
+    config_path = path / "config_test__model.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config.pop("persistence_schema")
+    config.pop("level_artifacts")
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    loaded = _make_store(embedding_model="test/model", store_path=str(path))
+    _load_trusted(loaded)
+
+    assert [document.metadata["file"] for document in loaded.l2_documents] == [
+        "m0.py",
+        "m1.py",
+    ]
+
+
 def test_failed_swap_preserves_the_serving_index(tmp_path):
     current = _make_store(embedding_model="test/model")
     current_chunks = _chunks(2)

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 import hashlib
 import json
 import pickle
+from pathlib import Path
 from unittest.mock import patch
 
 import faiss
 import numpy as np
 import pytest
 
+from codenib._atomic_directory import capture_directory_ownership
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
     VECTOR_VIEW_UPDATE_MARKER,
@@ -29,6 +31,7 @@ from codenib.index.embedding.artifact_integrity import (
     vector_level_artifact_records,
 )
 from codenib.index.embedding.vector_store import CodeVectorStore
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 
 _DIM = 16
 
@@ -63,6 +66,30 @@ def _make_store(**kwargs) -> CodeVectorStore:
         return_value=_FakeEmbedding(_DIM),
     ):
         return CodeVectorStore(dimension=_DIM, **kwargs)
+
+
+def _authorization(store: CodeVectorStore, path=None):
+    root = Path(path) if path is not None else Path(store.store_path)
+    return _mint_trusted_local_admin_authorization(
+        capture_directory_ownership(root),
+        view_type="vector",
+        semantic_contract=store.artifact_metadata,
+        evidence=("vector-store-test-local-admin",),
+    )
+
+
+def _load_trusted(store: CodeVectorStore, path=None) -> None:
+    store.load(
+        path,
+        native_index_authorization=_authorization(store, path),
+    )
+
+
+def _swap_trusted(store: CodeVectorStore, path) -> None:
+    store.swap_index(
+        str(path),
+        native_index_authorization=_authorization(store, path),
+    )
 
 
 def _chunks(n: int) -> list:
@@ -183,7 +210,7 @@ def test_ivf_save_load_roundtrip(tmp_path):
     store.save(path)
 
     loaded = _make_store(index_type="ivf", ivf_nlist=5, ivf_nprobe=5, store_path=path)
-    loaded.load(path)
+    _load_trusted(loaded, path)
     assert loaded.l2_index.ntotal == 5
     res = loaded.search(chunks[1]["content"], top_k=3)
     assert res and res[0].node_name == chunks[1]["name"]
@@ -204,7 +231,7 @@ def test_save_removes_persisted_level_after_last_document_is_deleted(tmp_path):
     assert config["l2_documents"] == 0
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
-    loaded.load()
+    _load_trusted(loaded)
     assert loaded.l2_index.ntotal == 0
     assert loaded.l2_documents == []
 
@@ -237,11 +264,11 @@ def test_failed_save_blocks_load_until_successful_retry(tmp_path):
     assert marker.is_file()
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="interrupted save marker"):
-        loaded.load()
+        _load_trusted(loaded)
 
     store.save(str(path))
     assert not marker.exists()
-    loaded.load()
+    _load_trusted(loaded)
     assert len(loaded.l2_documents) == 2
 
 
@@ -254,7 +281,7 @@ def test_load_rejects_incomplete_multi_artifact_update(tmp_path):
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="incomplete update marker"):
-        loaded.load()
+        _load_trusted(loaded)
 
 
 def test_load_prefers_portable_json_documents(tmp_path):
@@ -287,7 +314,7 @@ def test_load_prefers_portable_json_documents(tmp_path):
     _commit_portable_documents(path, "test__model")
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
-    loaded.load()
+    _load_trusted(loaded)
 
     assert [document.metadata["file"] for document in loaded.l2_documents] == [
         "m0.py",
@@ -311,7 +338,7 @@ def test_load_rejects_invalid_portable_json_documents(tmp_path):
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="invalid content or metadata"):
-        loaded.load()
+        _load_trusted(loaded)
 
 
 def test_load_rejects_faiss_document_count_mismatch(tmp_path):
@@ -337,7 +364,7 @@ def test_load_rejects_faiss_document_count_mismatch(tmp_path):
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="2 vectors for 1 documents"):
-        loaded.load()
+        _load_trusted(loaded)
 
 
 def test_load_rejects_top_level_document_count_mismatch(tmp_path):
@@ -353,7 +380,7 @@ def test_load_rejects_top_level_document_count_mismatch(tmp_path):
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="config expects 3 documents, loaded 2"):
-        loaded.load()
+        _load_trusted(loaded)
 
 
 def test_load_rejects_same_count_torn_document_write(tmp_path):
@@ -372,9 +399,12 @@ def test_load_rejects_same_count_torn_document_write(tmp_path):
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(
         ValueError,
-        match="committed documents vector artifact does not match",
+        match=(
+            "committed documents vector artifact does not match|"
+            "vector artifact does not match its fingerprint"
+        ),
     ):
-        loaded.load()
+        _load_trusted(loaded)
 
 
 def test_load_rejects_vector_config_from_another_manifest_generation(tmp_path):
@@ -395,8 +425,11 @@ def test_load_rejects_vector_config_from_another_manifest_generation(tmp_path):
         artifact_metadata={"persistence_config_fingerprint": expected},
     )
 
-    with pytest.raises(ValueError, match="manifest fingerprint"):
-        loaded.load()
+    with pytest.raises(
+        ValueError,
+        match="manifest fingerprint|vector artifact does not match its fingerprint",
+    ):
+        _load_trusted(loaded)
 
 
 def test_zero_top_level_count_does_not_resurrect_stale_level_files(tmp_path):
@@ -413,7 +446,7 @@ def test_zero_top_level_count_does_not_resurrect_stale_level_files(tmp_path):
     config_path.write_text(json.dumps(config), encoding="utf-8")
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
-    loaded.load()
+    _load_trusted(loaded)
 
     assert loaded.l2_index.ntotal == 0
     assert loaded.l2_documents == []
@@ -431,7 +464,7 @@ def test_failed_swap_preserves_the_serving_index(tmp_path):
     (replacement_path / "l2" / "documents_test__model.pkl").unlink()
 
     with pytest.raises(ValueError, match="vector artifact file"):
-        current.swap_index(str(replacement_path))
+        _swap_trusted(current, replacement_path)
 
     assert current.l2_index.ntotal == 2
     assert len(current.l2_documents) == 2
@@ -452,7 +485,7 @@ def test_successful_swap_replaces_all_levels(tmp_path):
     replacement.add_code_chunks([replacement_chunk], level="l2")
     replacement.save(str(replacement_path))
 
-    current.swap_index(str(replacement_path))
+    _swap_trusted(current, replacement_path)
 
     assert current.l0_index.ntotal == 0
     assert current.l0_documents == []
@@ -485,4 +518,4 @@ def test_load_rejects_faiss_dimension_mismatch(tmp_path):
         )
 
     with pytest.raises(ValueError, match="FAISS dimension mismatch"):
-        loaded.load()
+        _load_trusted(loaded)

--- a/test/mcp/test_mcp_e2e.py
+++ b/test/mcp/test_mcp_e2e.py
@@ -10,6 +10,7 @@ from the configured CodeNib prebuilt root.
 """
 
 import asyncio
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -37,9 +38,15 @@ class TestMCPServerE2E:
     @pytest.fixture(autouse=True)
     def reset_server_context(self):
         """Reset global server context before each test."""
+        previous_context = server_module._ctx
         server_module._ctx = None
+        if previous_context is not None:
+            previous_context.close()
         yield
+        current_context = server_module._ctx
         server_module._ctx = None
+        if current_context is not None:
+            current_context.close()
 
     @pytest.fixture
     def test_manifest_path(self, tmp_path):
@@ -146,52 +153,80 @@ class TestMCPServerE2E:
 
         Ensures MCP protocol layer adds no transformation overhead.
         """
+        from codenib.index.embedding.artifact_integrity import (
+            capture_authenticated_vector_view,
+        )
         from codenib.index.embedding.vector_store import CodeVectorStore
+        from codenib.native_index_authorization import (
+            _mint_trusted_local_admin_authorization,
+        )
 
         # Direct vector store call
-        vector_store = CodeVectorStore(
-            embedding_model="jinaai/jina-code-embeddings-1.5b",
-            embedding_provider="huggingface",
-            dimension=1536,
-            index_metric="ip",
-            store_path=str(TEST_REPO_PATH),
-        )
-        vector_store.load()
-
-        query = "coordinate transformation"
-        top_k = 5
-
-        direct_results = vector_store.search_with_content(
-            query=query, top_k=top_k, level="l2"
-        )
-
-        # MCP server call
-        mock_mcp = MagicMock()
-        with patch.object(server_module, "MCPServer", return_value=mock_mcp):
-            with patch.object(server_module, "mcp", mock_mcp):
-                server_module.init_server(test_manifest_path)
-
-        mcp_results = asyncio.run(
-            server_module.semantic_search(query=query, top_k=top_k, level="l2")
-        )
-
-        # Should have same number of results
-        assert len(mcp_results) == len(direct_results)
-
-        # Scores should match (within floating point tolerance)
-        for i in range(len(direct_results)):
-            direct_score = float(direct_results[i].score)
-            mcp_score = float(mcp_results[i]["score"])
-
-            assert abs(direct_score - mcp_score) < 1e-6, (
-                f"Score mismatch at position {i}: "
-                f"direct={direct_score:.6f}, mcp={mcp_score:.6f}"
+        artifact_contract = {
+            "embedding_model": "jinaai/jina-code-embeddings-1.5b",
+            "embedding_provider": "huggingface",
+            "dimension": 1536,
+            "index_metric": "ip",
+        }
+        with capture_authenticated_vector_view(TEST_REPO_PATH) as vector_view:
+            native_authorization = _mint_trusted_local_admin_authorization(
+                vector_view.ownership,
+                view_type="vector",
+                semantic_contract=artifact_contract,
+                evidence=(
+                    "mcp-e2e-direct-vector-view",
+                    "captured-vector-tree-subject",
+                ),
             )
 
-        print("\n=== MCP Layer Equivalence ===")
-        print(f"Results: {len(mcp_results)}")
-        print("Scores match: ✓")
-        print("MCP adds no transformation overhead: ✓")
+        with ExitStack() as resources:
+            vector_store = CodeVectorStore(
+                embedding_model="jinaai/jina-code-embeddings-1.5b",
+                embedding_provider="huggingface",
+                dimension=1536,
+                index_metric="ip",
+                store_path=str(TEST_REPO_PATH),
+                artifact_metadata=artifact_contract,
+            )
+            resources.callback(vector_store.close)
+            vector_store.load(
+                native_index_authorization=native_authorization,
+            )
+
+            query = "coordinate transformation"
+            top_k = 5
+
+            direct_results = vector_store.search_with_content(
+                query=query, top_k=top_k, level="l2"
+            )
+
+            # MCP server call
+            mock_mcp = MagicMock()
+            with patch.object(server_module, "MCPServer", return_value=mock_mcp):
+                with patch.object(server_module, "mcp", mock_mcp):
+                    server_module.init_server(test_manifest_path)
+
+            mcp_results = asyncio.run(
+                server_module.semantic_search(query=query, top_k=top_k, level="l2")
+            )
+
+            # Should have same number of results
+            assert len(mcp_results) == len(direct_results)
+
+            # Scores should match (within floating point tolerance)
+            for i in range(len(direct_results)):
+                direct_score = float(direct_results[i].score)
+                mcp_score = float(mcp_results[i]["score"])
+
+                assert abs(direct_score - mcp_score) < 1e-6, (
+                    f"Score mismatch at position {i}: "
+                    f"direct={direct_score:.6f}, mcp={mcp_score:.6f}"
+                )
+
+            print("\n=== MCP Layer Equivalence ===")
+            print(f"Results: {len(mcp_results)}")
+            print("Scores match: ✓")
+            print("MCP adds no transformation overhead: ✓")
 
     def test_mcp_server_status(self, test_manifest_path):
         """Test server_status resource returns correct info."""

--- a/test/mcp/test_search_semantic_integration.py
+++ b/test/mcp/test_search_semantic_integration.py
@@ -9,6 +9,7 @@ Uses pre-built indexes from the configured CodeNib prebuilt root.
 """
 
 import asyncio
+from contextlib import ExitStack
 
 import pytest
 
@@ -57,20 +58,43 @@ class TestSearchSemanticIntegration:
         )
 
         # Manually load vector store (since we're bypassing ServerContext.load)
+        resources = ExitStack()
         ctx = ServerContext(manifest=manifest)
+        resources.callback(ctx.close)
 
+        from codenib.index.embedding.artifact_integrity import (
+            capture_authenticated_vector_view,
+        )
         from codenib.index.embedding.vector_store import CodeVectorStore
+        from codenib.native_index_authorization import (
+            _mint_trusted_local_admin_authorization,
+        )
 
+        artifact_contract = dict(manifest.indexes["vector"].config)
+        with capture_authenticated_vector_view(TEST_REPO_PATH) as vector_view:
+            authorization = _mint_trusted_local_admin_authorization(
+                vector_view.ownership,
+                view_type="vector",
+                semantic_contract=artifact_contract,
+                evidence=(
+                    "semantic-integration-local-vector-view",
+                    "captured-vector-tree-subject",
+                ),
+            )
         ctx.vector = CodeVectorStore(
             embedding_model="jinaai/jina-code-embeddings-1.5b",
             embedding_provider="huggingface",
             dimension=1536,
             index_metric="ip",
             store_path=str(TEST_REPO_PATH),  # Parent directory
+            artifact_metadata=artifact_contract,
         )
-        ctx.vector.load()
+        ctx.vector.load(native_index_authorization=authorization)
 
-        return ctx
+        try:
+            yield ctx
+        finally:
+            resources.close()
 
     def test_search_semantic_real_query(self, real_context):
         """Test semantic search with a real query on astropy code."""

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -17,13 +17,9 @@ import pytest
 
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
-from codenib.index.embedding.artifact_integrity import (
-    capture_authenticated_vector_view,
-)
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.mcp.context import RUNTIME_VIEW_NAMES, ServerContext
-from codenib.native_index_authorization import (
-    _mint_trusted_local_admin_authorization,
-)
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.provider_routes import resolve_inference_route
 from codenib.source_fingerprint import capture_repository_source, fingerprint_repository
 
@@ -125,6 +121,43 @@ def test_server_context_load_failure_closes_transferred_source_authority(
         ServerContext.load(manifest, views=[], source_binding=binding)
 
     assert not binding.usable
+
+
+def test_server_context_load_uses_one_detached_source_identity_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=binding.fingerprint,
+        file_count=binding.file_count,
+    )
+    binding_type = type(binding)
+    real_snapshot = binding_type.authenticated_identity_snapshot
+
+    def snapshot_then_replace_public_projection(source):
+        snapshot = real_snapshot(source)
+        source.root = tmp_path / "substituted"
+        source.fingerprint = "sha256-v2:" + ("0" * 64)
+        source.file_count = 0
+        source.file_records = ()
+        return snapshot
+
+    monkeypatch.setattr(
+        binding_type,
+        "authenticated_identity_snapshot",
+        snapshot_then_replace_public_projection,
+    )
+
+    context = ServerContext.load(manifest, views=(), source_binding=binding)
+    try:
+        assert context.source_verified
+    finally:
+        context.close()
 
 
 def test_server_context_provider_failure_closes_transferred_source_authority(
@@ -924,6 +957,127 @@ def test_load_vector_accepts_compiler_manifest_identity(tmp_path: Path) -> None:
     assert "vector" not in ctx.errors
 
 
+@pytest.mark.parametrize(
+    "interruption",
+    [KeyboardInterrupt("vector load interrupted"), SystemExit("vector load exited")],
+)
+def test_load_vector_closes_unpublished_state_after_base_exception(
+    tmp_path: Path,
+    interruption: BaseException,
+) -> None:
+    manifest, vector_dir = _portable_vector_manifest(tmp_path)
+    manifest.save(tmp_path / "repo_manifest.json")
+    vector = MagicMock()
+    vector.load.side_effect = interruption
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
+
+    with patch(
+        "codenib.index.embedding.vector_store.CodeVectorStore",
+        return_value=vector,
+    ):
+        with pytest.raises(type(interruption)) as caught:
+            ServerContext.load(
+                tmp_path / "repo_manifest.json",
+                views={"vector"},
+                native_index_authorization=authorization,
+            )
+
+    assert caught.value is interruption
+    vector.close.assert_called_once_with()
+
+
+def test_server_context_load_closes_published_vector_after_late_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, vector_dir = _portable_vector_manifest(tmp_path)
+    manifest.save(tmp_path / "repo_manifest.json")
+    vector = MagicMock()
+    vector.embedding_model = "test-model"
+    vector.get_stats.return_value = {"total_documents": 1}
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
+    failure = KeyboardInterrupt("late context configuration interruption")
+    monkeypatch.setattr(
+        ServerContext,
+        "configure_lsp_provider",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(failure),
+    )
+
+    with patch(
+        "codenib.index.embedding.vector_store.CodeVectorStore",
+        return_value=vector,
+    ):
+        with pytest.raises(KeyboardInterrupt) as caught:
+            ServerContext.load(
+                tmp_path / "repo_manifest.json",
+                views={"vector"},
+                native_index_authorization=authorization,
+            )
+
+    assert caught.value is failure
+    vector.close.assert_called_once_with()
+
+
+def test_server_context_load_preserves_runtime_cancellation_and_retry_owners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("VALUE = 1\n", encoding="utf-8")
+    binding = capture_repository_source(repo)
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=binding.fingerprint,
+        file_count=binding.file_count,
+    )
+    vector = MagicMock()
+    interruption = KeyboardInterrupt("vector cleanup interrupted")
+    vector.close.side_effect = interruption
+    source_type = type(binding)
+    real_source_close = source_type.close
+    source_close_calls = 0
+
+    def persistent_source_close(_binding) -> None:
+        nonlocal source_close_calls
+        source_close_calls += 1
+        raise OSError("persistent source cleanup EIO")
+
+    def load_views(ctx, _selected):
+        ctx.vector = vector
+        return {}
+
+    monkeypatch.setattr(source_type, "close", persistent_source_close)
+    monkeypatch.setattr(ServerContext, "load_views", load_views)
+    monkeypatch.setattr(
+        ServerContext,
+        "configure_lsp_provider",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ValueError("late context setup failed")
+        ),
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        ServerContext.load(manifest, views=(), source_binding=binding)
+
+    assert caught.value is interruption
+    assert caught.value.context_cleanup_owner.vector is vector
+    assert caught.value.source_cleanup_owner is binding
+    vector.close.assert_called_once_with()
+    assert source_close_calls == 2
+
+    vector.close.side_effect = None
+    monkeypatch.setattr(source_type, "close", real_source_close)
+    caught.value.context_cleanup_owner.close()
+    assert binding.closed
+
+
 def test_validate_views_probes_vector_without_loading_embedding_model(
     tmp_path: Path,
 ) -> None:
@@ -1237,6 +1391,86 @@ def test_validate_views_stops_zoekt_probe(manifest_dir: Path) -> None:
     fake_searcher.stop.assert_called_once_with()
 
 
+@pytest.mark.parametrize(
+    "cleanup_failure",
+    [
+        pytest.param(RuntimeError("zoekt stop failed"), id="exception"),
+        pytest.param(KeyboardInterrupt("zoekt stop interrupted"), id="cancellation"),
+    ],
+)
+def test_validate_views_closes_vector_after_zoekt_cleanup_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cleanup_failure: BaseException,
+) -> None:
+    zoekt = MagicMock()
+    zoekt.stop.side_effect = cleanup_failure
+    vector = MagicMock()
+
+    def load_zoekt(context) -> None:
+        context.zoekt = zoekt
+
+    def load_vector(context, *, probe: bool = False) -> None:
+        assert probe
+        context.vector = vector
+
+    monkeypatch.setattr(ServerContext, "_load_zoekt", load_zoekt)
+    monkeypatch.setattr(ServerContext, "_load_vector", load_vector)
+
+    with pytest.raises(type(cleanup_failure)) as caught:
+        ServerContext.validate_views(
+            RepoManifest(repo_path=str(tmp_path)),
+            views={"zoekt", "vector"},
+        )
+
+    assert caught.value is cleanup_failure
+    vector.close.assert_called_once_with()
+    owner = caught.value.context_cleanup_owner
+    assert owner.zoekt is zoekt
+    assert owner.vector is None
+
+    zoekt.stop.side_effect = None
+    owner.close()
+    assert owner.zoekt is None
+
+
+def test_validate_views_preserves_loader_cancellation_and_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    zoekt = MagicMock()
+    zoekt.stop.side_effect = RuntimeError("zoekt stop failed")
+    vector = MagicMock()
+    interruption = KeyboardInterrupt("vector probe interrupted")
+
+    def load_zoekt(context) -> None:
+        context.zoekt = zoekt
+
+    def load_vector(context, *, probe: bool = False) -> None:
+        assert probe
+        context.vector = vector
+        raise interruption
+
+    monkeypatch.setattr(ServerContext, "_load_zoekt", load_zoekt)
+    monkeypatch.setattr(ServerContext, "_load_vector", load_vector)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        ServerContext.validate_views(
+            RepoManifest(repo_path=str(tmp_path)),
+            views={"zoekt", "vector"},
+        )
+
+    assert caught.value is interruption
+    vector.close.assert_called_once_with()
+    owner = caught.value.context_cleanup_owner
+    assert owner.zoekt is zoekt
+    assert owner.vector is None
+
+    zoekt.stop.side_effect = None
+    owner.close()
+    assert owner.zoekt is None
+
+
 def test_zoekt_unavailable_recorded_in_errors(manifest_dir: Path) -> None:
     """If the zoekt binary is missing, ServerContext records the error and keeps zoekt=None."""
     from codenib.index.trigram import ZoektUnavailableError
@@ -1257,6 +1491,78 @@ def test_zoekt_unavailable_recorded_in_errors(manifest_dir: Path) -> None:
     assert ctx.zoekt is None
     assert "zoekt" in ctx.errors
     assert "binary not found" in ctx.errors["zoekt"]
+
+
+def test_zoekt_start_cancellation_stops_unpublished_searcher(
+    manifest_dir: Path,
+) -> None:
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    _add_zoekt_entry(manifest_dir / "repo_manifest.json", shard_dir)
+    searcher = MagicMock()
+    interruption = KeyboardInterrupt("zoekt start interrupted")
+    searcher.start.side_effect = interruption
+
+    with patch(
+        "codenib.index.trigram.ZoektSearcher",
+        return_value=searcher,
+    ):
+        with pytest.raises(KeyboardInterrupt) as caught:
+            ServerContext.load(manifest_dir / "repo_manifest.json", views={"zoekt"})
+
+    assert caught.value is interruption
+    searcher.stop.assert_called_once_with()
+
+
+def test_zoekt_cleanup_cancellation_exposes_retryable_context_owner(
+    manifest_dir: Path,
+) -> None:
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    _add_zoekt_entry(manifest_dir / "repo_manifest.json", shard_dir)
+    searcher = MagicMock()
+    searcher.start.side_effect = RuntimeError("zoekt start failed")
+    interruption = KeyboardInterrupt("zoekt stop interrupted")
+    searcher.stop.side_effect = interruption
+
+    with patch(
+        "codenib.index.trigram.ZoektSearcher",
+        return_value=searcher,
+    ):
+        with pytest.raises(KeyboardInterrupt) as caught:
+            ServerContext.load(manifest_dir / "repo_manifest.json", views={"zoekt"})
+
+    assert caught.value is interruption
+    owner = caught.value.context_cleanup_owner
+    assert owner.zoekt is searcher
+    searcher.stop.side_effect = None
+    owner.close()
+    assert owner.zoekt is None
+
+
+def test_zoekt_port_failure_does_not_publish_stopped_searcher(
+    manifest_dir: Path,
+) -> None:
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    _add_zoekt_entry(manifest_dir / "repo_manifest.json", shard_dir)
+    searcher = MagicMock()
+    type(searcher).port = property(
+        lambda _searcher: (_ for _ in ()).throw(RuntimeError("port failed"))
+    )
+
+    with patch(
+        "codenib.index.trigram.ZoektSearcher",
+        return_value=searcher,
+    ):
+        context = ServerContext.load(
+            manifest_dir / "repo_manifest.json",
+            views={"zoekt"},
+        )
+
+    assert context.zoekt is None
+    assert context.errors["zoekt"] == "port failed"
+    searcher.stop.assert_called_once_with()
 
 
 def test_zoekt_skipped_when_entry_absent(manifest_dir: Path) -> None:

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -19,6 +19,356 @@ from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprin
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.mcp.context import RUNTIME_VIEW_NAMES, ServerContext
 from codenib.provider_routes import resolve_inference_route
+from codenib.source_fingerprint import capture_repository_source, fingerprint_repository
+
+
+class _PendingSourceOwner:
+    def __init__(self, source: object) -> None:
+        self.source = source
+        self.closed = False
+
+    @property
+    def pending_sources(self) -> tuple[object, ...]:
+        return () if self.closed else (self.source,)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_server_context_rejects_mismatched_source_authority(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "a.py").write_bytes(b"A\n")
+    (second / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(first)
+    identity = fingerprint_repository(second)
+    manifest = RepoManifest(
+        repo_path=str(second),
+        source_fingerprint=identity.value,
+        file_count=identity.file_count,
+    )
+
+    with pytest.raises(ValueError, match="does not match the manifest"):
+        ServerContext.load(manifest, views=[], source_binding=binding)
+
+    assert not binding.usable
+
+
+def test_server_context_load_failure_closes_transferred_source_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=binding.fingerprint,
+        file_count=binding.file_count,
+    )
+
+    def fail_load_views(self, _views):
+        raise RuntimeError("injected load failure")
+
+    monkeypatch.setattr(ServerContext, "load_views", fail_load_views)
+    with pytest.raises(RuntimeError, match="injected load failure"):
+        ServerContext.load(manifest, views=[], source_binding=binding)
+
+    assert not binding.usable
+
+
+def test_server_context_provider_failure_closes_transferred_source_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=binding.fingerprint,
+        file_count=binding.file_count,
+    )
+
+    def fail_provider_configuration(self, **_kwargs):
+        raise RuntimeError("injected provider configuration failure")
+
+    monkeypatch.setattr(
+        ServerContext,
+        "configure_lsp_provider",
+        fail_provider_configuration,
+    )
+    with pytest.raises(RuntimeError, match="provider configuration failure"):
+        ServerContext.load(manifest, views=[], source_binding=binding)
+
+    assert not binding.usable
+
+
+def test_init_server_provider_reconfiguration_failure_closes_new_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.mcp import server as server_module
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    identity = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=identity.value,
+        file_count=identity.file_count,
+        languages=["cpp"],
+    ).save(manifest_path)
+    captured = []
+    configure_calls = []
+
+    def capture(*args, **kwargs):
+        source = capture_repository_source(*args, **kwargs)
+        captured.append(source)
+        return source
+
+    def configure(
+        self,
+        *,
+        allow_native: bool,
+        native_disabled_reason: str = "native_provider_not_authorized",
+    ):
+        configure_calls.append((allow_native, native_disabled_reason))
+        self._lsp_allow_native = allow_native
+        self._lsp_native_disabled_reason = native_disabled_reason
+        if allow_native:
+            raise RuntimeError("injected native provider configuration failure")
+        self.lsp_provider = None
+        self.lsp_provider_selection = {"status": "unavailable"}
+        return dict(self.lsp_provider_selection)
+
+    monkeypatch.setattr(
+        "codenib.source_fingerprint.capture_repository_source",
+        capture,
+    )
+    monkeypatch.setattr(ServerContext, "configure_lsp_provider", configure)
+    previous_context = object()
+    monkeypatch.setattr(server_module, "_ctx", previous_context)
+
+    with pytest.raises(RuntimeError, match="native provider configuration failure"):
+        server_module.init_server(manifest_path)
+
+    assert configure_calls == [
+        (False, "local_source_not_verified"),
+        (False, "local_source_not_verified"),
+        (True, "local_source_not_verified"),
+    ]
+    assert len(captured) == 1
+    assert captured[0].closed
+    assert server_module._ctx is previous_context
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("context close interrupted"), id="keyboard"),
+        pytest.param(SystemExit("context close exited"), id="system-exit"),
+    ],
+)
+def test_server_context_mismatch_propagates_after_close_cancellation_and_old_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "a.py").write_bytes(b"A\n")
+    (second / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(first)
+    identity = fingerprint_repository(second)
+    manifest = RepoManifest(
+        repo_path=str(second),
+        source_fingerprint=identity.value,
+        file_count=identity.file_count,
+    )
+    old_source = object()
+    old_owner = _PendingSourceOwner(old_source)
+    method = ServerContext.load.__func__
+    source_type = type(binding)
+    real_close = source_type.close
+    close_calls = 0
+    injected_owner = False
+
+    def close_then_interrupt(source) -> None:
+        nonlocal close_calls
+        close_calls += 1
+        real_close(source)
+        raise interruption
+
+    def attach_old_owner(frame, event, arg):
+        nonlocal injected_owner
+        if (
+            not injected_owner
+            and frame.f_code is method.__code__
+            and event == "exception"
+            and isinstance(arg[1], ValueError)
+            and "does not match the manifest" in str(arg[1])
+        ):
+            injected_owner = True
+            arg[1].source_cleanup_owner = old_owner
+        return attach_old_owner
+
+    monkeypatch.setattr(source_type, "close", close_then_interrupt)
+    sys.settrace(attach_old_owner)
+    try:
+        with pytest.raises(type(interruption)) as caught:
+            ServerContext.load(manifest, views=[], source_binding=binding)
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected_owner
+    assert close_calls == 1
+    assert binding.closed
+    assert caught.value.source_cleanup_owner is old_owner
+
+    old_owner.close()
+    assert old_owner.closed
+
+
+def test_server_context_mismatch_merges_old_owner_with_persistent_close_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "a.py").write_bytes(b"A\n")
+    (second / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(first)
+    identity = fingerprint_repository(second)
+    manifest = RepoManifest(
+        repo_path=str(second),
+        source_fingerprint=identity.value,
+        file_count=identity.file_count,
+    )
+    old_source = object()
+    old_owner = _PendingSourceOwner(old_source)
+    method = ServerContext.load.__func__
+    source_type = type(binding)
+    real_close = source_type.close
+    primary_error: BaseException | None = None
+
+    def persistent_close(_source) -> None:
+        raise OSError("injected persistent context close EIO")
+
+    def attach_old_owner(frame, event, arg):
+        nonlocal primary_error
+        if (
+            primary_error is None
+            and frame.f_code is method.__code__
+            and event == "exception"
+            and isinstance(arg[1], ValueError)
+            and "does not match the manifest" in str(arg[1])
+        ):
+            primary_error = arg[1]
+            arg[1].source_cleanup_owner = old_owner
+        return attach_old_owner
+
+    monkeypatch.setattr(source_type, "close", persistent_close)
+    sys.settrace(attach_old_owner)
+    try:
+        with pytest.raises(ValueError, match="does not match the manifest") as caught:
+            ServerContext.load(manifest, views=[], source_binding=binding)
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is primary_error
+    retry_owner = caught.value.source_cleanup_owner
+    assert set(retry_owner.pending_sources) == {old_source, binding}
+    assert not binding.closed
+
+    monkeypatch.setattr(source_type, "close", real_close)
+    retry_owner.close()
+    assert retry_owner.closed
+    assert old_owner.closed
+    assert binding.closed
+
+
+def test_local_bm25_without_source_binding_is_persisted_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.index.sparse_idx.bm25_index as bm25_module
+
+    view = tmp_path / "bm25"
+    view.mkdir()
+    secret = tmp_path / "secret.py"
+    secret.write_text("API_KEY = 'LOCAL_BM25_SECRET'\n", encoding="utf-8")
+    (view / "documents.json").write_text(
+        json.dumps(
+            [
+                {
+                    "page_content": "safe persisted needle",
+                    "metadata": {
+                        "file": str(secret),
+                        "name": "needle",
+                        "node_id": "secret.py:needle",
+                        "type": "variable",
+                        "start_line": 0,
+                        "end_line": 0,
+                    },
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (view / "bm25_metadata.json").write_text(
+        json.dumps(
+            {
+                "project_root": str(tmp_path),
+                "max_k": 10,
+                "language": "english",
+            }
+        ),
+        encoding="utf-8",
+    )
+    legacy = "sha256:" + "a" * 64
+    manifest = RepoManifest(
+        repo_path=str(tmp_path),
+        source_fingerprint=legacy,
+        last_indexed_source_fingerprint=legacy,
+        indexes={
+            "bm25": IndexEntry(
+                index_type="bm25",
+                path=str(view),
+                built_at="2026-01-01T00:00:00+00:00",
+                built_at_epoch=1.0,
+                status="fresh",
+                source_fingerprint=legacy,
+                config={
+                    "artifact_file_fingerprints": bm25_artifact_file_fingerprints(view)
+                },
+            )
+        },
+    )
+    monkeypatch.setattr(
+        bm25_module,
+        "_read_source_text",
+        lambda *_args: pytest.fail("unbound BM25 must not read live source"),
+    )
+
+    context = ServerContext.load(manifest, views={"bm25"})
+
+    assert context.bm25 is not None
+    assert context.bm25.source_mode == bm25_module.SOURCE_MODE_PERSISTED_ONLY
+    results = context.bm25.search("needle", return_code_content=True)
+    assert results and results[0].content is None
+    assert "LOCAL_BM25_SECRET" not in repr(results)
 
 
 def test_context_import_does_not_require_optional_mcp_dependency() -> None:
@@ -113,29 +463,44 @@ def test_load_selects_only_requested_views(
     assert calls == ["bm25"]
 
 
-def test_portable_context_never_attaches_project_local_native_provider(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_portable_artifact_context_never_loads_graph_or_other_native_views(
+    manifest_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    graph = object()
+    calls = _record_view_loads(monkeypatch)
 
-    def load_graph(self):
-        self.symbol_graph = graph
-
-    monkeypatch.setattr(ServerContext, "_load_symbol_graph", load_graph)
-    manifest = RepoManifest(repo_path=str(tmp_path), languages=["cpp"])
     with patch("codenib.ls_router.LSIndexer") as indexer:
         ctx = ServerContext.load(
-            manifest,
-            views={"symbol_graph"},
-            artifact={"verified": True},
+            manifest_dir / "repo_manifest.json",
+            artifact={"schema": "codenib.context-artifact.v1"},
         )
 
     indexer.assert_not_called()
-    assert ctx.lsp_provider.graph is graph
-    assert ctx.lsp_provider_selection["backend"] == "persisted-symbol-graph-v1"
+    assert calls == ["bm25", "vector"]
+    assert ctx.lsp_provider is None
+    assert ctx.lsp_provider_selection["backend"] == "unavailable"
     assert ctx.lsp_provider_selection["fallback_reason"] == (
         "portable_artifact_uses_persisted_graph"
     )
+    with pytest.raises(ValueError, match="cannot load native views"):
+        ctx.load_views({"symbol_graph"})
+
+
+def test_empty_portable_artifact_context_stays_native_view_inert(
+    manifest_dir: Path,
+) -> None:
+    ctx = ServerContext.load(
+        manifest_dir / "repo_manifest.json",
+        views=(),
+        artifact={},
+    )
+
+    assert ctx.artifact == {}
+    with pytest.raises(
+        ValueError,
+        match="portable artifact contexts cannot load native views: symbol_graph",
+    ):
+        ctx.load_views({"symbol_graph"})
 
 
 def test_load_views_adds_resources_idempotently(
@@ -159,11 +524,11 @@ def test_load_views_adds_resources_idempotently(
     assert ctx.loaded_views == frozenset({"bm25"})
 
 
-def test_load_views_rebinds_lsp_provider_after_lazy_graph_load(
+def test_load_views_rebinds_persisted_provider_after_lazy_graph_load(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     manifest = RepoManifest(repo_path=str(tmp_path), languages=["cpp"])
-    ctx = ServerContext.load(manifest, views=(), artifact={"verified": True})
+    ctx = ServerContext.load(manifest, views=())
     graph = object()
 
     def load_graph(self):
@@ -180,7 +545,7 @@ def test_load_views_rebinds_lsp_provider_after_lazy_graph_load(
         "backend": "persisted-symbol-graph-v1",
         "status": "ok",
         "index_snapshot": "symbol_graph:unknown:0:0",
-        "fallback_reason": "portable_artifact_uses_persisted_graph",
+        "fallback_reason": "local_source_not_verified",
         "capabilities": {
             "definition": True,
             "references": True,
@@ -387,11 +752,15 @@ def test_load_vector_accepts_compiler_manifest_identity(tmp_path: Path) -> None:
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 3}
+    authorization = object()
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
     ) as cls:
-        ctx = ServerContext.load(tmp_path / "repo_manifest.json")
+        ctx = ServerContext.load(
+            tmp_path / "repo_manifest.json",
+            native_index_authorization=authorization,
+        )
 
     cls.assert_called_once_with(
         embedding_model="test-model",
@@ -412,7 +781,9 @@ def test_load_vector_accepts_compiler_manifest_identity(tmp_path: Path) -> None:
         max_seq_length=8192,
         revision="model-commit",
     )
-    vector.load.assert_called_once_with()
+    vector.load.assert_called_once_with(
+        native_index_authorization=authorization,
+    )
     assert ctx.vector is vector
     assert "vector" not in ctx.errors
 
@@ -442,15 +813,23 @@ def test_validate_views_probes_vector_without_loading_embedding_model(
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 3}
+    authorization = object()
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
     ) as cls:
-        errors = ServerContext.validate_views(manifest, views={"vector"})
+        errors = ServerContext.validate_views(
+            manifest,
+            views={"vector"},
+            native_index_authorization=authorization,
+        )
 
     assert errors == {}
     assert cls.call_args.kwargs["embedding"].dimension == 384
+    vector.load.assert_called_once_with(
+        native_index_authorization=authorization,
+    )
 
 
 def test_load_vector_rebinds_openai_credential_without_persisting_it(
@@ -496,11 +875,15 @@ def test_load_vector_rebinds_openai_credential_without_persisting_it(
     vector = MagicMock()
     vector.embedding_model = route.model
     vector.get_stats.return_value = {"total_documents": 3}
+    authorization = object()
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
     ) as cls:
-        ctx = ServerContext.load(tmp_path / "repo_manifest.json")
+        ctx = ServerContext.load(
+            tmp_path / "repo_manifest.json",
+            native_index_authorization=authorization,
+        )
 
     kwargs = cls.call_args.kwargs
     assert kwargs["embedding_provider"] == "openai"
@@ -551,17 +934,24 @@ def test_validate_views_does_not_require_remote_embedding_credentials(
     vector = MagicMock()
     vector.embedding_model = route.model
     vector.get_stats.return_value = {"total_documents": 3}
+    authorization = object()
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
     ) as cls:
-        errors = ServerContext.validate_views(manifest, views={"vector"})
+        errors = ServerContext.validate_views(
+            manifest,
+            views={"vector"},
+            native_index_authorization=authorization,
+        )
 
     assert errors == {}
     assert "api_key" not in cls.call_args.kwargs
     assert cls.call_args.kwargs["embedding"].dimension == 1536
-    vector.load.assert_called_once_with()
+    vector.load.assert_called_once_with(
+        native_index_authorization=authorization,
+    )
     vector.close.assert_called_once_with()
 
 
@@ -588,12 +978,17 @@ def test_validate_views_rejects_empty_vector_artifact(tmp_path: Path) -> None:
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 0}
+    authorization = object()
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
     ):
-        errors = ServerContext.validate_views(manifest, views={"vector"})
+        errors = ServerContext.validate_views(
+            manifest,
+            views={"vector"},
+            native_index_authorization=authorization,
+        )
 
     assert errors == {"vector": "vector index contains no documents"}
     vector.close.assert_called_once_with()

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -17,7 +17,13 @@ import pytest
 
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import (
+    capture_authenticated_vector_view,
+)
 from codenib.mcp.context import RUNTIME_VIEW_NAMES, ServerContext
+from codenib.native_index_authorization import (
+    _mint_trusted_local_admin_authorization,
+)
 from codenib.provider_routes import resolve_inference_route
 from codenib.source_fingerprint import capture_repository_source, fingerprint_repository
 
@@ -33,6 +39,47 @@ class _PendingSourceOwner:
 
     def close(self) -> None:
         self.closed = True
+
+
+def _authorize_test_vector(vector_dir: Path, semantic_contract):
+    with capture_authenticated_vector_view(vector_dir) as vector_view:
+        return _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "mcp-context-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+
+
+def _portable_vector_manifest(tmp_path: Path) -> tuple[RepoManifest, Path]:
+    vector_dir = tmp_path / "portable-vector"
+    vector_dir.mkdir()
+    config = {
+        "embedding_model": "test-model",
+        "embedding_provider": "huggingface",
+        "embedding_dimension": 4,
+        "dimension": 4,
+        "embedding_kwargs": {},
+    }
+    return (
+        RepoManifest(
+            repo_path=str(tmp_path),
+            indexes={
+                "vector": IndexEntry(
+                    index_type="vector",
+                    path=str(vector_dir),
+                    built_at="2026-08-11T00:00:00Z",
+                    built_at_epoch=0.0,
+                    status="fresh",
+                    config=config,
+                )
+            },
+        ),
+        vector_dir,
+    )
 
 
 def test_server_context_rejects_mismatched_source_authority(tmp_path: Path) -> None:
@@ -503,6 +550,92 @@ def test_empty_portable_artifact_context_stays_native_view_inert(
         ctx.load_views({"symbol_graph"})
 
 
+@pytest.mark.parametrize("origin", ["plain", "binding"])
+def test_portable_artifact_eager_load_rejects_exact_native_authority_before_parser(
+    tmp_path: Path,
+    origin: str,
+) -> None:
+    manifest, vector_dir = _portable_vector_manifest(tmp_path)
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
+    origin_kwargs = (
+        {"artifact": {"schema": "codenib.context-artifact.v1"}}
+        if origin == "plain"
+        else {"artifact_binding": MagicMock()}
+    )
+
+    with (
+        patch("codenib.mcp.context.require_authorized_vector_view") as exact_gate,
+        patch(
+            "codenib.index.embedding.vector_store.CodeVectorStore"
+        ) as vector_constructor,
+        patch("codenib.index.embedding.vector_store.faiss.read_index") as faiss_parser,
+        patch(
+            "codenib.index.embedding.vector_store.compat_pickle.load"
+        ) as pickle_parser,
+    ):
+        with pytest.raises(
+            ValueError,
+            match="portable artifact contexts cannot authorize native vector",
+        ):
+            ServerContext.load(
+                manifest,
+                views={"vector"},
+                native_index_authorization=authorization,
+                **origin_kwargs,
+            )
+
+    exact_gate.assert_not_called()
+    vector_constructor.assert_not_called()
+    faiss_parser.assert_not_called()
+    pickle_parser.assert_not_called()
+
+
+def test_plain_portable_artifact_lazy_load_stays_inert_with_exact_authority(
+    tmp_path: Path,
+) -> None:
+    manifest, vector_dir = _portable_vector_manifest(tmp_path)
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
+    context = ServerContext.load(
+        manifest,
+        views=(),
+        artifact={"schema": "codenib.context-artifact.v1"},
+    )
+
+    with (
+        patch("codenib.mcp.context.require_authorized_vector_view") as exact_gate,
+        patch(
+            "codenib.index.embedding.vector_store.CodeVectorStore"
+        ) as vector_constructor,
+        patch("codenib.index.embedding.vector_store.faiss.read_index") as faiss_parser,
+        patch(
+            "codenib.index.embedding.vector_store.compat_pickle.load"
+        ) as pickle_parser,
+    ):
+        with pytest.raises(
+            ValueError,
+            match="portable artifact contexts cannot authorize native parsing",
+        ):
+            context.load_views(
+                {"vector"},
+                native_index_authorization=authorization,
+            )
+
+        assert context._native_index_authorization is None
+        errors = context.load_views({"vector"})
+
+    assert "external authorization" in errors["vector"]
+    exact_gate.assert_not_called()
+    vector_constructor.assert_not_called()
+    faiss_parser.assert_not_called()
+    pickle_parser.assert_not_called()
+
+
 def test_load_views_adds_resources_idempotently(
     manifest_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -752,7 +885,10 @@ def test_load_vector_accepts_compiler_manifest_identity(tmp_path: Path) -> None:
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 3}
-    authorization = object()
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
@@ -813,7 +949,10 @@ def test_validate_views_probes_vector_without_loading_embedding_model(
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 3}
-    authorization = object()
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
@@ -875,7 +1014,10 @@ def test_load_vector_rebinds_openai_credential_without_persisting_it(
     vector = MagicMock()
     vector.embedding_model = route.model
     vector.get_stats.return_value = {"total_documents": 3}
-    authorization = object()
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
@@ -934,7 +1076,10 @@ def test_validate_views_does_not_require_remote_embedding_credentials(
     vector = MagicMock()
     vector.embedding_model = route.model
     vector.get_stats.return_value = {"total_documents": 3}
-    authorization = object()
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
@@ -978,7 +1123,10 @@ def test_validate_views_rejects_empty_vector_artifact(tmp_path: Path) -> None:
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 0}
-    authorization = object()
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",

--- a/test/mcp_server/test_explore_tool.py
+++ b/test/mcp_server/test_explore_tool.py
@@ -15,6 +15,12 @@ from codenib.mcp.tools.explore import explore_context_impl
 
 
 def _context(tmp_path, *, verified: bool = True):
+    def read_source_bytes(relative: str, *, max_bytes: int) -> bytes:
+        payload = (tmp_path / relative).read_bytes()
+        if len(payload) > max_bytes:
+            raise ValueError("test source exceeds its bound")
+        return payload
+
     return SimpleNamespace(
         manifest=RepoManifest(
             repo_path=str(tmp_path),
@@ -25,6 +31,7 @@ def _context(tmp_path, *, verified: bool = True):
         artifact={"repository": "example/project"},
         source_verified=verified,
         source_error=None if verified else "checkout fingerprint mismatch",
+        read_source_bytes=read_source_bytes,
         bm25=object(),
         vector=None,
         symbol_graph=object(),

--- a/test/mcp_server/test_source_tool.py
+++ b/test/mcp_server/test_source_tool.py
@@ -82,7 +82,7 @@ def test_read_source_rejects_noncanonical_paths(
         read_source_impl(_context(tmp_path), file_path)
 
 
-def test_read_source_accepts_absolute_contained_symlink_and_rejects_nonregular(
+def test_read_source_rejects_absolute_symlink_and_nonregular(
     tmp_path: Path,
 ) -> None:
     source = tmp_path / "source.py"
@@ -90,9 +90,8 @@ def test_read_source_accepts_absolute_contained_symlink_and_rejects_nonregular(
     (tmp_path / "link.py").symlink_to(source)
     (tmp_path / "folder").mkdir()
 
-    assert read_source_impl(_context(tmp_path), "link.py", 1, 1)["content"] == (
-        "value = 1\n"
-    )
+    with pytest.raises(ValueError, match="readable regular"):
+        read_source_impl(_context(tmp_path), "link.py", 1, 1)
     with pytest.raises(ValueError, match="readable regular"):
         read_source_impl(_context(tmp_path), "folder")
 

--- a/test/mcp_server/test_source_tool.py
+++ b/test/mcp_server/test_source_tool.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import errno
 import json
 import os
 import subprocess
@@ -12,11 +14,14 @@ from types import SimpleNamespace
 
 import pytest
 
+import codenib.artifacts.runtime as artifact_runtime_module
 import codenib.mcp.server as server_module
-from codenib.compiler.manifest import RepoManifest
+import codenib.source_fingerprint as source_fingerprint_module
+from codenib._contained_source import read_repository_file
+from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.mcp.tools._validation import MAX_SOURCE_CONTENT_CHARS
 from codenib.mcp.tools.source import read_source_impl
-from codenib.source_fingerprint import fingerprint_repository
+from codenib.source_fingerprint import RepositorySourceBinding, fingerprint_repository
 
 
 def _context(repo: Path, *, verified: bool = True):
@@ -26,12 +31,18 @@ def _context(repo: Path, *, verified: bool = True):
         source_fingerprint="sha256:" + "b" * 64,
         languages=["python"],
     )
-    return SimpleNamespace(
+    context = SimpleNamespace(
         manifest=manifest,
         artifact={"repository": "example/project"},
         source_verified=verified,
-        source_error=None if verified else "checkout drifted",
+        source_error=None if verified else "source content drifted",
     )
+    context.read_source_bytes = lambda relative, max_bytes: read_repository_file(
+        repo,
+        relative,
+        max_bytes=max_bytes,
+    )
+    return context
 
 
 def test_read_source_returns_bounded_verified_window(tmp_path: Path) -> None:
@@ -50,6 +61,9 @@ def test_read_source_returns_bounded_verified_window(tmp_path: Path) -> None:
         "commit": "a" * 40,
         "source_fingerprint": "sha256:" + "b" * 64,
         "verified": True,
+        "verification_scope": "content-bytes",
+        "commit_verified": False,
+        "checkout_state": "not-attested",
     }
 
 
@@ -68,7 +82,7 @@ def test_read_source_rejects_noncanonical_paths(
         read_source_impl(_context(tmp_path), file_path)
 
 
-def test_read_source_rejects_absolute_symlinks_and_nonregular_files(
+def test_read_source_accepts_absolute_contained_symlink_and_rejects_nonregular(
     tmp_path: Path,
 ) -> None:
     source = tmp_path / "source.py"
@@ -76,8 +90,9 @@ def test_read_source_rejects_absolute_symlinks_and_nonregular_files(
     (tmp_path / "link.py").symlink_to(source)
     (tmp_path / "folder").mkdir()
 
-    with pytest.raises(ValueError, match="readable regular"):
-        read_source_impl(_context(tmp_path), "link.py")
+    assert read_source_impl(_context(tmp_path), "link.py", 1, 1)["content"] == (
+        "value = 1\n"
+    )
     with pytest.raises(ValueError, match="readable regular"):
         read_source_impl(_context(tmp_path), "folder")
 
@@ -139,10 +154,10 @@ def test_read_source_rejects_invalid_windows(
         read_source_impl(_context(tmp_path), "source.py", start, end)
 
 
-def test_read_source_requires_verified_checkout(tmp_path: Path) -> None:
+def test_read_source_requires_content_authenticated_binding(tmp_path: Path) -> None:
     (tmp_path / "source.py").write_text("value = 1\n", encoding="utf-8")
 
-    with pytest.raises(RuntimeError, match="checkout drifted"):
+    with pytest.raises(RuntimeError, match="source content drifted"):
         read_source_impl(_context(tmp_path, verified=False), "source.py")
 
 
@@ -198,10 +213,387 @@ def test_init_server_disables_source_reads_after_checkout_drift(
 
     server_module.init_server(manifest_path)
     assert server_module.get_context().source_verified is True
+    initial_manifest = asyncio.run(server_module.get_manifest())
+    assert initial_manifest["runtime"]["source_read"] == {
+        "verified": True,
+        "error": None,
+        "verification_scope": "content-bytes",
+        "commit_verified": False,
+        "checkout_state": "not-attested",
+    }
 
     source.write_text("value = 2\n", encoding="utf-8")
+    runtime_manifest = asyncio.run(server_module.get_manifest())
+    assert runtime_manifest["runtime"]["source_read"]["verified"] is False
+    assert runtime_manifest["runtime"]["source_read"]["verification_scope"] is None
+    assert runtime_manifest["runtime"]["source_read"]["commit_verified"] is False
+    assert (
+        runtime_manifest["runtime"]["source_read"]["checkout_state"] == "not-attested"
+    )
+    assert server_module.get_context().source_verified is False
+    assert "inventory changed" in str(
+        runtime_manifest["runtime"]["source_read"]["error"]
+    )
+
     server_module.init_server(manifest_path)
 
     ctx = server_module.get_context()
     assert ctx.source_verified is False
     assert "do not match the indexed content" in str(ctx.source_error)
+
+
+def test_init_server_capture_return_cancellation_closes_preowned_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+    captured: list[RepositorySourceBinding] = []
+    real_capture = source_fingerprint_module.capture_repository_source
+    interruption = KeyboardInterrupt("injected after MCP source capture returned")
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        raise interruption
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        capture,
+    )
+    monkeypatch.setattr(server_module, "_ctx", None)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        server_module.init_server(manifest_path)
+
+    assert caught.value is interruption
+    assert len(captured) == 1
+    assert captured[0].closed
+    assert server_module._ctx is None
+
+
+def test_init_server_persistent_close_eio_preserves_primary_and_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source_path = repo / "source.py"
+    source_path.write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+    source_path.write_text("value = 2\n", encoding="utf-8")
+    captured: list[RepositorySourceBinding] = []
+    real_capture = source_fingerprint_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        return source
+
+    def persistent_eio(source: RepositorySourceBinding) -> None:
+        if source in captured:
+            raise OSError(errno.EIO, "injected MCP source close EIO")
+        real_close(source)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        capture,
+    )
+    monkeypatch.setattr(RepositorySourceBinding, "close", persistent_eio)
+    monkeypatch.setattr(server_module, "_ctx", None)
+    with pytest.raises(ValueError, match="do not match the indexed content") as caught:
+        server_module.init_server(manifest_path)
+
+    assert len(captured) == 1
+    owner = caught.value.source_cleanup_owner
+    assert owner.pending_sources == (captured[0],)
+    assert not captured[0].closed
+    assert server_module._ctx is None
+
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    owner.close()
+    assert owner.closed
+    assert captured[0].closed
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(
+            KeyboardInterrupt("cleanup closed then interrupted"), id="keyboard"
+        ),
+        pytest.param(SystemExit("cleanup closed then exited"), id="system-exit"),
+    ],
+)
+def test_init_server_propagates_cleanup_cancellation_after_owner_is_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+    real_capture = source_fingerprint_module.capture_repository_source
+    real_owner_close = artifact_runtime_module.SourceBindingCleanupOwner.close
+    injected = False
+
+    def fail_capture(*args, **kwargs):
+        real_capture(*args, **kwargs)
+        raise ValueError("injected capture primary")
+
+    def close_then_interrupt(owner) -> None:
+        nonlocal injected
+        real_owner_close(owner)
+        if not injected:
+            injected = True
+            raise interruption
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        fail_capture,
+    )
+    monkeypatch.setattr(
+        artifact_runtime_module.SourceBindingCleanupOwner,
+        "close",
+        close_then_interrupt,
+    )
+    previous_context = SimpleNamespace(marker="previous")
+    monkeypatch.setattr(server_module, "_ctx", previous_context)
+
+    with pytest.raises(type(interruption)) as caught:
+        server_module.init_server(manifest_path)
+
+    assert caught.value is interruption
+    assert server_module._ctx is previous_context
+
+
+def test_init_server_primary_cancellation_wins_and_retains_eio_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+    real_capture = source_fingerprint_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+    captured: list[RepositorySourceBinding] = []
+    primary = KeyboardInterrupt("injected capture cancellation")
+
+    def interrupt_capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        raise primary
+
+    def persistent_eio(source: RepositorySourceBinding) -> None:
+        if source in captured:
+            raise OSError(errno.EIO, "injected cleanup EIO")
+        real_close(source)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        interrupt_capture,
+    )
+    monkeypatch.setattr(RepositorySourceBinding, "close", persistent_eio)
+    previous_context = SimpleNamespace(marker="previous")
+    monkeypatch.setattr(server_module, "_ctx", previous_context)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        server_module.init_server(manifest_path)
+
+    assert caught.value is primary
+    owner = caught.value.source_cleanup_owner
+    assert owner.pending_sources == (captured[0],)
+    assert server_module._ctx is previous_context
+
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    owner.close()
+    assert owner.closed
+
+
+def test_init_server_does_not_downgrade_capture_error_with_nested_pending_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+
+    class PendingOwner:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    pending = PendingOwner()
+    primary = ValueError("capture failed with partial owner")
+    primary.source_cleanup_owner = pending  # type: ignore[attr-defined]
+
+    def fail_capture(*_args, **_kwargs):
+        raise primary
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        fail_capture,
+    )
+    previous_context = SimpleNamespace(marker="previous")
+    monkeypatch.setattr(server_module, "_ctx", previous_context)
+
+    with pytest.raises(ValueError) as caught:
+        server_module.init_server(manifest_path)
+
+    assert caught.value is primary
+    assert caught.value.source_cleanup_owner is pending
+    assert server_module._ctx is previous_context
+    pending.close()
+
+
+def test_init_server_attaches_nested_owner_to_actual_cleanup_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+
+    class PendingOwner:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    pending = PendingOwner()
+    primary = ValueError("capture failed with partial owner")
+    primary.source_cleanup_owner = pending  # type: ignore[attr-defined]
+    interruption = SystemExit("cleanup cancellation")
+    real_owner_close = artifact_runtime_module.SourceBindingCleanupOwner.close
+    injected = False
+
+    def fail_capture(*_args, **_kwargs):
+        raise primary
+
+    def interrupt_empty_owner(owner) -> None:
+        nonlocal injected
+        real_owner_close(owner)
+        if not injected:
+            injected = True
+            raise interruption
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        fail_capture,
+    )
+    monkeypatch.setattr(
+        artifact_runtime_module.SourceBindingCleanupOwner,
+        "close",
+        interrupt_empty_owner,
+    )
+    previous_context = SimpleNamespace(marker="previous")
+    monkeypatch.setattr(server_module, "_ctx", previous_context)
+
+    with pytest.raises(SystemExit) as caught:
+        server_module.init_server(manifest_path)
+
+    assert caught.value is interruption
+    assert caught.value.source_cleanup_owner is pending
+    assert server_module._ctx is previous_context
+    pending.close()
+
+
+def test_init_server_never_treats_explicit_legacy_identity_as_verified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_fingerprint = "sha256:" + "a" * 64
+    manifest = RepoManifest(
+        repo_path="/unavailable",
+        source_fingerprint=legacy_fingerprint,
+        indexes={
+            "vector": IndexEntry(
+                index_type="vector",
+                path="/must-not-be-read/vector",
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=0.0,
+                status="fresh",
+                source_fingerprint=legacy_fingerprint,
+            )
+        },
+    )
+    from codenib import native_index_authorization
+    from codenib.index.embedding import artifact_integrity
+
+    capture_calls: list[str] = []
+    mint_calls: list[str] = []
+    monkeypatch.setattr(
+        artifact_integrity,
+        "capture_authenticated_vector_view",
+        lambda _path: capture_calls.append("capture"),
+    )
+    monkeypatch.setattr(
+        native_index_authorization,
+        "_mint_trusted_local_admin_authorization",
+        lambda *_args, **_kwargs: mint_calls.append("mint"),
+    )
+    monkeypatch.setattr(server_module, "_ctx", None)
+
+    server_module.init_server(manifest)
+
+    ctx = server_module.get_context()
+    assert ctx.source_verified is False
+    assert "source binding has not been verified" in str(ctx.source_error)
+    assert ctx.vector is None
+    assert "external authorization" in ctx.errors["vector"]
+    assert capture_calls == []
+    assert mint_calls == []

--- a/test/mcp_server/test_zoekt_searcher.py
+++ b/test/mcp_server/test_zoekt_searcher.py
@@ -6,9 +6,7 @@
 
 from __future__ import annotations
 
-import dis
 import os
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -284,50 +282,17 @@ class TestSearcherLifecycle:
         proc.poll.return_value = None
         proc.wait.return_value = 0
 
-        def spawn(owner, *_args, **_kwargs):
+        interruption = KeyboardInterrupt("injected after Popen ownership transfer")
+
+        def spawn_then_interrupt(owner, *_args, **_kwargs):
             owner.retain(proc)
-            return proc
+            raise interruption
 
-        monkeypatch.setattr(zoekt_module, "_OwnedZoektProcess", spawn)
-
-        instructions = list(dis.get_instructions(ZoektSearcher.start))
-        load_index = next(
-            index
-            for index, instruction in enumerate(instructions)
-            if instruction.opname == "LOAD_GLOBAL"
-            and instruction.argval == "_OwnedZoektProcess"
-        )
-        handoff_offset = next(
-            instruction.offset
-            for instruction in instructions[load_index:]
-            if instruction.opname == "POP_TOP"
-        )
-        interruption = KeyboardInterrupt("injected after Popen return")
-        injected = False
-
-        def trace(frame, event, _arg):
-            nonlocal injected
-            if frame.f_code is ZoektSearcher.start.__code__ and event == "call":
-                frame.f_trace_opcodes = True
-            if (
-                not injected
-                and frame.f_code is ZoektSearcher.start.__code__
-                and event == "opcode"
-                and frame.f_lasti == handoff_offset
-            ):
-                injected = True
-                raise interruption
-            return trace
-
-        sys.settrace(trace)
-        try:
-            with pytest.raises(KeyboardInterrupt) as caught:
-                searcher.start()
-        finally:
-            sys.settrace(None)
+        monkeypatch.setattr(zoekt_module, "_OwnedZoektProcess", spawn_then_interrupt)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            searcher.start()
 
         assert caught.value is interruption
-        assert injected
         proc.terminate.assert_called_once_with()
         proc.wait.assert_called_once_with(timeout=5)
         assert searcher._proc is None

--- a/test/mcp_server/test_zoekt_searcher.py
+++ b/test/mcp_server/test_zoekt_searcher.py
@@ -6,7 +6,9 @@
 
 from __future__ import annotations
 
+import dis
 import os
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -235,3 +237,97 @@ class TestSearcherStartPreconditions:
             ZoektUnavailableError, match="index directory does not exist"
         ):
             s.start()
+
+
+class TestSearcherLifecycle:
+    def test_stop_retains_failed_process_and_visits_all_cleanup(self, tmp_path) -> None:
+        searcher = ZoektSearcher(index_dir=str(tmp_path))
+        proc = MagicMock()
+        proc.poll.return_value = None
+        terminate_failure = RuntimeError("terminate failed")
+        proc.terminate.side_effect = terminate_failure
+        proc.wait.side_effect = [
+            RuntimeError("wait failed"),
+            RuntimeError("wait failed"),
+        ]
+        proc.kill.side_effect = RuntimeError("kill failed")
+        searcher._proc = proc
+
+        with pytest.raises(RuntimeError) as caught:
+            searcher.stop()
+
+        assert caught.value is terminate_failure
+        assert caught.value.zoekt_cleanup_owner is searcher
+        assert searcher._proc is proc
+        proc.terminate.assert_called_once_with()
+        proc.kill.assert_called_once_with()
+        assert proc.wait.call_count == 2
+
+        proc.terminate.side_effect = None
+        proc.wait.side_effect = None
+        proc.wait.return_value = 0
+        proc.kill.side_effect = None
+        searcher.stop()
+        assert searcher._proc is None
+
+    def test_start_retains_popen_result_at_first_python_handoff(
+        self,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import codenib.index.trigram.zoekt_searcher as zoekt_module
+
+        binary = tmp_path / "zoekt-webserver"
+        binary.write_bytes(b"")
+        searcher = ZoektSearcher(index_dir=str(tmp_path), binary=str(binary))
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.wait.return_value = 0
+
+        def spawn(owner, *_args, **_kwargs):
+            owner.retain(proc)
+            return proc
+
+        monkeypatch.setattr(zoekt_module, "_OwnedZoektProcess", spawn)
+
+        instructions = list(dis.get_instructions(ZoektSearcher.start))
+        load_index = next(
+            index
+            for index, instruction in enumerate(instructions)
+            if instruction.opname == "LOAD_GLOBAL"
+            and instruction.argval == "_OwnedZoektProcess"
+        )
+        handoff_offset = next(
+            instruction.offset
+            for instruction in instructions[load_index:]
+            if instruction.opname == "POP_TOP"
+        )
+        interruption = KeyboardInterrupt("injected after Popen return")
+        injected = False
+
+        def trace(frame, event, _arg):
+            nonlocal injected
+            if frame.f_code is ZoektSearcher.start.__code__ and event == "call":
+                frame.f_trace_opcodes = True
+            if (
+                not injected
+                and frame.f_code is ZoektSearcher.start.__code__
+                and event == "opcode"
+                and frame.f_lasti == handoff_offset
+            ):
+                injected = True
+                raise interruption
+            return trace
+
+        sys.settrace(trace)
+        try:
+            with pytest.raises(KeyboardInterrupt) as caught:
+                searcher.start()
+        finally:
+            sys.settrace(None)
+
+        assert caught.value is interruption
+        assert injected
+        proc.terminate.assert_called_once_with()
+        proc.wait.assert_called_once_with(timeout=5)
+        assert searcher._proc is None

--- a/test/model/test_retrieve_pipeline_indexer_routing.py
+++ b/test/model/test_retrieve_pipeline_indexer_routing.py
@@ -209,3 +209,59 @@ def test_retrieve_rerank_cache_miss_reuses_loaded_embedding(monkeypatch, tmp_pat
     assert result is built_store
     assert len(builder_calls) == 1
     assert builder_calls[0]["embedding"] is embedding
+
+
+def test_retrieve_rerank_cache_load_closes_store_on_base_exception(
+    monkeypatch,
+    tmp_path,
+):
+    from codenib.model import retrieve_rerank_pipeline as pipeline_module
+
+    index_path = tmp_path / "index"
+    index_path.mkdir()
+    (index_path / "config_model.json").write_text("{}", encoding="utf-8")
+    primary = SystemExit("stop vector load")
+    stores = []
+
+    class FakeVectorStore:
+        def __init__(self, **_kwargs):
+            self.embedding = object()
+            self.close_calls = 0
+            stores.append(self)
+
+        def load(self, _path, **_kwargs):
+            raise primary
+
+        def close(self):
+            self.close_calls += 1
+
+    monkeypatch.setattr(pipeline_module, "CodeVectorStore", FakeVectorStore)
+    monkeypatch.setattr(
+        pipeline_module,
+        "_mint_trusted_local_vector_authorization",
+        lambda *_args, **_kwargs: object(),
+    )
+
+    pipeline = object.__new__(pipeline_module.RetrieveRerankPipeline)
+    pipeline.repo_path = str(tmp_path)
+    pipeline.index_path = index_path
+    pipeline.retrieval_level = "l2"
+    pipeline.languages = ["python"]
+    pipeline.max_lines_per_chunk = 300
+    pipeline.index_metric = "ip"
+    pipeline.profiler = None
+
+    observed = None
+    try:
+        pipeline._initialize_vector_store(
+            embedding_model="model",
+            embedding_provider="huggingface",
+            embedding_dimension=4,
+            embedding_kwargs={},
+        )
+    except BaseException as exc:  # noqa: B036 - assert BaseException identity
+        observed = exc
+
+    assert observed is primary
+    assert len(stores) == 1
+    assert stores[0].close_calls == 1

--- a/test/sandbox/test_docker.py
+++ b/test/sandbox/test_docker.py
@@ -146,14 +146,8 @@ def test_container_fingerprint_helper_matches_host_v2_framing(tmp_path: Path) ->
     (source / "package" / "module.py").write_bytes(b"VALUE = 1\n")
     try:
         (source / "relative-link").symlink_to("b")
-        (source / "absolute-link").symlink_to(source / "b")
         (source / "relative-directory-link").symlink_to("package")
-        (source / "absolute-directory-link").symlink_to(source / "package")
         (source / "relative-root-link").symlink_to(".", target_is_directory=True)
-        (source / "absolute-root-link").symlink_to(
-            source,
-            target_is_directory=True,
-        )
         (source / "broken-link").symlink_to("missing")
         (source / "loop-link").symlink_to("loop-link")
         os.mkfifo(source / ".codenib-hidden-pipe")
@@ -242,7 +236,8 @@ def test_container_fingerprint_helper_rejects_outside_directory_symlink(
     )
 
     assert completed.returncode != 0
-    assert "outside the repository" in completed.stderr
+    expected_error = "target must be relative" if absolute else "outside the repository"
+    assert expected_error in completed.stderr
 
 
 def _spec(tmp_path: Path, *, limits=None):

--- a/test/sandbox/test_docker.py
+++ b/test/sandbox/test_docker.py
@@ -7,12 +7,15 @@ from __future__ import annotations
 import io
 import json
 import os
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
 from codenib.sandbox import (
     DockerSandboxProvider,
     ExecRequest,
@@ -25,10 +28,17 @@ from codenib.sandbox import (
     SandboxSpec,
     SandboxUnavailableError,
 )
-from codenib.sandbox.docker import _normalize_no_index_patch
+from codenib.sandbox.docker import _FINGERPRINT_SOURCE_SCRIPT, _normalize_no_index_patch
+from codenib.source_fingerprint import (
+    SOURCE_FINGERPRINT_VERSION,
+    RepositoryChangedError,
+    fingerprint_repository,
+)
 
 DIGEST = "sha256:" + "a" * 64
 IMAGE = f"registry.example/codenib-agent@{DIGEST}"
+SOURCE_FINGERPRINT = "sha256-v2:" + "e" * 64
+TEST_DOCKER_BINARY = str(Path(sys.executable).resolve(strict=True))
 
 
 class RecordingCLI:
@@ -72,7 +82,7 @@ class RecordingCLI:
             stdout = json.dumps(
                 {
                     "file_count": 2,
-                    "source_fingerprint": "sha256:" + "e" * 64,
+                    "source_fingerprint": SOURCE_FINGERPRINT,
                 }
             )
         else:
@@ -124,6 +134,115 @@ class HangingProcess(FinishedProcess):
             returncode=None,
             **kwargs,
         )
+
+
+def test_container_fingerprint_helper_matches_host_v2_framing(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    baseline = tmp_path / "baseline"
+    source.mkdir()
+    (source / "a").write_bytes(b"")
+    (source / "b").write_bytes(b"X\0F\0c\0Y")
+    (source / "package").mkdir()
+    (source / "package" / "module.py").write_bytes(b"VALUE = 1\n")
+    try:
+        (source / "relative-link").symlink_to("b")
+        (source / "absolute-link").symlink_to(source / "b")
+        (source / "relative-directory-link").symlink_to("package")
+        (source / "absolute-directory-link").symlink_to(source / "package")
+        (source / "relative-root-link").symlink_to(".", target_is_directory=True)
+        (source / "absolute-root-link").symlink_to(
+            source,
+            target_is_directory=True,
+        )
+        (source / "broken-link").symlink_to("missing")
+        (source / "loop-link").symlink_to("loop-link")
+        os.mkfifo(source / ".codenib-hidden-pipe")
+        (source / "fifo-link").symlink_to(".codenib-hidden-pipe")
+    except OSError as exc:  # pragma: no cover - platform capability
+        pytest.skip(f"source fingerprint parity needs symlink support: {exc}")
+
+    expected = fingerprint_repository(source)
+    baseline.mkdir()
+    for path in source.iterdir():
+        destination = baseline / path.name
+        if path.is_symlink():
+            destination.symlink_to(os.readlink(path))
+        elif path.name == ".codenib-hidden-pipe":
+            os.mkfifo(destination)
+        elif path.is_dir():
+            shutil.copytree(path, destination, symlinks=True)
+        else:
+            shutil.copy2(path, destination)
+    source_label = str(source)
+    source.rename(tmp_path / "source-unmounted")
+    script = _FINGERPRINT_SOURCE_SCRIPT.replace(
+        "pathlib.Path('/workspace')",
+        f"pathlib.Path({str(baseline)!r})",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            script,
+            "[]",
+            str(SOURCE_FINGERPRINT_VERSION),
+            str(REPOSITORY_FILTER_POLICY_VERSION),
+            source_label,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    observed = json.loads(completed.stdout)
+
+    assert observed == {
+        "file_count": expected.file_count,
+        "source_fingerprint": expected.value,
+    }
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_container_fingerprint_helper_rejects_outside_directory_symlink(
+    tmp_path: Path,
+    absolute: bool,
+) -> None:
+    baseline = tmp_path / "baseline"
+    outside = tmp_path / "outside"
+    baseline.mkdir()
+    outside.mkdir()
+    (baseline / "outside-link").symlink_to(
+        outside if absolute else "../outside",
+        target_is_directory=True,
+    )
+    with pytest.raises(RepositoryChangedError):
+        fingerprint_repository(baseline)
+
+    script = _FINGERPRINT_SOURCE_SCRIPT.replace(
+        "pathlib.Path('/workspace')",
+        f"pathlib.Path({str(baseline)!r})",
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            script,
+            "[]",
+            str(SOURCE_FINGERPRINT_VERSION),
+            str(REPOSITORY_FILTER_POLICY_VERSION),
+            str(baseline),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "outside the repository" in completed.stderr
 
 
 def _spec(tmp_path: Path, *, limits=None):
@@ -193,7 +312,7 @@ def _git_repo(tmp_path: Path) -> tuple[Path, str]:
 
 def test_create_replays_default_security_flags(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     session = _provider(tmp_path, cli).create(_spec(tmp_path))
@@ -244,7 +363,7 @@ def test_create_rejects_symlinked_source_path(tmp_path):
 
 def test_agent_command_is_after_image_and_uses_non_root_user(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     processes = []
@@ -276,7 +395,7 @@ def test_write_file_enables_interactive_stdin_and_isolates_helper(
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     processes = []
@@ -305,7 +424,7 @@ def test_write_file_enables_interactive_stdin_and_isolates_helper(
 
 def test_read_file_uses_isolated_python_and_read_only_mount(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     processes = []
@@ -333,7 +452,7 @@ def test_read_file_uses_isolated_python_and_read_only_mount(monkeypatch, tmp_pat
 
 def test_file_byte_limit_zero_fails_instead_of_using_default(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     session = _provider(tmp_path, RecordingCLI()).create(_spec(tmp_path))
 
@@ -345,7 +464,7 @@ def test_file_byte_limit_zero_fails_instead_of_using_default(monkeypatch, tmp_pa
 
 def test_host_secrets_are_not_forwarded(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     monkeypatch.setenv("GITHUB_TOKEN", "do-not-forward")
     monkeypatch.setenv("OPENAI_API_KEY", "do-not-forward")
@@ -372,7 +491,7 @@ def test_host_secrets_are_not_forwarded(monkeypatch, tmp_path):
         "PATH": "/usr/bin:/bin",
     }
     assert processes[0][0][:3] == [
-        "/usr/bin/docker",
+        TEST_DOCKER_BINARY,
         "--host",
         f"unix:///run/user/{os.getuid()}/docker.sock",
     ]
@@ -381,7 +500,7 @@ def test_host_secrets_are_not_forwarded(monkeypatch, tmp_path):
 
 def test_revision_snapshot_archives_git_objects_not_worktree(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     source, revision = _git_repo(tmp_path)
     spec = SandboxSpec(
@@ -406,7 +525,7 @@ def test_revision_snapshot_archives_git_objects_not_worktree(monkeypatch, tmp_pa
     assert "dst=/repository.git,readonly" in rendered
     assert f"type=bind,src={source},dst=/source" not in rendered
     assert revision in archive_call
-    assert session.metadata.source_fingerprint == "sha256:" + "e" * 64
+    assert session.metadata.source_fingerprint == SOURCE_FINGERPRINT
     created = json.loads(
         (session.audit_dir / "events.jsonl").read_text().splitlines()[0]
     )
@@ -418,7 +537,7 @@ def test_revision_snapshot_archives_git_objects_not_worktree(monkeypatch, tmp_pa
 
 def test_revision_snapshot_rejects_submodules(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     source, first_revision = _git_repo(tmp_path)
     subprocess.run(
@@ -467,7 +586,7 @@ def test_revision_snapshot_rejects_submodules(monkeypatch, tmp_path):
 
 def test_revision_snapshot_rejects_tracked_symlinks(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     source, _ = _git_repo(tmp_path)
     os.symlink("tracked.txt", source / "tracked-link")
@@ -507,7 +626,7 @@ def test_revision_snapshot_rejects_tracked_symlinks(monkeypatch, tmp_path):
 
 def test_revision_snapshot_allows_unmatched_archive_attribute(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     source, _ = _git_repo(tmp_path)
     (source / ".gitattributes").write_text(
@@ -709,7 +828,7 @@ def test_revision_snapshot_checks_effective_info_attributes(
 
 def test_revision_snapshot_requires_repository_top_level(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     source, revision = _git_repo(tmp_path)
     subdirectory = source / "nested"
@@ -728,7 +847,7 @@ def test_revision_snapshot_requires_repository_top_level(monkeypatch, tmp_path):
 
 def test_non_rootless_daemon_fails_before_volume_creation(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI(rootless=False)
 
@@ -742,7 +861,7 @@ def test_non_rootless_daemon_fails_before_volume_creation(monkeypatch, tmp_path)
 
 def test_image_declared_volume_fails_closed(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI(
         image_overrides={"Config": {"Env": [], "Volumes": {"/data": {}}}}
@@ -754,7 +873,7 @@ def test_image_declared_volume_fails_closed(monkeypatch, tmp_path):
 
 def test_timeout_kills_and_removes_container(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     process = None
@@ -785,7 +904,7 @@ def test_timeout_kills_and_removes_container(monkeypatch, tmp_path):
 
 def test_output_limit_is_hard_and_audited(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
 
@@ -806,7 +925,7 @@ def test_output_limit_is_hard_and_audited(monkeypatch, tmp_path):
 
 def test_model_preview_budget_is_shared_across_stdout_and_stderr(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
 
     def popen(argv, **kwargs):
@@ -831,7 +950,7 @@ def test_model_preview_budget_is_shared_across_stdout_and_stderr(monkeypatch, tm
 
 def test_diff_output_limit_fails_without_returning_partial_patch(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
 
     def popen(argv, **kwargs):
@@ -850,7 +969,7 @@ def test_diff_output_limit_fails_without_returning_partial_patch(monkeypatch, tm
 
 def test_timeout_cleanup_failure_poisons_session(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
 
     class FailingCleanupCLI(RecordingCLI):
@@ -887,7 +1006,7 @@ def test_timeout_cleanup_failure_poisons_session(monkeypatch, tmp_path):
 
 def test_close_is_idempotent_and_removes_both_volumes(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     session = _provider(tmp_path, cli).create(_spec(tmp_path))
@@ -905,7 +1024,7 @@ def test_close_is_idempotent_and_removes_both_volumes(monkeypatch, tmp_path):
 
 def test_close_remains_closed_when_final_audit_write_fails(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     session = _provider(tmp_path, RecordingCLI()).create(_spec(tmp_path))
     original_record = session._record_audit
@@ -925,7 +1044,7 @@ def test_close_remains_closed_when_final_audit_write_fails(monkeypatch, tmp_path
 @pytest.mark.parametrize("failed_phase", ["command_started", "command_finished"])
 def test_command_audit_failure_poisons_session(monkeypatch, tmp_path, failed_phase):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     session = _provider(tmp_path, RecordingCLI()).create(_spec(tmp_path))
     original_record = session._record_audit
@@ -947,7 +1066,7 @@ def test_artifact_bundle_size_is_bounded_and_partial_file_removed(
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     provider = _provider(tmp_path, RecordingCLI())
     session = provider.create(_spec(tmp_path))
@@ -978,7 +1097,7 @@ def test_artifact_bundle_size_is_bounded_and_partial_file_removed(
 
 def test_artifact_bundle_is_controller_private(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     provider = _provider(tmp_path, RecordingCLI())
     session = provider.create(_spec(tmp_path))

--- a/test/test_native_index_authorization.py
+++ b/test/test_native_index_authorization.py
@@ -12,7 +12,7 @@ import pytest
 from codenib._atomic_directory import capture_directory_ownership
 from codenib.native_index_authorization import (
     NATIVE_INDEX_SUBJECT_SCHEMA,
-    mint_trusted_local_authorization,
+    _mint_trusted_local_admin_authorization,
     native_index_subject,
     require_native_index_authorization,
 )
@@ -42,7 +42,7 @@ def test_native_index_authorization_is_process_local_and_exact(tmp_path: Path) -
     payload.write_bytes(b"native")
     ownership = capture_directory_ownership(root)
     semantic = {"dimension": 3, "index_metric": "ip"}
-    authorization = mint_trusted_local_authorization(
+    authorization = _mint_trusted_local_admin_authorization(
         ownership,
         view_type="vector",
         semantic_contract=semantic,
@@ -66,6 +66,56 @@ def test_native_index_authorization_is_process_local_and_exact(tmp_path: Path) -
             changed,
             view_type="vector",
             semantic_contract=semantic,
+        )
+
+
+def test_native_index_authorization_is_immutable_and_pid_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.native_index_authorization as authorization_module
+
+    root = tmp_path / "vector"
+    root.mkdir()
+    (root / "index.faiss").write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+    semantic = {"dimension": 3}
+    authorization = _mint_trusted_local_admin_authorization(
+        ownership,
+        view_type="vector",
+        semantic_contract=semantic,
+        evidence=("verified-local-boundary",),
+    )
+
+    with pytest.raises(AttributeError, match="immutable"):
+        authorization.subject_digest = "0" * 64
+
+    monkeypatch.setattr(
+        authorization_module.os,
+        "getpid",
+        lambda: authorization.process_id + 1,
+    )
+    with pytest.raises(ValueError, match="another process"):
+        require_native_index_authorization(
+            authorization,
+            ownership,
+            view_type="vector",
+            semantic_contract=semantic,
+        )
+
+
+def test_trusted_local_issuer_requires_auditable_evidence(tmp_path: Path) -> None:
+    root = tmp_path / "vector"
+    root.mkdir()
+    (root / "index.faiss").write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+
+    with pytest.raises(ValueError, match="evidence"):
+        _mint_trusted_local_admin_authorization(
+            ownership,
+            view_type="vector",
+            semantic_contract={"dimension": 3},
+            evidence=(),
         )
 
 

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -4,33 +4,1095 @@
 
 from __future__ import annotations
 
+import dis
+import errno
 import hashlib
+import inspect
 import os
 import subprocess
+import sys
+import threading
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import codenib._contained_source as contained_source_module
+import codenib._windows_fs_authority as windows_fs_module
+import codenib.source_fingerprint as source_fingerprint_module
+from codenib.artifacts.runtime import SourceBindingCleanupOwner
 from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
 from codenib.source_fingerprint import (
     SOURCE_FINGERPRINT_VERSION,
     RepositoryChangedError,
+    RepositorySourceBinding,
+    capture_repository_source,
     fingerprint_repository,
+    fingerprint_repository_v1_for_diagnostics,
+    is_legacy_source_fingerprint_v1,
+    is_secure_source_fingerprint_v2,
     repository_source_is_dirty,
+    source_fingerprint_version,
 )
+
+
+class _InterruptAfterPopList(list[int]):
+    def __init__(self, values: list[int], interruption: BaseException) -> None:
+        super().__init__(values)
+        self._interruption = interruption
+        self._armed = True
+
+    def pop(self, *args):
+        value = super().pop(*args)
+        if self._armed:
+            self._armed = False
+            raise self._interruption
+        return value
+
+
+class _AcquireThenInterruptRLock:
+    def __init__(self) -> None:
+        self.runtime = threading.RLock()
+        self.acquire_calls = 0
+        self.acquire_interrupted = False
+        self.probe_interrupted = False
+        self.acquire_failure = KeyboardInterrupt("injected completed acquire")
+
+    def acquire(self, *args, **kwargs):
+        self.acquire_calls += 1
+        acquired = self.runtime.acquire(*args, **kwargs)
+        if not self.acquire_interrupted:
+            self.acquire_interrupted = True
+            raise self.acquire_failure
+        return acquired
+
+    def release(self) -> None:
+        self.runtime.release()
+
+    def _is_owned(self) -> bool:
+        if self.acquire_interrupted and not self.probe_interrupted:
+            self.probe_interrupted = True
+            raise SystemExit("injected acquisition recovery cancellation")
+        return self.runtime._is_owned()
+
+
+class _ReleaseThenInterruptRLock:
+    def __init__(self) -> None:
+        self.runtime = threading.RLock()
+        self.release_calls = 0
+        self.release_interrupted = False
+        self.probe_interrupted = False
+        self.release_failure = KeyboardInterrupt("injected completed release")
+
+    def acquire(self, *args, **kwargs):
+        return self.runtime.acquire(*args, **kwargs)
+
+    def release(self) -> None:
+        self.release_calls += 1
+        self.runtime.release()
+        if not self.release_interrupted:
+            self.release_interrupted = True
+            raise self.release_failure
+
+    def _is_owned(self) -> bool:
+        if self.release_interrupted and not self.probe_interrupted:
+            self.probe_interrupted = True
+            raise SystemExit("injected release recovery cancellation")
+        return self.runtime._is_owned()
+
+
+def test_source_lock_double_acquire_cancellation_does_not_add_native_recursion() -> (
+    None
+):
+    lock = source_fingerprint_module._SourceLifecycleRLock()
+    runtime = _AcquireThenInterruptRLock()
+    lock._lock = runtime
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with source_fingerprint_module._SourceLockLease(lock) as failure:
+            assert failure is runtime.acquire_failure
+            raise failure
+
+    assert caught.value is runtime.acquire_failure
+    assert runtime.acquire_calls == 1
+    assert lock.depth() == 0
+    acquired_elsewhere = []
+
+    def acquire_elsewhere() -> None:
+        acquired = runtime.runtime.acquire(timeout=1)
+        acquired_elsewhere.append(acquired)
+        if acquired:
+            runtime.runtime.release()
+
+    thread = threading.Thread(target=acquire_elsewhere)
+    thread.start()
+    thread.join(timeout=2)
+    assert acquired_elsewhere == [True]
+
+
+def test_source_lock_double_release_cancellation_does_not_retry_native_release() -> (
+    None
+):
+    lock = source_fingerprint_module._SourceLifecycleRLock()
+    runtime = _ReleaseThenInterruptRLock()
+    lock._lock = runtime
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with source_fingerprint_module._SourceLockLease(lock):
+            pass
+
+    assert caught.value is runtime.release_failure
+    assert runtime.release_calls == 1
+    assert lock.depth() == 0
+    assert runtime.runtime.acquire(timeout=1)
+    runtime.runtime.release()
+
+
+def test_source_lock_persistent_probe_failure_is_bounded() -> None:
+    class BrokenProbeRLock:
+        def acquire(self, *args, **kwargs):
+            raise AssertionError("native acquire must wait for a successful probe")
+
+        def release(self) -> None:
+            raise AssertionError("unacquired lock must not be released")
+
+        def _is_owned(self) -> bool:
+            raise RuntimeError("persistent ownership probe failure")
+
+    lock = source_fingerprint_module._SourceLifecycleRLock()
+    lock._lock = BrokenProbeRLock()
+
+    with pytest.raises(RuntimeError, match="persistent ownership probe failure"):
+        source_fingerprint_module._SourceLockLease(lock).__enter__()
+
+
+def test_repository_source_binding_reads_exact_captured_records(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+    hidden = repo / ".hidden"
+    hidden.mkdir()
+    (hidden / "target.py").write_bytes(b"TARGET = 2\n")
+    (repo / "link.py").symlink_to(".hidden/target.py")
+    expected = fingerprint_repository(repo)
+
+    with capture_repository_source(repo) as binding:
+        assert binding.fingerprint == expected.value
+        assert binding.file_count == expected.file_count
+        assert {record.path for record in binding.file_records} == {
+            ".hidden/target.py",
+            "a.py",
+            "link.py",
+        }
+        assert binding.read_bytes("a.py", max_bytes=1024) == b"VALUE = 1\n"
+        assert binding.read_bytes("link.py", max_bytes=1024) == b"TARGET = 2\n"
+
+
+def test_repository_source_binding_poisoned_by_touched_or_unrelated_change(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "a.py"
+    other = repo / "b.py"
+    source.write_bytes(b"VALUE = 1\n")
+    other.write_bytes(b"OTHER = 1\n")
+    binding = capture_repository_source(repo)
+    other.write_bytes(b"OTHER = 999\n")
+
+    with pytest.raises(RepositoryChangedError):
+        binding.read_bytes("a.py", max_bytes=1024)
+
+    other.write_bytes(b"OTHER = 1\n")
+    with pytest.raises(RepositoryChangedError, match="poisoned"):
+        binding.read_bytes("a.py", max_bytes=1024)
+    binding.close()
+
+
+def test_repository_source_binding_rejects_legal_replacement_root(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+    binding = capture_repository_source(repo)
+    pinned = tmp_path / "pinned"
+    repo.rename(pinned)
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+
+    with pytest.raises(RepositoryChangedError):
+        binding.verify_snapshot()
+    assert not binding.usable
+    binding.close()
+
+
+def test_source_authority_rejects_preexisting_ancestor_symlink(
+    tmp_path: Path,
+) -> None:
+    foreign = tmp_path / "foreign"
+    repo = foreign / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+    trusted = tmp_path / "trusted"
+    trusted.mkdir()
+    (trusted / "alias").symlink_to(foreign, target_is_directory=True)
+
+    with pytest.raises(RepositoryChangedError):
+        fingerprint_repository(trusted / "alias" / "repo")
+
+
+def test_repository_source_binding_rejects_replaced_ancestor(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "parent"
+    repo = parent / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+    binding = capture_repository_source(repo)
+    saved = tmp_path / "saved-parent"
+    parent.rename(saved)
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+
+    with pytest.raises(RepositoryChangedError):
+        binding.verify_snapshot()
+    binding.close()
+
+
+def test_repository_source_read_session_scans_whole_tree_twice(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    (repo / "b.py").write_bytes(b"B\n")
+    binding = capture_repository_source(repo)
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    scans = 0
+
+    def counted_scan(*args, **kwargs):
+        nonlocal scans
+        scans += 1
+        return real_scan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        counted_scan,
+    )
+    with binding.read_session():
+        assert binding.read_bytes("a.py", max_bytes=16) == b"A\n"
+        assert binding.read_bytes("b.py", max_bytes=16) == b"B\n"
+
+    assert scans == 2
+    binding.close()
+
+
+def test_repository_source_read_session_trace_interrupt_releases_lock(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    wrapped = RepositorySourceBinding.read_session.__wrapped__
+    lines, first_line = inspect.getsourcelines(wrapped)
+    target_line = first_line + next(
+        index
+        for index, line in enumerate(lines)
+        if "if self._session_depth == 0:" in line
+    )
+    interrupted = False
+
+    def interrupt_after_acquire(frame, event, _arg):
+        nonlocal interrupted
+        if (
+            not interrupted
+            and frame.f_code is wrapped.__code__
+            and event == "line"
+            and frame.f_lineno == target_line
+        ):
+            interrupted = True
+            raise KeyboardInterrupt("injected after lock acquisition")
+        return interrupt_after_acquire
+
+    sys.settrace(interrupt_after_acquire)
+    try:
+        with pytest.raises(KeyboardInterrupt, match="after lock acquisition"):
+            with binding.read_session():
+                pytest.fail("interruption must happen before the session body")
+    finally:
+        sys.settrace(None)
+
+    completed = threading.Event()
+
+    def close_from_another_thread() -> None:
+        binding.close()
+        completed.set()
+
+    thread = threading.Thread(target=close_from_another_thread)
+    thread.start()
+    thread.join(timeout=2)
+    assert completed.is_set(), "interrupted acquisition stranded the source lock"
+    assert binding.closed
+
+
+def test_repository_source_read_session_exit_interrupt_poison_closes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    scans = 0
+    interruption = KeyboardInterrupt("injected exit inventory interruption")
+
+    def interrupt_exit(*args, **kwargs):
+        nonlocal scans
+        scans += 1
+        if scans == 2:
+            raise interruption
+        return real_scan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        interrupt_exit,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with binding.read_session():
+            assert binding.read_bytes("a.py", max_bytes=16) == b"A\n"
+
+    assert caught.value is interruption
+    assert binding.closed
+    assert not binding.usable
+
+
+def test_repository_source_read_session_preserves_body_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    scans = 0
+    primary = KeyboardInterrupt("primary session cancellation")
+
+    def interrupt_exit(*args, **kwargs):
+        nonlocal scans
+        scans += 1
+        if scans == 2:
+            raise SystemExit("secondary exit cancellation")
+        return real_scan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        interrupt_exit,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with binding.read_session():
+            raise primary
+
+    assert caught.value is primary
+    assert binding.closed
+
+
+@pytest.mark.parametrize(
+    ("timing", "interruption"),
+    [
+        pytest.param(
+            "before",
+            KeyboardInterrupt("injected before descriptor close"),
+            id="before-close",
+        ),
+        pytest.param(
+            "after",
+            SystemExit("injected after descriptor close"),
+            id="after-close",
+        ),
+    ],
+)
+def test_repository_source_close_finishes_descriptor_chain_before_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    timing: str,
+    interruption: BaseException,
+) -> None:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting needs /proc/self/fd")
+    repo = tmp_path / "one" / "two" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"A\n")
+    before = len(tuple(descriptor_root.iterdir()))
+    binding = capture_repository_source(repo)
+    authority = binding._posix_authority
+    assert authority is not None
+    targets = set(authority._resources)
+    real_close = os.close
+    calls = 0
+    injected = False
+    seen: set[int] = set()
+
+    def interrupt_one_close(descriptor: int) -> None:
+        nonlocal calls, injected
+        if descriptor in targets:
+            seen.add(descriptor)
+            calls += 1
+            if calls == 2 and not injected:
+                injected = True
+                if timing == "before":
+                    raise interruption
+                real_close(descriptor)
+                raise interruption
+        real_close(descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "close", interrupt_one_close)
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert injected
+    assert binding.closed
+    assert targets <= seen
+    after = len(tuple(descriptor_root.iterdir()))
+    assert after <= before + 1
+
+
+def test_repository_source_close_commits_interrupted_owner_pop(
+    tmp_path: Path,
+) -> None:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting needs /proc/self/fd")
+    repo = tmp_path / "parent" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"A\n")
+    before = len(tuple(descriptor_root.iterdir()))
+    binding = capture_repository_source(repo)
+    authority = binding._posix_authority
+    assert authority is not None
+    interruption = KeyboardInterrupt("injected after descriptor owner pop")
+    authority._resources = _InterruptAfterPopList(
+        authority._resources,
+        interruption,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert binding.closed
+    assert len(tuple(descriptor_root.iterdir())) <= before + 1
+
+
+def test_repository_source_close_persistent_eio_keeps_owner_and_closes_rest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "one" / "two" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    authority = binding._posix_authority
+    assert authority is not None
+    targets = tuple(authority._resources)
+    failed = targets[-1]
+    real_close = os.close
+
+    def fail_one_descriptor(descriptor: int) -> None:
+        if descriptor == failed:
+            raise OSError(errno.EIO, "injected persistent close EIO")
+        real_close(descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "close", fail_one_descriptor)
+    with pytest.raises(OSError, match="persistent close EIO"):
+        binding.close()
+
+    assert not binding.closed
+    assert not binding.usable
+    assert authority._resources == [failed]
+    for descriptor in targets[:-1]:
+        with pytest.raises(OSError) as caught:
+            os.fstat(descriptor)
+        assert caught.value.errno == errno.EBADF
+
+    monkeypatch.setattr(source_fingerprint_module.os, "close", real_close)
+    binding.close()
+    assert binding.closed
+
+
+def test_repository_source_close_preflight_eio_keeps_owner_and_closes_rest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "one" / "two" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    authority = binding._posix_authority
+    assert authority is not None
+    targets = tuple(authority._resources)
+    failed = targets[-1]
+    real_fstat = os.fstat
+
+    def fail_one_descriptor(descriptor: int):
+        if descriptor == failed:
+            raise OSError(errno.EIO, "injected persistent fstat EIO")
+        return real_fstat(descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "fstat", fail_one_descriptor)
+    with pytest.raises(OSError, match="persistent fstat EIO"):
+        binding.close()
+
+    assert not binding.closed
+    assert not binding.usable
+    assert authority._resources == [failed]
+    for descriptor in targets[:-1]:
+        with pytest.raises(OSError) as caught:
+            real_fstat(descriptor)
+        assert caught.value.errno == errno.EBADF
+
+    monkeypatch.setattr(source_fingerprint_module.os, "fstat", real_fstat)
+    binding.close()
+    assert binding.closed
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("root open interrupted"), id="keyboard"),
+        pytest.param(SystemExit("root open exited"), id="system-exit"),
+    ],
+)
+def test_repository_root_open_failure_closes_owned_descriptors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting needs /proc/self/fd")
+    repo = tmp_path / "parent" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"A\n")
+    before = len(tuple(descriptor_root.iterdir()))
+    real_fstat = os.fstat
+    calls = 0
+
+    def interrupt_after_child_open(descriptor: int):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise interruption
+        return real_fstat(descriptor)
+
+    monkeypatch.setattr(
+        source_fingerprint_module.os,
+        "fstat",
+        interrupt_after_child_open,
+    )
+    with pytest.raises(type(interruption)) as caught:
+        fingerprint_repository(repo)
+
+    assert caught.value is interruption
+    after = len(tuple(descriptor_root.iterdir()))
+    assert after <= before + 1
+
+
+def test_capture_root_construction_eio_keeps_preinstalled_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "parent" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "source.py").write_bytes(b"VALUE = 1\n")
+    owner = SourceBindingCleanupOwner()
+    interruption = KeyboardInterrupt("injected POSIX root construction failure")
+    real_open = os.open
+    real_fstat = os.fstat
+    real_close = os.close
+    opened: list[int] = []
+    fstat_calls = 0
+
+    def record_open(*args, **kwargs):
+        descriptor = real_open(*args, **kwargs)
+        opened.append(descriptor)
+        return descriptor
+
+    def interrupt_metadata(descriptor: int):
+        nonlocal fstat_calls
+        fstat_calls += 1
+        if fstat_calls == 2:
+            raise interruption
+        return real_fstat(descriptor)
+
+    failed = -1
+
+    def persistent_close(descriptor: int) -> None:
+        nonlocal failed
+        if descriptor in opened and failed < 0:
+            failed = descriptor
+        if descriptor == failed:
+            raise OSError(errno.EIO, "injected POSIX construction close EIO")
+        real_close(descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "open", record_open)
+    monkeypatch.setattr(source_fingerprint_module.os, "fstat", interrupt_metadata)
+    monkeypatch.setattr(source_fingerprint_module.os, "close", persistent_close)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        capture_repository_source(repo, _source_owner=owner.retain)
+
+    assert caught.value is interruption
+    assert not owner.closed
+    assert owner.pending_sources
+    assert failed >= 0
+    assert real_fstat(failed)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "fstat", real_fstat)
+    monkeypatch.setattr(source_fingerprint_module.os, "close", real_close)
+    owner.close()
+    assert owner.closed
+
+
+def test_capture_scan_eio_keeps_primary_and_explicit_partial_fd_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "source.py").write_bytes(b"VALUE = 1\n")
+    interruption = SystemExit("injected POSIX scan failure")
+    real_close = os.close
+    scan_descriptor = -1
+
+    def interrupt_scan(descriptor: int):
+        nonlocal scan_descriptor
+        scan_descriptor = descriptor
+        raise interruption
+
+    def persistent_close(descriptor: int) -> None:
+        if descriptor == scan_descriptor:
+            raise OSError(errno.EIO, "injected POSIX scan close EIO")
+        real_close(descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "scandir", interrupt_scan)
+    monkeypatch.setattr(
+        source_fingerprint_module.os,
+        "supports_fd",
+        {*os.supports_fd, interrupt_scan},
+    )
+    monkeypatch.setattr(source_fingerprint_module.os, "close", persistent_close)
+
+    with pytest.raises(SystemExit) as caught:
+        capture_repository_source(tmp_path)
+
+    assert caught.value is interruption
+    cleanup_owner = caught.value.source_cleanup_owner
+    assert not cleanup_owner.closed
+    assert scan_descriptor in cleanup_owner.descriptors
+    assert os.fstat(scan_descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "close", real_close)
+    cleanup_owner.close()
+    assert cleanup_owner.closed
+
+
+def test_posix_resolution_construction_eio_keeps_primary_and_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_bytes(b"VALUE = 1\n")
+    authority = source_fingerprint_module._open_pinned_repository_root(repo)
+    expected = contained_source_module._version_identity(source.lstat())
+    interruption = KeyboardInterrupt("injected POSIX resolution failure")
+    real_open = os.open
+    real_fstat = os.fstat
+    real_close = os.close
+    failed = -1
+
+    def record_open(path, flags, *args, **kwargs):
+        nonlocal failed
+        descriptor = real_open(path, flags, *args, **kwargs)
+        if path == "source.py":
+            failed = descriptor
+        return descriptor
+
+    def interrupt_source_metadata(descriptor: int):
+        if descriptor == failed:
+            raise interruption
+        return real_fstat(descriptor)
+
+    def persistent_close(descriptor: int) -> None:
+        if descriptor == failed:
+            raise OSError(errno.EIO, "injected POSIX resolution close EIO")
+        real_close(descriptor)
+
+    monkeypatch.setattr(contained_source_module.os, "open", record_open)
+    monkeypatch.setattr(contained_source_module.os, "fstat", interrupt_source_metadata)
+    monkeypatch.setattr(contained_source_module.os, "close", persistent_close)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with contained_source_module._resolved_repository_file_at(
+            repo,
+            authority.descriptor,
+            "source.py",
+            expected_root_identity=authority.root_identity,
+            expected_final_identity=expected,
+        ):
+            pytest.fail("resolution construction must not yield")
+
+    assert caught.value is interruption
+    cleanup_owner = caught.value.source_cleanup_owner
+    assert not cleanup_owner.closed
+    assert failed >= 0
+    assert real_fstat(failed)
+
+    monkeypatch.setattr(contained_source_module.os, "fstat", real_fstat)
+    monkeypatch.setattr(contained_source_module.os, "close", real_close)
+    cleanup_owner.close()
+    authority.close()
+    assert cleanup_owner.closed
 
 
 def _legacy_link_only_digest(path: bytes, target: bytes) -> str:
     digest = hashlib.sha256()
     digest.update(
         (
-            f"codenib-source-fingerprint:{SOURCE_FINGERPRINT_VERSION}:"
-            f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
+            "codenib-source-fingerprint:1:" f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
         ).encode("ascii")
     )
     digest.update(b"L\0" + path + b"\0" + target + b"\0")
     return f"sha256:{digest.hexdigest()}"
+
+
+class _FakeWindowsSourceApi:
+    """HANDLE-only Windows source model with exact 128-bit identities."""
+
+    def __init__(self) -> None:
+        self.nodes: dict[bytes, dict[str, object]] = {}
+        self.handles: dict[int, bytes] = {}
+        self.offsets: dict[int, int] = {}
+        self.next_id = 1
+        self.next_handle = 100
+        self.open_relative_hook = None
+        self.create_root_hook = None
+        self.query_reparse_hook = None
+        self.created_paths: list[str] = []
+        self.volume_id = self.add_directory()
+        self.root_id = self.add_directory(self.volume_id, "repo")
+
+    def _file_id(self) -> bytes:
+        value = self.next_id.to_bytes(16, "little")
+        self.next_id += 1
+        return value
+
+    def add_directory(
+        self,
+        parent: bytes | None = None,
+        name: str = "",
+    ) -> bytes:
+        file_id = self._file_id()
+        self.nodes[file_id] = {
+            "kind": "directory",
+            "children": {},
+            "data": b"",
+            "version": 1,
+            "file_id": file_id,
+            "reparse": None,
+        }
+        if parent is not None:
+            self._children(parent)[name] = file_id
+        return file_id
+
+    def add_file(self, parent: bytes, name: str, data: bytes) -> bytes:
+        file_id = self._file_id()
+        self.nodes[file_id] = {
+            "kind": "file",
+            "children": {},
+            "data": data,
+            "version": 1,
+            "file_id": file_id,
+            "reparse": None,
+        }
+        self._children(parent)[name] = file_id
+        return file_id
+
+    def add_symlink(
+        self,
+        parent: bytes,
+        name: str,
+        target: str,
+        *,
+        directory: bool = False,
+        absolute: bool = False,
+        substitute: str | None = None,
+    ) -> bytes:
+        file_id = self._file_id()
+        point = windows_fs_module.WindowsReparsePoint(
+            tag=windows_fs_module.IO_REPARSE_TAG_SYMLINK,
+            substitute_name=substitute or target,
+            print_name=target,
+            flags=0 if absolute else windows_fs_module.SYMLINK_FLAG_RELATIVE,
+        )
+        self.nodes[file_id] = {
+            "kind": "directory-link" if directory else "link",
+            "children": {},
+            "data": b"",
+            "version": 1,
+            "file_id": file_id,
+            "reparse": point,
+        }
+        self._children(parent)[name] = file_id
+        return file_id
+
+    def add_unknown_reparse(self, parent: bytes, name: str) -> bytes:
+        file_id = self._file_id()
+        self.nodes[file_id] = {
+            "kind": "link",
+            "children": {},
+            "data": b"",
+            "version": 1,
+            "file_id": file_id,
+            "reparse": windows_fs_module.WindowsReparsePoint(
+                tag=windows_fs_module.IO_REPARSE_TAG_MOUNT_POINT,
+                substitute_name=None,
+                print_name=None,
+            ),
+        }
+        self._children(parent)[name] = file_id
+        return file_id
+
+    def _children(self, file_id: bytes) -> dict[str, bytes]:
+        children = self.nodes[file_id]["children"]
+        assert isinstance(children, dict)
+        return children
+
+    def _new_handle(self, file_id: bytes) -> int:
+        handle = self.next_handle
+        self.next_handle += 1
+        self.handles[handle] = file_id
+        self.offsets[handle] = 0
+        return handle
+
+    def create_directory_handle(self, _path: Path) -> int:
+        self.created_paths.append(str(_path))
+        file_id = self.volume_id
+        if self.create_root_hook is not None:
+            file_id = self.create_root_hook(file_id)
+        return self._new_handle(file_id)
+
+    def duplicate_handle(self, handle: int) -> int:
+        return self._new_handle(self.handles[handle])
+
+    def close(self, handle: int) -> None:
+        self.handles.pop(handle, None)
+        self.offsets.pop(handle, None)
+
+    def metadata(self, handle: int) -> windows_fs_module.WindowsHandleMetadata:
+        file_id = self.handles[handle]
+        node = self.nodes[file_id]
+        kind = str(node["kind"])
+        directory = kind in {"directory", "directory-link"}
+        reparse = node["reparse"]
+        attributes = windows_fs_module.FILE_ATTRIBUTE_DIRECTORY if directory else 0
+        reparse_tag = 0
+        if isinstance(reparse, windows_fs_module.WindowsReparsePoint):
+            attributes |= windows_fs_module.FILE_ATTRIBUTE_REPARSE_POINT
+            reparse_tag = reparse.tag
+        data = node["data"]
+        assert isinstance(data, bytes)
+        version = int(node["version"])
+        return windows_fs_module.WindowsHandleMetadata(
+            st_dev=7,
+            st_ino=int.from_bytes(file_id[:8], "little"),
+            st_mode=windows_fs_module.windows_mode_from_attributes(attributes),
+            st_size=len(data),
+            st_mtime_ns=version,
+            st_ctime_ns=version,
+            st_nlink=1,
+            st_file_attributes=attributes,
+            file_id_128=file_id,
+            reparse_tag=reparse_tag,
+            delete_pending=False,
+        )
+
+    def iter_directory(self, handle: int):
+        parent_id = self.handles[handle]
+        for name, file_id in list(self._children(parent_id).items()):
+            child_handle = self._new_handle(file_id)
+            try:
+                metadata = self.metadata(child_handle)
+            finally:
+                self.close(child_handle)
+            yield windows_fs_module.WindowsDirectoryEntry(
+                name=name,
+                file_id=int.from_bytes(file_id[:8], "little"),
+                attributes=metadata.st_file_attributes,
+                file_id_128=file_id,
+                reparse_tag=metadata.reparse_tag,
+            )
+
+    def enumerate_directory(
+        self,
+        handle: int,
+    ) -> tuple[windows_fs_module.WindowsDirectoryEntry, ...]:
+        return tuple(self.iter_directory(handle))
+
+    def open_relative(
+        self,
+        parent_handle: int,
+        name: str,
+        *,
+        desired_access: int,
+        is_directory: bool,
+        allow_reparse: bool,
+    ) -> int:
+        del desired_access
+        parent_id = self.handles[parent_handle]
+        file_id = self._children(parent_id)[name]
+        if self.open_relative_hook is not None:
+            file_id = self.open_relative_hook(parent_id, name, file_id)
+        node = self.nodes[file_id]
+        directory = str(node["kind"]) in {"directory", "directory-link"}
+        assert directory is is_directory
+        if node["reparse"] is not None and not allow_reparse:
+            raise ValueError("fake no-follow open rejected a reparse point")
+        assert allow_reparse is (node["reparse"] is not None)
+        return self._new_handle(file_id)
+
+    def query_reparse_point(
+        self,
+        handle: int,
+    ) -> windows_fs_module.WindowsReparsePoint:
+        point = self.nodes[self.handles[handle]]["reparse"]
+        assert isinstance(point, windows_fs_module.WindowsReparsePoint)
+        if self.query_reparse_hook is not None:
+            return self.query_reparse_hook(point)
+        return point
+
+    def read(self, handle: int, size: int) -> bytes:
+        node = self.nodes[self.handles[handle]]
+        data = node["data"]
+        assert isinstance(data, bytes)
+        offset = self.offsets[handle]
+        block = data[offset : offset + size]
+        self.offsets[handle] += len(block)
+        return block
+
+
+def _open_fake_windows_resolution(
+    api: _FakeWindowsSourceApi,
+    relative: str,
+):
+    selected, authority, root_identity = (
+        contained_source_module._open_windows_pinned_repository_root(
+            Path(r"C:\repo"),
+            api=api,
+        )
+    )
+    scan = source_fingerprint_module._scan_pinned_windows_repository(
+        selected,
+        authority.handle,
+        excluded=(),
+        collect_entries=True,
+    )
+    record = next(entry for entry in scan.entries if entry.relative == relative)
+    binding = contained_source_module._open_windows_resolution_at(
+        Path(r"C:\repo"),
+        authority,
+        tuple(relative.split("/")),
+        expected_root_identity=root_identity,
+        expected_final_identity=source_fingerprint_module._entry_version_identity(
+            record.metadata
+        ),
+        allow_stable_unresolved=True,
+        api=selected,
+    )
+    return authority, binding
+
+
+def _fake_windows_resolution_handoff_case(
+    case: str,
+) -> tuple[
+    _FakeWindowsSourceApi,
+    object,
+    tuple[object, ...],
+    tuple[object, ...],
+]:
+    api = _FakeWindowsSourceApi()
+    if case == "regular":
+        api.add_file(api.root_id, "current.py", b"VALUE = 1\n")
+    elif case == "link-loop":
+        api.add_symlink(api.root_id, "current.py", "current.py")
+    elif case == "directory":
+        api.add_symlink(api.root_id, "current.py", ".", directory=True)
+    elif case == "missing":
+        api.add_symlink(api.root_id, "current.py", "missing.py")
+    else:  # pragma: no cover - test parameter invariant
+        raise AssertionError(case)
+    selected, authority, root_identity = (
+        contained_source_module._open_windows_pinned_repository_root(
+            Path(r"C:\repo"),
+            api=api,
+        )
+    )
+    scan = source_fingerprint_module._scan_pinned_windows_repository(
+        selected,
+        authority.handle,
+        excluded=(),
+        collect_entries=True,
+    )
+    record = scan.entries[0]
+    if case == "missing":
+        del api._children(api.root_id)["current.py"]
+    return (
+        api,
+        authority,
+        root_identity,
+        source_fingerprint_module._entry_version_identity(record.metadata),
+    )
+
+
+def _opcode_offset(
+    function,
+    *,
+    source_text: str,
+    opname: str,
+    argval: object | None = None,
+    occurrence: str = "last",
+) -> int:
+    lines, first_line = inspect.getsourcelines(function)
+    matching_lines = [
+        first_line + index for index, line in enumerate(lines) if source_text in line
+    ]
+    assert matching_lines
+    target_line = matching_lines[-1] if occurrence == "last" else matching_lines[0]
+    current_line = None
+    matches: list[int] = []
+    for instruction in dis.get_instructions(function):
+        if instruction.starts_line is not None:
+            current_line = instruction.starts_line
+        if (
+            current_line == target_line
+            and instruction.opname == opname
+            and (argval is None or instruction.argval == argval)
+        ):
+            matches.append(instruction.offset)
+    assert matches
+    return matches[-1] if occurrence == "last" else matches[0]
 
 
 def test_fingerprint_changes_with_source_content_and_path(tmp_path):
@@ -46,6 +1108,1422 @@ def test_fingerprint_changes_with_source_content_and_path(tmp_path):
     source.rename(tmp_path / "renamed.py")
     changed_path = fingerprint_repository(tmp_path)
     assert changed_path.value != changed_content.value
+
+
+def test_v2_fingerprint_is_canonical_and_deterministic(tmp_path: Path) -> None:
+    (tmp_path / "module.py").write_bytes(b"VALUE = 1\n")
+
+    first = fingerprint_repository(tmp_path)
+    second = fingerprint_repository(tmp_path)
+
+    assert SOURCE_FINGERPRINT_VERSION == 2
+    assert first == second
+    assert first.value.startswith("sha256-v2:")
+    assert is_secure_source_fingerprint_v2(first.value)
+    assert source_fingerprint_version(first.value) == 2
+
+
+def test_windows_fake_regular_tree_matches_posix_v1_and_v2(
+    tmp_path: Path,
+) -> None:
+    package = tmp_path / "package"
+    package.mkdir()
+    (tmp_path / "module.py").write_bytes(b"VALUE = 1\n")
+    (package / "nested.py").write_bytes(b"NESTED = 1\n")
+    expected_v1 = fingerprint_repository_v1_for_diagnostics(tmp_path)
+    expected_v2 = fingerprint_repository(tmp_path)
+
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "module.py", b"VALUE = 1\n")
+    fake_package = api.add_directory(api.root_id, "package")
+    api.add_file(fake_package, "nested.py", b"NESTED = 1\n")
+
+    observed_v1 = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=1,
+        api=api,
+    )
+    observed_v2 = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+    )
+
+    assert observed_v1 == expected_v1
+    assert observed_v2 == expected_v2
+    assert api.handles == {}
+    assert set(api.created_paths) == {"C:\\"}
+
+
+def test_windows_reparse_parser_is_bounded_and_exact() -> None:
+    substitute = r"target.py".encode("utf-16-le")
+    printable = r"target.py".encode("utf-16-le")
+    path_buffer = substitute + printable
+    data_length = 12 + len(path_buffer)
+    payload = b"".join(
+        (
+            windows_fs_module.IO_REPARSE_TAG_SYMLINK.to_bytes(4, "little"),
+            data_length.to_bytes(2, "little"),
+            b"\0\0",
+            (0).to_bytes(2, "little"),
+            len(substitute).to_bytes(2, "little"),
+            len(substitute).to_bytes(2, "little"),
+            len(printable).to_bytes(2, "little"),
+            windows_fs_module.SYMLINK_FLAG_RELATIVE.to_bytes(4, "little"),
+            path_buffer,
+        )
+    )
+
+    assert windows_fs_module.parse_windows_reparse_data(payload) == (
+        windows_fs_module.WindowsReparsePoint(
+            tag=windows_fs_module.IO_REPARSE_TAG_SYMLINK,
+            substitute_name="target.py",
+            print_name="target.py",
+            flags=windows_fs_module.SYMLINK_FLAG_RELATIVE,
+        )
+    )
+    with pytest.raises(RuntimeError, match="out of bounds"):
+        windows_fs_module.parse_windows_reparse_data(
+            payload[:10] + (0xFFFE).to_bytes(2, "little") + payload[12:]
+        )
+
+
+def test_windows_fake_public_contained_read_and_hash_close_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "target.py", b"VALUE = 1\n")
+    api.add_symlink(api.root_id, "current.py", "target.py")
+    monkeypatch.setattr(contained_source_module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        contained_source_module,
+        "_windows_kernel_api",
+        lambda: api,
+    )
+    monkeypatch.setattr(
+        contained_source_module,
+        "_shared_windows_require_source_api",
+        lambda _api: None,
+    )
+
+    contained_source_module.validate_repository_file(
+        r"C:\repo",
+        "current.py",
+    )
+    assert (
+        contained_source_module.read_repository_file(
+            r"C:\repo",
+            "current.py",
+            max_bytes=64,
+        )
+        == b"VALUE = 1\n"
+    )
+    digest = hashlib.sha256()
+    contained_source_module.update_repository_file_hash(
+        r"C:\repo",
+        "current.py",
+        digest,
+    )
+
+    assert digest.hexdigest() == hashlib.sha256(b"VALUE = 1\n").hexdigest()
+    assert api.handles == {}
+
+
+def test_windows_fake_relative_symlink_matches_posix_v1_and_v2(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "target.py").write_bytes(b"VALUE = 1\n")
+    try:
+        (tmp_path / "current.py").symlink_to("target.py")
+    except OSError as exc:  # pragma: no cover - platform capability
+        pytest.skip(f"symlink parity fixture is unavailable: {exc}")
+    expected_v1 = fingerprint_repository_v1_for_diagnostics(tmp_path)
+    expected_v2 = fingerprint_repository(tmp_path)
+
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "target.py", b"VALUE = 1\n")
+    api.add_symlink(api.root_id, "current.py", "target.py")
+
+    assert (
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=1,
+            api=api,
+        )
+        == expected_v1
+    )
+    assert (
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+        == expected_v2
+    )
+    assert api.handles == {}
+
+
+def test_windows_fake_excludes_contained_directory_and_root_links() -> None:
+    api = _FakeWindowsSourceApi()
+    package = api.add_directory(api.root_id, "package")
+    api.add_file(package, "module.py", b"VALUE = 1\n")
+    baseline_v1 = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=1,
+        api=api,
+    )
+    baseline_v2 = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+    )
+    api.add_symlink(
+        api.root_id,
+        "package-link",
+        "package",
+        directory=True,
+    )
+    api.add_symlink(api.root_id, "root-link", ".", directory=True)
+
+    assert (
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=1,
+            api=api,
+        )
+        == baseline_v1
+    )
+    assert (
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+        == baseline_v2
+    )
+    assert api.handles == {}
+
+
+def test_windows_fake_accepts_absolute_contained_symlink() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "target.py", b"VALUE = 1\n")
+    api.add_symlink(
+        api.root_id,
+        "current.py",
+        r"C:\repo\target.py",
+        absolute=True,
+        substitute=r"\??\C:\repo\target.py",
+    )
+
+    observed = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+    )
+
+    assert observed.file_count == 2
+    assert observed.value.startswith("sha256-v2:")
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    "target,absolute,substitute",
+    [
+        (r"..\outside.py", False, None),
+        (r"C:\outside.py", True, r"\??\C:\outside.py"),
+    ],
+)
+def test_windows_fake_rejects_outside_symlink_without_handle_leak(
+    target: str,
+    absolute: bool,
+    substitute: str | None,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(
+        api.root_id,
+        "current.py",
+        target,
+        absolute=absolute,
+        substitute=substitute,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_broken_link_preserves_v1_link_only_semantics() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(api.root_id, "link.py", "missing.py")
+
+    legacy = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=1,
+        api=api,
+    )
+    current = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+    )
+
+    assert legacy.value == _legacy_link_only_digest(b"link.py", b"missing.py")
+    assert legacy.file_count == current.file_count == 1
+    assert current.value != legacy.value
+    assert api.handles == {}
+
+
+def test_windows_fake_rejects_junction_or_unknown_reparse() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_unknown_reparse(api.root_id, "unsafe")
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_rejects_zero_128_bit_entry_identity() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    iter_directory = api.iter_directory
+
+    def zero_identity(handle: int):
+        for entry in iter_directory(handle):
+            yield windows_fs_module.WindowsDirectoryEntry(
+                name=entry.name,
+                file_id=0,
+                attributes=entry.attributes,
+                file_id_128=b"\0" * 16,
+                reparse_tag=entry.reparse_tag,
+            )
+
+    api.iter_directory = zero_identity  # type: ignore[method-assign]
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_rejects_root_a_to_b_to_a_rebind() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 'owned'\n")
+    foreign = api.add_directory()
+    api.add_file(foreign, "source.py", b"VALUE = 'foreign'\n")
+    injected = False
+
+    def reversible_swap(parent: bytes, name: str, original: bytes) -> bytes:
+        nonlocal injected
+        if parent == api.volume_id and name == "repo" and not injected:
+            injected = True
+            return foreign
+        return original
+
+    api.open_relative_hook = reversible_swap
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert injected
+    assert api.handles == {}
+
+
+def test_windows_fake_authority_rejects_late_root_a_to_b_to_a_rebind() -> None:
+    api = _FakeWindowsSourceApi()
+    foreign = api.add_directory()
+    authority = windows_fs_module.open_lexical_directory_authority(
+        r"C:\repo",
+        api=api,
+    )
+    iter_directory = api.iter_directory
+    injected = False
+
+    def reversible_rebind(handle: int):
+        nonlocal injected
+        if api.handles[handle] == api.volume_id and not injected:
+            injected = True
+            yield windows_fs_module.WindowsDirectoryEntry(
+                name="repo",
+                file_id=int.from_bytes(foreign[:8], "little"),
+                attributes=windows_fs_module.FILE_ATTRIBUTE_DIRECTORY,
+                file_id_128=foreign,
+            )
+            return
+        yield from iter_directory(handle)
+
+    api.iter_directory = reversible_rebind  # type: ignore[method-assign]
+    try:
+        with pytest.raises(RuntimeError, match="binding changed"):
+            authority.verify()
+    finally:
+        authority.close()
+
+    assert injected
+    assert api.handles == {}
+
+
+def test_windows_fake_rejects_walker_to_open_foreign_replacement() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 'owned'\n")
+    foreign = api.add_file(api.root_id, ".foreign", b"VALUE = 'foreign'\n")
+    injected = False
+
+    def substitute_open(parent: bytes, name: str, original: bytes) -> bytes:
+        nonlocal injected
+        if parent == api.root_id and name == "source.py" and not injected:
+            injected = True
+            return foreign
+        return original
+
+    api.open_relative_hook = substitute_open
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert injected
+    assert api.handles == {}
+
+
+def test_windows_fake_lexical_root_rejects_intermediate_reparse() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(
+        api.volume_id,
+        "alias",
+        "repo",
+        directory=True,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\alias\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_baseexception_during_reparse_query_closes_handles() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(api.root_id, "current.py", "missing.py")
+
+    def interrupt(_point):
+        raise KeyboardInterrupt("injected reparse interruption")
+
+    api.query_reparse_hook = interrupt
+
+    with pytest.raises(KeyboardInterrupt, match="injected"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_scan_eio_keeps_primary_and_partial_handle_owner() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(api.root_id, "current.py", "missing.py")
+    interruption = SystemExit("injected Windows scan failure")
+    real_query = api.query_reparse_point
+    real_close = api.close
+    failed = 0
+
+    def interrupt_query(handle: int):
+        nonlocal failed
+        failed = handle
+        raise interruption
+
+    def persistent_close(handle: int) -> None:
+        if handle == failed:
+            raise OSError(errno.EIO, "injected Windows scan close EIO")
+        real_close(handle)
+
+    api.query_reparse_point = interrupt_query  # type: ignore[method-assign]
+    api.close = persistent_close  # type: ignore[method-assign]
+
+    with pytest.raises(SystemExit) as caught:
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert caught.value is interruption
+    cleanup_owner = caught.value.source_cleanup_owner
+    assert not cleanup_owner.closed
+    assert failed in api.handles
+
+    api.query_reparse_point = real_query  # type: ignore[method-assign]
+    api.close = real_close  # type: ignore[method-assign]
+    cleanup_owner.close()
+    assert cleanup_owner.closed
+    assert api.handles == {}
+
+
+def test_windows_resolution_construction_eio_keeps_primary_and_retry_owner() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(api.root_id, "current.py", "missing.py")
+    selected, authority, root_identity = (
+        contained_source_module._open_windows_pinned_repository_root(
+            Path(r"C:\repo"),
+            api=api,
+        )
+    )
+    scan = source_fingerprint_module._scan_pinned_windows_repository(
+        selected,
+        authority.handle,
+        excluded=(),
+        collect_entries=True,
+    )
+    record = scan.entries[0]
+    real_query = api.query_reparse_point
+    real_close = api.close
+    interruption = SystemExit("injected Windows resolution failure")
+    failed = 0
+
+    def interrupt_query(handle: int):
+        nonlocal failed
+        failed = handle
+        raise interruption
+
+    def persistent_close(handle: int) -> None:
+        if handle == failed:
+            raise OSError(errno.EIO, "injected Windows resolution close EIO")
+        real_close(handle)
+
+    api.query_reparse_point = interrupt_query  # type: ignore[method-assign]
+    api.close = persistent_close  # type: ignore[method-assign]
+
+    with pytest.raises(SystemExit) as caught:
+        contained_source_module._open_windows_resolution_at(
+            Path(r"C:\repo"),
+            authority,
+            ("current.py",),
+            expected_root_identity=root_identity,
+            expected_final_identity=(
+                source_fingerprint_module._entry_version_identity(record.metadata)
+            ),
+            allow_stable_unresolved=True,
+            api=selected,
+        )
+
+    assert caught.value is interruption
+    cleanup_owner = caught.value.source_cleanup_owner
+    assert not cleanup_owner.closed
+    assert failed in api.handles
+
+    api.query_reparse_point = real_query  # type: ignore[method-assign]
+    api.close = real_close  # type: ignore[method-assign]
+    cleanup_owner.close()
+    authority.close()
+    assert cleanup_owner.closed
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    ("timing", "interruption"),
+    [
+        pytest.param(
+            "before",
+            KeyboardInterrupt("injected before resolution HANDLE close"),
+            id="before-close",
+        ),
+        pytest.param(
+            "after",
+            SystemExit("injected after resolution HANDLE close"),
+            id="after-close",
+        ),
+    ],
+)
+def test_windows_fake_resolution_close_finishes_chain_before_cancellation(
+    timing: str,
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    authority, binding = _open_fake_windows_resolution(api, "source.py")
+    targets = set(binding.handles)
+    real_close = api.close
+    injected = False
+    seen: set[int] = set()
+
+    def interrupt_one_close(handle: int) -> None:
+        nonlocal injected
+        if handle in targets:
+            seen.add(handle)
+            if not injected:
+                injected = True
+                if timing == "before":
+                    raise interruption
+                real_close(handle)
+                raise interruption
+        real_close(handle)
+
+    api.close = interrupt_one_close  # type: ignore[method-assign]
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert injected
+    assert binding.closed
+    assert binding.handles == []
+    assert targets <= seen
+    assert targets.isdisjoint(api.handles)
+
+    api.close = real_close  # type: ignore[method-assign]
+    authority.close()
+    assert api.handles == {}
+
+
+def test_windows_fake_resolution_close_persistent_eio_retains_retry_owner() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    authority, binding = _open_fake_windows_resolution(api, "source.py")
+    targets = tuple(binding.handles)
+    failed = targets[-1]
+    real_close = api.close
+
+    def persistent_eio(handle: int) -> None:
+        if handle == failed:
+            raise OSError(errno.EIO, "injected resolution HANDLE EIO")
+        real_close(handle)
+
+    api.close = persistent_eio  # type: ignore[method-assign]
+    with pytest.raises(OSError, match="resolution HANDLE EIO"):
+        binding.close()
+
+    assert not binding.closed
+    assert binding.handles == [failed]
+    assert set(api.handles) == {failed, *authority.handles}
+    with pytest.raises(ValueError, match="closed"):
+        binding.verify()
+
+    api.close = real_close  # type: ignore[method-assign]
+    binding.close()
+    assert binding.closed
+    authority.close()
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize("case", ["regular", "link-loop", "directory", "missing"])
+@pytest.mark.parametrize("timing", ["before-store", "after-store"])
+def test_windows_resolution_binding_slot_store_cancellation_closes_every_branch(
+    case: str,
+    timing: str,
+) -> None:
+    api, authority, root_identity, expected_identity = (
+        _fake_windows_resolution_handoff_case(case)
+    )
+    interruption = KeyboardInterrupt(f"injected {case} {timing}")
+
+    class InterruptingSlot(contained_source_module._SourceCleanupSlot):
+        def own(self, resource: object) -> None:
+            is_binding = isinstance(
+                resource,
+                contained_source_module._WindowsResolutionBinding,
+            )
+            if is_binding and timing == "before-store":
+                raise interruption
+            super().own(resource)
+            if is_binding and timing == "after-store":
+                raise interruption
+
+    slot = InterruptingSlot()
+    with pytest.raises(KeyboardInterrupt) as caught:
+        contained_source_module._open_windows_resolution_at(
+            Path(r"C:\repo"),
+            authority,
+            ("current.py",),
+            expected_root_identity=root_identity,
+            expected_final_identity=expected_identity,
+            allow_stable_unresolved=True,
+            api=api,
+            cleanup_slot=slot,
+        )
+
+    assert caught.value is interruption
+    assert slot.closed
+    assert set(api.handles) == set(authority.handles)
+    authority.close()
+    assert api.handles == {}
+
+
+def test_windows_resolution_return_cancellation_closes_slot_owner() -> None:
+    api, authority, root_identity, expected_identity = (
+        _fake_windows_resolution_handoff_case("regular")
+    )
+    method = contained_source_module._open_windows_resolution_at
+    target_offset = _opcode_offset(
+        method,
+        source_text="return binding",
+        opname="LOAD_FAST",
+        argval="binding",
+    )
+    interruption = SystemExit("injected resolution RETURN_VALUE cancellation")
+    injected = False
+    slot = contained_source_module._SourceCleanupSlot()
+
+    def interrupt_return(frame, event, _arg):
+        nonlocal injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "opcode"
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            raise interruption
+        frame.f_trace_opcodes = True
+        return interrupt_return
+
+    sys.settrace(interrupt_return)
+    try:
+        with pytest.raises(SystemExit) as caught:
+            method(
+                Path(r"C:\repo"),
+                authority,
+                ("current.py",),
+                expected_root_identity=root_identity,
+                expected_final_identity=expected_identity,
+                allow_stable_unresolved=True,
+                api=api,
+                cleanup_slot=slot,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected
+    assert slot.closed
+    assert set(api.handles) == set(authority.handles)
+    authority.close()
+    assert api.handles == {}
+
+
+def test_windows_resolution_return_eio_retains_owner_without_double_close() -> None:
+    api, authority, root_identity, expected_identity = (
+        _fake_windows_resolution_handoff_case("regular")
+    )
+    method = contained_source_module._open_windows_resolution_at
+    target_offset = _opcode_offset(
+        method,
+        source_text="return binding",
+        opname="LOAD_FAST",
+        argval="binding",
+    )
+    interruption = KeyboardInterrupt("injected resolution return cancellation")
+    real_close = api.close
+    failed = 0
+    close_calls: dict[int, int] = {}
+    injected = False
+    armed = False
+    slot = contained_source_module._SourceCleanupSlot()
+
+    def persistent_close(handle: int) -> None:
+        nonlocal failed
+        if not armed:
+            real_close(handle)
+            return
+        close_calls[handle] = close_calls.get(handle, 0) + 1
+        if handle not in authority.handles and not failed:
+            failed = handle
+        if handle == failed:
+            raise OSError(errno.EIO, "injected resolution return close EIO")
+        real_close(handle)
+
+    def interrupt_return(frame, event, _arg):
+        nonlocal armed, injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "opcode"
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            armed = True
+            raise interruption
+        frame.f_trace_opcodes = True
+        return interrupt_return
+
+    api.close = persistent_close  # type: ignore[method-assign]
+    sys.settrace(interrupt_return)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            method(
+                Path(r"C:\repo"),
+                authority,
+                ("current.py",),
+                expected_root_identity=root_identity,
+                expected_final_identity=expected_identity,
+                allow_stable_unresolved=True,
+                api=api,
+                cleanup_slot=slot,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert caught.value.source_cleanup_owner is slot
+    assert failed in api.handles
+    closed_once = {
+        handle
+        for handle, calls in close_calls.items()
+        if handle != failed and calls == 1
+    }
+    assert closed_once
+
+    api.close = real_close  # type: ignore[method-assign]
+    slot.close()
+    assert slot.closed
+    assert set(api.handles) == set(authority.handles)
+    assert all(close_calls[handle] == 1 for handle in closed_once)
+    authority.close()
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("after final resolution close"), id="keyboard"),
+        pytest.param(SystemExit("after final resolution close"), id="system-exit"),
+    ],
+)
+def test_windows_resolution_close_retry_publishes_closed_after_empty_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    authority, binding = _open_fake_windows_resolution(api, "source.py")
+    real_close_handles = contained_source_module._close_windows_handles
+    injected = False
+
+    def close_then_interrupt(*args, **kwargs):
+        nonlocal injected
+        failure = real_close_handles(*args, **kwargs)
+        if not injected:
+            injected = True
+            raise interruption
+        return failure
+
+    monkeypatch.setattr(
+        contained_source_module,
+        "_close_windows_handles",
+        close_then_interrupt,
+    )
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert binding.handles == []
+    assert not binding.closed
+
+    binding.close()
+    assert binding.closed
+    authority.close()
+    assert api.handles == {}
+
+
+def test_windows_fake_resolution_close_uses_stable_handle_cookie() -> None:
+    api = _FakeWindowsSourceApi()
+    file_id = api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    authority, binding = _open_fake_windows_resolution(api, "source.py")
+    api.nodes[file_id]["version"] = 2
+
+    binding.close()
+
+    assert binding.closed
+    authority.close()
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    ("timing", "interruption"),
+    [
+        pytest.param(
+            "before",
+            KeyboardInterrupt("injected before HANDLE close"),
+            id="before-close",
+        ),
+        pytest.param(
+            "after",
+            SystemExit("injected after HANDLE close"),
+            id="after-close",
+        ),
+    ],
+)
+def test_windows_fake_binding_close_finishes_handle_chain_before_cancellation(
+    timing: str,
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    targets = set(api.handles)
+    real_close = api.close
+    calls = 0
+    injected = False
+    seen: set[int] = set()
+
+    def interrupt_one_close(handle: int) -> None:
+        nonlocal calls, injected
+        if handle in targets:
+            seen.add(handle)
+            calls += 1
+            if calls == 2 and not injected:
+                injected = True
+                if timing == "before":
+                    raise interruption
+                real_close(handle)
+                raise interruption
+        real_close(handle)
+
+    api.close = interrupt_one_close  # type: ignore[method-assign]
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert injected
+    assert binding.closed
+    assert targets <= seen
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_close_commits_interrupted_owner_pop() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    interruption = SystemExit("injected after HANDLE owner pop")
+    authority.handles = _InterruptAfterPopList(
+        authority.handles,
+        interruption,
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert binding.closed
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize("timing", ["before-root-store", "after-root-store", "return"])
+def test_windows_repository_binding_handoff_cancellation_closes_slot_owner(
+    timing: str,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    method = source_fingerprint_module._fingerprint_windows_repository
+    store_offset = _opcode_offset(
+        method,
+        source_text="root_authority = None",
+        opname="STORE_FAST",
+        argval="root_authority",
+    )
+    instructions = list(dis.get_instructions(method))
+    store_index = next(
+        index
+        for index, instruction in enumerate(instructions)
+        if instruction.offset == store_offset
+    )
+    offsets = {
+        "before-root-store": store_offset,
+        "after-root-store": instructions[store_index + 1].offset,
+        "return": _opcode_offset(
+            method,
+            source_text="return binding",
+            opname="LOAD_FAST",
+            argval="binding",
+        ),
+    }
+    target_offset = offsets[timing]
+    interruption = SystemExit(f"injected repository {timing} cancellation")
+    injected = False
+    owner = SourceBindingCleanupOwner()
+
+    def interrupt_handoff(frame, event, _arg):
+        nonlocal injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "opcode"
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            raise interruption
+        frame.f_trace_opcodes = True
+        return interrupt_handoff
+
+    sys.settrace(interrupt_handoff)
+    try:
+        with pytest.raises(SystemExit) as caught:
+            method(
+                r"C:\repo",
+                exclude_roots=(),
+                version=SOURCE_FINGERPRINT_VERSION,
+                api=api,
+                retain_binding=True,
+                source_owner=owner.retain,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected
+    assert owner.pending_sources == ()
+    owner.close()
+    assert owner.closed
+    assert api.handles == {}
+
+
+def test_windows_repository_return_eio_attaches_retry_owner_without_double_close() -> (
+    None
+):
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    method = source_fingerprint_module._fingerprint_windows_repository
+    target_offset = _opcode_offset(
+        method,
+        source_text="return binding",
+        opname="LOAD_FAST",
+        argval="binding",
+    )
+    interruption = KeyboardInterrupt("injected repository return cancellation")
+    owner = SourceBindingCleanupOwner()
+    real_close = api.close
+    failed = 0
+    close_calls: dict[int, int] = {}
+    injected = False
+    armed = False
+
+    def persistent_close(handle: int) -> None:
+        nonlocal failed
+        if not armed:
+            real_close(handle)
+            return
+        close_calls[handle] = close_calls.get(handle, 0) + 1
+        if not failed:
+            failed = handle
+        if handle == failed:
+            raise OSError(errno.EIO, "injected repository return close EIO")
+        real_close(handle)
+
+    def interrupt_return(frame, event, _arg):
+        nonlocal armed, injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "opcode"
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            armed = True
+            raise interruption
+        frame.f_trace_opcodes = True
+        return interrupt_return
+
+    api.close = persistent_close  # type: ignore[method-assign]
+    sys.settrace(interrupt_return)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            method(
+                r"C:\repo",
+                exclude_roots=(),
+                version=SOURCE_FINGERPRINT_VERSION,
+                api=api,
+                retain_binding=True,
+                source_owner=owner.retain,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    retry_owner = caught.value.source_cleanup_owner
+    assert not retry_owner.closed
+    assert failed in api.handles
+    closed_once = {
+        handle
+        for handle, calls in close_calls.items()
+        if handle != failed and calls == 1
+    }
+    assert closed_once
+
+    api.close = real_close  # type: ignore[method-assign]
+    owner.close()
+    assert owner.closed
+    assert api.handles == {}
+    assert all(close_calls[handle] == 1 for handle in closed_once)
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("after final authority close"), id="keyboard"),
+        pytest.param(SystemExit("after final authority close"), id="system-exit"),
+    ],
+)
+def test_windows_binding_close_retry_converges_after_empty_authority_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    real_close_handles = windows_fs_module._close_windows_handles
+    injected = False
+
+    def close_then_interrupt(*args, **kwargs):
+        nonlocal injected
+        failure = real_close_handles(*args, **kwargs)
+        if not injected:
+            injected = True
+            raise interruption
+        return failure
+
+    monkeypatch.setattr(
+        windows_fs_module,
+        "_close_windows_handles",
+        close_then_interrupt,
+    )
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert authority.handles == []
+    assert not authority.closed
+    assert not binding.closed
+
+    binding.close()
+    assert authority.closed
+    assert binding.closed
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_close_persistent_eio_keeps_owner_and_closes_rest() -> (
+    None
+):
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    targets = tuple(authority.handles)
+    failed = targets[-1]
+    real_close = api.close
+
+    def fail_one_handle(handle: int) -> None:
+        if handle == failed:
+            raise OSError(errno.EIO, "injected persistent HANDLE EIO")
+        real_close(handle)
+
+    api.close = fail_one_handle  # type: ignore[method-assign]
+    with pytest.raises(OSError, match="persistent HANDLE EIO"):
+        binding.close()
+
+    assert not binding.closed
+    assert not binding.usable
+    assert authority.handles == [failed]
+    assert set(api.handles) == {failed}
+
+    api.close = real_close  # type: ignore[method-assign]
+    binding.close()
+    assert binding.closed
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_close_preflight_eio_keeps_owner_and_closes_rest() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    targets = tuple(authority.handles)
+    failed = targets[-1]
+    real_metadata = api.metadata
+
+    def fail_one_handle(handle: int):
+        if handle == failed:
+            raise OSError(errno.EIO, "injected persistent HANDLE metadata EIO")
+        return real_metadata(handle)
+
+    api.metadata = fail_one_handle  # type: ignore[method-assign]
+    with pytest.raises(OSError, match="persistent HANDLE metadata EIO"):
+        binding.close()
+
+    assert not binding.closed
+    assert not binding.usable
+    assert authority.handles == [failed]
+    assert set(api.handles) == {failed}
+
+    api.metadata = real_metadata  # type: ignore[method-assign]
+    binding.close()
+    assert binding.closed
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_close_uses_stable_handle_identity() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    api.nodes[api.root_id]["version"] = 2
+
+    binding.close()
+
+    assert binding.closed
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_close_does_not_close_reused_handle() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    reused = authority.handles[-1]
+    replacement_id = api.add_directory()
+    api.close(reused)
+    api.handles[reused] = replacement_id
+    api.offsets[reused] = 0
+
+    with pytest.raises(RuntimeError, match="ownership changed"):
+        binding.close()
+
+    assert binding.closed
+    assert api.handles == {reused: replacement_id}
+    api.close(reused)
+
+
+def test_windows_kernel_close_checks_closehandle_result() -> None:
+    class CloseFailureApi(windows_fs_module.WindowsKernelApi):
+        def _raise_last_error(self, context: str) -> None:
+            raise OSError(errno.EIO, context)
+
+    api = object.__new__(CloseFailureApi)
+    api.kernel32 = SimpleNamespace(CloseHandle=lambda _handle: 0)
+    api.invalid_handle = -1
+
+    with pytest.raises(OSError, match="could not close"):
+        api.close(41)
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("Windows root interrupted"), id="keyboard"),
+        pytest.param(SystemExit("Windows root exited"), id="system-exit"),
+    ],
+)
+def test_windows_fake_root_open_failure_closes_owned_handles(
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    real_metadata = api.metadata
+    calls = 0
+
+    def interrupt_after_child_open(handle: int):
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise interruption
+        return real_metadata(handle)
+
+    api.metadata = interrupt_after_child_open  # type: ignore[method-assign]
+    with pytest.raises(type(interruption)) as caught:
+        windows_fs_module.open_lexical_directory_authority(
+            r"C:\repo",
+            api=api,
+        )
+
+    assert caught.value is interruption
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("after direct authority close"), id="keyboard"),
+        pytest.param(SystemExit("after direct authority close"), id="system-exit"),
+    ],
+)
+def test_windows_authority_close_retry_converges_after_last_handle_removed(
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    authority = windows_fs_module.open_lexical_directory_authority(
+        r"C:\repo",
+        api=api,
+    )
+    real_close_handles = windows_fs_module._close_windows_handles
+    injected = False
+
+    def close_then_interrupt(*args, **kwargs):
+        nonlocal injected
+        failure = real_close_handles(*args, **kwargs)
+        if not injected:
+            injected = True
+            raise interruption
+        return failure
+
+    monkeypatch.setattr(
+        windows_fs_module,
+        "_close_windows_handles",
+        close_then_interrupt,
+    )
+    with pytest.raises(type(interruption)) as caught:
+        authority.close()
+
+    assert caught.value is interruption
+    assert authority.handles == []
+    assert not authority.closed
+
+    authority.close()
+    assert authority.closed
+    assert api.handles == {}
+
+
+def test_windows_root_construction_eio_keeps_preinstalled_retry_owner() -> None:
+    api = _FakeWindowsSourceApi()
+    owner = SourceBindingCleanupOwner()
+    real_metadata = api.metadata
+    real_close = api.close
+    interruption = KeyboardInterrupt("injected Windows root construction failure")
+    metadata_calls = 0
+    failed = 0
+
+    def interrupt_metadata(handle: int):
+        nonlocal metadata_calls
+        metadata_calls += 1
+        if metadata_calls == 3:
+            raise interruption
+        return real_metadata(handle)
+
+    def persistent_close(handle: int) -> None:
+        nonlocal failed
+        if not failed:
+            failed = handle
+        if handle == failed:
+            raise OSError(errno.EIO, "injected Windows construction close EIO")
+        real_close(handle)
+
+    api.metadata = interrupt_metadata  # type: ignore[method-assign]
+    api.close = persistent_close  # type: ignore[method-assign]
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+            retain_binding=True,
+            source_owner=owner.retain,
+        )
+
+    assert caught.value is interruption
+    assert not owner.closed
+    assert failed in api.handles
+
+    api.metadata = real_metadata  # type: ignore[method-assign]
+    api.close = real_close  # type: ignore[method-assign]
+    owner.close()
+    assert owner.closed
+    assert api.handles == {}
 
 
 def test_fingerprint_ignores_generated_and_explicit_artifact_roots(tmp_path):
@@ -110,10 +2588,283 @@ def test_fingerprint_preserves_v1_link_only_terminal_digest(
         target = "link.py"
     link.symlink_to(target)
 
-    observed = fingerprint_repository(repo)
+    observed = fingerprint_repository_v1_for_diagnostics(repo)
+    current = fingerprint_repository(repo)
 
     assert observed.file_count == 1
     assert observed.value == _legacy_link_only_digest(b"link.py", os.fsencode(target))
+    assert is_legacy_source_fingerprint_v1(observed.value)
+    assert source_fingerprint_version(observed.value) == 1
+    assert current.value != observed.value
+
+
+def test_v2_framing_separates_a_v1_structural_collision(tmp_path: Path) -> None:
+    state_a = tmp_path / "state-a"
+    state_b = tmp_path / "state-b"
+    state_a.mkdir()
+    state_b.mkdir()
+    (state_a / "a").write_bytes(b"")
+    (state_a / "b").write_bytes(b"X\0F\0c\0Y")
+    (state_b / "a").write_bytes(b"\0F\0b\0X")
+    (state_b / "c").write_bytes(b"Y")
+
+    legacy_a = fingerprint_repository_v1_for_diagnostics(state_a)
+    legacy_b = fingerprint_repository_v1_for_diagnostics(state_b)
+    current_a = fingerprint_repository(state_a)
+    current_b = fingerprint_repository(state_b)
+
+    assert legacy_a.file_count == legacy_b.file_count == 2
+    assert legacy_a.value == legacy_b.value
+    assert current_a.file_count == current_b.file_count == 2
+    assert current_a.value != current_b.value
+
+
+def test_fingerprint_rejects_reversible_root_swap_after_enumeration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    replacement = tmp_path / "replacement"
+    parked = tmp_path / "parked"
+    repo.mkdir()
+    replacement.mkdir()
+    (repo / "source.py").write_text("VALUE = 'owned'\n", encoding="utf-8")
+    (replacement / "source.py").write_text("VALUE = 'foreign'\n", encoding="utf-8")
+    real_resolve = source_fingerprint_module._resolved_repository_file_at
+    swapped = False
+
+    @contextmanager
+    def swap_root(root, descriptor, relative, **kwargs):
+        nonlocal swapped
+        if swapped:
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+            return
+        swapped = True
+        repo.rename(parked)
+        replacement.rename(repo)
+        try:
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+        finally:
+            repo.rename(replacement)
+            parked.rename(repo)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_repository_file_at",
+        swap_root,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        fingerprint_repository(repo)
+    assert (repo / "source.py").read_text(encoding="utf-8") == "VALUE = 'owned'\n"
+    assert (replacement / "source.py").read_text(encoding="utf-8") == (
+        "VALUE = 'foreign'\n"
+    )
+
+
+def test_fingerprint_never_resolves_replaceable_root_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    replacement = tmp_path / "replacement"
+    parked = tmp_path / "parked"
+    repo.mkdir()
+    replacement.mkdir()
+    (repo / "source.py").write_text("VALUE = 'owned'\n", encoding="utf-8")
+    (replacement / "source.py").write_text("VALUE = 'foreign'\n", encoding="utf-8")
+    expected = fingerprint_repository(repo)
+    real_resolve = Path.resolve
+    resolve_calls = 0
+
+    def redirect_during_resolve(path, *args, **kwargs):
+        nonlocal resolve_calls
+        resolve_calls += 1
+        repo.rename(parked)
+        replacement.rename(repo)
+        try:
+            return real_resolve(replacement, *args, **kwargs)
+        finally:
+            repo.rename(replacement)
+            parked.rename(repo)
+
+    monkeypatch.setattr(Path, "resolve", redirect_during_resolve)
+
+    assert fingerprint_repository(repo) == expected
+    assert resolve_calls == 0
+
+
+def test_fingerprint_rejects_symlink_repository_root(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    alias = tmp_path / "alias"
+    repo.mkdir()
+    (repo / "source.py").write_text("VALUE = 1\n", encoding="utf-8")
+    try:
+        alias.symlink_to(repo, target_is_directory=True)
+    except OSError as exc:  # pragma: no cover - platform capability
+        pytest.skip(f"source fingerprint root test needs symlink support: {exc}")
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        fingerprint_repository(alias)
+
+
+def test_scan_charges_wide_directory_before_sorting_all_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = 0
+
+    class WideDirectory:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            nonlocal observed
+            observed += 1
+            if observed > 4:  # pragma: no cover - proves eager scan regression
+                raise AssertionError("scanner consumed entries beyond its budget")
+            return SimpleNamespace(name=f"source-{observed}.py")
+
+    descriptor = os.open(tmp_path, source_fingerprint_module._directory_flags())
+    try:
+        monkeypatch.setattr(source_fingerprint_module, "_MAX_SOURCE_ENTRIES", 3)
+        monkeypatch.setattr(
+            source_fingerprint_module.os,
+            "scandir",
+            lambda _descriptor: WideDirectory(),
+        )
+
+        with pytest.raises(ValueError, match="entry limit"):
+            source_fingerprint_module._scan_pinned_repository(
+                descriptor,
+                excluded=(),
+                collect_entries=True,
+            )
+    finally:
+        os.close(descriptor)
+
+    assert observed == 4
+
+
+def test_fingerprint_scan_failure_closes_pinned_root_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():  # pragma: no cover - non-Linux host
+        pytest.skip("descriptor accounting needs /proc/self/fd")
+    (tmp_path / "source.py").write_text("VALUE = 1\n", encoding="utf-8")
+    before = len(tuple(descriptor_root.iterdir()))
+
+    def fail_scan(*_args, **_kwargs):
+        raise ValueError("injected scan failure")
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        fail_scan,
+    )
+    for _ in range(32):
+        with pytest.raises(RepositoryChangedError, match="repository changed"):
+            fingerprint_repository(tmp_path)
+
+    after = len(tuple(descriptor_root.iterdir()))
+    assert after <= before + 1
+
+
+def test_fingerprint_rejects_reversible_intermediate_swap_after_enumeration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    package = repo / "package"
+    replacement = tmp_path / "replacement"
+    parked = tmp_path / "parked"
+    package.mkdir(parents=True)
+    replacement.mkdir()
+    (package / "source.py").write_text("VALUE = 'owned'\n", encoding="utf-8")
+    (replacement / "source.py").write_text("VALUE = 'foreign'\n", encoding="utf-8")
+    real_resolve = source_fingerprint_module._resolved_repository_file_at
+    swapped = False
+
+    @contextmanager
+    def swap_intermediate(root, descriptor, relative, **kwargs):
+        nonlocal swapped
+        if swapped or relative != "package/source.py":
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+            return
+        swapped = True
+        package.rename(parked)
+        replacement.rename(package)
+        try:
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+        finally:
+            package.rename(replacement)
+            parked.rename(package)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_repository_file_at",
+        swap_intermediate,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        fingerprint_repository(repo)
+    assert (package / "source.py").read_text(encoding="utf-8") == ("VALUE = 'owned'\n")
+    assert (replacement / "source.py").read_text(encoding="utf-8") == (
+        "VALUE = 'foreign'\n"
+    )
+
+
+def test_fingerprint_rejects_file_swap_in_walker_to_open_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.py"
+    foreign = tmp_path / ".foreign"
+    parked = tmp_path / ".parked"
+    source.write_text("VALUE = 'owned'\n", encoding="utf-8")
+    foreign.write_text("VALUE = 'foreign'\n", encoding="utf-8")
+    real_resolve = source_fingerprint_module._resolved_repository_file_at
+    swapped = False
+
+    @contextmanager
+    def swap_file(root, descriptor, relative, **kwargs):
+        nonlocal swapped
+        if swapped or relative != "source.py":
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+            return
+        swapped = True
+        source.rename(parked)
+        foreign.rename(source)
+        try:
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+        finally:
+            source.rename(foreign)
+            parked.rename(source)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_repository_file_at",
+        swap_file,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        fingerprint_repository(tmp_path)
+    assert source.read_text(encoding="utf-8") == "VALUE = 'owned'\n"
+    assert foreign.read_text(encoding="utf-8") == "VALUE = 'foreign'\n"
 
 
 def test_fingerprint_accepts_absolute_contained_symlink(tmp_path: Path) -> None:
@@ -128,13 +2879,147 @@ def test_fingerprint_accepts_absolute_contained_symlink(tmp_path: Path) -> None:
     assert observed.file_count == 2
 
 
-def test_fingerprint_rejects_source_symlink_outside_repository(tmp_path) -> None:
+def test_fingerprint_excludes_contained_directory_symlink_in_v1_and_v2(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    package = repo / "package"
+    package.mkdir(parents=True)
+    (package / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
+    link = repo / "package-link"
+    link.symlink_to("package", target_is_directory=True)
+
+    current_with_link = fingerprint_repository(repo)
+    legacy_with_link = fingerprint_repository_v1_for_diagnostics(repo)
+    link.unlink()
+
+    assert fingerprint_repository(repo) == current_with_link
+    assert fingerprint_repository_v1_for_diagnostics(repo) == legacy_with_link
+    assert current_with_link.file_count == legacy_with_link.file_count == 1
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_fingerprint_excludes_repository_root_directory_symlink_in_v1_and_v2(
+    tmp_path: Path,
+    absolute: bool,
+) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
-    (tmp_path / "outside.py").write_text("SECRET = 1\n")
-    (repo / "current.py").symlink_to("../outside.py")
+    (repo / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
+    link = repo / "root-link"
+    link.symlink_to(repo if absolute else ".", target_is_directory=True)
+
+    current_with_link = fingerprint_repository(repo)
+    legacy_with_link = fingerprint_repository_v1_for_diagnostics(repo)
+    link.unlink()
+
+    assert fingerprint_repository(repo) == current_with_link
+    assert fingerprint_repository_v1_for_diagnostics(repo) == legacy_with_link
+    assert current_with_link.file_count == legacy_with_link.file_count == 1
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_fingerprint_rejects_source_symlink_outside_repository(
+    tmp_path: Path,
+    absolute: bool,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("SECRET = 1\n")
+    (repo / "current.py").symlink_to(outside if absolute else "../outside.py")
 
     with pytest.raises(RepositoryChangedError, match="could not be read consistently"):
+        fingerprint_repository(repo)
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_fingerprint_rejects_directory_symlink_outside_repository(
+    tmp_path: Path,
+    absolute: bool,
+) -> None:
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    repo.mkdir()
+    outside.mkdir()
+    (repo / "outside-link").symlink_to(
+        outside if absolute else "../outside",
+        target_is_directory=True,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="could not be read consistently"):
+        fingerprint_repository(repo)
+
+
+def test_inventory_scan_never_follows_source_symlinks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("SECRET = 1\n", encoding="utf-8")
+    (repo / "current.py").symlink_to(outside)
+    descriptor = os.open(repo, source_fingerprint_module._directory_flags())
+    real_stat = os.stat
+
+    def reject_follow(path, *args, **kwargs):
+        if kwargs.get("dir_fd") is not None and kwargs.get("follow_symlinks", True):
+            raise AssertionError("inventory scan followed a source symlink")
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "stat", reject_follow)
+    try:
+        scan = source_fingerprint_module._scan_pinned_repository(
+            descriptor,
+            excluded=(),
+            collect_entries=True,
+        )
+    finally:
+        os.close(descriptor)
+
+    assert [entry.relative for entry in scan.entries] == ["current.py"]
+
+
+def test_fingerprint_rejects_link_to_directory_swap_before_classification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    directory = repo / "package"
+    repo.mkdir()
+    directory.mkdir()
+    (directory / "module.py").write_text("VALUE = 2\n", encoding="utf-8")
+    (repo / "target.py").write_text("VALUE = 1\n", encoding="utf-8")
+    link = repo / "current.py"
+    link.symlink_to("target.py")
+    real_resolve = source_fingerprint_module._resolved_repository_file_at
+    swapped = False
+
+    @contextmanager
+    def swap_to_directory(root, descriptor, relative, **kwargs):
+        nonlocal swapped
+        if swapped or relative != "current.py":
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+            return
+        swapped = True
+        link.unlink()
+        link.symlink_to("package", target_is_directory=True)
+        try:
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+        finally:
+            link.unlink()
+            link.symlink_to("target.py")
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_repository_file_at",
+        swap_to_directory,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
         fingerprint_repository(repo)
 
 
@@ -201,3 +3086,172 @@ def test_dirty_check_ignores_generated_dirs_but_detects_source_changes(tmp_path)
 
     source.write_text("VALUE = 2\n")
     assert repository_source_is_dirty(tmp_path) is True
+
+
+def test_dirty_check_never_resolves_replaceable_root_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    observed_command: list[str] = []
+
+    def reject_resolve(*_args, **_kwargs):
+        raise AssertionError("dirty check must keep the lexical repository root")
+
+    def clean_status(command, **_kwargs):
+        observed_command.extend(command)
+        return subprocess.CompletedProcess(command, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(Path, "resolve", reject_resolve)
+    monkeypatch.setattr(source_fingerprint_module.subprocess, "run", clean_status)
+
+    assert repository_source_is_dirty(repo) is False
+    assert observed_command[0:3] == ["git", "-C", str(repo)]
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_source_authority_abi_layout_node(tmp_path: Path) -> None:
+    import ctypes
+
+    api = windows_fs_module.windows_kernel_api()
+    assert ctypes.sizeof(api.FILE_ID_128) == 16
+    assert ctypes.sizeof(api.FILE_ID_INFO) == 24
+    assert api.FILE_ID_EXTD_DIR_INFO.FileId.offset == 72
+    assert api.FILE_ID_EXTD_DIR_INFO.FileName.offset == 88
+
+    handle = api.create_directory_handle(tmp_path)
+    reopened = 0
+    try:
+        metadata = api.metadata(handle)
+        assert windows_fs_module.windows_file_id_is_reliable(metadata.file_id_128)
+        reopened = api.open_by_extended_id(
+            handle,
+            metadata.file_id_128,
+            desired_access=(
+                windows_fs_module.FILE_LIST_DIRECTORY
+                | windows_fs_module.FILE_READ_ATTRIBUTES
+                | windows_fs_module.SYNCHRONIZE
+            ),
+            is_directory=True,
+        )
+        assert api.metadata(reopened).file_identity == metadata.file_identity
+    finally:
+        if reopened:
+            api.close(reopened)
+        api.close(handle)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_source_v2_regular_and_contained_symlink_node(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "target.py"
+    target.write_bytes(b"VALUE = 1\n")
+    try:
+        (repo / "relative.py").symlink_to("target.py")
+        (repo / "absolute.py").symlink_to(target)
+    except OSError as exc:  # pragma: no cover - Windows policy dependent
+        pytest.skip(f"Windows symlink creation is unavailable: {exc}")
+
+    first = fingerprint_repository(repo)
+    second = fingerprint_repository(repo)
+    legacy = fingerprint_repository_v1_for_diagnostics(repo)
+
+    assert first == second
+    assert first.file_count == legacy.file_count == 3
+    assert first.value.startswith("sha256-v2:")
+    assert legacy.value.startswith("sha256:")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_source_v2_rejects_outside_symlink_node(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_bytes(b"SECRET = 1\n")
+    try:
+        (repo / "current.py").symlink_to(outside)
+    except OSError as exc:  # pragma: no cover - Windows policy dependent
+        pytest.skip(f"Windows symlink creation is unavailable: {exc}")
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        fingerprint_repository(repo)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_source_root_handle_blocks_reversible_swap_node(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_bytes(b"VALUE = 1\n")
+    parked = tmp_path / "parked"
+    scan = source_fingerprint_module._scan_pinned_windows_repository
+    attempted = False
+
+    def attempt_swap(*args, **kwargs):
+        nonlocal attempted
+        if not attempted:
+            attempted = True
+            with pytest.raises(OSError):
+                repo.rename(parked)
+        return scan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_windows_repository",
+        attempt_swap,
+    )
+
+    assert fingerprint_repository(repo).file_count == 1
+    assert attempted
+    assert repo.is_dir()
+    assert not parked.exists()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_source_failure_closes_all_handles_node(
+    tmp_path: Path,
+) -> None:
+    import ctypes
+    import ctypes.wintypes as wintypes
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_bytes(b"SECRET = 1\n")
+    try:
+        (repo / "current.py").symlink_to(outside)
+    except OSError as exc:  # pragma: no cover - Windows policy dependent
+        pytest.skip(f"Windows symlink creation is unavailable: {exc}")
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetCurrentProcess.argtypes = ()
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.GetProcessHandleCount.argtypes = (
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.GetProcessHandleCount.restype = wintypes.BOOL
+
+    def handle_count() -> int:
+        count = wintypes.DWORD()
+        if not kernel32.GetProcessHandleCount(
+            kernel32.GetCurrentProcess(),
+            ctypes.byref(count),
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+        return int(count.value)
+
+    before = handle_count()
+    for _ in range(32):
+        with pytest.raises(RepositoryChangedError):
+            fingerprint_repository(repo)
+    after = handle_count()
+
+    assert after <= before + 2

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import dis
 import errno
 import hashlib
 import inspect
@@ -1593,35 +1592,6 @@ def _fake_windows_resolution_handoff_case(
     )
 
 
-def _opcode_offset(
-    function,
-    *,
-    source_text: str,
-    opname: str,
-    argval: object | None = None,
-    occurrence: str = "last",
-) -> int:
-    lines, first_line = inspect.getsourcelines(function)
-    matching_lines = [
-        first_line + index for index, line in enumerate(lines) if source_text in line
-    ]
-    assert matching_lines
-    target_line = matching_lines[-1] if occurrence == "last" else matching_lines[0]
-    current_line = None
-    matches: list[int] = []
-    for instruction in dis.get_instructions(function):
-        if instruction.starts_line is not None:
-            current_line = instruction.starts_line
-        if (
-            current_line == target_line
-            and instruction.opname == opname
-            and (argval is None or instruction.argval == argval)
-        ):
-            matches.append(instruction.offset)
-    assert matches
-    return matches[-1] if occurrence == "last" else matches[0]
-
-
 def test_fingerprint_changes_with_source_content_and_path(tmp_path):
     source = tmp_path / "module.py"
     source.write_text("VALUE = 1\n")
@@ -2393,82 +2363,63 @@ def test_windows_resolution_binding_slot_store_cancellation_closes_every_branch(
     assert api.handles == {}
 
 
-def test_windows_resolution_return_cancellation_closes_slot_owner() -> None:
+def test_windows_resolution_completed_binding_cancellation_closes_slot_owner() -> None:
     (
         api,
         authority,
         root_identity,
         expected_identity,
     ) = _fake_windows_resolution_handoff_case("regular")
-    method = contained_source_module._open_windows_resolution_at
-    target_offset = _opcode_offset(
-        method,
-        source_text="return binding",
-        opname="LOAD_FAST",
-        argval="binding",
-    )
-    interruption = SystemExit("injected resolution RETURN_VALUE cancellation")
-    injected = False
-    slot = contained_source_module._SourceCleanupSlot()
+    interruption = SystemExit("injected after completed resolution handoff")
 
-    def interrupt_return(frame, event, _arg):
-        nonlocal injected
-        if (
-            not injected
-            and frame.f_code is method.__code__
-            and event == "opcode"
-            and frame.f_lasti == target_offset
-        ):
-            injected = True
-            raise interruption
-        frame.f_trace_opcodes = True
-        return interrupt_return
+    class InterruptingSlot(contained_source_module._SourceCleanupSlot):
+        def own(self, resource: object) -> None:
+            super().own(resource)
+            if isinstance(resource, contained_source_module._WindowsResolutionBinding):
+                raise interruption
 
-    sys.settrace(interrupt_return)
-    try:
-        with pytest.raises(SystemExit) as caught:
-            method(
-                Path(r"C:\repo"),
-                authority,
-                ("current.py",),
-                expected_root_identity=root_identity,
-                expected_final_identity=expected_identity,
-                allow_stable_unresolved=True,
-                api=api,
-                cleanup_slot=slot,
-            )
-    finally:
-        sys.settrace(None)
+    slot = InterruptingSlot()
+    with pytest.raises(SystemExit) as caught:
+        contained_source_module._open_windows_resolution_at(
+            Path(r"C:\repo"),
+            authority,
+            ("current.py",),
+            expected_root_identity=root_identity,
+            expected_final_identity=expected_identity,
+            allow_stable_unresolved=True,
+            api=api,
+            cleanup_slot=slot,
+        )
 
     assert caught.value is interruption
-    assert injected
     assert slot.closed
     assert set(api.handles) == set(authority.handles)
     authority.close()
     assert api.handles == {}
 
 
-def test_windows_resolution_return_eio_retains_owner_without_double_close() -> None:
+def test_windows_resolution_handoff_eio_retains_owner_without_double_close() -> None:
     (
         api,
         authority,
         root_identity,
         expected_identity,
     ) = _fake_windows_resolution_handoff_case("regular")
-    method = contained_source_module._open_windows_resolution_at
-    target_offset = _opcode_offset(
-        method,
-        source_text="return binding",
-        opname="LOAD_FAST",
-        argval="binding",
-    )
-    interruption = KeyboardInterrupt("injected resolution return cancellation")
+    interruption = KeyboardInterrupt("injected resolution handoff cancellation")
     real_close = api.close
     failed = 0
     close_calls: dict[int, int] = {}
-    injected = False
     armed = False
-    slot = contained_source_module._SourceCleanupSlot()
+
+    class InterruptingSlot(contained_source_module._SourceCleanupSlot):
+        def own(self, resource: object) -> None:
+            nonlocal armed
+            super().own(resource)
+            if isinstance(resource, contained_source_module._WindowsResolutionBinding):
+                armed = True
+                raise interruption
+
+    slot = InterruptingSlot()
 
     def persistent_close(handle: int) -> None:
         nonlocal failed
@@ -2482,36 +2433,18 @@ def test_windows_resolution_return_eio_retains_owner_without_double_close() -> N
             raise OSError(errno.EIO, "injected resolution return close EIO")
         real_close(handle)
 
-    def interrupt_return(frame, event, _arg):
-        nonlocal armed, injected
-        if (
-            not injected
-            and frame.f_code is method.__code__
-            and event == "opcode"
-            and frame.f_lasti == target_offset
-        ):
-            injected = True
-            armed = True
-            raise interruption
-        frame.f_trace_opcodes = True
-        return interrupt_return
-
     api.close = persistent_close  # type: ignore[method-assign]
-    sys.settrace(interrupt_return)
-    try:
-        with pytest.raises(KeyboardInterrupt) as caught:
-            method(
-                Path(r"C:\repo"),
-                authority,
-                ("current.py",),
-                expected_root_identity=root_identity,
-                expected_final_identity=expected_identity,
-                allow_stable_unresolved=True,
-                api=api,
-                cleanup_slot=slot,
-            )
-    finally:
-        sys.settrace(None)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        contained_source_module._open_windows_resolution_at(
+            Path(r"C:\repo"),
+            authority,
+            ("current.py",),
+            expected_root_identity=root_identity,
+            expected_final_identity=expected_identity,
+            allow_stable_unresolved=True,
+            api=api,
+            cleanup_slot=slot,
+        )
 
     assert caught.value is interruption
     assert caught.value.source_cleanup_owner is slot
@@ -2674,72 +2607,38 @@ def test_windows_fake_binding_close_commits_interrupted_owner_pop() -> None:
     assert api.handles == {}
 
 
-@pytest.mark.parametrize("timing", ["before-root-store", "after-root-store", "return"])
+@pytest.mark.parametrize("timing", ["before-binding-store", "after-binding-store"])
 def test_windows_repository_binding_handoff_cancellation_closes_slot_owner(
     timing: str,
 ) -> None:
     api = _FakeWindowsSourceApi()
     api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
-    method = source_fingerprint_module._fingerprint_windows_repository
-    store_offset = _opcode_offset(
-        method,
-        source_text="root_authority = None",
-        opname="STORE_FAST",
-        argval="root_authority",
-    )
-    instructions = list(dis.get_instructions(method))
-    store_index = next(
-        index
-        for index, instruction in enumerate(instructions)
-        if instruction.offset == store_offset
-    )
-    offsets = {
-        "before-root-store": store_offset,
-        "after-root-store": instructions[store_index + 1].offset,
-        "return": _opcode_offset(
-            method,
-            source_text="return binding",
-            opname="LOAD_FAST",
-            argval="binding",
-        ),
-    }
-    target_offset = offsets[timing]
     interruption = SystemExit(f"injected repository {timing} cancellation")
-    injected = False
-    owner = SourceBindingCleanupOwner()
 
-    def interrupt_handoff(frame, event, _arg):
-        nonlocal injected
-        if (
-            not injected
-            and frame.f_code is method.__code__
-            and event == "opcode"
-            and frame.f_lasti == target_offset
-        ):
-            injected = True
-            raise interruption
-        frame.f_trace_opcodes = True
-        return interrupt_handoff
+    class InterruptingSlot(contained_source_module._SourceCleanupSlot):
+        def own(self, resource: object) -> None:
+            is_binding = isinstance(resource, RepositorySourceBinding)
+            if is_binding and timing == "before-binding-store":
+                raise interruption
+            super().own(resource)
+            if is_binding and timing == "after-binding-store":
+                raise interruption
 
-    sys.settrace(interrupt_handoff)
-    try:
-        with pytest.raises(SystemExit) as caught:
-            method(
-                r"C:\repo",
-                exclude_roots=(),
-                version=SOURCE_FINGERPRINT_VERSION,
-                api=api,
-                retain_binding=True,
-                source_owner=owner.retain,
-            )
-    finally:
-        sys.settrace(None)
+    slot = InterruptingSlot()
+    with pytest.raises(SystemExit) as caught:
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+            retain_binding=True,
+            cleanup_slot=slot,
+        )
 
     assert caught.value is interruption
-    assert injected
-    assert owner.pending_sources == ()
-    owner.close()
-    assert owner.closed
+    assert slot.pending_sources == ()
+    slot.close()
+    assert slot.closed
     assert api.handles == {}
 
 
@@ -2748,20 +2647,21 @@ def test_windows_repository_return_eio_attaches_retry_owner_without_double_close
 ):
     api = _FakeWindowsSourceApi()
     api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
-    method = source_fingerprint_module._fingerprint_windows_repository
-    target_offset = _opcode_offset(
-        method,
-        source_text="return binding",
-        opname="LOAD_FAST",
-        argval="binding",
-    )
-    interruption = KeyboardInterrupt("injected repository return cancellation")
-    owner = SourceBindingCleanupOwner()
+    interruption = KeyboardInterrupt("injected repository binding cancellation")
     real_close = api.close
     failed = 0
     close_calls: dict[int, int] = {}
-    injected = False
     armed = False
+
+    class InterruptingSlot(contained_source_module._SourceCleanupSlot):
+        def own(self, resource: object) -> None:
+            nonlocal armed
+            super().own(resource)
+            if isinstance(resource, RepositorySourceBinding):
+                armed = True
+                raise interruption
+
+    slot = InterruptingSlot()
 
     def persistent_close(handle: int) -> None:
         nonlocal failed
@@ -2775,34 +2675,16 @@ def test_windows_repository_return_eio_attaches_retry_owner_without_double_close
             raise OSError(errno.EIO, "injected repository return close EIO")
         real_close(handle)
 
-    def interrupt_return(frame, event, _arg):
-        nonlocal armed, injected
-        if (
-            not injected
-            and frame.f_code is method.__code__
-            and event == "opcode"
-            and frame.f_lasti == target_offset
-        ):
-            injected = True
-            armed = True
-            raise interruption
-        frame.f_trace_opcodes = True
-        return interrupt_return
-
     api.close = persistent_close  # type: ignore[method-assign]
-    sys.settrace(interrupt_return)
-    try:
-        with pytest.raises(KeyboardInterrupt) as caught:
-            method(
-                r"C:\repo",
-                exclude_roots=(),
-                version=SOURCE_FINGERPRINT_VERSION,
-                api=api,
-                retain_binding=True,
-                source_owner=owner.retain,
-            )
-    finally:
-        sys.settrace(None)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+            retain_binding=True,
+            cleanup_slot=slot,
+        )
 
     assert caught.value is interruption
     retry_owner = caught.value.source_cleanup_owner
@@ -2816,8 +2698,8 @@ def test_windows_repository_return_eio_attaches_retry_owner_without_double_close
     assert closed_once
 
     api.close = real_close  # type: ignore[method-assign]
-    owner.close()
-    assert owner.closed
+    slot.close()
+    assert slot.closed
     assert api.handles == {}
     assert all(close_calls[handle] == 1 for handle in closed_once)
 

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -9,6 +9,9 @@ import errno
 import hashlib
 import inspect
 import os
+import select
+import signal
+import stat
 import subprocess
 import sys
 import threading
@@ -167,6 +170,48 @@ def test_source_lock_persistent_probe_failure_is_bounded() -> None:
         source_fingerprint_module._SourceLockLease(lock).__enter__()
 
 
+def test_source_lock_concurrent_child_first_touch_uses_one_process_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock = source_fingerprint_module._SourceLifecycleRLock()
+    original_rlock = threading.RLock
+    construction_barrier = threading.Barrier(2)
+    start_barrier = threading.Barrier(3)
+    observed = []
+
+    def synchronized_rlock():
+        candidate = original_rlock()
+        construction_barrier.wait(timeout=2)
+        return candidate
+
+    monkeypatch.setattr(
+        source_fingerprint_module.os,
+        "getpid",
+        lambda: lock._pid + 1,
+    )
+    monkeypatch.setattr(
+        source_fingerprint_module.threading,
+        "RLock",
+        synchronized_rlock,
+    )
+
+    def first_touch() -> None:
+        start_barrier.wait(timeout=2)
+        assert lock.depth() == 0
+        observed.append(lock._lock)
+
+    threads = [threading.Thread(target=first_touch) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    start_barrier.wait(timeout=2)
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(observed) == 2
+    assert observed[0] is observed[1] is lock._lock
+
+
 def test_repository_source_binding_reads_exact_captured_records(
     tmp_path: Path,
 ) -> None:
@@ -189,6 +234,484 @@ def test_repository_source_binding_reads_exact_captured_records(
         }
         assert binding.read_bytes("a.py", max_bytes=1024) == b"VALUE = 1\n"
         assert binding.read_bytes("link.py", max_bytes=1024) == b"TARGET = 2\n"
+
+
+def test_repository_source_snapshot_revalidates_excluded_symlink_target(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    hidden = repo / ".codenib-cache"
+    hidden.mkdir(parents=True)
+    target = hidden / "target.py"
+    target.write_bytes(b"VALUE = 1\n")
+    link = repo / "visible.py"
+    link.symlink_to(".codenib-cache/target.py")
+    binding = capture_repository_source(repo)
+
+    target.write_bytes(b"VALUE = 2\n")
+
+    with pytest.raises(RepositoryChangedError):
+        binding.verify_snapshot()
+    assert not binding.usable
+
+
+def test_repository_source_snapshot_binds_excluded_symlink_text(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    hidden = repo / ".codenib-cache"
+    hidden.mkdir(parents=True)
+    (hidden / "first.py").write_bytes(b"SAME\n")
+    (hidden / "second.py").write_bytes(b"SAME\n")
+    link = repo / "visible.py"
+    link.symlink_to(".codenib-cache/first.py")
+    binding = capture_repository_source(repo)
+
+    link.unlink()
+    link.symlink_to(".codenib-cache/second.py")
+
+    with pytest.raises(RepositoryChangedError):
+        binding.verify_snapshot()
+    assert not binding.usable
+
+
+def test_repository_source_snapshot_revalidates_unresolved_excluded_target(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    hidden = repo / ".codenib-cache"
+    hidden.mkdir(parents=True)
+    (repo / "visible.py").symlink_to(".codenib-cache/later.py")
+    binding = capture_repository_source(repo)
+
+    (hidden / "later.py").write_bytes(b"VALUE = 1\n")
+
+    with pytest.raises(RepositoryChangedError):
+        binding.verify_snapshot()
+    assert not binding.usable
+
+
+def test_fingerprint_final_gate_revalidates_excluded_link_target_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    hidden = repo / ".codenib-cache"
+    hidden.mkdir(parents=True)
+    (repo / "visible.py").symlink_to(".codenib-cache/later.py")
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    changed = False
+
+    def change_before_final_link_check(descriptor, *, excluded, collect_entries):
+        nonlocal changed
+        if not collect_entries and not changed:
+            changed = True
+            (hidden / "later.py").write_bytes(b"VALUE = 1\n")
+        return real_scan(
+            descriptor,
+            excluded=excluded,
+            collect_entries=collect_entries,
+        )
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        change_before_final_link_check,
+    )
+
+    with pytest.raises(RepositoryChangedError):
+        fingerprint_repository(repo)
+    assert changed
+
+
+@pytest.mark.parametrize("field", ["root", "fingerprint", "file_count", "records"])
+def test_repository_source_binding_rejects_public_identity_mutation(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    repo = tmp_path / field
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+    binding = capture_repository_source(repo)
+    if field == "root":
+        binding.root = tmp_path / "other"
+    elif field == "fingerprint":
+        binding.fingerprint = "sha256-v2:" + "f" * 64
+    elif field == "file_count":
+        binding.file_count += 1
+    else:
+        record = binding.file_records[0]
+        object.__setattr__(record, "sha256", "f" * 64)
+
+    with pytest.raises(RepositoryChangedError, match="public"):
+        binding.verify_snapshot()
+    assert not binding.usable
+
+
+def test_repository_source_identity_snapshot_is_detached(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+
+    with capture_repository_source(repo) as binding:
+        first = binding.authenticated_identity_snapshot()
+        object.__setattr__(first.file_records[0], "sha256", "f" * 64)
+        second = binding.authenticated_identity_snapshot()
+
+        assert second.file_records[0].sha256 != "f" * 64
+        assert binding.read_bytes("a.py", max_bytes=1024) == b"VALUE = 1\n"
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_repository_source_child_close_resets_inherited_locked_rlock(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+    binding = capture_repository_source(repo)
+    held = threading.Event()
+    release = threading.Event()
+
+    def hold_lock() -> None:
+        binding._lock.acquire()
+        held.set()
+        release.wait(timeout=10)
+        binding._lock.release()
+
+    thread = threading.Thread(target=hold_lock)
+    thread.start()
+    assert held.wait(timeout=2)
+    read_descriptor, write_descriptor = os.pipe()
+    child = os.fork()
+    if child == 0:  # pragma: no cover - assertions are reported through the pipe
+        try:
+            os.close(read_descriptor)
+            binding.close()
+            os.write(write_descriptor, b"1" if binding.closed else b"0")
+        except BaseException:  # noqa: B036 - report child failure through pipe
+            os.write(write_descriptor, b"E")
+        finally:
+            os.close(write_descriptor)
+            os._exit(0)
+
+    os.close(write_descriptor)
+    try:
+        ready, _, _ = select.select([read_descriptor], [], [], 3)
+        if not ready:
+            os.kill(child, signal.SIGKILL)
+            pytest.fail("fork child deadlocked on an inherited source lock")
+        assert os.read(read_descriptor, 1) == b"1"
+    finally:
+        os.close(read_descriptor)
+        release.set()
+        thread.join(timeout=2)
+        os.waitpid(child, 0)
+        binding.close()
+
+
+def test_posix_resolution_cleanup_does_not_close_reused_descriptor(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    cleanup = contained_source_module._PosixDescriptorCleanup()
+    descriptor = cleanup.open(first, os.O_RDONLY)
+    os.close(descriptor)
+    replacement = os.open(second, os.O_RDONLY)
+    assert replacement == descriptor
+
+    try:
+        with pytest.raises(RuntimeError, match="ownership changed"):
+            cleanup.close()
+        assert os.read(replacement, 6) == b"second"
+    finally:
+        os.close(replacement)
+
+
+def test_posix_resolution_cleanup_commits_close_then_reuse_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    cleanup = contained_source_module._PosixDescriptorCleanup()
+    descriptor = cleanup.open(first, os.O_RDONLY)
+    real_close = os.close
+    replacement = -1
+    interruption = KeyboardInterrupt("injected close completion cancellation")
+
+    def close_then_reuse(value: int) -> None:
+        nonlocal replacement
+        if value == descriptor and replacement < 0:
+            real_close(value)
+            replacement = os.open(second, os.O_RDONLY)
+            assert replacement == descriptor
+            raise interruption
+        real_close(value)
+
+    monkeypatch.setattr(contained_source_module.os, "close", close_then_reuse)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        cleanup.close()
+
+    assert caught.value is interruption
+    assert cleanup.closed
+    assert os.read(replacement, 6) == b"second"
+    monkeypatch.setattr(contained_source_module.os, "close", real_close)
+    real_close(replacement)
+
+
+def test_posix_resolution_cleanup_rejects_same_inode_new_ofd_after_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source"
+    source.write_bytes(b"owned")
+    cleanup = contained_source_module._PosixDescriptorCleanup()
+    descriptor = cleanup.open(source, os.O_RDONLY)
+    real_close = os.close
+    replacement = -1
+    interruption = KeyboardInterrupt("injected same-inode fd reuse")
+
+    def close_then_reopen_same_inode(value: int) -> None:
+        nonlocal replacement
+        if value == descriptor and replacement < 0:
+            real_close(value)
+            replacement = os.open(source, os.O_RDONLY)
+            assert replacement == descriptor
+            raise interruption
+        real_close(value)
+
+    monkeypatch.setattr(
+        contained_source_module.os,
+        "close",
+        close_then_reopen_same_inode,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        cleanup.close()
+
+    assert caught.value is interruption
+    assert cleanup.closed
+    monkeypatch.setattr(contained_source_module.os, "close", real_close)
+    cleanup.close()
+    assert os.read(replacement, 5) == b"owned"
+    real_close(replacement)
+
+
+def test_posix_resolution_cleanup_coordinates_dup_alias_close_cookie(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source"
+    source.write_bytes(b"owned")
+    cleanup = contained_source_module._PosixDescriptorCleanup()
+    original = cleanup.open(source, os.O_RDONLY)
+    duplicate = cleanup.dup(original)
+    real_close = os.close
+    interruption = KeyboardInterrupt("injected before dup alias close")
+    injected = False
+
+    def interrupt_duplicate(value: int) -> None:
+        nonlocal injected
+        if value == duplicate and not injected:
+            injected = True
+            raise interruption
+        real_close(value)
+
+    monkeypatch.setattr(contained_source_module.os, "close", interrupt_duplicate)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        cleanup.close()
+
+    assert caught.value is interruption
+    assert cleanup.descriptors == [duplicate]
+    with pytest.raises(OSError) as original_error:
+        os.fstat(original)
+    assert original_error.value.errno == errno.EBADF
+    assert os.fstat(duplicate)
+
+    monkeypatch.setattr(contained_source_module.os, "close", real_close)
+    cleanup.close()
+    assert cleanup.closed
+    with pytest.raises(OSError) as duplicate_error:
+        os.fstat(duplicate)
+    assert duplicate_error.value.errno == errno.EBADF
+
+
+def test_posix_cleanup_coordinates_close_cookie_across_dup_owners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source"
+    source.write_bytes(b"owned")
+    original_owner = contained_source_module._PosixDescriptorCleanup()
+    alias_owner = contained_source_module._PosixDescriptorCleanup()
+    original = original_owner.open(source, os.O_RDONLY)
+    duplicate = alias_owner.dup(original)
+    baseline = dict(contained_source_module._CLOSE_COOKIE_COUNTS)
+    real_close = os.close
+    interruption = KeyboardInterrupt("injected before cross-owner alias close")
+    injected = False
+
+    def interrupt_duplicate(value: int) -> None:
+        nonlocal injected
+        if value == duplicate and not injected:
+            injected = True
+            raise interruption
+        real_close(value)
+
+    monkeypatch.setattr(contained_source_module.os, "close", interrupt_duplicate)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        alias_owner.close()
+    assert caught.value is interruption
+    assert len(contained_source_module._CLOSE_COOKIE_COUNTS) == len(baseline) + 1
+
+    original_owner.close()
+    assert original_owner.closed
+    monkeypatch.setattr(contained_source_module.os, "close", real_close)
+    alias_owner.close()
+    assert alias_owner.closed
+    assert contained_source_module._CLOSE_COOKIE_COUNTS == baseline
+
+
+def test_posix_directory_cleanup_falls_back_when_cookie_seek_is_unsupported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup = contained_source_module._PosixDescriptorCleanup()
+    descriptor = cleanup.open(
+        tmp_path,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+    )
+    baseline = dict(contained_source_module._CLOSE_COOKIE_COUNTS)
+    real_lseek = os.lseek
+
+    def reject_directory_cookie(value: int, offset: int, whence: int) -> int:
+        if value == descriptor:
+            raise OSError(errno.EINVAL, "directory offsets are opaque")
+        return real_lseek(value, offset, whence)
+
+    monkeypatch.setattr(contained_source_module.os, "lseek", reject_directory_cookie)
+    cleanup.close()
+
+    assert cleanup.closed
+    assert contained_source_module._CLOSE_COOKIE_COUNTS == baseline
+    with pytest.raises(OSError) as caught:
+        os.fstat(descriptor)
+    assert caught.value.errno == errno.EBADF
+
+
+def test_posix_directory_cleanup_retains_no_cookie_close_interruption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup = contained_source_module._PosixDescriptorCleanup()
+    descriptor = cleanup.open(
+        tmp_path,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+    )
+    real_lseek = os.lseek
+    real_close = os.close
+    interruption = KeyboardInterrupt("injected before no-cookie directory close")
+    injected = False
+
+    def reject_directory_cookie(value: int, offset: int, whence: int) -> int:
+        if value == descriptor:
+            raise OSError(errno.ESPIPE, "directory is not seekable")
+        return real_lseek(value, offset, whence)
+
+    def interrupt_before_close(value: int) -> None:
+        nonlocal injected
+        if value == descriptor and not injected:
+            injected = True
+            raise interruption
+        real_close(value)
+
+    monkeypatch.setattr(contained_source_module.os, "lseek", reject_directory_cookie)
+    monkeypatch.setattr(contained_source_module.os, "close", interrupt_before_close)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        cleanup.close()
+
+    assert caught.value is interruption
+    assert cleanup.descriptors == [descriptor]
+    assert os.fstat(descriptor)
+    cleanup.close()
+    assert cleanup.closed
+
+
+def test_posix_resolution_cleanup_closes_owned_file_after_size_change(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    source.write_bytes(b"first")
+    cleanup = contained_source_module._PosixDescriptorCleanup()
+    descriptor = cleanup.open(source, os.O_RDONLY)
+
+    source.write_bytes(b"a longer replacement on the same inode")
+    cleanup.close()
+
+    assert cleanup.closed
+    with pytest.raises(OSError) as caught:
+        os.fstat(descriptor)
+    assert caught.value.errno == errno.EBADF
+
+
+def test_posix_root_authority_cleanup_closes_owned_directory_after_chmod(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    authority = source_fingerprint_module._open_pinned_repository_root(repo)
+    descriptors = tuple(authority._resources)
+
+    repo.chmod(0o700)
+    authority.close()
+
+    assert authority.closed
+    for descriptor in descriptors:
+        with pytest.raises(OSError) as caught:
+            os.fstat(descriptor)
+        assert caught.value.errno == errno.EBADF
+
+
+def test_posix_root_cleanup_rejects_same_inode_new_ofd_after_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    authority = source_fingerprint_module._open_pinned_repository_root(repo)
+    descriptor = authority._resources[-1]
+    real_close = os.close
+    replacement = -1
+    interruption = KeyboardInterrupt("injected same-directory fd reuse")
+
+    def close_then_reopen_same_inode(value: int) -> None:
+        nonlocal replacement
+        if value == descriptor and replacement < 0:
+            real_close(value)
+            replacement = os.open(repo, os.O_RDONLY | os.O_DIRECTORY)
+            assert replacement == descriptor
+            raise interruption
+        real_close(value)
+
+    monkeypatch.setattr(
+        source_fingerprint_module.os,
+        "close",
+        close_then_reopen_same_inode,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        authority.close()
+
+    assert caught.value is interruption
+    assert authority.closed
+    monkeypatch.setattr(source_fingerprint_module.os, "close", real_close)
+    authority.close()
+    assert stat.S_ISDIR(os.fstat(replacement).st_mode)
+    real_close(replacement)
 
 
 def test_repository_source_binding_poisoned_by_touched_or_unrelated_change(
@@ -997,11 +1520,13 @@ def _open_fake_windows_resolution(
     api: _FakeWindowsSourceApi,
     relative: str,
 ):
-    selected, authority, root_identity = (
-        contained_source_module._open_windows_pinned_repository_root(
-            Path(r"C:\repo"),
-            api=api,
-        )
+    (
+        selected,
+        authority,
+        root_identity,
+    ) = contained_source_module._open_windows_pinned_repository_root(
+        Path(r"C:\repo"),
+        api=api,
     )
     scan = source_fingerprint_module._scan_pinned_windows_repository(
         selected,
@@ -1043,11 +1568,13 @@ def _fake_windows_resolution_handoff_case(
         api.add_symlink(api.root_id, "current.py", "missing.py")
     else:  # pragma: no cover - test parameter invariant
         raise AssertionError(case)
-    selected, authority, root_identity = (
-        contained_source_module._open_windows_pinned_repository_root(
-            Path(r"C:\repo"),
-            api=api,
-        )
+    (
+        selected,
+        authority,
+        root_identity,
+    ) = contained_source_module._open_windows_pinned_repository_root(
+        Path(r"C:\repo"),
+        api=api,
     )
     scan = source_fingerprint_module._scan_pinned_windows_repository(
         selected,
@@ -1312,7 +1839,7 @@ def test_windows_fake_excludes_contained_directory_and_root_links() -> None:
     assert api.handles == {}
 
 
-def test_windows_fake_accepts_absolute_contained_symlink() -> None:
+def test_windows_fake_rejects_absolute_contained_symlink() -> None:
     api = _FakeWindowsSourceApi()
     api.add_file(api.root_id, "target.py", b"VALUE = 1\n")
     api.add_symlink(
@@ -1323,15 +1850,85 @@ def test_windows_fake_accepts_absolute_contained_symlink() -> None:
         substitute=r"\??\C:\repo\target.py",
     )
 
-    observed = source_fingerprint_module._fingerprint_windows_repository(
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_binds_initial_symlink_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "first.py", b"SAME\n")
+    api.add_file(api.root_id, "second.py", b"SAME\n")
+    link_id = api.add_symlink(api.root_id, "current.py", "first.py")
+    original = api.nodes[link_id]["reparse"]
+    replacement = windows_fs_module.WindowsReparsePoint(
+        tag=windows_fs_module.IO_REPARSE_TAG_SYMLINK,
+        substitute_name="second.py",
+        print_name="second.py",
+        flags=windows_fs_module.SYMLINK_FLAG_RELATIVE,
+    )
+    real_resolve = source_fingerprint_module._resolved_windows_repository_file_at
+    swapped = False
+
+    @contextmanager
+    def swap_target(root, authority, relative, **kwargs):
+        nonlocal swapped
+        if swapped or relative != "current.py":
+            with real_resolve(root, authority, relative, **kwargs) as binding:
+                yield binding
+            return
+        swapped = True
+        api.nodes[link_id]["reparse"] = replacement
+        try:
+            with real_resolve(root, authority, relative, **kwargs) as binding:
+                yield binding
+        finally:
+            api.nodes[link_id]["reparse"] = original
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_windows_repository_file_at",
+        swap_target,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert swapped
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_revalidates_unresolved_excluded_target() -> None:
+    api = _FakeWindowsSourceApi()
+    hidden = api.add_directory(api.root_id, ".codenib-cache")
+    api.add_symlink(api.root_id, "visible.py", r".codenib-cache\later.py")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
         r"C:\repo",
         exclude_roots=(),
         version=SOURCE_FINGERPRINT_VERSION,
         api=api,
+        retain_binding=True,
     )
+    assert isinstance(binding, RepositorySourceBinding)
 
-    assert observed.file_count == 2
-    assert observed.value.startswith("sha256-v2:")
+    api.add_file(hidden, "later.py", b"VALUE = 1\n")
+
+    with pytest.raises(RepositoryChangedError):
+        binding.verify_snapshot()
+    binding.close()
     assert api.handles == {}
 
 
@@ -1606,11 +2203,13 @@ def test_windows_fake_scan_eio_keeps_primary_and_partial_handle_owner() -> None:
 def test_windows_resolution_construction_eio_keeps_primary_and_retry_owner() -> None:
     api = _FakeWindowsSourceApi()
     api.add_symlink(api.root_id, "current.py", "missing.py")
-    selected, authority, root_identity = (
-        contained_source_module._open_windows_pinned_repository_root(
-            Path(r"C:\repo"),
-            api=api,
-        )
+    (
+        selected,
+        authority,
+        root_identity,
+    ) = contained_source_module._open_windows_pinned_repository_root(
+        Path(r"C:\repo"),
+        api=api,
     )
     scan = source_fingerprint_module._scan_pinned_windows_repository(
         selected,
@@ -1754,9 +2353,12 @@ def test_windows_resolution_binding_slot_store_cancellation_closes_every_branch(
     case: str,
     timing: str,
 ) -> None:
-    api, authority, root_identity, expected_identity = (
-        _fake_windows_resolution_handoff_case(case)
-    )
+    (
+        api,
+        authority,
+        root_identity,
+        expected_identity,
+    ) = _fake_windows_resolution_handoff_case(case)
     interruption = KeyboardInterrupt(f"injected {case} {timing}")
 
     class InterruptingSlot(contained_source_module._SourceCleanupSlot):
@@ -1792,9 +2394,12 @@ def test_windows_resolution_binding_slot_store_cancellation_closes_every_branch(
 
 
 def test_windows_resolution_return_cancellation_closes_slot_owner() -> None:
-    api, authority, root_identity, expected_identity = (
-        _fake_windows_resolution_handoff_case("regular")
-    )
+    (
+        api,
+        authority,
+        root_identity,
+        expected_identity,
+    ) = _fake_windows_resolution_handoff_case("regular")
     method = contained_source_module._open_windows_resolution_at
     target_offset = _opcode_offset(
         method,
@@ -1844,9 +2449,12 @@ def test_windows_resolution_return_cancellation_closes_slot_owner() -> None:
 
 
 def test_windows_resolution_return_eio_retains_owner_without_double_close() -> None:
-    api, authority, root_identity, expected_identity = (
-        _fake_windows_resolution_handoff_case("regular")
-    )
+    (
+        api,
+        authority,
+        root_identity,
+        expected_identity,
+    ) = _fake_windows_resolution_handoff_case("regular")
     method = contained_source_module._open_windows_resolution_at
     target_offset = _opcode_offset(
         method,
@@ -2389,6 +2997,49 @@ def test_windows_fake_binding_close_does_not_close_reused_handle() -> None:
     api.close(reused)
 
 
+def test_windows_fake_binding_close_preserves_observable_reuse_after_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    target = authority.handles[-1]
+    replacement_id = api.add_directory()
+    real_close = api.close
+    interruption = KeyboardInterrupt("injected after observable HANDLE reuse")
+    replaced = False
+
+    def close_then_reuse(handle: int) -> None:
+        nonlocal replaced
+        real_close(handle)
+        if handle == target and not replaced:
+            api.handles[target] = replacement_id
+            api.offsets[target] = 0
+            replaced = True
+            raise interruption
+
+    monkeypatch.setattr(api, "close", close_then_reuse)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert binding.closed
+    assert api.handles == {target: replacement_id}
+    binding.close()
+    assert api.handles == {target: replacement_id}
+    monkeypatch.setattr(api, "close", real_close)
+    real_close(target)
+
+
 def test_windows_kernel_close_checks_closehandle_result() -> None:
     class CloseFailureApi(windows_fs_module.WindowsKernelApi):
         def _raise_last_error(self, context: str) -> None:
@@ -2867,16 +3518,15 @@ def test_fingerprint_rejects_file_swap_in_walker_to_open_window(
     assert foreign.read_text(encoding="utf-8") == "VALUE = 'foreign'\n"
 
 
-def test_fingerprint_accepts_absolute_contained_symlink(tmp_path: Path) -> None:
+def test_fingerprint_rejects_absolute_contained_symlink(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     target = repo / "target.py"
     target.write_text("VALUE = 1\n", encoding="utf-8")
     (repo / "link.py").symlink_to(target)
 
-    observed = fingerprint_repository(repo)
-
-    assert observed.file_count == 2
+    with pytest.raises(RepositoryChangedError):
+        fingerprint_repository(repo)
 
 
 def test_fingerprint_excludes_contained_directory_symlink_in_v1_and_v2(
@@ -2908,6 +3558,13 @@ def test_fingerprint_excludes_repository_root_directory_symlink_in_v1_and_v2(
     (repo / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
     link = repo / "root-link"
     link.symlink_to(repo if absolute else ".", target_is_directory=True)
+
+    if absolute:
+        with pytest.raises(RepositoryChangedError, match="read consistently"):
+            fingerprint_repository(repo)
+        with pytest.raises(RepositoryChangedError, match="read consistently"):
+            fingerprint_repository_v1_for_diagnostics(repo)
+        return
 
     current_with_link = fingerprint_repository(repo)
     legacy_with_link = fingerprint_repository_v1_for_diagnostics(repo)
@@ -3152,7 +3809,6 @@ def test_windows_real_source_v2_regular_and_contained_symlink_node(
     target.write_bytes(b"VALUE = 1\n")
     try:
         (repo / "relative.py").symlink_to("target.py")
-        (repo / "absolute.py").symlink_to(target)
     except OSError as exc:  # pragma: no cover - Windows policy dependent
         pytest.skip(f"Windows symlink creation is unavailable: {exc}")
 
@@ -3161,7 +3817,7 @@ def test_windows_real_source_v2_regular_and_contained_symlink_node(
     legacy = fingerprint_repository_v1_for_diagnostics(repo)
 
     assert first == second
-    assert first.file_count == legacy.file_count == 3
+    assert first.file_count == legacy.file_count == 2
     assert first.value.startswith("sha256-v2:")
     assert legacy.value.startswith("sha256:")
 

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -26,6 +26,16 @@ from codenib.web.repo_registry import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _stub_vector_authorization(monkeypatch: pytest.MonkeyPatch):
+    authorization = object()
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._mint_trusted_local_vector_authorization",
+        lambda *_args, **_kwargs: authorization,
+    )
+    return authorization
+
+
 def test_fresh_registry_is_isolated_from_singleton():
     singleton = SkillRegistry()
     reg_a = _fresh_registry()
@@ -388,7 +398,7 @@ def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
             self.loaded = None
             created.append(self)
 
-        def load(self, path):
+        def load(self, path, **_kwargs):
             self.loaded = path
 
     monkeypatch.setattr(
@@ -424,6 +434,57 @@ def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
     assert second.kwargs["embedding"] is first.embedding
 
 
+def test_vector_load_failure_does_not_publish_embedding_and_retains_cleanup_owner(
+    monkeypatch,
+):
+    primary = RuntimeError("vector load failed")
+    cleanup = KeyboardInterrupt("vector cleanup interrupted")
+    created = []
+
+    class FakeVectorStore:
+        def __init__(self, **_kwargs):
+            self.embedding = object()
+            self.close_calls = 0
+            created.append(self)
+
+        def load(self, _path, **_kwargs):
+            assert registry._embeddings == {}
+            raise primary
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise cleanup
+
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: FakeVectorStore,
+    )
+    registry = RepoRegistry(QAConfig(embedding_provider="huggingface"))
+    entry = SimpleNamespace(
+        path="/tmp/vector",
+        config={
+            "embedding_model": "vendor/model",
+            "embedding_provider": "huggingface",
+            "embedding_dimension": 384,
+        },
+    )
+
+    observed = None
+    try:
+        registry._load_vector_store(entry)
+    except BaseException as exc:  # noqa: B036 - assert primary/cleanup priority
+        observed = exc
+
+    assert observed is cleanup
+    assert observed.__cause__ is primary
+    assert registry._embeddings == {}
+    assert observed.vector_cleanup_owner is created[0]
+
+    observed.vector_cleanup_owner.close()
+    assert created[0].close_calls == 2
+
+
 def test_vector_store_restores_manifest_embedding_identity(monkeypatch):
     created = []
 
@@ -433,7 +494,7 @@ def test_vector_store_restores_manifest_embedding_identity(monkeypatch):
             self.embedding = kwargs.get("embedding") or object()
             created.append(self)
 
-        def load(self, _path):
+        def load(self, _path, **_kwargs):
             pass
 
     monkeypatch.setattr(
@@ -473,7 +534,7 @@ def test_vector_store_supports_legacy_prebuilt_route_fallback(monkeypatch):
             self.embedding = object()
             created.append(self)
 
-        def load(self, _path):
+        def load(self, _path, **_kwargs):
             pass
 
     monkeypatch.setattr(
@@ -509,7 +570,7 @@ def test_vector_store_fills_legacy_dimension_with_persisted_provider(monkeypatch
             self.embedding = object()
             created.append(self)
 
-        def load(self, _path):
+        def load(self, _path, **_kwargs):
             pass
 
     monkeypatch.setattr(
@@ -567,7 +628,7 @@ def test_vector_store_cache_separates_model_revisions(monkeypatch):
             self.embedding = kwargs.get("embedding") or object()
             created.append(self)
 
-        def load(self, _path):
+        def load(self, _path, **_kwargs):
             pass
 
     monkeypatch.setattr(
@@ -605,7 +666,7 @@ def test_remote_embedding_override_cannot_replace_artifact_route(
             self.embedding = object()
             created.append(self)
 
-        def load(self, _path):
+        def load(self, _path, **_kwargs):
             pass
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Retain authenticated source, archive, vector, and runtime authorities across production consumers so mutable paths and interrupted cleanup cannot silently replace verified bytes, leak native resources, or publish partially validated state.

This branch is rebased directly onto current `main` after #586 and #617 merged.

## Changes

- Bind source-fingerprint v2 computation and retained reads to lexical, no-follow filesystem authorities on POSIX and Windows, including hidden symlink targets and detached identity snapshots.
- Require explicit native-vector authorization at every production loader; verify captured trees before swapping live indices and preserve retryable FAISS ownership on cancellation or validation failure.
- Keep context-artifact, MCP, BM25, CLI, compiler, web, benchmark, and example consumers inside explicit binding and vector-store lifecycles.
- Restore bounded Windows archive extraction, preflight real ZIP central-directory entries before `ZipFile` allocation, and retain cleanup owners across malformed-input translation.
- Harden POSIX descriptor/OFD cleanup, fork behavior, Zoekt process handoff/stop retry, and source/archive cleanup without weakening absolute-symlink rejection.
- Record the remaining exact same-inode/same-FILE_ID close-after-cancellation ambiguity as a native-owner promotion gate rather than overstating the Python guarantee.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Post-rebase focused surface: `935 passed, 16 skipped, 11 deselected`.
- Post-rebase unit tier: `5010 passed, 71 skipped, 191 deselected`.
- The only manually deselected case is an exact-base cache-lock/umask failure reproduced on the prior clean base; it creates mode `0775` under the local `0002` umask.
- All repository pre-commit hooks and `git diff --check` passed.
- Python source/bytecode compatibility, updated atomic cleanup annotations, ZIP envelope preflight, vector consumers, and Zoekt lifecycle tests are included in the focused result.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Dependencies #584, #585, #586, and the extracted atomic-cleanup replacement #617 are merged into `main`; the branch was rebased after those merges.
