### PR TITLE
fix(vector): close native index authority boundaries

### DIFF
--- a/codenib/agent/runner.py
+++ b/codenib/agent/runner.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     List,
     Mapping,
@@ -66,6 +67,8 @@ from .tools.defaults import (
 from .tools.spec import ToolRegistry
 
 if TYPE_CHECKING:
+    from ..compiler.manifest import IndexEntry
+    from ..native_index_authorization import NativeIndexAuthorization
     from ..sandbox.protocol import SandboxSession
 
 logger = get_logger(__name__)
@@ -1623,6 +1626,12 @@ class CodeNibAgentOptions:
     bm25-only, even when ``embedding_search`` is in ``allowed_skills`` —
     CAR couldn't route to it at runtime anyway. (In ``manifest`` mode
     this rule is moot — the manifest dictates what exists.)
+
+    Native vector parsers are fail-closed. Pass either an already-bound
+    ``native_index_authorization`` or a
+    ``native_index_authorization_resolver`` that receives the exact manifest
+    ``IndexEntry`` about to be loaded. The two options are mutually exclusive;
+    neither can be derived from manifest fields by the agent runtime.
     """
 
     # --- index source: exactly one of these three must be set ---
@@ -1641,6 +1650,10 @@ class CodeNibAgentOptions:
     default_level: str = "l2"
     rebuild_indexes: bool = False
     skills_dir: Optional[str] = None
+    native_index_authorization: Optional["NativeIndexAuthorization"] = None
+    native_index_authorization_resolver: Optional[
+        Callable[["IndexEntry"], Optional["NativeIndexAuthorization"]]
+    ] = None
 
     # --- skill gating ---
     allowed_skills: Optional[List[str]] = None
@@ -1692,6 +1705,22 @@ def query(
     opts = options or CodeNibAgentOptions()
 
     _check_exactly_one_mode(opts)
+    if opts.contexts is not None and (
+        opts.native_index_authorization is not None
+        or opts.native_index_authorization_resolver is not None
+    ):
+        raise ValueError(
+            "native-index authorization options are not accepted in contexts "
+            "mode because its pre-built objects are not loaded by query()"
+        )
+    if (
+        opts.native_index_authorization is not None
+        and opts.native_index_authorization_resolver is not None
+    ):
+        raise ValueError(
+            "provide either native_index_authorization or "
+            "native_index_authorization_resolver, not both"
+        )
     if opts.sandbox is not None and opts.manifest is None:
         raise ValueError(
             "query() sandbox execution requires a trusted, revision-matched "
@@ -1788,6 +1817,10 @@ def query(
             skill_registry=registry,
             default_top_k=opts.default_top_k,
             default_level=opts.default_level,
+            native_index_authorization=opts.native_index_authorization,
+            native_index_authorization_resolver=(
+                opts.native_index_authorization_resolver
+            ),
         )
         SkillRegistry.reset()
         registry = SkillRegistry()
@@ -2041,6 +2074,8 @@ def _build_contexts(
         default_top_k=opts.default_top_k,
         default_level=opts.default_level,
         rebuild=opts.rebuild_indexes,
+        native_index_authorization=opts.native_index_authorization,
+        native_index_authorization_resolver=(opts.native_index_authorization_resolver),
     )
 
 

--- a/codenib/agent/runner.py
+++ b/codenib/agent/runner.py
@@ -37,6 +37,7 @@ from ..llm.litellm_chat import LiteLLMChat, RetryConfig
 from ..llm.usage import UsageTracker
 from ..log_utils import get_logger
 from ..paths import repo_index_dir
+from ..source_fingerprint import is_secure_source_fingerprint_v2
 from .agent_types import AgentResult, ToolCallRecord
 from .boundary import from_agent_repr_arg, is_line_bearing, to_agent_repr
 from .history import PlainChatHistory, TokenBudgetedChatHistory
@@ -250,6 +251,14 @@ class AgentRunner:
                 raise ValueError(
                     "sandbox execution requires matching source fingerprints in "
                     "the manifest and sandbox metadata"
+                )
+            if not (
+                is_secure_source_fingerprint_v2(manifest_fingerprint)
+                and is_secure_source_fingerprint_v2(sandbox_fingerprint)
+            ):
+                raise ValueError(
+                    "sandbox execution requires matching secure source "
+                    "fingerprint v2 identities"
                 )
             if manifest_fingerprint != sandbox_fingerprint:
                 raise ValueError(
@@ -1721,6 +1730,14 @@ def query(
             raise ValueError(
                 "sandbox execution requires matching source fingerprints in the "
                 "manifest and sandbox metadata"
+            )
+        if not (
+            is_secure_source_fingerprint_v2(manifest_fingerprint)
+            and is_secure_source_fingerprint_v2(sandbox_fingerprint)
+        ):
+            raise ValueError(
+                "sandbox execution requires matching secure source fingerprint "
+                "v2 identities"
             )
         if manifest_fingerprint != sandbox_fingerprint:
             raise ValueError(

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -34,6 +34,7 @@ from ..index.embedding.artifact_integrity import (
     require_complete_vector_view,
     validate_vector_config_artifact,
 )
+from ..native_index_authorization import _mint_trusted_local_admin_authorization
 from ..provider_routes import resolve_embedding_artifact_route
 from .portable_views import normalize_owned_query_view, validate_portable_query_view
 from .security import assert_no_credential_fields, assert_publishable_tree, file_sha256
@@ -250,6 +251,15 @@ def stage_context_artifact(
             artifact_root=manifest_root,
         )
     selected = _selected_views(manifest, views)
+    if "vector" in selected and not validate_checkout:
+        # Native parsing is an administrative action.  Even callers that have
+        # already performed a broader publication check must bind this exact
+        # manifest to the current source tree before this function may mint.
+        validate_checkout_identity(
+            repo_path,
+            manifest,
+            artifact_root=manifest_root,
+        )
     unsupported = sorted(set(selected) - PORTABLE_CONTEXT_VIEWS)
     if unsupported:
         raise ValueError(
@@ -289,24 +299,41 @@ def stage_context_artifact(
             if view == "vector":
                 require_complete_vector_view(source)
                 expected_config = entry.config.get("persistence_config_fingerprint")
-                if expected_config is not None:
-                    validate_vector_config_artifact(
-                        source,
-                        route.model.replace("/", "__"),
-                        expected_config,
+                if expected_config is None:
+                    raise ValueError(
+                        "portable vector staging requires its config fingerprint"
                     )
+                validate_vector_config_artifact(
+                    source,
+                    route.model.replace("/", "__"),
+                    expected_config,
+                )
             elif view == "bm25":
                 # Validate the committed source generation before copying and
                 # rewriting its machine-local metadata. Otherwise staging
                 # could bless a torn or tampered source with fresh hashes.
                 require_bm25_manifest_artifact(entry)
             relative = _copy_view(source, stage, view)
+            owned_view = stage.joinpath(*PurePosixPath(relative).parts)
+            native_authorization = None
+            if view == "vector":
+                copied_ownership = capture_directory_ownership(owned_view)
+                native_authorization = _mint_trusted_local_admin_authorization(
+                    copied_ownership,
+                    view_type="vector",
+                    semantic_contract=entry.config,
+                    evidence=(
+                        "context-stage-local-admin",
+                        "manifest-and-checkout-validated",
+                    ),
+                )
             adjustments = normalize_owned_query_view(
-                stage.joinpath(*PurePosixPath(relative).parts),
+                owned_view,
                 repo_path=repo_path,
                 view_type=view,
                 view_config=entry.config,
                 source_trust="trusted-local",
+                native_index_authorization=native_authorization,
             )
             entry_data = entry.to_dict()
             entry_data["path"] = relative

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -19,7 +19,9 @@ from typing import Any, Iterable, Literal, Mapping
 
 from .. import compat_pickle
 from .._atomic_directory import (
+    _annotate_secondary_error,
     capture_directory_ownership,
+    directory_ownership_file_records,
     directory_ownership_inventory,
     directory_ownership_root_identity,
 )
@@ -30,6 +32,12 @@ from ..index.embedding.artifact_integrity import (
     VECTOR_VIEW_UPDATE_MARKER,
 )
 from ..index.embedding.model_policy import resolve_embedding_load_policy_from_options
+from ..native_index_authorization import (
+    MissingNativeIndexAuthorizationError,
+    NativeIndexAuthorization,
+    require_native_index_authorization,
+    require_native_index_authorization_preflight,
+)
 from ..provider_routes import normalize_provider, resolve_embedding_artifact_route
 from .security import assert_publishable_json_value
 
@@ -54,6 +62,7 @@ _PICKLE_SUFFIXES = frozenset({".pkl", ".pickle"})
 _WINDOWS_REPARSE_POINT = 0x400
 _MAX_CONFIG_JSON_BYTES = 16 * 1024 * 1024
 _MAX_DOCUMENTS_JSON_BYTES = 256 * 1024 * 1024
+_MAX_FAISS_INDEX_BYTES = 8 * 1024 * 1024 * 1024
 _JSON_READ_CHUNK_BYTES = 1024 * 1024
 SourceTrust = Literal["portable-inert", "trusted-local"]
 
@@ -638,6 +647,9 @@ class _OwnedViewReader:
                 self._cached_payloads[relative] = payload
             if keep_descriptor:
                 os.lseek(descriptor, 0, os.SEEK_SET)
+                previous = self._authenticated_files.pop(relative, None)
+                if previous is not None:
+                    os.close(previous[0])
                 self._authenticated_files[relative] = (descriptor, opened)
                 descriptor = -1
         except OSError as exc:
@@ -985,6 +997,38 @@ def _owned_inventory_paths(root: Path, ownership: object, *, kind: str) -> set[P
     }
 
 
+def _authenticate_initial_file(
+    reader: _OwnedViewReader,
+    root: Path,
+    ownership: object,
+    path: Path,
+    *,
+    max_bytes: int,
+    cache_bytes: bool = False,
+    keep_descriptor: bool = False,
+) -> None:
+    """Bind one later read/parser to the bytes in the initial tree capture."""
+
+    relative = path.relative_to(root).as_posix()
+    record = next(
+        (
+            item
+            for item in directory_ownership_file_records(ownership)
+            if item.path == relative
+        ),
+        None,
+    )
+    if record is None:
+        raise ValueError(f"portable vector artifact is missing: {relative}")
+    reader.authenticate(
+        path,
+        {"size": record.size, "sha256": record.sha256},
+        cache_bytes=cache_bytes,
+        max_bytes=max_bytes,
+        keep_descriptor=keep_descriptor,
+    )
+
+
 def _pickle_paths(root: Path, ownership: object) -> list[Path]:
     return sorted(
         path
@@ -1123,7 +1167,7 @@ def _validate_vector_model_policy(
     *,
     ownership: object,
     model_suffix: str,
-    source_trust: SourceTrust,
+    native_authorized: bool,
 ) -> None:
     """Reject ambiguous multi-model trees and untrusted serialized objects."""
 
@@ -1154,7 +1198,7 @@ def _validate_vector_model_policy(
         )
 
     pickles = _pickle_paths(root, ownership)
-    if source_trust == "portable-inert":
+    if not native_authorized:
         _reject_inert_pickles(root, ownership)
         return
 
@@ -1316,17 +1360,13 @@ def _validate_vector_semantics(
 def _faiss_contract(
     path: Path,
     *,
-    reader: _OwnedViewReader | None = None,
+    reader: _OwnedViewReader,
 ) -> tuple[int, int, str, str, bool]:
     """Read the persisted index contract, importing FAISS on demand."""
 
     try:
         faiss = importlib.import_module("faiss")
-        index = (
-            faiss.read_index(str(path))
-            if reader is None
-            else reader.faiss_index(path, faiss)
-        )
+        index = reader.faiss_index(path, faiss)
         dimension = int(index.d)
         total = int(index.ntotal)
         is_trained = bool(index.is_trained)
@@ -1360,8 +1400,8 @@ def _validate_level_semantics(
     metric: object,
     index_type: str,
     count: int,
+    reader: _OwnedViewReader,
     canonicalize: bool = True,
-    reader: _OwnedViewReader | None = None,
 ) -> None:
     if not present:
         return
@@ -1437,9 +1477,9 @@ def _validate_vector_layout(
     expected_dimension: int,
     expected_metric: str,
     expected_index_type: str,
-    source_trust: SourceTrust,
+    native_authorized: bool,
+    reader: _OwnedViewReader,
     canonicalize_level_configs: bool = True,
-    reader: _OwnedViewReader | None = None,
 ) -> tuple[
     str,
     dict[Path, list[dict[str, Any]]],
@@ -1519,14 +1559,19 @@ def _validate_vector_layout(
         path = present[0]
         document_format = path.suffix.removeprefix(".")
         if document_format == "pkl":
-            if source_trust != "trusted-local":
-                raise ValueError(
-                    "portable-inert vector view must not deserialize documents"
+            if not native_authorized:
+                raise MissingNativeIndexAuthorizationError(
+                    "vector pickle deserialization requires external native "
+                    "authorization"
                 )
-            if reader is None:
-                raise RuntimeError(
-                    "trusted-local vector normalization requires an owned reader"
-                )
+            _authenticate_initial_file(
+                reader,
+                root,
+                ownership,
+                path,
+                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+                cache_bytes=True,
+            )
             payload = _normalize_pickle_documents(path, repo_path, reader=reader)
         else:
             payload = _normalize_json_documents(path, repo_path, reader=reader)
@@ -1536,22 +1581,14 @@ def _validate_vector_layout(
                 f"expected {count}, found {len(payload)}"
             )
         count = len(payload)
-        if reader is not None:
-            reader.pin_file(index_path)
-        dimension, total, metric, index_type, is_trained = _faiss_contract(
+        _authenticate_initial_file(
+            reader,
+            root,
+            ownership,
             index_path,
-            reader=reader,
+            max_bytes=_MAX_FAISS_INDEX_BYTES,
+            keep_descriptor=native_authorized,
         )
-        if dimension != expected_dimension:
-            raise ValueError(
-                f"portable vector FAISS dimension mismatch in {level}: "
-                f"expected {expected_dimension}, found {dimension}"
-            )
-        if total != count:
-            raise ValueError(
-                f"portable vector FAISS count mismatch in {level}: "
-                f"expected {count}, found {total}"
-            )
         derived_counts[level] = count
         if legacy_counts and count == 0:
             stale_paths.update(
@@ -1565,20 +1602,35 @@ def _validate_vector_layout(
                 if candidate in inventory_files
             )
             continue
-        if metric != expected_metric:
-            raise ValueError(
-                f"portable vector FAISS metric mismatch in {level}: "
-                f"expected {expected_metric}, found {metric}"
+        if native_authorized:
+            dimension, total, metric, index_type, is_trained = _faiss_contract(
+                index_path,
+                reader=reader,
             )
-        if index_type != expected_index_type:
-            raise ValueError(
-                f"portable vector FAISS index type mismatch in {level}: "
-                f"expected {expected_index_type}, found {index_type}"
-            )
-        if index_type == "ivf" and not is_trained:
-            raise ValueError(
-                f"portable vector active IVF index is untrained in {level}"
-            )
+            if dimension != expected_dimension:
+                raise ValueError(
+                    f"portable vector FAISS dimension mismatch in {level}: "
+                    f"expected {expected_dimension}, found {dimension}"
+                )
+            if total != count:
+                raise ValueError(
+                    f"portable vector FAISS count mismatch in {level}: "
+                    f"expected {count}, found {total}"
+                )
+            if metric != expected_metric:
+                raise ValueError(
+                    f"portable vector FAISS metric mismatch in {level}: "
+                    f"expected {expected_metric}, found {metric}"
+                )
+            if index_type != expected_index_type:
+                raise ValueError(
+                    f"portable vector FAISS index type mismatch in {level}: "
+                    f"expected {expected_index_type}, found {index_type}"
+                )
+            if index_type == "ivf" and not is_trained:
+                raise ValueError(
+                    f"portable vector active IVF index is untrained in {level}"
+                )
         level_config_path = level_path / f"config_{model_suffix}.json"
         _validate_level_semantics(
             level_config_path,
@@ -1815,7 +1867,7 @@ def _normalize_vector_view(
     initial_tree: object,
     reader: _OwnedViewReader,
     view_config: Mapping[str, Any],
-    source_trust: SourceTrust,
+    native_authorized: bool,
 ) -> dict[str, Any]:
     assert_no_secret_fields(view_config, source="portable vector view config")
     initial_files = _owned_inventory_paths(root, initial_tree, kind="file")
@@ -1843,7 +1895,7 @@ def _normalize_vector_view(
         root,
         ownership=initial_tree,
         model_suffix=model_suffix,
-        source_trust=source_trust,
+        native_authorized=native_authorized,
     )
     expected_config = view_config.get("persistence_config_fingerprint")
     config_path = root / f"config_{model_suffix}.json"
@@ -1892,7 +1944,7 @@ def _normalize_vector_view(
         expected_dimension=expected_dimension,
         expected_metric=expected_metric,
         expected_index_type=expected_index_type,
-        source_trust=source_trust,
+        native_authorized=native_authorized,
         reader=reader,
     )
     _validate_view_document_count(view_config, counts)
@@ -2066,12 +2118,14 @@ def normalize_owned_query_view(
     view_type: str,
     view_config: Mapping[str, Any],
     source_trust: SourceTrust = "portable-inert",
+    native_index_authorization: NativeIndexAuthorization | None = None,
 ) -> dict[str, Any]:
     """Normalize one copied view and return its portable identity adjustments.
 
     ``root`` must be a caller-owned copy that can be safely rewritten.
-    ``source_trust`` defaults to inert portable data; only ``trusted-local`` may
-    deserialize the exact legacy vector pickle names owned by this program.
+    ``source_trust`` is descriptive compatibility metadata, not authority.
+    Native FAISS or legacy pickle parsing requires a process-local authorization
+    bound to the initial captured tree and this exact view config.
     """
 
     if not isinstance(source_trust, str) or source_trust not in {
@@ -2079,12 +2133,55 @@ def normalize_owned_query_view(
         "trusted-local",
     }:
         raise ValueError(f"invalid portable query view source trust: {source_trust!r}")
+    if not isinstance(view_config, Mapping):
+        raise ValueError(f"portable {view_type} normalization requires its view config")
+    try:
+        view_config_snapshot = json.loads(
+            _json_bytes(dict(view_config)),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "portable query view config is not canonical JSON data"
+        ) from exc
+    if not isinstance(view_config_snapshot, dict):  # pragma: no cover - dict encoded
+        raise ValueError("portable query view config must be a JSON object")
+    if native_index_authorization is not None:
+        if view_type != "vector":
+            raise ValueError(
+                "native index authorization is only valid for vector views"
+            )
+        require_native_index_authorization_preflight(
+            native_index_authorization,
+            view_type="vector",
+        )
     normalized_root, repository = _owned_view_root(root, repo_path)
     try:
         initial_tree = capture_directory_ownership(normalized_root)
         reader = _OwnedViewReader(normalized_root, initial_tree)
     except (OSError, RuntimeError, ValueError) as exc:
         raise RuntimeError("portable query view could not be captured safely") from exc
+    native_authorized = False
+    if native_index_authorization is not None:
+        try:
+            require_native_index_authorization(
+                native_index_authorization,
+                initial_tree,
+                view_type="vector",
+                semantic_contract=view_config_snapshot,
+            )
+        except BaseException as primary_error:
+            try:
+                reader.close()
+            except BaseException as cleanup_error:  # noqa: B036 - preserve primary
+                _annotate_secondary_error(
+                    primary_error,
+                    "portable query view reader cleanup also failed",
+                    cleanup_error,
+                )
+            raise
+        native_authorized = True
     try:
         if view_type == "vector":
             return _normalize_vector_view(
@@ -2092,8 +2189,8 @@ def normalize_owned_query_view(
                 repository,
                 initial_tree=initial_tree,
                 reader=reader,
-                view_config=view_config,
-                source_trust=source_trust,
+                view_config=view_config_snapshot,
+                native_authorized=native_authorized,
             )
         if view_type == "bm25":
             return _normalize_bm25_view(
@@ -2254,6 +2351,7 @@ def _authenticate_vector_generation(
             root / level / index_name,
             index_record,
             cache_bytes=False,
+            max_bytes=_MAX_FAISS_INDEX_BYTES,
             keep_descriptor=True,
         )
     return config
@@ -2368,7 +2466,7 @@ def _validate_portable_vector_view(
         root,
         ownership=initial_tree,
         model_suffix=model_suffix,
-        source_trust="portable-inert",
+        native_authorized=False,
     )
     expected_config = view_config.get("persistence_config_fingerprint")
     if expected_config is None:
@@ -2407,7 +2505,7 @@ def _validate_portable_vector_view(
         expected_dimension=expected_dimension,
         expected_metric=expected_metric,
         expected_index_type=expected_index_type,
-        source_trust="portable-inert",
+        native_authorized=False,
         canonicalize_level_configs=False,
         reader=reader,
     )

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -917,6 +917,7 @@ def _audit_local_wiki(local) -> dict[str, object]:
 
     from .llm.litellm_chat import LiteLLMChat
     from .web.config import load_config
+    from .web.native_authority import authorize_local_manifest_vector
     from .web.repo_registry import RepoRegistry
     from .wiki.agent_wiki import AgentWiki
     from .wiki.quality import audit_wiki
@@ -931,7 +932,10 @@ def _audit_local_wiki(local) -> dict[str, object]:
     if local.runtime_env.get("CODENIB_EMBEDDING_API_KEY"):
         config.embedding_api_key = local.runtime_env["CODENIB_EMBEDDING_API_KEY"]
 
-    registry = RepoRegistry(config)
+    registry = RepoRegistry(
+        config,
+        native_index_authorization_resolver=authorize_local_manifest_vector,
+    )
     registry.load_all()
     bundle = registry.get(local.repo_id)
     if bundle is None:

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -517,13 +517,17 @@ def _run_mcp(args: argparse.Namespace) -> int:
         command = [
             "--artifact",
             str(Path(os.path.abspath(os.fspath(Path(args.artifact).expanduser())))),
-            "--log-level",
-            args.log_level,
-            "--tool-surface",
-            args.tool_surface,
         ]
         if args.repo is not None:
             command.extend(("--repo", str(resolve_repo_path(args.repo))))
+        command.extend(
+            (
+                "--log-level",
+                args.log_level,
+                "--tool-surface",
+                args.tool_surface,
+            )
+        )
         if args.repository:
             command.extend(("--repository", args.repository))
         mcp_main(command)
@@ -600,6 +604,18 @@ def _paths_overlap(first: Path, second: Path) -> bool:
     return first == second or first in second.parents or second in first.parents
 
 
+def _canonical_publication_path(value: str | Path) -> Path:
+    """Resolve existing output ancestors before validation and publication."""
+
+    lexical = Path(os.path.abspath(os.fspath(Path(value).expanduser())))
+    try:
+        return lexical.resolve(strict=False)
+    except (OSError, RuntimeError) as exc:
+        raise CLIError(
+            f"publication output path could not be resolved safely: {lexical}"
+        ) from exc
+
+
 def _validate_publish_outputs(
     repo_path: Path,
     *,
@@ -608,29 +624,33 @@ def _validate_publish_outputs(
 ) -> None:
     """Reject destructive publication paths before any index work starts."""
 
+    site_identity = (
+        _canonical_publication_path(site_output) if site_output is not None else None
+    )
+    context_identity = (
+        _canonical_publication_path(context_output)
+        if context_output is not None
+        else None
+    )
     if (
-        site_output is not None
-        and context_output is not None
-        and _paths_overlap(site_output, context_output)
+        site_identity is not None
+        and context_identity is not None
+        and _paths_overlap(site_identity, context_identity)
     ):
         raise CLIError("Wiki and context artifact outputs must not overlap")
 
     from .paths import repo_index_dir
 
     protected = (
-        (repo_path, "repository"),
+        (_canonical_publication_path(repo_path), "repository"),
         (
-            Path(
-                os.path.abspath(
-                    os.fspath(repo_index_dir(repo_path).expanduser()),
-                )
-            ),
+            _canonical_publication_path(repo_index_dir(repo_path)),
             "index state",
         ),
     )
     for output, output_name in (
-        (site_output, "Wiki"),
-        (context_output, "context artifact"),
+        (site_identity, "Wiki"),
+        (context_identity, "context artifact"),
     ):
         if output is None:
             continue
@@ -806,12 +826,10 @@ def _run_artifact_mcp_config(args: argparse.Namespace) -> int:
 def _run_publish(args: argparse.Namespace) -> int:
     repo_path = resolve_repo_path(args.repo)
     site_output = (
-        Path(os.path.abspath(os.fspath(Path(args.site_output).expanduser())))
-        if args.site_output
-        else None
+        _canonical_publication_path(args.site_output) if args.site_output else None
     )
     context_output = (
-        Path(os.path.abspath(os.fspath(Path(args.context_output).expanduser())))
+        _canonical_publication_path(args.context_output)
         if args.context_output
         else None
     )
@@ -839,11 +857,11 @@ def _run_publish(args: argparse.Namespace) -> int:
     from .web.static_export import export_static_wiki
 
     manifest = RepoManifest.load(manifest_path)
-    site_output = site_output or _default_distribution_dir(
-        manifest_path, "wiki", manifest.commit
+    site_output = site_output or _canonical_publication_path(
+        _default_distribution_dir(manifest_path, "wiki", manifest.commit)
     )
-    context_output = context_output or _default_distribution_dir(
-        manifest_path, "context", manifest.commit
+    context_output = context_output or _canonical_publication_path(
+        _default_distribution_dir(manifest_path, "context", manifest.commit)
     )
     _validate_publish_outputs(
         repo_path,

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -13,6 +13,7 @@ import os
 import re
 import shlex
 import shutil
+import stat
 import sys
 from collections import Counter
 from dataclasses import dataclass, field
@@ -218,8 +219,9 @@ def _split_values(values: Iterable[str] | None) -> list[str]:
 def detect_languages(repo_path: str | os.PathLike[str]) -> list[str]:
     """Detect supported source languages, ordered by source-file count."""
     from .languages import extension_to_language_map
+    from .source_fingerprint import lexical_repository_path
 
-    root = Path(repo_path).expanduser().resolve()
+    root = lexical_repository_path(repo_path)
     extension_map = extension_to_language_map("chunker")
     counts: Counter[str] = Counter()
 
@@ -260,8 +262,18 @@ def normalize_languages(values: Iterable[str]) -> list[str]:
 
 
 def resolve_repo_path(value: str) -> Path:
-    path = Path(value).expanduser().resolve()
-    if not path.is_dir():
+    from .source_fingerprint import lexical_repository_path
+
+    path = lexical_repository_path(value)
+    try:
+        metadata = path.lstat()
+    except OSError:
+        metadata = None
+    if (
+        metadata is None
+        or stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+    ):
         raise CLIError(f"repository directory does not exist: {path}")
     return path
 
@@ -271,22 +283,40 @@ def resolve_manifest_path(value: str) -> Path:
     from .compiler.manifest import MANIFEST_FILENAME
     from .paths import legacy_repo_index_dir, repo_index_dir
 
-    path = Path(value).expanduser().resolve()
-    if path.is_dir():
+    path = Path(os.path.abspath(os.fspath(Path(value).expanduser())))
+    try:
+        metadata = path.lstat()
+    except OSError:
+        metadata = None
+    if metadata is not None and stat.S_ISLNK(metadata.st_mode):
+        raise CLIError(f"manifest path must not be a symbolic link: {path}")
+    if metadata is not None and stat.S_ISDIR(metadata.st_mode):
         candidates = (
             repo_index_dir(path) / MANIFEST_FILENAME,
             legacy_repo_index_dir(path) / MANIFEST_FILENAME,
         )
         path = next(
-            (candidate for candidate in candidates if candidate.is_file()),
+            (
+                candidate
+                for candidate in candidates
+                if _is_regular_file_nofollow(candidate)
+            ),
             candidates[0],
         )
-    if not path.is_file():
+    if not _is_regular_file_nofollow(path):
         raise CLIError(
             f"manifest not found: {path}\n"
             "Run `codenib index <repo>` before starting this command."
         )
     return path
+
+
+def _is_regular_file_nofollow(path: Path) -> bool:
+    try:
+        metadata = path.lstat()
+    except OSError:
+        return False
+    return stat.S_ISREG(metadata.st_mode)
 
 
 def _selected_languages(repo_path: Path, explicit: Iterable[str]) -> list[str]:
@@ -484,17 +514,16 @@ def _run_mcp(args: argparse.Namespace) -> int:
     from .mcp.server import main as mcp_main
 
     if args.artifact:
-        repo_path = resolve_repo_path(args.repo)
         command = [
             "--artifact",
-            str(Path(args.artifact).expanduser().resolve()),
-            "--repo",
-            str(repo_path),
+            str(Path(os.path.abspath(os.fspath(Path(args.artifact).expanduser())))),
             "--log-level",
             args.log_level,
             "--tool-surface",
             args.tool_surface,
         ]
+        if args.repo is not None:
+            command.extend(("--repo", str(resolve_repo_path(args.repo))))
         if args.repository:
             command.extend(("--repository", args.repository))
         mcp_main(command)
@@ -516,7 +545,7 @@ def _run_export(args: argparse.Namespace) -> int:
     repo_path = resolve_repo_path(args.repo)
     manifest_path = resolve_manifest_path(str(repo_path))
     output_dir = (
-        Path(args.output).expanduser().resolve()
+        Path(os.path.abspath(os.fspath(Path(args.output).expanduser())))
         if args.output
         else manifest_path.parent / "static-wiki"
     )
@@ -590,7 +619,14 @@ def _validate_publish_outputs(
 
     protected = (
         (repo_path, "repository"),
-        (repo_index_dir(repo_path).expanduser().resolve(), "index state"),
+        (
+            Path(
+                os.path.abspath(
+                    os.fspath(repo_index_dir(repo_path).expanduser()),
+                )
+            ),
+            "index state",
+        ),
     )
     for output, output_name in (
         (site_output, "Wiki"),
@@ -615,7 +651,7 @@ def _run_artifact_pack(args: argparse.Namespace) -> int:
 
     manifest = RepoManifest.load(manifest_path)
     output_dir = (
-        Path(args.output).expanduser().resolve()
+        Path(os.path.abspath(os.fspath(Path(args.output).expanduser())))
         if args.output
         else _default_distribution_dir(
             manifest_path,
@@ -770,10 +806,12 @@ def _run_artifact_mcp_config(args: argparse.Namespace) -> int:
 def _run_publish(args: argparse.Namespace) -> int:
     repo_path = resolve_repo_path(args.repo)
     site_output = (
-        Path(args.site_output).expanduser().resolve() if args.site_output else None
+        Path(os.path.abspath(os.fspath(Path(args.site_output).expanduser())))
+        if args.site_output
+        else None
     )
     context_output = (
-        Path(args.context_output).expanduser().resolve()
+        Path(os.path.abspath(os.fspath(Path(args.context_output).expanduser())))
         if args.context_output
         else None
     )
@@ -2014,8 +2052,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     mcp_parser.add_argument(
         "--repo",
-        default=".",
-        help="exact checkout bound to --artifact",
+        help="optional exact checkout bound to --artifact",
     )
     mcp_parser.add_argument(
         "--repository",

--- a/codenib/clients/_manifest.py
+++ b/codenib/clients/_manifest.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from typing import Callable
@@ -14,7 +15,8 @@ from codenib.compiler.manifest import MANIFEST_FILENAME, RepoManifest
 from codenib.paths import legacy_repo_index_dir, repo_index_dir
 from codenib.source_fingerprint import (
     fingerprint_repository,
-    repository_source_is_dirty,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
 )
 
 ManifestResolver = Callable[[Path], str | Path]
@@ -58,39 +60,25 @@ def _validate_source_identity(
             f"manifest: {head} != {expected_commit}"
         )
 
-    excluded = (repo_index_dir(repo), legacy_repo_index_dir(repo))
-    if expected_commit and head == expected_commit:
-        if not repository_source_is_dirty(repo, exclude_roots=excluded):
-            return
-        if not manifest.source_fingerprint:
-            raise ValueError(
-                f"{integration_name} checkout has source changes that the CodeNib "
-                "manifest cannot validate"
-            )
-
-    if manifest.source_fingerprint:
-        observed = fingerprint_repository(repo, exclude_roots=excluded).value
-        if observed != manifest.source_fingerprint:
-            raise ValueError(
-                f"{integration_name} checkout source fingerprint does not match the "
-                "CodeNib manifest"
-            )
-        return
-
-    if expected_commit:
+    if not is_secure_source_fingerprint_v2(manifest.source_fingerprint):
         raise ValueError(
-            f"{integration_name} cannot read the checkout revision required by the "
+            f"{integration_name} CodeNib manifest has no secure v2 source "
+            "fingerprint; rebuild the index"
+        )
+
+    excluded = (repo_index_dir(repo), legacy_repo_index_dir(repo))
+    observed = fingerprint_repository(repo, exclude_roots=excluded).value
+    if observed != manifest.source_fingerprint:
+        raise ValueError(
+            f"{integration_name} checkout source fingerprint does not match the "
             "CodeNib manifest"
         )
-    raise ValueError(
-        f"{integration_name} CodeNib manifest has no commit or source fingerprint"
-    )
 
 
 def resolve_checkout_manifest(repo_path: str | Path) -> Path:
     """Resolve the canonical or legacy CodeNib manifest for one checkout."""
 
-    repo = Path(repo_path).expanduser().resolve()
+    repo = lexical_repository_path(repo_path)
     candidates = (
         repo_index_dir(repo) / MANIFEST_FILENAME,
         legacy_repo_index_dir(repo) / MANIFEST_FILENAME,
@@ -104,7 +92,7 @@ def resolve_checkout_manifest(repo_path: str | Path) -> Path:
             f"CodeNib manifest not found for {repo}: {manifest_path}. "
             "Run `codenib index <repo> --preset graph` first."
         )
-    return manifest_path.resolve()
+    return manifest_path
 
 
 def select_checkout_manifest(
@@ -116,13 +104,15 @@ def select_checkout_manifest(
 ) -> Path:
     """Select and validate the manifest bound to an external-policy request."""
 
-    repo = Path(repo_path).expanduser().resolve()
+    repo = lexical_repository_path(repo_path)
     if manifest_path is not None and manifest_resolver is not None:
         raise ValueError("Specify either manifest_path or manifest_resolver, not both")
     if manifest_path is not None:
-        selected = Path(manifest_path).expanduser().resolve()
+        selected = Path(os.path.abspath(os.fspath(Path(manifest_path).expanduser())))
     elif manifest_resolver is not None:
-        selected = Path(manifest_resolver(repo)).expanduser().resolve()
+        selected = Path(
+            os.path.abspath(os.fspath(Path(manifest_resolver(repo)).expanduser()))
+        )
     else:
         selected = resolve_checkout_manifest(repo)
 
@@ -130,7 +120,7 @@ def select_checkout_manifest(
         raise FileNotFoundError(f"CodeNib manifest not found: {selected}")
     manifest = RepoManifest.load(selected)
     if manifest.repo_path:
-        manifest_repo = Path(manifest.repo_path).expanduser().resolve()
+        manifest_repo = lexical_repository_path(manifest.repo_path)
         if manifest_repo != repo:
             raise ValueError(
                 f"{integration_name} repo_path does not match the CodeNib manifest: "

--- a/codenib/clients/agentless_agent.py
+++ b/codenib/clients/agentless_agent.py
@@ -25,6 +25,7 @@ from codenib.eval.benchmarks.agentless import (
 )
 from codenib.integrations._repository import RepositoryEntity
 from codenib.integrations.agentless import AgentlessRepositoryProvider
+from codenib.source_fingerprint import lexical_repository_path
 from codenib.types import NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
 
 
@@ -198,7 +199,7 @@ class AgentlessAgent:
     ) -> BaselineRunResult:
         """Localize one issue through the shared baseline interface."""
 
-        repo = Path(repo_path).expanduser().resolve()
+        repo = lexical_repository_path(repo_path)
         if not repo.is_dir():
             return BaselineRunResult(
                 success=False,

--- a/codenib/clients/cosil_agent.py
+++ b/codenib/clients/cosil_agent.py
@@ -23,6 +23,7 @@ from codenib.eval.benchmarks.cosil import (
     parse_cosil_locations,
 )
 from codenib.integrations.cosil import CoSILRepositoryProvider, get_cosil_tool_schemas
+from codenib.source_fingerprint import lexical_repository_path
 
 _FALSE_OBSERVATION = (
     "I have already checked this function/class and it is not related to the bug. "
@@ -157,7 +158,7 @@ class CoSILAgent:
         repo_path: str,
         context: Optional[Mapping[str, Any]] = None,
     ) -> BaselineRunResult:
-        repo = Path(repo_path).expanduser().resolve()
+        repo = lexical_repository_path(repo_path)
         if not repo.is_dir():
             return BaselineRunResult(
                 success=False,

--- a/codenib/clients/locagent_agent.py
+++ b/codenib/clients/locagent_agent.py
@@ -19,6 +19,7 @@ from codenib.eval.baseline import BaselineLocation, BaselineRunResult
 from codenib.eval.benchmarks.locagent import LocAgentLocation, parse_locagent_locations
 from codenib.integrations._repository import RepositoryAdapter, RepositoryEntity
 from codenib.integrations.locagent import LocAgentToolProvider
+from codenib.source_fingerprint import lexical_repository_path
 from codenib.types import (
     NODE_TYPE_CLASS,
     NODE_TYPE_FUNCTION,
@@ -280,7 +281,7 @@ class LocAgentAgent:
     ) -> BaselineRunResult:
         """Localize one task through the shared external-agent interface."""
 
-        repo = Path(repo_path).expanduser().resolve()
+        repo = lexical_repository_path(repo_path)
         if not repo.is_dir():
             return BaselineRunResult(
                 success=False,

--- a/codenib/clients/orcaloca_agent.py
+++ b/codenib/clients/orcaloca_agent.py
@@ -24,6 +24,7 @@ from codenib.clients._manifest import (
 )
 from codenib.eval.baseline import BaselineLocation, BaselineRunResult
 from codenib.eval.benchmarks.orcaloca import OrcaLocaLocation, parse_orcaloca_locations
+from codenib.source_fingerprint import lexical_repository_path
 
 OrcaLocaPayload = str | Mapping[str, Any] | Sequence[Mapping[str, Any]]
 
@@ -151,7 +152,7 @@ class OrcaLocaAgent:
     ) -> BaselineRunResult:
         """Localize one task using the shared external-agent interface."""
 
-        repo = Path(repo_path).expanduser().resolve()
+        repo = lexical_repository_path(repo_path)
         if not repo.is_dir():
             return BaselineRunResult(
                 success=False,

--- a/codenib/compiler/artifact_quality.py
+++ b/codenib/compiler/artifact_quality.py
@@ -12,8 +12,15 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
 from .. import compat_pickle
+from .._captured_directory import AuthenticatedSnapshotReader
 from ..git_snapshot import GitSourceSurface, normalize_repository_path
 from ..graph.code_graph import CodeGraph
+from ..index.embedding.artifact_integrity import AuthenticatedVectorView
+from ..native_index_authorization import (
+    NativeIndexAuthorization,
+    require_native_index_authorization,
+    require_native_index_authorization_preflight,
+)
 from ..types import NODE_TYPE_DIRECTORY, NODE_TYPE_FILE, ROOT_NODE, is_symbol_node
 
 ARTIFACT_QUALITY_SCHEMA_VERSION = 1
@@ -242,32 +249,37 @@ def constrain_and_assess_graph_artifact(
 
 
 def _load_vector_level(
-    root: Path,
+    view: AuthenticatedVectorView,
     level: str,
     model_suffix: str,
 ) -> tuple[list[Any], int, list[str], bool]:
     import faiss
 
     failures = []
-    level_root = root / level
-    config_path = level_root / f"config_{model_suffix}.json"
-    index_path = level_root / f"index_{model_suffix}.faiss"
-    documents_path = level_root / f"documents_{model_suffix}.pkl"
-    for path in (config_path, index_path, documents_path):
-        if not path.is_file():
-            failures.append(f"missing:{path.name}")
+    config_relative = f"{level}/config_{model_suffix}.json"
+    index_relative = f"{level}/index_{model_suffix}.faiss"
+    documents_relative = f"{level}/documents_{model_suffix}.pkl"
+    for relative in (config_relative, index_relative, documents_relative):
+        if not view.has_file(relative):
+            failures.append(f"missing:{Path(relative).name}")
     if failures:
         return [], 0, failures, False
 
     try:
-        config = json.loads(config_path.read_text(encoding="utf-8"))
-        with documents_path.open("rb") as handle:
-            documents = list(compat_pickle.load(handle))
-        index = faiss.read_index(str(index_path))
+        config = view.load_json_object(
+            config_relative,
+            label=f"vector {level} quality config",
+        )
+        with view.authenticated_snapshot(documents_relative) as (snapshot, _record):
+            documents = list(compat_pickle.load(AuthenticatedSnapshotReader(snapshot)))
+        with view.authenticated_snapshot(index_relative) as (snapshot, _record):
+            source = AuthenticatedSnapshotReader(snapshot)
+            callback_reader = faiss.PyCallbackIOReader(  # type: ignore[attr-defined]
+                source.read
+            )
+            index = faiss.read_index(callback_reader)
     except Exception as exc:
         return [], 0, [f"unreadable_level:{type(exc).__name__}"], False
-    if not isinstance(config, Mapping):
-        return [], 0, ["invalid_level_config"], False
     expected = config.get("num_documents")
     if not isinstance(expected, int) or isinstance(expected, bool) or expected < 0:
         failures.append("invalid_document_config_count")
@@ -350,38 +362,55 @@ def vector_artifact_files_match(
     ) == dict(expected_fingerprints)
 
 
-def assess_vector_artifact(
-    root: str | Path,
+def _captured_vector_artifact_file_fingerprints(
+    view: AuthenticatedVectorView,
+    *,
+    model_suffix: str,
+    build_levels: Sequence[str],
+) -> dict[str, dict[str, Any]]:
+    """Return fingerprints from the exact tree authorized for assessment."""
+
+    fingerprints: dict[str, dict[str, Any]] = {}
+    for relative_path in _vector_artifact_relative_paths(model_suffix, build_levels):
+        relative = relative_path.as_posix()
+        if not view.has_file(relative):
+            continue
+        record = view.record(relative)
+        fingerprints[relative] = {
+            "size": record.size,
+            "sha256": record.sha256,
+        }
+    return fingerprints
+
+
+def _assess_captured_vector_artifact(
     *,
     embedding_model: str,
     build_levels: Sequence[str],
     surface: GitSourceSurface,
     expected_artifact: Mapping[str, Any],
     required_l0_files: Sequence[str] = (),
+    authenticated_view: AuthenticatedVectorView,
 ) -> dict[str, Any]:
-    """Validate vector files, provenance, commit paths, and L0 GT coverage."""
-
-    artifact_root = Path(root)
     model_suffix = embedding_model.replace("/", "__")
-    top_config_path = artifact_root / f"config_{model_suffix}.json"
+    top_config_relative = f"config_{model_suffix}.json"
     failures: list[str] = []
     top_config: Mapping[str, Any] = {}
-    if not top_config_path.is_file():
+    if not authenticated_view.has_file(top_config_relative):
         failures.append("missing_top_config")
     else:
         try:
-            top_config = json.loads(top_config_path.read_text(encoding="utf-8"))
+            top_config = authenticated_view.load_json_object(
+                top_config_relative,
+                label="vector quality top-level config",
+            )
         except Exception as exc:
             failures.append(f"unreadable_top_config:{type(exc).__name__}")
         else:
-            if not isinstance(top_config, Mapping):
-                failures.append("invalid_top_config")
-                top_config = {}
-            else:
-                if top_config.get("embedding_model") != embedding_model:
-                    failures.append("embedding_model_mismatch")
-                if top_config.get("artifact") != dict(expected_artifact):
-                    failures.append("artifact_identity_mismatch")
+            if top_config.get("embedding_model") != embedding_model:
+                failures.append("embedding_model_mismatch")
+            if top_config.get("artifact") != dict(expected_artifact):
+                failures.append("artifact_identity_mismatch")
 
     levels: dict[str, Any] = {}
     all_paths: set[str] = set()
@@ -391,9 +420,8 @@ def assess_vector_artifact(
     normalized_levels = tuple(dict.fromkeys(level.lower() for level in build_levels))
     unexpected_levels = []
     for level in sorted({"l0", "l2"} - set(normalized_levels)):
-        level_root = artifact_root / level
         if any(
-            (level_root / name).exists()
+            authenticated_view.has_file(f"{level}/{name}")
             for name in (
                 f"config_{model_suffix}.json",
                 f"index_{model_suffix}.faiss",
@@ -405,7 +433,7 @@ def assess_vector_artifact(
             failures.append(f"unexpected_level:{level}")
     for level in normalized_levels:
         documents, vector_count, level_failures, loaded = _load_vector_level(
-            artifact_root, level, model_suffix
+            authenticated_view, level, model_suffix
         )
         paths = set()
         for document_index, document in enumerate(documents):
@@ -447,9 +475,9 @@ def assess_vector_artifact(
     missing = tuple(path for path in required if path not in l0_paths)
     if missing:
         failures.append("missing_required_l0_files")
-    file_fingerprints = vector_artifact_file_fingerprints(
-        artifact_root,
-        embedding_model=embedding_model,
+    file_fingerprints = _captured_vector_artifact_file_fingerprints(
+        authenticated_view,
+        model_suffix=model_suffix,
         build_levels=normalized_levels,
     )
     expected_file_count = len(
@@ -479,6 +507,68 @@ def assess_vector_artifact(
         "failure_names": sorted(set(failures)),
         "passed": not failures,
     }
+
+
+def assess_vector_artifact(
+    root: str | Path,
+    *,
+    embedding_model: str,
+    build_levels: Sequence[str],
+    surface: GitSourceSurface,
+    expected_artifact: Mapping[str, Any],
+    required_l0_files: Sequence[str] = (),
+    authenticated_view: AuthenticatedVectorView,
+    native_index_authorization: NativeIndexAuthorization | None,
+) -> dict[str, Any]:
+    """Validate one externally authorized, already-captured vector artifact.
+
+    The assessor is a generic artifact consumer, not an administrative trust
+    boundary: callers must supply both the exact captured view and an
+    out-of-band capability bound to that view and ``expected_artifact``.  No
+    artifact field can authorize the pickle or FAISS parsers used below.
+    """
+
+    from .._atomic_directory import lexical_directory_path
+
+    require_native_index_authorization_preflight(
+        native_index_authorization,
+        view_type="vector",
+    )
+    artifact_root = lexical_directory_path(Path(root))
+    if authenticated_view.root != artifact_root:
+        raise ValueError("authenticated vector view does not match assessment root")
+    require_native_index_authorization(
+        native_index_authorization,
+        authenticated_view.ownership,
+        view_type="vector",
+        semantic_contract=expected_artifact,
+    )
+
+    primary_error: BaseException | None = None
+    try:
+        return _assess_captured_vector_artifact(
+            embedding_model=embedding_model,
+            build_levels=build_levels,
+            surface=surface,
+            expected_artifact=expected_artifact,
+            required_l0_files=required_l0_files,
+            authenticated_view=authenticated_view,
+        )
+    except BaseException as exc:
+        primary_error = exc
+        raise
+    finally:
+        try:
+            authenticated_view.verify_final()
+        except BaseException as verification_error:
+            if primary_error is None:
+                raise
+            add_note = getattr(primary_error, "add_note", None)
+            if callable(add_note):
+                add_note(
+                    "secondary authenticated-vector final verification failure: "
+                    f"{type(verification_error).__name__}: {verification_error}"
+                )
 
 
 def write_artifact_quality(path: str | Path, report: Mapping[str, Any]) -> None:

--- a/codenib/compiler/cache_lock.py
+++ b/codenib/compiler/cache_lock.py
@@ -109,6 +109,55 @@ def _remember_cleanup_interruption(
     return deferred if deferred is not None else interruption
 
 
+def _annotate_secondary_cleanup_error(
+    primary_error: BaseException,
+    label: str,
+    cleanup_error: BaseException,
+) -> None:
+    """Keep cleanup diagnostics reachable without replacing the first fault."""
+
+    message = f"{label}: {cleanup_error!r}"
+    try:
+        add_note = getattr(primary_error, "add_note", None)
+        if callable(add_note):
+            add_note(message)
+            return
+    except BaseException:  # noqa: B036 - annotation must not mask primary
+        pass
+    try:
+        notes = list(getattr(primary_error, "_codenib_cleanup_notes", ()))
+        notes.append(message)
+        primary_error._codenib_cleanup_notes = tuple(notes)  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - primary still remains authoritative
+        pass
+    try:
+        if primary_error.__cause__ is None:
+            primary_error.__cause__ = cleanup_error
+    except BaseException:  # noqa: B036 - primary still remains authoritative
+        pass
+
+
+def _finish_cleanup_preserving_primary(
+    primary_error: BaseException | None,
+    label: str,
+    cleanup: Callable[[], BaseException | None],
+) -> None:
+    """Finish cleanup, propagating it only when no earlier failure exists."""
+
+    try:
+        deferred = cleanup()
+        if deferred is not None:
+            raise deferred
+    except BaseException as cleanup_error:  # noqa: B036 - preserve first fault
+        if primary_error is None:
+            raise
+        _annotate_secondary_cleanup_error(
+            primary_error,
+            label,
+            cleanup_error,
+        )
+
+
 def _posix_lifecycle_guard_is_owned() -> bool:
     """Return whether the current CPython thread owns the lifecycle RLock."""
 
@@ -467,6 +516,7 @@ def _open_posix_cache_directory(cache_dir: str | Path) -> Iterator[tuple[Path, i
         descriptor = os.open(cache, _directory_open_flags())
     except OSError as exc:
         raise RuntimeError(f"could not open compiler cache directory: {cache}") from exc
+    primary_error: BaseException | None = None
     try:
         metadata = os.fstat(descriptor)
         if not stat.S_ISDIR(metadata.st_mode) or _is_reparse_point(metadata):
@@ -477,8 +527,15 @@ def _open_posix_cache_directory(cache_dir: str | Path) -> Iterator[tuple[Path, i
         flags = fcntl.fcntl(descriptor, fcntl.F_GETFD)
         fcntl.fcntl(descriptor, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
         yield cache, descriptor
+    except BaseException as exc:  # noqa: B036 - cleanup preserves first fault
+        primary_error = exc
+        raise
     finally:
-        os.close(descriptor)
+        _finish_cleanup_preserving_primary(
+            primary_error,
+            "compiler cache directory cleanup also failed",
+            lambda: _close_descriptor_for_cleanup(descriptor, None),
+        )
 
 
 def _posix_lock_flags(*, create: bool) -> int:
@@ -589,25 +646,29 @@ def _open_posix_lock_file(
                     raise RuntimeError(
                         f"could not open compiler cache lock: {lock_path}"
                     ) from exc
-                deferred = _close_owned_descriptor_for_cleanup(
-                    descriptor,
-                    descriptor_owner,
-                    None,
-                    active_registry=_ACTIVE_POSIX_LOCK_DESCRIPTORS,
-                )
-                if deferred is not None:
-                    raise deferred
-                raise
-            except BaseException:
-                if descriptor is not None:
-                    deferred = _close_owned_descriptor_for_cleanup(
+                _finish_cleanup_preserving_primary(
+                    exc,
+                    "compiler cache lock acquisition cleanup also failed",
+                    lambda descriptor=descriptor: _close_owned_descriptor_for_cleanup(
                         descriptor,
                         descriptor_owner,
                         None,
                         active_registry=_ACTIVE_POSIX_LOCK_DESCRIPTORS,
+                    ),
+                )
+                raise
+            except BaseException as exc:
+                if descriptor is not None:
+                    _finish_cleanup_preserving_primary(
+                        exc,
+                        "compiler cache lock acquisition cleanup also failed",
+                        lambda descriptor=descriptor: _close_owned_descriptor_for_cleanup(
+                            descriptor,
+                            descriptor_owner,
+                            None,
+                            active_registry=_ACTIVE_POSIX_LOCK_DESCRIPTORS,
+                        ),
                     )
-                    if deferred is not None:
-                        raise deferred
                 raise
             return descriptor, identity
         raise RuntimeError(f"compiler cache lock changed repeatedly: {lock_path}")
@@ -647,6 +708,7 @@ def _posix_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
         lock_path = cache / COMPILER_CACHE_LOCK_FILENAME
         descriptor_owner: list[int] = []
         locked = False
+        primary_error: BaseException | None = None
         try:
             descriptor, identity = _open_posix_lock_file(
                 cache,
@@ -663,11 +725,21 @@ def _posix_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
                 expected_identity=identity,
             )
             yield
+        except BaseException as exc:  # noqa: B036 - cleanup preserves first fault
+            primary_error = exc
+            raise
         finally:
             # The child-side at-fork callback already closed its inherited
             # descriptor.  The generation guard prevents closing a reused fd.
             if descriptor_owner and _POSIX_FORK_GENERATION == owner_generation:
-                _close_posix_lock_file(descriptor_owner, locked=locked)
+                _finish_cleanup_preserving_primary(
+                    primary_error,
+                    "compiler cache lock cleanup also failed",
+                    lambda: _close_posix_lock_file(
+                        descriptor_owner,
+                        locked=locked,
+                    ),
+                )
 
 
 def _windows_identity(metadata: os.stat_result, path: Path) -> tuple[int, ...]:
@@ -768,23 +840,27 @@ def _open_windows_lock_file(
                 raise RuntimeError(
                     f"could not open compiler cache lock: {lock_path}"
                 ) from exc
-            deferred = _close_owned_descriptor_for_cleanup(
-                descriptor,
-                owner,
-                None,
-            )
-            if deferred is not None:
-                raise deferred
-            raise
-        except BaseException:
-            if descriptor is not None:
-                deferred = _close_owned_descriptor_for_cleanup(
+            _finish_cleanup_preserving_primary(
+                exc,
+                "compiler cache lock acquisition cleanup also failed",
+                lambda descriptor=descriptor: _close_owned_descriptor_for_cleanup(
                     descriptor,
                     owner,
                     None,
+                ),
+            )
+            raise
+        except BaseException as exc:
+            if descriptor is not None:
+                _finish_cleanup_preserving_primary(
+                    exc,
+                    "compiler cache lock acquisition cleanup also failed",
+                    lambda descriptor=descriptor: _close_owned_descriptor_for_cleanup(
+                        descriptor,
+                        owner,
+                        None,
+                    ),
                 )
-                if deferred is not None:
-                    raise deferred
             raise
         return descriptor, identity
     raise RuntimeError(f"compiler cache lock changed repeatedly: {lock_path}")
@@ -852,6 +928,7 @@ def _windows_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
     cache_identity = _validate_windows_cache(cache)
     descriptor_owner: list[int] = []
     locked = False
+    primary_error: BaseException | None = None
     try:
         descriptor, lock_identity = _open_windows_lock_file(
             cache,
@@ -867,9 +944,19 @@ def _windows_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
             expected_identity=lock_identity,
         )
         yield
+    except BaseException as exc:  # noqa: B036 - cleanup preserves first fault
+        primary_error = exc
+        raise
     finally:
         if descriptor_owner:
-            _close_windows_lock_file(descriptor_owner, locked=locked)
+            _finish_cleanup_preserving_primary(
+                primary_error,
+                "compiler cache lock cleanup also failed",
+                lambda: _close_windows_lock_file(
+                    descriptor_owner,
+                    locked=locked,
+                ),
+            )
 
 
 @contextmanager

--- a/codenib/compiler/checkout_identity.py
+++ b/codenib/compiler/checkout_identity.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-from ..source_fingerprint import fingerprint_repository
+from ..source_fingerprint import (
+    fingerprint_repository,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
+)
 from .manifest import RepoManifest
 
 
@@ -33,25 +37,30 @@ def validate_checkout_identity(
 ) -> None:
     """Reject source or commit drift between a checkout and its manifest."""
 
-    repo_path = repo_path.expanduser().resolve()
-    artifact_root = artifact_root.expanduser().resolve()
+    repo_path = lexical_repository_path(repo_path)
+    artifact_root = lexical_repository_path(artifact_root)
     excluded_roots = (
         (artifact_root,)
         if artifact_root != repo_path and repo_path in artifact_root.parents
         else ()
     )
     expected_source = (manifest.source_fingerprint or "").strip()
-    if expected_source:
-        actual_source = fingerprint_repository(
-            repo_path,
-            exclude_roots=excluded_roots,
-        ).value
-        if actual_source != expected_source:
-            raise ValueError(
-                "repository source files do not match the indexed content. "
-                "Rebuild the index for the current working tree before serving "
-                "or publishing context."
-            )
+    if not is_secure_source_fingerprint_v2(expected_source):
+        raise ValueError(
+            "repository manifest uses a legacy or unsupported source fingerprint "
+            "(including a missing value). Rebuild the index before serving or "
+            "publishing context."
+        )
+    actual_source = fingerprint_repository(
+        repo_path,
+        exclude_roots=excluded_roots,
+    ).value
+    if actual_source != expected_source:
+        raise ValueError(
+            "repository source files do not match the indexed content. "
+            "Rebuild the index for the current working tree before serving "
+            "or publishing context."
+        )
 
     expected = (manifest.commit or "").strip()
     actual = checkout_commit(repo_path)

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -46,6 +46,10 @@ from .verification import NullVerifier, UpdateVerifier, VerificationResult
 logger = logging.getLogger(__name__)
 
 
+class _AtomicIncrementalRebuildRequired(RuntimeError):
+    """Signal that vector deltas must use the complete-generation builder."""
+
+
 def _git_output(repo_path: str, *args: str) -> str:
     """Run git in *repo_path* and return stripped stdout ("" on any failure)."""
     try:
@@ -270,52 +274,122 @@ class VectorIndexBuilder:
         return vector_config_artifact_record(output_dir, model_suffix)
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
+        from pathlib import Path, PurePosixPath
+
+        from .._atomic_directory import (
+            PublicationDirectoryReader,
+            reopen_authenticated_directory,
+        )
+        from .._captured_directory import OwnedDirectoryStage
         from ..index.embedding.artifact_integrity import (
             begin_vector_view_update,
             finish_vector_view_update,
         )
+        from ..index.embedding.builders import _PrivateBuildDirectory
 
-        output_dir: str = kwargs["output_dir"]
-        begin_vector_view_update(output_dir)
-        status = self._build_once(scope, **kwargs)
-        finish_vector_view_update(output_dir)
+        output_path = Path(kwargs["output_dir"])
+        publication_stage = OwnedDirectoryStage.prepare(
+            output_path,
+            allow_empty_destination=True,
+        )
+
+        def copy_generation(reader: PublicationDirectoryReader) -> None:
+            for record in reader.file_records():
+                relative = PurePosixPath(record.path)
+                with reader.iter_authenticated_chunks(
+                    relative,
+                    max_bytes=record.size,
+                ) as chunks:
+                    publication_stage.write_file(
+                        relative,
+                        chunks,
+                        mode=record.mode,
+                        max_bytes=record.size,
+                    )
+
+        try:
+            with _PrivateBuildDirectory(
+                prefix=f".{output_path.name}.generation-build-",
+                parent=output_path.parent,
+            ) as build_root:
+                build_path = build_root.path
+                writer_path = build_root.writer_path
+                with build_root.path_operation("vector update marker begin"):
+                    begin_vector_view_update(writer_path)
+                build_kwargs = dict(kwargs)
+                build_kwargs["output_dir"] = str(writer_path)
+                build_kwargs["_published_output_dir"] = str(output_path)
+                build_kwargs["_build_root_guard"] = build_root
+                status = self._build_once(scope, **build_kwargs)
+                with build_root.path_operation("vector update marker finish"):
+                    finish_vector_view_update(writer_path)
+
+                model_suffix = self._embedding_route().model.replace("/", "__")
+                generation_ownership = build_root.capture_ownership(
+                    required_root_file=f"config_{model_suffix}.json",
+                )
+                reopen_authenticated_directory(
+                    build_path,
+                    generation_ownership,
+                    copy_generation,
+                )
+
+            publication_stage.publish()
+        except BaseException:  # noqa: B036 - preserve publication interruptions
+            try:
+                publication_stage.discard()
+            except BaseException:  # noqa: B036 - retain the generation failure
+                logger.exception("Could not isolate failed vector generation stage")
+            raise
         return status
 
     def _build_once(self, scope: str, **kwargs: Any) -> IndexStatus:
         repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
+        published_output_dir: str = kwargs.get("_published_output_dir", output_dir)
+        build_root_guard = kwargs.get("_build_root_guard")
 
         from pathlib import Path
 
-        from ..index.embedding.builders import build_hierarchical_vector_store
+        from ..index.embedding.builders import (
+            _PrivateBuildDirectory,
+            build_hierarchical_vector_store,
+        )
         from ..index.incremental import (
             EmbeddingsCache,
             IncrementalChunkStore,
             IncrementalState,
         )
 
-        os.makedirs(output_dir, exist_ok=True)
+        if not isinstance(build_root_guard, _PrivateBuildDirectory):
+            raise RuntimeError("full vector build requires its private root owner")
+        build_root_guard.require_writer_path(Path(output_dir))
+        build_root_guard.verify("full vector build entry")
         artifact_identity = self.artifact_identity()
-        vs = build_hierarchical_vector_store(
-            repo_path=repo_path,
-            index_path=output_dir,
-            plan_name=None,
-            languages=self.languages,
-            max_lines_per_chunk=self.max_lines_per_chunk,
-            build_levels=self.build_levels,
-            embedding_model=artifact_identity["embedding_model"],
-            embedding_provider=artifact_identity["embedding_provider"],
-            embedding_dimension=self.embedding_dimension,
-            embedding_kwargs=self._embedding_call_kwargs(),
-            index_metric=self.index_metric,
-            artifact_metadata=artifact_identity,
-            # ``build`` is the compiler's full-materialization path. Reusing an
-            # artifact merely because its model config exists would let stale
-            # vectors be stamped with the current source fingerprint. Cross-
-            # commit reuse belongs to ``incremental_update`` instead.
-            force_rebuild=True,
-            strict_chunking=True,
-        )
+        with build_root_guard.path_operation("hierarchical vector build"):
+            vs = build_hierarchical_vector_store(
+                repo_path=repo_path,
+                index_path=output_dir,
+                plan_name=None,
+                languages=self.languages,
+                max_lines_per_chunk=self.max_lines_per_chunk,
+                build_levels=self.build_levels,
+                embedding_model=artifact_identity["embedding_model"],
+                embedding_provider=artifact_identity["embedding_provider"],
+                embedding_dimension=self.embedding_dimension,
+                embedding_kwargs=self._embedding_call_kwargs(),
+                index_metric=self.index_metric,
+                artifact_metadata=artifact_identity,
+                # ``build`` is the compiler's full-materialization path.
+                # Reusing an artifact merely because its model config exists
+                # would stamp stale vectors with the current source identity.
+                force_rebuild=True,
+                strict_chunking=True,
+                # ``build`` owns the complete private generation tree.  Its
+                # outer OwnedDirectoryStage is the publication boundary.
+                _atomic_publish=False,
+                _build_root_guard=build_root_guard,
+            )
         self._validate_vector_dimension(vs)
 
         doc_count = {}
@@ -382,23 +456,27 @@ class VectorIndexBuilder:
             for content_hash, vec in hash_to_vec.items():
                 emb_cache.put(content_hash, vec)
 
-        chunk_store.save(Path(output_dir) / "chunk_store.pkl")
+        with build_root_guard.path_operation("incremental chunk seed save"):
+            chunk_store.save(Path(output_dir) / "chunk_store.pkl")
         logger.info(
             "Seeded embeddings cache with %d vectors from initial build.",
             emb_cache.size(),
         )
-        emb_cache.save(Path(output_dir) / "embeddings_cache.pkl")
+        with build_root_guard.path_operation("embedding cache seed save"):
+            emb_cache.save(Path(output_dir) / "embeddings_cache.pkl")
 
         # Persist incremental state so callers don't need to track last_commit
         inc_state = IncrementalState(
             last_commit=head_commit,
             chunk_store_path="chunk_store.pkl",
             embeddings_cache_path="embeddings_cache.pkl",
-            index_path=str(Path(output_dir).expanduser().resolve()),
+            index_path=str(Path(published_output_dir).expanduser().resolve()),
             build_levels=list(self.build_levels),
         )
-        inc_state.save(Path(output_dir))
-        persistence_config = self._persistence_config_fingerprint(output_dir)
+        with build_root_guard.path_operation("incremental state seed save"):
+            inc_state.save(Path(output_dir))
+        with build_root_guard.path_operation("persistence fingerprint read"):
+            persistence_config = self._persistence_config_fingerprint(output_dir)
 
         return IndexStatus(
             index_type="vector",
@@ -406,7 +484,7 @@ class VectorIndexBuilder:
             last_built=time.time(),
             age_seconds=0.0,
             scope=scope,
-            path=output_dir,
+            path=published_output_dir,
             metadata={
                 **artifact_identity,
                 "persistence_config_fingerprint": persistence_config,
@@ -416,25 +494,44 @@ class VectorIndexBuilder:
         )
 
     def incremental_update(self, scope: str, **kwargs: Any) -> IndexStatus:
-        """Update the vector view, rebuilding on any incremental-path failure."""
+        """Update the vector view, rebuilding on recoverable path failures."""
+
+        from ..native_index_authorization import (
+            MissingNativeIndexAuthorizationError,
+            NativeIndexAuthorizationError,
+        )
 
         try:
             return self._incremental_update_once(scope, **kwargs)
+        except MissingNativeIndexAuthorizationError as exc:
+            return self._rebuild_after_incremental_failure(scope, kwargs, exc)
+        except NativeIndexAuthorizationError:
+            # An explicit capability is caller-supplied authority.  Never turn
+            # a malformed, foreign-process, or mismatched token into a source
+            # rebuild that appears to have accepted it.
+            raise
         except Exception as exc:  # noqa: BLE001 - failed deltas must not publish
-            logger.warning("vector: incremental update failed (%s); rebuilding", exc)
-            build_kwargs = {
-                key: value
-                for key, value in kwargs.items()
-                if key not in {"last_commit", "previous_artifact_config"}
-            }
-            status = self.build(scope, **build_kwargs)
-            status.metadata["update_mode"] = "full_rebuild"
-            status.metadata["incremental_fallback_reason"] = type(exc).__name__
-            return status
+            return self._rebuild_after_incremental_failure(scope, kwargs, exc)
+
+    def _rebuild_after_incremental_failure(
+        self,
+        scope: str,
+        kwargs: Dict[str, Any],
+        exc: Exception,
+    ) -> IndexStatus:
+        logger.warning("vector: incremental update failed (%s); rebuilding", exc)
+        build_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key not in {"last_commit", "previous_artifact_config"}
+        }
+        status = self.build(scope, **build_kwargs)
+        status.metadata["update_mode"] = "full_rebuild"
+        status.metadata["incremental_fallback_reason"] = type(exc).__name__
+        return status
 
     def _incremental_update_once(self, scope: str, **kwargs: Any) -> IndexStatus:
-        """
-        Attempt one vector-index update using git diff detection.
+        """Validate one delta request and route it to an atomic full rebuild.
 
         Required kwargs
         ---------------
@@ -446,12 +543,10 @@ class VectorIndexBuilder:
             The git SHA recorded when the index was last fully built.
             Pass an empty string to force a full rebuild.
 
-        The method loads the existing ``CodeVectorStore``, ``IncrementalChunkStore``,
-        and ``EmbeddingsCache`` from *output_dir*, runs the incremental update
-        pipeline, then saves all state back to disk.
-
-        Missing or incompatible state propagates to :meth:`incremental_update`,
-        which rebuilds conservatively exactly once.
+        Path-based vector persistence cannot safely update the live generation
+        in place.  After exact authorization and state validation, this method
+        therefore raises a private recoverable signal.  The public wrapper
+        rebuilds one complete private generation and switches it atomically.
         """
         from ..native_index_authorization import (
             require_native_index_authorization_preflight,
@@ -459,7 +554,7 @@ class VectorIndexBuilder:
 
         native_index_authorization = kwargs.get("native_index_authorization")
         # Reject before constructing an embedding backend. The public wrapper
-        # catches this and performs one source-derived full rebuild.
+        # rebuilds only for a missing token and propagates explicit bad tokens.
         require_native_index_authorization_preflight(
             native_index_authorization,
             view_type="vector",
@@ -467,29 +562,32 @@ class VectorIndexBuilder:
 
         from pathlib import Path
 
-        from ..code_chunker import CodeChunker, RepoChunkingConfig
-        from ..index.embedding.vector_store import CodeVectorStore
-        from ..index.incremental import (
-            EmbeddingsCache,
-            GitDiffDetector,
-            IncrementalChunkStore,
-            IncrementalIndexUpdater,
-            IncrementalState,
-        )
+        from ..index.incremental import IncrementalState
 
-        repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
         last_commit: str = kwargs.get("last_commit", "")
 
-        from ..index.embedding._lifecycle import close_vector_after_failure
         from ..index.embedding.artifact_integrity import (
-            _mint_trusted_local_vector_authorization,
-            begin_vector_view_update,
-            finish_vector_view_update,
+            require_authorized_vector_view,
             require_complete_vector_view,
         )
 
         require_complete_vector_view(output_dir)
+        artifact_identity = self.artifact_identity()
+        previous_artifact = kwargs.get("previous_artifact_config")
+        if previous_artifact is not None and not isinstance(previous_artifact, dict):
+            raise ValueError("previous vector artifact config must be a mapping")
+        load_identity = (
+            dict(previous_artifact)
+            if previous_artifact is not None
+            else artifact_identity
+        )
+        require_authorized_vector_view(
+            output_dir,
+            native_index_authorization,
+            load_identity,
+        )
+
         inc_state = IncrementalState.load(Path(output_dir))
         if inc_state is None:
             raise ValueError("incremental state is missing")
@@ -528,122 +626,9 @@ class VectorIndexBuilder:
 
         if not has_chunk_store or not has_emb_cache:
             raise ValueError("incremental chunk or embedding state is missing")
-
-        # Load existing artifacts
-        artifact_identity = self.artifact_identity()
-        previous_artifact = kwargs.get("previous_artifact_config")
-        if previous_artifact is not None and not isinstance(previous_artifact, dict):
-            raise ValueError("previous vector artifact config must be a mapping")
-        load_identity = (
-            dict(previous_artifact)
-            if previous_artifact is not None
-            else artifact_identity
-        )
-        native_authorization = _mint_trusted_local_vector_authorization(
-            output_dir,
-            load_identity,
-            evidence=("compiler-incremental-vector-view",),
-        )
-        vector_store = CodeVectorStore(
-            embedding_model=artifact_identity["embedding_model"],
-            embedding_provider=artifact_identity["embedding_provider"],
-            dimension=self.embedding_dimension,
-            index_metric=self.index_metric,
-            store_path=output_dir,
-            artifact_metadata=load_identity,
-            **self._embedding_call_kwargs(),
-        )
-        try:
-            self._validate_vector_dimension(vector_store)
-            vector_store.load(
-                output_dir,
-                native_index_authorization=native_authorization,
-            )
-        except BaseException as primary:  # noqa: B036 - close partial native state
-            close_vector_after_failure(vector_store, primary)
-            raise
-
-        chunk_store = IncrementalChunkStore.load(chunk_store_path)
-        embeddings_cache = EmbeddingsCache.load(embeddings_cache_path)
-
-        # Build chunkers matching the original build config
-        primary = self.languages[0] if self.languages else "python"
-        repo_cfg = RepoChunkingConfig(languages=self.languages)
-        chunker = CodeChunker(
-            language=primary,
-            repo_config=repo_cfg,
-            max_lines_per_chunk=self.max_lines_per_chunk,
-        )
-
-        # L0 chunker for file skeletons (only if L0 was part of the build)
-        l0_chunker = None
-        if "l0" in self.build_levels:
-            l0_chunker = CodeChunker(
-                language=primary,
-                repo_config=repo_cfg,
-                max_lines_per_chunk=self.max_lines_per_chunk,
-                chunk_depth=0,
-                skeleton_mode=True,
-            )
-
-        diff_detector = GitDiffDetector()
-        updater = IncrementalIndexUpdater(
-            chunker=chunker,
-            embedding_model=vector_store.embedding,
-            diff_detector=diff_detector,
-            l0_chunker=l0_chunker,
-        )
-
-        result = updater.update(
-            repo_path=repo_path,
-            vector_store=vector_store,
-            chunk_store=chunk_store,
-            embeddings_cache=embeddings_cache,
-            last_commit=last_commit,
-        )
-        if not result.new_commit:
-            raise ValueError("incremental update did not resolve a target commit")
-
-        # Persist updated state
-        begin_vector_view_update(output_dir)
-        vector_store.save(output_dir)
-        chunk_store.save(chunk_store_path)
-        embeddings_cache.save(embeddings_cache_path)
-
-        # Update incremental state with the new commit.
-        new_state = IncrementalState(
-            last_commit=result.new_commit,
-            chunk_store_path="chunk_store.pkl",
-            embeddings_cache_path="embeddings_cache.pkl",
-            index_path=str(expected_index_path),
-            build_levels=list(self.build_levels),
-        )
-        new_state.save(Path(output_dir))
-        persistence_config = self._persistence_config_fingerprint(output_dir)
-        finish_vector_view_update(output_dir)
-
-        doc_count = {}
-        if vector_store.l0_documents:
-            doc_count["l0"] = len(vector_store.l0_documents)
-        if vector_store.l2_documents:
-            doc_count["l2"] = len(vector_store.l2_documents)
-
-        return IndexStatus(
-            index_type="vector",
-            state=IndexState.FRESH,
-            last_built=time.time(),
-            age_seconds=0.0,
-            scope=scope,
-            path=output_dir,
-            metadata={
-                **self.artifact_identity(),
-                "persistence_config_fingerprint": persistence_config,
-                "document_count": doc_count,
-                "chunks_reembedded": result.chunks_reembedded,
-                "chunks_from_cache": result.chunks_from_cache,
-                "cache_hit_rate": result.cache_hit_rate,
-                "new_commit": result.new_commit,
-            },
+        raise _AtomicIncrementalRebuildRequired(
+            "in-place vector delta publication is disabled; rebuild one "
+            "complete generation"
         )
 
 

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -453,6 +453,18 @@ class VectorIndexBuilder:
         Missing or incompatible state propagates to :meth:`incremental_update`,
         which rebuilds conservatively exactly once.
         """
+        from ..native_index_authorization import (
+            require_native_index_authorization_preflight,
+        )
+
+        native_index_authorization = kwargs.get("native_index_authorization")
+        # Reject before constructing an embedding backend. The public wrapper
+        # catches this and performs one source-derived full rebuild.
+        require_native_index_authorization_preflight(
+            native_index_authorization,
+            view_type="vector",
+        )
+
         from pathlib import Path
 
         from ..code_chunker import CodeChunker, RepoChunkingConfig

--- a/codenib/compiler/index_compiler.py
+++ b/codenib/compiler/index_compiler.py
@@ -33,7 +33,7 @@ from ..paths import REPO_INDEX_DIRNAME
 from ..source_fingerprint import (
     SourceFingerprint,
     fingerprint_repository,
-    repository_source_is_dirty,
+    is_secure_source_fingerprint_v2,
 )
 from .cache_lock import compiler_cache_lock
 from .index_builders import IndexBuilderRegistry
@@ -124,9 +124,12 @@ class IndexCompiler:
         """
         Advance an existing manifest to the repo's current HEAD.
 
-        Each builder is asked for an incremental update rather than a full
-        build. Builders without a real delta path fall back to a rebuild
-        internally, so the result is always correct -- only the cost differs.
+        Requested views are rebuilt from the captured source generation.  An
+        incremental delta is unsafe until the Git cleanliness/HEAD observation
+        can be bound to the same pinned repository authority as the source
+        fingerprint; a path-based status check can otherwise observe a
+        temporary replacement repository and authorize reuse for different
+        bytes.
 
         Falls back to a full :meth:`compile_repo` when there is no existing
         manifest, or when the previously indexed commit cannot be determined.
@@ -256,10 +259,6 @@ class IndexCompiler:
 
         head_commit = self._get_head_commit(repo_path)
         source = source or fingerprint_repository(repo_path, exclude_roots=(cache,))
-        source_is_dirty = repository_source_is_dirty(
-            repo_path,
-            exclude_roots=(cache,),
-        )
         existing = existing_manifest
         languages = list(self._config.languages)
         if existing is not None:
@@ -327,23 +326,23 @@ class IndexCompiler:
             previous_entry_compatible = (
                 previous_entry is not None
                 and previous_entry.status in {"fresh", "stale"}
+                and existing is not None
+                and is_secure_source_fingerprint_v2(existing.source_fingerprint)
+                and is_secure_source_fingerprint_v2(previous_entry.source_fingerprint)
                 and self._entry_matches_builder(previous_entry, builder)
             )
             if previous_entry_compatible:
                 previous_commit = previous_entry.commit
                 if not previous_commit and existing is not None:
                     previous_commit = existing.last_indexed_commit
-            incremental_from = (
-                previous_commit
-                if (
-                    not force_rebuild
-                    and previous_commit
-                    and head_commit
-                    and previous_commit != head_commit
-                    and not source_is_dirty
-                )
-                else None
-            )
+            # Do not seed an incremental builder from a Git status/HEAD check
+            # performed through a separately resolved path.  A repository can
+            # be A for both source fingerprints, B (clean) only for that check,
+            # and A again before the build.  Until Git observations share the
+            # pinned source authority, a full rebuild is the only safe reuse
+            # policy.  ``previous_commit`` is still retained below so a failed
+            # rebuild can preserve the last known generation in the manifest.
+            incremental_from = None
 
             output_dir = os.path.join(cache, idx_type)
             result = self._build_one(
@@ -485,7 +484,8 @@ class IndexCompiler:
         if commit and entry.commit != commit:
             return False
         return (
-            bool(source_fingerprint) and entry.source_fingerprint == source_fingerprint
+            is_secure_source_fingerprint_v2(source_fingerprint)
+            and entry.source_fingerprint == source_fingerprint
         )
 
     @staticmethod

--- a/codenib/compiler/skill_context.py
+++ b/codenib/compiler/skill_context.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, Set
 
 from ..agent.skills.core import SkillType
 from ..agent.skills.registry import SkillRegistry
@@ -46,7 +46,10 @@ from ..provider_routes import resolve_embedding_artifact_route
 from .artifact_fingerprints import require_bm25_manifest_artifact
 from .index_builders import IndexBuilderRegistry, register_default_builders
 from .index_compiler import IndexCompiler, IndexCompilerConfig
-from .manifest import RepoManifest
+from .manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
+
+if TYPE_CHECKING:
+    from ..native_index_authorization import NativeIndexAuthorization
 
 logger = logging.getLogger(__name__)
 
@@ -280,6 +283,34 @@ def _looks_built(cache_dir: str, index_type: str) -> bool:
     return any(p.iterdir())
 
 
+def _current_cached_vector_entry(
+    cache_dir: str,
+    vector_path: str,
+) -> IndexEntry | None:
+    """Return trusted caller metadata for a current conventional cache entry."""
+
+    manifest_path = Path(cache_dir) / MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return None
+    try:
+        manifest = RepoManifest.load(manifest_path)
+    except Exception as exc:  # noqa: BLE001 - unusable metadata cannot bind a token
+        logger.warning("Ignoring unusable cache manifest %s: %s", manifest_path, exc)
+        return None
+    entry = manifest.indexes.get("vector")
+    if entry is None or not manifest.index_is_current("vector"):
+        return None
+    expected = os.path.abspath(os.path.expanduser(vector_path))
+    recorded = os.path.abspath(os.path.expanduser(entry.path))
+    if recorded != expected:
+        logger.warning(
+            "Ignoring vector metadata for a different cache path: %s",
+            entry.path,
+        )
+        return None
+    return entry
+
+
 def _load_bm25(index_path: str):
     """Load a BM25 index from an arbitrary directory path.
 
@@ -306,6 +337,7 @@ def _load_vector(
     artifact_metadata: Optional[Dict[str, Any]] = None,
     trust_remote_code: bool = False,
     default_batch_size: Optional[int] = None,
+    native_index_authorization: NativeIndexAuthorization | None = None,
 ):
     """Load a FAISS vector store from an arbitrary directory path."""
     from ..index.embedding._lifecycle import close_vector_after_failure
@@ -313,6 +345,17 @@ def _load_vector(
         _mint_trusted_local_vector_authorization,
     )
     from ..index.embedding.vector_store import CodeVectorStore
+    from ..native_index_authorization import (
+        require_native_index_authorization_preflight,
+    )
+
+    # Reject absent or malformed authority before initializing an embedding
+    # model or client. The exact tree and semantic contract are checked again
+    # by ``CodeVectorStore.load`` after it captures the view.
+    require_native_index_authorization_preflight(
+        native_index_authorization,
+        view_type="vector",
+    )
 
     kwargs = dict(embedding_kwargs or {})
     if embedding_revision is not None:
@@ -361,16 +404,16 @@ def _run_compiler(
     *,
     languages: Sequence[str],
     builder_registry: IndexBuilderRegistry,
-) -> None:
+) -> RepoManifest | None:
     if not index_types:
-        return
+        return None
     cfg = IndexCompilerConfig(
         cache_dir_name=Path(cache_dir).name,
         index_types=list(index_types),
         languages=list(languages),
     )
     compiler = IndexCompiler(builder_registry, cfg)
-    compiler.compile_repo(
+    return compiler.compile_repo(
         repo_path,
         index_types=list(index_types),
         cache_dir=cache_dir,
@@ -395,6 +438,7 @@ def build_skill_contexts(
     trust_remote_code: Optional[bool] = None,
     embedding_batch_size: Optional[int] = None,
     embedding_max_seq_length: Optional[int] = None,
+    native_index_authorization: NativeIndexAuthorization | None = None,
 ) -> Dict[str, Any]:
     """Build the union of indexes required by *skill_ids* and package them.
 
@@ -445,8 +489,15 @@ def build_skill_contexts(
         trust_remote_code=trust_remote_code,
     )
 
+    compiled_manifest: RepoManifest | None = None
+    compiled_types: Set[str] = set()
     if needed:
         missing = _missing_index_types(needed, cache_dir, rebuild=rebuild)
+        # An existing native vector cache is not self-authorizing. Without a
+        # caller-issued capability, rebuild it from the repository source so
+        # this compiler invocation owns the bytes it will authorize below.
+        if "vector" in needed and native_index_authorization is None:
+            missing = sorted(set(missing) | {"vector"})
         if missing:
             registry = builder_registry
             if registry is None:
@@ -462,27 +513,67 @@ def build_skill_contexts(
                     embedding_max_seq_length=embedding_max_seq_length,
                 )
             logger.info("Building missing indexes %s under %s", missing, cache_dir)
-            _run_compiler(
+            compiled_manifest = _run_compiler(
                 repo_path,
                 missing,
                 cache_dir,
                 languages=languages,
                 builder_registry=registry,
             )
+            compiled_types.update(missing)
 
     # Load required types plus any optional type already present on disk
     # (optional types are never built here — used-if-present only).
     loadable: Set[str] = set(needed)
     for t in optional:
         if _looks_built(cache_dir, t):
+            if t == "vector" and native_index_authorization is None:
+                logger.warning(
+                    "Skipping optional native vector cache without external "
+                    "authorization"
+                )
+                continue
             loadable.add(t)
 
     loaded: Dict[str, Any] = {}
     if "bm25" in loadable:
         loaded["bm25"] = _load_bm25(_index_dir(cache_dir, "bm25"))
     if "vector" in loadable:
+        vector_path = _index_dir(cache_dir, "vector")
+        vector_artifact_metadata: Dict[str, Any] | None = None
+        vector_authorization = native_index_authorization
+        if "vector" in compiled_types and compiled_manifest is not None:
+            vector_entry = compiled_manifest.indexes.get("vector")
+            if (
+                vector_entry is not None
+                and vector_entry.status == "fresh"
+                and compiled_manifest.index_is_current("vector")
+            ):
+                from ..index.embedding.artifact_integrity import (
+                    capture_authenticated_vector_view,
+                )
+                from ..native_index_authorization import (
+                    _mint_trusted_local_admin_authorization,
+                )
+
+                vector_path = vector_entry.path
+                vector_artifact_metadata = dict(vector_entry.config)
+                with capture_authenticated_vector_view(vector_path) as vector_view:
+                    vector_authorization = _mint_trusted_local_admin_authorization(
+                        vector_view.ownership,
+                        view_type="vector",
+                        semantic_contract=vector_artifact_metadata,
+                        evidence=(
+                            "skill-context-compiler-owned-build",
+                            "captured-vector-tree-subject",
+                        ),
+                    )
+        elif vector_authorization is not None:
+            cached_entry = _current_cached_vector_entry(cache_dir, vector_path)
+            if cached_entry is not None:
+                vector_artifact_metadata = dict(cached_entry.config)
         loaded["vector"] = _load_vector(
-            _index_dir(cache_dir, "vector"),
+            vector_path,
             embedding_model=embedding_model,
             embedding_provider="huggingface",
             embedding_dimension=embedding_dimension,
@@ -494,6 +585,8 @@ def build_skill_contexts(
             ),
             trust_remote_code=load_policy.trust_remote_code,
             default_batch_size=embedding_batch_size,
+            artifact_metadata=vector_artifact_metadata,
+            native_index_authorization=vector_authorization,
         )
     if "symbol_graph" in loadable:
         try:
@@ -536,6 +629,7 @@ def load_contexts_from_manifest(
     skill_registry: Optional[SkillRegistry] = None,
     default_top_k: int = 10,
     default_level: str = "l2",
+    native_index_authorization: NativeIndexAuthorization | None = None,
 ) -> Dict[str, Any]:
     """Load index artifacts directly from a pre-built ``RepoManifest``.
 
@@ -573,6 +667,16 @@ def load_contexts_from_manifest(
             entry = manifest.indexes.get(req.index_type)
             fresh = entry is not None and manifest.index_is_current(req.index_type)
             if fresh:
+                if (
+                    req.index_type == "vector"
+                    and not getattr(req, "required", True)
+                    and native_index_authorization is None
+                ):
+                    logger.warning(
+                        "Skipping optional manifest vector view without external "
+                        "native-index authorization"
+                    )
+                    continue
                 needed.add(req.index_type)
             elif getattr(req, "required", True):
                 raise ValueError(
@@ -602,6 +706,7 @@ def load_contexts_from_manifest(
             index_metric=vec_entry.config.get("index_metric", "ip"),
             embedding_kwargs=embedding_kwargs,
             artifact_metadata=vec_entry.config,
+            native_index_authorization=native_index_authorization,
         )
     if "symbol_graph" in needed:
         loaded["symbol_graph"] = _load_symbol_graph(

--- a/codenib/compiler/skill_context.py
+++ b/codenib/compiler/skill_context.py
@@ -371,9 +371,6 @@ def _load_vector(
 ):
     """Load a FAISS vector store from an arbitrary directory path."""
     from ..index.embedding._lifecycle import close_vector_after_failure
-    from ..index.embedding.artifact_integrity import (
-        _mint_trusted_local_vector_authorization,
-    )
     from ..index.embedding.vector_store import CodeVectorStore
 
     # Bind the capability to the exact tree and semantic contract before the
@@ -392,11 +389,6 @@ def _load_vector(
         kwargs["default_batch_size"] = default_batch_size
 
     artifact_contract = dict(artifact_metadata or {})
-    native_authorization = _mint_trusted_local_vector_authorization(
-        index_path,
-        artifact_contract,
-        evidence=("compiler-skill-context-vector-view",),
-    )
     store = CodeVectorStore(
         embedding_model=embedding_model,
         embedding_provider=embedding_provider,
@@ -409,7 +401,7 @@ def _load_vector(
     try:
         store.load(
             index_path,
-            native_index_authorization=native_authorization,
+            native_index_authorization=native_index_authorization,
         )
         return store
     except BaseException as primary:  # noqa: B036 - close partial native state

--- a/codenib/compiler/skill_context.py
+++ b/codenib/compiler/skill_context.py
@@ -32,10 +32,21 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, Set
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+)
 
 from ..agent.skills.core import SkillType
 from ..agent.skills.registry import SkillRegistry
+from ..index.embedding.artifact_integrity import require_authorized_vector_view
 from ..index.embedding.model_policy import (
     DEFAULT_EMBEDDING_DIMENSION,
     DEFAULT_EMBEDDING_MODEL,
@@ -50,6 +61,10 @@ from .manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
 
 if TYPE_CHECKING:
     from ..native_index_authorization import NativeIndexAuthorization
+
+NativeIndexAuthorizationResolver = Callable[
+    [IndexEntry], "NativeIndexAuthorization | None"
+]
 
 logger = logging.getLogger(__name__)
 
@@ -311,6 +326,21 @@ def _current_cached_vector_entry(
     return entry
 
 
+def _resolve_native_vector_authorization(
+    entry: IndexEntry,
+    resolver: NativeIndexAuthorizationResolver,
+):
+    """Resolve external authority from the exact entry about to be loaded."""
+
+    authorization = resolver(entry)
+    if authorization is None:
+        raise ValueError(
+            "native-index authorization resolver returned no authorization "
+            "for a required vector view"
+        )
+    return authorization
+
+
 def _load_bm25(index_path: str):
     """Load a BM25 index from an arbitrary directory path.
 
@@ -345,16 +375,14 @@ def _load_vector(
         _mint_trusted_local_vector_authorization,
     )
     from ..index.embedding.vector_store import CodeVectorStore
-    from ..native_index_authorization import (
-        require_native_index_authorization_preflight,
-    )
 
-    # Reject absent or malformed authority before initializing an embedding
-    # model or client. The exact tree and semantic contract are checked again
-    # by ``CodeVectorStore.load`` after it captures the view.
-    require_native_index_authorization_preflight(
+    # Bind the capability to the exact tree and semantic contract before the
+    # constructor can initialize an embedding model or remote client. The
+    # store repeats the exact check around its native parser load.
+    require_authorized_vector_view(
+        index_path,
         native_index_authorization,
-        view_type="vector",
+        artifact_metadata or {},
     )
 
     kwargs = dict(embedding_kwargs or {})
@@ -439,6 +467,7 @@ def build_skill_contexts(
     embedding_batch_size: Optional[int] = None,
     embedding_max_seq_length: Optional[int] = None,
     native_index_authorization: NativeIndexAuthorization | None = None,
+    native_index_authorization_resolver: NativeIndexAuthorizationResolver | None = None,
 ) -> Dict[str, Any]:
     """Build the union of indexes required by *skill_ids* and package them.
 
@@ -465,8 +494,21 @@ def build_skill_contexts(
     ``config.yaml`` on disk, so callers no longer have to pre-populate the
     ``SkillRegistry`` before calling this (see #154). The registry is only
     consulted for skills that are not present on disk.
+
+    Existing native vector views require either a capability already bound to
+    the intended cache or a resolver that receives its current manifest entry.
+    When this function itself compiles new bytes, it may mint only for that
+    compiler-owned captured output.
     """
     skill_ids = list(skill_ids)
+    if (
+        native_index_authorization is not None
+        and native_index_authorization_resolver is not None
+    ):
+        raise ValueError(
+            "provide either native_index_authorization or "
+            "native_index_authorization_resolver, not both"
+        )
     skill_registry = skill_registry or SkillRegistry()
 
     cache_dir = cache_dir or os.path.join(
@@ -496,7 +538,11 @@ def build_skill_contexts(
         # An existing native vector cache is not self-authorizing. Without a
         # caller-issued capability, rebuild it from the repository source so
         # this compiler invocation owns the bytes it will authorize below.
-        if "vector" in needed and native_index_authorization is None:
+        if (
+            "vector" in needed
+            and native_index_authorization is None
+            and native_index_authorization_resolver is None
+        ):
             missing = sorted(set(missing) | {"vector"})
         if missing:
             registry = builder_registry
@@ -527,7 +573,11 @@ def build_skill_contexts(
     loadable: Set[str] = set(needed)
     for t in optional:
         if _looks_built(cache_dir, t):
-            if t == "vector" and native_index_authorization is None:
+            if (
+                t == "vector"
+                and native_index_authorization is None
+                and native_index_authorization_resolver is None
+            ):
                 logger.warning(
                     "Skipping optional native vector cache without external "
                     "authorization"
@@ -558,36 +608,58 @@ def build_skill_contexts(
 
                 vector_path = vector_entry.path
                 vector_artifact_metadata = dict(vector_entry.config)
-                with capture_authenticated_vector_view(vector_path) as vector_view:
-                    vector_authorization = _mint_trusted_local_admin_authorization(
-                        vector_view.ownership,
-                        view_type="vector",
-                        semantic_contract=vector_artifact_metadata,
-                        evidence=(
-                            "skill-context-compiler-owned-build",
-                            "captured-vector-tree-subject",
-                        ),
+                if native_index_authorization_resolver is not None:
+                    vector_authorization = _resolve_native_vector_authorization(
+                        vector_entry,
+                        native_index_authorization_resolver,
                     )
+                else:
+                    with capture_authenticated_vector_view(vector_path) as vector_view:
+                        vector_authorization = _mint_trusted_local_admin_authorization(
+                            vector_view.ownership,
+                            view_type="vector",
+                            semantic_contract=vector_artifact_metadata,
+                            evidence=(
+                                "skill-context-compiler-owned-build",
+                                "captured-vector-tree-subject",
+                            ),
+                        )
         elif vector_authorization is not None:
             cached_entry = _current_cached_vector_entry(cache_dir, vector_path)
             if cached_entry is not None:
                 vector_artifact_metadata = dict(cached_entry.config)
-        loaded["vector"] = _load_vector(
-            vector_path,
-            embedding_model=embedding_model,
-            embedding_provider="huggingface",
-            embedding_dimension=embedding_dimension,
-            embedding_revision=load_policy.revision,
-            embedding_kwargs=(
-                {"max_seq_length": embedding_max_seq_length}
-                if embedding_max_seq_length is not None
-                else None
-            ),
-            trust_remote_code=load_policy.trust_remote_code,
-            default_batch_size=embedding_batch_size,
-            artifact_metadata=vector_artifact_metadata,
-            native_index_authorization=vector_authorization,
-        )
+        elif native_index_authorization_resolver is not None:
+            cached_entry = _current_cached_vector_entry(cache_dir, vector_path)
+            if cached_entry is None:
+                raise ValueError(
+                    "cannot resolve native-index authorization without a current "
+                    "vector manifest entry"
+                )
+            vector_artifact_metadata = dict(cached_entry.config)
+            vector_authorization = _resolve_native_vector_authorization(
+                cached_entry,
+                native_index_authorization_resolver,
+            )
+        # Required vectors always reach the fail-closed loader, even when a
+        # broken compiler result omitted its authority. Optional vectors may
+        # still degrade when no external capability was supplied.
+        if vector_authorization is not None or "vector" in needed:
+            loaded["vector"] = _load_vector(
+                vector_path,
+                embedding_model=embedding_model,
+                embedding_provider="huggingface",
+                embedding_dimension=embedding_dimension,
+                embedding_revision=load_policy.revision,
+                embedding_kwargs=(
+                    {"max_seq_length": embedding_max_seq_length}
+                    if embedding_max_seq_length is not None
+                    else None
+                ),
+                trust_remote_code=load_policy.trust_remote_code,
+                default_batch_size=embedding_batch_size,
+                artifact_metadata=vector_artifact_metadata,
+                native_index_authorization=vector_authorization,
+            )
     if "symbol_graph" in loadable:
         try:
             loaded["symbol_graph"] = _load_symbol_graph(
@@ -630,6 +702,7 @@ def load_contexts_from_manifest(
     default_top_k: int = 10,
     default_level: str = "l2",
     native_index_authorization: NativeIndexAuthorization | None = None,
+    native_index_authorization_resolver: NativeIndexAuthorizationResolver | None = None,
 ) -> Dict[str, Any]:
     """Load index artifacts directly from a pre-built ``RepoManifest``.
 
@@ -647,6 +720,10 @@ def load_contexts_from_manifest(
     model/dimension are read from ``manifest.indexes["vector"].config``
     when present.
 
+    ``native_index_authorization_resolver``, when supplied, is invoked with
+    that exact vector ``IndexEntry`` and must return an out-of-band capability
+    bound to the same tree and config. Manifest data never mints authority.
+
     Raises:
         ValueError: if any ``skill_ids`` *requires* an ``index_type`` that
             isn't present in the manifest or whose ``status != "fresh"``.
@@ -655,6 +732,14 @@ def load_contexts_from_manifest(
             beats the deferred "Skill not available" at tool-call time.
     """
     skill_ids = list(skill_ids)
+    if (
+        native_index_authorization is not None
+        and native_index_authorization_resolver is not None
+    ):
+        raise ValueError(
+            "provide either native_index_authorization or "
+            "native_index_authorization_resolver, not both"
+        )
     registry = skill_registry or SkillRegistry()
 
     # Map skill_id → list of index_types to load, validating required ones.
@@ -671,6 +756,7 @@ def load_contexts_from_manifest(
                     req.index_type == "vector"
                     and not getattr(req, "required", True)
                     and native_index_authorization is None
+                    and native_index_authorization_resolver is None
                 ):
                     logger.warning(
                         "Skipping optional manifest vector view without external "
@@ -695,6 +781,12 @@ def load_contexts_from_manifest(
         loaded["bm25"] = _load_bm25(bm25_entry.path)
     if "vector" in needed:
         vec_entry = manifest.indexes["vector"]
+        vector_authorization = native_index_authorization
+        if native_index_authorization_resolver is not None:
+            vector_authorization = _resolve_native_vector_authorization(
+                vec_entry,
+                native_index_authorization_resolver,
+            )
         route = resolve_embedding_artifact_route(vec_entry.config)
         embedding_kwargs = route.embedding_backend_kwargs()
         embedding_kwargs.update(route.client_kwargs())
@@ -706,7 +798,7 @@ def load_contexts_from_manifest(
             index_metric=vec_entry.config.get("index_metric", "ip"),
             embedding_kwargs=embedding_kwargs,
             artifact_metadata=vec_entry.config,
-            native_index_authorization=native_index_authorization,
+            native_index_authorization=vector_authorization,
         )
     if "symbol_graph" in needed:
         loaded["symbol_graph"] = _load_symbol_graph(

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -273,7 +273,7 @@ def _attach_vector_view_cleanup_owner(
 
     owner = getattr(cleanup_error, "captured_directory_cleanup_owner", None)
     if owner is None:
-        owner = view.reader
+        owner = getattr(view, "reader", view)
     try:
         primary.captured_directory_cleanup_owner = owner  # type: ignore[attr-defined]
     except BaseException:  # noqa: B036 - traceback still retains local view

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -6,16 +6,20 @@
 
 """Reusable embedding builders for hierarchical pipelines."""
 
+from __future__ import annotations
+
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ...code_chunker import CodeChunker, RepoChunkingConfig
 from ...log_utils import get_logger
 from ...profiler import Profiler
 from ._lifecycle import close_vector_after_failure
-from .artifact_integrity import _mint_trusted_local_vector_authorization
 from .vector_store import CodeVectorStore
+
+if TYPE_CHECKING:
+    from ...native_index_authorization import NativeIndexAuthorization
 
 logger = get_logger(__name__)
 
@@ -72,6 +76,7 @@ def build_hierarchical_vector_store(
     force_rebuild: bool = False,
     strict_chunking: bool = False,
     artifact_metadata: Optional[Dict[str, Any]] = None,
+    native_index_authorization: NativeIndexAuthorization | None = None,
 ) -> CodeVectorStore:
     """Build (or load) a hierarchical vector store (L0/L2) for a repository.
 
@@ -85,16 +90,27 @@ def build_hierarchical_vector_store(
         store_path = store_path / plan_name
 
     normalized_levels = [level.lower() for level in (build_levels or ["l0", "l2"])]
-    if force_rebuild:
+    model_suffix = embedding_model.replace("/", "__")
+    config_path = store_path / f"config_{model_suffix}.json"
+    cache_without_authority = (
+        not force_rebuild
+        and config_path.exists()
+        and native_index_authorization is None
+    )
+    effective_force_rebuild = force_rebuild or cache_without_authority
+    if effective_force_rebuild and not repo_path:
+        raise ValueError(
+            "repo_path is required to rebuild a vector index when no authorized "
+            "cache can be loaded"
+        )
+    if effective_force_rebuild:
         _remove_unrequested_model_levels(
             store_path,
             embedding_model,
             normalized_levels,
         )
 
-    if not force_rebuild:
-        model_suffix = embedding_model.replace("/", "__")
-        config_path = store_path / f"config_{model_suffix}.json"
+    if not effective_force_rebuild:
         if config_path.exists():
             logger.info(
                 "Pre-built index found at %s — loading instead of rebuilding "
@@ -102,11 +118,6 @@ def build_hierarchical_vector_store(
                 store_path,
             )
             artifact_contract = dict(artifact_metadata or {})
-            native_authorization = _mint_trusted_local_vector_authorization(
-                store_path,
-                artifact_contract,
-                evidence=("hierarchical-vector-builder-cache",),
-            )
             vector_store = CodeVectorStore(
                 embedding_model=embedding_model,
                 embedding_provider=embedding_provider,
@@ -130,7 +141,18 @@ def build_hierarchical_vector_store(
             except BaseException as primary:  # noqa: B036 - close partial state
                 close_vector_after_failure(vector_store, primary)
                 raise
+    elif cache_without_authority:
+        logger.warning(
+            "Pre-built index found at %s but no external native-index "
+            "authorization was supplied; rebuilding from repository source.",
+            store_path,
+        )
 
+    if not repo_path:
+        raise ValueError(
+            "repo_path is required to build a vector index when no authorized "
+            "cache can be loaded"
+        )
     languages = languages or ["python"]
     build_levels = normalized_levels
     repo_cfg = RepoChunkingConfig(languages=languages)

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -8,14 +8,27 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
-from pathlib import Path
+import os
+import stat
+import tempfile
+from contextlib import contextmanager, nullcontext
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from ..._atomic_directory import (
+    PublicationDirectoryReader,
+    capture_directory_ownership,
+    directory_ownership_root_identity,
+    discard_owned_directory,
+    lexical_directory_path,
+    reopen_authenticated_directory,
+)
+from ..._captured_directory import OwnedDirectoryStage
 from ...code_chunker import CodeChunker, RepoChunkingConfig
 from ...log_utils import get_logger
 from ...profiler import Profiler
 from ._lifecycle import close_vector_after_failure
+from .artifact_integrity import VECTOR_VIEW_UPDATE_MARKER
 from .vector_store import CodeVectorStore
 
 if TYPE_CHECKING:
@@ -23,29 +36,277 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_MODEL_LEVEL_FILE_TEMPLATES = (
+    "config_{model_suffix}.json",
+    "index_{model_suffix}.faiss",
+    "documents_{model_suffix}.pkl",
+    "documents_{model_suffix}.json",
+    "index_{model_suffix}.pkl",
+)
+_GENERATION_STATE_ROOT_FILES = frozenset(
+    {
+        VECTOR_VIEW_UPDATE_MARKER,
+        "chunk_store.json",
+        "chunk_store.pkl",
+        "embeddings_cache.json",
+        "embeddings_cache.npz",
+        "embeddings_cache.pkl",
+        "incremental_state.json",
+    }
+)
 
-def _remove_unrequested_model_levels(
-    store_path: Path,
-    embedding_model: str,
-    build_levels: List[str],
-) -> None:
-    model_suffix = embedding_model.replace("/", "__")
-    requested = frozenset(build_levels)
-    for level in ("l0", "l2"):
-        if level in requested:
-            continue
-        level_path = store_path / level
-        for name in (
-            f"config_{model_suffix}.json",
-            f"index_{model_suffix}.faiss",
-            f"documents_{model_suffix}.pkl",
-            f"index_{model_suffix}.pkl",
-        ):
-            (level_path / name).unlink(missing_ok=True)
+
+def _metadata_root_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+class _PrivateBuildDirectory:
+    """Retain and continuously verify one private path-based build root.
+
+    Model/index libraries still require a filesystem path.  Capturing only
+    after those libraries return is insufficient: a callback can rename the
+    private root and recreate its old name.  This owner captures the empty root
+    before the first callback, retains its directory descriptor where the host
+    supports it, and brackets every path-based operation with a no-follow root
+    binding check.
+    """
+
+    def __init__(self, *, parent: Path, prefix: str) -> None:
+        self.path = lexical_directory_path(
+            Path(tempfile.mkdtemp(prefix=prefix, dir=str(parent)))
+        )
+        self._descriptor = -1
+        self._closed = False
+        self._dirty = False
+        self._writer_path: Path | None = None
+        self._cleanup_ownership = capture_directory_ownership(self.path)
+        self._root_identity = directory_ownership_root_identity(self._cleanup_ownership)
+        flags = os.O_RDONLY
+        flags |= getattr(os, "O_DIRECTORY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        flags |= getattr(os, "O_CLOEXEC", 0)
         try:
-            level_path.rmdir()
-        except OSError:
-            pass
+            try:
+                self._descriptor = os.open(self.path, flags)
+            except OSError:
+                if os.name != "nt":
+                    raise
+            self.verify("private build root initialization")
+            if self._descriptor >= 0:
+                for descriptor_root in (Path("/proc/self/fd"), Path("/dev/fd")):
+                    candidate = descriptor_root / str(self._descriptor)
+                    try:
+                        if (
+                            _metadata_root_identity(os.stat(candidate))
+                            == self._root_identity
+                        ):
+                            self._writer_path = candidate
+                            break
+                    except OSError:
+                        continue
+        except BaseException as primary_error:
+            if self._descriptor >= 0:
+                os.close(self._descriptor)
+                self._descriptor = -1
+            try:
+                discard_owned_directory(self.path, self._cleanup_ownership)
+            except BaseException as cleanup_error:  # noqa: B036 - retain primary
+                add_note = getattr(primary_error, "add_note", None)
+                if callable(add_note):
+                    add_note(
+                        "private build initialization cleanup also failed: "
+                        f"{cleanup_error}"
+                    )
+            raise
+
+    @property
+    def writer_path(self) -> Path:
+        """Return a path whose resolution is anchored to the retained root fd."""
+
+        self.verify("descriptor-anchored writer path selection")
+        if self._writer_path is None:
+            raise RuntimeError(
+                "safe path-based vector builds require a descriptor-anchored "
+                "directory path on this platform"
+            )
+        try:
+            if (
+                _metadata_root_identity(os.stat(self._writer_path))
+                != self._root_identity
+            ):
+                raise RuntimeError("descriptor-anchored private build path changed")
+        except OSError as exc:
+            raise RuntimeError(
+                "descriptor-anchored private build path changed"
+            ) from exc
+        return self._writer_path
+
+    def require_writer_path(self, path: Path) -> None:
+        if lexical_directory_path(path) != self.writer_path:
+            raise RuntimeError(
+                "path-based vector writer is not anchored to its private root"
+            )
+
+    def verify(self, operation: str) -> None:
+        if self._closed:
+            raise RuntimeError("private build root owner is closed")
+        try:
+            if self._descriptor >= 0:
+                path_metadata = os.stat(self.path, follow_symlinks=False)
+                path_identity = _metadata_root_identity(path_metadata)
+                descriptor_identity = _metadata_root_identity(
+                    os.fstat(self._descriptor)
+                )
+            else:
+                ownership = capture_directory_ownership(
+                    self.path,
+                    allow_empty_root=True,
+                )
+                path_identity = directory_ownership_root_identity(ownership)
+                descriptor_identity = path_identity
+                path_metadata = os.stat(self.path, follow_symlinks=False)
+        except OSError as exc:
+            raise RuntimeError(
+                f"private build root changed during {operation}"
+            ) from exc
+        if (
+            not stat.S_ISDIR(path_metadata.st_mode)
+            or path_identity != self._root_identity
+            or descriptor_identity != self._root_identity
+        ):
+            raise RuntimeError(f"private build root changed during {operation}")
+
+    @contextmanager
+    def path_operation(self, operation: str):
+        """Require the same retained root immediately before and after a call."""
+
+        self.verify(f"before {operation}")
+        self._dirty = True
+        try:
+            yield
+        except BaseException as primary_error:  # noqa: B036 - retain interrupt
+            try:
+                self.verify(f"after failed {operation}")
+            except BaseException as continuity_error:  # noqa: B036
+                add_note = getattr(primary_error, "add_note", None)
+                if callable(add_note):
+                    add_note(
+                        "private build root verification also failed: "
+                        f"{continuity_error}"
+                    )
+            raise
+        self.verify(f"after {operation}")
+
+    def capture_ownership(self, *, required_root_file: str) -> object:
+        self.verify("before final ownership capture")
+        ownership = capture_directory_ownership(
+            self.path,
+            required_root_file=required_root_file,
+        )
+        if directory_ownership_root_identity(ownership) != self._root_identity:
+            raise RuntimeError("private build root changed during final capture")
+        self.verify("after final ownership capture")
+        self._cleanup_ownership = ownership
+        self._dirty = False
+        return ownership
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        cleanup_error: BaseException | None = None
+        try:
+            if self._dirty:
+                self.verify("cleanup capture")
+                ownership = capture_directory_ownership(
+                    self.path,
+                    allow_empty_root=True,
+                )
+                if directory_ownership_root_identity(ownership) != self._root_identity:
+                    raise RuntimeError("private build root changed during cleanup")
+                self._cleanup_ownership = ownership
+        except BaseException as exc:  # noqa: B036 - close the retained handle
+            cleanup_error = exc
+        finally:
+            if self._descriptor >= 0:
+                try:
+                    os.close(self._descriptor)
+                except OSError as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+                self._descriptor = -1
+            self._closed = True
+        try:
+            discard_owned_directory(self.path, self._cleanup_ownership)
+        except BaseException as exc:  # noqa: B036 - report safe orphaning
+            if cleanup_error is None:
+                cleanup_error = exc
+        if cleanup_error is not None:
+            raise cleanup_error
+
+    def __enter__(self) -> _PrivateBuildDirectory:
+        return self
+
+    def __exit__(self, _exc_type, exc, _traceback) -> None:
+        try:
+            self.close()
+        except BaseException as cleanup_error:  # noqa: B036 - retain primary
+            if exc is None:
+                raise
+            add_note = getattr(exc, "add_note", None)
+            if callable(add_note):
+                add_note(f"private build root cleanup also failed: {cleanup_error}")
+
+
+def _model_level_file_names(model_suffix: str) -> tuple[str, ...]:
+    return tuple(
+        template.format(model_suffix=model_suffix)
+        for template in _MODEL_LEVEL_FILE_TEMPLATES
+    )
+
+
+def _replaced_generation_paths(
+    model_suffix: str,
+) -> frozenset[str]:
+    paths = {
+        f"config_{model_suffix}.json",
+        f".config_{model_suffix}.json.save-in-progress",
+        *_GENERATION_STATE_ROOT_FILES,
+    }
+    paths.update(
+        f"{level}/{name}"
+        for level in ("l0", "l2")
+        for name in _model_level_file_names(model_suffix)
+    )
+    return frozenset(paths)
+
+
+def _copy_captured_tree(
+    reader: PublicationDirectoryReader,
+    stage: OwnedDirectoryStage,
+    *,
+    excluded: frozenset[str] = frozenset(),
+) -> None:
+    """Copy authenticated regular files into an authority-owned private stage."""
+
+    for record in reader.file_records():
+        relative = PurePosixPath(record.path)
+        if relative.as_posix() in excluded:
+            continue
+        with reader.iter_authenticated_chunks(
+            relative,
+            max_bytes=record.size,
+        ) as chunks:
+            stage.write_file(
+                relative,
+                chunks,
+                mode=record.mode,
+                max_bytes=record.size,
+            )
 
 
 def _profiler_section(profiler, label, metadata=None):
@@ -77,13 +338,17 @@ def build_hierarchical_vector_store(
     strict_chunking: bool = False,
     artifact_metadata: Optional[Dict[str, Any]] = None,
     native_index_authorization: NativeIndexAuthorization | None = None,
+    _atomic_publish: bool = True,
+    _build_root_guard: _PrivateBuildDirectory | None = None,
 ) -> CodeVectorStore:
     """Build (or load) a hierarchical vector store (L0/L2) for a repository.
 
     When ``force_rebuild=False`` (the default) and a saved index for the
     requested ``embedding_model`` already exists at ``index_path``, the store
     is loaded from disk instead of re-chunking and re-embedding the repository.
-    Pass ``force_rebuild=True`` to unconditionally rebuild.
+    Pass ``force_rebuild=True`` to unconditionally rebuild. Rebuilds compose a
+    complete private tree and atomically switch the directory only after save
+    and ownership verification succeed.
     """
     store_path = Path(index_path)
     if plan_name:
@@ -103,13 +368,6 @@ def build_hierarchical_vector_store(
             "repo_path is required to rebuild a vector index when no authorized "
             "cache can be loaded"
         )
-    if effective_force_rebuild:
-        _remove_unrequested_model_levels(
-            store_path,
-            embedding_model,
-            normalized_levels,
-        )
-
     if not effective_force_rebuild:
         if config_path.exists():
             logger.info(
@@ -118,6 +376,13 @@ def build_hierarchical_vector_store(
                 store_path,
             )
             artifact_contract = dict(artifact_metadata or {})
+            from .artifact_integrity import require_authorized_vector_view
+
+            require_authorized_vector_view(
+                store_path,
+                native_index_authorization,
+                artifact_contract,
+            )
             vector_store = CodeVectorStore(
                 embedding_model=embedding_model,
                 embedding_provider=embedding_provider,
@@ -226,32 +491,94 @@ def build_hierarchical_vector_store(
         "avg_chunk_loc": round(total_loc / max(total_chunks, 1), 1),
     }
 
-    store_path.mkdir(parents=True, exist_ok=True)
-    vector_store = CodeVectorStore(
-        embedding_model=embedding_model,
-        embedding_provider=embedding_provider,
-        dimension=embedding_dimension,
-        index_metric=index_metric,
-        index_type=index_type,
-        ivf_nlist=ivf_nlist,
-        ivf_nprobe=ivf_nprobe,
-        store_path=str(store_path),
-        profiler=profiler,
-        embedding=embedding,
-        artifact_metadata=artifact_metadata,
-        **(embedding_kwargs or {}),
-    )
+    def materialize(
+        build_path: Path,
+        build_root: _PrivateBuildDirectory,
+    ) -> CodeVectorStore:
+        with build_root.path_operation("vector store initialization"):
+            vector_store = CodeVectorStore(
+                embedding_model=embedding_model,
+                embedding_provider=embedding_provider,
+                dimension=embedding_dimension,
+                index_metric=index_metric,
+                index_type=index_type,
+                ivf_nlist=ivf_nlist,
+                ivf_nprobe=ivf_nprobe,
+                store_path=str(build_path),
+                profiler=profiler,
+                embedding=embedding,
+                artifact_metadata=artifact_metadata,
+                **(embedding_kwargs or {}),
+            )
 
-    if l0_chunks:
-        vector_store.add_code_chunks(
-            [chunk._asdict() for chunk in l0_chunks], level="l0"
-        )
-    if l2_chunks:
-        vector_store.add_code_chunks(
-            [chunk._asdict() for chunk in l2_chunks], level="l2"
-        )
+        if l0_chunks:
+            with build_root.path_operation("L0 vector materialization"):
+                vector_store.add_code_chunks(
+                    [chunk._asdict() for chunk in l0_chunks], level="l0"
+                )
+        if l2_chunks:
+            with build_root.path_operation("L2 vector materialization"):
+                vector_store.add_code_chunks(
+                    [chunk._asdict() for chunk in l2_chunks], level="l2"
+                )
+        with build_root.path_operation("vector store save"):
+            vector_store.save(str(build_path))
+        return vector_store
 
-    vector_store.save(str(store_path))
+    if _atomic_publish:
+        publication_stage = OwnedDirectoryStage.prepare(
+            store_path,
+            allow_empty_destination=True,
+        )
+        try:
+            previous_ownership = publication_stage.expected_destination_ownership
+            if previous_ownership is not None:
+                reopen_authenticated_directory(
+                    store_path,
+                    previous_ownership,  # type: ignore[arg-type]
+                    lambda reader: _copy_captured_tree(
+                        reader,
+                        publication_stage,
+                        excluded=_replaced_generation_paths(model_suffix),
+                    ),
+                )
+
+            with _PrivateBuildDirectory(
+                prefix=f".{store_path.name}.vector-build-",
+                parent=store_path.parent,
+            ) as build_root:
+                build_path = build_root.path
+                vector_store = materialize(build_root.writer_path, build_root)
+                build_ownership = build_root.capture_ownership(
+                    required_root_file=f"config_{model_suffix}.json",
+                )
+                reopen_authenticated_directory(
+                    build_path,
+                    build_ownership,
+                    lambda reader: _copy_captured_tree(reader, publication_stage),
+                )
+
+            publication_stage.publish()
+        except BaseException:  # noqa: B036 - preserve interrupts across rollback
+            try:
+                publication_stage.discard()
+            except BaseException:  # noqa: B036 - retain the publication failure
+                logger.exception("Could not isolate failed vector publication stage")
+            raise
+    else:
+        # The compiler uses this only inside its private full-generation tree;
+        # the outer OwnedDirectoryStage is the sole publication transaction.
+        if _build_root_guard is None or not isinstance(
+            _build_root_guard, _PrivateBuildDirectory
+        ):
+            raise RuntimeError(
+                "non-atomic vector materialization requires its private root owner"
+            )
+        _build_root_guard.require_writer_path(store_path)
+        _build_root_guard.verify("non-atomic vector materialization entry")
+        vector_store = materialize(store_path, _build_root_guard)
+
+    vector_store.store_path = store_path
     vector_store.chunk_stats = chunk_stats
     return vector_store
 

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -400,7 +400,7 @@ def build_hierarchical_vector_store(
             try:
                 vector_store.load(
                     str(store_path),
-                    native_index_authorization=native_authorization,
+                    native_index_authorization=native_index_authorization,
                 )
                 return vector_store
             except BaseException as primary:  # noqa: B036 - close partial state

--- a/codenib/model/embedding_retrieve_pipeline.py
+++ b/codenib/model/embedding_retrieve_pipeline.py
@@ -4,16 +4,16 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
-from ..index.embedding.artifact_integrity import (
-    _mint_trusted_local_vector_authorization,
-)
 from ..log_utils import get_logger
 from ..types import QueriedNode
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from ..native_index_authorization import NativeIndexAuthorization
 
 
 class EmbeddingRetrievePipeline:
@@ -79,6 +79,7 @@ class EmbeddingRetrievePipeline:
         index_type: str = "flat",
         ivf_nlist: int = 100,
         ivf_nprobe: int = 8,
+        native_index_authorization: NativeIndexAuthorization | None = None,
     ) -> None:
         self.top_k = top_k
         _embedding_kwargs = dict(embedding_kwargs or {})
@@ -124,9 +125,15 @@ class EmbeddingRetrievePipeline:
                 ivf_nlist=ivf_nlist,
                 ivf_nprobe=ivf_nprobe,
                 force_rebuild=force_rebuild,
+                native_index_authorization=native_index_authorization,
             )
 
-    def load_index(self, index_path: str) -> None:
+    def load_index(
+        self,
+        index_path: str,
+        *,
+        native_index_authorization: NativeIndexAuthorization | None = None,
+    ) -> None:
         """Hot-swap the FAISS index without reloading the embedding model.
 
         Validates the pre-built index at *index_path* before releasing the
@@ -134,14 +141,9 @@ class EmbeddingRetrievePipeline:
         faster than creating a new :class:`EmbeddingRetrievePipeline` for each
         instance, and a failed replacement leaves the current index available.
         """
-        native_authorization = _mint_trusted_local_vector_authorization(
-            index_path,
-            self.vector_store.artifact_metadata,
-            evidence=("embedding-retrieval-vector-swap",),
-        )
         self.vector_store.swap_index(
             index_path,
-            native_index_authorization=native_authorization,
+            native_index_authorization=native_index_authorization,
         )
 
     def query(self, query: str, top_k: Optional[int] = None) -> List[QueriedNode]:

--- a/codenib/model/graph_retrieve_pipeline.py
+++ b/codenib/model/graph_retrieve_pipeline.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..graph.roi_subgraph import ROISubgraph
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
@@ -15,6 +15,9 @@ from ..log_utils import get_logger
 from ..ls_router import build_graph_for_languages
 from ..profiler import Profiler
 from ..types import QueriedNode
+
+if TYPE_CHECKING:
+    from ..native_index_authorization import NativeIndexAuthorization
 
 logger = get_logger(__name__)
 
@@ -85,6 +88,7 @@ class SparseSeededGraphRetrievePipeline:
         max_lines_per_chunk: int = 300,
         project_name: Optional[str] = None,
         profiler: Optional[Profiler] = None,
+        native_index_authorization: NativeIndexAuthorization | None = None,
     ) -> None:
         self.stage1_topk = stage1_topk
         self.stage2_topk = stage2_topk
@@ -152,6 +156,7 @@ class SparseSeededGraphRetrievePipeline:
                     embedding_kwargs=embedding_kwargs,
                     index_metric="ip",
                     profiler=profiler,
+                    native_index_authorization=native_index_authorization,
                 )
 
     def query(

--- a/codenib/model/hybrid_retrieve_pipeline.py
+++ b/codenib/model/hybrid_retrieve_pipeline.py
@@ -78,11 +78,14 @@ References
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence
+from typing import TYPE_CHECKING, List, Optional, Sequence
 
 from ..compiler import build_skill_contexts
 from ..log_utils import get_logger
 from ..types import QueriedNode
+
+if TYPE_CHECKING:
+    from ..native_index_authorization import NativeIndexAuthorization
 
 logger = get_logger(__name__)
 
@@ -126,6 +129,7 @@ class HybridRetrievePipeline:
         trust_remote_code: Optional[bool] = None,
         languages: Sequence[str] = ("python",),
         embedding_batch_size: int = 8,
+        native_index_authorization: NativeIndexAuthorization | None = None,
     ):
         self.repo_path = repo_path
         self.stage1_topk = stage1_topk
@@ -163,6 +167,7 @@ class HybridRetrievePipeline:
             default_level="l2",  # embedding level
             trust_remote_code=trust_remote_code,
             embedding_batch_size=embedding_batch_size,  # Avoid CUDA OOM
+            native_index_authorization=native_index_authorization,
         )
 
         retrieve_ctx = contexts.get("retrieve")

--- a/codenib/model/retrieve_rerank_pipeline.py
+++ b/codenib/model/retrieve_rerank_pipeline.py
@@ -13,6 +13,7 @@ from ..code_chunker import CodeChunker, RepoChunkingConfig
 from ..graph.code_graph import CodeGraph
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
 from ..index.embedding._lifecycle import close_vector_after_failure
+from ..index.embedding.artifact_integrity import require_authorized_vector_view
 from ..index.embedding.model_policy import resolve_embedding_load_policy_from_options
 from ..index.rerank.cross_encoder import build_reranker
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
@@ -816,6 +817,15 @@ class RetrieveRerankPipeline:
         l2_path = self.index_path / "l2"
 
         cache_exists = config_file.exists() or (l0_path.exists() and l2_path.exists())
+        force_rebuild = False
+        authorization = getattr(self, "_native_index_authorization", None)
+        if cache_exists and authorization is not None:
+            require_authorized_vector_view(
+                self.index_path,
+                authorization,
+                {},
+            )
+
         vector_store = CodeVectorStore(
             embedding_model=embedding_model,
             embedding_provider=embedding_provider,
@@ -823,8 +833,6 @@ class RetrieveRerankPipeline:
             store_path=str(self.index_path),
             **embedding_kwargs,
         )
-        force_rebuild = False
-        authorization = getattr(self, "_native_index_authorization", None)
         if cache_exists and authorization is not None:
             logger.info(
                 "Loading hierarchical vector store from cache.",

--- a/codenib/model/retrieve_rerank_pipeline.py
+++ b/codenib/model/retrieve_rerank_pipeline.py
@@ -7,15 +7,12 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Set
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Set
 
 from ..code_chunker import CodeChunker, RepoChunkingConfig
 from ..graph.code_graph import CodeGraph
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
 from ..index.embedding._lifecycle import close_vector_after_failure
-from ..index.embedding.artifact_integrity import (
-    _mint_trusted_local_vector_authorization,
-)
 from ..index.embedding.model_policy import resolve_embedding_load_policy_from_options
 from ..index.rerank.cross_encoder import build_reranker
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
@@ -42,6 +39,9 @@ from .retrieval_planner import (
 )
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from ..native_index_authorization import NativeIndexAuthorization
 
 SUPPORTED_ENGINES = {"dense", "sparse"}
 RETRIEVAL_TOP_K = 100
@@ -189,6 +189,7 @@ class RetrieveRerankPipeline:
         enable_rerank: bool = True,
         vector_masks: Optional[Dict[str, Set[str]]] = None,
         rerank_candidate_top_k: Optional[int] = None,
+        native_index_authorization: NativeIndexAuthorization | None = None,
     ) -> None:
         self.repo_path = self._validate_repo(repo_path)
         self.index_path = Path(index_path)
@@ -199,6 +200,7 @@ class RetrieveRerankPipeline:
         self.enable_rerank = enable_rerank
         self.index_metric = "ip"
         self.profiler = None
+        self._native_index_authorization = native_index_authorization
         self.retrieval_mode = (retrieval_mode or "dense").strip().lower()
         self.retrieval_planner = retrieval_planner
         if self.retrieval_planner is None and self.retrieval_mode == "auto":
@@ -814,13 +816,6 @@ class RetrieveRerankPipeline:
         l2_path = self.index_path / "l2"
 
         cache_exists = config_file.exists() or (l0_path.exists() and l2_path.exists())
-        native_authorization = None
-        if cache_exists:
-            native_authorization = _mint_trusted_local_vector_authorization(
-                self.index_path,
-                {},
-                evidence=("retrieve-rerank-local-vector-cache",),
-            )
         vector_store = CodeVectorStore(
             embedding_model=embedding_model,
             embedding_provider=embedding_provider,
@@ -828,7 +823,9 @@ class RetrieveRerankPipeline:
             store_path=str(self.index_path),
             **embedding_kwargs,
         )
-        if cache_exists:
+        force_rebuild = False
+        authorization = getattr(self, "_native_index_authorization", None)
+        if cache_exists and authorization is not None:
             logger.info(
                 "Loading hierarchical vector store from cache.",
                 extra={"index_path": str(self.index_path)},
@@ -836,14 +833,13 @@ class RetrieveRerankPipeline:
             try:
                 vector_store.load(
                     str(self.index_path),
-                    native_index_authorization=native_authorization,
+                    native_index_authorization=authorization,
                 )
                 missing_levels = []
                 if not vector_store.l0_documents:
                     missing_levels.append("l0")
                 if self.retrieval_level == "l2" and not vector_store.l2_documents:
                     missing_levels.append("l2")
-
                 if not missing_levels:
                     return vector_store
 
@@ -853,9 +849,17 @@ class RetrieveRerankPipeline:
                     extra={"index_path": str(self.index_path)},
                 )
                 vector_store.clear()
+                force_rebuild = True
             except BaseException as primary:  # noqa: B036 - close partial state
                 close_vector_after_failure(vector_store, primary)
                 raise
+        elif cache_exists:
+            logger.warning(
+                "Cached vector store at %s has no external native-index "
+                "authorization; rebuilding from repository source.",
+                self.index_path,
+            )
+            force_rebuild = True
 
         logger.info("Building hierarchical vector store index.")
         vector_store = build_hierarchical_vector_store(
@@ -872,6 +876,8 @@ class RetrieveRerankPipeline:
             embedding=vector_store.embedding,
             index_metric=self.index_metric,
             profiler=self.profiler,
+            force_rebuild=force_rebuild,
+            native_index_authorization=authorization,
         )
         return vector_store
 

--- a/codenib/native_index_authorization.py
+++ b/codenib/native_index_authorization.py
@@ -31,6 +31,18 @@ _DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _TOKEN_SEAL = object()
 
 
+class NativeIndexAuthorizationError(ValueError):
+    """Base error for a supplied native-index capability that cannot be used."""
+
+
+class MissingNativeIndexAuthorizationError(NativeIndexAuthorizationError):
+    """Raised when a native parser was invoked without an external capability."""
+
+
+class InvalidNativeIndexAuthorizationError(NativeIndexAuthorizationError):
+    """Raised when an explicitly supplied capability is malformed or mismatched."""
+
+
 def _canonical_json(value: Any) -> bytes:
     return json.dumps(
         value,
@@ -221,13 +233,21 @@ def require_native_index_authorization(
     view_type: str,
     semantic_contract: Mapping[str, Any],
 ) -> NativeIndexSubject:
+    if authorization is None:
+        raise MissingNativeIndexAuthorizationError(
+            "native index parsing requires external authorization"
+        )
     if (
         not isinstance(authorization, NativeIndexAuthorization)
         or authorization._seal is not _TOKEN_SEAL
     ):
-        raise ValueError("native index parsing requires external authorization")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization is malformed"
+        )
     if authorization.process_id != os.getpid():
-        raise ValueError("native index authorization belongs to another process")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization belongs to another process"
+        )
     subject = native_index_subject(
         ownership,
         view_type=view_type,
@@ -238,15 +258,21 @@ def require_native_index_authorization(
         or authorization.subject_digest != subject.digest
         or not _DIGEST_RE.fullmatch(authorization.subject_digest)
     ):
-        raise ValueError("native index authorization does not match captured bytes")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization does not match captured bytes"
+        )
     if (
         authorization.trust_class == "trusted-local"
         and authorization.root_identity
         != (directory_ownership_root_identity(ownership))  # type: ignore[arg-type]
     ):
-        raise ValueError("trusted-local authorization does not match the root identity")
+        raise InvalidNativeIndexAuthorizationError(
+            "trusted-local authorization does not match the root identity"
+        )
     if authorization.trust_class != "trusted-local":
-        raise ValueError("native index authorization has an unsupported trust class")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization has an unsupported trust class"
+        )
     return subject
 
 
@@ -257,26 +283,39 @@ def require_native_index_authorization_preflight(
 ) -> None:
     """Reject malformed or foreign-process tokens before expensive capture."""
 
+    if authorization is None:
+        raise MissingNativeIndexAuthorizationError(
+            "native index parsing requires external authorization"
+        )
     if (
         not isinstance(authorization, NativeIndexAuthorization)
         or authorization._seal is not _TOKEN_SEAL
     ):
-        raise ValueError("native index parsing requires external authorization")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization is malformed"
+        )
     if authorization.process_id != os.getpid():
-        raise ValueError("native index authorization belongs to another process")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization belongs to another process"
+        )
     if (
         authorization.trust_class != "trusted-local"
         or authorization.view_type != view_type
         or not _DIGEST_RE.fullmatch(authorization.subject_digest)
         or authorization.root_identity is None
     ):
-        raise ValueError("native index authorization has an invalid preliminary scope")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization has an invalid preliminary scope"
+        )
 
 
 __all__ = [
     "FAISS_PARSER_CONTRACT",
+    "InvalidNativeIndexAuthorizationError",
+    "MissingNativeIndexAuthorizationError",
     "NATIVE_INDEX_SUBJECT_SCHEMA",
     "NativeIndexAuthorization",
+    "NativeIndexAuthorizationError",
     "NativeIndexSubject",
     "native_index_subject",
     "require_native_index_authorization",

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -33,6 +33,7 @@ from ..log_utils import get_logger
 from ..wiki import WikiBuilder
 from ..wiki.narrator import Narrator
 from .config import load_config
+from .native_authority import authorize_local_manifest_vector
 from .ports import argparse_tcp_port
 from .repo_registry import RepoRegistry
 from .repository_files import live_source_slice
@@ -77,7 +78,15 @@ def _wiki_narrator(config):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     config = load_config()
-    registry = RepoRegistry(config)
+    # The production service is the local administrator boundary: it verifies
+    # source fingerprint v2 and the exact captured vector tree through this
+    # injected resolver. RepoRegistry itself remains unable to mint authority.
+    # Sparse mode never invokes the resolver and therefore performs no extra
+    # source capture.
+    registry = RepoRegistry(
+        config,
+        native_index_authorization_resolver=authorize_local_manifest_vector,
+    )
     logger.info("Loading QA repos from %s ...", config.registry_path)
     registry.load_all()
     app.state.registry = registry

--- a/codenib/web/local.py
+++ b/codenib/web/local.py
@@ -16,10 +16,14 @@ from typing import Any, Mapping
 
 import yaml
 
-from ..compiler.checkout_identity import validate_checkout_identity
 from ..compiler.manifest import RepoManifest
 from ..compiler.snapshot_store import normalize_repo
 from ..llm.options import validate_model_options
+from ..source_fingerprint import (
+    capture_repository_source,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
+)
 from .config import RepoEntry, save_registry
 
 
@@ -73,14 +77,39 @@ def prepare_local_wiki(
     model_options: Mapping[str, Any] | None = None,
 ) -> LocalWiki:
     """Write the registry and config consumed by the existing Wiki service."""
-    repo_path = repo_path.expanduser().resolve()
-    manifest_path = manifest_path.expanduser().resolve()
+    repo_path = lexical_repository_path(repo_path)
+    manifest_path = Path(os.path.abspath(os.fspath(manifest_path.expanduser())))
     manifest = RepoManifest.load(str(manifest_path))
-    validate_checkout_identity(
-        repo_path,
-        manifest,
-        artifact_root=manifest_path.parent,
+    if not is_secure_source_fingerprint_v2(manifest.source_fingerprint):
+        raise ValueError("local wiki source reads require source fingerprint v2")
+    from ..artifacts.runtime import (
+        SourceBindingCleanupOwner,
+        _attach_source_cleanup_owner,
     )
+
+    cleanup_owner = SourceBindingCleanupOwner()
+    try:
+        source_binding = capture_repository_source(
+            repo_path,
+            exclude_roots=(manifest_path.parent,),
+            _source_owner=cleanup_owner.retain,
+        )
+        if (
+            source_binding.fingerprint != manifest.source_fingerprint
+            or source_binding.file_count != manifest.file_count
+        ):
+            raise ValueError("repository source content does not match the manifest")
+    except BaseException as primary:  # noqa: B036 - preserve validation fault
+        try:
+            cleanup_owner.close()
+        except BaseException:  # noqa: B036 - expose retry owner on primary
+            _attach_source_cleanup_owner(primary, cleanup_owner)
+        raise
+    try:
+        cleanup_owner.close()
+    except BaseException as cleanup_failure:  # noqa: B036 - retryable owner
+        _attach_source_cleanup_owner(cleanup_failure, cleanup_owner)
+        raise
 
     data_dir = manifest_path.parent / "wiki"
     data_dir.mkdir(parents=True, exist_ok=True)

--- a/codenib/web/native_authority.py
+++ b/codenib/web/native_authority.py
@@ -14,7 +14,7 @@ from ..artifacts.runtime import (
     _raise_source_cleanup_failure,
     _source_cleanup_owner_is_pending,
 )
-from ..compiler.cache_lock import compiler_cache_lock
+from ..compiler.cache_lock import COMPILER_CACHE_LOCK_FILENAME, compiler_cache_lock
 from ..compiler.manifest import IndexEntry, RepoManifest
 from ..index.embedding.artifact_integrity import capture_authenticated_vector_view
 from ..native_index_authorization import (
@@ -57,6 +57,25 @@ def _require_same_vector_manifest(
         or not observed.index_is_current("vector")
     ):
         raise ValueError("vector manifest changed before native authorization")
+
+
+def _manifest_source_exclusions(
+    repo_path: Path,
+    manifest_path: Path,
+) -> tuple[Path, ...]:
+    """Exclude a nested cache directory, or only a root-level manifest file."""
+
+    manifest_parent = manifest_path.parent
+    try:
+        manifest_parent.relative_to(repo_path)
+    except ValueError:
+        return ()
+    if manifest_parent == repo_path:
+        return (
+            manifest_path,
+            manifest_parent / COMPILER_CACHE_LOCK_FILENAME,
+        )
+    return (manifest_parent,)
 
 
 def _raise_after_source_cleanup(
@@ -121,7 +140,7 @@ def authorize_local_manifest_vector(
         try:
             source_binding = capture_repository_source(
                 repo_path,
-                exclude_roots=(manifest_path.parent,),
+                exclude_roots=_manifest_source_exclusions(repo_path, manifest_path),
                 _source_owner=cleanup_owner.retain,
             )
             if (

--- a/codenib/web/native_authority.py
+++ b/codenib/web/native_authority.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trusted local boundary for native vector views served by the Web runtime."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ..artifacts.runtime import (
+    SourceBindingCleanupOwner,
+    _raise_source_cleanup_failure,
+    _source_cleanup_owner_is_pending,
+)
+from ..compiler.cache_lock import compiler_cache_lock
+from ..compiler.manifest import IndexEntry, RepoManifest
+from ..index.embedding.artifact_integrity import capture_authenticated_vector_view
+from ..native_index_authorization import (
+    NativeIndexAuthorization,
+    _mint_trusted_local_admin_authorization,
+)
+from ..source_fingerprint import (
+    capture_repository_source,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
+)
+from .config import RepoEntry
+
+
+def _absolute_manifest_path(value: str) -> Path:
+    lexical = Path(os.path.abspath(os.fspath(Path(value).expanduser())))
+    try:
+        resolved = lexical.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"manifest not found: {lexical}") from exc
+    if not resolved.is_file():
+        raise FileNotFoundError(f"manifest not found: {lexical}")
+    return resolved
+
+
+def _require_same_vector_manifest(
+    expected: RepoManifest,
+    observed: RepoManifest,
+    expected_vector: IndexEntry,
+) -> None:
+    """Reject a manifest or vector entry that changed around authorization."""
+
+    observed_vector = observed.indexes.get("vector")
+    if (
+        observed.repo_path != expected.repo_path
+        or observed.commit != expected.commit
+        or observed.source_fingerprint != expected.source_fingerprint
+        or observed.file_count != expected.file_count
+        or observed_vector != expected_vector
+        or not observed.index_is_current("vector")
+    ):
+        raise ValueError("vector manifest changed before native authorization")
+
+
+def _raise_after_source_cleanup(
+    owner: SourceBindingCleanupOwner,
+    primary: BaseException,
+) -> None:
+    """Close retained source authority without hiding the first failure."""
+
+    cleanup_failure: BaseException | None = None
+    try:
+        owner.close()
+    except BaseException as exc:  # noqa: B036 - shared priority decides
+        cleanup_failure = exc
+    pending_owner = owner if _source_cleanup_owner_is_pending(owner) else None
+    nested_owner = getattr(primary, "source_cleanup_owner", None)
+    if pending_owner is None and _source_cleanup_owner_is_pending(nested_owner):
+        pending_owner = nested_owner
+    _raise_source_cleanup_failure(primary, cleanup_failure, pending_owner)
+
+
+def authorize_local_manifest_vector(
+    repo_entry: RepoEntry,
+    manifest: RepoManifest,
+    vector_entry: IndexEntry,
+) -> NativeIndexAuthorization:
+    """Authorize one exact local vector tree after source-bound admin checks.
+
+    The Web registry is only a consumer and cannot mint from an artifact path.
+    Its production entry points inject this resolver as the trusted boundary.
+    The resolver serializes against the compiler, verifies source fingerprint
+    v2 through retained authority, captures the exact vector tree, and binds
+    the capability to the unmodified manifest config. The later vector loader
+    independently recaptures the tree and checks the same capability subject.
+    """
+
+    recorded_vector = manifest.indexes.get("vector")
+    if recorded_vector is not vector_entry or not manifest.index_is_current("vector"):
+        raise ValueError("resolver did not receive the current manifest vector entry")
+    if not is_secure_source_fingerprint_v2(manifest.source_fingerprint):
+        raise ValueError("native vector authorization requires source fingerprint v2")
+
+    repo_path = lexical_repository_path(repo_entry.repo_dir)
+    manifest_repo_path = lexical_repository_path(manifest.repo_path)
+    if repo_path != manifest_repo_path:
+        raise ValueError("registry repository path does not match the vector manifest")
+    if (
+        repo_entry.base_commit
+        and manifest.commit
+        and repo_entry.base_commit != manifest.commit
+    ):
+        raise ValueError("registry commit does not match the vector manifest")
+
+    manifest_path = _absolute_manifest_path(repo_entry.manifest_path)
+
+    cleanup_owner: SourceBindingCleanupOwner | None = None
+    authorization: NativeIndexAuthorization | None = None
+    with compiler_cache_lock(manifest_path.parent):
+        observed_manifest = RepoManifest.load(str(manifest_path))
+        _require_same_vector_manifest(manifest, observed_manifest, vector_entry)
+
+        cleanup_owner = SourceBindingCleanupOwner()
+        try:
+            source_binding = capture_repository_source(
+                repo_path,
+                exclude_roots=(manifest_path.parent,),
+                _source_owner=cleanup_owner.retain,
+            )
+            if (
+                source_binding.fingerprint != manifest.source_fingerprint
+                or source_binding.file_count != manifest.file_count
+            ):
+                raise ValueError(
+                    "repository source content does not match the vector manifest"
+                )
+
+            with capture_authenticated_vector_view(vector_entry.path) as vector_view:
+                authorization = _mint_trusted_local_admin_authorization(
+                    vector_view.ownership,
+                    view_type="vector",
+                    semantic_contract=dict(vector_entry.config or {}),
+                    evidence=(
+                        "web-local-admin-manifest-intent",
+                        "source-content-fingerprint-v2-bound",
+                        "captured-vector-tree-subject",
+                    ),
+                )
+                vector_view.verify_final()
+
+            source_binding.verify_snapshot()
+            final_manifest = RepoManifest.load(str(manifest_path))
+            _require_same_vector_manifest(manifest, final_manifest, vector_entry)
+        except BaseException as primary:  # noqa: B036 - preserve verification fault
+            _raise_after_source_cleanup(cleanup_owner, primary)
+
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup_owner.close()
+        except BaseException as exc:  # noqa: B036 - retryable owner
+            cleanup_failure = exc
+        pending_owner = (
+            cleanup_owner if _source_cleanup_owner_is_pending(cleanup_owner) else None
+        )
+        if cleanup_failure is not None:
+            _raise_source_cleanup_failure(
+                cleanup_failure,
+                None,
+                pending_owner,
+            )
+        if pending_owner is not None:
+            _raise_source_cleanup_failure(
+                RuntimeError("repository source cleanup did not finish"),
+                None,
+                pending_owner,
+            )
+
+    if authorization is None:  # pragma: no cover - successful path always mints
+        raise AssertionError("native vector authorization was not minted")
+    return authorization
+
+
+__all__ = ["authorize_local_manifest_vector"]

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -20,7 +20,7 @@ from threading import Lock
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
-from ..compiler.manifest import RepoManifest
+from ..compiler.manifest import IndexEntry, RepoManifest
 from ..index.embedding._lifecycle import close_vector_after_failure
 from ..log_utils import get_logger
 from ..provider_routes import normalize_endpoint, resolve_embedding_artifact_route
@@ -359,11 +359,32 @@ class RepoRegistry:
         config: QAConfig,
         *,
         native_index_authorization_resolver: (
-            Callable[[Any], NativeIndexAuthorization | None] | None
+            Callable[
+                [RepoEntry, RepoManifest, IndexEntry],
+                NativeIndexAuthorization | None,
+            ]
+            | None
         ) = None,
+        allow_missing_native_index_authorization: bool = False,
     ) -> None:
+        if (
+            "vector" in config.index_types()
+            and native_index_authorization_resolver is None
+            and not allow_missing_native_index_authorization
+        ):
+            from ..native_index_authorization import (
+                MissingNativeIndexAuthorizationError,
+            )
+
+            raise MissingNativeIndexAuthorizationError(
+                "hybrid mode requires an external native-index authorization "
+                "resolver"
+            )
         self._config = config
         self._native_index_authorization_resolver = native_index_authorization_resolver
+        self._allow_missing_native_index_authorization = (
+            allow_missing_native_index_authorization
+        )
         self._bundles: Dict[str, RepoBundle] = {}
         # One embedding model per model name, shared across repos: the GPU model
         # is loaded once instead of once per CodeVectorStore (one per repo).
@@ -411,31 +432,47 @@ class RepoRegistry:
         native_index_authorization: NativeIndexAuthorization,
     ) -> "CodeVectorStore":
         """Load a manifest vector view with the configured embedding backend."""
-        from ..native_index_authorization import (
-            require_native_index_authorization_preflight,
+        from ..index.embedding.artifact_integrity import (
+            require_authorized_vector_view,
         )
 
-        require_native_index_authorization_preflight(
+        # The manifest's exact config is part of the native capability subject.
+        # Legacy route defaults are query-time compatibility inputs only: adding
+        # them to ``artifact_metadata`` would change the semantic contract after
+        # the caller had already bound its token to ``vec_entry.config``.
+        semantic_contract = dict(vec_entry.config or {})
+        # Preliminary token shape checks are intentionally not enough: reject a
+        # valid but wrong-tree or wrong-semantic capability before constructing
+        # an embedding client/model. CodeVectorStore.load recaptures and checks
+        # again, so any drift after this gate also fails before native parsing.
+        require_authorized_vector_view(
+            vec_entry.path,
             native_index_authorization,
-            view_type="vector",
+            semantic_contract,
         )
-        artifact_config = dict(vec_entry.config or {})
-        legacy_route = not artifact_config.get("embedding_route")
+        effective_route_config = dict(semantic_contract)
+        legacy_route = not effective_route_config.get("embedding_route")
         legacy_fallbacks = []
-        if legacy_route and not artifact_config.get("embedding_provider"):
+        if legacy_route and not effective_route_config.get("embedding_provider"):
             # Pre-provider manifests from build_qa_index.py intentionally relied
             # on the QA runtime route. Keep that narrow compatibility path while
             # requiring all newly built artifacts to persist their provider.
-            artifact_config["embedding_provider"] = self._config.embedding_provider
+            effective_route_config["embedding_provider"] = (
+                self._config.embedding_provider
+            )
             legacy_fallbacks.append(f"provider={self._config.embedding_provider}")
             if self._config.embedding_base_url:
-                artifact_config["embedding_endpoint"] = self._config.embedding_base_url
+                effective_route_config["embedding_endpoint"] = (
+                    self._config.embedding_base_url
+                )
         if (
             legacy_route
-            and "dimension" not in artifact_config
-            and "embedding_dimension" not in artifact_config
+            and "dimension" not in effective_route_config
+            and "embedding_dimension" not in effective_route_config
         ):
-            artifact_config["embedding_dimension"] = self._config.embedding_dimension
+            effective_route_config["embedding_dimension"] = (
+                self._config.embedding_dimension
+            )
             legacy_fallbacks.append(f"dimension={self._config.embedding_dimension}")
         if legacy_fallbacks:
             logger.warning(
@@ -445,7 +482,7 @@ class RepoRegistry:
                 vec_entry.path,
                 ", ".join(legacy_fallbacks),
             )
-        route = resolve_embedding_artifact_route(artifact_config)
+        route = resolve_embedding_artifact_route(effective_route_config)
         configured_endpoint = normalize_endpoint(self._config.embedding_base_url)
         if configured_endpoint is not None and configured_endpoint != route.endpoint:
             raise ValueError(
@@ -477,10 +514,10 @@ class RepoRegistry:
             embedding_model=route.model,
             embedding_provider=route.provider,
             dimension=route.dimension,
-            index_metric=artifact_config.get("index_metric", "ip"),
+            index_metric=effective_route_config.get("index_metric", "ip"),
             store_path=vec_entry.path,
             embedding=self._embeddings.get(cache_key),
-            artifact_metadata=artifact_config,
+            artifact_metadata=semantic_contract,
             **embedding_kwargs,
         )
         candidate_embedding = missing_embedding
@@ -540,40 +577,46 @@ class RepoRegistry:
             bm25_index.load_index(bm25_entry.path)
 
         vec_entry = manifest.indexes.get("vector")
-        if (
-            "vector" in index_types
-            and vec_entry is not None
-            and manifest.index_is_current("vector")
-        ):
+        if "vector" in index_types:
+            if vec_entry is None or not manifest.index_is_current("vector"):
+                if self._allow_missing_native_index_authorization:
+                    logger.warning(
+                        "Skipping missing or stale optional vector view; "
+                        "BM25 remains available"
+                    )
+                else:
+                    raise ValueError(
+                        "hybrid mode requires a current vector manifest entry"
+                    )
+                bundle.vector_store = None
+                bundle.bm25 = bm25_index
+                return
+
             authorization = None
-            if self._native_index_authorization_resolver is not None:
-                try:
-                    authorization = self._native_index_authorization_resolver(vec_entry)
-                except Exception as exc:  # noqa: BLE001 - BM25 remains usable
-                    logger.warning(
-                        "Native vector authorization failed for %s: %s",
-                        vec_entry.path,
-                        exc,
-                    )
+            resolver = self._native_index_authorization_resolver
+            if resolver is not None:
+                authorization = resolver(bundle.entry, manifest, vec_entry)
             if authorization is None:
-                logger.warning(
-                    "Skipping native vector view at %s without external "
-                    "authorization; BM25 remains available",
-                    vec_entry.path,
-                )
-            else:
-                try:
-                    vector_store = self._load_vector_store(
-                        vec_entry,
-                        native_index_authorization=authorization,
-                    )
-                except Exception as exc:  # noqa: BLE001 - BM25 remains usable
+                if self._allow_missing_native_index_authorization:
                     logger.warning(
-                        "Skipping unusable native vector view at %s: %s; "
-                        "BM25 remains available",
+                        "Skipping optional native vector view at %s without "
+                        "external authorization; BM25 remains available",
                         vec_entry.path,
-                        exc,
                     )
+                else:
+                    from ..native_index_authorization import (
+                        MissingNativeIndexAuthorizationError,
+                    )
+
+                    raise MissingNativeIndexAuthorizationError(
+                        "native-index authorization resolver returned no "
+                        "authorization for a required hybrid vector view"
+                    )
+            else:
+                vector_store = self._load_vector_store(
+                    vec_entry,
+                    native_index_authorization=authorization,
+                )
 
         bundle.vector_store = vector_store
         bundle.bm25 = bm25_index

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -432,9 +432,7 @@ class RepoRegistry:
         native_index_authorization: NativeIndexAuthorization,
     ) -> "CodeVectorStore":
         """Load a manifest vector view with the configured embedding backend."""
-        from ..index.embedding.artifact_integrity import (
-            require_authorized_vector_view,
-        )
+        from ..index.embedding.artifact_integrity import require_authorized_vector_view
 
         # The manifest's exact config is part of the native capability subject.
         # Legacy route defaults are query-time compatibility inputs only: adding

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -22,9 +22,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
 from ..index.embedding._lifecycle import close_vector_after_failure
-from ..index.embedding.artifact_integrity import (
-    _mint_trusted_local_vector_authorization,
-)
 from ..log_utils import get_logger
 from ..provider_routes import normalize_endpoint, resolve_embedding_artifact_route
 from ..repository_summary import read_repository_summary
@@ -37,6 +34,7 @@ if TYPE_CHECKING:
     from ..index.embedding.vector_store import CodeVectorStore
     from ..index.sparse_idx.bm25_index import BM25CodeIndexer
     from ..llm.litellm_chat import LiteLLMChat
+    from ..native_index_authorization import NativeIndexAuthorization
 
 logger = get_logger(__name__)
 
@@ -356,8 +354,16 @@ class RepoBundle:
 class RepoRegistry:
     """Holds the loaded :class:`RepoBundle` objects, keyed by instance id."""
 
-    def __init__(self, config: QAConfig) -> None:
+    def __init__(
+        self,
+        config: QAConfig,
+        *,
+        native_index_authorization_resolver: (
+            Callable[[Any], NativeIndexAuthorization | None] | None
+        ) = None,
+    ) -> None:
         self._config = config
+        self._native_index_authorization_resolver = native_index_authorization_resolver
         self._bundles: Dict[str, RepoBundle] = {}
         # One embedding model per model name, shared across repos: the GPU model
         # is loaded once instead of once per CodeVectorStore (one per repo).
@@ -398,8 +404,21 @@ class RepoRegistry:
             runtime_loader=self._load_repo_runtime,
         )
 
-    def _load_vector_store(self, vec_entry: Any) -> "CodeVectorStore":
+    def _load_vector_store(
+        self,
+        vec_entry: Any,
+        *,
+        native_index_authorization: NativeIndexAuthorization,
+    ) -> "CodeVectorStore":
         """Load a manifest vector view with the configured embedding backend."""
+        from ..native_index_authorization import (
+            require_native_index_authorization_preflight,
+        )
+
+        require_native_index_authorization_preflight(
+            native_index_authorization,
+            view_type="vector",
+        )
         artifact_config = dict(vec_entry.config or {})
         legacy_route = not artifact_config.get("embedding_route")
         legacy_fallbacks = []
@@ -452,11 +471,6 @@ class RepoRegistry:
             client_kwargs = route.client_kwargs()
         embedding_kwargs.update(client_kwargs)
 
-        native_authorization = _mint_trusted_local_vector_authorization(
-            vec_entry.path,
-            artifact_config,
-            evidence=("web-repository-local-vector-view",),
-        )
         missing_embedding = object()
         previous_embedding = self._embeddings.get(cache_key, missing_embedding)
         vector_store = _vector_store_type()(
@@ -474,7 +488,7 @@ class RepoRegistry:
             candidate_embedding = vector_store.embedding
             vector_store.load(
                 vec_entry.path,
-                native_index_authorization=native_authorization,
+                native_index_authorization=native_index_authorization,
             )
             # Publish the reusable client only after the authenticated vector
             # view loaded successfully.  The exception handler below rolls
@@ -531,7 +545,35 @@ class RepoRegistry:
             and vec_entry is not None
             and manifest.index_is_current("vector")
         ):
-            vector_store = self._load_vector_store(vec_entry)
+            authorization = None
+            if self._native_index_authorization_resolver is not None:
+                try:
+                    authorization = self._native_index_authorization_resolver(vec_entry)
+                except Exception as exc:  # noqa: BLE001 - BM25 remains usable
+                    logger.warning(
+                        "Native vector authorization failed for %s: %s",
+                        vec_entry.path,
+                        exc,
+                    )
+            if authorization is None:
+                logger.warning(
+                    "Skipping native vector view at %s without external "
+                    "authorization; BM25 remains available",
+                    vec_entry.path,
+                )
+            else:
+                try:
+                    vector_store = self._load_vector_store(
+                        vec_entry,
+                        native_index_authorization=authorization,
+                    )
+                except Exception as exc:  # noqa: BLE001 - BM25 remains usable
+                    logger.warning(
+                        "Skipping unusable native vector view at %s: %s; "
+                        "BM25 remains available",
+                        vec_entry.path,
+                        exc,
+                    )
 
         bundle.vector_store = vector_store
         bundle.bm25 = bm25_index

--- a/docs/incremental_graph/index.md
+++ b/docs/incremental_graph/index.md
@@ -41,7 +41,7 @@ compiler.update_repo("/path/to/repo")    # incremental advance to HEAD
 - **Nothing to do** — `HEAD` unchanged and every requested index `fresh`: returns the existing manifest untouched.
 - **Retry incomplete builds** — `HEAD` unchanged but some requested index is missing or not `fresh` (a previous run failed partway): re-runs a full `compile_repo()` so the failed indexes are retried instead of staying stale.
 - **Full rebuild fallback** — no manifest, an unreadable manifest, or an empty `last_indexed_commit` (no complete baseline was ever established): falls back to `compile_repo()`.
-- **Incremental advance** — otherwise, each builder's `incremental_update(..., last_commit=<previous>)` runs. Builders without a real delta path (BM25, Zoekt) rebuild internally, the vector builder applies a git-diff-driven embedding update, and the symbol-graph builder runs the LSP patcher described below — the result is always correct, only the cost differs.
+- **Incremental advance** — otherwise, each builder's `incremental_update(..., last_commit=<previous>)` runs. Builders without a safely publishable delta path rebuild internally. BM25 and Zoekt rebuild, and the vector builder validates the existing generation and its native-read authority before publishing one complete private-generation rebuild; it does not mutate the live vector tree in place. The symbol-graph builder runs the LSP patcher described below — the result is always correct, only the cost differs.
 
 ### last_indexed_commit Semantics
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -285,6 +285,25 @@ failure exists. Closing that remaining arbitrary call-entry gap, the raw
 resource-return gap, and exact-identity ABA requires native ownership. This
 does not complete M1 producer wiring.
 
+Native vector parsing is now a separate local-authority boundary. Portable
+validation and normalization remain inert: they authenticate the declared
+FAISS bytes and canonical JSON inventory without importing FAISS or
+deserializing pickle, and a descriptive `trusted-local` string cannot grant
+native access. Native consumers must present a process-local authorization
+bound to the exact captured vector tree and semantic configuration before any
+embedding model, remote client, pickle decoder, or FAISS parser is created.
+Compiler rebuilds write the vector files, incremental state, caches, and update
+marker into one descriptor-anchored private generation, then publish the whole
+directory through the owned-directory transaction. The live git-diff vector
+delta is disabled until it can satisfy the same publication boundary; an
+incremental request therefore validates its existing authority and state, then
+performs a complete private-generation rebuild. The Web runtime mints local
+authorization outside the registry only while holding the hardened compiler
+cache lock and revalidating the source-fingerprint-v2 repository, manifest, and
+captured vector tree. These compatibility and publication gates preserve the
+previous complete vector generation on interruption, but they do not complete
+the catalog-backed M2 generation coordinator or durable worker wiring.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/examples/eval_synthesized_queries.py
+++ b/examples/eval_synthesized_queries.py
@@ -44,6 +44,7 @@ Usage:
         --queries-dir synthesized_queries/ \
         --filter-instance "astral-sh__ruff-15309"
 """
+
 from __future__ import annotations
 
 import argparse
@@ -56,7 +57,7 @@ import time
 from collections import Counter, defaultdict
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
 if _PROJECT_ROOT not in sys.path:
@@ -75,6 +76,42 @@ from codenib.paths import prebuilt_data_dir, repo_index_dir, user_state_dir
 from codenib.types import QueriedNode
 
 logger = get_logger(__name__)
+
+
+def _load_vector_from_local_admin_boundary(
+    store: Any,
+    path: str | Path,
+    *,
+    semantic_contract: Mapping[str, Any],
+    evidence: str,
+) -> None:
+    """Authorize one compiler-produced local view for this eval process."""
+
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
+
+    if not evidence:
+        raise ValueError("local vector authorization evidence must be non-empty")
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                evidence,
+                "synthesized-query-eval-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Language detection
@@ -373,14 +410,8 @@ def _make_agent(
     from codenib.compiler.manifest import RepoManifest
     from codenib.compiler.params import SessionContext
     from codenib.index.embedding import CodeVectorStore
-    from codenib.index.embedding.artifact_integrity import (
-        capture_authenticated_vector_view,
-    )
     from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
     from codenib.llm.litellm_chat import LiteLLMChat
-    from codenib.native_index_authorization import (
-        _mint_trusted_local_admin_authorization,
-    )
     from codenib.ops.rerank import RerankContext
     from codenib.ops.retrieve import RetrieveContext
 
@@ -428,16 +459,6 @@ def _make_agent(
         ):
             entry = manifest.indexes["vector"]
             artifact_contract = dict(entry.config)
-            with capture_authenticated_vector_view(entry.path) as vector_view:
-                native_authorization = _mint_trusted_local_admin_authorization(
-                    vector_view.ownership,
-                    view_type="vector",
-                    semantic_contract=artifact_contract,
-                    evidence=(
-                        "synthesized-eval-local-vector-view",
-                        "captured-vector-tree-subject",
-                    ),
-                )
             vector_store = CodeVectorStore(
                 embedding_model=artifact_contract.get(
                     "embedding_model", args.embedding_model
@@ -450,9 +471,11 @@ def _make_agent(
                 artifact_metadata=artifact_contract,
             )
             resources.callback(vector_store.close)
-            vector_store.load(
+            _load_vector_from_local_admin_boundary(
+                vector_store,
                 entry.path,
-                native_index_authorization=native_authorization,
+                semantic_contract=artifact_contract,
+                evidence="synthesized-query-eval-compiled-local-manifest",
             )
 
         ctx: Dict[str, Any] = {

--- a/examples/skill_agent.py
+++ b/examples/skill_agent.py
@@ -35,7 +35,7 @@ import os
 import sys
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Mapping
 
 # ---------------------------------------------------------------------------
 # Ensure the project root is on sys.path when running as a script
@@ -53,6 +53,41 @@ from codenib.ops.rerank import RerankContext
 from codenib.ops.retrieve import RetrieveContext
 from codenib.paths import repo_index_dir
 from codenib.types import QueriedNode
+
+
+def _load_vector_from_local_admin_boundary(
+    store: Any,
+    path: str | Path,
+    *,
+    semantic_contract: Mapping[str, Any],
+    evidence: str,
+) -> None:
+    """Authorize one lexical local cache owned by this example invocation."""
+
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
+
+    if not evidence:
+        raise ValueError("local vector authorization evidence must be non-empty")
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                evidence,
+                "skill-agent-example-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
 
 
 def parse_args() -> argparse.Namespace:
@@ -129,12 +164,6 @@ def build_vector_store(
 ):
     """Build (or load) hierarchical embedding index."""
     from codenib.index.embedding import CodeVectorStore, build_hierarchical_vector_store
-    from codenib.index.embedding.artifact_integrity import (
-        capture_authenticated_vector_view,
-    )
-    from codenib.native_index_authorization import (
-        _mint_trusted_local_admin_authorization,
-    )
 
     store_path = Path(index_path)
     store_path.mkdir(parents=True, exist_ok=True)
@@ -144,16 +173,6 @@ def build_vector_store(
     if l0.exists() and l2.exists():
         print("  Embedding: loading cached index")
         artifact_contract: Dict[str, Any] = {}
-        with capture_authenticated_vector_view(store_path) as vector_view:
-            native_authorization = _mint_trusted_local_admin_authorization(
-                vector_view.ownership,
-                view_type="vector",
-                semantic_contract=artifact_contract,
-                evidence=(
-                    "skill-agent-cached-vector-view",
-                    "captured-vector-tree-subject",
-                ),
-            )
         with ExitStack() as resources:
             vs = CodeVectorStore(
                 embedding_model=embedding_model,
@@ -163,9 +182,11 @@ def build_vector_store(
                 artifact_metadata=artifact_contract,
             )
             resources.callback(vs.close)
-            vs.load(
-                str(store_path),
-                native_index_authorization=native_authorization,
+            _load_vector_from_local_admin_boundary(
+                vs,
+                store_path,
+                semantic_contract=artifact_contract,
+                evidence="skill-agent-standalone-local-cache",
             )
             if vs.l0_documents and vs.l2_documents:
                 resources.pop_all()
@@ -327,13 +348,7 @@ def run_agent(args: argparse.Namespace) -> None:
     from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
     from codenib.compiler.manifest import RepoManifest
     from codenib.index.embedding import CodeVectorStore
-    from codenib.index.embedding.artifact_integrity import (
-        capture_authenticated_vector_view,
-    )
     from codenib.llm.litellm_chat import LiteLLMChat
-    from codenib.native_index_authorization import (
-        _mint_trusted_local_admin_authorization,
-    )
 
     repo_path = os.path.abspath(args.repo)
     cache_dir = args.index_path or str(repo_index_dir(repo_path))
@@ -416,16 +431,6 @@ def run_agent(args: argparse.Namespace) -> None:
             emb_dim = artifact_contract.get(
                 "embedding_dimension", args.embedding_dimension
             )
-            with capture_authenticated_vector_view(entry.path) as vector_view:
-                native_authorization = _mint_trusted_local_admin_authorization(
-                    vector_view.ownership,
-                    view_type="vector",
-                    semantic_contract=artifact_contract,
-                    evidence=(
-                        "skill-agent-manifest-vector-view",
-                        "captured-vector-tree-subject",
-                    ),
-                )
             vector_store = CodeVectorStore(
                 embedding_model=emb_model,
                 embedding_provider="huggingface",
@@ -434,9 +439,11 @@ def run_agent(args: argparse.Namespace) -> None:
                 artifact_metadata=artifact_contract,
             )
             resources.callback(vector_store.close)
-            vector_store.load(
+            _load_vector_from_local_admin_boundary(
+                vector_store,
                 entry.path,
-                native_index_authorization=native_authorization,
+                semantic_contract=artifact_contract,
+                evidence="skill-agent-compiled-local-manifest",
             )
             print(f"  Loaded vector store from {entry.path}")
 

--- a/examples/swerank_retrieve_rerank.py
+++ b/examples/swerank_retrieve_rerank.py
@@ -229,7 +229,7 @@ def resolve_index_dir(
     if commit and not repository_source_is_dirty(repo):
         source_key = f"git-{commit.lower()}"
     else:
-        fingerprint = fingerprint_repository(repo).value.removeprefix("sha256:")
+        fingerprint = fingerprint_repository(repo).value.replace(":", "-", 1)
         source_key = f"source-{fingerprint}"
 
     profile_key = _cache_profile_key(languages, args.max_lines_per_chunk)
@@ -370,7 +370,9 @@ def render_results(
 
 
 def run(args: argparse.Namespace) -> int:
-    repo = Path(args.repo).expanduser().resolve()
+    from codenib.source_fingerprint import lexical_repository_path
+
+    repo = lexical_repository_path(args.repo)
     if not repo.is_dir():
         raise ValueError(f"repository directory does not exist: {repo}")
 

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -6,7 +6,7 @@
 
 """
 Build and cache hierarchical embedding indices for SWE-bench or CodeNib-base instances.
-Each instance's embedding will be stored in <storage-dir>/{instance_id}/
+Each instance's embedding is stored under its artifact directory.
 
 Usage:
     # SWE-bench Lite (default, Python-only)
@@ -23,6 +23,7 @@ Usage:
 
 import argparse
 import gc
+import hashlib
 import json
 import logging
 import sys
@@ -71,6 +72,9 @@ DEFAULT_MULTILINGUAL_REPO_LANG_CSV = (
     / "data"
     / "swebench_multilingual_repos.csv"
 )
+
+_SNAPSHOT_DEFAULT_VECTOR_PLAN_NAME = "vector"
+_VECTOR_QUALITY_DIRECTORY = ".artifact-quality"
 
 
 def parse_args():
@@ -230,7 +234,11 @@ def parse_args():
         "--plan-name",
         type=str,
         default=None,
-        help="Optional plan name to nest embedding artifacts under.",
+        help=(
+            "Optional plan name used to isolate the strict vector tree. "
+            "Snapshot-addressed artifacts default to a private "
+            f"{_SNAPSHOT_DEFAULT_VECTOR_PLAN_NAME!r} subtree."
+        ),
     )
 
     # Storage configuration
@@ -407,13 +415,46 @@ def _load_dataset(args):
     )
 
 
-def _vector_artifact_root(root: Path, plan_name: Optional[str]) -> Path:
-    return root / plan_name if plan_name else root
+def _effective_vector_plan_name(
+    plan_name: Optional[str],
+    artifact_layout: str,
+) -> Optional[str]:
+    """Return the private vector-tree name used by the build command."""
+
+    if plan_name:
+        return plan_name
+    if artifact_layout == "snapshot":
+        return _SNAPSHOT_DEFAULT_VECTOR_PLAN_NAME
+    return None
 
 
-def _vector_quality_path(root: Path, embedding_model: str) -> Path:
+def _vector_artifact_root(
+    root: Path,
+    plan_name: Optional[str],
+    artifact_layout: str = "instance",
+) -> Path:
+    effective_plan = _effective_vector_plan_name(plan_name, artifact_layout)
+    return root / effective_plan if effective_plan else root
+
+
+def _vector_quality_path(
+    root: Path,
+    plan_name: Optional[str],
+    embedding_model: str,
+    artifact_layout: str = "instance",
+) -> Path:
+    effective_plan = _effective_vector_plan_name(plan_name, artifact_layout)
+    plan_identity = hashlib.sha256(
+        (effective_plan or "<root-vector-tree>").encode("utf-8")
+    ).hexdigest()[:16]
     model_suffix = embedding_model.replace("/", "__")
-    return root / f"artifact_quality_{model_suffix}.json"
+    resolved_root = root.resolve(strict=False)
+    return (
+        resolved_root.parent
+        / _VECTOR_QUALITY_DIRECTORY
+        / resolved_root.name
+        / f"{plan_identity}__artifact_quality_{model_suffix}.json"
+    )
 
 
 def _assess_vector_artifact_as_local_admin(
@@ -516,6 +557,7 @@ def _required_l0_files(
 def _quality_report_is_reusable(
     root: Path,
     *,
+    quality_path: Path,
     embedding_model: str,
     instance: dict[str, Any],
     expected_configuration: Mapping[str, Any],
@@ -524,7 +566,6 @@ def _quality_report_is_reusable(
 ) -> bool:
     """Revalidate an assessed artifact before skipping its isolated child."""
 
-    quality_path = _vector_quality_path(root, embedding_model)
     config_path = root / f"config_{embedding_model.replace('/', '__')}.json"
     try:
         quality = json.loads(quality_path.read_text(encoding="utf-8"))
@@ -683,7 +724,17 @@ def build_embeddings(args):
                 if "l0" in build_levels
                 else ()
             )
-            artifact_root = _vector_artifact_root(instance_final_dir, args.plan_name)
+            artifact_root = _vector_artifact_root(
+                instance_final_dir,
+                args.plan_name,
+                args.artifact_layout,
+            )
+            quality_path = _vector_quality_path(
+                instance_final_dir,
+                args.plan_name,
+                args.embedding_model,
+                args.artifact_layout,
+            )
 
             # Reuse only artifacts that pass identity, file, and coverage checks.
             model_suffix = args.embedding_model.replace("/", "__")
@@ -709,7 +760,7 @@ def build_embeddings(args):
                     artifact_root,
                 )
                 write_artifact_quality(
-                    _vector_quality_path(artifact_root, args.embedding_model),
+                    quality_path,
                     existing_quality,
                 )
                 skipped += 1
@@ -740,7 +791,10 @@ def build_embeddings(args):
                 embedding_kwargs["max_seq_length"] = args.max_seq_length
 
             logger.info("Building hierarchical vector store...")
-            plan_name = args.plan_name
+            plan_name = _effective_vector_plan_name(
+                args.plan_name,
+                args.artifact_layout,
+            )
             with instance_profiler.section("build_vector_store"):
                 vector_store = build_hierarchical_vector_store(
                     repo_path=repo_path,
@@ -771,7 +825,6 @@ def build_embeddings(args):
                 surface=surface,
                 required_l0_files=required_l0,
             )
-            quality_path = _vector_quality_path(artifact_root, args.embedding_model)
             write_artifact_quality(quality_path, artifact_quality)
             if not artifact_quality["passed"]:
                 raise RuntimeError(
@@ -931,7 +984,17 @@ def build_embeddings_isolated(args):
         # Trust only artifacts carrying a passing model-specific quality report.
         instance_dir_name = instance_id.replace("/", "__")
         instance_final_dir = Path(args.storage_dir) / instance_dir_name
-        artifact_root = _vector_artifact_root(instance_final_dir, args.plan_name)
+        artifact_root = _vector_artifact_root(
+            instance_final_dir,
+            args.plan_name,
+            args.artifact_layout,
+        )
+        quality_path = _vector_quality_path(
+            instance_final_dir,
+            args.plan_name,
+            args.embedding_model,
+            args.artifact_layout,
+        )
         instance_languages = _resolve_languages(
             dict(instance),
             args.languages,
@@ -950,6 +1013,7 @@ def build_embeddings_isolated(args):
         )
         if not args.force_rebuild and _quality_report_is_reusable(
             artifact_root,
+            quality_path=quality_path,
             embedding_model=args.embedding_model,
             instance=dict(instance),
             expected_configuration=expected_configuration,

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -45,12 +45,18 @@ from codenib.compiler.snapshot_store import ArtifactProfile  # noqa: E402
 from codenib.compiler.snapshot_store import SnapshotArtifactStore, SourceSnapshot
 from codenib.git_snapshot import GitSourceSurface  # noqa: E402
 from codenib.index.embedding import build_hierarchical_vector_store  # noqa: E402
+from codenib.index.embedding.artifact_integrity import (  # noqa: E402
+    capture_authenticated_vector_view,
+)
 from codenib.index.embedding.model_policy import (  # noqa: E402
     DEFAULT_EMBEDDING_MODEL,
     resolve_embedding_load_policy,
 )
 from codenib.languages import extensions_for_language  # noqa: E402
 from codenib.log_utils import get_logger  # noqa: E402
+from codenib.native_index_authorization import (  # noqa: E402
+    _mint_trusted_local_admin_authorization,
+)
 from codenib.paths import prebuilt_data_dir  # noqa: E402
 from codenib.profiler import Profiler  # noqa: E402
 from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION  # noqa: E402
@@ -410,6 +416,35 @@ def _vector_quality_path(root: Path, embedding_model: str) -> Path:
     return root / f"artifact_quality_{model_suffix}.json"
 
 
+def _assess_vector_artifact_as_local_admin(
+    root: Path,
+    *,
+    artifact_metadata: Mapping[str, Any],
+    evidence: str,
+    **assessment_kwargs: Any,
+) -> dict[str, Any]:
+    """Assess bytes owned by this local build command's lexical boundary."""
+
+    with capture_authenticated_vector_view(root) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=artifact_metadata,
+            evidence=(
+                evidence,
+                "embedding-build-command-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+        return assess_vector_artifact(
+            root,
+            expected_artifact=artifact_metadata,
+            authenticated_view=vector_view,
+            native_index_authorization=authorization,
+            **assessment_kwargs,
+        )
+
+
 def _artifact_metadata(
     *,
     instance: dict[str, Any],
@@ -653,14 +688,21 @@ def build_embeddings(args):
             # Reuse only artifacts that pass identity, file, and coverage checks.
             model_suffix = args.embedding_model.replace("/", "__")
             config_file = artifact_root / f"config_{model_suffix}.json"
-            existing_quality = assess_vector_artifact(
-                artifact_root,
-                embedding_model=args.embedding_model,
-                build_levels=build_levels,
-                surface=surface,
-                expected_artifact=artifact_metadata,
-                required_l0_files=required_l0,
-            )
+            if artifact_root.is_dir():
+                existing_quality = _assess_vector_artifact_as_local_admin(
+                    artifact_root,
+                    artifact_metadata=artifact_metadata,
+                    evidence="embedding-build-existing-local-cache",
+                    embedding_model=args.embedding_model,
+                    build_levels=build_levels,
+                    surface=surface,
+                    required_l0_files=required_l0,
+                )
+            else:
+                existing_quality = {
+                    "passed": False,
+                    "failure_names": ["missing_artifact_root"],
+                }
             if existing_quality["passed"] and not args.force_rebuild:
                 logger.info(
                     "Embedding already exists and passed quality gates at %s; skipping",
@@ -720,12 +762,13 @@ def build_embeddings(args):
                     artifact_metadata=artifact_metadata,
                 )
 
-            artifact_quality = assess_vector_artifact(
+            artifact_quality = _assess_vector_artifact_as_local_admin(
                 artifact_root,
+                artifact_metadata=artifact_metadata,
+                evidence="embedding-build-finished-local-output",
                 embedding_model=args.embedding_model,
                 build_levels=build_levels,
                 surface=surface,
-                expected_artifact=artifact_metadata,
                 required_l0_files=required_l0,
             )
             quality_path = _vector_quality_path(artifact_root, args.embedding_model)

--- a/scripts/mcp_benchmark_codenib_base.py
+++ b/scripts/mcp_benchmark_codenib_base.py
@@ -19,16 +19,14 @@ import time
 from collections import defaultdict
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List, Mapping
 
 import datasets
 
 from codenib.compiler.manifest import IndexEntry, RepoManifest
-from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.search import search_semantic
-from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.paths import prebuilt_data_dir
 
 CODENIB_DATA = prebuilt_data_dir()
@@ -51,6 +49,41 @@ LANGUAGE_GROUP_MAP: Dict[str, List[str]] = {
     "Rust": ["rust"],
     "TypeScript/JavaScript": ["typescript", "javascript"],
 }
+
+
+def _load_vector_from_local_admin_boundary(
+    store: CodeVectorStore,
+    path: str | Path,
+    *,
+    semantic_contract: Mapping[str, Any],
+    evidence: str,
+) -> None:
+    """Authorize one prebuilt local benchmark view at the CLI boundary."""
+
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
+
+    if not evidence:
+        raise ValueError("local vector authorization evidence must be non-empty")
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                evidence,
+                "mcp-benchmark-cli-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
 
 
 def _normalize_symbol(s: str) -> str:
@@ -151,17 +184,6 @@ async def benchmark_instance(
         ctx = ServerContext(manifest=manifest)
         resources.callback(ctx.close)
         try:
-            with capture_authenticated_vector_view(repo_dir) as vector_view:
-                native_authorization = _mint_trusted_local_admin_authorization(
-                    vector_view.ownership,
-                    view_type="vector",
-                    semantic_contract=artifact_contract,
-                    evidence=(
-                        "mcp-benchmark-local-vector-view",
-                        "captured-vector-tree-subject",
-                    ),
-                )
-
             ctx.vector = CodeVectorStore(
                 embedding_model=embedding_model,
                 embedding_provider="huggingface",
@@ -176,8 +198,11 @@ async def benchmark_instance(
                 ),
                 trust_remote_code=(embedding_model == DEFAULT_EMBEDDING_MODEL),
             )
-            ctx.vector.load(
-                native_index_authorization=native_authorization,
+            _load_vector_from_local_admin_boundary(
+                ctx.vector,
+                manifest.indexes["vector"].path,
+                semantic_contract=artifact_contract,
+                evidence="mcp-benchmark-prebuilt-local-index",
             )
         except Exception as e:
             return {

--- a/test/agent/test_embedding_search_e2e.py
+++ b/test/agent/test_embedding_search_e2e.py
@@ -27,6 +27,9 @@ from pathlib import Path
 
 import pytest
 
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
+
 
 def _cuda_available() -> bool:
     try:
@@ -51,16 +54,30 @@ DEFAULT_EMBEDDING_PROVIDER = "huggingface"
 EMBEDDING_INDEX_PATH = "/tmp/embedding_e2e_index"
 
 
+def _load_test_owned_vector(store, path):
+    """Authorize the session-owned local E2E cache, never artifact input."""
+
+    semantic_contract = dict(store.artifact_metadata)
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "embedding-search-e2e-local-cache",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
+
+
 @pytest.fixture(scope="session")
 def vector_store(httpie_cli_repo):
     """Build or load a CodeVectorStore for the httpie/cli repo."""
     from codenib.index.embedding import CodeVectorStore, build_hierarchical_vector_store
-    from codenib.index.embedding.artifact_integrity import (
-        capture_authenticated_vector_view,
-    )
-    from codenib.native_index_authorization import (
-        _mint_trusted_local_admin_authorization,
-    )
 
     repo_path = str(httpie_cli_repo)
     store_root = Path(EMBEDDING_INDEX_PATH)
@@ -71,16 +88,6 @@ def vector_store(httpie_cli_repo):
         if l0_dir.exists() and l2_dir.exists():
             print(f"\n[e2e] Loading cached index from {EMBEDDING_INDEX_PATH}")
             artifact_contract = {}
-            with capture_authenticated_vector_view(store_root) as vector_view:
-                authorization = _mint_trusted_local_admin_authorization(
-                    vector_view.ownership,
-                    view_type="vector",
-                    semantic_contract=artifact_contract,
-                    evidence=(
-                        "embedding-e2e-local-vector-view",
-                        "captured-vector-tree-subject",
-                    ),
-                )
             vs = CodeVectorStore(
                 embedding_model=DEFAULT_EMBEDDING_MODEL,
                 embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
@@ -98,10 +105,7 @@ def vector_store(httpie_cli_repo):
                 },
             )
             resources.callback(vs.close)
-            vs.load(
-                EMBEDDING_INDEX_PATH,
-                native_index_authorization=authorization,
-            )
+            _load_test_owned_vector(vs, EMBEDDING_INDEX_PATH)
         else:
             print(
                 f"\n[e2e] Building index for {repo_path} into "

--- a/test/agent/test_query.py
+++ b/test/agent/test_query.py
@@ -156,6 +156,34 @@ class TestPreconditions:
         assert result.answer == "ok"
         assert called["n"] == 0
 
+    def test_repo_mode_threads_native_authorization_resolver(self, monkeypatch):
+        from codenib import compiler as compiler_mod
+
+        captured = {}
+
+        def resolver(_entry):
+            return object()
+
+        def fake_build(**kwargs):
+            captured.update(kwargs)
+            return {}
+
+        monkeypatch.setattr(compiler_mod, "build_skill_contexts", fake_build)
+
+        result = query(
+            "hello",
+            options=CodeNibAgentOptions(
+                repo_path="/tmp/repo",
+                llm=_mock_llm_final_answer(answer="ok"),
+                allowed_skills=["bm25_search"],
+                native_index_authorization_resolver=resolver,
+            ),
+        )
+
+        assert result.answer == "ok"
+        assert captured["native_index_authorization"] is None
+        assert captured["native_index_authorization_resolver"] is resolver
+
 
 # ---------------------------------------------------------------------------
 # Compile-table threading

--- a/test/agent/test_query_manifest.py
+++ b/test/agent/test_query_manifest.py
@@ -126,6 +126,39 @@ class TestExactlyOneModeEnforced:
                 ),
             )
 
+    def test_native_token_and_resolver_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="either native_index_authorization"):
+            query(
+                "anything",
+                options=CodeNibAgentOptions(
+                    repo_path="/tmp/x",
+                    llm=_mock_llm_final_answer(),
+                    native_index_authorization=object(),
+                    native_index_authorization_resolver=lambda _entry: object(),
+                ),
+            )
+
+    @pytest.mark.parametrize(
+        "authority_options",
+        [
+            {"native_index_authorization": object()},
+            {"native_index_authorization_resolver": lambda _entry: object()},
+        ],
+    )
+    def test_contexts_mode_rejects_unused_authority_options(
+        self,
+        authority_options,
+    ):
+        with pytest.raises(ValueError, match="not accepted in contexts mode"):
+            query(
+                "anything",
+                options=CodeNibAgentOptions(
+                    contexts={},
+                    llm=_mock_llm_final_answer(),
+                    **authority_options,
+                ),
+            )
+
 
 # ---------------------------------------------------------------------------
 # Manifest mode wiring
@@ -133,6 +166,33 @@ class TestExactlyOneModeEnforced:
 
 
 class TestManifestMode:
+    def test_manifest_mode_threads_native_authorization_resolver(self, monkeypatch):
+        from codenib import compiler as compiler_pkg
+
+        captured = {}
+
+        def resolver(_entry):
+            return object()
+
+        def fake_load(*_args, **kwargs):
+            captured.update(kwargs)
+            return {}
+
+        monkeypatch.setattr(compiler_pkg, "load_contexts_from_manifest", fake_load)
+
+        query(
+            "noop",
+            options=CodeNibAgentOptions(
+                manifest=_fake_manifest(),
+                llm=_mock_llm_final_answer(),
+                allowed_skills=["bm25_search"],
+                native_index_authorization_resolver=resolver,
+            ),
+        )
+
+        assert captured["native_index_authorization"] is None
+        assert captured["native_index_authorization_resolver"] is resolver
+
     def test_manifest_mode_skips_build_skill_contexts(self, monkeypatch):
         """When ``manifest`` is set, the inline build path must never run.
 

--- a/test/agent/test_runner_sandbox.py
+++ b/test/agent/test_runner_sandbox.py
@@ -8,6 +8,7 @@ import base64
 import json
 import subprocess
 import sys
+from dataclasses import replace
 from pathlib import Path
 from types import MappingProxyType, SimpleNamespace
 from unittest.mock import MagicMock
@@ -50,7 +51,7 @@ class FakeSandbox:
             source_revision="c" * 40,
             network="none",
             rootless_runtime=True,
-            source_fingerprint="sha256:" + "e" * 64,
+            source_fingerprint="sha256-v2:" + "e" * 64,
         )
 
     def execute(self, request):
@@ -326,7 +327,10 @@ def test_sandbox_prompt_hides_host_path_and_uses_workspace_root(tmp_path):
 
 
 def test_sandbox_manifest_revision_must_match():
-    manifest = RepoManifest(commit="d" * 40, source_fingerprint="sha256:" + "e" * 64)
+    manifest = RepoManifest(
+        commit="d" * 40,
+        source_fingerprint="sha256-v2:" + "e" * 64,
+    )
     with pytest.raises(ValueError, match="does not match"):
         AgentRunner(
             MagicMock(spec=LiteLLMChat),
@@ -347,13 +351,48 @@ def test_sandbox_manifest_requires_revision():
 
 
 def test_sandbox_manifest_fingerprint_must_match():
-    manifest = RepoManifest(commit="c" * 40, source_fingerprint="sha256:" + "f" * 64)
+    manifest = RepoManifest(
+        commit="c" * 40,
+        source_fingerprint="sha256-v2:" + "f" * 64,
+    )
     with pytest.raises(ValueError, match="fingerprint does not match"):
         AgentRunner(
             MagicMock(spec=LiteLLMChat),
             SkillRegistry(),
             sandbox=FakeSandbox(),
             manifest=manifest,
+        )
+
+
+def test_sandbox_matching_legacy_fingerprint_cannot_authorize_runner():
+    sandbox = FakeSandbox()
+    legacy = "sha256:" + "e" * 64
+    sandbox.metadata = replace(sandbox.metadata, source_fingerprint=legacy)
+    manifest = RepoManifest(commit="c" * 40, source_fingerprint=legacy)
+
+    with pytest.raises(ValueError, match="secure source fingerprint v2"):
+        AgentRunner(
+            MagicMock(spec=LiteLLMChat),
+            SkillRegistry(),
+            sandbox=sandbox,
+            manifest=manifest,
+        )
+
+
+def test_query_matching_legacy_fingerprint_cannot_authorize_context_loading():
+    sandbox = FakeSandbox()
+    legacy = "sha256:" + "e" * 64
+    sandbox.metadata = replace(sandbox.metadata, source_fingerprint=legacy)
+    manifest = RepoManifest(commit="c" * 40, source_fingerprint=legacy)
+
+    with pytest.raises(ValueError, match="secure source fingerprint v2"):
+        query(
+            "noop",
+            options=CodeNibAgentOptions(
+                manifest=manifest,
+                llm=MagicMock(spec=LiteLLMChat),
+                sandbox=sandbox,
+            ),
         )
 
 

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -571,6 +571,31 @@ def test_context_artifact_rejects_unpublished_vector_generation(tmp_path: Path) 
         )
 
 
+def test_context_vector_requires_config_authority_before_mint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, manifest_path, _vector = _fixture_vector_manifest(tmp_path)
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["vector"].config.pop("persistence_config_fingerprint")
+    manifest.save(manifest_path)
+    import codenib.artifacts.context as context_module
+
+    monkeypatch.setattr(
+        context_module,
+        "_mint_trusted_local_admin_authorization",
+        lambda *args, **kwargs: pytest.fail(
+            "unanchored vector config must not mint native authorization"
+        ),
+    )
+    with pytest.raises(ValueError, match="requires its config fingerprint"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "publish" / "context",
+        )
+
+
 def test_context_artifact_rejects_tampered_vector_level(tmp_path: Path) -> None:
     repo, manifest_path, vector = _fixture_vector_manifest(tmp_path)
     documents = vector / "l2" / "documents_test__model.pkl"
@@ -639,6 +664,30 @@ def test_context_artifact_rejects_source_drift(tmp_path: Path) -> None:
             repo,
             manifest_path,
             tmp_path / "publish" / "context",
+        )
+
+
+def test_context_vector_never_mints_from_unvalidated_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, manifest_path, _vector = _fixture_vector_manifest(tmp_path)
+    (repo / "sample.py").write_text("VALUE = 2\n")
+    import codenib.artifacts.context as context_module
+
+    monkeypatch.setattr(
+        context_module,
+        "_mint_trusted_local_admin_authorization",
+        lambda *args, **kwargs: pytest.fail(
+            "source drift must be rejected before native authorization"
+        ),
+    )
+    with pytest.raises(ValueError, match="source files do not match"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "publish" / "context",
+            validate_checkout=False,
         )
 
 

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -15,7 +15,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from codenib._atomic_directory import capture_directory_ownership
 from codenib.artifacts import normalize_owned_query_view, validate_portable_query_view
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.index.embedding.artifact_integrity import (

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -24,9 +24,7 @@ from codenib.index.embedding.artifact_integrity import (
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
-from codenib.native_index_authorization import (
-    _mint_trusted_local_admin_authorization,
-)
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.provider_routes import resolve_inference_route
 
 _VECTOR_CONFIG = {
@@ -814,6 +812,10 @@ def test_normalize_vector_converts_trusted_pickle_and_strips_build_state(
         view_type="vector",
         view_config=_VECTOR_CONFIG,
         source_trust="trusted-local",
+        native_index_authorization=_authorize_vector_runtime(
+            vector,
+            _VECTOR_CONFIG,
+        ),
     )
 
     documents_path = level / f"documents_{_MODEL_SUFFIX}.json"
@@ -908,8 +910,9 @@ def test_portable_vector_validator_rejects_noncanonical_json_without_mutation(
     } == before_modes
 
 
-def test_portable_vector_validator_rechecks_faiss_semantics_after_records(
+def test_portable_vector_validator_treats_authenticated_faiss_as_inert_bytes(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo, _source = _repository(tmp_path)
     vector = _vector_view(tmp_path, repo, document_format="json")
@@ -938,13 +941,18 @@ def test_portable_vector_validator_rechecks_faiss_semantics_after_records(
         ),
     }
 
-    with pytest.raises(ValueError, match="FAISS dimension mismatch"):
-        validate_portable_query_view(
-            vector,
-            repo_path=repo,
-            view_type="vector",
-            view_config=view_config,
-        )
+    faiss = importlib.import_module("faiss")
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("portable validation must not parse FAISS bytes")
+
+    monkeypatch.setattr(faiss, "read_index", fail_if_called)
+    validate_portable_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=view_config,
+    )
 
 
 @pytest.mark.parametrize("artifact", ["config", "documents", "faiss"])
@@ -1010,36 +1018,35 @@ def test_portable_vector_rejects_fifo_swapped_after_capture_without_blocking(
         target.write_bytes(original)
 
 
-def test_portable_vector_parses_faiss_from_authenticated_callback_reader(
+def test_portable_vector_normalize_and_validate_do_not_parse_faiss(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo, _source = _repository(tmp_path)
     vector = _vector_view(tmp_path, repo, document_format="json")
+    import codenib.artifacts.portable_views as portable_views_module
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("portable normalization must not invoke native parsers")
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "importlib",
+        SimpleNamespace(import_module=fail_if_called),
+    )
+    monkeypatch.setattr(portable_views_module.compat_pickle, "load", fail_if_called)
     adjustments = normalize_owned_query_view(
         vector,
         repo_path=repo,
         view_type="vector",
         view_config=_VECTOR_CONFIG,
     )
-    faiss = importlib.import_module("faiss")
-    real_read_index = faiss.read_index
-    sources: list[object] = []
-
-    def tracking_read_index(source, *args, **kwargs):
-        sources.append(source)
-        return real_read_index(source, *args, **kwargs)
-
-    monkeypatch.setattr(faiss, "read_index", tracking_read_index)
     validate_portable_query_view(
         vector,
         repo_path=repo,
         view_type="vector",
         view_config={**_VECTOR_CONFIG, **adjustments},
     )
-
-    assert len(sources) == 1
-    assert not isinstance(sources[0], (str, Path))
 
 
 def test_portable_vector_rejects_external_symlink_swap_and_restore(
@@ -1313,6 +1320,10 @@ def test_normalize_upgrades_fully_legacy_vector_config(tmp_path: Path) -> None:
         view_type="vector",
         view_config=_VECTOR_CONFIG,
         source_trust="trusted-local",
+        native_index_authorization=_authorize_vector_runtime(
+            vector,
+            _VECTOR_CONFIG,
+        ),
     )
 
     upgraded = json.loads(config_path.read_text(encoding="utf-8"))
@@ -1440,6 +1451,43 @@ def test_normalize_prunes_current_model_files_for_zero_count(tmp_path: Path) -> 
         view_type="vector",
         view_config=_VECTOR_CONFIG,
         source_trust="trusted-local",
+        native_index_authorization=_authorize_vector_runtime(
+            vector,
+            _VECTOR_CONFIG,
+        ),
+    )
+
+    assert not stale.exists()
+
+
+def test_inert_zero_and_nonzero_levels_never_invoke_native_parsers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    stale = vector / "l0"
+    stale.mkdir()
+    (stale / f"documents_{_MODEL_SUFFIX}.json").write_text("[]\n", encoding="utf-8")
+    _write_faiss(stale / f"index_{_MODEL_SUFFIX}.faiss", count=0)
+    (stale / f"config_{_MODEL_SUFFIX}.json").write_text("{}\n", encoding="utf-8")
+    import codenib.artifacts.portable_views as portable_views_module
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("portable-inert levels must not invoke native parsers")
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "importlib",
+        SimpleNamespace(import_module=fail_if_called),
+    )
+    monkeypatch.setattr(portable_views_module.compat_pickle, "load", fail_if_called)
+
+    normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
     )
 
     assert not stale.exists()
@@ -1467,15 +1515,20 @@ def test_normalize_inert_pickle_rejects_before_loading(
 ) -> None:
     repo, _source = _repository(tmp_path)
     vector = _vector_view(tmp_path, repo, document_format="pkl")
+    import codenib.artifacts.portable_views as portable_views_module
+
     called = False
 
-    def fail_if_called(_handle):
+    def fail_if_called(*_args, **_kwargs):
         nonlocal called
         called = True
         raise AssertionError("pickle loader must not run")
 
+    monkeypatch.setattr(portable_views_module.compat_pickle, "load", fail_if_called)
     monkeypatch.setattr(
-        "codenib.artifacts.portable_views.compat_pickle.load", fail_if_called
+        portable_views_module,
+        "importlib",
+        SimpleNamespace(import_module=fail_if_called),
     )
     with pytest.raises(ValueError, match="portable-inert.*pickle"):
         normalize_owned_query_view(
@@ -1483,8 +1536,113 @@ def test_normalize_inert_pickle_rejects_before_loading(
             repo_path=repo,
             view_type="vector",
             view_config=_VECTOR_CONFIG,
+            source_trust="trusted-local",
         )
     assert called is False
+
+
+def test_malformed_native_authorization_rejects_before_parsers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="pkl")
+    faiss = importlib.import_module("faiss")
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("invalid authorization must not reach native parsers")
+
+    monkeypatch.setattr(
+        "codenib.artifacts.portable_views.compat_pickle.load", fail_if_called
+    )
+    monkeypatch.setattr(faiss, "read_index", fail_if_called)
+    with pytest.raises(ValueError, match="authorization.*malformed"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+            native_index_authorization=object(),  # type: ignore[arg-type]
+        )
+
+
+def test_native_authorization_tree_drift_rejects_before_parsers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="pkl")
+    authorization = _authorize_vector_runtime(vector, _VECTOR_CONFIG)
+    index_path = vector / "l2" / f"index_{_MODEL_SUFFIX}.faiss"
+    index_path.write_bytes(index_path.read_bytes() + b"drift")
+    faiss = importlib.import_module("faiss")
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("drifted authorization must not reach native parsers")
+
+    monkeypatch.setattr(
+        "codenib.artifacts.portable_views.compat_pickle.load", fail_if_called
+    )
+    monkeypatch.setattr(faiss, "read_index", fail_if_called)
+    with pytest.raises(ValueError, match="authorization does not match captured bytes"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+            native_index_authorization=authorization,
+        )
+
+
+def test_native_authorization_config_drift_rejects_before_parsers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="pkl")
+    authorization = _authorize_vector_runtime(vector, _VECTOR_CONFIG)
+    changed_config = {**_VECTOR_CONFIG, "index_metric": "l2"}
+    faiss = importlib.import_module("faiss")
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_close = portable_views_module._OwnedViewReader.close
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("config drift must not reach native parsers")
+
+    monkeypatch.setattr(
+        "codenib.artifacts.portable_views.compat_pickle.load", fail_if_called
+    )
+    monkeypatch.setattr(faiss, "read_index", fail_if_called)
+
+    def close_then_fail(reader):
+        real_close(reader)
+        raise RuntimeError("injected reader close failure")
+
+    monkeypatch.setattr(
+        portable_views_module._OwnedViewReader,
+        "close",
+        close_then_fail,
+    )
+    with pytest.raises(
+        ValueError,
+        match="authorization does not match captured bytes",
+    ) as exc_info:
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=changed_config,
+            native_index_authorization=authorization,
+        )
+    notes = (
+        *getattr(exc_info.value, "__notes__", ()),
+        *getattr(exc_info.value, "_codenib_cleanup_notes", ()),
+    )
+    assert any(
+        "reader cleanup also failed" in note and "injected reader close failure" in note
+        for note in notes
+    )
 
 
 def test_portable_views_do_not_import_faiss_eagerly() -> None:
@@ -1712,6 +1870,10 @@ def test_normalize_schema6_rejects_faiss_metric_drift(tmp_path: Path) -> None:
             repo_path=repo,
             view_type="vector",
             view_config=view_config,
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                view_config,
+            ),
         )
 
 
@@ -1730,6 +1892,10 @@ def test_normalize_schema6_rejects_faiss_index_type_drift(tmp_path: Path) -> Non
             repo_path=repo,
             view_type="vector",
             view_config=view_config,
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                view_config,
+            ),
         )
 
 
@@ -1783,6 +1949,10 @@ def test_runtime_and_normalize_reject_untrained_active_ivf_before_first_search(
             repo_path=repo,
             view_type="vector",
             view_config=view_config,
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                view_config,
+            ),
         )
 
 
@@ -1823,6 +1993,10 @@ def test_normalize_vector_rejects_mixed_document_formats(tmp_path: Path) -> None
             repo_path=repo,
             view_type="vector",
             view_config=_VECTOR_CONFIG,
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                _VECTOR_CONFIG,
+            ),
             source_trust="trusted-local",
         )
 
@@ -1867,13 +2041,15 @@ def test_normalize_vector_rejects_malformed_committed_json(tmp_path: Path) -> No
         )
 
 
-def test_normalize_vector_rejects_residual_pickle(tmp_path: Path) -> None:
+def test_trusted_local_string_does_not_authorize_residual_pickle(
+    tmp_path: Path,
+) -> None:
     repo, _source = _repository(tmp_path)
     vector = _vector_view(tmp_path, repo, document_format="json")
     residual = vector / "unexamined.pkl"
     residual.write_bytes(b"must-not-publish")
 
-    with pytest.raises(ValueError, match="unexpected pickle"):
+    with pytest.raises(ValueError, match="portable-inert.*pickle"):
         normalize_owned_query_view(
             vector,
             repo_path=repo,
@@ -2381,6 +2557,10 @@ def test_normalize_rejects_faiss_shape_drift(
             repo_path=repo,
             view_type="vector",
             view_config=_VECTOR_CONFIG,
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                _VECTOR_CONFIG,
+            ),
         )
 
 

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -20,10 +20,13 @@ from codenib.artifacts import normalize_owned_query_view, validate_portable_quer
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    capture_authenticated_vector_view,
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
-from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
+from codenib.native_index_authorization import (
+    _mint_trusted_local_admin_authorization,
+)
 from codenib.provider_routes import resolve_inference_route
 
 _VECTOR_CONFIG = {
@@ -39,13 +42,19 @@ _MODEL_SUFFIX = "test__model"
 _REVISION = "a" * 40
 
 
-def _vector_authorization(vector: Path, store):
-    return _mint_trusted_local_admin_authorization(
-        capture_directory_ownership(vector),
-        view_type="vector",
-        semantic_contract=store.artifact_metadata,
-        evidence=("portable-vector-view-test-local-admin",),
-    )
+def _authorize_vector_runtime(path: Path, semantic_contract: dict[str, object]):
+    """Mint the exact process-local capability used by real FAISS load tests."""
+
+    with capture_authenticated_vector_view(path) as view:
+        return _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "portable-vector-runtime-contract-test",
+                "captured-vector-tree-subject",
+            ),
+        )
 
 
 def _tree(root: Path) -> dict[str, bytes]:
@@ -1524,7 +1533,12 @@ def test_normalize_schema6_view_loads_with_runtime_contract(
         trust_remote_code=False,
     )
 
-    store.load(native_index_authorization=_vector_authorization(vector, store))
+    store.load(
+        native_index_authorization=_authorize_vector_runtime(
+            vector,
+            store.artifact_metadata,
+        )
+    )
 
     assert len(store.l2_documents) == 1
     assert int(store.l2_index.ntotal) == 1
@@ -1719,7 +1733,7 @@ def test_normalize_schema6_rejects_faiss_index_type_drift(tmp_path: Path) -> Non
         )
 
 
-def test_normalize_rejects_untrained_active_ivf_before_runtime_first_search(
+def test_runtime_and_normalize_reject_untrained_active_ivf_before_first_search(
     tmp_path: Path,
 ) -> None:
     from codenib.index.embedding.vector_store import CodeVectorStore
@@ -1756,7 +1770,12 @@ def test_normalize_rejects_untrained_active_ivf_before_runtime_first_search(
         trust_remote_code=False,
     )
     with pytest.raises(ValueError, match="FAISS index is not trained"):
-        store.load(native_index_authorization=_vector_authorization(vector, store))
+        store.load(
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                store.artifact_metadata,
+            )
+        )
 
     with pytest.raises(ValueError, match="active IVF index is untrained"):
         normalize_owned_query_view(

--- a/test/artifacts/test_publish.py
+++ b/test/artifacts/test_publish.py
@@ -13,6 +13,7 @@ import pytest
 from codenib import cli
 from codenib.artifacts import CONTEXT_ARTIFACT_MANIFEST
 from codenib.compiler.index_compiler import IndexCompiler
+from codenib.paths import repo_index_dir
 from codenib.web.static_export import STATIC_EXPORT_MANIFEST
 
 
@@ -277,6 +278,56 @@ def test_publish_rejects_output_inside_repository_before_indexing(
 
     assert result == 2
     assert not (repo / "published").exists()
+
+
+@pytest.mark.parametrize(
+    ("output_option", "protected_name"),
+    [
+        ("--site-output", "repository"),
+        ("--context-output", "index"),
+    ],
+)
+def test_publish_rejects_symlinked_output_ancestor_before_indexing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output_option: str,
+    protected_name: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "runtime.py").write_text("VALUE = 1\n")
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "home"))
+    protected = repo if protected_name == "repository" else repo_index_dir(repo)
+    protected.mkdir(parents=True, exist_ok=True)
+    alias = tmp_path / "output-alias"
+    alias.symlink_to(protected, target_is_directory=True)
+    monkeypatch.setattr(
+        cli,
+        "_run_index",
+        lambda *_args, **_kwargs: pytest.fail("publish indexed before preflight"),
+    )
+    site = tmp_path / "site"
+    context = tmp_path / "context"
+    if output_option == "--site-output":
+        site = alias / "published"
+    else:
+        context = alias / "published"
+
+    result = cli.run(
+        [
+            "publish",
+            str(repo),
+            "--site-output",
+            str(site),
+            "--context-output",
+            str(context),
+            "--frontend-dir",
+            str(_frontend(tmp_path)),
+        ]
+    )
+
+    assert result == 2
+    assert not (protected / "published").exists()
 
 
 def test_publication_environment_marks_custom_embedding_key_as_secret(

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -49,6 +49,7 @@ from codenib.artifacts import (
 from codenib.cli import run
 from codenib.compiler.index_builders import VectorIndexBuilder
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import vector_config_artifact_record
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.source import read_source_impl
@@ -227,6 +228,11 @@ def _vector_artifact(tmp_path: Path) -> tuple[Path, Path, str]:
             level="l2",
         )
         store.save()
+
+    config["persistence_config_fingerprint"] = vector_config_artifact_record(
+        vector,
+        "test__model",
+    )
 
     source_identity = fingerprint_repository(repo)
     manifest_path = index_root / "repo_manifest.json"

--- a/test/compiler/test_artifact_quality.py
+++ b/test/compiler/test_artifact_quality.py
@@ -11,7 +11,9 @@ from types import SimpleNamespace
 
 import faiss
 import numpy as np
+import pytest
 
+from codenib import compat_pickle
 from codenib.compiler.artifact_quality import (
     assess_vector_artifact,
     constrain_and_assess_graph_artifact,
@@ -19,6 +21,8 @@ from codenib.compiler.artifact_quality import (
 )
 from codenib.git_snapshot import GitSourceSurface
 from codenib.graph.code_graph import CodeGraph
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 
 
 def _git(repo, *args):
@@ -42,6 +46,28 @@ def _source_surface(tmp_path):
     _git(repo, "add", "src/main.py")
     _git(repo, "commit", "-m", "initial")
     return repo, GitSourceSurface.load(repo)
+
+
+def _assess_vector_as_trusted_local_admin(root, **kwargs):
+    """Test-only lexical admin boundary for locally constructed fixtures."""
+
+    expected_artifact = kwargs["expected_artifact"]
+    with capture_authenticated_vector_view(root) as view:
+        authorization = _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=expected_artifact,
+            evidence=(
+                "artifact-quality-test-owned-fixture",
+                "captured-vector-tree-subject",
+            ),
+        )
+        return assess_vector_artifact(
+            root,
+            authenticated_view=view,
+            native_index_authorization=authorization,
+            **kwargs,
+        )
 
 
 def test_graph_quality_removes_paths_outside_commit(tmp_path):
@@ -105,7 +131,10 @@ def test_graph_quality_reports_malformed_paths_before_constraining(tmp_path):
     assert "../generated.py" not in graph.name_to_vertex
 
 
-def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
+def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(
+    tmp_path,
+    monkeypatch,
+):
     _repo, surface = _source_surface(tmp_path)
     model = "test/model"
     suffix = "test__model"
@@ -137,7 +166,66 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
         encoding="utf-8",
     )
 
-    report = assess_vector_artifact(
+    def parser_must_not_run(*_args, **_kwargs):
+        raise AssertionError("native parser ran before external authorization")
+
+    with capture_authenticated_vector_view(root) as view:
+        with monkeypatch.context() as guard:
+            guard.setattr(compat_pickle, "load", parser_must_not_run)
+            guard.setattr(faiss, "read_index", parser_must_not_run)
+            with pytest.raises(ValueError, match="requires external authorization"):
+                assess_vector_artifact(
+                    root,
+                    embedding_model=model,
+                    build_levels=["l0"],
+                    surface=surface,
+                    expected_artifact=identity,
+                    required_l0_files=["src/main.py"],
+                    authenticated_view=view,
+                    native_index_authorization=None,
+                )
+
+    with capture_authenticated_vector_view(root) as view:
+        authorization = _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=identity,
+            evidence=(
+                "artifact-quality-primary-error-test",
+                "captured-vector-tree-subject",
+            ),
+        )
+
+        def fail_assessment(_paths):
+            raise ValueError("primary assessment failure")
+
+        def fail_final_verification():
+            raise RuntimeError("secondary final verification failure")
+
+        failing_surface = SimpleNamespace(
+            commit=surface.commit,
+            tree=surface.tree,
+            classify=fail_assessment,
+        )
+        with monkeypatch.context() as guard:
+            guard.setattr(
+                type(view),
+                "verify_final",
+                lambda _self: fail_final_verification(),
+            )
+            with pytest.raises(ValueError, match="primary assessment failure"):
+                assess_vector_artifact(
+                    root,
+                    embedding_model=model,
+                    build_levels=["l0"],
+                    surface=failing_surface,
+                    expected_artifact=identity,
+                    required_l0_files=["src/main.py"],
+                    authenticated_view=view,
+                    native_index_authorization=authorization,
+                )
+
+    report = _assess_vector_as_trusted_local_admin(
         root,
         embedding_model=model,
         build_levels=["l0"],
@@ -171,7 +259,7 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
     stale_level.mkdir()
     stale_index = stale_level / f"index_{suffix}.faiss"
     stale_index.write_bytes(b"stale")
-    unexpected = assess_vector_artifact(
+    unexpected = _assess_vector_as_trusted_local_admin(
         root,
         embedding_model=model,
         build_levels=["l0"],
@@ -186,7 +274,7 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
     documents[0].metadata = []
     with documents_path.open("wb") as handle:
         pickle.dump(documents, handle)
-    invalid = assess_vector_artifact(
+    invalid = _assess_vector_as_trusted_local_admin(
         root,
         embedding_model=model,
         build_levels=["l0"],
@@ -203,7 +291,7 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
         documents[0].metadata = metadata
         with documents_path.open("wb") as handle:
             pickle.dump(documents, handle)
-        invalid_path = assess_vector_artifact(
+        invalid_path = _assess_vector_as_trusted_local_admin(
             root,
             embedding_model=model,
             build_levels=["l0"],
@@ -225,7 +313,7 @@ def test_vector_quality_does_not_report_missing_level_as_empty(tmp_path):
         encoding="utf-8",
     )
 
-    report = assess_vector_artifact(
+    report = _assess_vector_as_trusted_local_admin(
         root,
         embedding_model=model,
         build_levels=["l0"],

--- a/test/compiler/test_cache_lock.py
+++ b/test/compiler/test_cache_lock.py
@@ -362,6 +362,19 @@ class _AbortLockBody(BaseException):
     pass
 
 
+def _assert_secondary_cleanup_diagnostic(
+    primary: BaseException,
+    cleanup: BaseException,
+) -> None:
+    notes = tuple(getattr(primary, "__notes__", ())) + tuple(
+        getattr(primary, "_codenib_cleanup_notes", ())
+    )
+    diagnostic = "\n".join(notes)
+    assert "compiler cache lock" in diagnostic
+    assert "cleanup also failed" in diagnostic
+    assert repr(cleanup) in diagnostic
+
+
 def test_base_exception_releases_lock_for_reacquisition(tmp_path: Path) -> None:
     cache = tmp_path / "cache"
 
@@ -369,6 +382,131 @@ def test_base_exception_releases_lock_for_reacquisition(tmp_path: Path) -> None:
         with compiler_cache_lock(cache):
             raise _AbortLockBody
 
+    with compiler_cache_lock(cache):
+        pass
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or not Path("/proc/self/fd").is_dir(),
+    reason="requires POSIX procfs descriptor accounting",
+)
+@pytest.mark.parametrize("failure_stage", ["entry", "body"])
+@pytest.mark.parametrize("close_phase", ["before", "after"])
+@pytest.mark.parametrize(
+    "primary_type",
+    [KeyboardInterrupt, SystemExit, GeneratorExit],
+)
+def test_posix_lock_cleanup_never_masks_first_base_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+    close_phase: str,
+    primary_type: type[BaseException],
+) -> None:
+    cache = tmp_path / "cache"
+    primary = primary_type(f"{failure_stage} primary")
+    cleanup = SystemExit(f"close {close_phase} cleanup")
+    real_validate = lock_module._validate_posix_lock_entry
+    real_close = lock_module.os.close
+    lock_descriptor: int | None = None
+    interrupted = False
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    def validate(descriptor, *args, **kwargs):
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+        if failure_stage == "entry":
+            raise primary
+        return real_validate(descriptor, *args, **kwargs)
+
+    def interrupt_lock_close(descriptor: int) -> None:
+        nonlocal interrupted
+        if descriptor == lock_descriptor and not interrupted:
+            interrupted = True
+            if close_phase == "after":
+                real_close(descriptor)
+            raise cleanup
+        real_close(descriptor)
+
+    monkeypatch.setattr(lock_module, "_validate_posix_lock_entry", validate)
+    monkeypatch.setattr(lock_module.os, "close", interrupt_lock_close)
+
+    with pytest.raises(primary_type) as caught:
+        with compiler_cache_lock(cache):
+            if failure_stage == "body":
+                raise primary
+            raise AssertionError("entry failure must prevent the lock body")
+
+    assert caught.value is primary
+    assert interrupted is True
+    _assert_secondary_cleanup_diagnostic(primary, cleanup)
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
+    assert lock_module._ACTIVE_POSIX_LOCK_DESCRIPTORS == set()
+
+    monkeypatch.setattr(lock_module.os, "close", real_close)
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_posix_lock_entry",
+        real_validate,
+    )
+    with compiler_cache_lock(cache):
+        pass
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or not Path("/proc/self/fd").is_dir(),
+    reason="requires POSIX procfs descriptor accounting",
+)
+@pytest.mark.parametrize("close_phase", ["before", "after"])
+def test_posix_lock_cleanup_is_primary_without_a_body_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    close_phase: str,
+) -> None:
+    cache = tmp_path / "cache"
+    cleanup = SystemExit(f"close {close_phase} cleanup")
+    real_validate = lock_module._validate_posix_lock_entry
+    real_close = lock_module.os.close
+    lock_descriptor: int | None = None
+    interrupted = False
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    def capture_descriptor(descriptor, *args, **kwargs):
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+        return real_validate(descriptor, *args, **kwargs)
+
+    def interrupt_lock_close(descriptor: int) -> None:
+        nonlocal interrupted
+        if descriptor == lock_descriptor and not interrupted:
+            interrupted = True
+            if close_phase == "after":
+                real_close(descriptor)
+            raise cleanup
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_posix_lock_entry",
+        capture_descriptor,
+    )
+    monkeypatch.setattr(lock_module.os, "close", interrupt_lock_close)
+
+    with pytest.raises(SystemExit) as caught:
+        with compiler_cache_lock(cache):
+            pass
+
+    assert caught.value is cleanup
+    assert interrupted is True
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
+    assert lock_module._ACTIVE_POSIX_LOCK_DESCRIPTORS == set()
+
+    monkeypatch.setattr(lock_module.os, "close", real_close)
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_posix_lock_entry",
+        real_validate,
+    )
     with compiler_cache_lock(cache):
         pass
 
@@ -1415,6 +1553,143 @@ def test_windows_lock_retries_contention_and_unlocks(
         lock_module._WINDOWS_LOCK_RETRY_SECONDS,
     ]
     assert lock_path.read_bytes() == b""
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="requires procfs descriptor accounting",
+)
+@pytest.mark.parametrize("failure_stage", ["entry", "body"])
+@pytest.mark.parametrize("close_phase", ["before", "after"])
+@pytest.mark.parametrize(
+    "primary_type",
+    [KeyboardInterrupt, SystemExit, GeneratorExit],
+)
+def test_windows_lock_cleanup_never_masks_first_base_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+    close_phase: str,
+    primary_type: type[BaseException],
+) -> None:
+    cache = tmp_path / "cache"
+    primary = primary_type(f"{failure_stage} primary")
+    cleanup = SystemExit(f"close {close_phase} cleanup")
+    real_validate = lock_module._validate_windows_lock_entry
+    real_close = lock_module.os.close
+    lock_descriptor: int | None = None
+    interrupted = False
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    def validate(descriptor, *args, **kwargs):
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+        if failure_stage == "entry":
+            raise primary
+        return real_validate(descriptor, *args, **kwargs)
+
+    def acquire(descriptor: int) -> None:
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+
+    def interrupt_lock_close(descriptor: int) -> None:
+        nonlocal interrupted
+        if descriptor == lock_descriptor and not interrupted:
+            interrupted = True
+            if close_phase == "after":
+                real_close(descriptor)
+            raise cleanup
+        real_close(descriptor)
+
+    monkeypatch.setattr(lock_module, "msvcrt", object())
+    monkeypatch.setattr(lock_module, "_validate_windows_lock_entry", validate)
+    monkeypatch.setattr(lock_module, "_acquire_windows_lock", acquire)
+    monkeypatch.setattr(lock_module, "_release_windows_lock", lambda _fd: None)
+    monkeypatch.setattr(lock_module.os, "close", interrupt_lock_close)
+
+    with pytest.raises(primary_type) as caught:
+        with lock_module._windows_compiler_cache_lock(cache):
+            if failure_stage == "body":
+                raise primary
+            raise AssertionError("entry failure must prevent the lock body")
+
+    assert caught.value is primary
+    assert interrupted is True
+    _assert_secondary_cleanup_diagnostic(primary, cleanup)
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
+
+    monkeypatch.setattr(lock_module.os, "close", real_close)
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_windows_lock_entry",
+        real_validate,
+    )
+    with lock_module._windows_compiler_cache_lock(cache):
+        pass
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="requires procfs descriptor accounting",
+)
+@pytest.mark.parametrize("close_phase", ["before", "after"])
+def test_windows_lock_cleanup_is_primary_without_a_body_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    close_phase: str,
+) -> None:
+    cache = tmp_path / "cache"
+    cleanup = SystemExit(f"close {close_phase} cleanup")
+    real_validate = lock_module._validate_windows_lock_entry
+    real_close = lock_module.os.close
+    lock_descriptor: int | None = None
+    interrupted = False
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    def capture_descriptor(descriptor, *args, **kwargs):
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+        return real_validate(descriptor, *args, **kwargs)
+
+    def acquire(descriptor: int) -> None:
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+
+    def interrupt_lock_close(descriptor: int) -> None:
+        nonlocal interrupted
+        if descriptor == lock_descriptor and not interrupted:
+            interrupted = True
+            if close_phase == "after":
+                real_close(descriptor)
+            raise cleanup
+        real_close(descriptor)
+
+    monkeypatch.setattr(lock_module, "msvcrt", object())
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_windows_lock_entry",
+        capture_descriptor,
+    )
+    monkeypatch.setattr(lock_module, "_acquire_windows_lock", acquire)
+    monkeypatch.setattr(lock_module, "_release_windows_lock", lambda _fd: None)
+    monkeypatch.setattr(lock_module.os, "close", interrupt_lock_close)
+
+    with pytest.raises(SystemExit) as caught:
+        with lock_module._windows_compiler_cache_lock(cache):
+            pass
+
+    assert caught.value is cleanup
+    assert interrupted is True
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
+
+    monkeypatch.setattr(lock_module.os, "close", real_close)
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_windows_lock_entry",
+        real_validate,
+    )
+    with lock_module._windows_compiler_cache_lock(cache):
+        pass
 
 
 @pytest.mark.skipif(

--- a/test/compiler/test_checkout_identity.py
+++ b/test/compiler/test_checkout_identity.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from codenib.compiler.checkout_identity import validate_checkout_identity
 from codenib.compiler.manifest import RepoManifest
 from codenib.source_fingerprint import fingerprint_repository
@@ -43,3 +45,59 @@ def test_checkout_identity_excludes_only_internal_artifact_tree(tmp_path: Path) 
     (artifact_root / "runtime.json").write_text("{}\n", encoding="utf-8")
 
     validate_checkout_identity(repo, manifest, artifact_root=artifact_root)
+
+
+def test_checkout_identity_rejects_legacy_v1_fingerprint(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=f"sha256:{'a' * 64}",
+        languages=["python"],
+    )
+
+    with pytest.raises(ValueError, match="legacy or unsupported"):
+        validate_checkout_identity(repo, manifest, artifact_root=tmp_path)
+
+
+def test_checkout_identity_rejects_missing_source_fingerprint(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        commit="a" * 40,
+        source_fingerprint="",
+        languages=["python"],
+    )
+
+    with pytest.raises(ValueError, match="legacy or unsupported"):
+        validate_checkout_identity(repo, manifest, artifact_root=tmp_path)
+
+
+def test_checkout_identity_never_resolves_replaceable_source_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    )
+    resolve_calls = 0
+
+    def forbidden_resolve(*_args, **_kwargs):
+        nonlocal resolve_calls
+        resolve_calls += 1
+        raise AssertionError("checkout identity followed a replaceable path")
+
+    monkeypatch.setattr(Path, "resolve", forbidden_resolve)
+
+    validate_checkout_identity(repo, manifest, artifact_root=tmp_path / "artifact")
+    assert resolve_calls == 0

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -19,13 +19,13 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
-from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
 import codenib.compiler.index_compiler as index_compiler_module
 from codenib._atomic_directory import (
     capture_directory_ownership,
     directory_ownership_digest,
     directory_ownership_root_identity,
 )
+from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
 from codenib.compiler.index_builders import (
     BM25IndexBuilder,
     IndexBuilderRegistry,
@@ -464,10 +464,7 @@ class TestVectorIndexBuilder:
     ):
         import codenib._atomic_directory as atomic_directory
         from codenib._captured_directory import OwnedDirectoryStage
-        from codenib.index.incremental import (
-            EmbeddingsCache,
-            IncrementalChunkStore,
-        )
+        from codenib.index.incremental import EmbeddingsCache, IncrementalChunkStore
         from codenib.index.incremental import IncrementalState as StateType
 
         output_path = tmp_path / "vector"

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import threading
 import time
@@ -19,6 +20,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
+import codenib.compiler.index_compiler as index_compiler_module
 from codenib.compiler.index_builders import (
     BM25IndexBuilder,
     IndexBuilderRegistry,
@@ -1720,7 +1722,7 @@ class TestUpdateRepo:
         assert calls == [("build", 1, None), ("build", 2, None)]
         assert manifest.indexes["rec"].config["builder_schema"] == 2
 
-    def test_uses_incremental_path_when_head_moved(self, tmp_path):
+    def test_clean_new_head_uses_authority_safe_full_rebuild(self, tmp_path):
         first = _git_repo(tmp_path)
         calls: list = []
         compiler = self._compiler(calls)
@@ -1729,9 +1731,72 @@ class TestUpdateRepo:
         assert first != second
 
         compiler.update_repo(str(tmp_path))
-        assert calls[-2] == ("incremental_update", first)
+        assert calls == [("build", None), ("build", None)]
 
-    def test_incremental_builder_receives_previous_manifest_config(self, tmp_path):
+    def test_path_status_a_b_a_cannot_authorize_incremental_reuse(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git_repo(repo)
+        calls: list = []
+        compiler = self._compiler(calls)
+        compiler.compile_repo(str(repo))
+        _commit(repo, "b.py")
+
+        clean_replacement = tmp_path / "clean-replacement"
+        shutil.copytree(repo, clean_replacement, symlinks=True)
+        (repo / "a.py").write_text("def dirty_a():\n    return 9\n")
+        parked = tmp_path / "parked-a"
+        status_calls = []
+
+        def observe_temporary_clean_replacement(*args, **kwargs):
+            status_calls.append((args, kwargs))
+            os.rename(repo, parked)
+            os.rename(clean_replacement, repo)
+            try:
+                return False
+            finally:
+                os.rename(repo, clean_replacement)
+                os.rename(parked, repo)
+
+        monkeypatch.setattr(
+            index_compiler_module,
+            "repository_source_is_dirty",
+            observe_temporary_clean_replacement,
+            raising=False,
+        )
+
+        compiler.update_repo(str(repo))
+
+        assert status_calls == []
+        assert calls == [("build", None), ("build", None)]
+
+    def test_v1_manifest_forces_full_rebuild_instead_of_incremental_update(
+        self,
+        tmp_path,
+    ):
+        _git_repo(tmp_path)
+        calls: list = []
+        compiler = self._compiler(calls)
+        manifest = compiler.compile_repo(str(tmp_path))
+        legacy = f"sha256:{'a' * 64}"
+        manifest.source_fingerprint = legacy
+        manifest.last_indexed_source_fingerprint = legacy
+        manifest.indexes["rec"].source_fingerprint = legacy
+        manifest.save(tmp_path / ".codenib_cache" / MANIFEST_FILENAME)
+        _commit(tmp_path, "b.py")
+        calls.clear()
+
+        rebuilt = compiler.update_repo(str(tmp_path))
+
+        assert calls == [("build", None)]
+        assert rebuilt.source_fingerprint.startswith("sha256-v2:")
+        assert rebuilt.indexes["rec"].source_fingerprint == (rebuilt.source_fingerprint)
+
+    def test_full_rebuild_does_not_receive_previous_manifest_config(self, tmp_path):
         _git_repo(tmp_path)
         observed = []
 
@@ -1764,15 +1829,15 @@ class TestUpdateRepo:
             registry,
             IndexCompilerConfig(index_types=["rec"], languages=["python"]),
         )
-        first_manifest = compiler.compile_repo(str(tmp_path))
+        compiler.compile_repo(str(tmp_path))
         _commit(tmp_path, "b.py")
 
         compiler.update_repo(str(tmp_path))
 
-        assert observed == [first_manifest.indexes["rec"].config]
+        assert observed == []
 
-    def test_incremental_graph_preserves_partial_language_coverage(self, tmp_path):
-        first = _git_repo(tmp_path)
+    def test_full_graph_rebuild_recomputes_partial_language_coverage(self, tmp_path):
+        _git_repo(tmp_path)
         calls = []
 
         class PartialGraphBuilder:
@@ -1825,7 +1890,7 @@ class TestUpdateRepo:
         manifest = compiler.update_repo(str(tmp_path))
         metadata = manifest.indexes["symbol_graph"].metadata
 
-        assert calls == [("build", None), ("incremental_update", first)]
+        assert calls == [("build", None), ("build", None)]
         assert metadata["available_languages"] == ["python"]
         assert metadata["failed_languages"] == {"cpp": "compile database unavailable"}
         assert metadata["partial"] is True
@@ -1871,7 +1936,7 @@ class TestUpdateRepo:
         def boom(scope, **kwargs):
             raise RuntimeError("builder exploded")
 
-        builder.incremental_update = boom
+        builder.build = boom
 
         manifest = compiler.update_repo(str(tmp_path))
         assert manifest.commit == second
@@ -1888,15 +1953,15 @@ class TestUpdateRepo:
         _commit(tmp_path, "b.py")
 
         builder = compiler._builders.get("rec")
-        healthy = builder.incremental_update
+        healthy = builder.build
 
         def boom(scope, **kwargs):
             raise RuntimeError("builder exploded")
 
-        builder.incremental_update = boom
+        builder.build = boom
         compiler.update_repo(str(tmp_path))
 
-        builder.incremental_update = healthy
+        builder.build = healthy
         calls.clear()
         compiler.update_repo(str(tmp_path))
         # Not a no-op: the failure left work to do.

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -297,6 +297,42 @@ class TestVectorIndexBuilder:
         assert result.metadata["update_mode"] == "full_rebuild"
         assert result.metadata["incremental_fallback_reason"] == "ValueError"
 
+    def test_missing_native_authority_rebuilds_before_model_initialization(
+        self,
+        tmp_path,
+    ):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        rebuilt = IndexStatus(
+            index_type="vector",
+            state=IndexState.FRESH,
+            path=str(tmp_path / "vector"),
+            metadata={},
+        )
+
+        with (
+            patch(
+                "codenib.index.embedding.vector_store.CodeVectorStore",
+                side_effect=AssertionError(
+                    "missing authority must not initialize an embedding model"
+                ),
+            ) as store_type,
+            patch.object(builder, "build", return_value=rebuilt) as mock_build,
+        ):
+            result = builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "vector"),
+                last_commit="a" * 40,
+            )
+
+        store_type.assert_not_called()
+        mock_build.assert_called_once()
+        assert result.metadata["update_mode"] == "full_rebuild"
+        assert result.metadata["incremental_fallback_reason"] == "ValueError"
+
     def test_missing_incremental_state_attempts_one_rebuild(self, tmp_path):
         builder = VectorIndexBuilder(
             embedding_model="test-model",
@@ -392,11 +428,18 @@ class TestVectorIndexBuilder:
         }
         vector_store = MagicMock(dimension=384)
         vector_store.load.side_effect = RuntimeError("stop after generation check")
+        authorization = object()
 
-        with patch(
-            "codenib.index.embedding.vector_store.CodeVectorStore",
-            return_value=vector_store,
-        ) as store_type:
+        with (
+            patch(
+                "codenib.native_index_authorization.require_native_index_authorization_preflight",
+                return_value=None,
+            ),
+            patch(
+                "codenib.index.embedding.vector_store.CodeVectorStore",
+                return_value=vector_store,
+            ) as store_type,
+        ):
             with pytest.raises(RuntimeError, match="generation check"):
                 builder._incremental_update_once(
                     scope="current_repo",
@@ -404,10 +447,15 @@ class TestVectorIndexBuilder:
                     output_dir=str(output_path),
                     last_commit="a" * 40,
                     previous_artifact_config=previous,
+                    native_index_authorization=authorization,
                 )
 
         assert store_type.call_args.kwargs["artifact_metadata"] == previous
         vector_store.close.assert_called_once_with()
+        vector_store.load.assert_called_once_with(
+            str(output_path),
+            native_index_authorization=authorization,
+        )
 
     @pytest.mark.parametrize("missing", ["chunk_json", "embedding_pair"])
     def test_pickle_only_incremental_state_forces_rebuild(self, tmp_path, missing):

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -21,6 +21,11 @@ import pytest
 
 from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
 import codenib.compiler.index_compiler as index_compiler_module
+from codenib._atomic_directory import (
+    capture_directory_ownership,
+    directory_ownership_digest,
+    directory_ownership_root_identity,
+)
 from codenib.compiler.index_builders import (
     BM25IndexBuilder,
     IndexBuilderRegistry,
@@ -46,6 +51,10 @@ from codenib.index.embedding.artifact_integrity import VECTOR_VIEW_UPDATE_MARKER
 from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
 from codenib.index.incremental import IncrementalState
 from codenib.ls_router import GraphBuildResult
+from codenib.native_index_authorization import (
+    InvalidNativeIndexAuthorizationError,
+    _mint_trusted_local_admin_authorization,
+)
 from codenib.repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     default_exclude_patterns,
@@ -215,13 +224,42 @@ class TestBM25IndexBuilder:
 # ---------------------------------------------------------------------------
 
 
+def _write_mock_vector_generation(root: Path, model_suffix: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"config_{model_suffix}.json").write_text(
+        '{"level_artifacts": {}}',
+        encoding="utf-8",
+    )
+    level = root / "l2"
+    level.mkdir()
+    (level / f"config_{model_suffix}.json").write_text("{}", encoding="utf-8")
+    (level / f"index_{model_suffix}.faiss").write_bytes(b"new-vector")
+    (level / f"documents_{model_suffix}.pkl").write_bytes(b"new-documents")
+
+
+def _tree_file_bytes(root: Path) -> dict[str, bytes]:
+    if not root.exists():
+        return {}
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
 class TestVectorIndexBuilder:
     @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
     def test_build_returns_status_with_stats(self, mock_build_fn, tmp_path):
         mock_vs = MagicMock()
         mock_vs.l0_documents = ["d1", "d2"]
         mock_vs.l2_documents = ["d3", "d4", "d5"]
-        mock_build_fn.return_value = mock_vs
+
+        def build_vector(**kwargs):
+            build_path = Path(kwargs["index_path"])
+            _write_mock_vector_generation(build_path, "test-model")
+            return mock_vs
+
+        mock_build_fn.side_effect = build_vector
 
         builder = VectorIndexBuilder(
             languages=["python"],
@@ -256,7 +294,319 @@ class TestVectorIndexBuilder:
         mock_build_fn.assert_called_once()
         assert mock_build_fn.call_args.kwargs["force_rebuild"] is True
         assert mock_build_fn.call_args.kwargs["strict_chunking"] is True
+        assert mock_build_fn.call_args.kwargs["_atomic_publish"] is False
         assert not (output_path / VECTOR_VIEW_UPDATE_MARKER).exists()
+
+    def test_build_publishes_one_complete_generation_without_stale_state(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        output_path = tmp_path / "vector"
+        output_path.mkdir()
+        (output_path / "config_test-model.json").write_bytes(b"old-config")
+        (output_path / "incremental_state.json").write_bytes(b"old-state")
+        (output_path / "chunk_store.json").write_bytes(b"old-chunks")
+        (output_path / VECTOR_VIEW_UPDATE_MARKER).write_bytes(b"stale-marker")
+        (output_path / "stale-owned-file").write_bytes(b"stale")
+
+        document = SimpleNamespace(
+            page_content="def fresh():\n    return 1\n",
+            metadata={
+                "file": "fresh.py",
+                "start_line": 0,
+                "end_line": 1,
+                "chunk_type": "function",
+                "name": "fresh",
+                "node_id": "fresh.py::fresh",
+            },
+        )
+        vector_store = MagicMock(
+            dimension=384,
+            l0_documents=[],
+            l2_documents=[document],
+        )
+        vector_store.get_embeddings_by_content_hash.return_value = {
+            "fresh-hash": [0.1, 0.2]
+        }
+        calls = []
+
+        def build_vector(**kwargs):
+            calls.append(kwargs)
+            build_path = Path(kwargs["index_path"])
+            assert (build_path / VECTOR_VIEW_UPDATE_MARKER).is_file()
+            _write_mock_vector_generation(build_path, "test-model")
+            return vector_store
+
+        monkeypatch.setattr(
+            "codenib.index.embedding.builders.build_hierarchical_vector_store",
+            build_vector,
+        )
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+
+        status = builder.build(
+            scope="current_repo",
+            repo_path=str(tmp_path),
+            output_dir=str(output_path),
+        )
+
+        files = _tree_file_bytes(output_path)
+        assert set(files) == {
+            "chunk_store.json",
+            "chunk_store.pkl",
+            "config_test-model.json",
+            "embeddings_cache.json",
+            "embeddings_cache.npz",
+            "embeddings_cache.pkl",
+            "incremental_state.json",
+            "l2/config_test-model.json",
+            "l2/documents_test-model.pkl",
+            "l2/index_test-model.faiss",
+        }
+        assert files["config_test-model.json"] != b"old-config"
+        assert VECTOR_VIEW_UPDATE_MARKER not in files
+        state = IncrementalState.load(output_path)
+        assert state is not None
+        assert state.index_path == str(output_path.resolve())
+        assert status.path == str(output_path)
+        assert calls[0]["_atomic_publish"] is False
+
+    @pytest.mark.parametrize("replacement", ["directory", "symlink"])
+    def test_build_private_root_replacement_cannot_publish_or_write_outside(
+        self,
+        replacement,
+        monkeypatch,
+        tmp_path,
+    ):
+        output_path = tmp_path / "vector"
+        _write_mock_vector_generation(output_path, "test-model")
+        (output_path / "incremental_state.json").write_bytes(b"old-state")
+        before_files = _tree_file_bytes(output_path)
+        before_ownership = capture_directory_ownership(output_path)
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        victim = outside / "victim.bin"
+        victim.write_bytes(b"outside-original")
+        vector_store = MagicMock(
+            dimension=384,
+            l0_documents=[],
+            l2_documents=[],
+        )
+
+        def replace_build_root(**kwargs):
+            anchored_root = Path(kwargs["index_path"])
+            named_root = anchored_root.resolve(strict=True)
+            moved_root = named_root.with_name(f"{named_root.name}.moved")
+            named_root.rename(moved_root)
+            if replacement == "directory":
+                named_root.mkdir()
+                (named_root / "attacker-tree").write_bytes(b"attacker")
+            else:
+                named_root.symlink_to(outside, target_is_directory=True)
+            (anchored_root / "victim.bin").write_bytes(b"private-only")
+            _write_mock_vector_generation(anchored_root, "test-model")
+            return vector_store
+
+        monkeypatch.setattr(
+            "codenib.index.embedding.builders.build_hierarchical_vector_store",
+            replace_build_root,
+        )
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+
+        with pytest.raises(RuntimeError, match="private build root changed"):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_path),
+            )
+
+        assert _tree_file_bytes(output_path) == before_files
+        after_ownership = capture_directory_ownership(output_path)
+        assert directory_ownership_root_identity(after_ownership) == (
+            directory_ownership_root_identity(before_ownership)
+        )
+        assert directory_ownership_digest(after_ownership) == (
+            directory_ownership_digest(before_ownership)
+        )
+        assert victim.read_bytes() == b"outside-original"
+
+    @pytest.mark.parametrize(
+        "phase",
+        [
+            "marker_begin",
+            "vector_save",
+            "after_vector",
+            "seed",
+            "save",
+            "state_save",
+            "marker_finish",
+            "before_publish",
+            "after_publish_rename",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "exception_type",
+        [KeyboardInterrupt, SystemExit, GeneratorExit],
+    )
+    def test_incremental_rebuild_base_exception_restores_previous_generation(
+        self,
+        phase,
+        exception_type,
+        monkeypatch,
+        tmp_path,
+    ):
+        import codenib._atomic_directory as atomic_directory
+        from codenib._captured_directory import OwnedDirectoryStage
+        from codenib.index.incremental import (
+            EmbeddingsCache,
+            IncrementalChunkStore,
+        )
+        from codenib.index.incremental import IncrementalState as StateType
+
+        output_path = tmp_path / "vector"
+        _write_mock_vector_generation(output_path, "test-model")
+        (output_path / "chunk_store.json").write_bytes(b"old-chunks")
+        (output_path / "embeddings_cache.json").write_bytes(b"old-cache")
+        (output_path / "embeddings_cache.npz").write_bytes(b"old-vectors")
+        IncrementalState(
+            last_commit="a" * 40,
+            chunk_store_path="chunk_store.pkl",
+            embeddings_cache_path="embeddings_cache.pkl",
+            index_path=str(output_path.resolve()),
+            build_levels=["l0", "l2"],
+        ).save(output_path)
+
+        document = SimpleNamespace(
+            page_content="def replacement():\n    return 2\n",
+            metadata={
+                "file": "replacement.py",
+                "start_line": 0,
+                "end_line": 1,
+                "chunk_type": "function",
+                "name": "replacement",
+                "node_id": "replacement.py::replacement",
+            },
+        )
+        vector_store = MagicMock(
+            dimension=384,
+            l0_documents=[],
+            l2_documents=[document],
+        )
+        vector_store.get_embeddings_by_content_hash.return_value = {
+            "replacement-hash": [0.3, 0.4]
+        }
+
+        def interrupt(*_args, **_kwargs):
+            raise exception_type(f"interrupt during {phase}")
+
+        def build_vector(**kwargs):
+            _write_mock_vector_generation(Path(kwargs["index_path"]), "test-model")
+            if phase == "vector_save":
+                interrupt()
+            return vector_store
+
+        monkeypatch.setattr(
+            "codenib.index.embedding.builders.build_hierarchical_vector_store",
+            build_vector,
+        )
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        previous_artifact = builder.artifact_identity()
+        before_files = _tree_file_bytes(output_path)
+        before_ownership = capture_directory_ownership(output_path)
+        authorization = _mint_trusted_local_admin_authorization(
+            before_ownership,
+            view_type="vector",
+            semantic_contract=previous_artifact,
+            evidence=("verified-incremental-rollback-test",),
+        )
+
+        if phase == "marker_begin":
+            monkeypatch.setattr(
+                "codenib.index.embedding.artifact_integrity."
+                "begin_vector_view_update",
+                interrupt,
+            )
+        elif phase == "after_vector":
+            monkeypatch.setattr(builder, "_validate_vector_dimension", interrupt)
+        elif phase == "seed":
+            monkeypatch.setattr(
+                IncrementalChunkStore,
+                "from_chunks",
+                classmethod(interrupt),
+            )
+        elif phase == "save":
+            monkeypatch.setattr(EmbeddingsCache, "save", interrupt)
+        elif phase == "state_save":
+            monkeypatch.setattr(StateType, "save", interrupt)
+        elif phase == "marker_finish":
+            monkeypatch.setattr(
+                "codenib.index.embedding.artifact_integrity."
+                "finish_vector_view_update",
+                interrupt,
+            )
+        elif phase == "before_publish":
+            real_publish = OwnedDirectoryStage.publish
+
+            def interrupt_final_publish(stage, *args, **kwargs):
+                if stage.destination == output_path.absolute():
+                    return interrupt()
+                return real_publish(stage, *args, **kwargs)
+
+            monkeypatch.setattr(
+                OwnedDirectoryStage,
+                "publish",
+                interrupt_final_publish,
+            )
+        elif phase == "after_publish_rename":
+            real_rename = atomic_directory._rename_noreplace_at
+            interrupted = False
+
+            def interrupt_after_rename(source, destination, source_fd, dest_fd):
+                nonlocal interrupted
+                real_rename(source, destination, source_fd, dest_fd)
+                if (
+                    source.startswith(".vector.normalize-")
+                    and destination == "vector"
+                    and not interrupted
+                ):
+                    interrupted = True
+                    interrupt()
+
+            monkeypatch.setattr(
+                atomic_directory,
+                "_rename_noreplace_at",
+                interrupt_after_rename,
+            )
+
+        with pytest.raises(exception_type, match=phase):
+            builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_path),
+                last_commit="a" * 40,
+                previous_artifact_config=previous_artifact,
+                native_index_authorization=authorization,
+            )
+
+        assert _tree_file_bytes(output_path) == before_files
+        after_ownership = capture_directory_ownership(output_path)
+        assert directory_ownership_root_identity(after_ownership) == (
+            directory_ownership_root_identity(before_ownership)
+        )
+        assert directory_ownership_digest(after_ownership) == (
+            directory_ownership_digest(before_ownership)
+        )
+        assert not list(tmp_path.glob(".vector.generation-build-*"))
 
     def test_incremental_failure_falls_back_to_full_build(self, tmp_path):
         builder = VectorIndexBuilder(
@@ -297,6 +647,161 @@ class TestVectorIndexBuilder:
         assert result.metadata["update_mode"] == "full_rebuild"
         assert result.metadata["incremental_fallback_reason"] == "ValueError"
 
+    def test_explicit_invalid_native_authority_propagates(self, tmp_path):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+
+        with patch.object(builder, "build") as mock_build:
+            with pytest.raises(
+                InvalidNativeIndexAuthorizationError,
+                match="malformed",
+            ):
+                builder.incremental_update(
+                    scope="current_repo",
+                    repo_path=str(tmp_path),
+                    output_dir=str(tmp_path / "vector"),
+                    last_commit="a" * 40,
+                    native_index_authorization=object(),
+                )
+
+        mock_build.assert_not_called()
+
+    def test_invalid_native_authority_error_is_propagated_unchanged(self, tmp_path):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        authorization_error = InvalidNativeIndexAuthorizationError(
+            "authorization does not match captured bytes"
+        )
+
+        with (
+            patch.object(
+                builder,
+                "_incremental_update_once",
+                side_effect=authorization_error,
+            ),
+            patch.object(builder, "build") as mock_build,
+        ):
+            with pytest.raises(InvalidNativeIndexAuthorizationError) as raised:
+                builder.incremental_update(
+                    scope="current_repo",
+                    repo_path=str(tmp_path),
+                    output_dir=str(tmp_path / "vector"),
+                    last_commit="a" * 40,
+                    native_index_authorization=object(),
+                )
+
+        assert raised.value is authorization_error
+        mock_build.assert_not_called()
+
+    def test_valid_native_authority_is_passed_to_incremental_path(self, tmp_path):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        authorization_root = tmp_path / "authorized-vector"
+        authorization_root.mkdir()
+        (authorization_root / "index.faiss").write_bytes(b"native")
+        authorization = _mint_trusted_local_admin_authorization(
+            capture_directory_ownership(authorization_root),
+            view_type="vector",
+            semantic_contract=builder.artifact_identity(),
+            evidence=("verified-test-boundary",),
+        )
+        updated = IndexStatus(
+            index_type="vector",
+            state=IndexState.FRESH,
+            path=str(tmp_path / "vector"),
+            metadata={"update_mode": "incremental"},
+        )
+
+        with patch.object(
+            builder,
+            "_incremental_update_once",
+            return_value=updated,
+        ) as incremental:
+            result = builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "vector"),
+                last_commit="a" * 40,
+                native_index_authorization=authorization,
+            )
+
+        assert result is updated
+        assert incremental.call_args.kwargs["native_index_authorization"] is (
+            authorization
+        )
+
+    @pytest.mark.parametrize("mismatch", ["tree", "semantic"])
+    def test_exact_native_authority_rejects_before_model_initialization(
+        self,
+        tmp_path,
+        mismatch,
+    ):
+        output_path = tmp_path / "vector"
+        IncrementalState(
+            last_commit="a" * 40,
+            chunk_store_path="chunk_store.pkl",
+            embeddings_cache_path="embeddings_cache.pkl",
+            index_path=str(output_path.resolve()),
+            build_levels=["l0", "l2"],
+        ).save(output_path)
+        (output_path / "chunk_store.json").write_text("{}", encoding="utf-8")
+        (output_path / "embeddings_cache.json").write_text("[]", encoding="utf-8")
+        (output_path / "embeddings_cache.npz").write_bytes(b"placeholder")
+
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        expected_semantic = builder.artifact_identity()
+        authorization_root = output_path
+        authorization_semantic = expected_semantic
+        if mismatch == "tree":
+            authorization_root = tmp_path / "other-vector"
+            authorization_root.mkdir()
+            (authorization_root / "config_test-model.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+        else:
+            authorization_semantic = {"embedding_dimension": 1024}
+        authorization = _mint_trusted_local_admin_authorization(
+            capture_directory_ownership(authorization_root),
+            view_type="vector",
+            semantic_contract=authorization_semantic,
+            evidence=(f"wrong-{mismatch}-test",),
+        )
+
+        with (
+            patch(
+                "codenib.index.embedding.vector_store.CodeVectorStore",
+                side_effect=AssertionError(
+                    "exact authorization must fail before model initialization"
+                ),
+            ) as store_type,
+            patch.object(builder, "build") as full_build,
+        ):
+            with pytest.raises(
+                InvalidNativeIndexAuthorizationError,
+                match="does not match captured bytes",
+            ):
+                builder.incremental_update(
+                    scope="current_repo",
+                    repo_path=str(tmp_path),
+                    output_dir=str(output_path),
+                    last_commit="a" * 40,
+                    previous_artifact_config=expected_semantic,
+                    native_index_authorization=authorization,
+                )
+
+        store_type.assert_not_called()
+        full_build.assert_not_called()
+
     def test_missing_native_authority_rebuilds_before_model_initialization(
         self,
         tmp_path,
@@ -331,7 +836,9 @@ class TestVectorIndexBuilder:
         store_type.assert_not_called()
         mock_build.assert_called_once()
         assert result.metadata["update_mode"] == "full_rebuild"
-        assert result.metadata["incremental_fallback_reason"] == "ValueError"
+        assert result.metadata["incremental_fallback_reason"] == (
+            "MissingNativeIndexAuthorizationError"
+        )
 
     def test_missing_incremental_state_attempts_one_rebuild(self, tmp_path):
         builder = VectorIndexBuilder(
@@ -402,7 +909,10 @@ class TestVectorIndexBuilder:
         mock_build.assert_called_once()
         assert result.metadata["update_mode"] == "full_rebuild"
 
-    def test_incremental_load_uses_previous_manifest_generation(self, tmp_path):
+    def test_authorized_incremental_generation_rebuilds_before_model_init(
+        self,
+        tmp_path,
+    ):
         output_path = tmp_path / "vector"
         IncrementalState(
             last_commit="a" * 40,
@@ -426,36 +936,52 @@ class TestVectorIndexBuilder:
                 "sha256": "0" * 64,
             },
         }
-        vector_store = MagicMock(dimension=384)
-        vector_store.load.side_effect = RuntimeError("stop after generation check")
-        authorization = object()
+        authorization = _mint_trusted_local_admin_authorization(
+            capture_directory_ownership(output_path),
+            view_type="vector",
+            semantic_contract=previous,
+            evidence=("verified-previous-generation",),
+        )
+        rebuilt = IndexStatus(
+            index_type="vector",
+            state=IndexState.FRESH,
+            path=str(output_path),
+            metadata={},
+        )
+        before = _tree_file_bytes(output_path)
 
         with (
             patch(
-                "codenib.native_index_authorization.require_native_index_authorization_preflight",
-                return_value=None,
-            ),
-            patch(
                 "codenib.index.embedding.vector_store.CodeVectorStore",
-                return_value=vector_store,
+                side_effect=AssertionError(
+                    "disabled in-place update must not initialize a model"
+                ),
             ) as store_type,
+            patch.object(builder, "build", return_value=rebuilt) as full_build,
         ):
-            with pytest.raises(RuntimeError, match="generation check"):
-                builder._incremental_update_once(
-                    scope="current_repo",
-                    repo_path=str(tmp_path),
-                    output_dir=str(output_path),
-                    last_commit="a" * 40,
-                    previous_artifact_config=previous,
-                    native_index_authorization=authorization,
-                )
+            result = builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_path),
+                last_commit="a" * 40,
+                previous_artifact_config=previous,
+                native_index_authorization=authorization,
+            )
 
-        assert store_type.call_args.kwargs["artifact_metadata"] == previous
-        vector_store.close.assert_called_once_with()
-        vector_store.load.assert_called_once_with(
-            str(output_path),
+        store_type.assert_not_called()
+        full_build.assert_called_once_with(
+            "current_repo",
+            repo_path=str(tmp_path),
+            output_dir=str(output_path),
             native_index_authorization=authorization,
         )
+        assert result is rebuilt
+        assert result.metadata["update_mode"] == "full_rebuild"
+        assert result.metadata["incremental_fallback_reason"] == (
+            "_AtomicIncrementalRebuildRequired"
+        )
+        assert _tree_file_bytes(output_path) == before
+        assert not (output_path / VECTOR_VIEW_UPDATE_MARKER).exists()
 
     @pytest.mark.parametrize("missing", ["chunk_json", "embedding_pair"])
     def test_pickle_only_incremental_state_forces_rebuild(self, tmp_path, missing):
@@ -580,12 +1106,21 @@ class TestVectorIndexBuilder:
                 repo_path="/fake/repo",
                 output_dir=str(output_path),
             )
-        assert (output_path / VECTOR_VIEW_UPDATE_MARKER).is_file()
+        assert not output_path.exists()
 
     @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
     def test_remote_runtime_secret_is_not_persisted(self, mock_build_fn, tmp_path):
         mock_vs = MagicMock(l0_documents=[], l2_documents=["doc"])
-        mock_build_fn.return_value = mock_vs
+
+        def build_vector(**kwargs):
+            build_path = Path(kwargs["index_path"])
+            _write_mock_vector_generation(
+                build_path,
+                "text-embedding-3-small",
+            )
+            return mock_vs
+
+        mock_build_fn.side_effect = build_vector
         output_path = tmp_path / "vector"
         output_path.mkdir()
         (output_path / "config_text-embedding-3-small.json").write_text(

--- a/test/compiler/test_manifest.py
+++ b/test/compiler/test_manifest.py
@@ -25,6 +25,11 @@ from codenib.compiler.resources import (
     IndexStatus,
     ResourceResolver,
 )
+from codenib.source_fingerprint import is_secure_source_fingerprint_v2
+
+_SOURCE_V2 = f"sha256-v2:{'a' * 64}"
+_OTHER_SOURCE_V2 = f"sha256-v2:{'b' * 64}"
+_LEGACY_SOURCE_V1 = f"sha256:{'c' * 64}"
 
 # ---------------------------------------------------------------------------
 # IndexEntry
@@ -287,7 +292,7 @@ class TestRepoManifest:
 
     def test_derive_capabilities_stale_source_excluded(self):
         m = RepoManifest(
-            source_fingerprint="sha256:current",
+            source_fingerprint=_SOURCE_V2,
             indexes={
                 "bm25": IndexEntry(
                     index_type="bm25",
@@ -295,7 +300,7 @@ class TestRepoManifest:
                     built_at="2024-01-15T10:30:00+00:00",
                     built_at_epoch=time.time(),
                     status="fresh",
-                    source_fingerprint="sha256:old",
+                    source_fingerprint=_OTHER_SOURCE_V2,
                 ),
             },
         )
@@ -304,8 +309,8 @@ class TestRepoManifest:
 
     def test_source_identity_roundtrip(self):
         m = RepoManifest(
-            source_fingerprint="sha256:current",
-            last_indexed_source_fingerprint="sha256:complete",
+            source_fingerprint=_SOURCE_V2,
+            last_indexed_source_fingerprint=_OTHER_SOURCE_V2,
             indexes={
                 "bm25": IndexEntry(
                     index_type="bm25",
@@ -313,16 +318,41 @@ class TestRepoManifest:
                     built_at="2024-01-15T10:30:00+00:00",
                     built_at_epoch=time.time(),
                     status="fresh",
-                    source_fingerprint="sha256:current",
+                    source_fingerprint=_SOURCE_V2,
                 )
             },
         )
 
         restored = RepoManifest.from_dict(m.to_dict())
 
-        assert restored.source_fingerprint == "sha256:current"
-        assert restored.last_indexed_source_fingerprint == "sha256:complete"
+        assert restored.source_fingerprint == _SOURCE_V2
+        assert restored.last_indexed_source_fingerprint == _OTHER_SOURCE_V2
         assert restored.index_is_current("bm25") is True
+
+    def test_v1_source_identity_loads_for_inert_query_compatibility(self):
+        restored = RepoManifest.from_dict(
+            RepoManifest(
+                source_fingerprint=_LEGACY_SOURCE_V1,
+                last_indexed_source_fingerprint=_LEGACY_SOURCE_V1,
+                indexes={
+                    "bm25": IndexEntry(
+                        index_type="bm25",
+                        path="/tmp/bm25",
+                        built_at="2024-01-15T10:30:00+00:00",
+                        built_at_epoch=time.time(),
+                        status="fresh",
+                        source_fingerprint=_LEGACY_SOURCE_V1,
+                    )
+                },
+            ).to_dict()
+        )
+
+        assert restored.source_fingerprint == _LEGACY_SOURCE_V1
+        assert restored.last_indexed_source_fingerprint == _LEGACY_SOURCE_V1
+        assert restored.index_is_current("bm25") is True
+        assert not is_secure_source_fingerprint_v2(restored.source_fingerprint)
+        restored.derive_capabilities()
+        assert restored.capabilities["sparse_search"] is True
 
     def test_empty_manifest(self):
         m = RepoManifest()

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -25,6 +25,8 @@ pin down:
 
 from __future__ import annotations
 
+from contextlib import nullcontext
+from types import SimpleNamespace
 from typing import List
 
 import pytest
@@ -40,7 +42,7 @@ from codenib.agent.skills.registry import SkillRegistry
 from codenib.compiler import resources as compiler_resources
 from codenib.compiler import skill_context
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
-from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.compiler.manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
 from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
 
 
@@ -500,6 +502,8 @@ def test_embedding_resource_limits_reach_builder_and_loader(
             "embedding_kwargs": {"max_seq_length": 8192},
             "trust_remote_code": False,
             "default_batch_size": 4,
+            "artifact_metadata": None,
+            "native_index_authorization": None,
         }
     ]
 
@@ -528,8 +532,125 @@ def test_bundled_embedding_policy_reaches_builder_and_loader(
             "embedding_kwargs": None,
             "trust_remote_code": True,
             "default_batch_size": None,
+            "artifact_metadata": None,
+            "native_index_authorization": None,
         }
     ]
+
+
+def test_existing_required_vector_without_authority_forces_rebuild(
+    registry,
+    mocked_build,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    vector = cache / "vector"
+    vector.mkdir(parents=True)
+    (vector / "existing").write_text("untrusted", encoding="utf-8")
+
+    skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["embedding_search"],
+        cache_dir=str(cache),
+        skill_registry=registry,
+    )
+
+    assert mocked_build["compile"] == [("vector",)]
+
+
+def test_compiler_owned_vector_mints_exact_manifest_contract(
+    registry,
+    mocked_build,
+    monkeypatch,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    vector = cache / "vector"
+    contract = {"embedding_fingerprint": "sha256:compiler-owned"}
+    entry = IndexEntry(
+        index_type="vector",
+        path=str(vector),
+        built_at="2026-08-11T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config=contract,
+    )
+    manifest = RepoManifest(indexes={"vector": entry})
+    ownership = object()
+    authorization = object()
+    minted = []
+
+    monkeypatch.setattr(
+        skill_context,
+        "_run_compiler",
+        lambda *_args, **_kwargs: manifest,
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.artifact_integrity.capture_authenticated_vector_view",
+        lambda path: nullcontext(SimpleNamespace(ownership=ownership, root=path)),
+    )
+
+    def mint(captured, **kwargs):
+        minted.append((captured, kwargs))
+        return authorization
+
+    monkeypatch.setattr(
+        "codenib.native_index_authorization._mint_trusted_local_admin_authorization",
+        mint,
+    )
+
+    skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["embedding_search"],
+        cache_dir=str(cache),
+        skill_registry=registry,
+    )
+
+    assert minted[0][0] is ownership
+    assert minted[0][1]["semantic_contract"] == contract
+    assert mocked_build["vector_kwargs"][0]["artifact_metadata"] == contract
+    assert (
+        mocked_build["vector_kwargs"][0]["native_index_authorization"] is authorization
+    )
+
+
+def test_existing_vector_token_uses_current_manifest_contract(
+    registry,
+    mocked_build,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    vector = cache / "vector"
+    vector.mkdir(parents=True)
+    (vector / "existing").write_text("captured", encoding="utf-8")
+    contract = {"embedding_fingerprint": "sha256:expected"}
+    RepoManifest(
+        indexes={
+            "vector": IndexEntry(
+                index_type="vector",
+                path=str(vector),
+                built_at="2026-08-11T00:00:00Z",
+                built_at_epoch=0.0,
+                status="fresh",
+                config=contract,
+            )
+        }
+    ).save(cache / MANIFEST_FILENAME)
+    authorization = object()
+
+    skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["embedding_search"],
+        cache_dir=str(cache),
+        skill_registry=registry,
+        native_index_authorization=authorization,
+    )
+
+    assert mocked_build["compile"] == []
+    assert mocked_build["vector_kwargs"][0]["artifact_metadata"] == contract
+    assert (
+        mocked_build["vector_kwargs"][0]["native_index_authorization"] is authorization
+    )
 
 
 def test_partial_cache_only_rebuilds_missing(registry, mocked_build, tmp_path):
@@ -554,6 +675,17 @@ def test_partial_cache_only_rebuilds_missing(registry, mocked_build, tmp_path):
 # optional index handling in build_skill_contexts — load-if-present only,
 # never build.
 # ---------------------------------------------------------------------------
+
+
+def _optional_vector_registry() -> SkillRegistry:
+    reg = SkillRegistry()
+    metadata = _make_meta("fallback_search", SkillType.RETRIEVAL)
+    metadata.index_requirements = [
+        compiler_resources.IndexRequirement(index_type="bm25"),
+        compiler_resources.IndexRequirement(index_type="vector", required=False),
+    ]
+    reg.register(metadata)
+    return reg
 
 
 def test_optional_index_loaded_when_already_present(
@@ -596,6 +728,29 @@ def test_optional_index_skipped_when_absent(mixed_registry, mocked_build, tmp_pa
     assert mocked_build["loaded"] == ["bm25"]
     assert "expand" not in contexts
     assert contexts["retrieve"].bm25 is not None
+
+
+def test_optional_vector_without_authority_preserves_bm25_fallback(
+    mocked_build,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    for index_type in ("bm25", "vector"):
+        directory = cache / index_type
+        directory.mkdir(parents=True)
+        (directory / "present").write_text("present", encoding="utf-8")
+
+    contexts = skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["fallback_search"],
+        cache_dir=str(cache),
+        skill_registry=_optional_vector_registry(),
+    )
+
+    assert mocked_build["compile"] == []
+    assert mocked_build["loaded"] == ["bm25"]
+    assert contexts["retrieve"].bm25 is not None
+    assert contexts["retrieve"].vector_store is None
 
 
 def test_build_skill_contexts_without_reset_is_idempotent(
@@ -857,6 +1012,76 @@ def test_manifest_skips_optional_index_when_absent(mixed_registry, mocked_build)
     assert mocked_build["loaded"] == ["bm25"]
     assert "expand" not in contexts
     assert contexts["retrieve"].bm25 is not None
+
+
+def test_manifest_optional_vector_without_authority_preserves_bm25_fallback(
+    mocked_build,
+):
+    manifest = RepoManifest(
+        indexes={
+            "bm25": _fresh_entry("bm25", "/idx/bm25"),
+            "vector": _fresh_entry("vector", "/idx/vector"),
+        }
+    )
+
+    contexts = skill_context.load_contexts_from_manifest(
+        manifest,
+        skill_ids=["fallback_search"],
+        skill_registry=_optional_vector_registry(),
+    )
+
+    assert mocked_build["loaded"] == ["bm25"]
+    assert contexts["retrieve"].bm25 is not None
+    assert contexts["retrieve"].vector_store is None
+
+
+def test_manifest_required_vector_without_authority_fails_before_model_init(
+    registry,
+    monkeypatch,
+):
+    entry = _fresh_entry("vector", "/idx/vector")
+    entry.config = {
+        "builder_schema": 2,
+        "embedding_model": "vendor/model",
+        "embedding_provider": "huggingface",
+        "embedding_dimension": 4,
+        "dimension": 4,
+        "embedding_kwargs": {},
+    }
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.CodeVectorStore",
+        lambda **_kwargs: pytest.fail(
+            "missing authority must fail before embedding model initialization"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires external authorization"):
+        skill_context.load_contexts_from_manifest(
+            RepoManifest(indexes={"vector": entry}),
+            skill_ids=["embedding_search"],
+            skill_registry=registry,
+        )
+
+
+def test_skill_vector_rejects_invalid_authority_before_model_init(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.CodeVectorStore",
+        lambda **_kwargs: pytest.fail(
+            "invalid authority must fail before embedding model initialization"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires external authorization"):
+        skill_context._load_vector(
+            str(tmp_path / "vector"),
+            embedding_model="vendor/model",
+            embedding_provider="huggingface",
+            embedding_dimension=4,
+            native_index_authorization=object(),
+        )
 
 
 def test_manifest_missing_required_index_raises(mixed_registry, mocked_build):

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -44,6 +44,7 @@ from codenib.compiler import skill_context
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
 from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
+from codenib.native_index_authorization import InvalidNativeIndexAuthorizationError
 
 
 def _make_meta(
@@ -653,6 +654,61 @@ def test_existing_vector_token_uses_current_manifest_contract(
     )
 
 
+def test_existing_vector_resolver_receives_exact_current_manifest_entry(
+    registry,
+    mocked_build,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    vector = cache / "vector"
+    vector.mkdir(parents=True)
+    (vector / "existing").write_text("captured", encoding="utf-8")
+    contract = {"embedding_fingerprint": "sha256:resolver-bound"}
+    expected_entry = IndexEntry(
+        index_type="vector",
+        path=str(vector),
+        built_at="2026-08-11T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config=contract,
+    )
+    RepoManifest(indexes={"vector": expected_entry}).save(cache / MANIFEST_FILENAME)
+    authorization = object()
+    resolved = []
+
+    contexts = skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["embedding_search"],
+        cache_dir=str(cache),
+        skill_registry=registry,
+        native_index_authorization_resolver=lambda entry: (
+            resolved.append(entry) or authorization
+        ),
+    )
+
+    assert contexts["retrieve"].vector_store is not None
+    assert mocked_build["compile"] == []
+    assert len(resolved) == 1
+    assert resolved[0].path == expected_entry.path
+    assert resolved[0].config == contract
+    assert mocked_build["vector_kwargs"][0]["artifact_metadata"] == contract
+    assert (
+        mocked_build["vector_kwargs"][0]["native_index_authorization"] is authorization
+    )
+
+
+def test_build_context_rejects_token_and_resolver_together(registry, tmp_path):
+    with pytest.raises(ValueError, match="either native_index_authorization"):
+        skill_context.build_skill_contexts(
+            repo_path=str(tmp_path),
+            skill_ids=["embedding_search"],
+            cache_dir=str(tmp_path / "cache"),
+            skill_registry=registry,
+            native_index_authorization=object(),
+            native_index_authorization_resolver=lambda _entry: object(),
+        )
+
+
 def test_partial_cache_only_rebuilds_missing(registry, mocked_build, tmp_path):
     """bm25 already built, vector missing → only vector is rebuilt."""
     cache = tmp_path / "cache"
@@ -1063,6 +1119,38 @@ def test_manifest_required_vector_without_authority_fails_before_model_init(
         )
 
 
+def test_manifest_vector_resolver_receives_exact_loaded_entry(
+    registry,
+    mocked_build,
+):
+    entry = _fresh_entry("vector", "/idx/vector")
+    entry.config = {
+        "builder_schema": 2,
+        "embedding_model": "vendor/model",
+        "embedding_provider": "huggingface",
+        "embedding_dimension": 4,
+        "dimension": 4,
+        "embedding_kwargs": {},
+    }
+    authorization = object()
+    resolved = []
+
+    contexts = skill_context.load_contexts_from_manifest(
+        RepoManifest(indexes={"vector": entry}),
+        skill_ids=["embedding_search"],
+        skill_registry=registry,
+        native_index_authorization_resolver=lambda candidate: (
+            resolved.append(candidate) or authorization
+        ),
+    )
+
+    assert contexts["retrieve"].vector_store is not None
+    assert resolved == [entry]
+    assert (
+        mocked_build["vector_kwargs"][0]["native_index_authorization"] is authorization
+    )
+
+
 def test_skill_vector_rejects_invalid_authority_before_model_init(
     monkeypatch,
     tmp_path,
@@ -1074,7 +1162,10 @@ def test_skill_vector_rejects_invalid_authority_before_model_init(
         ),
     )
 
-    with pytest.raises(ValueError, match="requires external authorization"):
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="malformed",
+    ):
         skill_context._load_vector(
             str(tmp_path / "vector"),
             embedding_model="vendor/model",

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -66,6 +66,7 @@ def _make_meta(
 
 def test_vector_loader_closes_partial_store_on_base_exception(monkeypatch):
     primary = KeyboardInterrupt("cancel vector load")
+    authorization = object()
     stores = []
 
     class FakeStore:
@@ -80,9 +81,9 @@ def test_vector_loader_closes_partial_store_on_base_exception(monkeypatch):
             self.close_calls += 1
 
     monkeypatch.setattr(
-        "codenib.index.embedding.artifact_integrity."
-        "_mint_trusted_local_vector_authorization",
-        lambda *_args, **_kwargs: object(),
+        skill_context,
+        "require_authorized_vector_view",
+        lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr(
         "codenib.index.embedding.vector_store.CodeVectorStore",
@@ -96,6 +97,7 @@ def test_vector_loader_closes_partial_store_on_base_exception(monkeypatch):
             embedding_model="model",
             embedding_provider="huggingface",
             embedding_dimension=4,
+            native_index_authorization=authorization,
         )
     except BaseException as exc:  # noqa: B036 - assert cancellation identity
         observed = exc

--- a/test/examples/test_swerank_retrieve_rerank.py
+++ b/test/examples/test_swerank_retrieve_rerank.py
@@ -130,7 +130,7 @@ def test_default_index_cache_fingerprints_dirty_checkout(recipe, monkeypatch, tm
         source_fingerprint,
         "fingerprint_repository",
         lambda repo: source_fingerprint.SourceFingerprint(
-            value=f"sha256:{'b' * 64}", file_count=3
+            value=f"sha256-v2:{'b' * 64}", file_count=3
         ),
     )
 
@@ -141,7 +141,7 @@ def test_default_index_cache_fingerprints_dirty_checkout(recipe, monkeypatch, tm
         state
         / "recipes"
         / "swerank-embed-small"
-        / f"source-{'b' * 64}"
+        / f"source-sha256-v2-{'b' * 64}"
         / recipe._cache_profile_key(["python"], args.max_lines_per_chunk)
     )
 

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -43,6 +43,12 @@ def test_cached_builder_closes_store_when_load_fails(monkeypatch, tmp_path):
     index_path = tmp_path / "index"
     index_path.mkdir()
     (index_path / "config_test-model.json").write_text("{}", encoding="utf-8")
+    authorization = _mint_trusted_local_admin_authorization(
+        atomic_directory.capture_directory_ownership(index_path),
+        view_type="vector",
+        semantic_contract={},
+        evidence=("cached-builder-cleanup-test",),
+    )
     primary = RuntimeError("cached load failed")
     stores = []
 
@@ -58,11 +64,6 @@ def test_cached_builder_closes_store_when_load_fails(monkeypatch, tmp_path):
             self.close_calls += 1
 
     monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
-    monkeypatch.setattr(
-        builders,
-        "_mint_trusted_local_vector_authorization",
-        lambda *_args, **_kwargs: object(),
-    )
 
     with pytest.raises(RuntimeError) as exc_info:
         builders.build_hierarchical_vector_store(
@@ -71,6 +72,7 @@ def test_cached_builder_closes_store_when_load_fails(monkeypatch, tmp_path):
             embedding_model="test-model",
             embedding_provider="huggingface",
             embedding_dimension=4,
+            native_index_authorization=authorization,
         )
 
     assert exc_info.value is primary

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -118,3 +118,167 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
     assert result.l2_documents
     assert all(not path.exists() for path in stale_files)
     assert unrelated.read_bytes() == b"other"
+
+
+def test_cached_index_without_authority_is_rebuilt_from_source(
+    monkeypatch,
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {
+            "file": "source.py",
+            "content": source.read_text(encoding="utf-8"),
+        },
+    )
+    calls = {"chunk": 0, "load": 0, "save": 0}
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            assert repo_path == str(repo)
+            calls["chunk"] += 1
+            return [chunk]
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def load(self, *_args, **_kwargs):
+            calls["load"] += 1
+
+        def add_code_chunks(self, chunks, level):
+            assert level == "l2"
+            self.l2_documents.extend(chunks)
+
+        def save(self, _path):
+            calls["save"] += 1
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+
+    index = tmp_path / "index"
+    stale_l0 = index / "l0"
+    stale_l0.mkdir(parents=True)
+    (index / "config_test-model.json").write_text("{}", encoding="utf-8")
+    (stale_l0 / "index_test-model.faiss").write_bytes(b"stale")
+
+    result = builders.build_hierarchical_vector_store(
+        repo_path=str(repo),
+        index_path=str(index),
+        languages=["python"],
+        build_levels=["l2"],
+        embedding_model="test-model",
+        embedding_provider="huggingface",
+        embedding_dimension=2,
+    )
+
+    assert result.l2_documents
+    assert calls == {"chunk": 1, "load": 0, "save": 1}
+    assert not stale_l0.exists()
+
+
+def test_cached_index_without_authority_or_source_is_left_unchanged(tmp_path):
+    index = tmp_path / "index"
+    stale_l0 = index / "l0"
+    stale_l0.mkdir(parents=True)
+    config = index / "config_test-model.json"
+    stale = stale_l0 / "index_test-model.faiss"
+    config.write_bytes(b"config")
+    stale.write_bytes(b"stale")
+    before = {
+        path.relative_to(index).as_posix(): path.read_bytes()
+        for path in index.rglob("*")
+        if path.is_file()
+    }
+
+    with pytest.raises(ValueError, match="repo_path is required to rebuild"):
+        builders.build_hierarchical_vector_store(
+            repo_path="",
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+        )
+
+    after = {
+        path.relative_to(index).as_posix(): path.read_bytes()
+        for path in index.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+
+
+def test_authorized_cache_is_loaded_without_rechunking(monkeypatch, tmp_path):
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "config_test-model.json").write_text("{}", encoding="utf-8")
+    authorization = object()
+    calls = []
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            pass
+
+        def load(self, path, *, native_index_authorization):
+            calls.append((path, native_index_authorization))
+
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+    monkeypatch.setattr(
+        builders,
+        "CodeChunker",
+        lambda **_kwargs: pytest.fail("authorized cache must not be rechunked"),
+    )
+
+    result = builders.build_hierarchical_vector_store(
+        repo_path="",
+        index_path=str(index),
+        embedding_model="test-model",
+        embedding_provider="huggingface",
+        embedding_dimension=2,
+        native_index_authorization=authorization,
+    )
+
+    assert isinstance(result, FakeStore)
+    assert calls == [(str(index), authorization)]
+
+
+def test_invalid_cache_authority_propagates_without_rebuild(monkeypatch, tmp_path):
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "config_test-model.json").write_text("{}", encoding="utf-8")
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            pass
+
+        def load(self, _path, *, native_index_authorization):
+            assert native_index_authorization is invalid_authorization
+            raise ValueError("authorization does not match captured bytes")
+
+    invalid_authorization = object()
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+    monkeypatch.setattr(
+        builders,
+        "CodeChunker",
+        lambda **_kwargs: pytest.fail("invalid authority must not trigger rebuild"),
+    )
+
+    with pytest.raises(ValueError, match="does not match captured bytes"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(tmp_path),
+            index_path=str(index),
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            native_index_authorization=invalid_authorization,
+        )

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -2,11 +2,41 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+import codenib._atomic_directory as atomic_directory
 from codenib.index.embedding import builders
+from codenib.index.embedding.artifact_integrity import VECTOR_VIEW_UPDATE_MARKER
+from codenib.native_index_authorization import (
+    InvalidNativeIndexAuthorizationError,
+    _mint_trusted_local_admin_authorization,
+)
+
+
+def _write_fake_vector_store(path, *, model_suffix, levels):
+    root = Path(path)
+    root.mkdir(parents=True, exist_ok=True)
+    for level in levels:
+        level_path = root / level
+        level_path.mkdir()
+        (level_path / f"config_{model_suffix}.json").write_text(
+            "{}",
+            encoding="utf-8",
+        )
+        (level_path / f"index_{model_suffix}.faiss").write_bytes(b"new-index")
+        (level_path / f"documents_{model_suffix}.pkl").write_bytes(b"new-docs")
+    (root / f"config_{model_suffix}.json").write_text("{}", encoding="utf-8")
+
+
+def _file_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
 
 
 def test_cached_builder_closes_store_when_load_fails(monkeypatch, tmp_path):
@@ -79,7 +109,11 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
             self.l2_documents.extend(chunks)
 
         def save(self, path):
-            pass
+            _write_fake_vector_store(
+                path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
 
     monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
     monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
@@ -97,6 +131,18 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
         path.write_bytes(b"stale")
     unrelated = stale_level / "index_other-model.faiss"
     unrelated.write_bytes(b"other")
+    generation_root = stale_level.parent
+    stale_state_files = [
+        generation_root / "chunk_store.json",
+        generation_root / "chunk_store.pkl",
+        generation_root / "embeddings_cache.json",
+        generation_root / "embeddings_cache.npz",
+        generation_root / "embeddings_cache.pkl",
+        generation_root / "incremental_state.json",
+        generation_root / VECTOR_VIEW_UPDATE_MARKER,
+    ]
+    for path in stale_state_files:
+        path.write_bytes(b"stale-generation-state")
 
     result = builders.build_hierarchical_vector_store(
         repo_path=str(tmp_path),
@@ -117,6 +163,7 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
     assert captured["strict_chunking"] is True
     assert result.l2_documents
     assert all(not path.exists() for path in stale_files)
+    assert all(not path.exists() for path in stale_state_files)
     assert unrelated.read_bytes() == b"other"
 
 
@@ -160,6 +207,11 @@ def test_cached_index_without_authority_is_rebuilt_from_source(
 
         def save(self, _path):
             calls["save"] += 1
+            _write_fake_vector_store(
+                _path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
 
     monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
     monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
@@ -222,7 +274,12 @@ def test_authorized_cache_is_loaded_without_rechunking(monkeypatch, tmp_path):
     index = tmp_path / "index"
     index.mkdir()
     (index / "config_test-model.json").write_text("{}", encoding="utf-8")
-    authorization = object()
+    authorization = _mint_trusted_local_admin_authorization(
+        atomic_directory.capture_directory_ownership(index),
+        view_type="vector",
+        semantic_contract={},
+        evidence=("verified-test-cache",),
+    )
     calls = []
 
     class FakeStore:
@@ -252,28 +309,84 @@ def test_authorized_cache_is_loaded_without_rechunking(monkeypatch, tmp_path):
     assert calls == [(str(index), authorization)]
 
 
-def test_invalid_cache_authority_propagates_without_rebuild(monkeypatch, tmp_path):
+def test_wrong_semantic_cache_authority_rejects_before_model_init(
+    monkeypatch,
+    tmp_path,
+):
     index = tmp_path / "index"
     index.mkdir()
     (index / "config_test-model.json").write_text("{}", encoding="utf-8")
 
-    class FakeStore:
-        def __init__(self, **_kwargs):
-            pass
-
-        def load(self, _path, *, native_index_authorization):
-            assert native_index_authorization is invalid_authorization
-            raise ValueError("authorization does not match captured bytes")
-
-    invalid_authorization = object()
-    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+    invalid_authorization = _mint_trusted_local_admin_authorization(
+        atomic_directory.capture_directory_ownership(index),
+        view_type="vector",
+        semantic_contract={"dimension": 3},
+        evidence=("wrong-semantic-test-cache",),
+    )
+    monkeypatch.setattr(
+        builders,
+        "CodeVectorStore",
+        lambda **_kwargs: pytest.fail(
+            "wrong-semantic authority must fail before model initialization"
+        ),
+    )
     monkeypatch.setattr(
         builders,
         "CodeChunker",
         lambda **_kwargs: pytest.fail("invalid authority must not trigger rebuild"),
     )
 
-    with pytest.raises(ValueError, match="does not match captured bytes"):
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="does not match captured bytes",
+    ):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(tmp_path),
+            index_path=str(index),
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            artifact_metadata={"dimension": 2},
+            native_index_authorization=invalid_authorization,
+        )
+
+
+def test_wrong_tree_cache_authority_rejects_before_model_init(
+    monkeypatch,
+    tmp_path,
+):
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "config_test-model.json").write_text("{}", encoding="utf-8")
+    other = tmp_path / "other-index"
+    other.mkdir()
+    (other / "config_test-model.json").write_text(
+        '{"different":true}',
+        encoding="utf-8",
+    )
+    invalid_authorization = _mint_trusted_local_admin_authorization(
+        atomic_directory.capture_directory_ownership(other),
+        view_type="vector",
+        semantic_contract={},
+        evidence=("wrong-tree-test-cache",),
+    )
+    monkeypatch.setattr(
+        builders,
+        "CodeVectorStore",
+        lambda **_kwargs: pytest.fail(
+            "wrong-tree authority must fail before model initialization"
+        ),
+    )
+    monkeypatch.setattr(
+        builders,
+        "CodeChunker",
+        lambda **_kwargs: pytest.fail("invalid authority must not trigger rebuild"),
+    )
+
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="does not match captured bytes",
+    ):
         builders.build_hierarchical_vector_store(
             repo_path=str(tmp_path),
             index_path=str(index),
@@ -282,3 +395,404 @@ def test_invalid_cache_authority_propagates_without_rebuild(monkeypatch, tmp_pat
             embedding_dimension=2,
             native_index_authorization=invalid_authorization,
         )
+
+
+def test_failed_staged_save_preserves_existing_cache(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": source.read_text()},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            return [chunk]
+
+    class FailingStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            getattr(self, f"{level}_documents").extend(chunks)
+
+        def save(self, path):
+            _write_fake_vector_store(
+                path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
+            raise RuntimeError("simulated staged save failure")
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FailingStore)
+
+    index = tmp_path / "index"
+    _write_fake_vector_store(
+        index,
+        model_suffix="test-model",
+        levels=("l0", "l2"),
+    )
+    before = _file_snapshot(index)
+
+    with pytest.raises(RuntimeError, match="staged save failure"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(repo),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert _file_snapshot(index) == before
+    assert not list(tmp_path.glob(".index.vector-build-*"))
+
+
+def test_bad_repository_preserves_existing_cache(monkeypatch, tmp_path):
+    class FailingChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            raise OSError("bad repository")
+
+    monkeypatch.setattr(builders, "CodeChunker", FailingChunker)
+    monkeypatch.setattr(
+        builders,
+        "CodeVectorStore",
+        lambda **_kwargs: pytest.fail("store must not be built after chunk failure"),
+    )
+
+    index = tmp_path / "index"
+    _write_fake_vector_store(
+        index,
+        model_suffix="test-model",
+        levels=("l0", "l2"),
+    )
+    before = _file_snapshot(index)
+
+    with pytest.raises(OSError, match="bad repository"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(tmp_path / "missing-repo"),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert _file_snapshot(index) == before
+
+
+def test_unrequested_symlink_level_rejects_rebuild_without_mutation(
+    monkeypatch,
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": source.read_text()},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            return [chunk]
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            getattr(self, f"{level}_documents").extend(chunks)
+
+        def save(self, path):
+            _write_fake_vector_store(
+                path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+
+    outside = tmp_path / "outside"
+    _write_fake_vector_store(
+        outside,
+        model_suffix="test-model",
+        levels=(),
+    )
+    outside_config = outside / "config_test-model.json"
+    outside_config.unlink()
+    (outside / "index_test-model.faiss").write_bytes(b"outside-index")
+    (outside / "documents_test-model.pkl").write_bytes(b"outside-docs")
+    before = _file_snapshot(outside)
+
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "l0").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises((ValueError, RuntimeError), match="link"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(repo),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert (index / "l0").is_symlink()
+    assert _file_snapshot(outside) == before
+
+
+def test_requested_symlink_level_rejects_publish_without_mutation(
+    monkeypatch,
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": source.read_text()},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            return [chunk]
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            getattr(self, f"{level}_documents").extend(chunks)
+
+        def save(self, path):
+            _write_fake_vector_store(
+                path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "index_test-model.faiss").write_bytes(b"outside-index")
+    before = _file_snapshot(outside)
+    index = tmp_path / "index"
+    index.mkdir()
+    old_config = index / "config_test-model.json"
+    old_config.write_bytes(b"old-config")
+    (index / "l2").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises((ValueError, RuntimeError), match="link"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(repo),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert old_config.read_bytes() == b"old-config"
+    assert (index / "l2").is_symlink()
+    assert _file_snapshot(outside) == before
+
+
+def test_interrupted_directory_switch_restores_old_cache(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": source.read_text()},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            return [chunk]
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            getattr(self, f"{level}_documents").extend(chunks)
+
+        def save(self, path):
+            _write_fake_vector_store(
+                path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+
+    index = tmp_path / "index"
+    _write_fake_vector_store(
+        index,
+        model_suffix="test-model",
+        levels=("l0", "l2"),
+    )
+    (index / "incremental_state.json").write_bytes(b"old-incremental-state")
+    before = _file_snapshot(index)
+    real_rename = atomic_directory._rename_noreplace_at
+    injected = False
+
+    def interrupt_after_publish(source_name, destination_name, source_fd, dest_fd):
+        nonlocal injected
+        real_rename(source_name, destination_name, source_fd, dest_fd)
+        if (
+            source_name.startswith(".index.normalize-")
+            and destination_name == "index"
+            and not injected
+        ):
+            injected = True
+            raise KeyboardInterrupt("simulated completed publication interrupt")
+
+    monkeypatch.setattr(
+        atomic_directory,
+        "_rename_noreplace_at",
+        interrupt_after_publish,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="publication interrupt"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(repo),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert injected is True
+    assert _file_snapshot(index) == before
+
+
+@pytest.mark.parametrize("replacement", ["directory", "symlink"])
+def test_private_build_root_replacement_cannot_publish_or_write_outside(
+    monkeypatch,
+    tmp_path,
+    replacement,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": source.read_text()},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            return [chunk]
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.bin"
+    victim.write_bytes(b"outside-original")
+
+    class ReplacingStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            getattr(self, f"{level}_documents").extend(chunks)
+
+        def save(self, path):
+            anchored_root = Path(path)
+            named_root = anchored_root.resolve(strict=True)
+            moved_root = named_root.with_name(f"{named_root.name}.moved")
+            named_root.rename(moved_root)
+            if replacement == "directory":
+                named_root.mkdir()
+                (named_root / "attacker-tree").write_bytes(b"attacker")
+            else:
+                named_root.symlink_to(outside, target_is_directory=True)
+
+            # A writer that continues using the supplied path remains anchored
+            # to the retained original inode, even after the public name is a
+            # directory or a symlink to the victim tree.
+            (anchored_root / "victim.bin").write_bytes(b"private-only")
+            _write_fake_vector_store(
+                anchored_root,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", ReplacingStore)
+
+    index = tmp_path / "index"
+    _write_fake_vector_store(
+        index,
+        model_suffix="test-model",
+        levels=("l0", "l2"),
+    )
+    before = _file_snapshot(index)
+
+    with pytest.raises(RuntimeError, match="private build root changed"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(repo),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert _file_snapshot(index) == before
+    assert victim.read_bytes() == b"outside-original"

--- a/test/index/test_vector_artifact_identity.py
+++ b/test/index/test_vector_artifact_identity.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import codenib.index.embedding.artifact_integrity as artifact_integrity_module
-from codenib._atomic_directory import capture_directory_ownership
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.index.embedding.vector_store import (
     CodeVectorStore,
     _LoadedVectorState,
@@ -99,12 +99,16 @@ def _store(
 
 
 def _authorization(path, store):
-    return _mint_trusted_local_admin_authorization(
-        capture_directory_ownership(path),
-        view_type="vector",
-        semantic_contract=store.artifact_metadata,
-        evidence=("vector-artifact-test-local-admin",),
-    )
+    with capture_authenticated_vector_view(path) as view:
+        return _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=store.artifact_metadata,
+            evidence=(
+                "vector-artifact-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
 
 
 def test_load_level_releases_native_index_when_validation_fails(

--- a/test/index/test_vector_artifact_identity.py
+++ b/test/index/test_vector_artifact_identity.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import codenib.index.embedding.artifact_integrity as artifact_integrity_module
+from codenib._atomic_directory import capture_directory_ownership
 from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.index.embedding.vector_store import (
     CodeVectorStore,

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -23,10 +23,10 @@ import faiss
 import numpy as np
 import pytest
 
-from codenib._atomic_directory import capture_directory_ownership
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
     VECTOR_VIEW_UPDATE_MARKER,
+    capture_authenticated_vector_view,
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
@@ -70,12 +70,16 @@ def _make_store(**kwargs) -> CodeVectorStore:
 
 def _authorization(store: CodeVectorStore, path=None):
     root = Path(path) if path is not None else Path(store.store_path)
-    return _mint_trusted_local_admin_authorization(
-        capture_directory_ownership(root),
-        view_type="vector",
-        semantic_contract=store.artifact_metadata,
-        evidence=("vector-store-test-local-admin",),
-    )
+    with capture_authenticated_vector_view(root) as view:
+        return _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=store.artifact_metadata,
+            evidence=(
+                "vector-store-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
 
 
 def _load_trusted(store: CodeVectorStore, path=None) -> None:

--- a/test/mcp/test_mcp_e2e.py
+++ b/test/mcp/test_mcp_e2e.py
@@ -18,13 +18,35 @@ import pytest
 
 import codenib.mcp.server as server_module
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.mcp.context import ServerContext
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.paths import prebuilt_data_dir
 
 # Test data from codenib-base-dataset
 CODENIB_DATA = prebuilt_data_dir()
 TEST_REPO = "astropy__astropy-12907"
 TEST_REPO_PATH = CODENIB_DATA / TEST_REPO
+
+
+def _load_test_owned_vector(store, path):
+    """Authorize one explicitly selected local E2E fixture tree."""
+
+    semantic_contract = dict(store.artifact_metadata)
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "mcp-e2e-direct-local-fixture",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
 
 
 @pytest.mark.slow
@@ -153,13 +175,7 @@ class TestMCPServerE2E:
 
         Ensures MCP protocol layer adds no transformation overhead.
         """
-        from codenib.index.embedding.artifact_integrity import (
-            capture_authenticated_vector_view,
-        )
         from codenib.index.embedding.vector_store import CodeVectorStore
-        from codenib.native_index_authorization import (
-            _mint_trusted_local_admin_authorization,
-        )
 
         # Direct vector store call
         artifact_contract = {
@@ -168,16 +184,6 @@ class TestMCPServerE2E:
             "dimension": 1536,
             "index_metric": "ip",
         }
-        with capture_authenticated_vector_view(TEST_REPO_PATH) as vector_view:
-            native_authorization = _mint_trusted_local_admin_authorization(
-                vector_view.ownership,
-                view_type="vector",
-                semantic_contract=artifact_contract,
-                evidence=(
-                    "mcp-e2e-direct-vector-view",
-                    "captured-vector-tree-subject",
-                ),
-            )
 
         with ExitStack() as resources:
             vector_store = CodeVectorStore(
@@ -189,9 +195,7 @@ class TestMCPServerE2E:
                 artifact_metadata=artifact_contract,
             )
             resources.callback(vector_store.close)
-            vector_store.load(
-                native_index_authorization=native_authorization,
-            )
+            _load_test_owned_vector(vector_store, TEST_REPO_PATH)
 
             query = "coordinate transformation"
             top_k = 5

--- a/test/mcp/test_search_semantic_integration.py
+++ b/test/mcp/test_search_semantic_integration.py
@@ -14,14 +14,35 @@ from contextlib import ExitStack
 import pytest
 
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.search import search_semantic
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.paths import prebuilt_data_dir
 
 # Test data directory
 CODENIB_DATA = prebuilt_data_dir()
 TEST_REPO = "astropy__astropy-12907"
 TEST_REPO_PATH = CODENIB_DATA / TEST_REPO
+
+
+def _load_test_owned_vector(store, path, semantic_contract):
+    """Authorize the explicitly configured local slow-test fixture."""
+
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "semantic-integration-local-fixture",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
 
 
 @pytest.mark.slow
@@ -37,6 +58,12 @@ class TestSearchSemanticIntegration:
         """Create ServerContext with real embedding index."""
         # Create manifest for test repo
         # Note: No actual manifest file exists, we construct it programmatically
+        vector_contract = {
+            "embedding_model": "jinaai/jina-code-embeddings-1.5b",
+            "embedding_provider": "huggingface",
+            "dimension": 1536,
+            "index_metric": "ip",
+        }
         manifest = RepoManifest(
             repo_path=str(TEST_REPO_PATH),
             commit="test",
@@ -47,12 +74,7 @@ class TestSearchSemanticIntegration:
                     built_at="2024-04-12T20:57:00Z",
                     built_at_epoch=1712957820.0,
                     status="fresh",
-                    config={
-                        "embedding_model": "jinaai/jina-code-embeddings-1.5b",
-                        "embedding_provider": "huggingface",
-                        "dimension": 1536,
-                        "index_metric": "ip",
-                    },
+                    config=vector_contract,
                 )
             },
         )
@@ -62,25 +84,9 @@ class TestSearchSemanticIntegration:
         ctx = ServerContext(manifest=manifest)
         resources.callback(ctx.close)
 
-        from codenib.index.embedding.artifact_integrity import (
-            capture_authenticated_vector_view,
-        )
         from codenib.index.embedding.vector_store import CodeVectorStore
-        from codenib.native_index_authorization import (
-            _mint_trusted_local_admin_authorization,
-        )
 
         artifact_contract = dict(manifest.indexes["vector"].config)
-        with capture_authenticated_vector_view(TEST_REPO_PATH) as vector_view:
-            authorization = _mint_trusted_local_admin_authorization(
-                vector_view.ownership,
-                view_type="vector",
-                semantic_contract=artifact_contract,
-                evidence=(
-                    "semantic-integration-local-vector-view",
-                    "captured-vector-tree-subject",
-                ),
-            )
         ctx.vector = CodeVectorStore(
             embedding_model="jinaai/jina-code-embeddings-1.5b",
             embedding_provider="huggingface",
@@ -89,7 +95,11 @@ class TestSearchSemanticIntegration:
             store_path=str(TEST_REPO_PATH),  # Parent directory
             artifact_metadata=artifact_contract,
         )
-        ctx.vector.load(native_index_authorization=authorization)
+        _load_test_owned_vector(
+            ctx.vector,
+            TEST_REPO_PATH,
+            artifact_contract,
+        )
 
         try:
             yield ctx

--- a/test/model/test_embedding_model_loading.py
+++ b/test/model/test_embedding_model_loading.py
@@ -73,6 +73,54 @@ def test_embedding_pipeline_rejects_huggingface_options_for_remote_provider(
         raise AssertionError("expected provider-specific options to be rejected")
 
 
+def test_embedding_pipeline_forwards_authority_to_cache_builder(
+    monkeypatch,
+    tmp_path,
+):
+    from codenib.model import embedding_retrieve_pipeline as module
+
+    calls = []
+    store = object()
+    authorization = object()
+    monkeypatch.setattr(
+        module,
+        "build_hierarchical_vector_store",
+        lambda **kwargs: calls.append(kwargs) or store,
+    )
+
+    pipeline = module.EmbeddingRetrievePipeline(
+        repo_path=str(tmp_path),
+        index_path=str(tmp_path / "index"),
+        native_index_authorization=authorization,
+    )
+
+    assert pipeline.vector_store is store
+    assert calls[0]["native_index_authorization"] is authorization
+
+
+def test_embedding_pipeline_hot_swap_forwards_exact_authority():
+    from codenib.model import embedding_retrieve_pipeline as module
+
+    calls = []
+    authorization = object()
+    pipeline = object.__new__(module.EmbeddingRetrievePipeline)
+    pipeline.vector_store = SimpleNamespace(
+        swap_index=lambda path, **kwargs: calls.append((path, kwargs))
+    )
+
+    pipeline.load_index(
+        "/idx/vector",
+        native_index_authorization=authorization,
+    )
+
+    assert calls == [
+        (
+            "/idx/vector",
+            {"native_index_authorization": authorization},
+        )
+    ]
+
+
 def test_retrieve_rerank_pipeline_preserves_embedding_model_policy():
     from codenib.model.retrieve_rerank_pipeline import RetrieveRerankPipeline
 

--- a/test/model/test_embedding_model_loading.py
+++ b/test/model/test_embedding_model_loading.py
@@ -180,14 +180,17 @@ def test_hybrid_pipeline_forwards_model_policy(monkeypatch, tmp_path):
     monkeypatch.setattr(module, "build_skill_contexts", fake_build_skill_contexts)
     monkeypatch.setattr(SkillLoader, "load_all", lambda *args, **kwargs: [])
     revision = "e" * 40
+    authorization = object()
 
     module.HybridRetrievePipeline(
         repo_path=str(tmp_path),
         embedding_model="vendor/custom-model",
         embedding_revision=revision,
         trust_remote_code=True,
+        native_index_authorization=authorization,
     )
 
     [kwargs] = calls
     assert kwargs["embedding_revision"] == revision
     assert kwargs["trust_remote_code"] is True
+    assert kwargs["native_index_authorization"] is authorization

--- a/test/model/test_retrieve_pipeline_indexer_routing.py
+++ b/test/model/test_retrieve_pipeline_indexer_routing.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 
 def make_fake_graph_builder(calls):
     def fake_build_graph_for_languages(
@@ -236,12 +238,6 @@ def test_retrieve_rerank_cache_load_closes_store_on_base_exception(
             self.close_calls += 1
 
     monkeypatch.setattr(pipeline_module, "CodeVectorStore", FakeVectorStore)
-    monkeypatch.setattr(
-        pipeline_module,
-        "_mint_trusted_local_vector_authorization",
-        lambda *_args, **_kwargs: object(),
-    )
-
     pipeline = object.__new__(pipeline_module.RetrieveRerankPipeline)
     pipeline.repo_path = str(tmp_path)
     pipeline.index_path = index_path
@@ -250,6 +246,7 @@ def test_retrieve_rerank_cache_load_closes_store_on_base_exception(
     pipeline.max_lines_per_chunk = 300
     pipeline.index_metric = "ip"
     pipeline.profiler = None
+    pipeline._native_index_authorization = object()
 
     observed = None
     try:
@@ -265,3 +262,98 @@ def test_retrieve_rerank_cache_load_closes_store_on_base_exception(
     assert observed is primary
     assert len(stores) == 1
     assert stores[0].close_calls == 1
+
+
+def test_retrieve_rerank_cache_without_authority_forces_source_rebuild(
+    monkeypatch,
+    tmp_path,
+):
+    from codenib.model import retrieve_rerank_pipeline as pipeline_module
+
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "config_model.json").write_text("{}", encoding="utf-8")
+    built_store = object()
+    builder_calls = []
+
+    class FakeVectorStore:
+        def __init__(self, **_kwargs):
+            self.embedding = object()
+
+        def load(self, *_args, **_kwargs):
+            raise AssertionError("unauthorized cache must not be loaded")
+
+    monkeypatch.setattr(pipeline_module, "CodeVectorStore", FakeVectorStore)
+    monkeypatch.setattr(
+        pipeline_module,
+        "build_hierarchical_vector_store",
+        lambda **kwargs: builder_calls.append(kwargs) or built_store,
+    )
+    pipeline = object.__new__(pipeline_module.RetrieveRerankPipeline)
+    pipeline.repo_path = str(tmp_path)
+    pipeline.index_path = index
+    pipeline.retrieval_level = "l2"
+    pipeline.languages = ["python"]
+    pipeline.max_lines_per_chunk = 300
+    pipeline.index_metric = "ip"
+    pipeline.profiler = None
+    pipeline._native_index_authorization = None
+
+    result = pipeline._initialize_vector_store(
+        embedding_model="model",
+        embedding_provider="huggingface",
+        embedding_dimension=4,
+        embedding_kwargs={},
+    )
+
+    assert result is built_store
+    assert builder_calls[0]["force_rebuild"] is True
+    assert builder_calls[0]["native_index_authorization"] is None
+
+
+def test_retrieve_rerank_authorized_cache_loads_without_rebuild(
+    monkeypatch,
+    tmp_path,
+):
+    from codenib.model import retrieve_rerank_pipeline as pipeline_module
+
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "config_model.json").write_text("{}", encoding="utf-8")
+    authorization = object()
+    loads = []
+
+    class FakeVectorStore:
+        def __init__(self, **_kwargs):
+            self.embedding = object()
+            self.l0_documents = [object()]
+            self.l2_documents = [object()]
+
+        def load(self, path, *, native_index_authorization):
+            loads.append((path, native_index_authorization))
+
+    monkeypatch.setattr(pipeline_module, "CodeVectorStore", FakeVectorStore)
+    monkeypatch.setattr(
+        pipeline_module,
+        "build_hierarchical_vector_store",
+        lambda **_kwargs: pytest.fail("authorized complete cache must be reused"),
+    )
+    pipeline = object.__new__(pipeline_module.RetrieveRerankPipeline)
+    pipeline.repo_path = str(tmp_path)
+    pipeline.index_path = index
+    pipeline.retrieval_level = "l2"
+    pipeline.languages = ["python"]
+    pipeline.max_lines_per_chunk = 300
+    pipeline.index_metric = "ip"
+    pipeline.profiler = None
+    pipeline._native_index_authorization = authorization
+
+    result = pipeline._initialize_vector_store(
+        embedding_model="model",
+        embedding_provider="huggingface",
+        embedding_dimension=4,
+        embedding_kwargs={},
+    )
+
+    assert isinstance(result, FakeVectorStore)
+    assert loads == [(str(index), authorization)]

--- a/test/model/test_retrieve_pipeline_indexer_routing.py
+++ b/test/model/test_retrieve_pipeline_indexer_routing.py
@@ -120,6 +120,7 @@ def test_graph_pipeline_routes_languages_to_graph_builder_and_rerank(
 
     repo_path = str(tmp_path / "repo")
     index_path = str(tmp_path / "index")
+    authorization = object()
     pipeline = pipeline_module.GraphRetrievePipeline(
         repo_path=repo_path,
         index_path=index_path,
@@ -130,6 +131,7 @@ def test_graph_pipeline_routes_languages_to_graph_builder_and_rerank(
         languages=["rust", "python"],
         graph_route="scip-candidate",
         project_name="repo__case",
+        native_index_authorization=authorization,
     )
 
     assert graph_calls == [
@@ -156,6 +158,7 @@ def test_graph_pipeline_routes_languages_to_graph_builder_and_rerank(
         "revision": "f" * 40,
         "trust_remote_code": True,
     }
+    assert vector_call["native_index_authorization"] is authorization
 
 
 def test_graph_retrieve_pipeline_name_is_sparse_seeded_alias():
@@ -315,12 +318,27 @@ def test_retrieve_rerank_authorized_cache_loads_without_rebuild(
     monkeypatch,
     tmp_path,
 ):
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
     from codenib.model import retrieve_rerank_pipeline as pipeline_module
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
 
     index = tmp_path / "index"
     index.mkdir()
     (index / "config_model.json").write_text("{}", encoding="utf-8")
-    authorization = object()
+    with capture_authenticated_vector_view(index) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract={},
+            evidence=(
+                "retrieve-cache-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
     loads = []
 
     class FakeVectorStore:

--- a/test/model/test_retrieve_pipeline_indexer_routing.py
+++ b/test/model/test_retrieve_pipeline_indexer_routing.py
@@ -241,6 +241,11 @@ def test_retrieve_rerank_cache_load_closes_store_on_base_exception(
             self.close_calls += 1
 
     monkeypatch.setattr(pipeline_module, "CodeVectorStore", FakeVectorStore)
+    monkeypatch.setattr(
+        pipeline_module,
+        "require_authorized_vector_view",
+        lambda *_args, **_kwargs: None,
+    )
     pipeline = object.__new__(pipeline_module.RetrieveRerankPipeline)
     pipeline.repo_path = str(tmp_path)
     pipeline.index_path = index_path

--- a/test/scripts/test_snapshot_artifact_builders.py
+++ b/test/scripts/test_snapshot_artifact_builders.py
@@ -121,6 +121,7 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(
 ):
     root = tmp_path / "artifact"
     root.mkdir()
+    quality_path = tmp_path / "quality.json"
     model = "test/model"
     suffix = "test__model"
     instance = {
@@ -137,6 +138,7 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(
     def is_reusable(expected_configuration=None, required_l0_files=()):
         return build_embeddings._quality_report_is_reusable(
             root,
+            quality_path=quality_path,
             embedding_model=model,
             instance=instance,
             expected_configuration=expected_configuration or {},
@@ -155,7 +157,6 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(
         ),
         encoding="utf-8",
     )
-    quality_path = root / f"artifact_quality_{suffix}.json"
     quality_path.write_text(
         json.dumps(
             {
@@ -259,7 +260,7 @@ def test_isolated_embedding_reuse_revalidates_assessed_files(tmp_path):
         f"documents_{suffix}.pkl",
     ):
         (level / name).write_bytes(name.encode("utf-8"))
-    quality_path = root / f"artifact_quality_{suffix}.json"
+    quality_path = tmp_path / "quality.json"
     quality_path.write_text(
         json.dumps(
             {
@@ -278,6 +279,7 @@ def test_isolated_embedding_reuse_revalidates_assessed_files(tmp_path):
     )
 
     kwargs = {
+        "quality_path": quality_path,
         "embedding_model": model,
         "instance": {
             "repo": "org/repo",
@@ -292,6 +294,48 @@ def test_isolated_embedding_reuse_revalidates_assessed_files(tmp_path):
     (level / f"index_{suffix}.faiss").write_bytes(b"corrupt")
 
     assert not build_embeddings._quality_report_is_reusable(root, **kwargs)
+
+
+def test_embedding_layout_keeps_profile_metadata_outside_vector_tree(tmp_path):
+    profile_root = tmp_path / "profile"
+    profile_root.mkdir()
+    (profile_root / "profile.json").write_text("{}\n", encoding="utf-8")
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (profile_root / "repo").symlink_to(repository, target_is_directory=True)
+
+    artifact_root = build_embeddings._vector_artifact_root(
+        profile_root,
+        None,
+        "snapshot",
+    )
+    quality_path = build_embeddings._vector_quality_path(
+        profile_root,
+        None,
+        "test/model",
+        "snapshot",
+    )
+    artifact_root.mkdir()
+    quality_path.parent.mkdir(parents=True)
+    quality_path.write_text("{}\n", encoding="utf-8")
+
+    assert artifact_root == profile_root / "vector"
+    assert build_embeddings._vector_artifact_root(profile_root, None) == profile_root
+    assert artifact_root not in quality_path.parents
+    assert profile_root not in quality_path.parents
+    profile_alias = tmp_path / "instance"
+    profile_alias.symlink_to(profile_root, target_is_directory=True)
+    assert (
+        build_embeddings._vector_quality_path(
+            profile_alias,
+            None,
+            "test/model",
+            "snapshot",
+        )
+        == quality_path
+    )
+    with build_embeddings.capture_authenticated_vector_view(artifact_root) as view:
+        assert view.root == artifact_root
 
 
 def test_graph_reuse_requires_matching_artifact_provenance(tmp_path):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -12,7 +13,9 @@ from types import SimpleNamespace
 import pytest
 import yaml
 
+import codenib.web.local as local_module
 from codenib import cli
+from codenib.source_fingerprint import RepositorySourceBinding
 from codenib.web import launcher
 from codenib.web.local import prepare_local_wiki
 
@@ -34,6 +37,18 @@ def test_parser_exposes_release_commands() -> None:
 
     publish = parser.parse_args(["publish", "."])
     assert publish.preset == "auto"
+
+
+def test_mcp_artifact_repo_is_explicit() -> None:
+    parser = cli.build_parser()
+
+    query_only = parser.parse_args(["mcp", "--artifact", "/tmp/context"])
+    bound = parser.parse_args(
+        ["mcp", "--artifact", "/tmp/context", "--repo", "/tmp/repo"]
+    )
+
+    assert query_only.repo is None
+    assert bound.repo == "/tmp/repo"
 
 
 @pytest.mark.parametrize(
@@ -941,6 +956,12 @@ def test_mcp_portable_artifact_forwards_full_tool_surface(
     ]
 
 
+def _test_source_fingerprint(repo: Path, cache: Path) -> str:
+    from codenib.source_fingerprint import fingerprint_repository
+
+    return fingerprint_repository(repo, exclude_roots=(cache,)).value
+
+
 def test_prepare_local_wiki_writes_single_repo_registry(
     tmp_path: Path,
 ) -> None:
@@ -948,9 +969,11 @@ def test_prepare_local_wiki_writes_single_repo_registry(
 
     manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
     manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
     manifest = RepoManifest(
         repo_path=str(tmp_path),
         commit="abc123",
+        source_fingerprint=source,
         languages=["python"],
         indexes={
             "bm25": IndexEntry(
@@ -959,6 +982,8 @@ def test_prepare_local_wiki_writes_single_repo_registry(
                 built_at="2026-07-25T00:00:00+00:00",
                 built_at_epoch=0.0,
                 status="fresh",
+                commit="abc123",
+                source_fingerprint=source,
             )
         },
     )
@@ -975,7 +1000,7 @@ def test_prepare_local_wiki_writes_single_repo_registry(
     assert local.repo_id == tmp_path.name.lower()
 
 
-def test_prepare_local_wiki_rejects_mismatched_checkout(
+def test_prepare_local_wiki_capture_return_cancellation_closes_source(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -983,25 +1008,107 @@ def test_prepare_local_wiki_rejects_mismatched_checkout(
 
     manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
     manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
+    RepoManifest(
+        repo_path=str(tmp_path),
+        source_fingerprint=source,
+        languages=["python"],
+    ).save(str(manifest_path))
+    captured: list[RepositorySourceBinding] = []
+    real_capture = local_module.capture_repository_source
+    interruption = SystemExit("injected after local wiki capture returned")
+
+    def capture(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        captured.append(binding)
+        raise interruption
+
+    monkeypatch.setattr(local_module, "capture_repository_source", capture)
+    with pytest.raises(SystemExit) as caught:
+        prepare_local_wiki(tmp_path, manifest_path, frontend_port=3000)
+
+    assert caught.value is interruption
+    assert len(captured) == 1
+    assert captured[0].closed
+
+
+def test_prepare_local_wiki_persistent_close_preserves_primary_and_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.compiler.manifest import RepoManifest
+
+    source_path = tmp_path / "module.py"
+    source_path.write_text("VALUE = 1\n")
+    manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
+    manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
+    RepoManifest(
+        repo_path=str(tmp_path),
+        source_fingerprint=source,
+        languages=["python"],
+    ).save(str(manifest_path))
+    source_path.write_text("VALUE = 2\n")
+    captured: list[RepositorySourceBinding] = []
+    real_capture = local_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+
+    def capture(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        captured.append(binding)
+        return binding
+
+    def persistent_eio(binding: RepositorySourceBinding) -> None:
+        if binding in captured:
+            raise OSError(errno.EIO, "injected local wiki source close EIO")
+        real_close(binding)
+
+    monkeypatch.setattr(local_module, "capture_repository_source", capture)
+    monkeypatch.setattr(RepositorySourceBinding, "close", persistent_eio)
+    with pytest.raises(ValueError, match="does not match the manifest") as caught:
+        prepare_local_wiki(tmp_path, manifest_path, frontend_port=3000)
+
+    assert len(captured) == 1
+    owner = caught.value.source_cleanup_owner
+    assert owner.pending_sources == (captured[0],)
+    assert not captured[0].closed
+
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    owner.close()
+    assert owner.closed
+    assert captured[0].closed
+
+
+def test_prepare_local_wiki_treats_manifest_commit_as_indexed_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.compiler.manifest import RepoManifest
+
+    manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
+    manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
     RepoManifest(
         repo_path=str(tmp_path),
         commit="a" * 40,
+        source_fingerprint=source,
         languages=["python"],
     ).save(str(manifest_path))
     monkeypatch.setattr(
         "codenib.compiler.checkout_identity.checkout_commit",
-        lambda _repo_path: "b" * 40,
+        lambda _repo_path: pytest.fail(
+            "local content authentication must not claim a Git HEAD attestation"
+        ),
     )
 
-    with pytest.raises(
-        ValueError,
-        match="repository checkout does not match the indexed snapshot",
-    ):
-        prepare_local_wiki(
-            tmp_path,
-            manifest_path,
-            frontend_port=3000,
-        )
+    local = prepare_local_wiki(
+        tmp_path,
+        manifest_path,
+        frontend_port=3000,
+    )
+
+    registry = json.loads((local.data_dir / "qa_registry.json").read_text())
+    assert registry[0]["base_commit"] == "a" * 40
 
 
 def test_prepare_local_wiki_rejects_changed_source_at_same_commit(
@@ -1027,7 +1134,7 @@ def test_prepare_local_wiki_rejects_changed_source_at_same_commit(
 
     with pytest.raises(
         ValueError,
-        match="repository source files do not match the indexed content",
+        match="repository source content does not match the manifest",
     ):
         prepare_local_wiki(
             tmp_path,
@@ -1044,9 +1151,11 @@ def test_prepare_local_wiki_uses_github_origin_identity(
 
     manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
     manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
     RepoManifest(
         repo_path=str(tmp_path),
         commit="abc123",
+        source_fingerprint=source,
         languages=["python"],
     ).save(str(manifest_path))
     monkeypatch.setattr(
@@ -1073,9 +1182,11 @@ def test_prepare_generated_wiki_keeps_secret_out_of_config(
 
     manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
     manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
     RepoManifest(
         repo_path=str(tmp_path),
         commit="abc123",
+        source_fingerprint=source,
         languages=["python"],
         indexes={
             "bm25": IndexEntry(
@@ -1084,6 +1195,8 @@ def test_prepare_generated_wiki_keeps_secret_out_of_config(
                 built_at="2026-07-25T00:00:00+00:00",
                 built_at_epoch=0.0,
                 status="fresh",
+                commit="abc123",
+                source_fingerprint=source,
             )
         },
     ).save(str(manifest_path))
@@ -1131,7 +1244,12 @@ def test_prepare_local_wiki_keeps_embedding_secret_process_local(
 
     manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
     manifest_path.parent.mkdir()
-    RepoManifest(repo_path=str(tmp_path), languages=["python"]).save(str(manifest_path))
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
+    RepoManifest(
+        repo_path=str(tmp_path),
+        source_fingerprint=source,
+        languages=["python"],
+    ).save(str(manifest_path))
     monkeypatch.setenv("EMBEDDING_KEY", "embedding-secret")
 
     local = prepare_local_wiki(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import errno
 import json
+import sys
 from pathlib import Path
 from subprocess import CompletedProcess
 from types import SimpleNamespace
@@ -1261,6 +1262,78 @@ def test_prepare_local_wiki_keeps_embedding_secret_process_local(
 
     assert "embedding-secret" not in local.config_path.read_text()
     assert local.runtime_env["CODENIB_EMBEDDING_API_KEY"] == "embedding-secret"
+
+
+def test_wiki_audit_injects_local_native_authority_resolver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = {}
+    config = SimpleNamespace(
+        model="model",
+        model_api_base=None,
+        model_api_key=None,
+        embedding_api_key=None,
+        wiki_generation_model="model",
+        wiki_generation_api_base=None,
+        wiki_generation_api_key=None,
+        wiki_generation_options={},
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo="owner/sample", base_commit="abc123")
+    )
+
+    def resolver(_repo_entry, _manifest, _vector_entry):
+        return object()
+
+    class Registry:
+        def __init__(self, supplied_config, **kwargs):
+            captured["config"] = supplied_config
+            captured.update(kwargs)
+
+        def load_all(self):
+            captured["loaded"] = True
+
+        def get(self, repo_id):
+            assert repo_id == "sample"
+            return bundle
+
+    monkeypatch.setattr("codenib.web.config.load_config", lambda _path: config)
+    monkeypatch.setattr(
+        "codenib.web.native_authority.authorize_local_manifest_vector",
+        resolver,
+    )
+    monkeypatch.setattr("codenib.web.repo_registry.RepoRegistry", Registry)
+    monkeypatch.setitem(
+        sys.modules,
+        "codenib.llm.litellm_chat",
+        SimpleNamespace(LiteLLMChat=lambda **_kwargs: object()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "codenib.wiki.agent_wiki",
+        SimpleNamespace(AgentWiki=lambda *_args, **_kwargs: object()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "codenib.wiki.quality",
+        SimpleNamespace(audit_wiki=lambda _builder: {"passed": True}),
+    )
+    local = SimpleNamespace(
+        config_path=tmp_path / "config.yaml",
+        runtime_env={},
+        repo_id="sample",
+        data_dir=tmp_path,
+    )
+
+    report = cli._audit_local_wiki(local)
+
+    assert report["passed"] is True
+    assert captured == {
+        "config": config,
+        "native_index_authorization_resolver": resolver,
+        "loaded": True,
+    }
 
 
 def test_wiki_audit_exits_without_starting_frontend(

--- a/test/test_native_index_authorization.py
+++ b/test/test_native_index_authorization.py
@@ -12,9 +12,13 @@ import pytest
 from codenib._atomic_directory import capture_directory_ownership
 from codenib.native_index_authorization import (
     NATIVE_INDEX_SUBJECT_SCHEMA,
+    InvalidNativeIndexAuthorizationError,
+    MissingNativeIndexAuthorizationError,
+    NativeIndexAuthorizationError,
     _mint_trusted_local_admin_authorization,
     native_index_subject,
     require_native_index_authorization,
+    require_native_index_authorization_preflight,
 )
 
 
@@ -60,7 +64,10 @@ def test_native_index_authorization_is_process_local_and_exact(tmp_path: Path) -
 
     payload.write_bytes(b"changed")
     changed = capture_directory_ownership(root)
-    with pytest.raises(ValueError, match="does not match captured bytes"):
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="does not match captured bytes",
+    ):
         require_native_index_authorization(
             authorization,
             changed,
@@ -95,7 +102,7 @@ def test_native_index_authorization_is_immutable_and_pid_bound(
         "getpid",
         lambda: authorization.process_id + 1,
     )
-    with pytest.raises(ValueError, match="another process"):
+    with pytest.raises(InvalidNativeIndexAuthorizationError, match="another process"):
         require_native_index_authorization(
             authorization,
             ownership,
@@ -125,10 +132,59 @@ def test_native_index_authorization_defaults_to_deny(tmp_path: Path) -> None:
     (root / "index.faiss").write_bytes(b"native")
     ownership = capture_directory_ownership(root)
 
-    with pytest.raises(ValueError, match="requires external authorization"):
+    with pytest.raises(
+        MissingNativeIndexAuthorizationError,
+        match="requires external authorization",
+    ):
         require_native_index_authorization(
             None,
             ownership,
             view_type="vector",
             semantic_contract={"dimension": 3},
+        )
+
+
+def test_native_index_authorization_errors_remain_value_errors() -> None:
+    assert issubclass(NativeIndexAuthorizationError, ValueError)
+    assert issubclass(MissingNativeIndexAuthorizationError, ValueError)
+    assert issubclass(InvalidNativeIndexAuthorizationError, ValueError)
+
+    import codenib.native_index_authorization as authorization_module
+
+    assert {
+        "NativeIndexAuthorizationError",
+        "MissingNativeIndexAuthorizationError",
+        "InvalidNativeIndexAuthorizationError",
+    } <= set(authorization_module.__all__)
+
+
+def test_explicit_malformed_authorization_is_not_missing() -> None:
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="malformed",
+    ):
+        require_native_index_authorization_preflight(object(), view_type="vector")
+
+
+def test_wrong_semantic_authorization_is_invalid(tmp_path: Path) -> None:
+    root = tmp_path / "vector"
+    root.mkdir()
+    (root / "index.faiss").write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+    authorization = _mint_trusted_local_admin_authorization(
+        ownership,
+        view_type="vector",
+        semantic_contract={"dimension": 3},
+        evidence=("verified-local-boundary",),
+    )
+
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="does not match captured bytes",
+    ):
+        require_native_index_authorization(
+            authorization,
+            ownership,
+            view_type="vector",
+            semantic_contract={"dimension": 4},
         )

--- a/test/test_vector_pre_model_authorization.py
+++ b/test/test_vector_pre_model_authorization.py
@@ -1,0 +1,375 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import (
+    capture_authenticated_vector_view,
+    require_authorized_vector_view,
+)
+from codenib.native_index_authorization import (
+    InvalidNativeIndexAuthorizationError,
+    MissingNativeIndexAuthorizationError,
+    _mint_trusted_local_admin_authorization,
+)
+
+_VECTOR_CONTRACT = {
+    "builder_schema": 2,
+    "embedding_model": "vendor/model",
+    "embedding_provider": "huggingface",
+    "embedding_dimension": 4,
+    "dimension": 4,
+    "embedding_kwargs": {},
+}
+
+
+def _mint_vector_authorization(root: Path, semantic_contract):
+    root.mkdir(parents=True, exist_ok=True)
+    with capture_authenticated_vector_view(root) as view:
+        return _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "pre-model-gate-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+
+
+def _authorization_case(
+    case: str,
+    *,
+    target: Path,
+    semantic_contract,
+    tmp_path: Path,
+):
+    if case == "missing":
+        return None
+    if case == "malformed":
+        return object()
+    if case == "wrong-tree":
+        wrong_root = tmp_path / f"wrong-tree-{target.name}"
+        return _mint_vector_authorization(wrong_root, semantic_contract)
+    if case == "wrong-semantic":
+        return _mint_vector_authorization(
+            target,
+            {"different": "semantic-contract"},
+        )
+    raise AssertionError(f"unsupported authorization case: {case}")
+
+
+def test_authorized_vector_gate_preserves_primary_base_exception_on_cleanup(
+    monkeypatch,
+) -> None:
+    from codenib.index.embedding import artifact_integrity
+
+    events = []
+    primary_error = KeyboardInterrupt("primary")
+
+    class FailingView:
+        ownership = object()
+
+        def verify_final(self):
+            events.append("verify")
+
+        def close(self):
+            events.append("close")
+            raise SystemExit("cleanup")
+
+    monkeypatch.setattr(
+        artifact_integrity,
+        "require_native_index_authorization_preflight",
+        lambda *_args, **_kwargs: events.append("preflight"),
+    )
+    monkeypatch.setattr(
+        artifact_integrity,
+        "capture_authenticated_vector_view",
+        lambda _root: events.append("capture") or FailingView(),
+    )
+
+    def fail_exact(*_args, **_kwargs):
+        events.append("exact")
+        raise primary_error
+
+    monkeypatch.setattr(
+        artifact_integrity,
+        "require_native_index_authorization",
+        fail_exact,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        require_authorized_vector_view("/vector", object(), {})
+
+    assert caught.value is primary_error
+    assert events == ["preflight", "capture", "exact", "close"]
+    cleanup_notes = getattr(primary_error, "__notes__", ()) or getattr(
+        primary_error,
+        "_codenib_cleanup_notes",
+        (),
+    )
+    assert any("cleanup" in note for note in cleanup_notes)
+
+
+@pytest.mark.parametrize(
+    ("case", "error_type"),
+    [
+        ("missing", MissingNativeIndexAuthorizationError),
+        ("malformed", InvalidNativeIndexAuthorizationError),
+        ("wrong-tree", InvalidNativeIndexAuthorizationError),
+        ("wrong-semantic", InvalidNativeIndexAuthorizationError),
+    ],
+)
+def test_skill_vector_rejects_unbound_authority_before_store_constructor(
+    monkeypatch,
+    tmp_path,
+    case,
+    error_type,
+) -> None:
+    from codenib.compiler import skill_context
+    from codenib.index.embedding import vector_store as vector_store_module
+
+    target = tmp_path / "skill-vector"
+    target.mkdir()
+    authorization = _authorization_case(
+        case,
+        target=target,
+        semantic_contract=_VECTOR_CONTRACT,
+        tmp_path=tmp_path,
+    )
+    constructors = []
+
+    monkeypatch.setattr(
+        vector_store_module,
+        "CodeVectorStore",
+        lambda **kwargs: constructors.append(kwargs),
+    )
+
+    with pytest.raises(error_type):
+        skill_context._load_vector(
+            str(target),
+            embedding_model="vendor/model",
+            embedding_provider="huggingface",
+            embedding_dimension=4,
+            artifact_metadata=dict(_VECTOR_CONTRACT),
+            native_index_authorization=authorization,
+        )
+
+    assert constructors == []
+
+
+def test_skill_vector_valid_authority_continues_to_store_load(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from codenib.compiler import skill_context
+    from codenib.index.embedding import vector_store as vector_store_module
+
+    target = tmp_path / "skill-vector"
+    authorization = _mint_vector_authorization(target, _VECTOR_CONTRACT)
+    constructors = []
+    loads = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs):
+            constructors.append(kwargs)
+
+        def load(self, path, *, native_index_authorization):
+            loads.append((path, native_index_authorization))
+
+    monkeypatch.setattr(vector_store_module, "CodeVectorStore", FakeVectorStore)
+
+    result = skill_context._load_vector(
+        str(target),
+        embedding_model="vendor/model",
+        embedding_provider="huggingface",
+        embedding_dimension=4,
+        artifact_metadata=dict(_VECTOR_CONTRACT),
+        native_index_authorization=authorization,
+    )
+
+    assert isinstance(result, FakeVectorStore)
+    assert len(constructors) == 1
+    assert loads == [(str(target), authorization)]
+
+
+def _server_context(target: Path, authorization):
+    from codenib.mcp.context import ServerContext
+
+    entry = IndexEntry(
+        index_type="vector",
+        path=str(target),
+        built_at="2026-08-11T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config=dict(_VECTOR_CONTRACT),
+    )
+    return ServerContext(
+        manifest=RepoManifest(indexes={"vector": entry}),
+        _native_index_authorization=authorization,
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["missing", "malformed", "wrong-tree", "wrong-semantic"],
+)
+def test_mcp_vector_rejects_unbound_authority_before_store_constructor(
+    monkeypatch,
+    tmp_path,
+    case,
+) -> None:
+    from codenib.index.embedding import vector_store as vector_store_module
+
+    target = tmp_path / "mcp-vector"
+    target.mkdir()
+    authorization = _authorization_case(
+        case,
+        target=target,
+        semantic_contract=_VECTOR_CONTRACT,
+        tmp_path=tmp_path,
+    )
+    constructors = []
+    monkeypatch.setattr(
+        vector_store_module,
+        "CodeVectorStore",
+        lambda **kwargs: constructors.append(kwargs),
+    )
+    context = _server_context(target, authorization)
+
+    context._load_vector(probe=True)
+
+    assert constructors == []
+    assert context.vector is None
+    assert "vector" in context.errors
+
+
+def test_mcp_vector_valid_authority_continues_to_store_load(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from codenib.index.embedding import vector_store as vector_store_module
+
+    target = tmp_path / "mcp-vector"
+    authorization = _mint_vector_authorization(target, _VECTOR_CONTRACT)
+    constructors = []
+    loads = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs):
+            constructors.append(kwargs)
+            self.embedding_model = kwargs["embedding_model"]
+
+        def load(self, *, native_index_authorization):
+            loads.append(native_index_authorization)
+
+        def get_stats(self):
+            return {"total_documents": 1}
+
+    monkeypatch.setattr(vector_store_module, "CodeVectorStore", FakeVectorStore)
+    context = _server_context(target, authorization)
+
+    context._load_vector(probe=True)
+
+    assert isinstance(context.vector, FakeVectorStore)
+    assert len(constructors) == 1
+    assert loads == [authorization]
+    assert "vector" not in context.errors
+
+
+def _retrieve_pipeline(pipeline_module, tmp_path, authorization):
+    pipeline = object.__new__(pipeline_module.RetrieveRerankPipeline)
+    pipeline.repo_path = str(tmp_path)
+    pipeline.index_path = tmp_path / "retrieve-vector"
+    pipeline.retrieval_level = "l2"
+    pipeline.languages = ["python"]
+    pipeline.max_lines_per_chunk = 300
+    pipeline.index_metric = "ip"
+    pipeline.profiler = None
+    pipeline._native_index_authorization = authorization
+    return pipeline
+
+
+@pytest.mark.parametrize("case", ["malformed", "wrong-tree", "wrong-semantic"])
+def test_retrieve_cache_rejects_unbound_authority_before_store_constructor(
+    monkeypatch,
+    tmp_path,
+    case,
+) -> None:
+    from codenib.model import retrieve_rerank_pipeline as pipeline_module
+
+    target = tmp_path / "retrieve-vector"
+    target.mkdir()
+    (target / "config_model.json").write_text("{}", encoding="utf-8")
+    authorization = _authorization_case(
+        case,
+        target=target,
+        semantic_contract={},
+        tmp_path=tmp_path,
+    )
+    constructors = []
+    monkeypatch.setattr(
+        pipeline_module,
+        "CodeVectorStore",
+        lambda **kwargs: constructors.append(kwargs),
+    )
+    pipeline = _retrieve_pipeline(pipeline_module, tmp_path, authorization)
+
+    with pytest.raises(InvalidNativeIndexAuthorizationError):
+        pipeline._initialize_vector_store(
+            embedding_model="model",
+            embedding_provider="huggingface",
+            embedding_dimension=4,
+            embedding_kwargs={},
+        )
+
+    assert constructors == []
+
+
+def test_retrieve_cache_valid_authority_continues_to_store_load(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from codenib.model import retrieve_rerank_pipeline as pipeline_module
+
+    target = tmp_path / "retrieve-vector"
+    target.mkdir()
+    (target / "config_model.json").write_text("{}", encoding="utf-8")
+    authorization = _mint_vector_authorization(target, {})
+    constructors = []
+    loads = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs):
+            constructors.append(kwargs)
+            self.embedding = object()
+            self.l0_documents = [object()]
+            self.l2_documents = [object()]
+
+        def load(self, path, *, native_index_authorization):
+            loads.append((path, native_index_authorization))
+
+    monkeypatch.setattr(pipeline_module, "CodeVectorStore", FakeVectorStore)
+    monkeypatch.setattr(
+        pipeline_module,
+        "build_hierarchical_vector_store",
+        lambda **_kwargs: pytest.fail("authorized cache must be reused"),
+    )
+    pipeline = _retrieve_pipeline(pipeline_module, tmp_path, authorization)
+
+    result = pipeline._initialize_vector_store(
+        embedding_model="model",
+        embedding_provider="huggingface",
+        embedding_dimension=4,
+        embedding_kwargs={},
+    )
+
+    assert isinstance(result, FakeVectorStore)
+    assert len(constructors) == 1
+    assert loads == [(str(target), authorization)]

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -14,6 +14,53 @@ from fastapi.testclient import TestClient
 import codenib.web.app as web_app
 
 
+def test_lifespan_injects_local_native_authority_resolver(monkeypatch):
+    captured = {}
+    config = SimpleNamespace(
+        registry_path="/tmp/qa_registry.json",
+        data_dir="/tmp/data",
+        wiki_generation_model="model",
+        wiki_agent=False,
+        wiki_generation_api_base=None,
+        wiki_generation_api_key=None,
+        wiki_generation_options={},
+    )
+    resolver = object()
+
+    class Registry:
+        def __init__(self, supplied_config, **kwargs):
+            captured["config"] = supplied_config
+            captured.update(kwargs)
+
+        def load_all(self):
+            captured["loaded"] = True
+
+        def list_infos(self):
+            return []
+
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "RepoRegistry", Registry)
+    monkeypatch.setattr(web_app, "authorize_local_manifest_vector", resolver)
+    monkeypatch.setattr(
+        web_app,
+        "_wiki_narrator",
+        lambda _config: SimpleNamespace(model="model", enabled=False, cache_dir=None),
+    )
+    application = SimpleNamespace(state=SimpleNamespace())
+
+    async def run_lifespan():
+        async with web_app.lifespan(application):
+            assert application.state.registry is not None
+
+    asyncio.run(run_lifespan())
+
+    assert captured == {
+        "config": config,
+        "native_index_authorization_resolver": resolver,
+        "loaded": True,
+    }
+
+
 def test_oversized_chat_request_is_rejected_before_runtime_lookup(monkeypatch):
     def unexpected_registry_lookup():
         raise AssertionError("invalid chat payload reached the repository runtime")

--- a/test/web/test_native_authority.py
+++ b/test/web/test_native_authority.py
@@ -1,0 +1,420 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Web runtime's trusted local native-index boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from codenib.compiler import cache_lock as cache_lock_module
+from codenib.compiler.cache_lock import (
+    COMPILER_CACHE_LOCK_FILENAME,
+    compiler_cache_lock,
+)
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
+from codenib.native_index_authorization import (
+    InvalidNativeIndexAuthorizationError,
+    require_native_index_authorization,
+)
+from codenib.source_fingerprint import (
+    RepositoryChangedError,
+    RepositorySourceBinding,
+    fingerprint_repository,
+)
+from codenib.web import native_authority as native_authority_module
+from codenib.web.config import RepoEntry
+from codenib.web.native_authority import authorize_local_manifest_vector
+
+
+def _local_vector_manifest(tmp_path):
+    source_file = tmp_path / "sample.py"
+    source_file.write_text("def sample():\n    return 1\n")
+    cache = tmp_path / ".codenib_cache"
+    vector = cache / "vector"
+    vector.mkdir(parents=True)
+    (vector / "config.json").write_text(json.dumps({"dimension": 3}))
+    source = fingerprint_repository(tmp_path, exclude_roots=(cache,)).value
+    config = {
+        "embedding_model": "vendor/model",
+        "embedding_provider": "huggingface",
+        "embedding_dimension": 3,
+        "index_metric": "ip",
+    }
+    vector_entry = IndexEntry(
+        index_type="vector",
+        path=str(vector),
+        built_at="2026-08-11T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config=config,
+        commit="abc123",
+        source_fingerprint=source,
+    )
+    manifest = RepoManifest(
+        repo_path=str(tmp_path),
+        commit="abc123",
+        source_fingerprint=source,
+        file_count=1,
+        languages=["python"],
+        indexes={"vector": vector_entry},
+    )
+    manifest_path = cache / "repo_manifest.json"
+    manifest.save(manifest_path)
+    repo_entry = RepoEntry(
+        instance_id="sample",
+        repo="owner/sample",
+        base_commit="abc123",
+        language="python",
+        repo_dir=str(tmp_path),
+        manifest_path=str(manifest_path),
+    )
+    return repo_entry, manifest, vector_entry, source_file
+
+
+def test_local_resolver_binds_exact_tree_and_unmodified_manifest_config(tmp_path):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+
+    authorization = authorize_local_manifest_vector(
+        repo_entry,
+        manifest,
+        vector_entry,
+    )
+
+    with capture_authenticated_vector_view(vector_entry.path) as view:
+        require_native_index_authorization(
+            authorization,
+            view.ownership,
+            view_type="vector",
+            semantic_contract=vector_entry.config,
+        )
+        with pytest.raises(
+            InvalidNativeIndexAuthorizationError,
+            match="does not match captured bytes",
+        ):
+            require_native_index_authorization(
+                authorization,
+                view.ownership,
+                view_type="vector",
+                semantic_contract={**vector_entry.config, "embedding_dimension": 4},
+            )
+
+
+def test_local_resolver_rejects_source_drift_before_vector_capture(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, source_file = _local_vector_manifest(tmp_path)
+    source_file.write_text("def changed():\n    return 2\n")
+    monkeypatch.setattr(
+        "codenib.web.native_authority.capture_authenticated_vector_view",
+        lambda _path: pytest.fail("source drift must fail before vector capture"),
+    )
+
+    with pytest.raises(ValueError, match="source content does not match"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+
+def test_local_resolver_rejects_manifest_drift_before_source_capture(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    observed = RepoManifest.load(repo_entry.manifest_path)
+    observed.indexes["vector"].config["embedding_dimension"] = 4
+    observed.save(repo_entry.manifest_path)
+    monkeypatch.setattr(
+        "codenib.web.native_authority.capture_repository_source",
+        lambda *_args, **_kwargs: pytest.fail(
+            "manifest drift must fail before source capture"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="manifest changed"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+
+def test_local_resolver_rejects_symlinked_compiler_lock_before_source_capture(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    cache = Path(repo_entry.manifest_path).parent
+    victim = cache / "lock-victim"
+    victim.write_bytes(b"victim must remain unchanged")
+    lock_path = cache / COMPILER_CACHE_LOCK_FILENAME
+    try:
+        lock_path.symlink_to(victim)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symbolic links are unavailable: {exc}")
+    monkeypatch.setattr(
+        native_authority_module,
+        "capture_repository_source",
+        lambda *_args, **_kwargs: pytest.fail(
+            "an unsafe compiler lock must fail before source capture"
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="compiler cache lock"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    assert victim.read_bytes() == b"victim must remain unchanged"
+    assert lock_path.is_symlink()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="exercises POSIX lock identity")
+def test_local_resolver_rejects_compiler_lock_entry_swap_before_source_capture(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    cache = Path(repo_entry.manifest_path).parent
+    lock_path = cache / COMPILER_CACHE_LOCK_FILENAME
+    lock_path.write_bytes(b"original")
+    replacement = cache / "replacement-lock"
+    replacement.write_bytes(b"replacement")
+    stolen = cache / "stolen-lock"
+    real_validate = cache_lock_module._validate_posix_lock_entry
+    calls = 0
+
+    def swap_after_first_validation(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        identity = real_validate(*args, **kwargs)
+        if calls == 1:
+            os.replace(lock_path, stolen)
+            os.replace(replacement, lock_path)
+        return identity
+
+    monkeypatch.setattr(
+        cache_lock_module,
+        "_validate_posix_lock_entry",
+        swap_after_first_validation,
+    )
+    monkeypatch.setattr(
+        native_authority_module,
+        "capture_repository_source",
+        lambda *_args, **_kwargs: pytest.fail(
+            "a swapped compiler lock must fail before source capture"
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="compiler cache lock changed"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    assert calls == 2
+    assert stolen.read_bytes() == b"original"
+    assert lock_path.read_bytes() == b"replacement"
+
+
+def test_local_resolver_rejects_source_drift_after_authorization(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, source_file = _local_vector_manifest(tmp_path)
+    real_mint = native_authority_module._mint_trusted_local_admin_authorization
+
+    def mint_then_change_source(*args, **kwargs):
+        authorization = real_mint(*args, **kwargs)
+        source_file.write_text("def changed_during_authorization():\n    return 2\n")
+        return authorization
+
+    monkeypatch.setattr(
+        native_authority_module,
+        "_mint_trusted_local_admin_authorization",
+        mint_then_change_source,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="source inventory changed"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+
+def test_local_resolver_rejects_vector_tree_drift_after_authorization(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    vector_config = Path(vector_entry.path) / "config.json"
+    real_mint = native_authority_module._mint_trusted_local_admin_authorization
+
+    def mint_then_change_tree(*args, **kwargs):
+        authorization = real_mint(*args, **kwargs)
+        vector_config.write_text(json.dumps({"dimension": 4}))
+        return authorization
+
+    monkeypatch.setattr(
+        native_authority_module,
+        "_mint_trusted_local_admin_authorization",
+        mint_then_change_tree,
+    )
+
+    with pytest.raises(ValueError, match="vector view changed"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+
+def test_local_resolver_propagates_source_cleanup_failure_with_retry_owner(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    cleanup_failure = OSError("source cleanup failed")
+    captured = []
+    real_capture = native_authority_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+
+    def capture(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        captured.append(binding)
+        return binding
+
+    def fail_cleanup(binding):
+        if binding in captured:
+            raise cleanup_failure
+        real_close(binding)
+
+    monkeypatch.setattr(native_authority_module, "capture_repository_source", capture)
+    monkeypatch.setattr(RepositorySourceBinding, "close", fail_cleanup)
+
+    with pytest.raises(OSError, match="source cleanup failed") as caught:
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    assert caught.value is cleanup_failure
+    retry_owner = caught.value.source_cleanup_owner
+    assert retry_owner.pending_sources == tuple(captured)
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    retry_owner.close()
+    assert retry_owner.closed
+
+
+def test_local_resolver_rejects_incomplete_source_cleanup(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    captured = []
+    real_capture = native_authority_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+
+    def capture(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        captured.append(binding)
+        return binding
+
+    def leave_open(binding):
+        if binding not in captured:
+            real_close(binding)
+
+    monkeypatch.setattr(native_authority_module, "capture_repository_source", capture)
+    monkeypatch.setattr(RepositorySourceBinding, "close", leave_open)
+
+    with pytest.raises(RuntimeError, match="source cleanup did not finish") as caught:
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    retry_owner = caught.value.source_cleanup_owner
+    assert retry_owner.pending_sources == tuple(captured)
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    retry_owner.close()
+    assert retry_owner.closed
+
+
+def test_local_resolver_preserves_first_base_exception_when_cleanup_also_fails(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    cache = Path(repo_entry.manifest_path).parent
+    primary = KeyboardInterrupt("authorization interrupted")
+    cleanup_failure = OSError("source cleanup also failed")
+    captured = []
+    real_capture = native_authority_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+
+    def capture(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        captured.append(binding)
+        return binding
+
+    def interrupt_vector_capture(_path):
+        raise primary
+
+    def fail_cleanup(binding):
+        if binding in captured:
+            raise cleanup_failure
+        real_close(binding)
+
+    monkeypatch.setattr(native_authority_module, "capture_repository_source", capture)
+    monkeypatch.setattr(
+        native_authority_module,
+        "capture_authenticated_vector_view",
+        interrupt_vector_capture,
+    )
+    monkeypatch.setattr(RepositorySourceBinding, "close", fail_cleanup)
+
+    with pytest.raises(KeyboardInterrupt, match="authorization interrupted") as caught:
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    assert caught.value is primary
+    assert caught.value.__cause__ is cleanup_failure
+    retry_owner = caught.value.source_cleanup_owner
+    assert retry_owner.pending_sources == tuple(captured)
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    retry_owner.close()
+    assert retry_owner.closed
+    with compiler_cache_lock(cache):
+        pass
+
+
+@pytest.mark.skipif(os.name != "posix", reason="exercises the reported POSIX probe")
+def test_local_resolver_preserves_body_interrupt_when_lock_close_fails_afterward(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    cache = Path(repo_entry.manifest_path).parent
+    primary = KeyboardInterrupt("resolver body interrupted")
+    cleanup = SystemExit("lock cleanup interrupted after close")
+    real_close = cache_lock_module._close_posix_lock_file
+
+    def interrupt_source_capture(*_args, **_kwargs):
+        raise primary
+
+    def close_then_interrupt(descriptor_owner, *, locked):
+        real_close(descriptor_owner, locked=locked)
+        raise cleanup
+
+    monkeypatch.setattr(
+        native_authority_module,
+        "capture_repository_source",
+        interrupt_source_capture,
+    )
+    monkeypatch.setattr(
+        cache_lock_module,
+        "_close_posix_lock_file",
+        close_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    assert caught.value is primary
+    notes = tuple(getattr(primary, "__notes__", ())) + tuple(
+        getattr(primary, "_codenib_cleanup_notes", ())
+    )
+    diagnostic = "\n".join(notes)
+    assert "compiler cache lock cleanup also failed" in diagnostic
+    assert repr(cleanup) in diagnostic
+    assert cache_lock_module._ACTIVE_POSIX_LOCK_DESCRIPTORS == set()
+
+    monkeypatch.setattr(
+        cache_lock_module,
+        "_close_posix_lock_file",
+        real_close,
+    )
+    with compiler_cache_lock(cache):
+        pass

--- a/test/web/test_native_authority.py
+++ b/test/web/test_native_authority.py
@@ -106,6 +106,42 @@ def test_local_resolver_binds_exact_tree_and_unmodified_manifest_config(tmp_path
             )
 
 
+def test_local_resolver_does_not_exclude_repo_for_root_manifest(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    root_manifest = tmp_path / "repo_manifest.json"
+    manifest.save(root_manifest)
+    repo_entry = RepoEntry(
+        instance_id=repo_entry.instance_id,
+        repo=repo_entry.repo,
+        base_commit=repo_entry.base_commit,
+        language=repo_entry.language,
+        repo_dir=repo_entry.repo_dir,
+        manifest_path=str(root_manifest),
+    )
+    real_capture = native_authority_module.capture_repository_source
+    observed_exclusions = []
+
+    def capture(path, *, exclude_roots, **kwargs):
+        observed_exclusions.append(exclude_roots)
+        return real_capture(path, exclude_roots=exclude_roots, **kwargs)
+
+    monkeypatch.setattr(native_authority_module, "capture_repository_source", capture)
+
+    authorization = authorize_local_manifest_vector(
+        repo_entry,
+        manifest,
+        vector_entry,
+    )
+
+    assert authorization is not None
+    assert observed_exclusions == [
+        (root_manifest, tmp_path / COMPILER_CACHE_LOCK_FILENAME)
+    ]
+
+
 def test_local_resolver_rejects_source_drift_before_vector_capture(
     tmp_path,
     monkeypatch,

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -26,14 +26,19 @@ from codenib.web.repo_registry import (
 )
 
 
-@pytest.fixture(autouse=True)
-def _stub_vector_authorization(monkeypatch: pytest.MonkeyPatch):
-    authorization = object()
+@pytest.fixture
+def native_authorization(monkeypatch):
+    token = object()
+
+    def preflight(authorization, *, view_type):
+        assert authorization is token
+        assert view_type == "vector"
+
     monkeypatch.setattr(
-        "codenib.web.repo_registry._mint_trusted_local_vector_authorization",
-        lambda *_args, **_kwargs: authorization,
+        "codenib.native_index_authorization.require_native_index_authorization_preflight",
+        preflight,
     )
-    return authorization
+    return token
 
 
 def test_fresh_registry_is_isolated_from_singleton():
@@ -231,6 +236,7 @@ def test_config_index_types_for_mode():
 )
 def test_repo_views_respect_configured_index_mode(
     monkeypatch,
+    native_authorization,
     mode,
     expected_vector_loads,
 ):
@@ -240,18 +246,90 @@ def test_repo_views_respect_configured_index_mode(
         index_is_current=lambda index_type: index_type == "vector",
     )
     bundle = SimpleNamespace(manifest=manifest)
-    registry = RepoRegistry(QAConfig(mode=mode))
+    registry = RepoRegistry(
+        QAConfig(mode=mode),
+        native_index_authorization_resolver=lambda _entry: native_authorization,
+    )
     loaded = []
     monkeypatch.setattr(
         registry,
         "_load_vector_store",
-        lambda entry: loaded.append(entry) or "vector-store",
+        lambda entry, **_kwargs: loaded.append(entry) or "vector-store",
     )
 
     registry._load_repo_views(bundle)
 
     assert loaded == [vector_entry] * expected_vector_loads
     assert bundle.vector_store == ("vector-store" if expected_vector_loads else None)
+
+
+@pytest.mark.parametrize("resolver_kind", ["missing", "raises", "invalid"])
+def test_repo_views_keep_bm25_when_vector_authority_is_unusable(
+    monkeypatch,
+    resolver_kind,
+):
+    class FakeBM25:
+        def load_index(self, path):
+            self.path = path
+
+    monkeypatch.setattr(
+        "codenib.index.sparse_idx.bm25_index.BM25CodeIndexer",
+        FakeBM25,
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.require_bm25_manifest_artifact",
+        lambda _entry: None,
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "unusable authority must fail before vector model initialization"
+        ),
+    )
+    if resolver_kind == "missing":
+        resolver = None
+    elif resolver_kind == "raises":
+
+        def resolver(_entry):
+            raise ValueError("denied")
+
+    else:
+
+        def resolver(_entry):
+            return object()
+
+    bm25_entry = SimpleNamespace(path="/idx/bm25", config={})
+    vector_entry = SimpleNamespace(path="/idx/vector", config={})
+    manifest = SimpleNamespace(
+        indexes={"bm25": bm25_entry, "vector": vector_entry},
+        index_is_current=lambda _index_type: True,
+    )
+    bundle = SimpleNamespace(manifest=manifest)
+    registry = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=resolver,
+    )
+
+    registry._load_repo_views(bundle)
+
+    assert bundle.bm25.path == "/idx/bm25"
+    assert bundle.vector_store is None
+
+
+def test_vector_authority_is_preflighted_before_model_initialization(monkeypatch):
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "invalid authority must fail before vector model initialization"
+        ),
+    )
+    registry = RepoRegistry(QAConfig())
+
+    with pytest.raises(ValueError, match="requires external authorization"):
+        registry._load_vector_store(
+            SimpleNamespace(path="/idx/vector", config={}),
+            native_index_authorization=object(),
+        )
 
 
 def test_config_paths(tmp_path):
@@ -388,7 +466,10 @@ def test_rejects_unknown_embedding_provider(tmp_path):
         load_config(str(cfg_file))
 
 
-def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
+def test_vector_store_uses_provider_config_and_reuses_client(
+    monkeypatch,
+    native_authorization,
+):
     created = []
 
     class FakeVectorStore:
@@ -398,8 +479,9 @@ def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
             self.loaded = None
             created.append(self)
 
-        def load(self, path, **_kwargs):
+        def load(self, path, **kwargs):
             self.loaded = path
+            assert kwargs["native_index_authorization"] is native_authorization
 
     monkeypatch.setattr(
         "codenib.web.repo_registry._vector_store_type",
@@ -423,8 +505,14 @@ def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
         },
     )
 
-    first = registry._load_vector_store(entry)
-    second = registry._load_vector_store(entry)
+    first = registry._load_vector_store(
+        entry,
+        native_index_authorization=native_authorization,
+    )
+    second = registry._load_vector_store(
+        entry,
+        native_index_authorization=native_authorization,
+    )
 
     assert first.loaded == "/tmp/vector"
     assert first.kwargs["embedding_provider"] == "openai"
@@ -436,6 +524,7 @@ def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
 
 def test_vector_load_failure_does_not_publish_embedding_and_retains_cleanup_owner(
     monkeypatch,
+    native_authorization,
 ):
     primary = RuntimeError("vector load failed")
     cleanup = KeyboardInterrupt("vector cleanup interrupted")
@@ -472,7 +561,10 @@ def test_vector_load_failure_does_not_publish_embedding_and_retains_cleanup_owne
 
     observed = None
     try:
-        registry._load_vector_store(entry)
+        registry._load_vector_store(
+            entry,
+            native_index_authorization=native_authorization,
+        )
     except BaseException as exc:  # noqa: B036 - assert primary/cleanup priority
         observed = exc
 
@@ -485,7 +577,10 @@ def test_vector_load_failure_does_not_publish_embedding_and_retains_cleanup_owne
     assert created[0].close_calls == 2
 
 
-def test_vector_store_restores_manifest_embedding_identity(monkeypatch):
+def test_vector_store_restores_manifest_embedding_identity(
+    monkeypatch,
+    native_authorization,
+):
     created = []
 
     class FakeVectorStore:
@@ -516,7 +611,10 @@ def test_vector_store_restores_manifest_embedding_identity(monkeypatch):
         },
     )
 
-    registry._load_vector_store(entry)
+    registry._load_vector_store(
+        entry,
+        native_index_authorization=native_authorization,
+    )
 
     assert created[0].kwargs["embedding_model"] == "nomic-ai/CodeRankEmbed"
     assert created[0].kwargs["dimension"] == 768
@@ -525,7 +623,10 @@ def test_vector_store_restores_manifest_embedding_identity(monkeypatch):
     assert created[0].kwargs["revision"] == "immutable-model-revision"
 
 
-def test_vector_store_supports_legacy_prebuilt_route_fallback(monkeypatch):
+def test_vector_store_supports_legacy_prebuilt_route_fallback(
+    monkeypatch,
+    native_authorization,
+):
     created = []
 
     class FakeVectorStore:
@@ -554,14 +655,20 @@ def test_vector_store_supports_legacy_prebuilt_route_fallback(monkeypatch):
         },
     )
 
-    registry._load_vector_store(entry)
+    registry._load_vector_store(
+        entry,
+        native_index_authorization=native_authorization,
+    )
 
     assert created[0].kwargs["embedding_provider"] == "huggingface"
     assert created[0].kwargs["embedding_model"] == "nomic-ai/CodeRankEmbed"
     assert created[0].kwargs["dimension"] == 768
 
 
-def test_vector_store_fills_legacy_dimension_with_persisted_provider(monkeypatch):
+def test_vector_store_fills_legacy_dimension_with_persisted_provider(
+    monkeypatch,
+    native_authorization,
+):
     created = []
 
     class FakeVectorStore:
@@ -591,12 +698,18 @@ def test_vector_store_fills_legacy_dimension_with_persisted_provider(monkeypatch
         },
     )
 
-    registry._load_vector_store(entry)
+    registry._load_vector_store(
+        entry,
+        native_index_authorization=native_authorization,
+    )
 
     assert created[0].kwargs["dimension"] == 768
 
 
-def test_vector_store_rejects_invalid_persisted_legacy_dimension(monkeypatch):
+def test_vector_store_rejects_invalid_persisted_legacy_dimension(
+    monkeypatch,
+    native_authorization,
+):
     monkeypatch.setattr(
         "codenib.web.repo_registry._vector_store_type",
         lambda: pytest.fail("invalid route must fail before loading the store"),
@@ -616,10 +729,16 @@ def test_vector_store_rejects_invalid_persisted_legacy_dimension(monkeypatch):
     )
 
     with pytest.raises(ValueError, match="dimension must be a positive integer"):
-        registry._load_vector_store(entry)
+        registry._load_vector_store(
+            entry,
+            native_index_authorization=native_authorization,
+        )
 
 
-def test_vector_store_cache_separates_model_revisions(monkeypatch):
+def test_vector_store_cache_separates_model_revisions(
+    monkeypatch,
+    native_authorization,
+):
     created = []
 
     class FakeVectorStore:
@@ -648,8 +767,14 @@ def test_vector_store_cache_separates_model_revisions(monkeypatch):
             },
         )
 
-    first = registry._load_vector_store(entry("revision-a"))
-    second = registry._load_vector_store(entry("revision-b"))
+    first = registry._load_vector_store(
+        entry("revision-a"),
+        native_index_authorization=native_authorization,
+    )
+    second = registry._load_vector_store(
+        entry("revision-b"),
+        native_index_authorization=native_authorization,
+    )
 
     assert first.embedding is not second.embedding
     assert second.kwargs["embedding"] is None
@@ -657,6 +782,7 @@ def test_vector_store_cache_separates_model_revisions(monkeypatch):
 
 def test_remote_embedding_override_cannot_replace_artifact_route(
     monkeypatch,
+    native_authorization,
 ):
     created = []
 
@@ -694,7 +820,10 @@ def test_remote_embedding_override_cannot_replace_artifact_route(
     )
 
     with pytest.raises(ValueError, match="endpoint does not match"):
-        registry._load_vector_store(entry)
+        registry._load_vector_store(
+            entry,
+            native_index_authorization=native_authorization,
+        )
 
     assert created == []
 

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -11,6 +11,11 @@ import pytest
 from codenib.agent.skills.registry import SkillRegistry
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.native_index_authorization import (
+    InvalidNativeIndexAuthorizationError,
+    MissingNativeIndexAuthorizationError,
+    _mint_trusted_local_admin_authorization,
+)
 from codenib.web.config import (
     QAConfig,
     RepoEntry,
@@ -30,13 +35,14 @@ from codenib.web.repo_registry import (
 def native_authorization(monkeypatch):
     token = object()
 
-    def preflight(authorization, *, view_type):
+    def require_view(root, authorization, semantic_contract):
+        assert root
         assert authorization is token
-        assert view_type == "vector"
+        assert isinstance(semantic_contract, dict)
 
     monkeypatch.setattr(
-        "codenib.native_index_authorization.require_native_index_authorization_preflight",
-        preflight,
+        "codenib.index.embedding.artifact_integrity.require_authorized_vector_view",
+        require_view,
     )
     return token
 
@@ -245,10 +251,17 @@ def test_repo_views_respect_configured_index_mode(
         indexes={"vector": vector_entry},
         index_is_current=lambda index_type: index_type == "vector",
     )
-    bundle = SimpleNamespace(manifest=manifest)
+    repo_entry = SimpleNamespace(instance_id="repo")
+    bundle = SimpleNamespace(entry=repo_entry, manifest=manifest)
+    resolved = []
+
+    def resolve(entry, resolved_manifest, resolved_vector):
+        resolved.append((entry, resolved_manifest, resolved_vector))
+        return native_authorization
+
     registry = RepoRegistry(
         QAConfig(mode=mode),
-        native_index_authorization_resolver=lambda _entry: native_authorization,
+        native_index_authorization_resolver=resolve,
     )
     loaded = []
     monkeypatch.setattr(
@@ -261,10 +274,13 @@ def test_repo_views_respect_configured_index_mode(
 
     assert loaded == [vector_entry] * expected_vector_loads
     assert bundle.vector_store == ("vector-store" if expected_vector_loads else None)
+    assert resolved == (
+        [(repo_entry, manifest, vector_entry)] if expected_vector_loads else []
+    )
 
 
-@pytest.mark.parametrize("resolver_kind", ["missing", "raises", "invalid"])
-def test_repo_views_keep_bm25_when_vector_authority_is_unusable(
+@pytest.mark.parametrize("resolver_kind", ["missing", "declines"])
+def test_repo_views_keep_bm25_only_for_explicit_optional_authority_policy(
     monkeypatch,
     resolver_kind,
 ):
@@ -288,15 +304,10 @@ def test_repo_views_keep_bm25_when_vector_authority_is_unusable(
     )
     if resolver_kind == "missing":
         resolver = None
-    elif resolver_kind == "raises":
-
-        def resolver(_entry):
-            raise ValueError("denied")
-
     else:
 
-        def resolver(_entry):
-            return object()
+        def resolver(_repo_entry, _manifest, _vector_entry):
+            return None
 
     bm25_entry = SimpleNamespace(path="/idx/bm25", config={})
     vector_entry = SimpleNamespace(path="/idx/vector", config={})
@@ -304,15 +315,139 @@ def test_repo_views_keep_bm25_when_vector_authority_is_unusable(
         indexes={"bm25": bm25_entry, "vector": vector_entry},
         index_is_current=lambda _index_type: True,
     )
-    bundle = SimpleNamespace(manifest=manifest)
+    bundle = SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
     registry = RepoRegistry(
         QAConfig(mode="hybrid"),
         native_index_authorization_resolver=resolver,
+        allow_missing_native_index_authorization=True,
     )
 
     registry._load_repo_views(bundle)
 
     assert bundle.bm25.path == "/idx/bm25"
+    assert bundle.vector_store is None
+
+
+@pytest.mark.parametrize("resolver_kind", ["missing", "declines"])
+def test_repo_views_fail_closed_when_required_authority_is_missing(
+    monkeypatch,
+    resolver_kind,
+):
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "missing authority must fail before vector model initialization"
+        ),
+    )
+    if resolver_kind == "missing":
+        resolver = None
+    else:
+
+        def decline(_repo, _manifest, _entry):
+            return None
+
+        resolver = decline
+
+    vector_entry = SimpleNamespace(path="/idx/vector", config={})
+    manifest = SimpleNamespace(
+        indexes={"vector": vector_entry},
+        index_is_current=lambda _index_type: True,
+    )
+    bundle = SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
+    if resolver is None:
+        with pytest.raises(
+            MissingNativeIndexAuthorizationError,
+            match="requires an external",
+        ):
+            RepoRegistry(QAConfig(mode="hybrid"))
+        return
+
+    registry = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=resolver,
+    )
+    with pytest.raises(MissingNativeIndexAuthorizationError, match="returned no"):
+        registry._load_repo_views(bundle)
+
+
+def test_repo_views_propagate_resolver_rejection_before_model_initialization(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "resolver rejection must fail before vector model initialization"
+        ),
+    )
+
+    def reject(_repo, _manifest, _entry):
+        raise ValueError("operator denied vector authority")
+
+    vector_entry = SimpleNamespace(path="/idx/vector", config={})
+    manifest = SimpleNamespace(
+        indexes={"vector": vector_entry},
+        index_is_current=lambda _index_type: True,
+    )
+    registry = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=reject,
+        allow_missing_native_index_authorization=True,
+    )
+
+    with pytest.raises(ValueError, match="operator denied"):
+        registry._load_repo_views(
+            SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
+        )
+
+
+def test_repo_views_propagate_vector_integrity_failures(
+    native_authorization, monkeypatch
+):
+    vector_entry = SimpleNamespace(path="/idx/vector", config={})
+    manifest = SimpleNamespace(
+        indexes={"vector": vector_entry},
+        index_is_current=lambda _index_type: True,
+    )
+    registry = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=(
+            lambda _repo, _manifest, _entry: native_authorization
+        ),
+        allow_missing_native_index_authorization=True,
+    )
+    monkeypatch.setattr(
+        registry,
+        "_load_vector_store",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ValueError("authenticated vector bytes changed")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="vector bytes changed"):
+        registry._load_repo_views(
+            SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
+        )
+
+
+def test_hybrid_requires_a_current_vector_unless_explicitly_optional(monkeypatch):
+    manifest = SimpleNamespace(
+        indexes={},
+        index_is_current=lambda _index_type: False,
+    )
+    bundle = SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
+    required = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=(lambda _repo, _manifest, _entry: object()),
+    )
+
+    with pytest.raises(ValueError, match="requires a current vector"):
+        required._load_repo_views(bundle)
+
+    optional = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        allow_missing_native_index_authorization=True,
+    )
+    optional._load_repo_views(bundle)
     assert bundle.vector_store is None
 
 
@@ -325,10 +460,57 @@ def test_vector_authority_is_preflighted_before_model_initialization(monkeypatch
     )
     registry = RepoRegistry(QAConfig())
 
-    with pytest.raises(ValueError, match="requires external authorization"):
+    with pytest.raises(ValueError, match="malformed"):
         registry._load_vector_store(
             SimpleNamespace(path="/idx/vector", config={}),
             native_index_authorization=object(),
+        )
+
+
+@pytest.mark.parametrize("mismatch", ["tree", "semantic"])
+def test_exact_vector_authority_is_checked_before_model_initialization(
+    tmp_path,
+    monkeypatch,
+    mismatch,
+):
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
+
+    authorized_root = tmp_path / "authorized"
+    loaded_root = tmp_path / "loaded"
+    authorized_root.mkdir()
+    loaded_root.mkdir()
+    (authorized_root / "config.json").write_text('{"tree":"authorized"}')
+    (loaded_root / "config.json").write_text('{"tree":"loaded"}')
+    manifest_config = {"embedding_model": "vendor/model"}
+    token_config = (
+        {"embedding_model": "different/model"}
+        if mismatch == "semantic"
+        else manifest_config
+    )
+    with capture_authenticated_vector_view(authorized_root) as view:
+        authorization = _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=token_config,
+            evidence=("test-local-admin",),
+        )
+    target = authorized_root if mismatch == "semantic" else loaded_root
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "wrong-tree or wrong-semantic authority must fail before model init"
+        ),
+    )
+
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="does not match captured bytes",
+    ):
+        RepoRegistry(QAConfig())._load_vector_store(
+            SimpleNamespace(path=str(target), config=manifest_config),
+            native_index_authorization=authorization,
         )
 
 
@@ -663,6 +845,7 @@ def test_vector_store_supports_legacy_prebuilt_route_fallback(
     assert created[0].kwargs["embedding_provider"] == "huggingface"
     assert created[0].kwargs["embedding_model"] == "nomic-ai/CodeRankEmbed"
     assert created[0].kwargs["dimension"] == 768
+    assert created[0].kwargs["artifact_metadata"] == entry.config
 
 
 def test_vector_store_fills_legacy_dimension_with_persisted_provider(


### PR DESCRIPTION
## Summary

Close native-vector authority and publication boundaries across compiler,
artifact, agent, MCP, Web, script, and cache consumers. The former stacked
dependencies through #587 are merged, and this branch is restacked directly
on current `main`.

## Changes

- Preserve lexical source boundaries through CLI, compiler, agent, and client
  entry points.
- Require exact captured-tree and semantic-contract authorization before
  constructing embedding models, remote clients, pickle decoders, or FAISS
  parsers, and pass that same external capability through every native load.
- Keep portable vector validation parser-inert; a descriptive `trusted-local`
  value no longer grants native access.
- Publish vector files, cache state, incremental state, and update markers as
  one descriptor-anchored private generation with an atomic directory switch.
- Disable live vector delta mutation until it can satisfy the same publication
  boundary; validated incremental requests use a safe complete-generation
  rebuild.
- Preserve the first cache-lock and captured-view failure across cleanup
  faults.
- Bind Web vector authorization to the complete repository source even when
  the manifest is stored at the repository root.
- Isolate snapshot vector trees from profile symlinks and quality receipts so
  repeated strict captures remain valid.
- Resolve publication output ancestors before overlap checks and use the same
  canonical paths for publication, preventing symlink redirects into source or
  index state.
- Document the publication and compatibility gates in the incremental and
  storage roadmaps.

Platforms without a descriptor-anchored path for native writers fail closed
before model construction instead of using a replaceable build pathname.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Full unit tier: `5167 passed, 71 skipped, 190 deselected`.
- Changed-surface unit sweep: `793 passed, 11 deselected`.
- Focused manifest, snapshot-layout, and publication-output regressions:
  `38 passed`.
- Pre-commit passed across the complete 62-file branch diff, including Black,
  isort, flake8, namespace checks, and `git diff --check`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

The branch is based directly on `main` at
`1de7d18f7480491ca050d7a7a09f22a7a5723a58`.
