### PR TITLE
feat(storage): validate strict publication inputs

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -10,9 +10,9 @@ import hashlib
 import os
 import stat
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Literal
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _EXPECTED_DESTINATION_UNSET = object()
@@ -57,13 +57,29 @@ class _OwnershipBudget:
 
 
 @dataclass(frozen=True, slots=True)
+class TreeFileRecord:
+    """Canonical content record captured before an owned file is consumed."""
+
+    path: str
+    mode: int
+    size: int
+    sha256: str
+
+
+DirectoryEntryPolicy = Callable[[str, Literal["directory", "file"], int, int], None]
+
+
+@dataclass(frozen=True, slots=True)
 class _TreeOwnership:
     root_identity: tuple[int, ...]
+    root_version_identity: tuple[int, ...]
     digest: str
     entries: int
     byte_count: int
     metadata_bytes: int
     inventory: tuple[tuple[str, str], ...]
+    file_records: tuple[TreeFileRecord, ...]
+    entry_identities: tuple[tuple[str, str, tuple[int, ...]], ...]
 
 
 class _PreviousOutputIdentityLost(RuntimeError):
@@ -223,7 +239,9 @@ def _hash_owned_regular_file(
     *,
     root_device: int,
     budget: _OwnershipBudget,
-) -> tuple[int, str]:
+    relative: str,
+    entry_policy: DirectoryEntryPolicy | None,
+) -> tuple[int, str, tuple[int, ...]]:
     flags = os.O_RDONLY | os.O_NOFOLLOW
     flags |= getattr(os, "O_CLOEXEC", 0)
     flags |= getattr(os, "O_NONBLOCK", 0)
@@ -238,6 +256,8 @@ def _hash_owned_regular_file(
         ):
             raise RuntimeError(f"directory ownership file changed: {path}")
         size = opened.st_size
+        if entry_policy is not None:
+            entry_policy(relative, "file", stat.S_IMODE(opened.st_mode), size)
         if size < 0 or budget.byte_count + size > _MAX_OWNERSHIP_BYTES:
             raise RuntimeError("directory ownership scan exceeds its byte limit")
         digest = hashlib.sha256()
@@ -265,7 +285,7 @@ def _hash_owned_regular_file(
     finally:
         os.close(descriptor)
     budget.byte_count += size
-    return size, digest.hexdigest()
+    return size, digest.hexdigest(), _ownership_version_identity(after)
 
 
 def _scan_owned_directory(
@@ -277,6 +297,9 @@ def _scan_owned_directory(
     mount_points: frozenset[str],
     budget: _OwnershipBudget,
     inventory: list[tuple[str, str]],
+    file_records: list[TreeFileRecord],
+    entry_identities: list[tuple[str, str, tuple[int, ...]]],
+    entry_policy: DirectoryEntryPolicy | None,
     depth: int,
     required_root_file: bytes | None = None,
     allow_empty_root: bool = False,
@@ -338,6 +361,13 @@ def _scan_owned_directory(
 
         entry_hasher = hashlib.sha256()
         if stat.S_ISDIR(metadata.st_mode):
+            if entry_policy is not None:
+                entry_policy(
+                    os.fsdecode(relative),
+                    "directory",
+                    stat.S_IMODE(metadata.st_mode),
+                    0,
+                )
             child_descriptor = os.open(name, flags, dir_fd=descriptor)
             try:
                 opened = os.fstat(child_descriptor)
@@ -355,6 +385,9 @@ def _scan_owned_directory(
                     mount_points=mount_points,
                     budget=budget,
                     inventory=inventory,
+                    file_records=file_records,
+                    entry_identities=entry_identities,
+                    entry_policy=entry_policy,
                     depth=depth + 1,
                 )
                 after = os.fstat(child_descriptor)
@@ -382,14 +415,23 @@ def _scan_owned_directory(
             entry_hasher.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
             entry_hasher.update(child_digest)
             inventory.append((os.fsdecode(relative), "directory"))
+            entry_identities.append(
+                (
+                    os.fsdecode(relative),
+                    "directory",
+                    _ownership_version_identity(after),
+                )
+            )
         elif stat.S_ISREG(metadata.st_mode):
-            size, digest = _hash_owned_regular_file(
+            size, digest, file_identity = _hash_owned_regular_file(
                 descriptor,
                 name,
                 child_path,
                 metadata,
                 root_device=root_device,
                 budget=budget,
+                relative=os.fsdecode(relative),
+                entry_policy=entry_policy,
             )
             digest_bytes = bytes.fromhex(digest)
             entry_hasher.update(b"F")
@@ -398,6 +440,15 @@ def _scan_owned_directory(
             entry_hasher.update(size.to_bytes(8, "big"))
             entry_hasher.update(digest_bytes)
             inventory.append((os.fsdecode(relative), "file"))
+            file_records.append(
+                TreeFileRecord(
+                    path=os.fsdecode(relative),
+                    mode=stat.S_IMODE(metadata.st_mode),
+                    size=size,
+                    sha256=digest,
+                )
+            )
+            entry_identities.append((os.fsdecode(relative), "file", file_identity))
         else:
             raise RuntimeError(
                 f"directory ownership scan refuses special content: {child_path}"
@@ -417,6 +468,7 @@ def capture_directory_ownership(
     *,
     required_root_file: str | None = None,
     allow_empty_root: bool = False,
+    entry_policy: DirectoryEntryPolicy | None = None,
 ) -> _TreeOwnership:
     """Return a bounded content token for one stable, real directory tree."""
 
@@ -459,11 +511,14 @@ def capture_directory_ownership(
         digest.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
         return _TreeOwnership(
             root_identity=_directory_inode_identity(metadata),
+            root_version_identity=_ownership_version_identity(metadata),
             digest=digest.hexdigest(),
             entries=0,
             byte_count=0,
             metadata_bytes=0,
             inventory=(),
+            file_records=(),
+            entry_identities=(),
         )
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     flags |= getattr(os, "O_CLOEXEC", 0)
@@ -474,6 +529,8 @@ def capture_directory_ownership(
             raise RuntimeError(f"directory ownership root changed: {path}")
         budget = _OwnershipBudget()
         inventory: list[tuple[str, str]] = []
+        file_records: list[TreeFileRecord] = []
+        entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
         digest = _scan_owned_directory(
             descriptor,
             path,
@@ -482,6 +539,9 @@ def capture_directory_ownership(
             mount_points=_linux_mount_points(),
             budget=budget,
             inventory=inventory,
+            file_records=file_records,
+            entry_identities=entry_identities,
+            entry_policy=entry_policy,
             depth=0,
             required_root_file=required_root_file_bytes,
             allow_empty_root=allow_empty_root,
@@ -498,11 +558,14 @@ def capture_directory_ownership(
         raise RuntimeError(f"directory ownership root changed: {path}")
     return _TreeOwnership(
         root_identity=_directory_inode_identity(opened),
+        root_version_identity=_ownership_version_identity(opened),
         digest=digest.hex(),
         entries=budget.entries,
         byte_count=budget.byte_count,
         metadata_bytes=budget.metadata_bytes,
         inventory=tuple(sorted(inventory)),
+        file_records=tuple(sorted(file_records, key=lambda record: record.path)),
+        entry_identities=tuple(sorted(entry_identities)),
     )
 
 
@@ -516,6 +579,36 @@ def directory_ownership_inventory(
     return ownership.inventory
 
 
+def directory_ownership_file_records(
+    ownership: _TreeOwnership,
+) -> tuple[TreeFileRecord, ...]:
+    """Return canonical per-file records bound by an ownership token."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.file_records
+
+
+def directory_ownership_entry_identities(
+    ownership: _TreeOwnership,
+) -> tuple[tuple[str, str, tuple[int, ...]], ...]:
+    """Return private filesystem identities captured for every tree entry."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.entry_identities
+
+
+def directory_ownership_root_version_identity(
+    ownership: _TreeOwnership,
+) -> tuple[int, ...]:
+    """Return the captured root version identity used by pinned readers."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.root_version_identity
+
+
 def directory_ownership_root_identity(
     ownership: _TreeOwnership,
 ) -> tuple[int, ...]:
@@ -526,17 +619,38 @@ def directory_ownership_root_identity(
     return ownership.root_identity
 
 
+def directory_ownership_digest(ownership: _TreeOwnership) -> str:
+    """Return the canonical complete-tree digest bound by a token."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.digest
+
+
 def _require_tree_ownership(
     path: Path,
     expected: _TreeOwnership,
     *,
     label: str,
+    allow_root_rename: bool = False,
 ) -> None:
+    allow_root_rename = allow_root_rename or label in {
+        "moved destination",
+        "previous destination",
+        "published staged directory",
+    }
     try:
         observed = capture_directory_ownership(path)
     except (OSError, ValueError, RuntimeError) as exc:
         raise RuntimeError(f"{label} changed during directory publication") from exc
-    if observed != expected:
+    if observed != expected and not (
+        allow_root_rename
+        and replace(
+            observed,
+            root_version_identity=expected.root_version_identity,
+        )
+        == expected
+    ):
         raise RuntimeError(f"{label} changed during directory publication")
 
 
@@ -1384,9 +1498,15 @@ def publish_staged_directory(
 
 
 __all__ = [
+    "DirectoryEntryPolicy",
+    "TreeFileRecord",
     "capture_directory_ownership",
+    "directory_ownership_digest",
+    "directory_ownership_entry_identities",
+    "directory_ownership_file_records",
     "directory_ownership_inventory",
     "directory_ownership_root_identity",
+    "directory_ownership_root_version_identity",
     "discard_owned_directory",
     "lexical_directory_path",
     "publish_staged_directory",

--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -6,13 +6,35 @@
 
 from __future__ import annotations
 
+import ctypes
+import errno
 import hashlib
 import os
+import secrets
 import stat
-import tempfile
+import sys
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
-from pathlib import Path
-from typing import Callable, Literal
+from pathlib import Path, PurePosixPath
+from typing import Callable, ContextManager, Iterator, Literal, Protocol, TypeVar
+
+from . import _windows_fs_authority as _windows_fs
+
+_WINDOWS_DELETE = _windows_fs.DELETE
+_WINDOWS_FILE_ATTRIBUTE_DIRECTORY = _windows_fs.FILE_ATTRIBUTE_DIRECTORY
+_WINDOWS_FILE_ATTRIBUTE_READONLY = _windows_fs.FILE_ATTRIBUTE_READONLY
+_WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT = _windows_fs.FILE_ATTRIBUTE_REPARSE_POINT
+_WINDOWS_FILE_LIST_DIRECTORY = _windows_fs.FILE_LIST_DIRECTORY
+_WINDOWS_FILE_READ_ATTRIBUTES = _windows_fs.FILE_READ_ATTRIBUTES
+_WINDOWS_FILE_READ_DATA = _windows_fs.FILE_READ_DATA
+_WINDOWS_SYNCHRONIZE = _windows_fs.SYNCHRONIZE
+_WindowsDirectoryEntry = _windows_fs.WindowsDirectoryEntry
+_WindowsHandleMetadata = _windows_fs.WindowsHandleMetadata
+_WindowsKernelApi = _windows_fs.WindowsKernelApi
+_windows_extended_path = _windows_fs.windows_extended_path
+_windows_mode_from_attributes = _windows_fs.windows_mode_from_attributes
+_shared_windows_kernel_api = _windows_fs.windows_kernel_api
+_shared_windows_require_publication_api = _windows_fs.windows_require_publication_api
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _EXPECTED_DESTINATION_UNSET = object()
@@ -24,15 +46,16 @@ _MAX_OWNERSHIP_METADATA_BYTES = 16 << 20
 _MAX_OWNERSHIP_PATH_BYTES = 4_096
 _MAX_OWNERSHIP_COMPONENT_BYTES = 255
 _OWNERSHIP_COPY_BYTES = 1 << 20
-_SAFE_REMOVAL_DIRECTORY_FDS = (
-    hasattr(os, "O_DIRECTORY")
-    and hasattr(os, "O_NOFOLLOW")
-    and os.open in os.supports_dir_fd
-    and os.stat in os.supports_dir_fd
-    and os.stat in os.supports_follow_symlinks
-    and os.scandir in os.supports_fd
-    and os.unlink in os.supports_dir_fd
-    and os.rmdir in os.supports_dir_fd
+_MAX_PUBLICATION_SNAPSHOT_BYTES = 64 << 20
+_MAX_PUBLICATION_STREAM_READ_BYTES = 8 << 20
+_RENAME_NOREPLACE = 1
+_RENAME_EXCL = 0x4
+_MAX_ORPHAN_NAME_ATTEMPTS = 128
+_DURABLE_PUBLICATION_FSYNC_BACKENDS = frozenset({"linux-renameat2"})
+_WINDOWS_RESERVED_BASENAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{number}" for number in range(1, 10)}
+    | {f"LPT{number}" for number in range(1, 10)}
 )
 _SAFE_OWNERSHIP_DIRECTORY_FDS = (
     hasattr(os, "O_DIRECTORY")
@@ -43,10 +66,7 @@ _SAFE_OWNERSHIP_DIRECTORY_FDS = (
     and os.scandir in os.supports_fd
 )
 
-
-@dataclass(slots=True)
-class _RemovalState:
-    destructive_started: bool = False
+_T = TypeVar("_T")
 
 
 @dataclass(slots=True)
@@ -82,17 +102,1629 @@ class _TreeOwnership:
     entry_identities: tuple[tuple[str, str, tuple[int, ...]], ...]
 
 
+@dataclass(frozen=True, slots=True)
+class _ExpectedPublicationFile:
+    record: TreeFileRecord
+    file_identity: tuple[int, ...]
+    directory_identities: tuple[tuple[str, tuple[int, ...]], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationFileSnapshot:
+    """Immutable bytes and their authenticated canonical file record."""
+
+    record: TreeFileRecord
+    _payload: bytes
+
+    def read_bytes(self) -> bytes:
+        return self._payload
+
+    def iter_bytes(self, *, chunk_size: int = _OWNERSHIP_COPY_BYTES) -> Iterator[bytes]:
+        if isinstance(chunk_size, bool) or not isinstance(chunk_size, int):
+            raise TypeError("publication snapshot chunk size must be an integer")
+        if chunk_size <= 0 or chunk_size > _OWNERSHIP_COPY_BYTES:
+            raise ValueError("publication snapshot chunk size is out of bounds")
+        for offset in range(0, len(self._payload), chunk_size):
+            yield self._payload[offset : offset + chunk_size]
+
+
+class PublicationAuthenticatedFile:
+    """One bounded file stream whose handle is verified when its context exits."""
+
+    __slots__ = (
+        "path",
+        "mode",
+        "size",
+        "_remaining",
+        "_read_callback",
+        "_verify_callback",
+        "_digest",
+        "_record",
+        "_closed",
+    )
+
+    def __init__(
+        self,
+        *,
+        path: str,
+        mode: int,
+        size: int,
+        read_callback: Callable[[int], bytes],
+        verify_callback: Callable[[], None],
+    ) -> None:
+        self.path = path
+        self.mode = mode
+        self.size = size
+        self._remaining = size
+        self._read_callback = read_callback
+        self._verify_callback = verify_callback
+        self._digest = hashlib.sha256()
+        self._record: TreeFileRecord | None = None
+        self._closed = False
+
+    @property
+    def record(self) -> TreeFileRecord:
+        if self._record is None:
+            raise RuntimeError(
+                "publication file record is available after context verification"
+            )
+        return self._record
+
+    def read(self, size: int = -1) -> bytes:
+        if self._closed:
+            raise ValueError("publication authenticated file is closed")
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError("publication authenticated read size must be an integer")
+        if size < 0:
+            if self._remaining > _MAX_PUBLICATION_STREAM_READ_BYTES:
+                raise ValueError(
+                    "unbounded publication reads are disabled for large files"
+                )
+            requested = self._remaining
+        else:
+            if size > _MAX_PUBLICATION_STREAM_READ_BYTES:
+                raise ValueError("publication read size exceeds its per-call limit")
+            requested = min(size, self._remaining)
+        if requested == 0:
+            return b""
+        block = self._read_callback(requested)
+        if not isinstance(block, bytes) or len(block) > requested:
+            raise RuntimeError("publication file backend returned invalid bytes")
+        if not block:
+            raise RuntimeError("publication authenticated file was truncated")
+        self._remaining -= len(block)
+        self._digest.update(block)
+        return block
+
+    def iter_bytes(
+        self,
+        *,
+        chunk_size: int = _OWNERSHIP_COPY_BYTES,
+    ) -> Iterator[bytes]:
+        if isinstance(chunk_size, bool) or not isinstance(chunk_size, int):
+            raise TypeError("publication stream chunk size must be an integer")
+        if chunk_size <= 0 or chunk_size > _MAX_PUBLICATION_STREAM_READ_BYTES:
+            raise ValueError("publication stream chunk size is out of bounds")
+        while self._remaining:
+            yield self.read(min(chunk_size, self._remaining))
+
+    def _finalize(self) -> None:
+        if self._closed:
+            return
+        try:
+            while self._remaining:
+                self.read(min(_OWNERSHIP_COPY_BYTES, self._remaining))
+            extra = self._read_callback(1)
+            self._verify_callback()
+            if extra:
+                raise RuntimeError("publication authenticated file grew while read")
+            self._record = TreeFileRecord(
+                path=self.path,
+                mode=self.mode,
+                size=self.size,
+                sha256=self._digest.hexdigest(),
+            )
+        finally:
+            self._closed = True
+
+
+class PublicationDirectoryReader:
+    """A child tree that is usable only during an authority-owned callback."""
+
+    __slots__ = (
+        "_diagnostic_path",
+        "root_identity",
+        "_capture",
+        "_open_file",
+        "_expected_ownership",
+        "_records_by_path",
+        "_entries_by_path",
+        "_authentication_failed",
+        "_active",
+    )
+
+    def __init__(
+        self,
+        display_path: Path,
+        root_identity: tuple[int, ...],
+        capture: Callable[
+            [str | None, bool, DirectoryEntryPolicy | None], _TreeOwnership
+        ],
+        open_file: Callable[
+            [PurePosixPath, int, _ExpectedPublicationFile],
+            ContextManager[PublicationAuthenticatedFile],
+        ],
+        expected_ownership: _TreeOwnership | None,
+    ) -> None:
+        self._diagnostic_path = display_path
+        self.root_identity = root_identity
+        self._capture = capture
+        self._open_file = open_file
+        self._expected_ownership = expected_ownership
+        self._records_by_path = (
+            {}
+            if expected_ownership is None
+            else {record.path: record for record in expected_ownership.file_records}
+        )
+        self._entries_by_path = (
+            {}
+            if expected_ownership is None
+            else {
+                path: (kind, identity)
+                for path, kind, identity in expected_ownership.entry_identities
+            }
+        )
+        self._authentication_failed = False
+        self._active = True
+        if (
+            expected_ownership is not None
+            and root_identity != expected_ownership.root_identity
+        ):
+            self._authentication_failed = True
+            raise RuntimeError(
+                "publication callback root differs from captured ownership"
+            )
+
+    def capture_ownership(
+        self,
+        *,
+        required_root_file: str | None = None,
+        allow_empty_root: bool = False,
+        entry_policy: DirectoryEntryPolicy | None = None,
+    ) -> _TreeOwnership:
+        """Capture through the already-open directory authority."""
+
+        if not self._active:
+            raise RuntimeError("publication tree reader is no longer active")
+        try:
+            observed = self._capture(
+                required_root_file,
+                allow_empty_root,
+                entry_policy,
+            )
+            if self._expected_ownership is not None:
+                _require_matching_ownership(
+                    observed,
+                    self._expected_ownership,
+                    label="publication callback tree",
+                    allow_root_rename=True,
+                )
+            return observed
+        except BaseException:
+            self._authentication_failed = True
+            raise
+
+    def inventory(self) -> tuple[tuple[str, str], ...]:
+        if not self._active:
+            raise RuntimeError("publication tree reader is no longer active")
+        if self._expected_ownership is not None:
+            return self._expected_ownership.inventory
+        return self.capture_ownership().inventory
+
+    def file_records(self) -> tuple[TreeFileRecord, ...]:
+        if not self._active:
+            raise RuntimeError("publication tree reader is no longer active")
+        if self._expected_ownership is not None:
+            return self._expected_ownership.file_records
+        return self.capture_ownership().file_records
+
+    def authenticated_snapshot(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> PublicationFileSnapshot:
+        if not self._active:
+            raise RuntimeError("publication tree reader is no longer active")
+        if isinstance(max_bytes, bool) or not isinstance(max_bytes, int):
+            raise TypeError("publication snapshot limit must be an integer")
+        if max_bytes < 0 or max_bytes > _MAX_PUBLICATION_SNAPSHOT_BYTES:
+            raise ValueError("publication snapshot limit is out of bounds")
+        normalized = _publication_relative_path(relative)
+        chunks: list[bytes] = []
+        with self.open_authenticated_file(
+            normalized,
+            max_bytes=max_bytes,
+        ) as authenticated:
+            chunks.extend(authenticated.iter_bytes())
+        return PublicationFileSnapshot(
+            record=authenticated.record,
+            _payload=b"".join(chunks),
+        )
+
+    def read_bytes(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        return self.authenticated_snapshot(
+            relative,
+            max_bytes=max_bytes,
+        ).read_bytes()
+
+    @contextmanager
+    def open_authenticated_file(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> Iterator[PublicationAuthenticatedFile]:
+        if not self._active:
+            raise RuntimeError("publication tree reader is no longer active")
+        if isinstance(max_bytes, bool) or not isinstance(max_bytes, int):
+            raise TypeError("publication stream limit must be an integer")
+        if max_bytes < 0 or max_bytes > _MAX_OWNERSHIP_BYTES:
+            raise ValueError("publication stream limit is out of bounds")
+        normalized = _publication_relative_path(relative)
+        expected = self._expected_file(normalized)
+        try:
+            with self._open_file(normalized, max_bytes, expected) as authenticated:
+                if (
+                    authenticated.path,
+                    authenticated.mode,
+                    authenticated.size,
+                ) != (
+                    expected.record.path,
+                    expected.record.mode,
+                    expected.record.size,
+                ):
+                    raise RuntimeError(
+                        "publication file metadata differs from captured ownership"
+                    )
+                yield authenticated
+            if authenticated.record != expected.record:
+                raise RuntimeError(
+                    "publication file bytes differ from captured ownership"
+                )
+        except BaseException:
+            self._authentication_failed = True
+            raise
+
+    @contextmanager
+    def iter_authenticated_chunks(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+        chunk_size: int = _OWNERSHIP_COPY_BYTES,
+    ) -> Iterator[Iterator[bytes]]:
+        with self.open_authenticated_file(
+            relative,
+            max_bytes=max_bytes,
+        ) as authenticated:
+            yield authenticated.iter_bytes(chunk_size=chunk_size)
+
+    def _expected_file(
+        self,
+        relative: PurePosixPath,
+    ) -> _ExpectedPublicationFile:
+        ownership = self._expected_ownership
+        if ownership is None:
+            self._authentication_failed = True
+            raise RuntimeError(
+                "publication file reads require captured callback ownership"
+            )
+        normalized = relative.as_posix()
+        try:
+            record = self._records_by_path[normalized]
+            kind, file_identity = self._entries_by_path[normalized]
+        except KeyError as exc:
+            self._authentication_failed = True
+            raise ValueError(
+                f"publication file is absent from captured ownership: {normalized}"
+            ) from exc
+        if kind != "file":
+            self._authentication_failed = True
+            raise ValueError(f"publication path is not a captured file: {normalized}")
+        directories: list[tuple[str, tuple[int, ...]]] = []
+        for depth in range(1, len(relative.parts)):
+            directory = "/".join(relative.parts[:depth])
+            try:
+                directory_kind, identity = self._entries_by_path[directory]
+            except KeyError as exc:
+                self._authentication_failed = True
+                raise RuntimeError(
+                    f"publication directory is absent from ownership: {directory}"
+                ) from exc
+            if directory_kind != "directory":
+                self._authentication_failed = True
+                raise RuntimeError(
+                    f"publication ancestor is not a directory: {directory}"
+                )
+            directories.append((directory, identity))
+        return _ExpectedPublicationFile(
+            record=record,
+            file_identity=file_identity,
+            directory_identities=tuple(directories),
+        )
+
+    def _require_valid(self) -> None:
+        if self._authentication_failed:
+            raise RuntimeError("publication callback suppressed authentication failure")
+
+    def _deactivate(self) -> None:
+        self._active = False
+
+
+_PublicationTreeReader = PublicationDirectoryReader
+
+
+def _annotate_secondary_error(
+    primary_error: BaseException,
+    label: str,
+    secondary_error: BaseException,
+) -> None:
+    message = f"{label}: {secondary_error!r}"
+    if hasattr(primary_error, "add_note"):
+        primary_error.add_note(message)
+        return
+    notes = list(getattr(primary_error, "_codenib_cleanup_notes", ()))
+    notes.append(message)
+    primary_error._codenib_cleanup_notes = tuple(notes)  # type: ignore[attr-defined]
+    if primary_error.__cause__ is None:
+        primary_error.__cause__ = secondary_error
+
+
+def _retain_first_error(
+    primary_error: BaseException | None,
+    label: str,
+    secondary_error: BaseException,
+) -> BaseException:
+    if primary_error is None:
+        return secondary_error
+    _annotate_secondary_error(primary_error, label, secondary_error)
+    return primary_error
+
+
+@dataclass(slots=True)
+class _PosixDescriptorRecord:
+    descriptor: int
+    identity: tuple[int, ...] | None = None
+
+
+class _PosixResourceOwner:
+    """Track POSIX descriptors without removing ownership before close.
+
+    Python can recover every failure after an integer has reached a local or
+    this owner.  It cannot cover an arbitrary opcode interruption between a raw
+    ``os.open``/``os.dup`` return and Python's first STORE; closing that final
+    P2 gap requires a native owning object.
+    """
+
+    __slots__ = ("_records",)
+
+    def __init__(self) -> None:
+        self._records: list[_PosixDescriptorRecord] = []
+
+    @property
+    def closed(self) -> bool:
+        # A compatibility cleanup path may close a retained descriptor with a
+        # previously captured real close function.  Reconcile that observable
+        # outcome before reporting ownership completion.
+        for record in self._records:
+            descriptor = record.descriptor
+            if descriptor < 0:
+                continue
+            try:
+                observed = os.fstat(descriptor)
+            except OSError as probe_error:
+                if probe_error.errno == errno.EBADF:
+                    record.descriptor = -1
+                continue
+            if (
+                record.identity is not None
+                and _resource_owner_identity(observed) != record.identity
+            ):
+                record.descriptor = -1
+        return all(record.descriptor < 0 for record in self._records)
+
+    def open(
+        self,
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        descriptor = -1
+        record: _PosixDescriptorRecord | None = None
+        try:
+            if dir_fd is None:
+                descriptor = os.open(path, flags, mode)
+            else:
+                descriptor = os.open(path, flags, mode, dir_fd=dir_fd)
+            record = _PosixDescriptorRecord(descriptor)
+            self._records.append(record)
+            record.identity = _resource_owner_identity(os.fstat(descriptor))
+            return descriptor
+        except BaseException as primary_error:
+            if descriptor >= 0:
+                if record is None:
+                    record = _PosixDescriptorRecord(descriptor)
+                if not any(candidate is record for candidate in self._records):
+                    try:
+                        self._records.append(record)
+                    except BaseException as registration_error:  # noqa: B036
+                        _annotate_secondary_error(
+                            primary_error,
+                            "descriptor ownership registration also failed",
+                            registration_error,
+                        )
+                        close_error = self._close_record(record)
+                        if close_error is not None:
+                            _annotate_secondary_error(
+                                primary_error,
+                                "unregistered descriptor cleanup also failed",
+                                close_error,
+                            )
+                        raise primary_error
+                self.close_record_after_error(record, primary_error)
+            raise
+
+    def duplicate(self, descriptor: int) -> int:
+        duplicate = -1
+        record: _PosixDescriptorRecord | None = None
+        try:
+            duplicate = os.dup(descriptor)
+            record = _PosixDescriptorRecord(duplicate)
+            self._records.append(record)
+            record.identity = _resource_owner_identity(os.fstat(duplicate))
+            return duplicate
+        except BaseException as primary_error:
+            if duplicate >= 0:
+                if record is None:
+                    record = _PosixDescriptorRecord(duplicate)
+                if not any(candidate is record for candidate in self._records):
+                    try:
+                        self._records.append(record)
+                    except BaseException as registration_error:  # noqa: B036
+                        _annotate_secondary_error(
+                            primary_error,
+                            "descriptor ownership registration also failed",
+                            registration_error,
+                        )
+                        close_error = self._close_record(record)
+                        if close_error is not None:
+                            _annotate_secondary_error(
+                                primary_error,
+                                "unregistered descriptor cleanup also failed",
+                                close_error,
+                            )
+                        raise primary_error
+                self.close_record_after_error(record, primary_error)
+            raise
+
+    def close_descriptor(self, descriptor: int) -> None:
+        record = self._record_for(descriptor)
+        if record is None:
+            return
+        close_error = self._close_record(record)
+        if close_error is not None:
+            raise close_error
+
+    def close_record_after_error(
+        self,
+        record: _PosixDescriptorRecord,
+        primary_error: BaseException,
+    ) -> None:
+        close_error = self._close_record(record)
+        if close_error is not None:
+            _annotate_secondary_error(
+                primary_error,
+                "descriptor cleanup also failed",
+                close_error,
+            )
+
+    def close_all(self) -> None:
+        primary_error: BaseException | None = None
+        for record in reversed(tuple(self._records)):
+            close_error = self._close_record(record)
+            if close_error is not None:
+                primary_error = _retain_first_error(
+                    primary_error,
+                    "additional descriptor cleanup failed",
+                    close_error,
+                )
+        if primary_error is not None:
+            raise primary_error
+
+    def close_all_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close_all()
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "publication authority cleanup also failed",
+                close_error,
+            )
+
+    def _record_for(self, descriptor: int) -> _PosixDescriptorRecord | None:
+        for record in reversed(self._records):
+            if record.descriptor == descriptor:
+                return record
+        return None
+
+    def _close_record(
+        self,
+        record: _PosixDescriptorRecord,
+    ) -> BaseException | None:
+        descriptor = record.descriptor
+        if descriptor < 0:
+            return None
+        try:
+            observed = os.fstat(descriptor)
+        except OSError as probe_error:
+            if probe_error.errno == errno.EBADF:
+                record.descriptor = -1
+                return None
+            return probe_error
+        except BaseException as probe_error:  # noqa: B036 - retain owner
+            return probe_error
+        observed_identity = _resource_owner_identity(observed)
+        if record.identity is None:
+            record.identity = observed_identity
+        elif observed_identity != record.identity:
+            record.descriptor = -1
+            return RuntimeError("publication descriptor ownership changed")
+
+        try:
+            os.close(descriptor)
+            record.descriptor = -1
+        except BaseException as close_error:  # noqa: B036 - reconcile close
+            if record.descriptor < 0:
+                return close_error
+            try:
+                rebound = os.fstat(descriptor)
+            except OSError as probe_error:
+                if probe_error.errno == errno.EBADF:
+                    record.descriptor = -1
+                else:
+                    _annotate_secondary_error(
+                        close_error,
+                        "descriptor close reconciliation failed",
+                        probe_error,
+                    )
+            except BaseException as probe_error:  # noqa: B036 - keep close error
+                _annotate_secondary_error(
+                    close_error,
+                    "descriptor close reconciliation failed",
+                    probe_error,
+                )
+            else:
+                if _resource_owner_identity(rebound) != record.identity:
+                    # The owned fd closed and the number is observably reused.
+                    # Do not close the replacement descriptor.
+                    record.descriptor = -1
+                # An exact dup2 ABA of the same inode is indistinguishable from
+                # a before-close failure in pure Python.  Proving that final P2
+                # case requires a native owner for the open file description.
+            return close_error
+        return None
+
+
+@dataclass(slots=True)
+class _WindowsHandleRecord:
+    handle: int
+    identity: tuple[int, ...] | None = None
+
+
+def _windows_handle_is_invalid_error(exc: OSError) -> bool:
+    return exc.errno == errno.EBADF or getattr(exc, "winerror", None) == 6
+
+
+class _WindowsResourceOwner:
+    """Track Windows HANDLEs through one-pass, retryable cleanup.
+
+    As with POSIX file descriptors, Python cannot own a raw HANDLE during the
+    arbitrary-opcode gap between a native call's integer return and the first
+    Python STORE.  Closing that final P2 gap requires a native owning object;
+    this class covers failures once the value has reached ``acquire``'s local.
+    """
+
+    __slots__ = ("_api", "_records")
+
+    def __init__(self, api: _WindowsKernelApi) -> None:
+        self._api = api
+        self._records: list[_WindowsHandleRecord] = []
+
+    @property
+    def closed(self) -> bool:
+        for record in self._records:
+            handle = record.handle
+            if not handle:
+                continue
+            try:
+                observed = self._api.metadata(handle)
+            except KeyError:
+                record.handle = 0
+                continue
+            except OSError as probe_error:
+                if _windows_handle_is_invalid_error(probe_error):
+                    record.handle = 0
+                continue
+            if (
+                record.identity is not None
+                and _resource_owner_identity(observed) != record.identity
+            ):
+                record.handle = 0
+        return all(record.handle == 0 for record in self._records)
+
+    def acquire(self, callback: Callable[[], int]) -> int:
+        handle = 0
+        record: _WindowsHandleRecord | None = None
+        try:
+            handle = callback()
+            record = _WindowsHandleRecord(handle)
+            self._records.append(record)
+            metadata = self._api.metadata(handle)
+            record.identity = _resource_owner_identity(metadata)
+            return handle
+        except BaseException as primary_error:
+            if handle:
+                if record is None:
+                    record = _WindowsHandleRecord(handle)
+                if not any(candidate is record for candidate in self._records):
+                    try:
+                        self._records.append(record)
+                    except BaseException as registration_error:  # noqa: B036
+                        _annotate_secondary_error(
+                            primary_error,
+                            "HANDLE ownership registration also failed",
+                            registration_error,
+                        )
+                        close_error = self._close_record(record)
+                        if close_error is not None:
+                            _annotate_secondary_error(
+                                primary_error,
+                                "unregistered HANDLE cleanup also failed",
+                                close_error,
+                            )
+                        raise primary_error
+                self.close_record_after_error(record, primary_error)
+            raise
+
+    def bind_identity(self, handle: int, metadata: _WindowsHandleMetadata) -> None:
+        record = self._record_for(handle)
+        if record is None:
+            raise RuntimeError("Windows HANDLE is not owned")
+        record.identity = _resource_owner_identity(metadata)
+
+    def release(self, handle: int) -> int:
+        """Relinquish a handle to a raw-return caller at the documented P2 edge."""
+
+        record = self._record_for(handle)
+        if record is None:
+            raise RuntimeError("Windows HANDLE is not owned")
+        record.handle = 0
+        return handle
+
+    def close_handle(self, handle: int) -> None:
+        record = self._record_for(handle)
+        if record is None:
+            return
+        close_error = self._close_record(record)
+        if close_error is not None:
+            raise close_error
+
+    def close_record_after_error(
+        self,
+        record: _WindowsHandleRecord,
+        primary_error: BaseException,
+    ) -> None:
+        close_error = self._close_record(record)
+        if close_error is not None:
+            _annotate_secondary_error(
+                primary_error,
+                "Windows HANDLE cleanup also failed",
+                close_error,
+            )
+
+    def close_all(self) -> None:
+        primary_error: BaseException | None = None
+        for record in reversed(tuple(self._records)):
+            close_error = self._close_record(record)
+            if close_error is not None:
+                primary_error = _retain_first_error(
+                    primary_error,
+                    "additional Windows HANDLE cleanup failed",
+                    close_error,
+                )
+        if primary_error is not None:
+            raise primary_error
+
+    def close_all_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close_all()
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "Windows authority cleanup also failed",
+                close_error,
+            )
+
+    def _record_for(self, handle: int) -> _WindowsHandleRecord | None:
+        for record in reversed(self._records):
+            if record.handle == handle:
+                return record
+        return None
+
+    def _close_record(
+        self,
+        record: _WindowsHandleRecord,
+    ) -> BaseException | None:
+        handle = record.handle
+        if not handle:
+            return None
+        try:
+            observed = self._api.metadata(handle)
+        except KeyError:
+            record.handle = 0
+            return None
+        except OSError as probe_error:
+            if _windows_handle_is_invalid_error(probe_error):
+                record.handle = 0
+                return None
+            return probe_error
+        except BaseException as probe_error:  # noqa: B036 - retain owner
+            return probe_error
+        observed_identity = _resource_owner_identity(observed)
+        if record.identity is None:
+            record.identity = observed_identity
+        elif observed_identity != record.identity:
+            record.handle = 0
+            return RuntimeError("publication HANDLE ownership changed")
+
+        try:
+            self._api.close(handle)
+            record.handle = 0
+        except BaseException as close_error:  # noqa: B036 - reconcile close
+            if not record.handle:
+                return close_error
+            try:
+                rebound = self._api.metadata(handle)
+            except KeyError:
+                record.handle = 0
+            except OSError as probe_error:
+                if _windows_handle_is_invalid_error(probe_error):
+                    record.handle = 0
+                else:
+                    _annotate_secondary_error(
+                        close_error,
+                        "Windows HANDLE close reconciliation failed",
+                        probe_error,
+                    )
+            except BaseException as probe_error:  # noqa: B036 - keep close error
+                _annotate_secondary_error(
+                    close_error,
+                    "Windows HANDLE close reconciliation failed",
+                    probe_error,
+                )
+            else:
+                if _resource_owner_identity(rebound) != record.identity:
+                    record.handle = 0
+                # Exact same-FILE_ID HANDLE reuse is the Windows equivalent of
+                # the POSIX dup2 ABA above and likewise needs a native owner.
+            return close_error
+        return None
+
+
+class _PublicationAuthorityOwner:
+    """Pre-existing slot for cancellation-safe authority handoff."""
+
+    __slots__ = ("_authority",)
+
+    def __init__(self) -> None:
+        self._authority: _PublicationAuthority | None = None
+
+    @property
+    def authority(self) -> _PublicationAuthority | None:
+        return self._authority
+
+    def install(self, authority: _PublicationAuthority) -> None:
+        if self._authority is not None:
+            raise RuntimeError("publication authority owner is already active")
+        self._authority = authority
+
+    def close(self) -> None:
+        authority = self._authority
+        if authority is None:
+            return
+        primary_error: BaseException | None = None
+        try:
+            authority.close()
+        except BaseException as close_error:  # noqa: B036 - reconcile owner state
+            primary_error = close_error
+        try:
+            close_complete = authority._closed
+        except BaseException as reconciliation_error:  # noqa: B036
+            if primary_error is None:
+                raise
+            _annotate_secondary_error(
+                primary_error,
+                "publication authority owner reconciliation also failed",
+                reconciliation_error,
+            )
+        else:
+            if close_complete:
+                self._authority = None
+        if primary_error is not None:
+            raise primary_error
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close()
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "publication authority owner cleanup also failed",
+                close_error,
+            )
+
+    def __enter__(self) -> _PublicationAuthorityOwner:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        if exc is None:
+            self.close()
+        else:
+            self.close_after_error(exc)
+
+
+class _PublicationAuthority:
+    """One pinned parent namespace and its platform-specific operations.
+
+    Child handles never escape this object.  Callers receive a bounded reader
+    only for the duration of ``read_child``; this keeps validation and hashing
+    on the same parent/source authority without relying on procfs aliases.
+    """
+
+    __slots__ = (
+        "display_parent",
+        "identity",
+        "backend_tag",
+        "_resource",
+        "_close_callback",
+        "_metadata_callback",
+        "_reader_callback",
+        "_rename_callback",
+        "_verify_callback",
+        "_close_complete_callback",
+        "_close_state",
+    )
+
+    def __init__(
+        self,
+        *,
+        display_parent: Path,
+        identity: tuple[int, ...],
+        backend_tag: str,
+        resource: int,
+        close_callback: Callable[[int], None],
+        metadata_callback: Callable[[str, Path, str], object | None],
+        reader_callback: Callable[
+            [
+                str,
+                Path,
+                str,
+                _TreeOwnership | None,
+                Callable[[_PublicationTreeReader], _T],
+            ],
+            _T,
+        ],
+        rename_callback: Callable[[str, str], None],
+        verify_callback: Callable[[], None],
+        close_complete_callback: Callable[[], bool],
+    ) -> None:
+        self.display_parent = display_parent
+        self.identity = identity
+        self.backend_tag = backend_tag
+        self._resource = resource
+        self._close_callback = close_callback
+        self._metadata_callback = metadata_callback
+        self._reader_callback = reader_callback
+        self._rename_callback = rename_callback
+        self._verify_callback = verify_callback
+        self._close_complete_callback = close_complete_callback
+        self._close_state = False
+
+    @property
+    def _closed(self) -> bool:
+        # Compatibility cleanup may resume the callback directly after an
+        # interruption.  Reflect the resource owner's state whenever callers
+        # inspect completion so a successful resumed cleanup is not forgotten.
+        if not self._close_state and self._close_complete_callback():
+            self._close_state = True
+        return self._close_state
+
+    @_closed.setter
+    def _closed(self, value: bool) -> None:
+        self._close_state = value
+
+    @property
+    def resource(self) -> int:
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        return self._resource
+
+    def child_metadata(
+        self,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> object | None:
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        child_name = _simple_child_name(name, label=label)
+        return self._metadata_callback(child_name, path, label)
+
+    def read_child(
+        self,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+        expected_ownership: _TreeOwnership | None = None,
+        callback: Callable[[_PublicationTreeReader], _T],
+    ) -> _T:
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        child_name = _simple_child_name(name, label=label)
+        return self._reader_callback(
+            child_name,
+            path,
+            label,
+            expected_ownership,
+            callback,
+        )
+
+    def capture_child(
+        self,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+        required_root_file: str | None = None,
+        allow_empty_root: bool = False,
+        entry_policy: DirectoryEntryPolicy | None = None,
+    ) -> _TreeOwnership:
+        return self.read_child(
+            name,
+            path=path,
+            label=label,
+            expected_ownership=None,
+            callback=lambda reader: reader.capture_ownership(
+                required_root_file=required_root_file,
+                allow_empty_root=allow_empty_root,
+                entry_policy=entry_policy,
+            ),
+        )
+
+    def rename_noreplace(self, source: str, destination: str) -> None:
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        self._rename_callback(
+            _simple_child_name(source, label="rename source"),
+            _simple_child_name(destination, label="rename destination"),
+        )
+
+    def verify_path_binding(self) -> None:
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        self._verify_callback()
+
+    def close(self) -> None:
+        if self._close_state:
+            return
+        primary_error: BaseException | None = None
+        try:
+            self._close_callback(self._resource)
+        except BaseException as close_error:  # noqa: B036 - reconcile owner state
+            primary_error = close_error
+        try:
+            close_complete = self._close_complete_callback()
+        except BaseException as reconciliation_error:  # noqa: B036
+            if primary_error is None:
+                raise
+            _annotate_secondary_error(
+                primary_error,
+                "publication authority close-state reconciliation also failed",
+                reconciliation_error,
+            )
+        else:
+            # Cleanup owns the close state.  A before-close interruption or
+            # persistent EIO retains the resource and keeps close retryable;
+            # an after-close interruption may still mark the authority closed.
+            self._close_state = close_complete
+        if primary_error is not None:
+            raise primary_error
+
+    def __enter__(self) -> _PublicationAuthority:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+@dataclass(frozen=True, slots=True)
+class _DirectoryOrphanLocator:
+    """A display path bound to a parent authority and complete tree token."""
+
+    parent_path: Path
+    child_name: str
+    backend_tag: str
+    parent_identity: tuple[int, ...]
+    ownership: _TreeOwnership
+
+
+@dataclass(frozen=True, slots=True)
+class DirectoryOrphan:
+    """Bounded isolation receipt for a tree left for cooperative GC.
+
+    ``verified_at_isolation`` records only the publication boundary.  It is not
+    a persistent proof: a quiescent GC must capture and verify the tree again.
+    """
+
+    locator: _DirectoryOrphanLocator
+    ownership_digest: str
+    entries: int
+    byte_count: int
+    verified_at_isolation: bool = True
+
+    @property
+    def path(self) -> Path:
+        """Return the display path; callers must not treat it as authority."""
+
+        return self.locator.parent_path / self.locator.child_name
+
+    @property
+    def parent_identity(self) -> tuple[int, ...]:
+        return self.locator.parent_identity
+
+    def reopen(
+        self,
+        callback: Callable[[_PublicationTreeReader], _T],
+    ) -> _T:
+        """Reopen this orphan through its parent identity and verify both sides."""
+
+        with _PublicationAuthorityOwner() as authority_owner:
+            authority = _open_publication_authority(
+                self.locator.parent_path,
+                parent_resource=None,
+                expected_parent_identity=self.locator.parent_identity,
+                authority_owner=authority_owner,
+            )
+            if authority.backend_tag != self.locator.backend_tag:
+                raise RuntimeError("directory orphan platform authority changed")
+
+            def use_verified(reader: _PublicationTreeReader) -> _T:
+                before = reader.capture_ownership()
+                _require_matching_ownership(
+                    before,
+                    self.locator.ownership,
+                    label="directory orphan",
+                    allow_root_rename=True,
+                )
+                result = callback(reader)
+                after = reader.capture_ownership()
+                if after != before:
+                    raise RuntimeError("directory orphan changed while reopened")
+                return result
+
+            return authority.read_child(
+                self.locator.child_name,
+                path=self.path,
+                label="directory orphan",
+                expected_ownership=self.locator.ownership,
+                callback=use_verified,
+            )
+
+    def rebind(self) -> _TreeOwnership:
+        """Return a fresh complete token after authority-bound verification."""
+
+        return self.reopen(lambda reader: reader.capture_ownership())
+
+
 class _PreviousOutputIdentityLost(RuntimeError):
     """The moved previous tree can no longer be trusted for rollback."""
 
 
 def lexical_directory_path(path: Path) -> Path:
-    """Resolve the parent without ever following the final path component."""
+    """Return one absolute lexical path without following any component."""
 
     candidate = path.expanduser()
     if candidate.name in {"", ".", ".."}:
         raise ValueError(f"directory path has no safe final component: {path}")
-    return candidate.parent.resolve() / candidate.name
+    return Path(os.path.abspath(os.fspath(candidate)))
+
+
+def _open_posix_publication_authority(
+    path: Path,
+    *,
+    parent_resource: int | None,
+    expected_parent_identity: tuple[int, ...] | None,
+    create_missing: bool = False,
+    authority_owner: _PublicationAuthorityOwner | None = None,
+) -> _PublicationAuthority:
+    if not _SAFE_OWNERSHIP_DIRECTORY_FDS:
+        raise RuntimeError(
+            "publication authority requires no-follow directory-fd support"
+        )
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+    resources = _PosixResourceOwner()
+    authority: _PublicationAuthority | None = None
+    try:
+        if not path.is_absolute() or path.anchor != os.path.sep:
+            raise ValueError("publication parent must be an absolute lexical path")
+        root_descriptor = resources.open(path.anchor, flags)
+        root_identity = _ownership_binding_identity(os.fstat(root_descriptor))
+        if not root_identity[0] or not root_identity[1]:
+            raise RuntimeError("publication root has no reliable identity")
+        path_bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
+        path_descriptor = root_descriptor
+        for part in path.parts[1:]:
+            try:
+                before = os.stat(
+                    part,
+                    dir_fd=path_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                if not create_missing:
+                    raise
+                try:
+                    os.mkdir(part, mode=0o755, dir_fd=path_descriptor)
+                except FileExistsError as exc:
+                    raise RuntimeError(
+                        "publication parent appeared while it was created"
+                    ) from exc
+                os.fsync(path_descriptor)
+                before = os.stat(
+                    part,
+                    dir_fd=path_descriptor,
+                    follow_symlinks=False,
+                )
+            if (
+                _is_link_or_reparse(before)
+                or not stat.S_ISDIR(before.st_mode)
+                or not before.st_dev
+                or not before.st_ino
+            ):
+                raise ValueError("publication parent must be a real directory")
+            child = resources.open(part, flags, dir_fd=path_descriptor)
+            opened_child = os.fstat(child)
+            binding_identity = _ownership_binding_identity(opened_child)
+            if binding_identity != _ownership_binding_identity(before):
+                raise RuntimeError("publication parent changed while it was opened")
+            path_bindings.append((path_descriptor, part, child, binding_identity))
+            path_descriptor = child
+
+        path_identity = publication_parent_identity(path_descriptor)
+        if parent_resource is None:
+            owned_descriptor = path_descriptor
+        else:
+            owned_descriptor = resources.duplicate(parent_resource)
+            if publication_parent_identity(owned_descriptor) != path_identity:
+                raise RuntimeError("publication parent path changed")
+        identity = publication_parent_identity(owned_descriptor)
+        if expected_parent_identity is not None and identity != tuple(
+            expected_parent_identity
+        ):
+            raise RuntimeError("publication parent identity does not match authority")
+
+        def verify_callback() -> None:
+            if (
+                _ownership_binding_identity(os.fstat(root_descriptor)) != root_identity
+                or publication_parent_identity(owned_descriptor) != identity
+            ):
+                raise RuntimeError("publication parent authority changed")
+            for parent, name, child, binding_identity in path_bindings:
+                try:
+                    observed = os.stat(
+                        name,
+                        dir_fd=parent,
+                        follow_symlinks=False,
+                    )
+                    opened_child = os.fstat(child)
+                except OSError as exc:
+                    raise RuntimeError("publication parent path changed") from exc
+                if (
+                    _is_link_or_reparse(observed)
+                    or not stat.S_ISDIR(observed.st_mode)
+                    or _ownership_binding_identity(observed) != binding_identity
+                    or _ownership_binding_identity(opened_child) != binding_identity
+                ):
+                    raise RuntimeError("publication parent path changed")
+
+        verify_callback()
+
+        def metadata_callback(
+            name: str,
+            display_path: Path,
+            label: str,
+        ) -> os.stat_result | None:
+            try:
+                metadata = os.stat(
+                    name,
+                    dir_fd=owned_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                return None
+            if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+                raise ValueError(
+                    f"{label} is not a directory or is a link: {display_path}"
+                )
+            return metadata
+
+        def reader_callback(
+            name: str,
+            display_path: Path,
+            label: str,
+            expected_ownership: _TreeOwnership | None,
+            callback: Callable[[_PublicationTreeReader], _T],
+        ) -> _T:
+            metadata = metadata_callback(name, display_path, label)
+            if metadata is None:
+                raise RuntimeError(f"{label} disappeared: {display_path}")
+            child_descriptor = resources.open(
+                name,
+                flags,
+                dir_fd=owned_descriptor,
+            )
+            reader: _PublicationTreeReader | None = None
+            primary_error: BaseException | None = None
+            try:
+                opened_child = os.fstat(child_descriptor)
+                if (
+                    _is_link_or_reparse(opened_child)
+                    or not stat.S_ISDIR(opened_child.st_mode)
+                    or _ownership_binding_identity(opened_child)
+                    != _ownership_binding_identity(metadata)
+                ):
+                    raise RuntimeError(f"{label} changed while it was opened")
+                root_identity = _directory_inode_identity(opened_child)
+                reader = _PublicationTreeReader(
+                    display_path,
+                    root_identity,
+                    lambda required_root_file, allow_empty_root, entry_policy: (
+                        _capture_posix_directory_descriptor(
+                            child_descriptor,
+                            display_path,
+                            required_root_file=required_root_file,
+                            allow_empty_root=allow_empty_root,
+                            entry_policy=entry_policy,
+                        )
+                    ),
+                    lambda relative, max_bytes, expected: _open_posix_authenticated_file(
+                        child_descriptor,
+                        display_path,
+                        relative,
+                        max_bytes=max_bytes,
+                        expected=expected,
+                    ),
+                    expected_ownership,
+                )
+                result = callback(reader)
+                reader._require_valid()
+                after = os.stat(
+                    name,
+                    dir_fd=owned_descriptor,
+                    follow_symlinks=False,
+                )
+                if _directory_inode_identity(after) != root_identity:
+                    raise RuntimeError(f"{label} namespace binding changed")
+                return result
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                if reader is not None:
+                    reader._deactivate()
+                try:
+                    resources.close_descriptor(child_descriptor)
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        raise
+                    _annotate_secondary_error(
+                        primary_error,
+                        "publication child descriptor cleanup also failed",
+                        close_error,
+                    )
+
+        def rename_callback(source: str, destination: str) -> None:
+            _rename_noreplace_at(
+                source,
+                destination,
+                owned_descriptor,
+                owned_descriptor,
+            )
+
+        def close_resources(_resource: int) -> None:
+            resources.close_all()
+
+        authority = _PublicationAuthority(
+            display_parent=path,
+            identity=identity,
+            backend_tag=(
+                "linux-renameat2"
+                if sys.platform.startswith("linux")
+                else "darwin-renameatx-np"
+            ),
+            resource=owned_descriptor,
+            close_callback=close_resources,
+            metadata_callback=metadata_callback,
+            reader_callback=reader_callback,
+            rename_callback=rename_callback,
+            verify_callback=verify_callback,
+            close_complete_callback=lambda: resources.closed,
+        )
+        if authority_owner is not None:
+            authority_owner.install(authority)
+        return authority
+    except BaseException as primary_error:
+        if (
+            authority is not None
+            and authority_owner is not None
+            and authority_owner.authority is authority
+        ):
+            authority_owner.close_after_error(primary_error)
+        else:
+            resources.close_all_after_error(primary_error)
+        raise
+
+
+def _open_publication_authority(
+    path: Path,
+    *,
+    parent_resource: int | None,
+    expected_parent_identity: tuple[int, ...] | None,
+    create_missing: bool = False,
+    authority_owner: _PublicationAuthorityOwner | None = None,
+) -> _PublicationAuthority:
+    """Open a platform authority before any namespace mutation."""
+
+    _require_rename_noreplace_platform()
+    if sys.platform.startswith("linux") or sys.platform == "darwin":
+        return _open_posix_publication_authority(
+            path,
+            parent_resource=parent_resource,
+            expected_parent_identity=expected_parent_identity,
+            create_missing=create_missing,
+            authority_owner=authority_owner,
+        )
+    if sys.platform == "win32":
+        if create_missing:
+            raise RuntimeError(
+                "safe creation of publication parents is unavailable on Windows"
+            )
+        return _open_windows_publication_authority(
+            path,
+            parent_resource=parent_resource,
+            expected_parent_identity=expected_parent_identity,
+            authority_owner=authority_owner,
+        )
+    raise RuntimeError("atomic directory publication is unsupported on this host")
+
+
+def _require_publication_parent_path(
+    path: Path,
+    expected_identity: tuple[int, ...],
+) -> None:
+    try:
+        observed = path.lstat()
+    except OSError as exc:
+        raise RuntimeError("publication parent path changed") from exc
+    if _directory_inode_identity(observed) != expected_identity:
+        raise RuntimeError("publication parent path changed")
+
+
+def _directory_or_missing_at(
+    parent_authority: _PublicationAuthority | int,
+    name: str,
+    *,
+    path: Path,
+    label: str,
+) -> object | None:
+    if isinstance(parent_authority, _PublicationAuthority):
+        return parent_authority.child_metadata(name, path=path, label=label)
+    try:
+        metadata = os.stat(
+            name,
+            dir_fd=parent_authority,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        return None
+    if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError(f"{label} is not a directory or is a link: {path}")
+    return metadata
+
+
+def _random_orphan_path(
+    *,
+    display_parent: Path,
+    destination_name: str,
+    purpose: str,
+) -> Path:
+    destination_digest = hashlib.sha256(os.fsencode(destination_name)).hexdigest()[:16]
+    compatible_prefix = f".{destination_name}.{purpose}-"
+    if len(os.fsencode(compatible_prefix)) + 32 <= _MAX_OWNERSHIP_COMPONENT_BYTES:
+        prefix = compatible_prefix
+    else:
+        prefix = f".codenib-{purpose}-{destination_digest}-"
+    name = f"{prefix}{secrets.token_hex(16)}"
+    _simple_child_name(name, label="directory orphan")
+    return display_parent / name
+
+
+def _claim_child_as_orphan(
+    parent_authority: _PublicationAuthority | int,
+    source_name: str,
+    *,
+    display_parent: Path,
+    destination_name: str,
+    purpose: str,
+) -> Path:
+    for _attempt in range(_MAX_ORPHAN_NAME_ATTEMPTS):
+        orphan = _random_orphan_path(
+            display_parent=display_parent,
+            destination_name=destination_name,
+            purpose=purpose,
+        )
+        try:
+            if isinstance(parent_authority, _PublicationAuthority):
+                parent_authority.rename_noreplace(source_name, orphan.name)
+            else:
+                _rename_noreplace_at(
+                    source_name,
+                    orphan.name,
+                    parent_authority,
+                    parent_authority,
+                )
+        except FileExistsError:
+            continue
+        except BaseException:
+            # A signal or injected failure can arrive after the kernel moved
+            # the source.  Best-effort no-replace restoration never overwrites
+            # a raced active child and never destroys the unknown candidate.
+            try:
+                if isinstance(parent_authority, _PublicationAuthority):
+                    parent_authority.rename_noreplace(orphan.name, source_name)
+                else:
+                    _rename_noreplace_at(
+                        orphan.name,
+                        source_name,
+                        parent_authority,
+                        parent_authority,
+                    )
+            except BaseException:  # noqa: B036 - preserve the unknown object
+                pass
+            raise
+        return orphan
+    raise RuntimeError("could not claim directory under a bounded orphan name")
+
+
+def _orphan_metadata(
+    authority: _PublicationAuthority,
+    path: Path,
+    ownership: _TreeOwnership,
+    *,
+    verified_at_isolation: bool = True,
+) -> DirectoryOrphan:
+    rebound = ownership
+    if verified_at_isolation:
+        rebound = authority.capture_child(
+            path.name,
+            path=path,
+            label="directory orphan",
+        )
+        _require_matching_ownership(
+            rebound,
+            ownership,
+            label="directory orphan",
+            allow_root_rename=True,
+        )
+    return DirectoryOrphan(
+        locator=_DirectoryOrphanLocator(
+            parent_path=authority.display_parent,
+            child_name=path.name,
+            backend_tag=authority.backend_tag,
+            parent_identity=authority.identity,
+            ownership=rebound,
+        ),
+        ownership_digest=rebound.digest,
+        entries=rebound.entries,
+        byte_count=rebound.byte_count,
+        verified_at_isolation=verified_at_isolation,
+    )
+
+
+def _restore_exact_previous_directory(
+    backup: Path,
+    destination: Path,
+    *,
+    destination_was_missing: bool,
+    parent_authority: _PublicationAuthority,
+    ownership: _TreeOwnership,
+) -> None:
+    if destination_was_missing:
+        return
+    _require_tree_ownership_at(
+        parent_authority,
+        backup.name,
+        path=backup,
+        expected=ownership,
+        label="previous destination",
+        allow_root_rename=True,
+    )
+    parent_authority.rename_noreplace(backup.name, destination.name)
+    try:
+        _require_tree_ownership_at(
+            parent_authority,
+            destination.name,
+            path=destination,
+            expected=ownership,
+            label="moved destination",
+            allow_root_rename=True,
+        )
+    except BaseException as ownership_error:  # noqa: B036 - async-safe rollback
+        # A raced object is preserved under quarantine; never treat it as the
+        # authenticated previous output merely because the rename completed.
+        try:
+            _quarantine_destination(
+                destination,
+                parent_authority=parent_authority,
+            )
+        except BaseException:  # noqa: B036 - preserve the primary failure
+            pass
+        raise _PreviousOutputIdentityLost(
+            "restored destination does not match the previous ownership token"
+        ) from ownership_error
+
+
+def _restore_claimed_directory(
+    backup: Path,
+    destination: Path,
+    *,
+    parent_authority: _PublicationAuthority,
+    context: str,
+) -> None:
+    """Restore an unauthenticated claim without overwriting a raced object."""
+
+    try:
+        parent_authority.rename_noreplace(backup.name, destination.name)
+    except BaseException as restore_error:  # noqa: B036 - report isolation
+        raise RuntimeError(
+            f"{context}; claimed root remains isolated at {backup}"
+        ) from restore_error
 
 
 def _directory_or_missing(path: Path, *, label: str) -> os.stat_result | None:
@@ -134,6 +1766,838 @@ def _directory_inode_identity(metadata: os.stat_result) -> tuple[int, ...]:
     )
 
 
+def publication_parent_identity(descriptor: int) -> tuple[int, ...]:
+    """Return the stable identity expected by descriptor-bound publication."""
+
+    if sys.platform == "win32":
+        return _windows_directory_identity_from_handle(descriptor)
+    metadata = os.fstat(descriptor)
+    if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError("publication parent descriptor is not a real directory")
+    if not metadata.st_dev or not metadata.st_ino:
+        raise RuntimeError("publication parent has no reliable filesystem identity")
+    return _directory_inode_identity(metadata)
+
+
+def _simple_child_name(value: str, *, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+        or "\x00" in value
+        or len(os.fsencode(value)) > _MAX_OWNERSHIP_COMPONENT_BYTES
+    ):
+        raise ValueError(f"{label} must be one bounded file name")
+    if sys.platform == "win32" and (
+        value[-1] in {" ", "."}
+        or any(ord(character) < 32 or character in '<>:"|?*' for character in value)
+        or value.split(".", 1)[0].upper() in _WINDOWS_RESERVED_BASENAMES
+    ):
+        raise ValueError(f"{label} is not a canonical Windows file name")
+    return value
+
+
+def _publication_relative_path(
+    value: str | PurePosixPath,
+) -> PurePosixPath:
+    raw = value.as_posix() if isinstance(value, PurePosixPath) else value
+    if (
+        not isinstance(raw, str)
+        or not raw
+        or raw in {".", ".."}
+        or "\\" in raw
+        or "\x00" in raw
+    ):
+        raise ValueError("publication reader path must be relative POSIX")
+    relative = PurePosixPath(raw)
+    if (
+        relative.is_absolute()
+        or relative.as_posix() != raw
+        or len(relative.parts) > _MAX_SAFE_REMOVAL_DEPTH
+        or len(raw.encode("utf-8", errors="strict")) > _MAX_OWNERSHIP_PATH_BYTES
+    ):
+        raise ValueError("publication reader path must be normalized and bounded")
+    for part in relative.parts:
+        _simple_child_name(part, label="publication reader component")
+    return relative
+
+
+def _rename_noreplace_at(
+    src: str,
+    dst: str,
+    src_dir_fd: int,
+    dst_dir_fd: int,
+) -> None:
+    """Atomically rename one POSIX child without replacing the destination."""
+
+    source = _simple_child_name(src, label="rename source")
+    destination = _simple_child_name(dst, label="rename destination")
+    if sys.platform.startswith("linux"):
+        symbol_name = "renameat2"
+        flags = _RENAME_NOREPLACE
+        required = "Linux renameat2"
+    elif sys.platform == "darwin":
+        symbol_name = "renameatx_np"
+        flags = _RENAME_EXCL
+        required = "macOS renameatx_np"
+    else:
+        raise RuntimeError("atomic no-replace POSIX rename is unsupported on this host")
+    libc = ctypes.CDLL(None, use_errno=True)
+    rename = getattr(libc, symbol_name, None)
+    if rename is None:
+        raise RuntimeError(
+            f"atomic no-replace directory publication requires {required}"
+        )
+    rename.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    )
+    rename.restype = ctypes.c_int
+    result = rename(
+        src_dir_fd,
+        os.fsencode(source),
+        dst_dir_fd,
+        os.fsencode(destination),
+        flags,
+    )
+    if result == 0:
+        return
+    error = ctypes.get_errno()
+    if error in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise FileExistsError(
+            error,
+            os.strerror(error),
+            destination,
+        )
+    if error in {errno.ENOSYS, errno.EINVAL, errno.ENOTSUP, errno.EOPNOTSUPP}:
+        raise RuntimeError(
+            "filesystem does not support atomic no-replace directory publication"
+        )
+    raise OSError(error, os.strerror(error), source, destination)
+
+
+def _require_rename_noreplace_platform() -> None:
+    """Fail before publication-side effects on unsupported host platforms."""
+
+    if sys.platform.startswith("linux"):
+        required_symbol = "renameat2"
+        required_label = "Linux renameat2"
+    elif sys.platform == "darwin":
+        required_symbol = "renameatx_np"
+        required_label = "macOS renameatx_np"
+    elif sys.platform == "win32":
+        _windows_require_publication_api()
+        return
+    else:
+        raise RuntimeError("atomic directory publication is unsupported on this host")
+    libc = ctypes.CDLL(None, use_errno=True)
+    if getattr(libc, required_symbol, None) is None:
+        raise RuntimeError(
+            f"atomic no-replace directory publication requires {required_label}"
+        )
+
+
+def _windows_kernel_api() -> _WindowsKernelApi:
+    return _shared_windows_kernel_api()
+
+
+def _windows_require_publication_api() -> None:
+    _shared_windows_require_publication_api(_windows_kernel_api())
+
+
+def _windows_directory_identity_from_handle(handle: int) -> tuple[int, ...]:
+    metadata = _windows_kernel_api().metadata(handle)
+    if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError("publication parent handle is not a real directory")
+    if not metadata.st_dev or not metadata.st_ino:
+        raise RuntimeError("publication parent has no reliable FILE_ID identity")
+    return _directory_inode_identity(metadata)
+
+
+def _windows_find_child(
+    api: _WindowsKernelApi,
+    parent_handle: int,
+    name: str,
+) -> _WindowsDirectoryEntry | None:
+    folded = name.casefold()
+    matches = [
+        entry
+        for entry in api.enumerate_directory(parent_handle)
+        if entry.name.casefold() == folded
+    ]
+    if len(matches) > 1:
+        raise RuntimeError("Windows directory contains ambiguous child names")
+    return matches[0] if matches else None
+
+
+def _windows_open_child_by_id(
+    api: _WindowsKernelApi,
+    parent_handle: int,
+    entry: _WindowsDirectoryEntry,
+    *,
+    desired_access: int,
+    expected_directory: bool | None,
+    resource_owner: _WindowsResourceOwner | None = None,
+) -> tuple[int, _WindowsHandleMetadata]:
+    if not entry.file_id:
+        raise RuntimeError("Windows directory entry has no reliable FILE_ID")
+    if entry.attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT:
+        raise RuntimeError("Windows publication refuses reparse-point content")
+    is_directory = bool(entry.attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+    if expected_directory is not None and is_directory != expected_directory:
+        raise ValueError("Windows publication child has the wrong object type")
+    selected_owner = (
+        _WindowsResourceOwner(api) if resource_owner is None else resource_owner
+    )
+    handle = selected_owner.acquire(
+        lambda: api.open_by_id(
+            parent_handle,
+            entry.file_id,
+            desired_access=desired_access,
+            is_directory=is_directory,
+        )
+    )
+    try:
+        metadata = api.metadata(handle)
+        if (
+            not metadata.st_dev
+            or not metadata.st_ino
+            or metadata.st_ino != entry.file_id
+            or bool(metadata.st_file_attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+            != is_directory
+            or metadata.st_file_attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
+        ):
+            raise RuntimeError("Windows FILE_ID child changed while it was opened")
+        selected_owner.bind_identity(handle, metadata)
+        if resource_owner is None:
+            selected_owner.release(handle)
+        return handle, metadata
+    except BaseException as primary_error:
+        try:
+            selected_owner.close_handle(handle)
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "Windows child HANDLE cleanup also failed",
+                close_error,
+            )
+        raise
+
+
+def _windows_owned_file_record(
+    api: _WindowsKernelApi,
+    parent_handle: int,
+    entry: _WindowsDirectoryEntry,
+    path: Path,
+    *,
+    root_device: int,
+    budget: _OwnershipBudget,
+    relative: str,
+    entry_policy: DirectoryEntryPolicy | None,
+) -> tuple[int, str, tuple[int, ...]]:
+    handle, opened = _windows_open_child_by_id(
+        api,
+        parent_handle,
+        entry,
+        desired_access=_WINDOWS_FILE_READ_DATA
+        | _WINDOWS_FILE_READ_ATTRIBUTES
+        | _WINDOWS_SYNCHRONIZE,
+        expected_directory=False,
+    )
+    try:
+        if opened.st_dev != root_device:
+            raise RuntimeError(f"directory ownership crosses a volume: {path}")
+        size = opened.st_size
+        if entry_policy is not None:
+            entry_policy(relative, "file", stat.S_IMODE(opened.st_mode), size)
+        if size < 0 or budget.byte_count + size > _MAX_OWNERSHIP_BYTES:
+            raise RuntimeError("directory ownership scan exceeds its byte limit")
+        digest = hashlib.sha256()
+        remaining = size
+        while remaining:
+            block = api.read(handle, min(remaining, _OWNERSHIP_COPY_BYTES))
+            if not block:
+                raise RuntimeError(f"directory ownership file was truncated: {path}")
+            digest.update(block)
+            remaining -= len(block)
+        if api.read(handle, 1):
+            raise RuntimeError(f"directory ownership file grew while read: {path}")
+        after = api.metadata(handle)
+        if _ownership_version_identity(after) != _ownership_version_identity(opened):
+            raise RuntimeError(f"directory ownership file changed: {path}")
+        rebound = _windows_find_child(api, parent_handle, entry.name)
+        if rebound is None or rebound.file_id != entry.file_id:
+            raise RuntimeError(f"directory ownership file changed: {path}")
+    finally:
+        api.close(handle)
+    budget.byte_count += size
+    return size, digest.hexdigest(), _ownership_version_identity(after)
+
+
+@contextmanager
+def _open_windows_authenticated_file(
+    api: _WindowsKernelApi,
+    root_handle: int,
+    root_path: Path,
+    relative: PurePosixPath,
+    *,
+    max_bytes: int,
+    expected: _ExpectedPublicationFile,
+) -> Iterator[PublicationAuthenticatedFile]:
+    root_before = api.metadata(root_handle)
+    parent_handle = root_handle
+    opened_directories: list[int] = []
+    bindings: list[tuple[int, str, int, int, tuple[int, ...]]] = []
+    file_handle = 0
+    authenticated: PublicationAuthenticatedFile | None = None
+    expected_directories = dict(expected.directory_identities)
+    traversed: list[str] = []
+    try:
+        for part in relative.parts[:-1]:
+            traversed.append(part)
+            relative_directory = "/".join(traversed)
+            entry = _windows_find_child(api, parent_handle, part)
+            if entry is None:
+                raise FileNotFoundError(relative.as_posix())
+            child_handle, opened = _windows_open_child_by_id(
+                api,
+                parent_handle,
+                entry,
+                desired_access=_WINDOWS_FILE_LIST_DIRECTORY
+                | _WINDOWS_FILE_READ_ATTRIBUTES
+                | _WINDOWS_SYNCHRONIZE,
+                expected_directory=True,
+            )
+            if opened.st_dev != root_before.st_dev:
+                api.close(child_handle)
+                raise RuntimeError("publication stream crosses a volume")
+            if expected_directories.get(
+                relative_directory
+            ) != _ownership_version_identity(opened):
+                api.close(child_handle)
+                raise RuntimeError(
+                    "publication stream directory differs from captured ownership"
+                )
+            bindings.append(
+                (
+                    parent_handle,
+                    part,
+                    entry.file_id,
+                    child_handle,
+                    _ownership_version_identity(opened),
+                )
+            )
+            opened_directories.append(child_handle)
+            parent_handle = child_handle
+
+        entry = _windows_find_child(api, parent_handle, relative.name)
+        if entry is None:
+            raise FileNotFoundError(relative.as_posix())
+        file_handle, opened_file = _windows_open_child_by_id(
+            api,
+            parent_handle,
+            entry,
+            desired_access=_WINDOWS_FILE_READ_DATA
+            | _WINDOWS_FILE_READ_ATTRIBUTES
+            | _WINDOWS_SYNCHRONIZE,
+            expected_directory=False,
+        )
+        if opened_file.st_dev != root_before.st_dev:
+            raise RuntimeError("publication stream crosses a volume")
+        if _ownership_version_identity(opened_file) != expected.file_identity:
+            raise RuntimeError(
+                "publication stream file differs from captured ownership"
+            )
+        if opened_file.st_size < 0 or opened_file.st_size > max_bytes:
+            raise ValueError(
+                f"publication stream exceeds its {max_bytes}-byte limit: {relative}"
+            )
+
+        def verify() -> None:
+            after_file = api.metadata(file_handle)
+            if _ownership_version_identity(after_file) != _ownership_version_identity(
+                opened_file
+            ):
+                raise RuntimeError("publication stream file changed while read")
+            rebound_file = _windows_find_child(api, parent_handle, relative.name)
+            if rebound_file is None or rebound_file.file_id != entry.file_id:
+                raise RuntimeError("publication stream file binding changed")
+            for bound_parent, name, file_id, handle, expected in reversed(bindings):
+                rebound = _windows_find_child(api, bound_parent, name)
+                if rebound is None or rebound.file_id != file_id:
+                    raise RuntimeError("publication stream directory binding changed")
+                if _ownership_version_identity(api.metadata(handle)) != expected:
+                    raise RuntimeError("publication stream directory changed")
+            root_after = api.metadata(root_handle)
+            if _ownership_version_identity(root_after) != _ownership_version_identity(
+                root_before
+            ):
+                raise RuntimeError("publication stream root changed")
+
+        authenticated = PublicationAuthenticatedFile(
+            path=relative.as_posix(),
+            mode=stat.S_IMODE(opened_file.st_mode),
+            size=opened_file.st_size,
+            read_callback=lambda size: api.read(file_handle, size),
+            verify_callback=verify,
+        )
+        yield authenticated
+    finally:
+        try:
+            if authenticated is not None:
+                authenticated._finalize()
+        finally:
+            if file_handle:
+                api.close(file_handle)
+            for handle in reversed(opened_directories):
+                api.close(handle)
+
+
+def _scan_windows_owned_directory(
+    api: _WindowsKernelApi,
+    handle: int,
+    path: Path,
+    parts: tuple[bytes, ...],
+    *,
+    root_device: int,
+    budget: _OwnershipBudget,
+    inventory: list[tuple[str, str]],
+    file_records: list[TreeFileRecord],
+    entry_identities: list[tuple[str, str, tuple[int, ...]]],
+    entry_policy: DirectoryEntryPolicy | None,
+    depth: int,
+    required_root_file: str | None = None,
+    allow_empty_root: bool = False,
+) -> bytes:
+    if depth > _MAX_SAFE_REMOVAL_DEPTH:
+        raise RuntimeError("directory ownership scan exceeds its depth limit")
+    before = api.metadata(handle)
+    if not stat.S_ISDIR(before.st_mode) or before.st_dev != root_device:
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    entries: list[tuple[bytes, _WindowsDirectoryEntry]] = []
+    for entry in api.enumerate_directory(handle):
+        _simple_child_name(entry.name, label="directory ownership component")
+        try:
+            raw_name = entry.name.encode("utf-8", errors="strict")
+        except UnicodeEncodeError as exc:
+            raise RuntimeError("Windows directory name is not valid Unicode") from exc
+        if not raw_name or len(raw_name) > _MAX_OWNERSHIP_COMPONENT_BYTES:
+            raise RuntimeError("directory ownership component exceeds its byte limit")
+        relative = _ownership_relative_path(parts + (raw_name,))
+        _reserve_ownership_record(budget, relative=relative)
+        entries.append((raw_name, entry))
+    entries.sort(key=lambda item: item[0])
+    if (
+        required_root_file is not None
+        and not (allow_empty_root and not entries)
+        and not any(entry.name == required_root_file for _raw, entry in entries)
+    ):
+        raise RuntimeError("directory ownership root is missing its required marker")
+
+    hasher = hashlib.sha256()
+    hasher.update(b"codenib.atomic-directory.v1\x00")
+    hasher.update(stat.S_IMODE(before.st_mode).to_bytes(4, "big"))
+    for raw_name, entry in entries:
+        child_parts = parts + (raw_name,)
+        relative_bytes = _ownership_relative_path(child_parts)
+        relative = relative_bytes.decode("utf-8", errors="strict")
+        child_path = path / entry.name
+        if entry.attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT:
+            raise RuntimeError(
+                f"directory ownership scan refuses linked content: {child_path}"
+            )
+        is_directory = bool(entry.attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+        entry_hasher = hashlib.sha256()
+        if is_directory:
+            child_handle, opened = _windows_open_child_by_id(
+                api,
+                handle,
+                entry,
+                desired_access=_WINDOWS_FILE_LIST_DIRECTORY
+                | _WINDOWS_FILE_READ_ATTRIBUTES
+                | _WINDOWS_SYNCHRONIZE,
+                expected_directory=True,
+            )
+            try:
+                if opened.st_dev != root_device:
+                    raise RuntimeError(
+                        f"directory ownership crosses a volume: {child_path}"
+                    )
+                if entry_policy is not None:
+                    entry_policy(
+                        relative,
+                        "directory",
+                        stat.S_IMODE(opened.st_mode),
+                        0,
+                    )
+                child_digest = _scan_windows_owned_directory(
+                    api,
+                    child_handle,
+                    child_path,
+                    child_parts,
+                    root_device=root_device,
+                    budget=budget,
+                    inventory=inventory,
+                    file_records=file_records,
+                    entry_identities=entry_identities,
+                    entry_policy=entry_policy,
+                    depth=depth + 1,
+                )
+                after = api.metadata(child_handle)
+                if _ownership_version_identity(after) != _ownership_version_identity(
+                    opened
+                ):
+                    raise RuntimeError(
+                        f"directory ownership directory changed: {child_path}"
+                    )
+            finally:
+                api.close(child_handle)
+            rebound = _windows_find_child(api, handle, entry.name)
+            if rebound is None or rebound.file_id != entry.file_id:
+                raise RuntimeError(
+                    f"directory ownership directory changed: {child_path}"
+                )
+            entry_hasher.update(b"D")
+            _ownership_hash_field(entry_hasher, relative_bytes)
+            entry_hasher.update(stat.S_IMODE(opened.st_mode).to_bytes(4, "big"))
+            entry_hasher.update(child_digest)
+            inventory.append((relative, "directory"))
+            entry_identities.append(
+                (relative, "directory", _ownership_version_identity(after))
+            )
+        else:
+            size, digest, file_identity = _windows_owned_file_record(
+                api,
+                handle,
+                entry,
+                child_path,
+                root_device=root_device,
+                budget=budget,
+                relative=relative,
+                entry_policy=entry_policy,
+            )
+            digest_bytes = bytes.fromhex(digest)
+            file_mode = stat.S_IMODE(file_identity[2])
+            entry_hasher.update(b"F")
+            _ownership_hash_field(entry_hasher, relative_bytes)
+            entry_hasher.update(file_mode.to_bytes(4, "big"))
+            entry_hasher.update(size.to_bytes(8, "big"))
+            entry_hasher.update(digest_bytes)
+            inventory.append((relative, "file"))
+            file_records.append(
+                TreeFileRecord(
+                    path=relative,
+                    mode=file_mode,
+                    size=size,
+                    sha256=digest,
+                )
+            )
+            entry_identities.append((relative, "file", file_identity))
+        if entry.name == required_root_file and is_directory:
+            raise RuntimeError("directory ownership root marker is not a regular file")
+        hasher.update(entry_hasher.digest())
+    after = api.metadata(handle)
+    if _ownership_version_identity(after) != _ownership_version_identity(before):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    return hasher.digest()
+
+
+def _capture_windows_directory_handle(
+    api: _WindowsKernelApi,
+    handle: int,
+    path: Path,
+    *,
+    required_root_file: str | None,
+    allow_empty_root: bool,
+    entry_policy: DirectoryEntryPolicy | None,
+) -> _TreeOwnership:
+    _required_root_file_bytes(required_root_file)
+    opened = api.metadata(handle)
+    if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    if not opened.st_dev or not opened.st_ino:
+        raise RuntimeError("directory ownership root has no reliable FILE_ID identity")
+    budget = _OwnershipBudget()
+    inventory: list[tuple[str, str]] = []
+    file_records: list[TreeFileRecord] = []
+    entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
+    digest = _scan_windows_owned_directory(
+        api,
+        handle,
+        path,
+        (),
+        root_device=opened.st_dev,
+        budget=budget,
+        inventory=inventory,
+        file_records=file_records,
+        entry_identities=entry_identities,
+        entry_policy=entry_policy,
+        depth=0,
+        required_root_file=required_root_file,
+        allow_empty_root=allow_empty_root,
+    )
+    after = api.metadata(handle)
+    if _ownership_version_identity(after) != _ownership_version_identity(opened):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    return _TreeOwnership(
+        root_identity=_directory_inode_identity(opened),
+        root_version_identity=_ownership_version_identity(opened),
+        digest=digest.hex(),
+        entries=budget.entries,
+        byte_count=budget.byte_count,
+        metadata_bytes=budget.metadata_bytes,
+        inventory=tuple(sorted(inventory)),
+        file_records=tuple(sorted(file_records, key=lambda record: record.path)),
+        entry_identities=tuple(sorted(entry_identities)),
+    )
+
+
+def _open_windows_publication_authority(
+    path: Path,
+    *,
+    parent_resource: int | None,
+    expected_parent_identity: tuple[int, ...] | None,
+    authority_owner: _PublicationAuthorityOwner | None = None,
+) -> _PublicationAuthority:
+    api = _windows_kernel_api()
+    resources = _WindowsResourceOwner(api)
+    authority: _PublicationAuthority | None = None
+    try:
+        parent_handle = resources.acquire(
+            lambda: (
+                api.create_directory_handle(path)
+                if parent_resource is None
+                else api.duplicate_handle(parent_resource)
+            )
+        )
+        opened = api.metadata(parent_handle)
+        resources.bind_identity(parent_handle, opened)
+        if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
+            raise ValueError("publication parent must be a real directory")
+        identity = _directory_inode_identity(opened)
+        if not opened.st_dev or not opened.st_ino:
+            raise RuntimeError("publication parent has no reliable FILE_ID identity")
+        if expected_parent_identity is not None and identity != tuple(
+            expected_parent_identity
+        ):
+            raise RuntimeError("publication parent identity does not match authority")
+        path_handle = resources.acquire(lambda: api.create_directory_handle(path))
+        if _directory_inode_identity(api.metadata(path_handle)) != identity:
+            raise RuntimeError("publication parent path changed")
+        owned_parent_handle = parent_handle
+
+        def open_child(
+            name: str,
+            *,
+            desired_access: int,
+        ) -> tuple[int, _WindowsHandleMetadata] | None:
+            entry = _windows_find_child(api, owned_parent_handle, name)
+            if entry is None:
+                return None
+            return _windows_open_child_by_id(
+                api,
+                owned_parent_handle,
+                entry,
+                desired_access=desired_access,
+                expected_directory=True,
+                resource_owner=resources,
+            )
+
+        def metadata_callback(
+            name: str,
+            display_path: Path,
+            label: str,
+        ) -> _WindowsHandleMetadata | None:
+            opened_child = open_child(
+                name,
+                desired_access=_WINDOWS_FILE_READ_ATTRIBUTES | _WINDOWS_SYNCHRONIZE,
+            )
+            if opened_child is None:
+                return None
+            handle, metadata = opened_child
+            primary_error: BaseException | None = None
+            try:
+                if metadata.st_dev != opened.st_dev:
+                    raise RuntimeError("publication child crosses a volume")
+                if _is_link_or_reparse(metadata):
+                    raise ValueError(
+                        f"{label} is not a directory or is a link: {display_path}"
+                    )
+                return metadata
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                try:
+                    resources.close_handle(handle)
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        raise
+                    _annotate_secondary_error(
+                        primary_error,
+                        "Windows metadata HANDLE cleanup also failed",
+                        close_error,
+                    )
+
+        def reader_callback(
+            name: str,
+            display_path: Path,
+            label: str,
+            expected_ownership: _TreeOwnership | None,
+            callback: Callable[[_PublicationTreeReader], _T],
+        ) -> _T:
+            opened_child = open_child(
+                name,
+                desired_access=_WINDOWS_FILE_LIST_DIRECTORY
+                | _WINDOWS_FILE_READ_ATTRIBUTES
+                | _WINDOWS_SYNCHRONIZE,
+            )
+            if opened_child is None:
+                raise RuntimeError(f"{label} disappeared: {display_path}")
+            handle, metadata = opened_child
+            if metadata.st_dev != opened.st_dev:
+                resources.close_handle(handle)
+                raise RuntimeError("publication child crosses a volume")
+            reader: _PublicationTreeReader | None = None
+            primary_error: BaseException | None = None
+            try:
+                reader = _PublicationTreeReader(
+                    display_path,
+                    _directory_inode_identity(metadata),
+                    lambda required_root_file, allow_empty_root, entry_policy: (
+                        _capture_windows_directory_handle(
+                            api,
+                            handle,
+                            display_path,
+                            required_root_file=required_root_file,
+                            allow_empty_root=allow_empty_root,
+                            entry_policy=entry_policy,
+                        )
+                    ),
+                    lambda relative, max_bytes, expected: (
+                        _open_windows_authenticated_file(
+                            api,
+                            handle,
+                            display_path,
+                            relative,
+                            max_bytes=max_bytes,
+                            expected=expected,
+                        )
+                    ),
+                    expected_ownership,
+                )
+                result = callback(reader)
+                reader._require_valid()
+                rebound = _windows_find_child(api, owned_parent_handle, name)
+                if rebound is None or rebound.file_id != metadata.st_ino:
+                    raise RuntimeError(f"{label} namespace binding changed")
+                return result
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                if reader is not None:
+                    reader._deactivate()
+                try:
+                    resources.close_handle(handle)
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        raise
+                    _annotate_secondary_error(
+                        primary_error,
+                        "Windows reader HANDLE cleanup also failed",
+                        close_error,
+                    )
+
+        def rename_callback(source: str, destination: str) -> None:
+            opened_source = open_child(
+                source,
+                desired_access=_WINDOWS_DELETE
+                | _WINDOWS_FILE_READ_ATTRIBUTES
+                | _WINDOWS_SYNCHRONIZE,
+            )
+            if opened_source is None:
+                raise FileNotFoundError(source)
+            source_handle, _metadata = opened_source
+            primary_error: BaseException | None = None
+            try:
+                api.rename_noreplace(
+                    source_handle,
+                    owned_parent_handle,
+                    destination,
+                )
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                try:
+                    resources.close_handle(source_handle)
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        raise
+                    _annotate_secondary_error(
+                        primary_error,
+                        "Windows rename HANDLE cleanup also failed",
+                        close_error,
+                    )
+
+        def verify_callback() -> None:
+            if _directory_inode_identity(api.metadata(owned_parent_handle)) != identity:
+                raise RuntimeError("publication parent authority changed")
+            rebound_handle = resources.acquire(
+                lambda: api.create_directory_handle(path)
+            )
+            primary_error: BaseException | None = None
+            try:
+                if _directory_inode_identity(api.metadata(rebound_handle)) != identity:
+                    raise RuntimeError("publication parent path changed")
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                try:
+                    resources.close_handle(rebound_handle)
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        raise
+                    _annotate_secondary_error(
+                        primary_error,
+                        "Windows verification HANDLE cleanup also failed",
+                        close_error,
+                    )
+
+        authority = _PublicationAuthority(
+            display_parent=path,
+            identity=identity,
+            backend_tag="windows-file-id",
+            resource=owned_parent_handle,
+            close_callback=lambda _resource: resources.close_all(),
+            metadata_callback=metadata_callback,
+            reader_callback=reader_callback,
+            rename_callback=rename_callback,
+            verify_callback=verify_callback,
+            close_complete_callback=lambda: resources.closed,
+        )
+        if authority_owner is not None:
+            authority_owner.install(authority)
+        return authority
+    except BaseException as primary_error:
+        if (
+            authority is not None
+            and authority_owner is not None
+            and authority_owner.authority is authority
+        ):
+            authority_owner.close_after_error(primary_error)
+        else:
+            resources.close_all_after_error(primary_error)
+        raise
+
+
 def _is_link_or_reparse(metadata: os.stat_result) -> bool:
     return stat.S_ISLNK(metadata.st_mode) or bool(
         getattr(metadata, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
@@ -172,11 +2636,48 @@ def _path_is_mount_point(
     *,
     mount_points: frozenset[str] | None = None,
 ) -> bool:
-    lexical = os.path.normpath(os.path.abspath(path))
+    lexical = os.path.normpath(os.path.realpath(path))
     observed_mount_points = (
         _linux_mount_points() if mount_points is None else mount_points
     )
-    return os.path.ismount(path) or lexical in observed_mount_points
+    return (
+        os.path.ismount(path)
+        or os.path.ismount(lexical)
+        or lexical in observed_mount_points
+    )
+
+
+class _ResourceIdentityMetadata(Protocol):
+    @property
+    def st_dev(self) -> int: ...
+
+    @property
+    def st_ino(self) -> int: ...
+
+    @property
+    def st_mode(self) -> int: ...
+
+
+def _resource_owner_identity(
+    metadata: _ResourceIdentityMetadata,
+) -> tuple[int, ...]:
+    """Identify one owned kernel object using only immutable identity fields.
+
+    Permission bits, sizes, timestamps, link counts, and reparse attributes may
+    change while the same descriptor or HANDLE remains owned.  They therefore
+    belong in namespace/content authentication, not close reconciliation.  A
+    Windows 128-bit FILE_ID is preferred when present; POSIX and test backends
+    use the device/inode pair.  The file type is stable for an object's life.
+    """
+
+    device = int(metadata.st_dev)
+    mode = int(metadata.st_mode)
+    file_id_128 = (
+        metadata.file_id_128 if isinstance(metadata, _WindowsHandleMetadata) else b""
+    )
+    if file_id_128:
+        return (device, 1, int.from_bytes(file_id_128, "big"), stat.S_IFMT(mode))
+    return (device, 0, int(metadata.st_ino), stat.S_IFMT(mode))
 
 
 def _ownership_binding_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -200,6 +2701,132 @@ def _ownership_version_identity(metadata: os.stat_result) -> tuple[int, ...]:
         metadata.st_ctime_ns,
         metadata.st_nlink,
     )
+
+
+@contextmanager
+def _open_posix_authenticated_file(
+    root_descriptor: int,
+    root_path: Path,
+    relative: PurePosixPath,
+    *,
+    max_bytes: int,
+    expected: _ExpectedPublicationFile,
+) -> Iterator[PublicationAuthenticatedFile]:
+    root_before = os.fstat(root_descriptor)
+    root_device = root_before.st_dev
+    flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    directory_flags = flags | os.O_DIRECTORY | getattr(os, "O_NONBLOCK", 0)
+    file_flags = flags | getattr(os, "O_NONBLOCK", 0)
+    descriptors: list[int] = [os.dup(root_descriptor)]
+    bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
+    file_descriptor = -1
+    authenticated: PublicationAuthenticatedFile | None = None
+    expected_directories = dict(expected.directory_identities)
+    traversed: list[str] = []
+    try:
+        for part in relative.parts[:-1]:
+            traversed.append(part)
+            relative_directory = "/".join(traversed)
+            parent = descriptors[-1]
+            metadata = os.stat(part, dir_fd=parent, follow_symlinks=False)
+            if (
+                _is_link_or_reparse(metadata)
+                or not stat.S_ISDIR(metadata.st_mode)
+                or metadata.st_dev != root_device
+            ):
+                raise RuntimeError(
+                    f"publication stream refuses directory: {root_path / relative}"
+                )
+            child = os.open(part, directory_flags, dir_fd=parent)
+            descriptors.append(child)
+            opened = os.fstat(child)
+            if _ownership_binding_identity(opened) != _ownership_binding_identity(
+                metadata
+            ):
+                raise RuntimeError("publication stream directory changed")
+            if expected_directories.get(
+                relative_directory
+            ) != _ownership_version_identity(opened):
+                raise RuntimeError(
+                    "publication stream directory differs from captured ownership"
+                )
+            bindings.append((parent, part, child, _ownership_version_identity(opened)))
+
+        parent = descriptors[-1]
+        name = relative.name
+        metadata = os.stat(name, dir_fd=parent, follow_symlinks=False)
+        if (
+            _is_link_or_reparse(metadata)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_dev != root_device
+        ):
+            raise RuntimeError(
+                f"publication stream refuses non-file: {root_path / relative}"
+            )
+        file_descriptor = os.open(name, file_flags, dir_fd=parent)
+        opened_file = os.fstat(file_descriptor)
+        if _ownership_binding_identity(opened_file) != _ownership_binding_identity(
+            metadata
+        ):
+            raise RuntimeError("publication stream file changed while opened")
+        if _ownership_version_identity(opened_file) != expected.file_identity:
+            raise RuntimeError(
+                "publication stream file differs from captured ownership"
+            )
+        if opened_file.st_size < 0 or opened_file.st_size > max_bytes:
+            raise ValueError(
+                f"publication stream exceeds its {max_bytes}-byte limit: {relative}"
+            )
+
+        def verify() -> None:
+            after_file = os.fstat(file_descriptor)
+            if _ownership_version_identity(after_file) != _ownership_version_identity(
+                opened_file
+            ):
+                raise RuntimeError("publication stream file changed while read")
+            path_after = os.stat(name, dir_fd=parent, follow_symlinks=False)
+            if _ownership_binding_identity(path_after) != _ownership_binding_identity(
+                opened_file
+            ):
+                raise RuntimeError("publication stream file binding changed")
+            for parent_fd, child_name, child_fd, expected in reversed(bindings):
+                child_after = os.fstat(child_fd)
+                path_child_after = os.stat(
+                    child_name,
+                    dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+                if _ownership_version_identity(
+                    child_after
+                ) != expected or _ownership_binding_identity(
+                    path_child_after
+                ) != _ownership_binding_identity(
+                    child_after
+                ):
+                    raise RuntimeError("publication stream directory binding changed")
+            root_after = os.fstat(root_descriptor)
+            if _ownership_version_identity(root_after) != _ownership_version_identity(
+                root_before
+            ):
+                raise RuntimeError("publication stream root changed")
+
+        authenticated = PublicationAuthenticatedFile(
+            path=relative.as_posix(),
+            mode=stat.S_IMODE(opened_file.st_mode),
+            size=opened_file.st_size,
+            read_callback=lambda size: os.read(file_descriptor, size),
+            verify_callback=verify,
+        )
+        yield authenticated
+    finally:
+        try:
+            if authenticated is not None:
+                authenticated._finalize()
+        finally:
+            if file_descriptor >= 0:
+                os.close(file_descriptor)
+            for descriptor in reversed(descriptors):
+                os.close(descriptor)
 
 
 def _ownership_hash_field(hasher, value: bytes) -> None:
@@ -251,6 +2878,8 @@ def _hash_owned_regular_file(
         if (
             not stat.S_ISREG(opened.st_mode)
             or opened.st_dev != root_device
+            or not opened.st_dev
+            or not opened.st_ino
             or _ownership_binding_identity(opened)
             != _ownership_binding_identity(metadata)
         ):
@@ -307,7 +2936,12 @@ def _scan_owned_directory(
     if depth > _MAX_SAFE_REMOVAL_DEPTH:
         raise RuntimeError("directory ownership scan exceeds its depth limit")
     before = os.fstat(descriptor)
-    if not stat.S_ISDIR(before.st_mode) or before.st_dev != root_device:
+    if (
+        not stat.S_ISDIR(before.st_mode)
+        or before.st_dev != root_device
+        or not before.st_dev
+        or not before.st_ino
+    ):
         raise RuntimeError(f"directory ownership root changed: {path}")
 
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
@@ -463,15 +3097,7 @@ def _scan_owned_directory(
     return hasher.digest()
 
 
-def capture_directory_ownership(
-    path: Path,
-    *,
-    required_root_file: str | None = None,
-    allow_empty_root: bool = False,
-    entry_policy: DirectoryEntryPolicy | None = None,
-) -> _TreeOwnership:
-    """Return a bounded content token for one stable, real directory tree."""
-
+def _required_root_file_bytes(required_root_file: str | None) -> bytes | None:
     required_root_file_bytes: bytes | None = None
     if required_root_file is not None:
         if (
@@ -484,77 +3110,48 @@ def capture_directory_ownership(
         required_root_file_bytes = os.fsencode(required_root_file)
         if len(required_root_file_bytes) > _MAX_OWNERSHIP_COMPONENT_BYTES:
             raise ValueError("directory ownership marker exceeds its byte limit")
+    return required_root_file_bytes
 
-    metadata = _directory_or_missing(path, label="directory ownership root")
-    if metadata is None:
-        raise RuntimeError(f"directory ownership root disappeared: {path}")
+
+def _capture_posix_directory_descriptor(
+    descriptor: int,
+    path: Path,
+    *,
+    required_root_file: str | None,
+    allow_empty_root: bool,
+    entry_policy: DirectoryEntryPolicy | None,
+) -> _TreeOwnership:
+    """Capture one already-open POSIX directory without reacquiring its path."""
+
+    required_root_file_bytes = _required_root_file_bytes(required_root_file)
+    opened = os.fstat(descriptor)
+    if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    if not opened.st_dev or not opened.st_ino:
+        raise RuntimeError("directory ownership root has no reliable identity")
     if _path_is_mount_point(path):
         raise RuntimeError(f"directory ownership root is mounted: {path}")
-    if not _SAFE_OWNERSHIP_DIRECTORY_FDS:
-        # A path-only fallback cannot safely traverse a non-empty tree.  It can
-        # still bind the empty sentinel used for a first publication: a raced
-        # entry is checked again after the sentinel is moved and cleanup uses
-        # rmdir rather than recursive deletion on the same platforms.
-        with os.scandir(path) as entries:
-            if next(iter(entries), None) is not None:
-                raise RuntimeError(
-                    "safe directory ownership requires no-follow directory-fd "
-                    "support for non-empty trees"
-                )
-        after = _directory_or_missing(path, label="directory ownership root")
-        if after is None or _ownership_binding_identity(
-            after
-        ) != _ownership_binding_identity(metadata):
-            raise RuntimeError(f"directory ownership root changed: {path}")
-        digest = hashlib.sha256()
-        digest.update(b"codenib.atomic-directory.v1\x00")
-        digest.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
-        return _TreeOwnership(
-            root_identity=_directory_inode_identity(metadata),
-            root_version_identity=_ownership_version_identity(metadata),
-            digest=digest.hexdigest(),
-            entries=0,
-            byte_count=0,
-            metadata_bytes=0,
-            inventory=(),
-            file_records=(),
-            entry_identities=(),
-        )
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    flags |= getattr(os, "O_CLOEXEC", 0)
-    descriptor = os.open(path, flags)
-    try:
-        opened = os.fstat(descriptor)
-        if _ownership_binding_identity(opened) != _ownership_binding_identity(metadata):
-            raise RuntimeError(f"directory ownership root changed: {path}")
-        budget = _OwnershipBudget()
-        inventory: list[tuple[str, str]] = []
-        file_records: list[TreeFileRecord] = []
-        entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
-        digest = _scan_owned_directory(
-            descriptor,
-            path,
-            (),
-            root_device=opened.st_dev,
-            mount_points=_linux_mount_points(),
-            budget=budget,
-            inventory=inventory,
-            file_records=file_records,
-            entry_identities=entry_identities,
-            entry_policy=entry_policy,
-            depth=0,
-            required_root_file=required_root_file_bytes,
-            allow_empty_root=allow_empty_root,
-        )
-        after = os.fstat(descriptor)
-        if _ownership_version_identity(after) != _ownership_version_identity(opened):
-            raise RuntimeError(f"directory ownership root changed: {path}")
-    finally:
-        os.close(descriptor)
-    path_after = _directory_or_missing(path, label="directory ownership root")
-    if path_after is None or _ownership_binding_identity(
-        path_after
-    ) != _ownership_binding_identity(metadata):
+    budget = _OwnershipBudget()
+    inventory: list[tuple[str, str]] = []
+    file_records: list[TreeFileRecord] = []
+    entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
+    digest = _scan_owned_directory(
+        descriptor,
+        path,
+        (),
+        root_device=opened.st_dev,
+        mount_points=_linux_mount_points(),
+        budget=budget,
+        inventory=inventory,
+        file_records=file_records,
+        entry_identities=entry_identities,
+        entry_policy=entry_policy,
+        depth=0,
+        required_root_file=required_root_file_bytes,
+        allow_empty_root=allow_empty_root,
+    )
+    after = os.fstat(descriptor)
+    if _ownership_version_identity(after) != _ownership_version_identity(opened):
         raise RuntimeError(f"directory ownership root changed: {path}")
     return _TreeOwnership(
         root_identity=_directory_inode_identity(opened),
@@ -567,6 +3164,103 @@ def capture_directory_ownership(
         file_records=tuple(sorted(file_records, key=lambda record: record.path)),
         entry_identities=tuple(sorted(entry_identities)),
     )
+
+
+def capture_directory_ownership(
+    path: Path,
+    *,
+    required_root_file: str | None = None,
+    allow_empty_root: bool = False,
+    entry_policy: DirectoryEntryPolicy | None = None,
+) -> _TreeOwnership:
+    """Return a bounded token through a pinned parent/source authority."""
+
+    lexical = lexical_directory_path(path)
+    with _PublicationAuthorityOwner() as authority_owner:
+        if sys.platform.startswith("linux") or sys.platform == "darwin":
+            authority = _open_posix_publication_authority(
+                lexical.parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+                authority_owner=authority_owner,
+            )
+        elif sys.platform == "win32":
+            authority = _open_windows_publication_authority(
+                lexical.parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+                authority_owner=authority_owner,
+            )
+        else:
+            raise RuntimeError(
+                "safe directory ownership capture is unsupported on this host"
+            )
+        return authority.capture_child(
+            lexical.name,
+            path=lexical,
+            label="directory ownership root",
+            required_root_file=required_root_file,
+            allow_empty_root=allow_empty_root,
+            entry_policy=entry_policy,
+        )
+
+
+def capture_directory_ownership_if_exists(
+    path: Path,
+    *,
+    required_root_file: str | None = None,
+    allow_empty_root: bool = False,
+    entry_policy: DirectoryEntryPolicy | None = None,
+) -> _TreeOwnership | None:
+    """Capture one existing tree or atomically observe that its child is absent.
+
+    The missing observation and any capture use one pinned parent authority.
+    A child that appears after a missing observation is not opened or blessed;
+    callers can pass the returned ``None`` into a later no-replace operation.
+    """
+
+    _required_root_file_bytes(required_root_file)
+    lexical = lexical_directory_path(path)
+    with _PublicationAuthorityOwner() as authority_owner:
+        if sys.platform.startswith("linux") or sys.platform == "darwin":
+            authority = _open_posix_publication_authority(
+                lexical.parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+                authority_owner=authority_owner,
+            )
+        elif sys.platform == "win32":
+            authority = _open_windows_publication_authority(
+                lexical.parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+                authority_owner=authority_owner,
+            )
+        else:
+            raise RuntimeError(
+                "safe directory ownership capture is unsupported on this host"
+            )
+        metadata = authority.child_metadata(
+            lexical.name,
+            path=lexical,
+            label="directory ownership root",
+        )
+        if metadata is None:
+            authority.verify_path_binding()
+            return None
+        initial_root_identity = _directory_inode_identity(metadata)
+        ownership = authority.capture_child(
+            lexical.name,
+            path=lexical,
+            label="directory ownership root",
+            required_root_file=required_root_file,
+            allow_empty_root=allow_empty_root,
+            entry_policy=entry_policy,
+        )
+        if ownership.root_identity != initial_root_identity:
+            raise RuntimeError("directory ownership root changed while it was captured")
+        authority.verify_path_binding()
+        return ownership
 
 
 def directory_ownership_inventory(
@@ -627,8 +3321,32 @@ def directory_ownership_digest(ownership: _TreeOwnership) -> str:
     return ownership.digest
 
 
-def _require_tree_ownership(
-    path: Path,
+def require_publishable_directory_ownership(
+    ownership: _TreeOwnership,
+    *,
+    label: str = "staged directory",
+) -> None:
+    """Require strong IDs and private regular files for a future active tree.
+
+    Observation tokens may describe a legacy destination containing hard
+    links because online publication only isolates that old root.  A staged
+    tree is different: every regular file must have exactly one link, or an
+    alias outside the root could mutate bytes after successful publication.
+    """
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    if not ownership.root_identity[0] or not ownership.root_identity[1]:
+        raise RuntimeError(f"{label} has no reliable root identity")
+    for path, kind, identity in ownership.entry_identities:
+        if not identity[0] or not identity[1]:
+            raise RuntimeError(f"{label} entry has no reliable identity: {path}")
+        if kind == "file" and identity[-1] != 1:
+            raise RuntimeError(f"{label} file has an external hard link: {path}")
+
+
+def _require_matching_ownership(
+    observed: _TreeOwnership,
     expected: _TreeOwnership,
     *,
     label: str,
@@ -639,10 +3357,6 @@ def _require_tree_ownership(
         "previous destination",
         "published staged directory",
     }
-    try:
-        observed = capture_directory_ownership(path)
-    except (OSError, ValueError, RuntimeError) as exc:
-        raise RuntimeError(f"{label} changed during directory publication") from exc
     if observed != expected and not (
         allow_root_rename
         and replace(
@@ -654,325 +3368,728 @@ def _require_tree_ownership(
         raise RuntimeError(f"{label} changed during directory publication")
 
 
-def discard_owned_directory(path: Path, ownership: _TreeOwnership) -> None:
-    """Best-effort cleanup that never follows a substituted root path."""
-
-    try:
-        metadata = _directory_or_missing(path, label="owned temporary directory")
-    except (OSError, ValueError):
-        return
-    if (
-        metadata is None
-        or _directory_inode_identity(metadata) != ownership.root_identity
-    ):
-        return
-    try:
-        _remove_owned_directory(path, ownership.root_identity)
-    except (OSError, RuntimeError, ValueError):
-        # Temporary cleanup must not reacquire or remove a replacement path.
-        # A partially removed owned tree is left for explicit orphan GC.
-        return
-
-
-def _require_safe_tree(
-    path: Path,
-    *,
-    root_device: int,
-    mount_points: frozenset[str],
-    depth: int = 0,
-) -> None:
-    """Preflight cleanup without following links or crossing mount boundaries."""
-
-    if depth > _MAX_SAFE_REMOVAL_DEPTH:
-        raise RuntimeError(f"directory cleanup exceeds its depth limit: {path}")
-    metadata = path.lstat()
-    if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
-        raise RuntimeError(f"directory cleanup target changed: {path}")
-    if metadata.st_dev != root_device or _path_is_mount_point(
-        path,
-        mount_points=mount_points,
-    ):
-        raise RuntimeError(f"refusing to remove a mounted directory tree: {path}")
-    with os.scandir(path) as entries:
-        for entry in entries:
-            child = path / entry.name
-            child_metadata = entry.stat(follow_symlinks=False)
-            if child_metadata.st_dev != root_device:
-                raise RuntimeError(
-                    f"refusing to cross a device during directory cleanup: {child}"
-                )
-            if _path_is_mount_point(child, mount_points=mount_points):
-                raise RuntimeError(
-                    f"refusing to remove a mounted filesystem entry: {child}"
-                )
-            if _is_link_or_reparse(child_metadata):
-                if stat.S_ISDIR(child_metadata.st_mode) or bool(
-                    getattr(child_metadata, "st_file_attributes", 0)
-                    & _FILE_ATTRIBUTE_REPARSE_POINT
-                ):
-                    raise RuntimeError(
-                        f"refusing to follow a linked directory during cleanup: {child}"
-                    )
-                continue
-            if stat.S_ISDIR(child_metadata.st_mode):
-                _require_safe_tree(
-                    child,
-                    root_device=root_device,
-                    mount_points=mount_points,
-                    depth=depth + 1,
-                )
-
-
-def _remove_tree_at(
-    parent_descriptor: int,
+def _require_tree_ownership_at(
+    authority: _PublicationAuthority,
     name: str,
-    path: Path,
     *,
-    root_device: int,
-    mount_points: frozenset[str],
-    removal_state: _RemovalState,
-    depth: int,
+    path: Path,
+    expected: _TreeOwnership,
+    label: str,
+    allow_root_rename: bool = False,
 ) -> None:
-    if depth > _MAX_SAFE_REMOVAL_DEPTH:
-        raise RuntimeError(f"directory cleanup exceeds its depth limit: {path}")
-    metadata = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
-    if (
-        _is_link_or_reparse(metadata)
-        or not stat.S_ISDIR(metadata.st_mode)
-        or metadata.st_dev != root_device
-        or _path_is_mount_point(path, mount_points=mount_points)
-    ):
-        raise RuntimeError(f"directory cleanup target changed: {path}")
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    descriptor = os.open(name, flags, dir_fd=parent_descriptor)
     try:
-        opened = os.fstat(descriptor)
-        if _directory_inode_identity(opened) != _directory_inode_identity(metadata):
-            raise RuntimeError(f"directory cleanup target changed: {path}")
-        if opened.st_dev != root_device or _path_is_mount_point(
-            path,
-            mount_points=mount_points,
-        ):
-            raise RuntimeError(f"refusing to remove a mounted directory tree: {path}")
-        while True:
-            # A fresh open file description resets the directory stream without
-            # materializing an attacker-sized list of names.  ``dup`` is not
-            # sufficient because it shares the directory offset.
-            scan_descriptor = os.open(".", flags, dir_fd=descriptor)
-            try:
-                if _directory_inode_identity(
-                    os.fstat(scan_descriptor)
-                ) != _directory_inode_identity(opened):
-                    raise RuntimeError(f"directory cleanup target changed: {path}")
-                with os.scandir(scan_descriptor) as entries:
-                    entry = next(iter(entries), None)
-            finally:
-                os.close(scan_descriptor)
-            if entry is None:
-                break
-            child_metadata = os.stat(
-                entry.name,
-                dir_fd=descriptor,
-                follow_symlinks=False,
-            )
-            child_path = path / entry.name
-            if child_metadata.st_dev != root_device:
-                raise RuntimeError(
-                    f"refusing to cross a device during directory cleanup: {child_path}"
-                )
-            if _path_is_mount_point(child_path, mount_points=mount_points):
-                raise RuntimeError(
-                    f"refusing to remove a mounted filesystem entry: {child_path}"
-                )
-            if stat.S_ISDIR(child_metadata.st_mode) and not _is_link_or_reparse(
-                child_metadata
-            ):
-                _remove_tree_at(
-                    descriptor,
-                    entry.name,
-                    child_path,
-                    root_device=root_device,
-                    mount_points=mount_points,
-                    removal_state=removal_state,
-                    depth=depth + 1,
-                )
-            else:
-                if bool(
-                    getattr(child_metadata, "st_file_attributes", 0)
-                    & _FILE_ATTRIBUTE_REPARSE_POINT
-                ):
-                    raise RuntimeError(
-                        f"refusing to remove a reparse point during cleanup: {child_path}"
-                    )
-                removal_state.destructive_started = True
-                os.unlink(entry.name, dir_fd=descriptor)
-        if _directory_inode_identity(os.fstat(descriptor)) != _directory_inode_identity(
-            opened
-        ):
-            raise RuntimeError(f"directory cleanup target changed: {path}")
-    finally:
-        os.close(descriptor)
-    removal_state.destructive_started = True
-    os.rmdir(name, dir_fd=parent_descriptor)
+        observed = authority.capture_child(
+            name,
+            path=path,
+            label=label,
+        )
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise RuntimeError(f"{label} changed during directory publication") from exc
+    _require_matching_ownership(
+        observed,
+        expected,
+        label=label,
+        allow_root_rename=allow_root_rename,
+    )
 
 
-def _remove_owned_directory(
+def _require_tree_ownership(
     path: Path,
-    expected_identity: tuple[int, ...],
+    expected: _TreeOwnership,
     *,
-    removal_state: _RemovalState | None = None,
+    label: str,
+    allow_root_rename: bool = False,
 ) -> None:
-    """Remove an owned tree without following links or crossing mounts."""
+    """Compatibility wrapper for non-publication ownership checks."""
 
-    if removal_state is None:
-        removal_state = _RemovalState()
-    metadata = _directory_or_missing(path, label="directory cleanup target")
-    if metadata is None or _directory_inode_identity(metadata) != expected_identity:
-        raise RuntimeError(f"directory cleanup target changed: {path}")
-    root_device = metadata.st_dev
-    if not _SAFE_REMOVAL_DIRECTORY_FDS:
-        with os.scandir(path) as entries:
-            if next(iter(entries), None) is not None:
+    try:
+        observed = capture_directory_ownership(path)
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise RuntimeError(f"{label} changed during directory publication") from exc
+    _require_matching_ownership(
+        observed,
+        expected,
+        label=label,
+        allow_root_rename=allow_root_rename,
+    )
+
+
+def reopen_authenticated_directory(
+    path: Path,
+    expected_ownership: _TreeOwnership,
+    callback: Callable[[PublicationDirectoryReader], _T],
+    *,
+    expected_parent_identity: tuple[int, ...] | None = None,
+) -> _T:
+    """Consume an existing tree through one backend-neutral authority.
+
+    The complete tree is freshly matched before and after ``callback``.  File
+    reads remain bound to ``expected_ownership`` and the callback-scoped reader
+    cannot escape as a path authority.  Linux/macOS use retained directory fds;
+    Windows uses retained parent/root HANDLEs and FILE_ID traversal.
+    """
+
+    if not isinstance(expected_ownership, _TreeOwnership):
+        raise TypeError(
+            "expected ownership must be a captured directory ownership token"
+        )
+    if not callable(callback):
+        raise TypeError("authenticated directory callback must be callable")
+    lexical = lexical_directory_path(path)
+    with _PublicationAuthorityOwner() as authority_owner:
+        authority = _open_publication_authority(
+            lexical.parent,
+            parent_resource=None,
+            expected_parent_identity=expected_parent_identity,
+            authority_owner=authority_owner,
+        )
+
+        def consume(reader: PublicationDirectoryReader) -> _T:
+            before = reader.capture_ownership()
+            if before != expected_ownership:
                 raise RuntimeError(
-                    "safe directory cleanup requires no-follow directory-fd support"
+                    "authenticated directory differs from expected ownership"
                 )
-        final_metadata = _directory_or_missing(
-            path,
-            label="empty directory cleanup target",
+            result = callback(reader)
+            # A validator may deliberately catch a stream/snapshot failure.
+            # Reject before another namespace observation can hide that failure.
+            reader._require_valid()
+            after = reader.capture_ownership()
+            if after != expected_ownership:
+                raise RuntimeError(
+                    "authenticated directory changed while it was consumed"
+                )
+            return result
+
+        result = authority.read_child(
+            lexical.name,
+            path=lexical,
+            label="authenticated directory",
+            expected_ownership=expected_ownership,
+            callback=consume,
+        )
+        authority.verify_path_binding()
+        return result
+
+
+def discard_owned_directory(
+    path: Path,
+    ownership: _TreeOwnership,
+) -> DirectoryOrphan | None:
+    """Atomically isolate an exact owned tree without recursively deleting it.
+
+    Under a hostile same-UID process there is no safe final ``stat -> unlink``
+    sequence: a validated entry can always be replaced immediately before the
+    destructive syscall.  Online cleanup therefore claims the complete root
+    under a random hidden name and returns bounded metadata for a later,
+    explicitly cooperative GC pass.
+    """
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    lexical = lexical_directory_path(path)
+    _require_rename_noreplace_platform()
+    authority_owner = _PublicationAuthorityOwner()
+    authority: _PublicationAuthority | None = None
+    primary_error: BaseException | None = None
+    try:
+        authority = _open_publication_authority(
+            lexical.parent,
+            parent_resource=None,
+            expected_parent_identity=None,
+            authority_owner=authority_owner,
+        )
+        metadata = _directory_or_missing_at(
+            authority,
+            lexical.name,
+            path=lexical,
+            label="owned temporary directory",
         )
         if (
-            final_metadata is None
-            or _directory_inode_identity(final_metadata) != expected_identity
+            metadata is None
+            or _directory_inode_identity(metadata) != ownership.root_identity
         ):
-            raise RuntimeError(f"directory cleanup target changed: {path}")
-        removal_state.destructive_started = True
-        path.rmdir()
-        return
-    _require_safe_tree(
-        path,
-        root_device=root_device,
-        mount_points=_linux_mount_points(),
-    )
-    parent_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    parent_descriptor = os.open(path.parent, parent_flags)
-    try:
-        _remove_tree_at(
-            parent_descriptor,
-            path.name,
-            path,
-            root_device=root_device,
-            mount_points=_linux_mount_points(),
-            removal_state=removal_state,
-            depth=0,
+            return None
+        try:
+            _require_tree_ownership_at(
+                authority,
+                lexical.name,
+                path=lexical,
+                expected=ownership,
+                label="owned temporary directory",
+            )
+        except (OSError, RuntimeError, ValueError):
+            return None
+        orphan = _claim_child_as_orphan(
+            authority,
+            lexical.name,
+            display_parent=lexical.parent,
+            destination_name=lexical.name,
+            purpose="discarded",
         )
+        try:
+            moved = _directory_or_missing_at(
+                authority,
+                orphan.name,
+                path=orphan,
+                label="discarded directory orphan",
+            )
+            if (
+                moved is None
+                or _directory_inode_identity(moved) != ownership.root_identity
+            ):
+                raise RuntimeError("discarded directory identity changed at claim")
+            _require_tree_ownership_at(
+                authority,
+                orphan.name,
+                path=orphan,
+                expected=ownership,
+                label="moved destination",
+                allow_root_rename=True,
+            )
+        except (OSError, RuntimeError, ValueError):
+            try:
+                authority.rename_noreplace(orphan.name, lexical.name)
+            except (OSError, RuntimeError):
+                return _orphan_metadata(
+                    authority,
+                    orphan,
+                    ownership,
+                    verified_at_isolation=False,
+                )
+            return None
+        try:
+            return _orphan_metadata(authority, orphan, ownership)
+        except (OSError, RuntimeError, ValueError):
+            # Isolation completed but a raced mutation prevented a verified
+            # receipt.  Restore without replacement; if that is no longer
+            # possible, return an explicitly unverified authority locator.
+            try:
+                authority.rename_noreplace(orphan.name, lexical.name)
+            except (OSError, RuntimeError):
+                return _orphan_metadata(
+                    authority,
+                    orphan,
+                    ownership,
+                    verified_at_isolation=False,
+                )
+            return None
+    except (OSError, RuntimeError, ValueError):
+        return None
+    except BaseException as exc:
+        primary_error = exc
+        raise
     finally:
-        os.close(parent_descriptor)
+        if primary_error is None:
+            authority_owner.close()
+        else:
+            authority_owner.close_after_error(primary_error)
 
 
-def _restore_previous_directory(
-    backup: Path,
+def _quarantine_destination(
     destination: Path,
     *,
-    destination_was_missing: bool,
-) -> None:
-    os.replace(backup, destination)
-    if destination_was_missing:
-        destination.rmdir()
-
-
-def _quarantine_destination(destination: Path) -> Path | None:
+    parent_descriptor: int | None = None,
+    parent_authority: _PublicationAuthority | None = None,
+) -> Path | None:
     """Move an untrusted post-publication object out of the caller's stage path."""
 
+    lexical = lexical_directory_path(destination)
+    authority_owner = _PublicationAuthorityOwner()
+    owned_authority: _PublicationAuthority | None = None
+    authority = parent_authority
+    primary_error: BaseException | None = None
     try:
-        destination.lstat()
-    except FileNotFoundError:
-        return None
-    quarantine = Path(
-        tempfile.mkdtemp(
-            prefix=f".{destination.name}.quarantine-",
-            dir=str(destination.parent),
+        if authority is None:
+            owned_authority = _open_publication_authority(
+                lexical.parent,
+                parent_resource=parent_descriptor,
+                expected_parent_identity=None,
+                authority_owner=authority_owner,
+            )
+            authority = owned_authority
+        metadata = authority.child_metadata(
+            lexical.name,
+            path=lexical,
+            label="quarantine destination",
         )
-    )
-    quarantine.rmdir()
-    try:
-        os.replace(destination, quarantine)
-    except BaseException:
-        try:
-            quarantine.rmdir()
-        except OSError:
-            pass
+        if metadata is None:
+            return None
+        return _claim_child_as_orphan(
+            authority,
+            lexical.name,
+            display_parent=lexical.parent,
+            destination_name=lexical.name,
+            purpose="quarantine",
+        )
+    except BaseException as exc:
+        primary_error = exc
         raise
-    return quarantine
+    finally:
+        if primary_error is None:
+            authority_owner.close()
+        else:
+            authority_owner.close_after_error(primary_error)
 
 
-def _recover_invalid_publication(
-    backup: Path,
+def _require_durable_publication_commit_authority(
+    publication_authority: _PublicationAuthority,
+) -> None:
+    """Reject unsupported strict commit authorities before any mutation."""
+
+    if (
+        not sys.platform.startswith("linux")
+        or publication_authority.backend_tag not in _DURABLE_PUBLICATION_FSYNC_BACKENDS
+    ):
+        raise RuntimeError(
+            "durable directory commit requires a supported Linux publication "
+            "authority"
+        )
+    resource = publication_authority.resource
+    if isinstance(resource, bool) or not isinstance(resource, int) or resource < 0:
+        raise RuntimeError(
+            "durable directory commit requires a valid POSIX parent descriptor"
+        )
+
+
+def _fsync_publication_parent_for_commit(
+    publication_authority: _PublicationAuthority,
+) -> None:
+    """Durably order a supported strict commit before its ownership handoff."""
+
+    os.fsync(publication_authority.resource)
+
+
+def _publish_staged_directory_with_authority(
+    publication_authority: _PublicationAuthority,
+    stage: Path,
     destination: Path,
     *,
-    destination_was_missing: bool,
-    expected_backup_identity: tuple[int, ...],
-    published_output_trusted: bool,
-) -> Path | None:
-    def require_expected_backup(*, message: str) -> None:
-        try:
-            backup_metadata = _directory_or_missing(
-                backup,
-                label="previous destination",
-            )
-        except (OSError, ValueError) as exc:
-            raise _PreviousOutputIdentityLost(message) from exc
-        if (
-            backup_metadata is None
-            or _directory_inode_identity(backup_metadata) != expected_backup_identity
-        ):
-            raise _PreviousOutputIdentityLost(message)
+    expected_destination_identity: tuple[int, ...] | None | object = (
+        _EXPECTED_DESTINATION_UNSET
+    ),
+    expected_stage_identity: tuple[int, ...] | None = None,
+    expected_stage_root_ownership: _TreeOwnership | None = None,
+    expected_destination_ownership: _TreeOwnership | None | object = (
+        _EXPECTED_OWNERSHIP_UNSET
+    ),
+    validate_staged_directory: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    validate_moved_destination: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    validate_published_destination: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    commit_callback: (
+        Callable[[_TreeOwnership, _TreeOwnership, DirectoryOrphan | None], None] | None
+    ) = None,
+) -> DirectoryOrphan | None:
+    """Publish a complete stage through a caller-owned parent authority.
 
-    if published_output_trusted:
-        require_expected_backup(
-            message=(
-                "publication committed; cleanup incomplete; previous output "
-                "identity lost"
+    Every namespace mutation is an atomic no-replace rename relative to the
+    pinned parent descriptor.  The previous tree is intentionally retained as
+    a hidden, fully authenticated orphan for cooperative GC; online recursive
+    deletion cannot be made safe against a hostile same-UID replacement race.
+
+    This helper borrows ``publication_authority``.  It never acquires, closes,
+    or transfers that authority.  ``commit_callback`` receives the sealed
+    pre-rename token, a fresh post-rename token, and the previous orphan.  It is
+    the final fallible action after publication is fully authenticated and the
+    supported parent namespace has been durably synchronized; once the callback
+    starts, its failures propagate without rolling the publication back.
+
+    Parent fsync orders only the namespace publication.  Strict callers must
+    durably seal every staged file and directory before invoking this helper;
+    a ``_TreeOwnership`` token authenticates observations but is not itself a
+    durability receipt.
+    """
+
+    stage_display = lexical_directory_path(stage)
+    destination_display = lexical_directory_path(destination)
+    if stage_display == destination_display:
+        raise ValueError("staged and destination directories must differ")
+    if stage_display.parent != destination_display.parent:
+        raise ValueError("staged and destination directories must share a parent")
+    if stage_display.parent != publication_authority.display_parent:
+        raise ValueError(
+            "staged and destination directories must match the authority parent"
+        )
+    if commit_callback is not None:
+        if not callable(commit_callback):
+            raise TypeError("directory commit callback must be callable")
+        _require_durable_publication_commit_authority(publication_authority)
+
+    def perform_publication() -> DirectoryOrphan | None:
+        stage_metadata = _directory_or_missing_at(
+            publication_authority,
+            stage_display.name,
+            path=stage_display,
+            label="staged directory",
+        )
+        if stage_metadata is None:
+            raise ValueError(f"staged directory does not exist: {stage_display}")
+        if (
+            expected_stage_identity is not None
+            and _directory_identity(stage_metadata) != expected_stage_identity
+        ):
+            raise RuntimeError("staged directory changed before directory publication")
+        required_stage_inode_identity = _directory_inode_identity(stage_metadata)
+        if (
+            expected_stage_root_ownership is not None
+            and required_stage_inode_identity
+            != expected_stage_root_ownership.root_identity
+        ):
+            raise RuntimeError("staged directory root changed before publication")
+
+        stage_ownership = publication_authority.capture_child(
+            stage_display.name,
+            path=stage_display,
+            label="staged directory",
+        )
+        require_publishable_directory_ownership(
+            stage_ownership,
+            label="staged directory",
+        )
+        if (
+            expected_stage_root_ownership is not None
+            and stage_ownership != expected_stage_root_ownership
+        ):
+            raise RuntimeError("staged directory changed before publication")
+        if validate_staged_directory is not None:
+            publication_authority.read_child(
+                stage_display.name,
+                path=stage_display,
+                label="staged directory",
+                expected_ownership=stage_ownership,
+                callback=validate_staged_directory,
+            )
+            _require_tree_ownership_at(
+                publication_authority,
+                stage_display.name,
+                path=stage_display,
+                expected=stage_ownership,
+                label="staged directory",
+            )
+
+        destination_metadata = _directory_or_missing_at(
+            publication_authority,
+            destination_display.name,
+            path=destination_display,
+            label="destination",
+        )
+        observed_destination_ownership = (
+            None
+            if destination_metadata is None
+            else publication_authority.capture_child(
+                destination_display.name,
+                path=destination_display,
+                label="destination",
             )
         )
-    try:
-        quarantine = _quarantine_destination(destination)
-    except Exception as quarantine_error:
-        raise RuntimeError(
-            "published directory identity failed validation; the suspect "
-            f"output remains at {destination} and the previous output remains "
-            f"at {backup}"
-        ) from quarantine_error
-    if not published_output_trusted:
-        suspect_disposition = (
-            f"suspect output was quarantined at {quarantine}"
-            if quarantine is not None
-            else "suspect output vanished before quarantine"
-        )
-        require_expected_backup(
-            message=(
-                "published directory identity failed validation; "
-                f"{suspect_disposition}; previous output identity lost; active "
-                "destination is absent"
+        if expected_destination_ownership is not _EXPECTED_OWNERSHIP_UNSET and (
+            observed_destination_ownership != expected_destination_ownership
+        ):
+            raise RuntimeError("destination changed before directory publication")
+        if expected_destination_identity is not _EXPECTED_DESTINATION_UNSET:
+            observed_identity = (
+                None
+                if destination_metadata is None
+                else _directory_identity(destination_metadata)
             )
+            if observed_identity != expected_destination_identity:
+                raise RuntimeError("destination changed before directory publication")
+
+        destination_was_missing = destination_metadata is None
+        _require_tree_ownership_at(
+            publication_authority,
+            stage_display.name,
+            path=stage_display,
+            expected=stage_ownership,
+            label="staged directory",
         )
-    try:
-        _restore_previous_directory(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
+        backup: Path | None = None
+        moved_destination_ownership: _TreeOwnership | None = None
+        required_destination_inode_identity: tuple[int, ...] | None = None
+        if not destination_was_missing:
+            assert observed_destination_ownership is not None
+            moved_destination_ownership = observed_destination_ownership
+            required_destination_inode_identity = _directory_inode_identity(
+                destination_metadata
+            )
+            _require_tree_ownership_at(
+                publication_authority,
+                destination_display.name,
+                path=destination_display,
+                expected=moved_destination_ownership,
+                label="destination",
+            )
+            backup = _claim_child_as_orphan(
+                publication_authority,
+                destination_display.name,
+                display_parent=destination_display.parent,
+                destination_name=destination_display.name,
+                purpose="previous",
+            )
+
+        def restore_previous(*, context: str) -> None:
+            if destination_was_missing:
+                return
+            assert backup is not None
+            assert moved_destination_ownership is not None
+            try:
+                _restore_exact_previous_directory(
+                    backup,
+                    destination_display,
+                    destination_was_missing=destination_was_missing,
+                    parent_authority=publication_authority,
+                    ownership=moved_destination_ownership,
+                )
+            except BaseException as restore_error:  # noqa: B036 - report isolation
+                raise RuntimeError(
+                    f"{context}; previous output remains isolated at {backup}"
+                ) from restore_error
+
+        try:
+            if destination_was_missing:
+                _require_tree_ownership_at(
+                    publication_authority,
+                    stage_display.name,
+                    path=stage_display,
+                    expected=stage_ownership,
+                    label="staged directory",
+                )
+            else:
+                assert backup is not None
+                assert moved_destination_ownership is not None
+                assert required_destination_inode_identity is not None
+                moved_metadata = _directory_or_missing_at(
+                    publication_authority,
+                    backup.name,
+                    path=backup,
+                    label="moved destination",
+                )
+                if (
+                    moved_metadata is None
+                    or _directory_inode_identity(moved_metadata)
+                    != required_destination_inode_identity
+                ):
+                    raise RuntimeError(
+                        "destination changed at the publication boundary"
+                    )
+                _require_tree_ownership_at(
+                    publication_authority,
+                    backup.name,
+                    path=backup,
+                    expected=moved_destination_ownership,
+                    label="moved destination",
+                    allow_root_rename=True,
+                )
+                if validate_moved_destination is not None:
+                    publication_authority.read_child(
+                        backup.name,
+                        path=backup,
+                        label="moved destination",
+                        expected_ownership=moved_destination_ownership,
+                        callback=validate_moved_destination,
+                    )
+                    _require_tree_ownership_at(
+                        publication_authority,
+                        backup.name,
+                        path=backup,
+                        expected=moved_destination_ownership,
+                        label="moved destination",
+                        allow_root_rename=True,
+                    )
+                _require_tree_ownership_at(
+                    publication_authority,
+                    stage_display.name,
+                    path=stage_display,
+                    expected=stage_ownership,
+                    label="staged directory",
+                )
+        except BaseException:
+            if backup is not None:
+                _restore_claimed_directory(
+                    backup,
+                    destination_display,
+                    parent_authority=publication_authority,
+                    context="destination validation failed after isolation",
+                )
+            raise
+
+        try:
+            publication_authority.rename_noreplace(
+                stage_display.name,
+                destination_display.name,
+            )
+        except BaseException:
+            # If the kernel completed the rename before an asynchronous error,
+            # isolate only a tree that still matches the complete stage token.
+            try:
+                _require_tree_ownership_at(
+                    publication_authority,
+                    destination_display.name,
+                    path=destination_display,
+                    expected=stage_ownership,
+                    label="published staged directory",
+                    allow_root_rename=True,
+                )
+            except BaseException:  # noqa: B036 - probe unknown syscall outcome
+                pass
+            else:
+                _quarantine_destination(
+                    destination_display,
+                    parent_authority=publication_authority,
+                )
+            restore_previous(context="directory publication failed")
+            raise
+
+        try:
+            published_metadata = _directory_or_missing_at(
+                publication_authority,
+                destination_display.name,
+                path=destination_display,
+                label="published staged directory",
+            )
+            if (
+                published_metadata is None
+                or _directory_inode_identity(published_metadata)
+                != required_stage_inode_identity
+            ):
+                raise RuntimeError(
+                    "staged directory changed at the publication boundary"
+                )
+            _require_tree_ownership_at(
+                publication_authority,
+                destination_display.name,
+                path=destination_display,
+                expected=stage_ownership,
+                label="published staged directory",
+                allow_root_rename=True,
+            )
+            if validate_published_destination is not None:
+                publication_authority.read_child(
+                    destination_display.name,
+                    path=destination_display,
+                    label="published staged directory",
+                    expected_ownership=stage_ownership,
+                    callback=validate_published_destination,
+                )
+                _require_tree_ownership_at(
+                    publication_authority,
+                    destination_display.name,
+                    path=destination_display,
+                    expected=stage_ownership,
+                    label="published staged directory",
+                    allow_root_rename=True,
+                )
+        except BaseException as boundary_error:  # noqa: B036 - safe rollback
+            quarantine = _quarantine_destination(
+                destination_display,
+                parent_authority=publication_authority,
+            )
+            restore_previous(
+                context="published directory failed validation and rollback failed"
+            )
+            quarantine_message = (
+                f" at {quarantine}" if quarantine is not None else " after it vanished"
+            )
+            raise RuntimeError(
+                "published directory identity failed validation; suspect output was "
+                f"quarantined{quarantine_message}"
+            ) from boundary_error
+
+        if backup is not None:
+            assert moved_destination_ownership is not None
+            try:
+                _require_tree_ownership_at(
+                    publication_authority,
+                    backup.name,
+                    path=backup,
+                    expected=moved_destination_ownership,
+                    label="previous destination",
+                    allow_root_rename=True,
+                )
+                if validate_moved_destination is not None:
+                    publication_authority.read_child(
+                        backup.name,
+                        path=backup,
+                        label="previous destination",
+                        expected_ownership=moved_destination_ownership,
+                        callback=validate_moved_destination,
+                    )
+                    _require_tree_ownership_at(
+                        publication_authority,
+                        backup.name,
+                        path=backup,
+                        expected=moved_destination_ownership,
+                        label="previous destination",
+                        allow_root_rename=True,
+                    )
+            except BaseException as previous_error:  # noqa: B036 - safe rollback
+                try:
+                    _require_tree_ownership_at(
+                        publication_authority,
+                        backup.name,
+                        path=backup,
+                        expected=moved_destination_ownership,
+                        label="previous destination",
+                        allow_root_rename=True,
+                    )
+                except BaseException as identity_error:  # noqa: B036
+                    raise _PreviousOutputIdentityLost(
+                        "directory publication committed; previous output identity "
+                        "lost; new output remains active and suspect previous root is "
+                        f"at {backup}"
+                    ) from identity_error
+                quarantine = _quarantine_destination(
+                    destination_display,
+                    parent_authority=publication_authority,
+                )
+                restore_previous(
+                    context=(
+                        "previous destination validation failed and rollback failed"
+                    )
+                )
+                raise RuntimeError(
+                    "previous destination failed validation; newly published output "
+                    f"was quarantined at {quarantine}"
+                ) from previous_error
+
+        previous_orphan: DirectoryOrphan | None = None
+        if backup is not None:
+            assert moved_destination_ownership is not None
+            previous_orphan = _orphan_metadata(
+                publication_authority,
+                backup,
+                moved_destination_ownership,
+            )
+
+        try:
+            published_ownership = publication_authority.capture_child(
+                destination_display.name,
+                path=destination_display,
+                label="published staged directory",
+            )
+        except (OSError, ValueError, RuntimeError) as exc:
+            raise RuntimeError(
+                "published staged directory changed during directory publication"
+            ) from exc
+        _require_matching_ownership(
+            published_ownership,
+            stage_ownership,
+            label="published staged directory",
+            allow_root_rename=True,
         )
-    except OSError as restore_error:
-        quarantine_message = (
-            f"; suspect output is quarantined at {quarantine}"
-            if quarantine is not None
-            else ""
-        )
-        raise RuntimeError(
-            "published directory identity failed validation and the previous "
-            f"output could not be restored; it remains at {backup}"
-            f"{quarantine_message}"
-        ) from restore_error
-    return quarantine
+        publication_authority.verify_path_binding()
+        if commit_callback is not None:
+            _fsync_publication_parent_for_commit(publication_authority)
+            commit_callback(stage_ownership, published_ownership, previous_orphan)
+        return previous_orphan
+
+    return perform_publication()
 
 
 def publish_staged_directory(
@@ -987,520 +4104,78 @@ def publish_staged_directory(
     expected_destination_ownership: _TreeOwnership | None | object = (
         _EXPECTED_OWNERSHIP_UNSET
     ),
-    validate_staged_directory: Callable[[Path], None] | None = None,
-    validate_moved_destination: Callable[[Path], None] | None = None,
-    validate_published_destination: Callable[[Path], None] | None = None,
-) -> None:
-    """Publish *stage*, restoring an existing destination on rename failure.
+    validate_staged_directory: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    validate_moved_destination: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    validate_published_destination: (
+        Callable[[PublicationDirectoryReader], None] | None
+    ) = None,
+    parent_descriptor: int | None = None,
+    expected_parent_identity: tuple[int, ...] | None = None,
+) -> DirectoryOrphan | None:
+    """Publish a complete stage through one pinned parent directory authority.
 
-    Both paths must share a parent filesystem so each rename is atomic. A
-    successful call consumes *stage*. If the final rename fails, the previous
-    destination is restored and *stage* remains available to caller cleanup.
+    Every namespace mutation is an atomic no-replace rename relative to the
+    pinned parent descriptor.  The previous tree is intentionally retained as
+    a hidden, fully authenticated orphan for cooperative GC; online recursive
+    deletion cannot be made safe against a hostile same-UID replacement race.
 
-    The destination-to-backup rename is the old tree's ownership linearization
-    point. Callers that observed the destination before building a stage must
-    pass that opaque ``expected_destination_ownership`` token; the helper
-    rejects any completed pre-linearization change. ``validate_staged_directory``
-    reruns the caller's artifact-specific verifier inside the publication
-    boundary. ``validate_moved_destination`` runs against the exact moved old
-    tree both before and after stage publication, while
-    ``validate_published_destination`` verifies the new tree before cleanup.
-    All cleanup preflight runs before deletion. An untrusted published tree is
-    quarantined before the previous root is considered for restoration. During
-    cleanup, the already-verified new tree stays active if the moved old root
-    loses its captured identity. Once destructive cleanup starts, publication
-    is also committed and failures preserve whatever remains at the backup
-    path.
+    The public compatibility wrapper owns the authority it opens.  The
+    publication mechanics live in ``_publish_staged_directory_with_authority``
+    so strict callers can retain a pre-opened authority across publication and
+    synchronous receipt consumption.
     """
 
-    # Only parents are resolved.  Resolving the final destination component
-    # would turn ``destination -> victim`` into ``victim`` and let a raced
-    # symlink redirect the replacement into an unrelated directory.
-    stage = lexical_directory_path(stage)
-    destination = lexical_directory_path(destination)
-    if stage == destination:
+    stage_display = lexical_directory_path(stage)
+    destination_display = lexical_directory_path(destination)
+    if stage_display == destination_display:
         raise ValueError("staged and destination directories must differ")
-    if stage.parent != destination.parent:
+    if stage_display.parent != destination_display.parent:
         raise ValueError("staged and destination directories must share a parent")
-    stage_metadata = _directory_or_missing(stage, label="staged directory")
-    if stage_metadata is None:
-        raise ValueError(f"staged directory does not exist: {stage}")
-    observed_stage_identity = _directory_identity(stage_metadata)
-    if (
-        expected_stage_identity is not None
-        and observed_stage_identity != expected_stage_identity
-    ):
-        raise RuntimeError("staged directory changed before directory publication")
-    required_stage_inode_identity = _directory_inode_identity(stage_metadata)
-    if (
-        expected_stage_root_ownership is not None
-        and required_stage_inode_identity != expected_stage_root_ownership.root_identity
-    ):
-        raise RuntimeError("staged directory root changed before publication")
-    expected_stage_ownership = None
-    if validate_staged_directory is not None:
-        if _SAFE_OWNERSHIP_DIRECTORY_FDS:
-            expected_stage_ownership = capture_directory_ownership(stage)
-        validate_staged_directory(stage)
-        if expected_stage_ownership is not None:
-            _require_tree_ownership(
-                stage,
-                expected_stage_ownership,
-                label="staged directory",
-            )
-    elif validate_published_destination is None:
-        expected_stage_ownership = capture_directory_ownership(stage)
-    destination_metadata = _directory_or_missing(
-        destination,
-        label="destination",
-    )
-    if expected_destination_ownership is not _EXPECTED_OWNERSHIP_UNSET:
-        observed_ownership = (
-            None
-            if destination_metadata is None
-            else capture_directory_ownership(destination)
-        )
-        if observed_ownership != expected_destination_ownership:
-            raise RuntimeError("destination changed before directory publication")
-    if expected_destination_identity is not _EXPECTED_DESTINATION_UNSET:
-        observed_identity = (
-            None
-            if destination_metadata is None
-            else _directory_identity(destination_metadata)
-        )
-        if observed_identity != expected_destination_identity:
-            raise RuntimeError("destination changed before directory publication")
 
-    destination_was_missing = destination_metadata is None
-    if destination_was_missing:
-        try:
-            destination.mkdir(mode=0o700)
-        except FileExistsError as exc:
-            raise ValueError(
-                f"destination appeared during publication: {destination}"
-            ) from exc
-        destination_metadata = _directory_or_missing(
-            destination,
-            label="destination sentinel",
-        )
-
-    if destination_metadata is None:
-        raise RuntimeError("destination sentinel disappeared during publication")
-    required_destination_inode_identity = _directory_inode_identity(
-        destination_metadata
-    )
+    authority_owner = _PublicationAuthorityOwner()
+    primary_error: BaseException | None = None
     try:
-        if destination_was_missing:
-            moved_destination_ownership = capture_directory_ownership(destination)
-        elif expected_destination_ownership is not _EXPECTED_OWNERSHIP_UNSET:
-            moved_destination_ownership = expected_destination_ownership
-        elif validate_moved_destination is None:
-            moved_destination_ownership = capture_directory_ownership(destination)
+        publication_authority = _open_publication_authority(
+            stage_display.parent,
+            parent_resource=parent_descriptor,
+            expected_parent_identity=expected_parent_identity,
+            authority_owner=authority_owner,
+        )
+        return _publish_staged_directory_with_authority(
+            publication_authority,
+            stage_display,
+            destination_display,
+            expected_destination_identity=expected_destination_identity,
+            expected_stage_identity=expected_stage_identity,
+            expected_stage_root_ownership=expected_stage_root_ownership,
+            expected_destination_ownership=expected_destination_ownership,
+            validate_staged_directory=validate_staged_directory,
+            validate_moved_destination=validate_moved_destination,
+            validate_published_destination=validate_published_destination,
+        )
+    except BaseException as exc:
+        primary_error = exc
+        raise
+    finally:
+        if primary_error is None:
+            authority_owner.close()
         else:
-            moved_destination_ownership = None
-    except BaseException:
-        if destination_was_missing:
-            try:
-                destination.rmdir()
-            except OSError:
-                pass
-        raise
-    try:
-        backup = Path(
-            tempfile.mkdtemp(
-                prefix=f".{destination.name}.previous-",
-                dir=str(destination.parent),
-            )
-        )
-        backup.rmdir()
-    except BaseException:
-        if destination_was_missing:
-            destination.rmdir()
-        raise
-
-    if expected_stage_ownership is not None:
-        try:
-            _require_tree_ownership(
-                stage,
-                expected_stage_ownership,
-                label="staged directory",
-            )
-        except Exception as exc:
-            if destination_was_missing:
-                destination.rmdir()
-            raise RuntimeError(
-                "staged directory changed before destination publication"
-            ) from exc
-        except BaseException:
-            if destination_was_missing:
-                try:
-                    destination.rmdir()
-                except OSError:
-                    pass
-            raise
-    try:
-        stage_before_destination_rename = _directory_or_missing(
-            stage,
-            label="staged directory",
-        )
-    except (OSError, ValueError) as exc:
-        if destination_was_missing:
-            destination.rmdir()
-        raise RuntimeError(
-            "staged directory changed before destination publication"
-        ) from exc
-    if (
-        stage_before_destination_rename is None
-        or _directory_inode_identity(stage_before_destination_rename)
-        != required_stage_inode_identity
-    ):
-        if destination_was_missing:
-            destination.rmdir()
-        raise RuntimeError("staged directory changed before destination publication")
-
-    try:
-        os.replace(destination, backup)
-    except BaseException:
-        try:
-            backup_after_error = _directory_or_missing(
-                backup,
-                label="moved destination after interrupted rename",
-            )
-            destination_after_error = _directory_or_missing(
-                destination,
-                label="destination after interrupted rename",
-            )
-        except (OSError, ValueError) as inspection_error:
-            raise RuntimeError(
-                "destination rename was interrupted and its publication state "
-                f"could not be inspected; the previous output may remain at {backup}"
-            ) from inspection_error
-        rename_completed = (
-            backup_after_error is not None
-            and _directory_inode_identity(backup_after_error)
-            == required_destination_inode_identity
-            and destination_after_error is None
-        )
-        if rename_completed:
-            try:
-                _restore_previous_directory(
-                    backup,
-                    destination,
-                    destination_was_missing=destination_was_missing,
-                )
-            except OSError as restore_error:
-                raise RuntimeError(
-                    "destination rename was interrupted after completion and the "
-                    f"previous output could not be restored; inspect {backup} and "
-                    f"{destination}"
-                ) from restore_error
-        elif destination_was_missing and (
-            destination_after_error is not None
-            and _directory_inode_identity(destination_after_error)
-            == required_destination_inode_identity
-        ):
-            try:
-                destination.rmdir()
-            except OSError:
-                # Preserve raced content at a destination that was initially
-                # absent; it must never be recursively cleaned here.
-                pass
-        raise
-    try:
-        moved_metadata = _directory_or_missing(
-            backup,
-            label="moved destination",
-        )
-    except (OSError, ValueError) as exc:
-        try:
-            _restore_previous_directory(
-                backup,
-                destination,
-                destination_was_missing=destination_was_missing,
-            )
-        except OSError as restore_error:
-            raise RuntimeError(
-                "destination changed at the publication boundary and the previous "
-                f"output could not be restored; it remains at {backup}"
-            ) from restore_error
-        raise RuntimeError("destination changed at the publication boundary") from exc
-    except BaseException:
-        try:
-            _restore_previous_directory(
-                backup,
-                destination,
-                destination_was_missing=destination_was_missing,
-            )
-        except OSError as restore_error:
-            raise RuntimeError(
-                "destination boundary inspection was interrupted and the previous "
-                f"output could not be restored; it remains at {backup}"
-            ) from restore_error
-        raise
-    if moved_metadata is None:
-        raise RuntimeError("destination disappeared at the publication boundary")
-    if _directory_inode_identity(moved_metadata) != required_destination_inode_identity:
-        _restore_previous_directory(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-        )
-        raise RuntimeError("destination changed at the publication boundary")
-
-    if moved_destination_ownership is not None:
-        try:
-            _require_tree_ownership(
-                backup,
-                moved_destination_ownership,
-                label="moved destination",
-            )
-        except Exception as ownership_error:
-            try:
-                _restore_previous_directory(
-                    backup,
-                    destination,
-                    destination_was_missing=destination_was_missing,
-                )
-            except OSError as restore_error:
-                raise RuntimeError(
-                    "destination changed at the publication boundary; raced "
-                    f"content remains at {destination}"
-                ) from restore_error
-            raise RuntimeError(
-                "destination changed at the publication boundary"
-            ) from ownership_error
-        except BaseException:
-            try:
-                _restore_previous_directory(
-                    backup,
-                    destination,
-                    destination_was_missing=destination_was_missing,
-                )
-            except OSError as restore_error:
-                raise RuntimeError(
-                    "destination ownership scan was interrupted and the previous "
-                    f"output could not be restored; it remains at {backup}"
-                ) from restore_error
-            raise
-
-    if validate_moved_destination is not None and not destination_was_missing:
-        try:
-            validate_moved_destination(backup)
-        except BaseException:
-            try:
-                _restore_previous_directory(
-                    backup,
-                    destination,
-                    destination_was_missing=False,
-                )
-            except OSError as restore_error:
-                raise RuntimeError(
-                    "moved destination validation failed and the previous output "
-                    f"could not be restored; it remains at {backup}"
-                ) from restore_error
-            raise
-
-    if expected_stage_ownership is not None:
-        try:
-            _require_tree_ownership(
-                stage,
-                expected_stage_ownership,
-                label="staged directory",
-            )
-        except BaseException:
-            _restore_previous_directory(
-                backup,
-                destination,
-                destination_was_missing=destination_was_missing,
-            )
-            raise
-    try:
-        stage_before_publish = _directory_or_missing(
-            stage,
-            label="staged directory",
-        )
-    except (OSError, ValueError) as exc:
-        _restore_previous_directory(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-        )
-        raise RuntimeError("staged directory changed before final publication") from exc
-    except BaseException:
-        try:
-            _restore_previous_directory(
-                backup,
-                destination,
-                destination_was_missing=destination_was_missing,
-            )
-        except OSError as restore_error:
-            raise RuntimeError(
-                "staged directory inspection was interrupted and the previous "
-                f"output could not be restored; it remains at {backup}"
-            ) from restore_error
-        raise
-    if (
-        stage_before_publish is None
-        or _directory_inode_identity(stage_before_publish)
-        != required_stage_inode_identity
-    ):
-        _restore_previous_directory(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-        )
-        raise RuntimeError("staged directory changed before final publication")
-
-    try:
-        os.replace(stage, destination)
-    except BaseException:
-        try:
-            _restore_previous_directory(
-                backup,
-                destination,
-                destination_was_missing=destination_was_missing,
-            )
-        except OSError as restore_error:
-            raise RuntimeError(
-                "directory publication failed and the previous output could "
-                f"not be restored; it remains at {backup}"
-            ) from restore_error
-        raise
-
-    try:
-        published_metadata = _directory_or_missing(
-            destination,
-            label="published staged directory",
-        )
-        if published_metadata is None:
-            raise RuntimeError("staged directory disappeared during publication")
-        if (
-            _directory_inode_identity(published_metadata)
-            != required_stage_inode_identity
-        ):
-            raise RuntimeError("staged directory changed at the publication boundary")
-        if expected_stage_ownership is not None:
-            _require_tree_ownership(
-                destination,
-                expected_stage_ownership,
-                label="published staged directory",
-            )
-        if validate_published_destination is not None:
-            validate_published_destination(destination)
-        if expected_stage_ownership is not None:
-            _require_tree_ownership(
-                destination,
-                expected_stage_ownership,
-                label="published staged directory",
-            )
-    except Exception as boundary_error:
-        quarantine = _recover_invalid_publication(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-            expected_backup_identity=_directory_inode_identity(moved_metadata),
-            published_output_trusted=False,
-        )
-        quarantine_message = (
-            f" at {quarantine}" if quarantine is not None else " because it vanished"
-        )
-        raise RuntimeError(
-            "published directory identity failed validation; suspect output was "
-            f"quarantined{quarantine_message}"
-        ) from boundary_error
-    except BaseException:
-        _recover_invalid_publication(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-            expected_backup_identity=_directory_inode_identity(moved_metadata),
-            published_output_trusted=False,
-        )
-        raise
-    if moved_destination_ownership is not None:
-        try:
-            _require_tree_ownership(
-                backup,
-                moved_destination_ownership,
-                label="previous destination",
-            )
-        except Exception as cleanup_error:
-            try:
-                quarantine = _recover_invalid_publication(
-                    backup,
-                    destination,
-                    destination_was_missing=destination_was_missing,
-                    expected_backup_identity=_directory_inode_identity(moved_metadata),
-                    published_output_trusted=True,
-                )
-            except _PreviousOutputIdentityLost as recovery_error:
-                raise recovery_error from cleanup_error
-            quarantine_message = (
-                f" at {quarantine}"
-                if quarantine is not None
-                else " because it vanished"
-            )
-            raise RuntimeError(
-                "previous destination failed safe cleanup validation; newly "
-                f"published output was quarantined{quarantine_message}"
-            ) from cleanup_error
-    if validate_moved_destination is not None and not destination_was_missing:
-        try:
-            validate_moved_destination(backup)
-        except Exception as cleanup_error:
-            try:
-                quarantine = _recover_invalid_publication(
-                    backup,
-                    destination,
-                    destination_was_missing=destination_was_missing,
-                    expected_backup_identity=_directory_inode_identity(moved_metadata),
-                    published_output_trusted=True,
-                )
-            except _PreviousOutputIdentityLost as recovery_error:
-                raise recovery_error from cleanup_error
-            quarantine_message = (
-                f" at {quarantine}"
-                if quarantine is not None
-                else " because it vanished"
-            )
-            raise RuntimeError(
-                "previous destination failed safe cleanup validation; newly "
-                f"published output was quarantined{quarantine_message}"
-            ) from cleanup_error
-
-    removal_state = _RemovalState()
-    try:
-        _remove_owned_directory(
-            backup,
-            _directory_inode_identity(moved_metadata),
-            removal_state=removal_state,
-        )
-    except Exception as cleanup_error:
-        if removal_state.destructive_started:
-            raise RuntimeError(
-                "directory publication committed; cleanup incomplete; previous "
-                f"output remains partially at {backup}"
-            ) from cleanup_error
-        quarantine = _recover_invalid_publication(
-            backup,
-            destination,
-            destination_was_missing=destination_was_missing,
-            expected_backup_identity=_directory_inode_identity(moved_metadata),
-            published_output_trusted=True,
-        )
-        quarantine_message = (
-            f" at {quarantine}" if quarantine is not None else " because it vanished"
-        )
-        raise RuntimeError(
-            "previous destination failed safe cleanup validation; newly "
-            f"published output was quarantined{quarantine_message}"
-        ) from cleanup_error
+            authority_owner.close_after_error(primary_error)
 
 
 __all__ = [
     "DirectoryEntryPolicy",
+    "DirectoryOrphan",
+    "PublicationAuthenticatedFile",
+    "PublicationDirectoryReader",
+    "PublicationFileSnapshot",
     "TreeFileRecord",
     "capture_directory_ownership",
+    "capture_directory_ownership_if_exists",
     "directory_ownership_digest",
     "directory_ownership_entry_identities",
     "directory_ownership_file_records",
@@ -1509,5 +4184,8 @@ __all__ = [
     "directory_ownership_root_version_identity",
     "discard_owned_directory",
     "lexical_directory_path",
+    "publication_parent_identity",
     "publish_staged_directory",
+    "reopen_authenticated_directory",
+    "require_publishable_directory_ownership",
 ]

--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -63,6 +63,7 @@ class _TreeOwnership:
     entries: int
     byte_count: int
     metadata_bytes: int
+    inventory: tuple[tuple[str, str], ...]
 
 
 class _PreviousOutputIdentityLost(RuntimeError):
@@ -275,6 +276,7 @@ def _scan_owned_directory(
     root_device: int,
     mount_points: frozenset[str],
     budget: _OwnershipBudget,
+    inventory: list[tuple[str, str]],
     depth: int,
     required_root_file: bytes | None = None,
     allow_empty_root: bool = False,
@@ -352,6 +354,7 @@ def _scan_owned_directory(
                     root_device=root_device,
                     mount_points=mount_points,
                     budget=budget,
+                    inventory=inventory,
                     depth=depth + 1,
                 )
                 after = os.fstat(child_descriptor)
@@ -378,6 +381,7 @@ def _scan_owned_directory(
             _ownership_hash_field(entry_hasher, relative)
             entry_hasher.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
             entry_hasher.update(child_digest)
+            inventory.append((os.fsdecode(relative), "directory"))
         elif stat.S_ISREG(metadata.st_mode):
             size, digest = _hash_owned_regular_file(
                 descriptor,
@@ -393,6 +397,7 @@ def _scan_owned_directory(
             entry_hasher.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
             entry_hasher.update(size.to_bytes(8, "big"))
             entry_hasher.update(digest_bytes)
+            inventory.append((os.fsdecode(relative), "file"))
         else:
             raise RuntimeError(
                 f"directory ownership scan refuses special content: {child_path}"
@@ -458,6 +463,7 @@ def capture_directory_ownership(
             entries=0,
             byte_count=0,
             metadata_bytes=0,
+            inventory=(),
         )
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     flags |= getattr(os, "O_CLOEXEC", 0)
@@ -467,6 +473,7 @@ def capture_directory_ownership(
         if _ownership_binding_identity(opened) != _ownership_binding_identity(metadata):
             raise RuntimeError(f"directory ownership root changed: {path}")
         budget = _OwnershipBudget()
+        inventory: list[tuple[str, str]] = []
         digest = _scan_owned_directory(
             descriptor,
             path,
@@ -474,6 +481,7 @@ def capture_directory_ownership(
             root_device=opened.st_dev,
             mount_points=_linux_mount_points(),
             budget=budget,
+            inventory=inventory,
             depth=0,
             required_root_file=required_root_file_bytes,
             allow_empty_root=allow_empty_root,
@@ -494,7 +502,28 @@ def capture_directory_ownership(
         entries=budget.entries,
         byte_count=budget.byte_count,
         metadata_bytes=budget.metadata_bytes,
+        inventory=tuple(sorted(inventory)),
     )
+
+
+def directory_ownership_inventory(
+    ownership: _TreeOwnership,
+) -> tuple[tuple[str, str], ...]:
+    """Return the bounded no-follow inventory captured with an ownership token."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.inventory
+
+
+def directory_ownership_root_identity(
+    ownership: _TreeOwnership,
+) -> tuple[int, ...]:
+    """Return the no-follow root identity bound by an ownership token."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    return ownership.root_identity
 
 
 def _require_tree_ownership(
@@ -1356,6 +1385,8 @@ def publish_staged_directory(
 
 __all__ = [
     "capture_directory_ownership",
+    "directory_ownership_inventory",
+    "directory_ownership_root_identity",
     "discard_owned_directory",
     "lexical_directory_path",
     "publish_staged_directory",

--- a/codenib/_bounded_json.py
+++ b/codenib/_bounded_json.py
@@ -1,0 +1,456 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Incremental, complexity-bounded parsing for large JSON document arrays."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Iterator
+from typing import Any, BinaryIO, Protocol
+
+_READ_BYTES = 1024 * 1024
+DEFAULT_MAX_ARRAY_ITEMS = 1_000_000
+DEFAULT_MAX_ELEMENT_BYTES = 64 * 1024 * 1024
+DEFAULT_MAX_NODES_PER_ELEMENT = 100_000
+DEFAULT_MAX_LEXICAL_TOKENS = 200_000
+DEFAULT_MAX_DEPTH = 64
+DEFAULT_MAX_KEY_BYTES = 4_096
+
+
+class BinaryReader(Protocol):
+    def read(self, size: int = -1) -> bytes: ...
+
+
+def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_number(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def validate_json_complexity(
+    value: Any,
+    *,
+    label: str,
+    max_nodes: int = DEFAULT_MAX_NODES_PER_ELEMENT,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_key_bytes: int = DEFAULT_MAX_KEY_BYTES,
+) -> None:
+    """Reject one decoded value before recursive consumers can exhaust resources."""
+
+    # Depth is one-based in both the lexical framer and decoded-tree check: the
+    # element itself is level one and its direct children are level two.
+    stack: list[tuple[Any, int]] = [(value, 1)]
+    nodes = 0
+    while stack:
+        current, depth = stack.pop()
+        nodes += 1
+        if nodes > max_nodes:
+            raise ValueError(f"{label} exceeds its {max_nodes}-node limit")
+        if depth > max_depth:
+            raise ValueError(f"{label} exceeds its {max_depth}-level depth limit")
+        if isinstance(current, dict):
+            for key, child in current.items():
+                if len(key.encode("utf-8", errors="surrogatepass")) > max_key_bytes:
+                    raise ValueError(
+                        f"{label} contains a key exceeding {max_key_bytes} bytes"
+                    )
+                stack.append((child, depth + 1))
+        elif isinstance(current, list):
+            stack.extend((child, depth + 1) for child in current)
+
+
+class _ByteStream:
+    def __init__(self, source: BinaryReader) -> None:
+        self._source = source
+        self._block = b""
+        self._position = 0
+        self._eof = False
+        self.offset = 0
+
+    def current_block(self) -> tuple[bytes, int] | None:
+        """Return the unread block slice without a Python call per byte."""
+
+        while self._position >= len(self._block):
+            if self._eof:
+                return None
+            self._block = self._source.read(_READ_BYTES)
+            self._position = 0
+            if not self._block:
+                self._eof = True
+                return None
+        return self._block, self._position
+
+    def advance(self, count: int) -> None:
+        if count < 0 or self._position + count > len(self._block):
+            raise AssertionError("invalid bounded JSON stream advance")
+        self._position += count
+        self.offset += count
+
+    def next(self) -> int | None:
+        current = self.current_block()
+        if current is None:
+            return None
+        block, position = current
+        value = block[position]
+        self.advance(1)
+        return value
+
+
+_JSON_WHITESPACE = frozenset(b" \t\r\n")
+_ATOM_DELIMITERS = frozenset(b" \t\r\n,]}:")
+
+
+def _next_non_whitespace(stream: _ByteStream) -> int | None:
+    while (value := stream.next()) is not None:
+        if value not in _JSON_WHITESPACE:
+            return value
+    return None
+
+
+def _frame_json_element(
+    stream: _ByteStream,
+    first: int,
+    *,
+    label: str,
+    max_element_bytes: int,
+    max_tokens: int,
+    max_depth: int,
+) -> tuple[bytearray, int]:
+    """Frame one complete array element before allocating its decoded DOM."""
+
+    payload = bytearray()
+    stack: list[int] = []
+    in_string = False
+    escaped = False
+    string_bytes = 0
+    in_atom = False
+    atom_bytes = 0
+    token_count = 0
+    first_pending = True
+
+    def reserve(count: int) -> None:
+        if len(payload) + count > max_element_bytes:
+            raise ValueError(f"{label} element exceeds {max_element_bytes} bytes")
+
+    while True:
+        if first_pending:
+            # ``first`` was already consumed by _next_non_whitespace.
+            block = bytes((first,))
+            position = 0
+            first_pending = False
+            synthetic = True
+        else:
+            current_block = stream.current_block()
+            if current_block is None:
+                raise ValueError(f"{label} is truncated JSON")
+            block, position = current_block
+            synthetic = False
+        index = position
+        while index < len(block):
+            current = block[index]
+
+            if in_string:
+                if escaped:
+                    escaped = False
+                    string_bytes += 1
+                    index += 1
+                    continue
+                quote = block.find(b'"', index)
+                slash = block.find(b"\\", index)
+                candidates = tuple(item for item in (quote, slash) if item >= 0)
+                special = min(candidates) if candidates else -1
+                if special < 0:
+                    string_bytes += len(block) - index
+                    index = len(block)
+                    break
+                string_bytes += special - index + 1
+                if block[special] == ord("\\"):
+                    escaped = True
+                else:
+                    in_string = False
+                index = special + 1
+                if string_bytes > max_element_bytes:
+                    raise ValueError(
+                        f"{label} string exceeds {max_element_bytes} bytes"
+                    )
+                continue
+
+            if in_atom:
+                if current in _ATOM_DELIMITERS:
+                    in_atom = False
+                    atom_bytes = 0
+                else:
+                    atom_bytes += 1
+                    if atom_bytes > 1_024:
+                        raise ValueError(f"{label} number/literal exceeds 1024 bytes")
+                    index += 1
+                    continue
+
+            if not stack and current in {ord(","), ord("]")}:
+                reserve(index - position)
+                payload.extend(block[position:index])
+                if not synthetic:
+                    stream.advance(index - position + 1)
+                while payload and payload[-1] in _JSON_WHITESPACE:
+                    payload.pop()
+                if not payload:
+                    raise ValueError(f"{label} contains an empty JSON array element")
+                return payload, current
+
+            if current == ord('"'):
+                token_count += 1
+                in_string = True
+                string_bytes = 0
+            elif current in {ord("{"), ord("[")}:
+                token_count += 1
+                stack.append(current)
+                if len(stack) > max_depth:
+                    raise ValueError(
+                        f"{label} exceeds its {max_depth}-level depth limit"
+                    )
+            elif current in {ord("}"), ord("]")}:
+                expected = ord("{") if current == ord("}") else ord("[")
+                if not stack or stack[-1] != expected:
+                    raise ValueError(f"{label} contains mismatched JSON delimiters")
+                stack.pop()
+            elif current in b"-0123456789tfn":
+                token_count += 1
+                in_atom = True
+                atom_bytes = 1
+            if token_count > max_tokens:
+                raise ValueError(f"{label} exceeds its {max_tokens}-token limit")
+            index += 1
+
+        reserve(len(block) - position)
+        payload.extend(block[position:])
+        if not synthetic:
+            stream.advance(len(block) - position)
+    raise ValueError(f"{label} is truncated JSON")
+
+
+def _bounded_parse_int(value: str) -> int:
+    if len(value) > 1_024:
+        raise ValueError("JSON integer exceeds its 1024-character limit")
+    return int(value)
+
+
+def _bounded_parse_float(value: str) -> float:
+    if len(value) > 1_024:
+        raise ValueError("JSON number exceeds its 1024-character limit")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("JSON number is not finite")
+    return parsed
+
+
+def iter_bounded_json_array(
+    source: BinaryReader,
+    *,
+    label: str,
+    max_items: int = DEFAULT_MAX_ARRAY_ITEMS,
+    max_element_bytes: int = DEFAULT_MAX_ELEMENT_BYTES,
+    max_nodes_per_element: int = DEFAULT_MAX_NODES_PER_ELEMENT,
+    max_lexical_tokens: int = DEFAULT_MAX_LEXICAL_TOKENS,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_key_bytes: int = DEFAULT_MAX_KEY_BYTES,
+) -> Iterator[Any]:
+    """Yield a top-level JSON array without retaining the complete input or DOM."""
+
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value <= 0
+        for value in (
+            max_items,
+            max_element_bytes,
+            max_nodes_per_element,
+            max_lexical_tokens,
+            max_depth,
+            max_key_bytes,
+        )
+    ):
+        raise ValueError("bounded JSON limits must be positive integers")
+    stream = _ByteStream(source)
+    decoder = json.JSONDecoder(
+        object_pairs_hook=_reject_duplicate_object,
+        parse_constant=_reject_nonfinite_number,
+        parse_int=_bounded_parse_int,
+        parse_float=_bounded_parse_float,
+    )
+    first = _next_non_whitespace(stream)
+    if first != ord("["):
+        raise ValueError(f"{label} must be a JSON list")
+    item_count = 0
+    first = _next_non_whitespace(stream)
+    if first == ord("]"):
+        first = None
+    elif first is None:
+        raise ValueError(f"{label} is truncated JSON")
+    while True:
+        if first is None:
+            break
+        element_offset = stream.offset - 1
+        while True:
+            try:
+                framed, delimiter = _frame_json_element(
+                    stream,
+                    first,
+                    label=label,
+                    max_element_bytes=max_element_bytes,
+                    max_tokens=max_lexical_tokens,
+                    max_depth=max_depth,
+                )
+                text = framed.decode("utf-8", errors="strict")
+                value, end = decoder.raw_decode(text, 0)
+                if end != len(text):
+                    raise ValueError(f"{label} element contains trailing data")
+                del text, framed
+                break
+            except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+                raise ValueError(
+                    f"{label} element {item_count} at byte {element_offset} "
+                    "contains invalid JSON"
+                ) from exc
+        validate_json_complexity(
+            value,
+            label=f"{label} element {item_count}",
+            max_nodes=max_nodes_per_element,
+            max_depth=max_depth,
+            max_key_bytes=max_key_bytes,
+        )
+        item_count += 1
+        if item_count > max_items:
+            raise ValueError(f"{label} exceeds its {max_items}-item limit")
+        yield value
+        if delimiter == ord("]"):
+            first = None
+        else:
+            first = _next_non_whitespace(stream)
+            if first is None:
+                raise ValueError(f"{label} is truncated JSON")
+            if first == ord("]"):
+                raise ValueError(f"{label} has a trailing JSON array comma")
+
+    if _next_non_whitespace(stream) is not None:
+        raise ValueError(f"{label} contains trailing data")
+
+
+def _indent(level: int) -> bytes:
+    return b"  " * level
+
+
+def _canonical_string_chunks(value: str) -> Iterator[bytes]:
+    from json.encoder import encode_basestring_ascii
+
+    yield b'"'
+    for offset in range(0, len(value), 64 * 1024):
+        encoded = encode_basestring_ascii(value[offset : offset + 64 * 1024])
+        yield encoded[1:-1].encode("ascii")
+    yield b'"'
+
+
+def canonical_json_value_chunks(value: Any, *, level: int = 0) -> Iterator[bytes]:
+    """Stream the exact stdlib canonical representation of one decoded value."""
+
+    if value is None:
+        yield b"null"
+    elif value is True:
+        yield b"true"
+    elif value is False:
+        yield b"false"
+    elif isinstance(value, str):
+        yield from _canonical_string_chunks(value)
+    elif isinstance(value, int):
+        yield str(value).encode("ascii")
+    elif isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("JSON number is not finite")
+        yield repr(value).encode("ascii")
+    elif isinstance(value, list):
+        if not value:
+            yield b"[]"
+            return
+        yield b"[\n"
+        for index, item in enumerate(value):
+            if index:
+                yield b",\n"
+            yield _indent(level + 1)
+            yield from canonical_json_value_chunks(item, level=level + 1)
+        yield b"\n" + _indent(level) + b"]"
+    elif isinstance(value, dict):
+        if not value:
+            yield b"{}"
+            return
+        yield b"{\n"
+        for index, key in enumerate(sorted(value)):
+            if index:
+                yield b",\n"
+            yield _indent(level + 1)
+            yield from _canonical_string_chunks(key)
+            yield b": "
+            yield from canonical_json_value_chunks(value[key], level=level + 1)
+        yield b"\n" + _indent(level) + b"}"
+    else:
+        raise TypeError(f"unsupported decoded JSON value: {type(value).__name__}")
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return b"".join(canonical_json_value_chunks(value))
+
+
+def canonical_json_array_chunks(values: Iterable[Any]) -> Iterator[bytes]:
+    """Encode values exactly like ``json.dumps(list(values), indent=2, ...)``."""
+
+    iterator = iter(values)
+    emitted = False
+    try:
+        for value in iterator:
+            if not emitted:
+                yield b"[\n"
+                emitted = True
+            else:
+                yield b",\n"
+            yield b"  "
+            yield from canonical_json_value_chunks(value, level=1)
+        yield b"\n]\n" if emitted else b"[]\n"
+    finally:
+        close_iterator = getattr(iterator, "close", None)
+        if callable(close_iterator):
+            close_iterator()
+
+
+def write_chunks(handle: BinaryIO, chunks: Iterable[bytes]) -> tuple[int, str]:
+    """Write chunks while returning their size and SHA-256."""
+
+    import hashlib
+
+    size = 0
+    digest = hashlib.sha256()
+    for chunk in chunks:
+        handle.write(chunk)
+        size += len(chunk)
+        digest.update(chunk)
+    return size, digest.hexdigest()
+
+
+__all__ = [
+    "DEFAULT_MAX_ARRAY_ITEMS",
+    "DEFAULT_MAX_DEPTH",
+    "DEFAULT_MAX_ELEMENT_BYTES",
+    "DEFAULT_MAX_KEY_BYTES",
+    "DEFAULT_MAX_NODES_PER_ELEMENT",
+    "canonical_json_array_chunks",
+    "canonical_json_bytes",
+    "canonical_json_value_chunks",
+    "iter_bounded_json_array",
+    "validate_json_complexity",
+    "write_chunks",
+]

--- a/codenib/_bounded_json.py
+++ b/codenib/_bounded_json.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from collections.abc import Iterable, Iterator
 from typing import Any, BinaryIO, Protocol
 
@@ -83,7 +84,12 @@ class _ByteStream:
         while self._position >= len(self._block):
             if self._eof:
                 return None
-            self._block = self._source.read(_READ_BYTES)
+            block = self._source.read(_READ_BYTES)
+            if type(block) is not bytes or len(block) > _READ_BYTES:
+                raise ValueError(
+                    "bounded JSON reader returned an invalid or oversized block"
+                )
+            self._block = block
             self._position = 0
             if not self._block:
                 self._eof = True
@@ -108,6 +114,7 @@ class _ByteStream:
 
 _JSON_WHITESPACE = frozenset(b" \t\r\n")
 _ATOM_DELIMITERS = frozenset(b" \t\r\n,]}:")
+_STRING_SPECIAL = re.compile(rb'["\\]')
 
 
 def _next_non_whitespace(stream: _ByteStream) -> int | None:
@@ -123,24 +130,42 @@ def _frame_json_element(
     *,
     label: str,
     max_element_bytes: int,
+    max_nodes: int,
     max_tokens: int,
     max_depth: int,
 ) -> tuple[bytearray, int]:
     """Frame one complete array element before allocating its decoded DOM."""
 
     payload = bytearray()
-    stack: list[int] = []
+    stack: list[list[Any]] = []
     in_string = False
+    string_is_key = False
     escaped = False
     string_bytes = 0
     in_atom = False
     atom_bytes = 0
     token_count = 0
+    node_count = 0
     first_pending = True
 
     def reserve(count: int) -> None:
         if len(payload) + count > max_element_bytes:
             raise ValueError(f"{label} element exceeds {max_element_bytes} bytes")
+
+    def start_value() -> None:
+        nonlocal node_count
+        # Match ``validate_json_complexity``: the element root is level one,
+        # and each containing object/array adds one level for its children.
+        depth = len(stack) + 1
+        if depth > max_depth:
+            raise ValueError(f"{label} exceeds its {max_depth}-level depth limit")
+        node_count += 1
+        if node_count > max_nodes:
+            raise ValueError(f"{label} exceeds its {max_nodes}-node limit")
+
+    def finish_value() -> None:
+        if stack:
+            stack[-1][1] = "comma_or_end"
 
     while True:
         if first_pending:
@@ -165,19 +190,21 @@ def _frame_json_element(
                     string_bytes += 1
                     index += 1
                     continue
-                quote = block.find(b'"', index)
-                slash = block.find(b"\\", index)
-                candidates = tuple(item for item in (quote, slash) if item >= 0)
-                special = min(candidates) if candidates else -1
-                if special < 0:
+                match = _STRING_SPECIAL.search(block, index)
+                if match is None:
                     string_bytes += len(block) - index
                     index = len(block)
                     break
+                special = match.start()
                 string_bytes += special - index + 1
                 if block[special] == ord("\\"):
                     escaped = True
                 else:
                     in_string = False
+                    if string_is_key:
+                        stack[-1][1] = "colon"
+                    else:
+                        finish_value()
                 index = special + 1
                 if string_bytes > max_element_bytes:
                     raise ValueError(
@@ -189,6 +216,7 @@ def _frame_json_element(
                 if current in _ATOM_DELIMITERS:
                     in_atom = False
                     atom_bytes = 0
+                    finish_value()
                 else:
                     atom_bytes += 1
                     if atom_bytes > 1_024:
@@ -211,22 +239,33 @@ def _frame_json_element(
                 token_count += 1
                 in_string = True
                 string_bytes = 0
+                string_is_key = bool(
+                    stack and stack[-1][0] == ord("{") and stack[-1][1] == "key_or_end"
+                )
+                if not string_is_key:
+                    start_value()
             elif current in {ord("{"), ord("[")}:
                 token_count += 1
-                stack.append(current)
-                if len(stack) > max_depth:
-                    raise ValueError(
-                        f"{label} exceeds its {max_depth}-level depth limit"
-                    )
+                start_value()
+                state = "key_or_end" if current == ord("{") else "value_or_end"
+                stack.append([current, state])
             elif current in {ord("}"), ord("]")}:
                 expected = ord("{") if current == ord("}") else ord("[")
-                if not stack or stack[-1] != expected:
+                if not stack or stack[-1][0] != expected:
                     raise ValueError(f"{label} contains mismatched JSON delimiters")
                 stack.pop()
+                finish_value()
             elif current in b"-0123456789tfn":
                 token_count += 1
+                start_value()
                 in_atom = True
                 atom_bytes = 1
+            elif current == ord(":") and stack and stack[-1][0] == ord("{"):
+                stack[-1][1] = "value"
+            elif current == ord(",") and stack:
+                stack[-1][1] = (
+                    "key_or_end" if stack[-1][0] == ord("{") else "value_or_end"
+                )
             if token_count > max_tokens:
                 raise ValueError(f"{label} exceeds its {max_tokens}-token limit")
             index += 1
@@ -297,28 +336,32 @@ def iter_bounded_json_array(
     while True:
         if first is None:
             break
+        if item_count >= max_items:
+            raise ValueError(f"{label} exceeds its {max_items}-item limit")
         element_offset = stream.offset - 1
-        while True:
+        framed, delimiter = _frame_json_element(
+            stream,
+            first,
+            label=label,
+            max_element_bytes=max_element_bytes,
+            max_nodes=max_nodes_per_element,
+            max_tokens=max_lexical_tokens,
+            max_depth=max_depth,
+        )
+        try:
             try:
-                framed, delimiter = _frame_json_element(
-                    stream,
-                    first,
-                    label=label,
-                    max_element_bytes=max_element_bytes,
-                    max_tokens=max_lexical_tokens,
-                    max_depth=max_depth,
-                )
                 text = framed.decode("utf-8", errors="strict")
                 value, end = decoder.raw_decode(text, 0)
                 if end != len(text):
                     raise ValueError(f"{label} element contains trailing data")
-                del text, framed
-                break
-            except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
-                raise ValueError(
-                    f"{label} element {item_count} at byte {element_offset} "
-                    "contains invalid JSON"
-                ) from exc
+            finally:
+                del framed
+        except (RecursionError, ValueError) as exc:
+            raise ValueError(
+                f"{label} element {item_count} at byte {element_offset} "
+                "contains invalid JSON"
+            ) from exc
+        del text
         validate_json_complexity(
             value,
             label=f"{label} element {item_count}",
@@ -327,8 +370,6 @@ def iter_bounded_json_array(
             max_key_bytes=max_key_bytes,
         )
         item_count += 1
-        if item_count > max_items:
-            raise ValueError(f"{label} exceeds its {max_items}-item limit")
         yield value
         if delimiter == ord("]"):
             first = None

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -1,0 +1,596 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Descriptor-bound reads and writes for already-captured directory trees."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import stat
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Iterator
+
+from ._atomic_directory import (
+    TreeFileRecord,
+    capture_directory_ownership,
+    directory_ownership_entry_identities,
+    directory_ownership_file_records,
+    directory_ownership_root_identity,
+    directory_ownership_root_version_identity,
+    discard_owned_directory,
+    lexical_directory_path,
+    publish_staged_directory,
+)
+
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+_MAX_RELATIVE_PATH_BYTES = 4_096
+_MAX_COMPONENTS = 256
+_COPY_BYTES = 1024 * 1024
+
+
+def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _root_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _captured_version_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0,
+        getattr(metadata, "st_file_attributes", 0),
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+    )
+
+
+def _relative_path(value: str | Path | PurePosixPath) -> PurePosixPath:
+    raw = value.as_posix() if isinstance(value, (Path, PurePosixPath)) else value
+    if not isinstance(raw, str) or not raw or "\\" in raw or "\x00" in raw:
+        raise ValueError("captured directory path must be relative POSIX")
+    relative = PurePosixPath(raw)
+    if (
+        relative.is_absolute()
+        or relative.as_posix() != raw
+        or any(part in {"", ".", ".."} for part in relative.parts)
+        or len(relative.parts) > _MAX_COMPONENTS
+        or len(os.fsencode(raw)) > _MAX_RELATIVE_PATH_BYTES
+    ):
+        raise ValueError("captured directory path must be normalized and bounded")
+    return relative
+
+
+class AuthenticatedFile:
+    """One opened file whose bytes must match the initial tree record."""
+
+    def __init__(
+        self,
+        descriptor: int,
+        opened: os.stat_result,
+        record: TreeFileRecord,
+    ) -> None:
+        self.descriptor = descriptor
+        self.opened = opened
+        self.record = record
+        self._hasher = hashlib.sha256()
+        self._consumed = 0
+        self._authenticated = False
+        self._closed = False
+
+    @property
+    def size(self) -> int:
+        return self.record.size
+
+    def read(self, size: int = -1) -> bytes:
+        if self._closed:
+            raise ValueError("authenticated file is closed")
+        remaining = self.record.size - self._consumed
+        if size is None or size < 0:
+            requested = remaining + 1
+        else:
+            requested = min(size, remaining + 1)
+        if requested == 0:
+            return b""
+        try:
+            block = os.read(self.descriptor, requested)
+        except OSError as exc:
+            raise ValueError(
+                f"captured file is not readable: {self.record.path}"
+            ) from exc
+        if self._consumed + len(block) > self.record.size:
+            raise ValueError(f"captured file grew while reading: {self.record.path}")
+        self._hasher.update(block)
+        self._consumed += len(block)
+        return block
+
+    def authenticate(self) -> None:
+        if self._authenticated:
+            return
+        while self._consumed < self.record.size:
+            block = self.read(min(_COPY_BYTES, self.record.size - self._consumed))
+            if not block:
+                raise ValueError(f"captured file was truncated: {self.record.path}")
+        try:
+            if os.read(self.descriptor, 1):
+                raise ValueError(
+                    f"captured file grew while reading: {self.record.path}"
+                )
+            after = os.fstat(self.descriptor)
+        except OSError as exc:
+            raise ValueError(
+                f"captured file changed while reading: {self.record.path}"
+            ) from exc
+        if (
+            _file_identity(after) != _file_identity(self.opened)
+            or self._hasher.hexdigest() != self.record.sha256
+        ):
+            raise ValueError(
+                f"captured file differs from its initial record: {self.record.path}"
+            )
+        self._authenticated = True
+
+    def rewind_authenticated(self) -> int:
+        """Authenticate the bytes, rewind the same fd, and return that fd."""
+
+        self.authenticate()
+        try:
+            os.lseek(self.descriptor, 0, os.SEEK_SET)
+        except OSError as exc:
+            raise ValueError(
+                f"captured file cannot be rewound: {self.record.path}"
+            ) from exc
+        return self.descriptor
+
+    def verify_unchanged(self) -> None:
+        self.authenticate()
+        try:
+            after = os.fstat(self.descriptor)
+        except OSError as exc:
+            raise ValueError(
+                f"captured file changed after authentication: {self.record.path}"
+            ) from exc
+        if _file_identity(after) != _file_identity(self.opened):
+            raise ValueError(
+                f"captured file changed after authentication: {self.record.path}"
+            )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            os.close(self.descriptor)
+        except OSError:
+            pass
+
+    def __enter__(self) -> AuthenticatedFile:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        try:
+            if exc_type is None:
+                self.authenticate()
+        finally:
+            self.close()
+
+
+class CapturedDirectoryReader:
+    """Read a fixed ownership token through one pinned no-follow root fd."""
+
+    def __init__(self, root: Path, ownership: object) -> None:
+        if not hasattr(os, "O_DIRECTORY") or not hasattr(os, "O_NOFOLLOW"):
+            raise RuntimeError(
+                "captured directory reads require no-follow directory descriptors"
+            )
+        self.root = lexical_directory_path(root)
+        self.ownership = ownership
+        self._descriptor = -1
+        self._records = {
+            record.path: record
+            for record in directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+        }
+        self._entry_identities = {
+            path: (kind, identity)
+            for path, kind, identity in directory_ownership_entry_identities(
+                ownership  # type: ignore[arg-type]
+            )
+        }
+        try:
+            flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+            self._descriptor = os.open(self.root, flags)
+            opened = os.fstat(self._descriptor)
+            if _root_identity(opened) != directory_ownership_root_identity(
+                ownership
+            ) or _captured_version_identity(
+                opened
+            ) != directory_ownership_root_version_identity(
+                ownership
+            ):
+                raise RuntimeError("captured directory root changed after capture")
+            self._opened_root = opened
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        if self._descriptor >= 0:
+            try:
+                os.close(self._descriptor)
+            except OSError:
+                pass
+            self._descriptor = -1
+
+    def __enter__(self) -> CapturedDirectoryReader:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    @property
+    def file_records(self) -> tuple[TreeFileRecord, ...]:
+        return tuple(sorted(self._records.values(), key=lambda record: record.path))
+
+    def record(self, relative: str | Path | PurePosixPath) -> TreeFileRecord:
+        normalized = _relative_path(relative).as_posix()
+        try:
+            return self._records[normalized]
+        except KeyError as exc:
+            raise ValueError(
+                f"captured directory has no initial file record: {normalized}"
+            ) from exc
+
+    def verify_root(self) -> None:
+        try:
+            opened = os.fstat(self._descriptor)
+            path_metadata = self.root.lstat()
+        except OSError as exc:
+            raise RuntimeError("captured directory root changed") from exc
+        if _file_identity(opened) != _file_identity(
+            self._opened_root
+        ) or _root_identity(path_metadata) != _root_identity(opened):
+            raise RuntimeError("captured directory root changed")
+
+    def _open(self, relative: PurePosixPath) -> tuple[int, os.stat_result]:
+        record = self.record(relative)
+        directory_descriptor = os.dup(self._descriptor)
+        source_descriptor = -1
+        try:
+            directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            directory_flags |= getattr(os, "O_CLOEXEC", 0) | getattr(
+                os, "O_NONBLOCK", 0
+            )
+            prefix: list[str] = []
+            for part in relative.parts[:-1]:
+                prefix.append(part)
+                prefix_text = "/".join(prefix)
+                expected_kind, expected_identity = self._entry_identities.get(
+                    prefix_text,
+                    (None, None),
+                )
+                before = os.stat(
+                    part,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if (
+                    expected_kind != "directory"
+                    or expected_identity is None
+                    or _captured_version_identity(before) != expected_identity
+                    or not stat.S_ISDIR(before.st_mode)
+                    or bool(
+                        getattr(before, "st_file_attributes", 0)
+                        & _FILE_ATTRIBUTE_REPARSE_POINT
+                    )
+                ):
+                    raise ValueError(
+                        f"captured path is not a real directory: {relative}"
+                    )
+                child = -1
+                try:
+                    child = os.open(
+                        part,
+                        directory_flags,
+                        dir_fd=directory_descriptor,
+                    )
+                    opened = os.fstat(child)
+                    if _root_identity(opened) != _root_identity(before):
+                        raise ValueError(
+                            f"captured directory changed while opening: {relative}"
+                        )
+                except BaseException:
+                    if child >= 0:
+                        os.close(child)
+                    raise
+                os.close(directory_descriptor)
+                directory_descriptor = child
+
+            name = relative.parts[-1]
+            expected_kind, expected_identity = self._entry_identities.get(
+                relative.as_posix(),
+                (None, None),
+            )
+            before = os.stat(
+                name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or expected_kind != "file"
+                or expected_identity is None
+                or _captured_version_identity(before) != expected_identity
+                or before.st_nlink != 1
+                or bool(
+                    getattr(before, "st_file_attributes", 0)
+                    & _FILE_ATTRIBUTE_REPARSE_POINT
+                )
+            ):
+                raise ValueError(f"captured path is not a private file: {relative}")
+            flags = os.O_RDONLY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+            source_descriptor = os.open(name, flags, dir_fd=directory_descriptor)
+            opened = os.fstat(source_descriptor)
+            if (
+                _file_identity(opened) != _file_identity(before)
+                or stat.S_IMODE(opened.st_mode) != record.mode
+                or opened.st_size != record.size
+            ):
+                raise ValueError(f"captured file changed while opening: {relative}")
+            owned = source_descriptor
+            source_descriptor = -1
+            return owned, opened
+        except OSError as exc:
+            raise ValueError(
+                f"captured file is not safely readable: {relative}"
+            ) from exc
+        finally:
+            if source_descriptor >= 0:
+                os.close(source_descriptor)
+            os.close(directory_descriptor)
+
+    def open_file(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> AuthenticatedFile:
+        normalized = _relative_path(relative)
+        record = self.record(normalized)
+        if max_bytes is not None and record.size > max_bytes:
+            raise ValueError(
+                f"captured file exceeds its {max_bytes}-byte limit: {normalized}"
+            )
+        descriptor, opened = self._open(normalized)
+        return AuthenticatedFile(descriptor, opened, record)
+
+    def read_bytes(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        with self.open_file(relative, max_bytes=max_bytes) as source:
+            payload = bytearray()
+            while block := source.read(_COPY_BYTES):
+                payload.extend(block)
+            return bytes(payload)
+
+    def authenticate(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> TreeFileRecord:
+        with self.open_file(relative, max_bytes=max_bytes) as source:
+            source.authenticate()
+            return source.record
+
+    @contextmanager
+    def authenticated_descriptor(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> Iterator[tuple[int, TreeFileRecord]]:
+        source = self.open_file(relative, max_bytes=max_bytes)
+        try:
+            descriptor = source.rewind_authenticated()
+            yield descriptor, source.record
+            source.verify_unchanged()
+        finally:
+            source.close()
+
+    def copy_chunks(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> Iterator[bytes]:
+        source = self.open_file(relative, max_bytes=max_bytes)
+        try:
+            while block := source.read(_COPY_BYTES):
+                yield block
+            source.authenticate()
+        finally:
+            source.close()
+
+
+class OwnedDirectoryStage:
+    """Build one new private sibling tree without path-based file mutation."""
+
+    def __init__(self, destination: Path) -> None:
+        self.destination = lexical_directory_path(destination)
+        self.path = lexical_directory_path(
+            Path(
+                tempfile.mkdtemp(
+                    prefix=f".{self.destination.name}.normalize-",
+                    dir=str(self.destination.parent),
+                )
+            )
+        )
+        self._initial = capture_directory_ownership(self.path)
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+        self._descriptor = os.open(self.path, flags)
+        self._published = False
+
+    def close(self) -> None:
+        if self._descriptor >= 0:
+            try:
+                os.close(self._descriptor)
+            except OSError:
+                pass
+            self._descriptor = -1
+
+    def discard(self) -> None:
+        self.close()
+        if not self._published:
+            discard_owned_directory(self.path, self._initial)
+
+    def _parent_descriptor(self, relative: PurePosixPath) -> int:
+        descriptor = os.dup(self._descriptor)
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+        try:
+            for part in relative.parts[:-1]:
+                try:
+                    os.mkdir(part, mode=0o700, dir_fd=descriptor)
+                except FileExistsError:
+                    pass
+                child = -1
+                try:
+                    child = os.open(part, flags, dir_fd=descriptor)
+                    opened = os.fstat(child)
+                    if not stat.S_ISDIR(opened.st_mode):
+                        raise ValueError(
+                            f"owned stage component is not a directory: {relative}"
+                        )
+                except BaseException:
+                    if child >= 0:
+                        os.close(child)
+                    raise
+                os.close(descriptor)
+                descriptor = child
+            return descriptor
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    def write_file(
+        self,
+        relative: str | Path | PurePosixPath,
+        chunks: Iterable[bytes],
+        *,
+        mode: int = 0o600,
+        max_bytes: int | None = None,
+    ) -> None:
+        normalized = _relative_path(relative)
+        parent = self._parent_descriptor(normalized)
+        temporary = f".{normalized.name}.tmp-{secrets.token_hex(12)}"
+        descriptor = -1
+        renamed = False
+        byte_count = 0
+        iterator = iter(chunks)
+        try:
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            descriptor = os.open(temporary, flags, mode, dir_fd=parent)
+            for chunk in iterator:
+                if not isinstance(chunk, bytes):
+                    raise TypeError("owned stage file chunks must be bytes")
+                byte_count += len(chunk)
+                if max_bytes is not None and byte_count > max_bytes:
+                    raise ValueError(
+                        f"owned stage file exceeds its {max_bytes}-byte limit: "
+                        f"{normalized}"
+                    )
+                view = memoryview(chunk)
+                while view:
+                    written = os.write(descriptor, view)
+                    if written <= 0:
+                        raise OSError("could not write owned stage file")
+                    view = view[written:]
+            os.fchmod(descriptor, mode)
+            os.fsync(descriptor)
+            os.close(descriptor)
+            descriptor = -1
+            try:
+                os.stat(
+                    normalized.name,
+                    dir_fd=parent,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                pass
+            else:
+                raise ValueError(f"owned stage file already exists: {normalized}")
+            os.rename(
+                temporary,
+                normalized.name,
+                src_dir_fd=parent,
+                dst_dir_fd=parent,
+            )
+            renamed = True
+            os.fsync(parent)
+        finally:
+            close_iterator = getattr(iterator, "close", None)
+            if callable(close_iterator):
+                close_iterator()
+            if descriptor >= 0:
+                os.close(descriptor)
+            if not renamed:
+                try:
+                    os.unlink(temporary, dir_fd=parent)
+                except OSError:
+                    pass
+            os.close(parent)
+
+    def publish(
+        self,
+        *,
+        expected_destination_ownership: object,
+        validate_staged_directory=None,
+        validate_published_destination=None,
+    ) -> None:
+        self.close()
+        publish_staged_directory(
+            self.path,
+            self.destination,
+            expected_stage_root_ownership=self._initial,
+            expected_destination_ownership=expected_destination_ownership,
+            validate_staged_directory=validate_staged_directory,
+            validate_published_destination=validate_published_destination,
+        )
+        self._published = True
+
+
+__all__ = [
+    "AuthenticatedFile",
+    "CapturedDirectoryReader",
+    "OwnedDirectoryStage",
+]

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -6,31 +6,140 @@
 
 from __future__ import annotations
 
+import ctypes
+import errno
 import hashlib
+import logging
 import os
 import secrets
 import stat
-import tempfile
+import sys
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Iterable, Iterator
+from typing import Callable, Iterable, Iterator, Mapping, TypeVar
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - Windows fails closed when requested
+    _fcntl = None  # type: ignore[assignment]
 
 from ._atomic_directory import (
+    DirectoryOrphan,
+    PublicationDirectoryReader,
     TreeFileRecord,
-    capture_directory_ownership,
+    _annotate_secondary_error,
+    _open_publication_authority,
+    _PosixResourceOwner,
+    _PublicationAuthority,
+    _PublicationAuthorityOwner,
+    _publish_staged_directory_with_authority,
+    _rename_noreplace_at,
+    _require_matching_ownership,
     directory_ownership_entry_identities,
     directory_ownership_file_records,
+    directory_ownership_inventory,
     directory_ownership_root_identity,
     directory_ownership_root_version_identity,
     discard_owned_directory,
     lexical_directory_path,
+    publication_parent_identity,
     publish_staged_directory,
 )
+from ._owned_file_publication import (
+    _CancellationSafeRLock,
+    _DescriptorOwner,
+)
+from ._owned_file_publication import _file_identity as _owned_file_identity
+
+logger = logging.getLogger(__name__)
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _MAX_RELATIVE_PATH_BYTES = 4_096
 _MAX_COMPONENTS = 256
 _COPY_BYTES = 1024 * 1024
+_MAX_IN_MEMORY_SNAPSHOT_BYTES = 512 * 1024 * 1024
+_MAX_SNAPSHOT_CONSUMER_READ_BYTES = 8 * 1024 * 1024
+_MFD_CLOEXEC = 0x0001
+_MFD_ALLOW_SEALING = 0x0002
+_F_ADD_SEALS = 1033
+_F_GET_SEALS = 1034
+_F_SEAL_SEAL = 0x0001
+_F_SEAL_SHRINK = 0x0002
+_F_SEAL_GROW = 0x0004
+_F_SEAL_WRITE = 0x0008
+_REQUIRED_SNAPSHOT_SEALS = _F_SEAL_SEAL | _F_SEAL_SHRINK | _F_SEAL_GROW | _F_SEAL_WRITE
+_UNSET_DESTINATION_OWNERSHIP = object()
+_MAX_WORKSPACE_ENTRIES = 500_000
+_MAX_WORKSPACE_FILE_BYTES = 64 * 1024 * 1024 * 1024
+_MAX_WORKSPACE_TOTAL_BYTES = 64 * 1024 * 1024 * 1024
+_WORKSPACE_PLAN_DOMAIN = b"codenib-owned-workspace-plan-v1"
+_WORKSPACE_RECEIPT_EMPTY = object()
+_WORKSPACE_RECEIPT_CLOSED = object()
+_WORKSPACE_RECEIPT_CLOSE = object()
+_WORKSPACE_OWNER_RECOVERY_LIMIT = 64
+_WorkspaceResult = TypeVar("_WorkspaceResult")
+
+
+class _SnapshotUnavailable(RuntimeError):
+    """The host cannot provide a sealed anonymous descriptor."""
+
+
+def _create_sealable_memfd() -> int:
+    """Create one anonymous Linux file or fail closed on unsupported hosts."""
+
+    create = getattr(os, "memfd_create", None)
+    if callable(create) and _fcntl is not None:
+        return create(
+            "codenib-authenticated-snapshot",
+            _MFD_CLOEXEC | _MFD_ALLOW_SEALING,
+        )
+    if os.name != "posix" or _fcntl is None:
+        raise _SnapshotUnavailable(
+            "sealed authenticated snapshots are unavailable on this host"
+        )
+    libc = ctypes.CDLL(None, use_errno=True)
+    create = getattr(libc, "memfd_create", None)
+    if create is None:
+        raise _SnapshotUnavailable(
+            "sealed authenticated snapshots are unavailable on this host"
+        )
+    create.argtypes = (ctypes.c_char_p, ctypes.c_uint)
+    create.restype = ctypes.c_int
+    descriptor = create(
+        b"codenib-authenticated-snapshot",
+        _MFD_CLOEXEC | _MFD_ALLOW_SEALING,
+    )
+    if descriptor < 0:
+        error = ctypes.get_errno()
+        raise _SnapshotUnavailable(
+            "sealed authenticated snapshots are unavailable on this host"
+        ) from OSError(error, os.strerror(error))
+    return descriptor
+
+
+def _write_all(descriptor: int, block: bytes) -> None:
+    view = memoryview(block)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError("could not write authenticated snapshot")
+        view = view[written:]
+
+
+def _seal_snapshot_descriptor(descriptor: int) -> None:
+    """Seal one fully written anonymous snapshot against later mutation."""
+
+    os.fsync(descriptor)
+    if _fcntl is None:
+        raise _SnapshotUnavailable(
+            "sealed authenticated snapshots are unavailable on this host"
+        )
+    _fcntl.fcntl(descriptor, _F_ADD_SEALS, _REQUIRED_SNAPSHOT_SEALS)
+    observed = _fcntl.fcntl(descriptor, _F_GET_SEALS)
+    if observed & _REQUIRED_SNAPSHOT_SEALS != _REQUIRED_SNAPSHOT_SEALS:
+        raise RuntimeError("authenticated snapshot could not be sealed")
+    os.lseek(descriptor, 0, os.SEEK_SET)
 
 
 def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -84,6 +193,749 @@ def _relative_path(value: str | Path | PurePosixPath) -> PurePosixPath:
     return relative
 
 
+def _workspace_mode(value: int, *, directory: bool) -> int:
+    label = "workspace directory mode" if directory else "workspace file mode"
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{label} must be an integer")
+    if value < 0 or value > 0o777:
+        raise ValueError(f"{label} must contain only portable permission bits")
+    if value & 0o022:
+        raise ValueError(f"{label} must not be group/world writable")
+    required = 0o700 if directory else 0o400
+    if value & required != required:
+        requirement = "owner rwx" if directory else "owner read"
+        raise ValueError(f"{label} must grant {requirement} permission")
+    return value
+
+
+def _workspace_frame(digest: "hashlib._Hash", domain: bytes, payload: bytes) -> None:
+    digest.update(len(domain).to_bytes(2, "big"))
+    digest.update(domain)
+    digest.update(len(payload).to_bytes(8, "big"))
+    digest.update(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceDirectory:
+    """One directory that a trusted provisioner must pre-open for a plan."""
+
+    path: PurePosixPath
+    mode: int = 0o700
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", _relative_path(self.path))
+        object.__setattr__(self, "mode", _workspace_mode(self.mode, directory=True))
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceFile:
+    """One required regular-file slot in an exact workspace plan."""
+
+    path: PurePosixPath
+    mode: int = 0o600
+    max_bytes: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", _relative_path(self.path))
+        object.__setattr__(self, "mode", _workspace_mode(self.mode, directory=False))
+        if isinstance(self.max_bytes, bool) or not isinstance(self.max_bytes, int):
+            raise TypeError("workspace file size limit must be an integer")
+        if self.max_bytes < 0 or self.max_bytes > _MAX_WORKSPACE_FILE_BYTES:
+            raise ValueError("workspace file size limit is out of bounds")
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspacePlan:
+    """Immutable exact skeleton and required file slots for one workspace."""
+
+    subject_digest: str
+    directories: tuple[WorkspaceDirectory, ...] = ()
+    files: tuple[WorkspaceFile, ...] = ()
+    root_mode: int = 0o700
+    digest: str = ""
+
+    def __post_init__(self) -> None:
+        subject = self.subject_digest
+        if (
+            not isinstance(subject, str)
+            or len(subject) != 64
+            or any(character not in "0123456789abcdef" for character in subject)
+        ):
+            raise ValueError("workspace plan subject digest must be lowercase sha256")
+        directories = tuple(self.directories)
+        files = tuple(self.files)
+        if len(directories) + len(files) > _MAX_WORKSPACE_ENTRIES:
+            raise ValueError("workspace plan has too many entries")
+        if not all(
+            isinstance(directory_item, WorkspaceDirectory)
+            for directory_item in directories
+        ):
+            raise TypeError("workspace plan directories must be WorkspaceDirectory")
+        if not all(isinstance(file_item, WorkspaceFile) for file_item in files):
+            raise TypeError("workspace plan files must be WorkspaceFile")
+        root_mode = _workspace_mode(self.root_mode, directory=True)
+
+        directory_by_path: dict[str, WorkspaceDirectory] = {}
+        file_by_path: dict[str, WorkspaceFile] = {}
+        portable_paths: dict[str, str] = {}
+        for directory_item in directories:
+            path = directory_item.path.as_posix()
+            if path in directory_by_path:
+                raise ValueError(f"workspace plan repeats directory: {path}")
+            portable = path.casefold()
+            previous = portable_paths.get(portable)
+            if previous is not None:
+                raise ValueError(
+                    "workspace plan has a portable path collision: "
+                    f"{previous!r} and {path!r}"
+                )
+            portable_paths[portable] = path
+            directory_by_path[path] = directory_item
+        total_bytes = 0
+        for file_item in files:
+            path = file_item.path.as_posix()
+            if path in file_by_path:
+                raise ValueError(f"workspace plan repeats file: {path}")
+            if path in directory_by_path:
+                raise ValueError(
+                    f"workspace plan path is both file and directory: {path}"
+                )
+            portable = path.casefold()
+            previous = portable_paths.get(portable)
+            if previous is not None:
+                raise ValueError(
+                    "workspace plan has a portable path collision: "
+                    f"{previous!r} and {path!r}"
+                )
+            portable_paths[portable] = path
+            file_by_path[path] = file_item
+            total_bytes += file_item.max_bytes
+            if total_bytes > _MAX_WORKSPACE_TOTAL_BYTES:
+                raise ValueError("workspace plan total byte limit is out of bounds")
+
+        for path in tuple(directory_by_path) + tuple(file_by_path):
+            relative = PurePosixPath(path)
+            for depth in range(1, len(relative.parts)):
+                ancestor = "/".join(relative.parts[:depth])
+                if ancestor not in directory_by_path:
+                    raise ValueError(
+                        f"workspace plan is missing directory ancestor: {ancestor}"
+                    )
+
+        canonical_directories = tuple(
+            sorted(directories, key=lambda item: item.path.as_posix())
+        )
+        canonical_files = tuple(sorted(files, key=lambda item: item.path.as_posix()))
+        plan_digest = hashlib.sha256()
+        _workspace_frame(plan_digest, b"domain", _WORKSPACE_PLAN_DOMAIN)
+        _workspace_frame(plan_digest, b"subject", subject.encode("ascii"))
+        _workspace_frame(plan_digest, b"root-mode", root_mode.to_bytes(2, "big"))
+        for directory_item in canonical_directories:
+            _workspace_frame(
+                plan_digest,
+                b"directory-path",
+                directory_item.path.as_posix().encode("utf-8"),
+            )
+            _workspace_frame(
+                plan_digest,
+                b"directory-mode",
+                directory_item.mode.to_bytes(2, "big"),
+            )
+        for file_item in canonical_files:
+            _workspace_frame(
+                plan_digest,
+                b"file-path",
+                file_item.path.as_posix().encode("utf-8"),
+            )
+            _workspace_frame(
+                plan_digest,
+                b"file-mode",
+                file_item.mode.to_bytes(2, "big"),
+            )
+            _workspace_frame(
+                plan_digest,
+                b"file-max-bytes",
+                file_item.max_bytes.to_bytes(8, "big"),
+            )
+        _workspace_frame(
+            plan_digest,
+            b"entry-count",
+            (len(canonical_directories) + len(canonical_files)).to_bytes(8, "big"),
+        )
+        object.__setattr__(self, "directories", canonical_directories)
+        object.__setattr__(self, "files", canonical_files)
+        object.__setattr__(self, "root_mode", root_mode)
+        object.__setattr__(self, "digest", plan_digest.hexdigest())
+
+
+class UnsupportedWorkspaceCreation(RuntimeError):
+    """Strict workspace creation is unavailable without a native creator."""
+
+
+@dataclass(slots=True)
+class _WorkspaceFileOwner:
+    owner: _DescriptorOwner
+    identity: tuple[int, ...] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkspacePublicationTransfer:
+    """Shared aggregate owner installed before any publication mutation."""
+
+    workspace: "OwnedWorkspaceAuthority"
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkspaceReservation:
+    transfer: _WorkspacePublicationTransfer
+
+
+@dataclass(slots=True)
+class _WorkspaceCleanup:
+    transfer: _WorkspacePublicationTransfer
+    attempted: bool = False
+
+
+class PublishedWorkspaceReceipt:
+    """Borrowed exact-generation receipt controlled by its caller-owned slot."""
+
+    __slots__ = (
+        "path",
+        "plan",
+        "sealed_ownership",
+        "ownership",
+        "parent_identity",
+        "orphan",
+        "durable",
+        "_transfer",
+        "_owner_pid",
+    )
+
+    def __init__(
+        self,
+        *,
+        transfer: _WorkspacePublicationTransfer,
+        path: Path,
+        plan: WorkspacePlan,
+        sealed_ownership: object,
+        published_ownership: object,
+        parent_identity: tuple[int, ...],
+        orphan: DirectoryOrphan | None,
+    ) -> None:
+        # Store the shared aggregate first.  A constructor interruption can
+        # therefore be reconciled against the same transfer held by the owner.
+        self._transfer = transfer
+        self.path = path
+        self.plan = plan
+        self.sealed_ownership = sealed_ownership
+        self.ownership = published_ownership
+        self.parent_identity = parent_identity
+        self.orphan = orphan
+        self.durable = True
+        self._owner_pid = os.getpid()
+
+    @property
+    def plan_digest(self) -> str:
+        return self.plan.digest
+
+    @property
+    def closed(self) -> bool:
+        return self._transfer.workspace._publication_transfer_closed(self._transfer)
+
+    def close(self) -> None:
+        raise RuntimeError("close the PublishedWorkspaceReceiptOwner, not its receipt")
+
+    def _consume_from_owner(
+        self,
+        close_authority: object,
+        callback: Callable[
+            ["PublishedWorkspaceReceipt", PublicationDirectoryReader],
+            _WorkspaceResult,
+        ],
+    ) -> _WorkspaceResult:
+        if close_authority is not _WORKSPACE_RECEIPT_CLOSE:
+            raise RuntimeError("published workspace receipt authority is invalid")
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "published workspace receipt cannot cross a PID boundary"
+            )
+        return self._transfer.workspace._consume_published_workspace(
+            self,
+            callback,
+        )
+
+    def _close_from_owner(self, close_authority: object) -> None:
+        if close_authority is not _WORKSPACE_RECEIPT_CLOSE:
+            raise RuntimeError("published workspace receipt close authority is invalid")
+        self._transfer.workspace._close_publication_transfer(self._transfer)
+
+
+class PublishedWorkspaceReceiptOwner:
+    """Caller-precreated one-shot owner for a published workspace generation."""
+
+    __slots__ = ("_slot", "_lock", "_owner_pid", "_process_locks")
+
+    def __init__(self) -> None:
+        self._slot: object = _WORKSPACE_RECEIPT_EMPTY
+        self._lock = _CancellationSafeRLock()
+        self._owner_pid = os.getpid()
+        self._process_locks = {self._owner_pid: self._lock}
+
+    @property
+    def state(self) -> str:
+        self._require_owner_pid()
+
+        def observe() -> str:
+            self._normalize_closed_locked()
+            return self._state_locked()
+
+        return self._lock.run(observe)
+
+    @property
+    def active(self) -> bool:
+        return self.state == "active"
+
+    @property
+    def closed(self) -> bool:
+        return self.state == "closed"
+
+    @property
+    def receipt(self) -> PublishedWorkspaceReceipt:
+        self._require_owner_pid()
+
+        def borrow() -> PublishedWorkspaceReceipt:
+            self._normalize_closed_locked()
+            if not isinstance(self._slot, PublishedWorkspaceReceipt):
+                raise RuntimeError(
+                    "published workspace receipt owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            return self._slot
+
+        return self._lock.run(borrow)
+
+    def consume(
+        self,
+        callback: Callable[
+            [PublishedWorkspaceReceipt, PublicationDirectoryReader],
+            _WorkspaceResult,
+        ],
+    ) -> _WorkspaceResult:
+        """Synchronously borrow one exact authenticated publication reader."""
+
+        if not callable(callback):
+            raise TypeError("published workspace receipt consumer must be callable")
+        self._require_owner_pid()
+        if self._lock.held_by_current_thread():
+            raise RuntimeError("published workspace receipt consume is reentrant")
+
+        def consume_locked() -> _WorkspaceResult:
+            self._normalize_closed_locked()
+            if not isinstance(self._slot, PublishedWorkspaceReceipt):
+                raise RuntimeError(
+                    "published workspace receipt owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            return self._slot._consume_from_owner(
+                _WORKSPACE_RECEIPT_CLOSE,
+                callback,
+            )
+
+        return self._lock.run(consume_locked)
+
+    def close(self) -> None:
+        current_pid = os.getpid()
+        owner_changed = current_pid != self._owner_pid
+        if owner_changed:
+            lifecycle_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+        else:
+            if self._lock.held_by_current_thread():
+                raise RuntimeError("published workspace receipt close is reentrant")
+            lifecycle_lock = self._lock
+
+        close_error: BaseException | None = None
+        try:
+            lifecycle_lock.run(self._close_locked)
+        except BaseException as exc:  # noqa: B036 - reconcile before PID report
+            close_error = exc
+
+        if owner_changed:
+            boundary_error = RuntimeError(
+                "published workspace receipt owner cannot cross a PID boundary"
+            )
+            if close_error is not None:
+                raise boundary_error from close_error
+            raise boundary_error
+        if close_error is not None:
+            raise close_error
+
+    def _close_locked(self) -> None:
+        self._normalize_closed_locked()
+        if self._slot is _WORKSPACE_RECEIPT_CLOSED:
+            return
+        if self._slot is _WORKSPACE_RECEIPT_EMPTY:
+            self._slot = _WORKSPACE_RECEIPT_CLOSED
+            return
+        if isinstance(self._slot, _WorkspaceReservation):
+            if os.getpid() == self._owner_pid:
+                raise RuntimeError(
+                    "published workspace receipt publication is in progress"
+                )
+            # The child owns only its inherited descriptor references.  It
+            # cannot wait for or affect the parent's in-flight publication,
+            # so revoke the child copy and run the transfer's raw inherited-fd
+            # cleanup before reporting the PID boundary.
+            cleanup = _WorkspaceCleanup(self._slot.transfer, attempted=True)
+            self._slot = cleanup
+        if isinstance(self._slot, PublishedWorkspaceReceipt):
+            receipt = self._slot
+            cleanup = _WorkspaceCleanup(receipt._transfer, attempted=True)
+            self._slot = cleanup
+        elif isinstance(self._slot, _WorkspaceCleanup):
+            cleanup = self._slot
+            cleanup.attempted = True
+        else:  # pragma: no cover - all private slot states are exhaustive
+            raise RuntimeError("published workspace receipt owner state is invalid")
+
+        primary_error: BaseException | None = None
+        try:
+            cleanup.transfer.workspace._close_publication_transfer(cleanup.transfer)
+        except BaseException as close_error:  # noqa: B036 - settle aggregate
+            primary_error = close_error
+        try:
+            if cleanup.transfer.workspace._publication_transfer_closed(
+                cleanup.transfer
+            ):
+                self._slot = _WORKSPACE_RECEIPT_CLOSED
+        except BaseException as observation_error:  # noqa: B036
+            if primary_error is None:
+                primary_error = observation_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace receipt close-state observation also failed",
+                    observation_error,
+                )
+        if primary_error is not None:
+            raise primary_error
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close()
+        except BaseException as cleanup_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "published workspace receipt cleanup also failed",
+                cleanup_error,
+            )
+
+    def _reserve(self, reservation: _WorkspaceReservation) -> None:
+        self._require_owner_pid()
+
+        def reserve() -> None:
+            if self._slot is not _WORKSPACE_RECEIPT_EMPTY:
+                raise RuntimeError(
+                    "published workspace receipt owner is "
+                    f"{self._state_locked()}, expected empty"
+                )
+            self._slot = reservation
+
+        self._lock.run(reserve)
+
+    def _install(
+        self,
+        reservation: _WorkspaceReservation,
+        receipt: PublishedWorkspaceReceipt,
+    ) -> None:
+        self._require_owner_pid()
+
+        def install() -> None:
+            if self._slot is not reservation:
+                raise RuntimeError("published workspace receipt reservation changed")
+            if receipt._transfer is not reservation.transfer:
+                raise RuntimeError("published workspace receipt transfer changed")
+            self._slot = receipt
+
+        self._lock.run(install)
+
+    def _owns_transfer(self, transfer: _WorkspacePublicationTransfer) -> bool:
+        def owns() -> bool:
+            return self._slot_transfer_locked() is transfer
+
+        return self._lock.run(owns)
+
+    def _has_active_transfer(self, transfer: _WorkspacePublicationTransfer) -> bool:
+        def active() -> bool:
+            return (
+                isinstance(self._slot, PublishedWorkspaceReceipt)
+                and self._slot._transfer is transfer
+            )
+
+        return self._lock.run(active)
+
+    def _transfer_state(self, transfer: _WorkspacePublicationTransfer) -> str:
+        def observe() -> str:
+            if isinstance(self._slot, PublishedWorkspaceReceipt):
+                return "active" if self._slot._transfer is transfer else "absent"
+            if isinstance(self._slot, _WorkspaceReservation):
+                return "reserved" if self._slot.transfer is transfer else "absent"
+            if isinstance(self._slot, _WorkspaceCleanup):
+                return "cleanup" if self._slot.transfer is transfer else "absent"
+            return "absent"
+
+        return self._lock.run(observe)
+
+    def _cancel_reservation(self, reservation: _WorkspaceReservation) -> None:
+        deferred: BaseException | None = None
+        for _attempt in range(_WORKSPACE_OWNER_RECOVERY_LIMIT):
+            try:
+                terminal = self._lock.run(
+                    lambda: self._cancel_reservation_locked(reservation)
+                )
+            except BaseException as cleanup_error:  # noqa: B036 - converge slot
+                if deferred is None:
+                    deferred = cleanup_error
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "workspace reservation cancellation also failed",
+                        cleanup_error,
+                    )
+                continue
+            if terminal:
+                if deferred is not None:
+                    raise deferred
+                return
+        if deferred is not None:
+            raise deferred
+        raise RuntimeError("workspace receipt reservation did not converge")
+
+    def _cancel_reservation_locked(
+        self,
+        reservation: _WorkspaceReservation,
+    ) -> bool:
+        if self._slot is reservation:
+            self._slot = _WorkspaceCleanup(reservation.transfer)
+        return self._slot is not reservation
+
+    def _normalize_closed_locked(self) -> None:
+        transfer = self._slot_transfer_locked()
+        if (
+            transfer is not None
+            and not isinstance(self._slot, _WorkspaceReservation)
+            and transfer.workspace._publication_transfer_closed(transfer)
+        ):
+            self._slot = _WORKSPACE_RECEIPT_CLOSED
+
+    def _slot_transfer_locked(self) -> _WorkspacePublicationTransfer | None:
+        if isinstance(self._slot, _WorkspaceReservation):
+            return self._slot.transfer
+        if isinstance(self._slot, _WorkspaceCleanup):
+            return self._slot.transfer
+        if isinstance(self._slot, PublishedWorkspaceReceipt):
+            return self._slot._transfer
+        return None
+
+    def _state_locked(self) -> str:
+        if self._slot is _WORKSPACE_RECEIPT_EMPTY:
+            return "empty"
+        if self._slot is _WORKSPACE_RECEIPT_CLOSED:
+            return "closed"
+        if isinstance(self._slot, _WorkspaceReservation):
+            return "reserved"
+        if isinstance(self._slot, PublishedWorkspaceReceipt):
+            return "active"
+        if isinstance(self._slot, _WorkspaceCleanup):
+            return "close-failed" if self._slot.attempted else "cleanup"
+        raise RuntimeError("published workspace receipt owner state is invalid")
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "published workspace receipt owner cannot cross a PID boundary"
+            )
+
+    def __enter__(self) -> "PublishedWorkspaceReceiptOwner":
+        self._require_owner_pid()
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        if exc is None:
+            self.close()
+        else:
+            self.close_after_error(exc)
+
+
+class AuthenticatedSnapshot:
+    """Read-only immutable bytes produced by one successful authentication."""
+
+    __slots__ = (
+        "record",
+        "_descriptor",
+        "_chunks",
+        "_chunk_index",
+        "_chunk_offset",
+        "_consumed",
+        "_closed",
+    )
+
+    def __init__(
+        self,
+        record: TreeFileRecord,
+        *,
+        descriptor: int = -1,
+        chunks: tuple[bytes, ...] | None = None,
+    ) -> None:
+        if (descriptor >= 0) == (chunks is not None):
+            raise ValueError("authenticated snapshot needs exactly one backing")
+        self.record = record
+        self._descriptor = descriptor
+        self._chunks = () if chunks is None else chunks
+        self._chunk_index = 0
+        self._chunk_offset = 0
+        self._consumed = 0
+        self._closed = False
+
+    @property
+    def descriptor(self) -> int:
+        if self._closed or self._descriptor < 0:
+            raise RuntimeError("authenticated snapshot has no sealed descriptor")
+        return self._descriptor
+
+    def read(self, size: int = -1) -> bytes:
+        if self._closed:
+            raise ValueError("authenticated snapshot is closed")
+        if self._descriptor >= 0:
+            requested = (
+                size
+                if size is not None and size >= 0
+                else self.record.size - self._consumed
+            )
+            block = os.read(self._descriptor, requested)
+            self._consumed += len(block)
+            return block
+        remaining = self.record.size - self._consumed
+        requested = remaining if size is None or size < 0 else min(size, remaining)
+        if requested <= 0:
+            return b""
+        output = bytearray()
+        while requested and self._chunk_index < len(self._chunks):
+            chunk = self._chunks[self._chunk_index]
+            available = len(chunk) - self._chunk_offset
+            consumed = min(requested, available)
+            output.extend(chunk[self._chunk_offset : self._chunk_offset + consumed])
+            requested -= consumed
+            self._consumed += consumed
+            self._chunk_offset += consumed
+            if self._chunk_offset == len(chunk):
+                self._chunk_index += 1
+                self._chunk_offset = 0
+        return bytes(output)
+
+    def readline(self, size: int = -1) -> bytes:
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError("authenticated snapshot readline size must be an integer")
+        limit = self.record.size if size < 0 else size
+        output = bytearray()
+        while len(output) < limit:
+            block = self.read(min(_COPY_BYTES, limit - len(output)))
+            if not block:
+                break
+            newline = block.find(b"\n")
+            if newline < 0:
+                output.extend(block)
+                continue
+            output.extend(block[: newline + 1])
+            # Pickle only uses readline during sequential consumption. A line
+            # with trailing bytes is rare; preserve them by rewinding the
+            # sealed fd or the immutable chunk cursor.
+            trailing = len(block) - newline - 1
+            if trailing:
+                self._rewind(trailing)
+            break
+        return bytes(output)
+
+    def _rewind(self, count: int) -> None:
+        if self._descriptor >= 0:
+            os.lseek(self._descriptor, -count, os.SEEK_CUR)
+            self._consumed -= count
+            return
+        self._consumed -= count
+        while count:
+            if self._chunk_offset:
+                moved = min(count, self._chunk_offset)
+                self._chunk_offset -= moved
+                count -= moved
+            else:
+                self._chunk_index -= 1
+                self._chunk_offset = len(self._chunks[self._chunk_index])
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._descriptor >= 0:
+            try:
+                os.close(self._descriptor)
+            except OSError:
+                pass
+            self._descriptor = -1
+        self._chunks = ()
+
+    def __enter__(self) -> AuthenticatedSnapshot:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+
+class AuthenticatedSnapshotReader:
+    """Bound each parser read while exposing only authenticated immutable bytes."""
+
+    __slots__ = ("record", "_snapshot", "_remaining")
+
+    def __init__(self, snapshot: AuthenticatedSnapshot) -> None:
+        self.record = snapshot.record
+        self._snapshot = snapshot
+        self._remaining = snapshot.record.size
+
+    def read(self, size: int = -1) -> bytes:
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError("authenticated snapshot read size must be an integer")
+        if self._remaining <= 0 or size == 0:
+            return b""
+        requested = (
+            _MAX_SNAPSHOT_CONSUMER_READ_BYTES
+            if size < 0
+            else min(size, _MAX_SNAPSHOT_CONSUMER_READ_BYTES)
+        )
+        block = self._snapshot.read(min(requested, self._remaining))
+        self._remaining -= len(block)
+        return block
+
+    def readline(self, size: int = -1) -> bytes:
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError("authenticated snapshot readline size must be an integer")
+        if self._remaining <= 0 or size == 0:
+            return b""
+        requested = (
+            _MAX_SNAPSHOT_CONSUMER_READ_BYTES
+            if size < 0
+            else min(size, _MAX_SNAPSHOT_CONSUMER_READ_BYTES)
+        )
+        block = self._snapshot.readline(min(requested, self._remaining))
+        self._remaining -= len(block)
+        return block
+
+
 class AuthenticatedFile:
     """One opened file whose bytes must match the initial tree record."""
 
@@ -127,6 +979,22 @@ class AuthenticatedFile:
         self._consumed += len(block)
         return block
 
+    def readline(self, size: int = -1) -> bytes:
+        """Provide the file protocol required by trusted-local Unpickler."""
+
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError("authenticated readline size must be an integer")
+        limit = self.record.size - self._consumed if size < 0 else size
+        payload = bytearray()
+        while len(payload) < limit:
+            block = self.read(1)
+            if not block:
+                break
+            payload.extend(block)
+            if block == b"\n":
+                break
+        return bytes(payload)
+
     def authenticate(self) -> None:
         if self._authenticated:
             return
@@ -153,17 +1021,55 @@ class AuthenticatedFile:
             )
         self._authenticated = True
 
-    def rewind_authenticated(self) -> int:
-        """Authenticate the bytes, rewind the same fd, and return that fd."""
+    def sealed_snapshot(self) -> int:
+        """Return an immutable private copy authenticated against the record."""
 
-        self.authenticate()
+        snapshot = -1
         try:
-            os.lseek(self.descriptor, 0, os.SEEK_SET)
-        except OSError as exc:
+            snapshot = _create_sealable_memfd()
+            while self._consumed < self.record.size:
+                block = self.read(min(_COPY_BYTES, self.record.size - self._consumed))
+                if not block:
+                    raise ValueError(f"captured file was truncated: {self.record.path}")
+                _write_all(snapshot, block)
+            self.authenticate()
+            _seal_snapshot_descriptor(snapshot)
+            owned = snapshot
+            snapshot = -1
+            return owned
+        except (OSError, RuntimeError) as exc:
             raise ValueError(
-                f"captured file cannot be rewound: {self.record.path}"
+                f"captured file could not be copied immutably: {self.record.path}"
             ) from exc
-        return self.descriptor
+        finally:
+            if snapshot >= 0:
+                os.close(snapshot)
+
+    def immutable_snapshot(self) -> AuthenticatedSnapshot:
+        """Authenticate into sealed Linux storage or bounded immutable bytes."""
+
+        try:
+            descriptor = self.sealed_snapshot()
+        except ValueError as exc:
+            if not isinstance(exc.__cause__, _SnapshotUnavailable):
+                raise
+            if self.record.size > _MAX_IN_MEMORY_SNAPSHOT_BYTES:
+                raise ValueError(
+                    "captured file needs a sealed snapshot above the "
+                    f"{_MAX_IN_MEMORY_SNAPSHOT_BYTES}-byte fallback limit: "
+                    f"{self.record.path}"
+                ) from exc
+            chunks: list[bytes] = []
+            while self._consumed < self.record.size:
+                block = self.read(min(_COPY_BYTES, self.record.size - self._consumed))
+                if not block:
+                    raise ValueError(
+                        f"captured file was truncated: {self.record.path}"
+                    ) from exc
+                chunks.append(block)
+            self.authenticate()
+            return AuthenticatedSnapshot(self.record, chunks=tuple(chunks))
+        return AuthenticatedSnapshot(self.record, descriptor=descriptor)
 
     def verify_unchanged(self) -> None:
         self.authenticate()
@@ -411,19 +1317,37 @@ class CapturedDirectoryReader:
             return source.record
 
     @contextmanager
+    def authenticated_snapshot(
+        self,
+        relative: str | Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> Iterator[tuple[AuthenticatedSnapshot, TreeFileRecord]]:
+        source = self.open_file(relative, max_bytes=max_bytes)
+        snapshot: AuthenticatedSnapshot | None = None
+        try:
+            snapshot = source.immutable_snapshot()
+            yield snapshot, source.record
+            source.verify_unchanged()
+        finally:
+            if snapshot is not None:
+                snapshot.close()
+            source.close()
+
+    @contextmanager
     def authenticated_descriptor(
         self,
         relative: str | Path | PurePosixPath,
         *,
         max_bytes: int | None = None,
     ) -> Iterator[tuple[int, TreeFileRecord]]:
-        source = self.open_file(relative, max_bytes=max_bytes)
-        try:
-            descriptor = source.rewind_authenticated()
-            yield descriptor, source.record
-            source.verify_unchanged()
-        finally:
-            source.close()
+        """Yield a sealed Linux fd; portable consumers should use snapshot()."""
+
+        with self.authenticated_snapshot(relative, max_bytes=max_bytes) as (
+            snapshot,
+            record,
+        ):
+            yield snapshot.descriptor, record
 
     def copy_chunks(
         self,
@@ -440,25 +1364,1469 @@ class CapturedDirectoryReader:
             source.close()
 
 
+class OwnedWorkspaceAuthority:
+    """Caller-owned strict writer for one pre-opened exact directory skeleton.
+
+    POSIX cannot atomically create a directory and return its descriptor.  This
+    authority therefore never provisions directories.  A trusted/quiescent
+    caller creates and opens the complete skeleton first, constructs this empty
+    owner, and then calls :meth:`adopt`.  Every later file create is relative to
+    a retained planned-parent descriptor; no runtime path is promoted into an
+    ownership boundary.
+
+    The object is deliberately pre-created before descriptor acquisition.  Its
+    resource owners remain reachable if ``KeyboardInterrupt`` or ``SystemExit``
+    lands at a Python return/store boundary.  ``close`` is retryable after a
+    persistent descriptor-close failure and never removes a path.
+    """
+
+    def __init__(self) -> None:
+        self._lock = _CancellationSafeRLock()
+        self._owner_pid = os.getpid()
+        self._process_locks = {self._owner_pid: self._lock}
+        self._state = "empty"
+        self._parent_owner = _PublicationAuthorityOwner()
+        self._resources = _PosixResourceOwner()
+        self._destination: Path | None = None
+        self._stage_path: Path | None = None
+        self._plan: WorkspacePlan | None = None
+        self._expected_destination: object | None = None
+        self._root_descriptor = -1
+        self._root_identity: tuple[int, ...] | None = None
+        self._directory_descriptors: dict[str, int] = {}
+        self._directory_identities: dict[str, tuple[int, ...]] = {}
+        self._file_owners: list[_WorkspaceFileOwner] = []
+        self._file_specs: dict[str, WorkspaceFile] = {}
+        self._written_files: dict[
+            str,
+            tuple[tuple[int, ...], int, int, str],
+        ] = {}
+        self._sealed_ownership: object | None = None
+        self._publication_transfer: _WorkspacePublicationTransfer | None = None
+        self._resources_transferred = False
+
+    @property
+    def state(self) -> str:
+        self._require_owner_pid()
+        return self._lock.run(lambda: self._state)
+
+    @property
+    def plan(self) -> WorkspacePlan:
+        self._require_owner_pid()
+
+        def get_plan() -> WorkspacePlan:
+            if self._plan is None:
+                raise RuntimeError("owned workspace authority has not been adopted")
+            return self._plan
+
+        return self._lock.run(get_plan)
+
+    @classmethod
+    def create(cls, *_args: object, **_kwargs: object) -> OwnedWorkspaceAuthority:
+        """Fail before mutation until a native create-and-open backend exists."""
+
+        raise UnsupportedWorkspaceCreation(
+            "strict workspace creation requires a trusted pre-opened skeleton"
+        )
+
+    def adopt(
+        self,
+        *,
+        destination: Path,
+        stage_name: str,
+        parent_descriptor: int,
+        root_descriptor: int,
+        directory_descriptors: Mapping[
+            str | Path | PurePosixPath,
+            int,
+        ],
+        plan: WorkspacePlan,
+        expected_destination: object | None,
+    ) -> None:
+        """Adopt a pre-opened sibling root and exact empty-file skeleton."""
+
+        self._require_owner_pid()
+        self._reject_reentrant("adopt")
+        self._lock.run(
+            lambda: self._adopt_locked(
+                destination=destination,
+                stage_name=stage_name,
+                parent_descriptor=parent_descriptor,
+                root_descriptor=root_descriptor,
+                directory_descriptors=directory_descriptors,
+                plan=plan,
+                expected_destination=expected_destination,
+            )
+        )
+
+    def _adopt_locked(
+        self,
+        *,
+        destination: Path,
+        stage_name: str,
+        parent_descriptor: int,
+        root_descriptor: int,
+        directory_descriptors: Mapping[
+            str | Path | PurePosixPath,
+            int,
+        ],
+        plan: WorkspacePlan,
+        expected_destination: object | None,
+    ) -> None:
+        self._require_owner_pid()
+        if self._state != "empty":
+            raise RuntimeError("owned workspace authority is not empty")
+        if not (sys.platform.startswith("linux") or sys.platform == "darwin"):
+            raise UnsupportedWorkspaceCreation(
+                "strict pre-opened workspaces require POSIX directory fds"
+            )
+        if not isinstance(plan, WorkspacePlan):
+            raise TypeError("owned workspace plan must be WorkspacePlan")
+        if (
+            isinstance(parent_descriptor, bool)
+            or not isinstance(parent_descriptor, int)
+            or parent_descriptor < 0
+            or isinstance(root_descriptor, bool)
+            or not isinstance(root_descriptor, int)
+            or root_descriptor < 0
+        ):
+            raise ValueError("workspace descriptors must be open integer descriptors")
+        stage_relative = _relative_path(stage_name)
+        if len(stage_relative.parts) != 1:
+            raise ValueError("workspace stage name must be one bounded file name")
+        destination_path = lexical_directory_path(destination)
+        stage_path = destination_path.parent / stage_relative.name
+        if stage_path == destination_path:
+            raise ValueError("workspace stage and destination must differ")
+
+        expected_directory_paths = {item.path.as_posix() for item in plan.directories}
+        normalized_descriptors: dict[str, int] = {}
+        if not isinstance(directory_descriptors, Mapping):
+            raise TypeError("workspace directory descriptors must be a mapping")
+        for raw_path, descriptor in directory_descriptors.items():
+            path = _relative_path(raw_path).as_posix()
+            if path in normalized_descriptors:
+                raise ValueError(f"workspace repeats directory descriptor: {path}")
+            if (
+                isinstance(descriptor, bool)
+                or not isinstance(descriptor, int)
+                or descriptor < 0
+            ):
+                raise ValueError(
+                    "workspace directory descriptors must be open integers"
+                )
+            normalized_descriptors[path] = descriptor
+        if set(normalized_descriptors) != expected_directory_paths:
+            raise ValueError(
+                "workspace directory descriptors must exactly match the plan"
+            )
+
+        if expected_destination is not None:
+            # Validate the private token before acquiring any authority.
+            directory_ownership_root_identity(expected_destination)
+
+        self._state = "adopting"
+        self._destination = destination_path
+        self._stage_path = stage_path
+        self._plan = plan
+        self._expected_destination = expected_destination
+        self._file_specs = {item.path.as_posix(): item for item in plan.files}
+        try:
+            _open_publication_authority(
+                destination_path.parent,
+                parent_resource=parent_descriptor,
+                expected_parent_identity=publication_parent_identity(parent_descriptor),
+                authority_owner=self._parent_owner,
+            )
+            authority = self._require_parent_authority()
+            flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0) | getattr(
+                os,
+                "O_NONBLOCK",
+                0,
+            )
+            self._root_descriptor = self._resources.open(
+                ".",
+                flags,
+                dir_fd=root_descriptor,
+            )
+            root_metadata = os.fstat(self._root_descriptor)
+            if not stat.S_ISDIR(root_metadata.st_mode):
+                raise ValueError("workspace root descriptor is not a directory")
+            if stat.S_IMODE(root_metadata.st_mode) != plan.root_mode:
+                raise ValueError("workspace root mode differs from its plan")
+            self._root_identity = _root_identity(root_metadata)
+            if self._root_identity[0] != authority.identity[0]:
+                raise ValueError(
+                    "workspace root and destination parent differ by device"
+                )
+
+            stage_metadata = authority.child_metadata(
+                stage_relative.name,
+                path=stage_path,
+                label="owned workspace stage",
+            )
+            if stage_metadata is None:
+                raise ValueError("owned workspace stage does not exist")
+            if _root_identity(stage_metadata) != self._root_identity:
+                raise RuntimeError("workspace stage name differs from its root handle")
+
+            expected_directory_modes = {
+                item.path.as_posix(): item.mode for item in plan.directories
+            }
+
+            def skeleton_policy(path: str, kind: str, mode: int, _size: int) -> None:
+                if kind != "directory":
+                    raise ValueError("workspace skeleton must contain no files")
+                expected_mode = expected_directory_modes.get(path)
+                if expected_mode is None or mode != expected_mode:
+                    raise ValueError(
+                        f"workspace skeleton directory differs from plan: {path}"
+                    )
+
+            skeleton = authority.capture_child(
+                stage_relative.name,
+                path=stage_path,
+                label="owned workspace stage",
+                allow_empty_root=True,
+                entry_policy=skeleton_policy,
+            )
+            expected_inventory = tuple(
+                (item.path.as_posix(), "directory") for item in plan.directories
+            )
+            if directory_ownership_inventory(skeleton) != expected_inventory:
+                raise ValueError("workspace skeleton differs from its exact plan")
+            if directory_ownership_root_identity(skeleton) != self._root_identity:
+                raise RuntimeError("workspace root changed while it was adopted")
+
+            captured_identities = {
+                path: (
+                    identity[0],
+                    identity[1],
+                    stat.S_IFMT(identity[2]),
+                    identity[4],
+                )
+                for path, kind, identity in directory_ownership_entry_identities(
+                    skeleton
+                )
+                if kind == "directory"
+            }
+            self._directory_descriptors = {"": self._root_descriptor}
+            self._directory_identities = {"": self._root_identity}
+            for item in plan.directories:
+                path = item.path.as_posix()
+                descriptor = self._resources.open(
+                    ".",
+                    flags,
+                    dir_fd=normalized_descriptors[path],
+                )
+                metadata = os.fstat(descriptor)
+                identity = _root_identity(metadata)
+                if (
+                    not stat.S_ISDIR(metadata.st_mode)
+                    or stat.S_IMODE(metadata.st_mode) != item.mode
+                    or identity != captured_identities.get(path)
+                    or identity[0] != self._root_identity[0]
+                ):
+                    raise RuntimeError(
+                        f"workspace directory handle differs from plan: {path}"
+                    )
+                parent_path = item.path.parent.as_posix()
+                if parent_path == ".":
+                    parent_path = ""
+                parent = self._directory_descriptors.get(parent_path)
+                if parent is None:
+                    raise RuntimeError(
+                        f"workspace directory parent was not retained: {path}"
+                    )
+                observed = os.stat(
+                    item.path.name,
+                    dir_fd=parent,
+                    follow_symlinks=False,
+                )
+                if _root_identity(observed) != identity:
+                    raise RuntimeError(
+                        f"workspace directory binding changed during adopt: {path}"
+                    )
+                self._directory_descriptors[path] = descriptor
+                self._directory_identities[path] = identity
+
+            destination_metadata = authority.child_metadata(
+                destination_path.name,
+                path=destination_path,
+                label="owned workspace destination",
+            )
+            if expected_destination is None:
+                if destination_metadata is not None:
+                    raise RuntimeError(
+                        "owned workspace destination was expected missing"
+                    )
+            else:
+                if destination_metadata is None:
+                    raise RuntimeError("owned workspace destination disappeared")
+                observed_destination = authority.capture_child(
+                    destination_path.name,
+                    path=destination_path,
+                    label="owned workspace destination",
+                    allow_empty_root=True,
+                )
+                if observed_destination != expected_destination:
+                    raise RuntimeError("owned workspace destination changed")
+            authority.verify_path_binding()
+            self._refresh_locked(require_complete=False)
+            self._state = "adopted"
+        except BaseException as refresh_error:
+            self._state = "failed"
+            self._close_resources_after_error_locked(refresh_error)
+            raise
+
+    def write_file(
+        self,
+        relative: str | Path | PurePosixPath,
+        chunks: Iterable[bytes],
+    ) -> None:
+        self._require_owner_pid()
+        self._reject_reentrant("write")
+        self._lock.run(lambda: self._write_file_locked(relative, chunks))
+
+    def _write_file_locked(
+        self,
+        relative: str | Path | PurePosixPath,
+        chunks: Iterable[bytes],
+    ) -> None:
+        self._require_owner_pid()
+        if self._state not in {"adopted", "writing"}:
+            raise RuntimeError(f"owned workspace cannot write while {self._state}")
+        normalized = _relative_path(relative)
+        path = normalized.as_posix()
+        spec = self._file_specs.get(path)
+        if spec is None:
+            raise ValueError(f"workspace file is absent from its plan: {path}")
+        if path in self._written_files:
+            raise ValueError(f"workspace file was already written: {path}")
+
+        descriptor = -1
+        descriptor_record = _WorkspaceFileOwner(_DescriptorOwner())
+        self._file_owners.append(descriptor_record)
+        iterator = None
+        primary_error: BaseException | None = None
+        record: tuple[tuple[int, ...], int, int, str] | None = None
+        try:
+            self._refresh_locked(require_complete=False)
+            iterator = iter(chunks)
+            parent_path = normalized.parent.as_posix()
+            if parent_path == ".":
+                parent_path = ""
+            parent = self._directory_descriptors[parent_path]
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            descriptor = descriptor_record.owner.open(
+                normalized.name,
+                flags,
+                0o600,
+                dir_fd=parent,
+            )
+            byte_count = 0
+            digest = hashlib.sha256()
+            for chunk in iterator:
+                if not isinstance(chunk, bytes):
+                    raise TypeError("owned workspace file chunks must be bytes")
+                byte_count += len(chunk)
+                if byte_count > spec.max_bytes:
+                    raise ValueError(
+                        f"workspace file exceeds its {spec.max_bytes}-byte limit: "
+                        f"{path}"
+                    )
+                digest.update(chunk)
+                view = memoryview(chunk)
+                while view:
+                    written = os.write(descriptor, view)
+                    if written <= 0:
+                        raise OSError("could not write owned workspace file")
+                    view = view[written:]
+            os.fchmod(descriptor, spec.mode)
+            os.fsync(descriptor)
+            opened = os.fstat(descriptor)
+            published = os.stat(
+                normalized.name,
+                dir_fd=parent,
+                follow_symlinks=False,
+            )
+            identity = _root_identity(opened)
+            descriptor_record.identity = _owned_file_identity(opened)
+            descriptor_record.owner.bind_identity(opened)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_nlink != 1
+                or stat.S_IMODE(opened.st_mode) != spec.mode
+                or opened.st_size != byte_count
+                or identity != _root_identity(published)
+                or self._root_identity is None
+                or identity[0] != self._root_identity[0]
+            ):
+                raise RuntimeError(f"owned workspace file changed: {path}")
+            os.fsync(parent)
+            record = (identity, spec.mode, byte_count, digest.hexdigest())
+        except BaseException as exc:  # noqa: B036 - cleanup before re-raise
+            primary_error = exc
+        finally:
+            try:
+                close_iterator = getattr(iterator, "close", None)
+            except BaseException as close_error:  # noqa: B036
+                if primary_error is None:
+                    primary_error = close_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "workspace producer cleanup lookup also failed",
+                        close_error,
+                    )
+            else:
+                if callable(close_iterator):
+                    try:
+                        close_iterator()
+                    except BaseException as close_error:  # noqa: B036
+                        if primary_error is None:
+                            primary_error = close_error
+                        else:
+                            _annotate_secondary_error(
+                                primary_error,
+                                "workspace producer cleanup also failed",
+                                close_error,
+                            )
+            if descriptor >= 0:
+                try:
+                    if descriptor_record.identity is None:
+                        metadata = os.fstat(descriptor)
+                        descriptor_record.identity = _owned_file_identity(metadata)
+                        descriptor_record.owner.bind_identity(metadata)
+                    assert descriptor_record.identity is not None
+                    descriptor_record.owner.close(
+                        expected_identity=descriptor_record.identity,
+                        retryable=True,
+                    )
+                except BaseException as close_error:  # noqa: B036
+                    if primary_error is None:
+                        primary_error = close_error
+                    else:
+                        _annotate_secondary_error(
+                            primary_error,
+                            "workspace file descriptor cleanup also failed",
+                            close_error,
+                        )
+
+        if primary_error is not None:
+            self._state = "failed"
+            self._close_resources_after_error_locked(primary_error)
+            raise primary_error.with_traceback(primary_error.__traceback__)
+        assert record is not None
+        try:
+            self._written_files[path] = record
+            self._refresh_locked(require_complete=False)
+            self._state = "writing"
+        except BaseException as transition_error:
+            self._state = "failed"
+            self._close_resources_after_error_locked(transition_error)
+            raise
+
+    def seal(self) -> object:
+        self._require_owner_pid()
+        self._reject_reentrant("seal")
+
+        def seal_locked() -> object:
+            self._require_owner_pid()
+            if self._state == "sealed" and self._sealed_ownership is not None:
+                return self._sealed_ownership
+            if self._state not in {"adopted", "writing"}:
+                raise RuntimeError(f"owned workspace cannot seal while {self._state}")
+            try:
+                ownership = self._refresh_locked(require_complete=True)
+                self._fsync_directories_locked()
+                ownership = self._refresh_locked(require_complete=True)
+            except BaseException as primary_error:
+                self._state = "failed"
+                self._close_resources_after_error_locked(primary_error)
+                raise
+            self._sealed_ownership = ownership
+            self._state = "sealed"
+            return ownership
+
+        return self._lock.run(seal_locked)
+
+    def _fsync_directories_locked(self) -> None:
+        """Persist the complete pre-opened skeleton from leaves to its root."""
+
+        ordered_paths = sorted(
+            self._directory_descriptors,
+            key=lambda path: (path.count("/") + bool(path), path),
+            reverse=True,
+        )
+        for path in ordered_paths:
+            os.fsync(self._directory_descriptors[path])
+
+    def publish_into(self, receipt_owner: PublishedWorkspaceReceiptOwner) -> None:
+        """Durably publish and install ownership in a pre-created caller slot."""
+
+        self._require_owner_pid()
+        self._reject_reentrant("publish")
+        if not isinstance(receipt_owner, PublishedWorkspaceReceiptOwner):
+            raise TypeError("receipt_owner must be a PublishedWorkspaceReceiptOwner")
+        transfer = _WorkspacePublicationTransfer(self)
+        reservation = _WorkspaceReservation(transfer)
+        try:
+            self._lock.run(
+                lambda: self._publish_into_locked(
+                    receipt_owner,
+                    transfer,
+                    reservation,
+                )
+            )
+        except BaseException as primary_error:  # noqa: B036 - reconcile owners
+            self._reconcile_publish_failure_outside_lock(
+                receipt_owner,
+                transfer,
+                reservation,
+                primary_error,
+            )
+            raise
+
+    def _publish_into_locked(
+        self,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        transfer: _WorkspacePublicationTransfer,
+        reservation: _WorkspaceReservation,
+    ) -> None:
+        self._require_owner_pid()
+        if self._state != "sealed" or self._sealed_ownership is None:
+            raise RuntimeError(f"owned workspace cannot publish while {self._state}")
+        if self._destination is None or self._stage_path is None or self._plan is None:
+            raise RuntimeError("owned workspace publication state is incomplete")
+
+        # This first ownership store and every later publication operation are
+        # covered by publish_into's outer exception reconciliation.  Keeping
+        # that reconciliation outside the workspace lock avoids an ABBA with
+        # receipt consume/close, whose lifecycle order is owner then workspace.
+        self._publication_transfer = transfer
+        self._resources_transferred = True
+        self._state = "reserving-publication"
+        receipt_owner._reserve(reservation)
+        self._state = "publishing"
+        sealed_ownership = self._sealed_ownership
+        destination = self._destination
+        plan = self._plan
+        authority = self._require_parent_authority()
+
+        def install_receipt(
+            committed_sealed: object,
+            published_ownership: object,
+            previous_orphan: DirectoryOrphan | None,
+        ) -> None:
+            if committed_sealed != sealed_ownership:
+                raise RuntimeError("published workspace sealed token changed")
+            _require_matching_ownership(
+                published_ownership,
+                sealed_ownership,
+                label="published workspace",
+                allow_root_rename=True,
+            )
+            receipt = PublishedWorkspaceReceipt(
+                transfer=transfer,
+                path=destination,
+                plan=plan,
+                sealed_ownership=sealed_ownership,
+                published_ownership=published_ownership,
+                parent_identity=authority.identity,
+                orphan=previous_orphan,
+            )
+            # State is written before install.  If install is interrupted
+            # before its slot store, the outer reconciliation demotes this to
+            # failed; after the store no later state write is required.
+            self._state = "published"
+            receipt_owner._install(reservation, receipt)
+
+        _publish_staged_directory_with_authority(
+            authority,
+            self._stage_path,
+            self._destination,
+            expected_stage_root_ownership=sealed_ownership,
+            expected_destination_ownership=self._expected_destination,
+            commit_callback=install_receipt,
+        )
+
+    def _reconcile_publish_failure_outside_lock(
+        self,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        transfer: _WorkspacePublicationTransfer,
+        reservation: _WorkspaceReservation,
+        primary_error: BaseException,
+    ) -> None:
+        """Settle a failed publication without ever nesting owner/workspace locks."""
+
+        deferred: BaseException | None = None
+        for _attempt in range(_WORKSPACE_OWNER_RECOVERY_LIMIT):
+            try:
+                terminal = self._reconcile_publish_failure_once(
+                    receipt_owner,
+                    transfer,
+                    reservation,
+                    primary_error,
+                )
+            except BaseException as reconciliation_error:  # noqa: B036
+                if deferred is None:
+                    deferred = reconciliation_error
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "workspace publication reconciliation also failed",
+                        reconciliation_error,
+                    )
+                continue
+            if terminal:
+                if deferred is not None:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "workspace publication reconciliation was interrupted",
+                        deferred,
+                    )
+                return
+        recovery_error = RuntimeError(
+            "workspace publication reconciliation did not converge"
+        )
+        if deferred is not None:
+            _annotate_secondary_error(
+                recovery_error,
+                "workspace publication reconciliation recovery also failed",
+                deferred,
+            )
+        _annotate_secondary_error(
+            primary_error,
+            "workspace publication ownership is unknown",
+            recovery_error,
+        )
+
+    def _reconcile_publish_failure_once(
+        self,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        transfer: _WorkspacePublicationTransfer,
+        reservation: _WorkspaceReservation,
+        primary_error: BaseException,
+    ) -> bool:
+        publication_started = self._lock.run(
+            lambda: self._publication_transfer is transfer
+        )
+        if not publication_started:
+            return True
+
+        transfer_state = self._receipt_transfer_state_after_error(
+            receipt_owner,
+            transfer,
+            primary_error,
+        )
+        if transfer_state == "unknown":
+            raise RuntimeError("workspace receipt ownership is unknown")
+        if transfer_state == "reserved":
+            receipt_owner._cancel_reservation(reservation)
+            transfer_state = self._receipt_transfer_state_after_error(
+                receipt_owner,
+                transfer,
+                primary_error,
+            )
+            if transfer_state in {"reserved", "unknown"}:
+                raise RuntimeError(
+                    "workspace receipt reservation cancellation did not settle"
+                )
+
+        def settle_workspace() -> None:
+            # The receipt owner lock is not held here.  A concurrent close may
+            # have completed after the owner snapshot; identity is therefore
+            # checked again before touching workspace state.
+            if self._publication_transfer is not transfer:
+                return
+            if transfer_state == "active":
+                self._state = "published"
+                return
+            if transfer_state == "cleanup":
+                self._state = "failed"
+                return
+            if transfer_state != "absent":
+                raise RuntimeError(
+                    "workspace receipt ownership state is invalid: " f"{transfer_state}"
+                )
+            # The owner never received the transfer.  Make public workspace
+            # close retryable before attempting aggregate cleanup, and clear
+            # the transfer marker last so an interrupted settle can resume.
+            self._resources_transferred = False
+            self._state = "failed"
+            self._close_resources_after_error_locked(primary_error)
+            self._publication_transfer = None
+
+        self._lock.run(settle_workspace)
+        return True
+
+    @staticmethod
+    def _receipt_transfer_state_after_error(
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        transfer: _WorkspacePublicationTransfer,
+        primary_error: BaseException,
+    ) -> str:
+        deferred: BaseException | None = None
+        for _attempt in range(_WORKSPACE_OWNER_RECOVERY_LIMIT):
+            try:
+                state = receipt_owner._transfer_state(transfer)
+            except BaseException as state_error:  # noqa: B036 - bounded recovery
+                if deferred is None:
+                    deferred = state_error
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "workspace receipt ownership observation also failed",
+                        state_error,
+                    )
+                continue
+            if deferred is not None:
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace receipt ownership observation was interrupted",
+                    deferred,
+                )
+            return state
+        recovery_error = RuntimeError(
+            "workspace receipt ownership observation did not converge"
+        )
+        if deferred is not None:
+            _annotate_secondary_error(
+                recovery_error,
+                "workspace receipt ownership recovery also failed",
+                deferred,
+            )
+        _annotate_secondary_error(
+            primary_error,
+            "workspace receipt ownership is unknown",
+            recovery_error,
+        )
+        # Unknown ownership must never trigger a competing resource close.
+        return "unknown"
+
+    def _consume_published_workspace(
+        self,
+        receipt: PublishedWorkspaceReceipt,
+        callback: Callable[
+            [PublishedWorkspaceReceipt, PublicationDirectoryReader],
+            _WorkspaceResult,
+        ],
+    ) -> _WorkspaceResult:
+        self._require_owner_pid()
+        self._reject_reentrant("consume")
+
+        def consume_locked() -> _WorkspaceResult:
+            if (
+                self._state != "published"
+                or self._publication_transfer is not receipt._transfer
+                or self._destination != receipt.path
+                or self._plan != receipt.plan
+            ):
+                raise RuntimeError("published workspace receipt is not active")
+            authority = self._require_parent_authority()
+            if authority.identity != receipt.parent_identity:
+                raise RuntimeError("published workspace parent authority changed")
+            root_before = os.fstat(self._root_descriptor)
+            if _root_identity(root_before) != directory_ownership_root_identity(
+                receipt.ownership
+            ) or _captured_version_identity(
+                root_before
+            ) != directory_ownership_root_version_identity(
+                receipt.ownership
+            ):
+                raise RuntimeError("published workspace root handle changed")
+            authority.verify_path_binding()
+
+            def exact_reader(
+                reader: PublicationDirectoryReader,
+            ) -> _WorkspaceResult:
+                before = reader.capture_ownership(allow_empty_root=True)
+                if before != receipt.ownership:
+                    raise RuntimeError("published workspace generation changed")
+                result = callback(receipt, reader)
+                after = reader.capture_ownership(allow_empty_root=True)
+                if after != before:
+                    raise RuntimeError(
+                        "published workspace changed during receipt consumption"
+                    )
+                return result
+
+            result = authority.read_child(
+                receipt.path.name,
+                path=receipt.path,
+                label="published workspace",
+                expected_ownership=receipt.ownership,
+                callback=exact_reader,
+            )
+            authority.verify_path_binding()
+            root_after = os.fstat(self._root_descriptor)
+            if _captured_version_identity(root_after) != _captured_version_identity(
+                root_before
+            ):
+                raise RuntimeError(
+                    "published workspace root changed during receipt consumption"
+                )
+            return result
+
+        return self._lock.run(consume_locked)
+
+    def _close_publication_transfer(
+        self,
+        transfer: _WorkspacePublicationTransfer,
+    ) -> None:
+        current_pid = os.getpid()
+        if current_pid != self._owner_pid:
+            child_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+            inherited_close_error: BaseException | None = None
+
+            def close_inherited() -> None:
+                self._require_publication_transfer_locked(transfer)
+                self._close_inherited_resources_locked()
+                if self._state == "closed":
+                    self._finish_publication_transfer_closed_locked(transfer)
+
+            try:
+                child_lock.run(close_inherited)
+            except BaseException as exc:  # noqa: B036 - report PID boundary
+                inherited_close_error = exc
+            boundary_error = RuntimeError(
+                "published workspace transfer cannot cross a PID boundary"
+            )
+            if inherited_close_error is not None:
+                raise boundary_error from inherited_close_error
+            raise boundary_error
+
+        self._reject_reentrant("receipt close")
+
+        def close_locked() -> None:
+            self._require_publication_transfer_locked(transfer)
+            primary_error: BaseException | None = None
+            try:
+                self._close_resources_locked()
+            except BaseException as close_error:  # noqa: B036 - reconcile transfer
+                primary_error = close_error
+            try:
+                if self._state == "closed":
+                    self._finish_publication_transfer_closed_locked(transfer)
+            except BaseException as transition_error:  # noqa: B036
+                if primary_error is None:
+                    primary_error = transition_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "workspace transfer close transition also failed",
+                        transition_error,
+                    )
+            if primary_error is not None:
+                raise primary_error
+
+        self._lock.run(close_locked)
+
+    def _publication_transfer_closed(
+        self,
+        transfer: _WorkspacePublicationTransfer,
+    ) -> bool:
+        def observe() -> bool:
+            return self._state == "closed" and (
+                self._publication_transfer is None
+                or self._publication_transfer is transfer
+            )
+
+        if os.getpid() != self._owner_pid:
+            return observe()
+        return self._lock.run(observe)
+
+    def _require_publication_transfer_locked(
+        self,
+        transfer: _WorkspacePublicationTransfer,
+    ) -> None:
+        if (
+            transfer.workspace is not self
+            or self._publication_transfer is not transfer
+            or not self._resources_transferred
+        ):
+            raise RuntimeError("published workspace transfer authority changed")
+
+    def _finish_publication_transfer_closed_locked(
+        self,
+        transfer: _WorkspacePublicationTransfer,
+    ) -> None:
+        self._require_publication_transfer_locked(transfer)
+        self._resources_transferred = False
+        self._publication_transfer = None
+
+    def _refresh_locked(self, *, require_complete: bool) -> object:
+        authority = self._require_parent_authority()
+        if (
+            self._stage_path is None
+            or self._root_identity is None
+            or self._plan is None
+        ):
+            raise RuntimeError("owned workspace authority is incomplete")
+        authority.verify_path_binding()
+        root_metadata = authority.child_metadata(
+            self._stage_path.name,
+            path=self._stage_path,
+            label="owned workspace stage",
+        )
+        if (
+            root_metadata is None
+            or _root_identity(root_metadata) != self._root_identity
+        ):
+            raise RuntimeError("owned workspace root changed")
+        if _root_identity(os.fstat(self._root_descriptor)) != self._root_identity:
+            raise RuntimeError("owned workspace root handle changed")
+
+        directory_specs = {
+            item.path.as_posix(): item for item in self._plan.directories
+        }
+        for path, descriptor in self._directory_descriptors.items():
+            metadata = os.fstat(descriptor)
+            expected_identity = self._directory_identities[path]
+            expected_mode = (
+                self._plan.root_mode if not path else directory_specs[path].mode
+            )
+            if (
+                _root_identity(metadata) != expected_identity
+                or stat.S_IMODE(metadata.st_mode) != expected_mode
+            ):
+                raise RuntimeError(
+                    "owned workspace directory handle changed"
+                    + (f": {path}" if path else "")
+                )
+            if path:
+                relative = PurePosixPath(path)
+                parent_path = relative.parent.as_posix()
+                if parent_path == ".":
+                    parent_path = ""
+                observed = os.stat(
+                    relative.name,
+                    dir_fd=self._directory_descriptors[parent_path],
+                    follow_symlinks=False,
+                )
+                if _root_identity(observed) != expected_identity:
+                    raise RuntimeError(
+                        f"owned workspace directory binding changed: {path}"
+                    )
+
+        allowed_files = self._written_files
+
+        def entry_policy(path: str, kind: str, mode: int, size: int) -> None:
+            if kind == "directory":
+                spec = directory_specs.get(path)
+                if spec is None or mode != spec.mode:
+                    raise RuntimeError(
+                        f"owned workspace contains an unplanned directory: {path}"
+                    )
+                return
+            record = allowed_files.get(path)
+            if record is None or (mode, size) != (record[1], record[2]):
+                raise RuntimeError(
+                    f"owned workspace contains an unplanned file: {path}"
+                )
+
+        observed = authority.capture_child(
+            self._stage_path.name,
+            path=self._stage_path,
+            label="owned workspace stage",
+            allow_empty_root=True,
+            entry_policy=entry_policy,
+        )
+        expected_inventory = tuple(
+            sorted(
+                [(path, "directory") for path in directory_specs]
+                + [(path, "file") for path in allowed_files]
+            )
+        )
+        if directory_ownership_inventory(observed) != expected_inventory:
+            raise RuntimeError("owned workspace inventory differs from its plan")
+        if directory_ownership_root_identity(observed) != self._root_identity:
+            raise RuntimeError("owned workspace root changed during verification")
+        identities = {
+            path: identity
+            for path, _kind, identity in directory_ownership_entry_identities(observed)
+        }
+        records = {
+            record.path: record for record in directory_ownership_file_records(observed)
+        }
+        for path, identity in self._directory_identities.items():
+            if not path:
+                continue
+            observed_identity = identities.get(path)
+            if (
+                observed_identity is None
+                or (
+                    observed_identity[0],
+                    observed_identity[1],
+                    stat.S_IFMT(observed_identity[2]),
+                    observed_identity[4],
+                )
+                != identity
+            ):
+                raise RuntimeError(f"owned workspace directory changed: {path}")
+        for path, (identity, mode, size, digest) in allowed_files.items():
+            observed_identity = identities.get(path)
+            record = records.get(path)
+            if (
+                observed_identity is None
+                or (
+                    observed_identity[0],
+                    observed_identity[1],
+                    stat.S_IFMT(observed_identity[2]),
+                    observed_identity[4],
+                )
+                != identity
+                or observed_identity[7] != 1
+                or record is None
+                or (record.mode, record.size, record.sha256) != (mode, size, digest)
+            ):
+                raise RuntimeError(f"owned workspace file changed: {path}")
+        if require_complete and set(allowed_files) != set(self._file_specs):
+            missing = sorted(set(self._file_specs) - set(allowed_files))
+            raise RuntimeError(
+                "owned workspace is missing required files: " + ", ".join(missing)
+            )
+        authority.verify_path_binding()
+        return observed
+
+    def close(self) -> None:
+        current_pid = os.getpid()
+        if current_pid != self._owner_pid:
+            if self._resources_transferred:
+                raise RuntimeError(
+                    "close the PublishedWorkspaceReceiptOwner for this transfer"
+                )
+            # An RLock held by another thread at fork can never be released in
+            # the child.  CPython's single dict.setdefault call installs one
+            # process-local lock before its return can be interrupted; every
+            # later child thread and cleanup retry therefore serializes on the
+            # same lock.  Close inherited descriptors without an OFD-offset
+            # cookie; the parent keeps independent object and fd state.
+            child_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+            inherited_close_error: BaseException | None = None
+            try:
+                child_lock.run(self._close_inherited_resources_locked)
+            except BaseException as exc:  # noqa: B036 - report PID boundary
+                inherited_close_error = exc
+            boundary_error = RuntimeError(
+                "owned workspace authority cannot cross a PID boundary"
+            )
+            if inherited_close_error is not None:
+                raise boundary_error from inherited_close_error
+            raise boundary_error
+        self._reject_reentrant("close")
+
+        def close_locked() -> None:
+            if self._resources_transferred:
+                raise RuntimeError(
+                    "close the PublishedWorkspaceReceiptOwner for this transfer"
+                )
+            self._close_resources_locked()
+
+        close_error: BaseException | None = None
+        try:
+            self._lock.run(close_locked)
+        except BaseException as exc:  # noqa: B036 - report PID after cleanup
+            close_error = exc
+        if close_error is not None:
+            raise close_error
+
+    def _close_inherited_resources_locked(self) -> None:
+        """Close only this fork child's inherited descriptor references."""
+
+        if self._state == "closed":
+            return
+        primary_error: BaseException | None = None
+        for record in reversed(tuple(self._file_owners)):
+            descriptor = record.owner.descriptor
+            if descriptor < 0:
+                continue
+            try:
+                close_error = self._close_inherited_file_descriptor(record)
+            except BaseException as unexpected_close_error:  # noqa: B036
+                close_error = unexpected_close_error
+            if close_error is not None:
+                if primary_error is None:
+                    primary_error = close_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "additional inherited workspace file cleanup failed",
+                        close_error,
+                    )
+        try:
+            self._resources.close_all()
+        except BaseException as close_error:  # noqa: B036 - cleanup all owners
+            if primary_error is None:
+                primary_error = close_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "inherited workspace directory cleanup also failed",
+                    close_error,
+                )
+        try:
+            self._parent_owner.close()
+        except BaseException as close_error:  # noqa: B036 - cleanup all owners
+            if primary_error is None:
+                primary_error = close_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "inherited workspace parent cleanup also failed",
+                    close_error,
+                )
+        try:
+            close_complete = (
+                all(record.owner.descriptor < 0 for record in self._file_owners)
+                and self._resources.closed
+                and self._parent_owner.authority is None
+            )
+        except BaseException as reconciliation_error:  # noqa: B036
+            if primary_error is None:
+                primary_error = reconciliation_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "inherited workspace close-state reconciliation also failed",
+                    reconciliation_error,
+                )
+        else:
+            if close_complete:
+                self._state = "closed"
+                self._root_descriptor = -1
+                self._directory_descriptors.clear()
+        if primary_error is not None:
+            raise primary_error
+
+    @staticmethod
+    def _close_inherited_file_descriptor(
+        record: _WorkspaceFileOwner,
+    ) -> BaseException | None:
+        descriptor = record.owner.descriptor
+        if descriptor < 0:
+            return None
+        try:
+            metadata = os.fstat(descriptor)
+        except OSError as probe_error:
+            if probe_error.errno == errno.EBADF:
+                OwnedWorkspaceAuthority._invalidate_inherited_file_owner(record)
+                return None
+            return probe_error
+        except BaseException as probe_error:  # noqa: B036 - retain owner
+            return probe_error
+        observed_identity = _owned_file_identity(metadata)
+        if record.identity is None:
+            record.identity = observed_identity
+            record.owner.bind_identity(metadata)
+        elif observed_identity != record.identity:
+            OwnedWorkspaceAuthority._invalidate_inherited_file_owner(record)
+            return RuntimeError("inherited workspace file descriptor changed")
+        try:
+            os.close(descriptor)
+        except BaseException as close_error:  # noqa: B036 - reconcile close
+            try:
+                rebound = os.fstat(descriptor)
+            except OSError as probe_error:
+                if probe_error.errno == errno.EBADF:
+                    OwnedWorkspaceAuthority._invalidate_inherited_file_owner(record)
+                else:
+                    _annotate_secondary_error(
+                        close_error,
+                        "inherited file close reconciliation also failed",
+                        probe_error,
+                    )
+            except BaseException as probe_error:  # noqa: B036 - keep close error
+                _annotate_secondary_error(
+                    close_error,
+                    "inherited file close reconciliation also failed",
+                    probe_error,
+                )
+            else:
+                if _owned_file_identity(rebound) != record.identity:
+                    OwnedWorkspaceAuthority._invalidate_inherited_file_owner(record)
+            return close_error
+        OwnedWorkspaceAuthority._invalidate_inherited_file_owner(record)
+        return None
+
+    @staticmethod
+    def _invalidate_inherited_file_owner(record: _WorkspaceFileOwner) -> None:
+        # This mutates only the post-fork child copy.  It intentionally avoids
+        # _DescriptorOwner.close(), whose lseek cookie would alter the parent's
+        # shared open-file-description offset.
+        record.owner._descriptor = -1
+        record.owner._identity = None
+        record.owner._close_cookie = None
+
+    def _close_resources_locked(self) -> None:
+        if self._state == "closed":
+            return
+        primary_error: BaseException | None = None
+        for record in reversed(tuple(self._file_owners)):
+            descriptor = record.owner.descriptor
+            if descriptor < 0:
+                continue
+            try:
+                if record.identity is None:
+                    metadata = os.fstat(descriptor)
+                    record.identity = _owned_file_identity(metadata)
+                    record.owner.bind_identity(metadata)
+                assert record.identity is not None
+                record.owner.close(
+                    expected_identity=record.identity,
+                    retryable=True,
+                )
+            except BaseException as close_error:  # noqa: B036 - cleanup all
+                if primary_error is None:
+                    primary_error = close_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "additional workspace file cleanup also failed",
+                        close_error,
+                    )
+        try:
+            self._resources.close_all()
+        except BaseException as close_error:  # noqa: B036 - cleanup all owners
+            if primary_error is None:
+                primary_error = close_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace directory cleanup also failed",
+                    close_error,
+                )
+        try:
+            self._parent_owner.close()
+        except BaseException as close_error:  # noqa: B036 - cleanup all owners
+            if primary_error is None:
+                primary_error = close_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace parent authority cleanup also failed",
+                    close_error,
+                )
+        try:
+            close_complete = (
+                all(record.owner.descriptor < 0 for record in self._file_owners)
+                and self._resources.closed
+                and self._parent_owner.authority is None
+            )
+        except BaseException as reconciliation_error:  # noqa: B036
+            if primary_error is None:
+                primary_error = reconciliation_error
+            else:
+                _annotate_secondary_error(
+                    primary_error,
+                    "workspace close-state reconciliation also failed",
+                    reconciliation_error,
+                )
+        else:
+            if close_complete:
+                self._state = "closed"
+                self._root_descriptor = -1
+                self._directory_descriptors.clear()
+        if primary_error is not None:
+            raise primary_error
+
+    def _close_resources_after_error_locked(
+        self,
+        primary_error: BaseException,
+    ) -> None:
+        try:
+            self._close_resources_locked()
+        except BaseException as close_error:  # noqa: B036 - keep primary
+            _annotate_secondary_error(
+                primary_error,
+                "owned workspace cleanup also failed",
+                close_error,
+            )
+
+    def _require_parent_authority(self) -> _PublicationAuthority:
+        authority = self._parent_owner.authority
+        if authority is None:
+            raise RuntimeError("owned workspace parent authority is closed")
+        return authority
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError("owned workspace authority cannot cross a PID boundary")
+
+    def _reject_reentrant(self, operation: str) -> None:
+        if self._lock.held_by_current_thread():
+            raise RuntimeError(f"owned workspace {operation} is reentrant")
+
+    def __enter__(self) -> OwnedWorkspaceAuthority:
+        self._require_owner_pid()
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        if exc is None:
+            self.close()
+        else:
+            try:
+                self.close()
+            except BaseException as close_error:  # noqa: B036 - keep primary
+                _annotate_secondary_error(
+                    exc,
+                    "owned workspace context cleanup also failed",
+                    close_error,
+                )
+
+
 class OwnedDirectoryStage:
     """Build one new private sibling tree without path-based file mutation."""
 
-    def __init__(self, destination: Path) -> None:
+    def __init__(
+        self,
+        destination: Path,
+        *,
+        _parent_authority: _PublicationAuthority | None = None,
+        _expected_destination_ownership: object = _UNSET_DESTINATION_OWNERSHIP,
+    ) -> None:
         self.destination = lexical_directory_path(destination)
-        self.path = lexical_directory_path(
-            Path(
-                tempfile.mkdtemp(
-                    prefix=f".{self.destination.name}.normalize-",
-                    dir=str(self.destination.parent),
-                )
-            )
+        self.path = self.destination.parent / (
+            f".{self.destination.name}.normalize-{secrets.token_hex(12)}"
         )
-        self._initial = capture_directory_ownership(self.path)
-        self._cleanup_ownership = self._initial
+        self._stage_parent_fd = -1
+        self._descriptor = -1
+        self._parent_authority = _parent_authority
+        self._has_expected_destination_ownership = (
+            _expected_destination_ownership is not _UNSET_DESTINATION_OWNERSHIP
+        )
+        self._expected_destination_ownership = _expected_destination_ownership
+        self._published = False
+        self._owned_directories: dict[str, tuple[int, ...]] = {}
+        self._owned_files: dict[
+            str,
+            tuple[tuple[int, ...], int, int, str],
+        ] = {}
+        self._cleanup_ownership = None
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
-        self._descriptor = os.open(self.path, flags)
-        self._published = False
+        created = False
+        try:
+            if self._parent_authority is None:
+                self._parent_authority = _open_publication_authority(
+                    self.destination.parent,
+                    parent_resource=None,
+                    expected_parent_identity=None,
+                )
+            self._stage_parent_fd = os.dup(self._parent_authority.resource)
+            self._parent_identity = self._parent_authority.identity
+            os.mkdir(
+                self.path.name,
+                mode=0o700,
+                dir_fd=self._stage_parent_fd,
+            )
+            created = True
+            created_metadata = os.stat(
+                self.path.name,
+                dir_fd=self._stage_parent_fd,
+                follow_symlinks=False,
+            )
+            try:
+                self._initial = self._parent_authority.capture_child(
+                    self.path.name,
+                    path=self.path,
+                    label="owned stage",
+                    allow_empty_root=True,
+                )
+            except RuntimeError as exc:
+                raise RuntimeError(
+                    "owned stage root changed during initialization"
+                ) from exc
+            self._descriptor = os.open(
+                self.path.name,
+                flags,
+                dir_fd=self._stage_parent_fd,
+            )
+            opened = os.fstat(self._descriptor)
+            if (
+                _root_identity(created_metadata) != _root_identity(opened)
+                or _root_identity(opened)
+                != directory_ownership_root_identity(self._initial)
+                or _captured_version_identity(opened)
+                != directory_ownership_root_version_identity(self._initial)
+            ):
+                raise RuntimeError("owned stage root changed during initialization")
+            self._stage_identity = _root_identity(opened)
+            self._cleanup_ownership = self._initial
+            self._verify_parent_path()
+        except BaseException:
+            self.close()
+            # A created but unverified stage is intentionally left as an
+            # orphan; deleting by name could remove a raced foreign object.
+            if not created:
+                self.path = self.destination.parent / self.path.name
+            raise
+
+    @classmethod
+    def prepare(
+        cls,
+        destination: Path,
+        *,
+        required_destination_file: str | None = None,
+        allow_empty_destination: bool = False,
+        create_parent: bool = True,
+    ) -> OwnedDirectoryStage:
+        """Capture the destination and build under one retained authority."""
+
+        lexical = lexical_directory_path(destination)
+        authority = _open_publication_authority(
+            lexical.parent,
+            parent_resource=None,
+            expected_parent_identity=None,
+            create_missing=create_parent,
+        )
+        try:
+            metadata = authority.child_metadata(
+                lexical.name,
+                path=lexical,
+                label="owned stage destination",
+            )
+            if metadata is None:
+                expected_ownership = None
+            else:
+                expected_ownership = authority.capture_child(
+                    lexical.name,
+                    path=lexical,
+                    label="owned stage destination",
+                    required_root_file=required_destination_file,
+                    allow_empty_root=allow_empty_destination,
+                )
+            authority.verify_path_binding()
+            return cls(
+                lexical,
+                _parent_authority=authority,
+                _expected_destination_ownership=expected_ownership,
+            )
+        except BaseException:
+            authority.close()
+            raise
+
+    @property
+    def expected_destination_ownership(self) -> object | None:
+        """Return the destination token captured by :meth:`prepare`."""
+
+        if not self._has_expected_destination_ownership:
+            raise RuntimeError("owned stage did not capture its destination")
+        return self._expected_destination_ownership
 
     def close(self) -> None:
         if self._descriptor >= 0:
@@ -467,47 +2835,113 @@ class OwnedDirectoryStage:
             except OSError:
                 pass
             self._descriptor = -1
-
-    def discard(self) -> None:
-        if not self._published:
+        if self._stage_parent_fd >= 0:
             try:
-                self._cleanup_ownership = self._capture_current_ownership()
-            except (OSError, RuntimeError, ValueError):
+                os.close(self._stage_parent_fd)
+            except OSError:
                 pass
-        self.close()
-        if not self._published:
-            discard_owned_directory(self.path, self._cleanup_ownership)
+            self._stage_parent_fd = -1
+        if self._parent_authority is not None:
+            self._parent_authority.close()
+            self._parent_authority = None
 
-    def _capture_current_ownership(self):
-        observed = capture_directory_ownership(self.path)
-        if directory_ownership_root_identity(observed) != (
-            directory_ownership_root_identity(self._initial)
+    @staticmethod
+    def _record_orphan(orphan: DirectoryOrphan | None, *, operation: str) -> None:
+        if orphan is None:
+            return
+        logger.warning(
+            "Owned directory %s retained an orphan for quiescent GC: "
+            "path=%s digest=%s entries=%d bytes=%d verified=%s",
+            operation,
+            orphan.path,
+            orphan.ownership_digest,
+            orphan.entries,
+            orphan.byte_count,
+            orphan.verified_at_isolation,
+        )
+
+    def discard(self) -> DirectoryOrphan | None:
+        ownership = self._cleanup_ownership
+        self.close()
+        if not self._published and ownership is not None:
+            orphan = discard_owned_directory(self.path, ownership)
+            self._record_orphan(orphan, operation="discard")
+            return orphan
+        return None
+
+    def _verify_parent_path(self) -> None:
+        if self._stage_parent_fd < 0 or self._parent_authority is None:
+            raise RuntimeError("owned stage parent is closed")
+        try:
+            opened = os.fstat(self._stage_parent_fd)
+            self._parent_authority.verify_path_binding()
+        except OSError as exc:
+            raise RuntimeError("owned stage parent changed") from exc
+        if _root_identity(opened) != self._parent_identity:
+            raise RuntimeError("owned stage parent changed")
+
+    def _verify_root_descriptor(self) -> None:
+        if self._descriptor < 0:
+            raise RuntimeError("owned stage is closed")
+        try:
+            opened = os.fstat(self._descriptor)
+            path_metadata = os.stat(
+                self.path.name,
+                dir_fd=self._stage_parent_fd,
+                follow_symlinks=False,
+            )
+        except OSError as exc:
+            raise RuntimeError("owned stage root changed") from exc
+        if (
+            _root_identity(opened) != self._stage_identity
+            or _root_identity(path_metadata) != self._stage_identity
         ):
             raise RuntimeError("owned stage root changed")
-        return observed
 
     def _parent_descriptor(self, relative: PurePosixPath) -> int:
+        self._verify_parent_path()
+        self._verify_root_descriptor()
         descriptor = os.dup(self._descriptor)
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+        prefix: list[str] = []
         try:
             for part in relative.parts[:-1]:
+                prefix.append(part)
+                tracked_path = "/".join(prefix)
+                created = False
                 try:
                     os.mkdir(part, mode=0o700, dir_fd=descriptor)
-                except FileExistsError:
-                    pass
+                except FileExistsError as exc:
+                    if tracked_path not in self._owned_directories:
+                        raise ValueError(
+                            f"owned stage component was not created here: {relative}"
+                        ) from exc
+                else:
+                    created = True
                 child = -1
                 try:
                     child = os.open(part, flags, dir_fd=descriptor)
                     opened = os.fstat(child)
-                    if not stat.S_ISDIR(opened.st_mode):
-                        raise ValueError(
-                            f"owned stage component is not a directory: {relative}"
-                        )
+                    identity = _root_identity(opened)
+                    if not stat.S_ISDIR(opened.st_mode) or (
+                        not created
+                        and self._owned_directories.get(tracked_path) != identity
+                    ):
+                        raise ValueError(f"owned stage component changed: {relative}")
+                    path_metadata = os.stat(
+                        part,
+                        dir_fd=descriptor,
+                        follow_symlinks=False,
+                    )
+                    if _root_identity(path_metadata) != identity:
+                        raise ValueError(f"owned stage component changed: {relative}")
                 except BaseException:
                     if child >= 0:
                         os.close(child)
                     raise
+                if created:
+                    self._owned_directories[tracked_path] = identity
                 os.close(descriptor)
                 descriptor = child
             return descriptor
@@ -524,13 +2958,15 @@ class OwnedDirectoryStage:
         max_bytes: int | None = None,
     ) -> None:
         normalized = _relative_path(relative)
-        parent = self._parent_descriptor(normalized)
         temporary = f".{normalized.name}.tmp-{secrets.token_hex(12)}"
+        parent = -1
         descriptor = -1
-        renamed = False
         byte_count = 0
-        iterator = iter(chunks)
+        digest = hashlib.sha256()
+        iterator = None
         try:
+            parent = self._parent_descriptor(normalized)
+            iterator = iter(chunks)
             flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
             flags |= getattr(os, "O_CLOEXEC", 0)
             descriptor = os.open(temporary, flags, mode, dir_fd=parent)
@@ -543,6 +2979,7 @@ class OwnedDirectoryStage:
                         f"owned stage file exceeds its {max_bytes}-byte limit: "
                         f"{normalized}"
                     )
+                digest.update(chunk)
                 view = memoryview(chunk)
                 while view:
                     written = os.write(descriptor, view)
@@ -551,61 +2988,151 @@ class OwnedDirectoryStage:
                     view = view[written:]
             os.fchmod(descriptor, mode)
             os.fsync(descriptor)
-            os.close(descriptor)
-            descriptor = -1
             try:
-                os.stat(
+                _rename_noreplace_at(
+                    temporary,
                     normalized.name,
-                    dir_fd=parent,
-                    follow_symlinks=False,
+                    parent,
+                    parent,
                 )
-            except FileNotFoundError:
-                pass
-            else:
-                raise ValueError(f"owned stage file already exists: {normalized}")
-            os.rename(
-                temporary,
+            except FileExistsError as exc:
+                raise ValueError(
+                    f"owned stage file already exists: {normalized}"
+                ) from exc
+            opened = os.fstat(descriptor)
+            published = os.stat(
                 normalized.name,
-                src_dir_fd=parent,
-                dst_dir_fd=parent,
+                dir_fd=parent,
+                follow_symlinks=False,
             )
-            renamed = True
+            if _root_identity(opened) != _root_identity(published):
+                raise RuntimeError(f"owned stage file changed: {normalized}")
+            self._owned_files[normalized.as_posix()] = (
+                _root_identity(opened),
+                stat.S_IMODE(opened.st_mode),
+                byte_count,
+                digest.hexdigest(),
+            )
             os.fsync(parent)
+            self._refresh_cleanup_ownership()
         finally:
-            close_iterator = getattr(iterator, "close", None)
-            if callable(close_iterator):
-                close_iterator()
-            if descriptor >= 0:
-                os.close(descriptor)
-            if not renamed:
-                try:
-                    os.unlink(temporary, dir_fd=parent)
-                except OSError:
-                    pass
-            os.close(parent)
+            try:
+                close_iterator = getattr(iterator, "close", None)
+                if callable(close_iterator):
+                    close_iterator()
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
+                # A failed temporary is left in the private stage. Name-based
+                # unlink cannot prove it is still the owned inode at deletion.
+                if parent >= 0:
+                    os.close(parent)
+
+    def _refresh_cleanup_ownership(self) -> None:
+        self._verify_parent_path()
+        self._verify_root_descriptor()
+        assert self._parent_authority is not None
+        observed = self._parent_authority.capture_child(
+            self.path.name,
+            path=self.path,
+            label="owned stage",
+            allow_empty_root=True,
+        )
+        expected_inventory = tuple(
+            sorted(
+                [(path, "directory") for path in self._owned_directories]
+                + [(path, "file") for path in self._owned_files]
+            )
+        )
+        if directory_ownership_inventory(observed) != expected_inventory:
+            raise RuntimeError("owned stage contains an untracked entry")
+        identities = {
+            path: identity
+            for path, _kind, identity in directory_ownership_entry_identities(observed)
+        }
+        records = {
+            record.path: record for record in directory_ownership_file_records(observed)
+        }
+        for path, identity in self._owned_directories.items():
+            observed_identity = identities.get(path)
+            if (
+                observed_identity is None
+                or (
+                    observed_identity[0],
+                    observed_identity[1],
+                    stat.S_IFMT(observed_identity[2]),
+                    observed_identity[4],
+                )
+                != identity
+            ):
+                raise RuntimeError(f"owned stage directory changed: {path}")
+        for path, (identity, mode, size, digest) in self._owned_files.items():
+            observed_identity = identities.get(path)
+            record = records.get(path)
+            if (
+                observed_identity is None
+                or (
+                    observed_identity[0],
+                    observed_identity[1],
+                    stat.S_IFMT(observed_identity[2]),
+                    observed_identity[4],
+                )
+                != identity
+                or record is None
+                or (record.mode, record.size, record.sha256) != (mode, size, digest)
+            ):
+                raise RuntimeError(f"owned stage file changed: {path}")
+        if directory_ownership_root_identity(observed) != self._stage_identity:
+            raise RuntimeError("owned stage root changed")
+        self._cleanup_ownership = observed
+
+    def capture_ownership(self) -> object:
+        """Return the exact current token for this owned stage."""
+
+        self._refresh_cleanup_ownership()
+        return self._cleanup_ownership
 
     def publish(
         self,
         *,
-        expected_destination_ownership: object,
+        expected_destination_ownership: object = _UNSET_DESTINATION_OWNERSHIP,
         validate_staged_directory=None,
         validate_published_destination=None,
-    ) -> None:
-        self._cleanup_ownership = self._capture_current_ownership()
-        self.close()
-        publish_staged_directory(
+    ) -> DirectoryOrphan | None:
+        if expected_destination_ownership is _UNSET_DESTINATION_OWNERSHIP:
+            if not self._has_expected_destination_ownership:
+                raise TypeError(
+                    "expected_destination_ownership is required for an "
+                    "unprepared owned stage"
+                )
+            expected_destination_ownership = self._expected_destination_ownership
+        self._refresh_cleanup_ownership()
+        orphan = publish_staged_directory(
             self.path,
             self.destination,
             expected_stage_root_ownership=self._cleanup_ownership,
             expected_destination_ownership=expected_destination_ownership,
             validate_staged_directory=validate_staged_directory,
             validate_published_destination=validate_published_destination,
+            parent_descriptor=self._stage_parent_fd,
+            expected_parent_identity=self._parent_identity,
         )
+        self._record_orphan(orphan, operation="publication")
         self._published = True
+        self.close()
+        return orphan
 
 
 __all__ = [
     "AuthenticatedFile",
+    "AuthenticatedSnapshotReader",
     "CapturedDirectoryReader",
     "OwnedDirectoryStage",
+    "OwnedWorkspaceAuthority",
+    "PublishedWorkspaceReceipt",
+    "PublishedWorkspaceReceiptOwner",
+    "UnsupportedWorkspaceCreation",
+    "WorkspaceDirectory",
+    "WorkspaceFile",
+    "WorkspacePlan",
 ]

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -454,6 +454,7 @@ class OwnedDirectoryStage:
             )
         )
         self._initial = capture_directory_ownership(self.path)
+        self._cleanup_ownership = self._initial
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
         self._descriptor = os.open(self.path, flags)
@@ -468,9 +469,22 @@ class OwnedDirectoryStage:
             self._descriptor = -1
 
     def discard(self) -> None:
+        if not self._published:
+            try:
+                self._cleanup_ownership = self._capture_current_ownership()
+            except (OSError, RuntimeError, ValueError):
+                pass
         self.close()
         if not self._published:
-            discard_owned_directory(self.path, self._initial)
+            discard_owned_directory(self.path, self._cleanup_ownership)
+
+    def _capture_current_ownership(self):
+        observed = capture_directory_ownership(self.path)
+        if directory_ownership_root_identity(observed) != (
+            directory_ownership_root_identity(self._initial)
+        ):
+            raise RuntimeError("owned stage root changed")
+        return observed
 
     def _parent_descriptor(self, relative: PurePosixPath) -> int:
         descriptor = os.dup(self._descriptor)
@@ -577,11 +591,12 @@ class OwnedDirectoryStage:
         validate_staged_directory=None,
         validate_published_destination=None,
     ) -> None:
+        self._cleanup_ownership = self._capture_current_ownership()
         self.close()
         publish_staged_directory(
             self.path,
             self.destination,
-            expected_stage_root_ownership=self._initial,
+            expected_stage_root_ownership=self._cleanup_ownership,
             expected_destination_ownership=expected_destination_ownership,
             validate_staged_directory=validate_staged_directory,
             validate_published_destination=validate_published_destination,

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -26,6 +26,7 @@ except ImportError:  # pragma: no cover - Windows fails closed when requested
 
 from ._atomic_directory import (
     _MAX_OWNERSHIP_ENTRIES,
+    _MAX_OWNERSHIP_METADATA_BYTES,
     _SAFE_OWNERSHIP_DIRECTORY_FDS,
     DirectoryOrphan,
     PublicationDirectoryReader,
@@ -74,6 +75,7 @@ _UNSET_DESTINATION_OWNERSHIP = object()
 _MAX_WORKSPACE_ENTRIES = _MAX_OWNERSHIP_ENTRIES
 _MAX_WORKSPACE_FILE_BYTES = 64 * 1024 * 1024 * 1024
 _MAX_WORKSPACE_TOTAL_BYTES = 64 * 1024 * 1024 * 1024
+_OWNERSHIP_RECORD_FIXED_METADATA_BYTES = 8 + 1 + 4 + 8 + 32
 _WORKSPACE_PLAN_DOMAIN = b"codenib-owned-workspace-plan-v1"
 _WORKSPACE_RECEIPT_EMPTY = object()
 _WORKSPACE_RECEIPT_CLOSED = object()
@@ -279,6 +281,7 @@ class WorkspacePlan:
         directory_by_path: dict[str, WorkspaceDirectory] = {}
         file_by_path: dict[str, WorkspaceFile] = {}
         portable_paths: dict[str, str] = {}
+        metadata_bytes = 0
         for directory_item in directories:
             path = directory_item.path.as_posix()
             if path in directory_by_path:
@@ -292,6 +295,11 @@ class WorkspacePlan:
                 )
             portable_paths[portable] = path
             directory_by_path[path] = directory_item
+            metadata_bytes += (
+                len(os.fsencode(path)) + _OWNERSHIP_RECORD_FIXED_METADATA_BYTES
+            )
+            if metadata_bytes > _MAX_OWNERSHIP_METADATA_BYTES:
+                raise ValueError("workspace plan path metadata exceeds its budget")
         total_bytes = 0
         for file_item in files:
             path = file_item.path.as_posix()
@@ -310,6 +318,11 @@ class WorkspacePlan:
                 )
             portable_paths[portable] = path
             file_by_path[path] = file_item
+            metadata_bytes += (
+                len(os.fsencode(path)) + _OWNERSHIP_RECORD_FIXED_METADATA_BYTES
+            )
+            if metadata_bytes > _MAX_OWNERSHIP_METADATA_BYTES:
+                raise ValueError("workspace plan path metadata exceeds its budget")
             total_bytes += file_item.max_bytes
             if total_bytes > _MAX_WORKSPACE_TOTAL_BYTES:
                 raise ValueError("workspace plan total byte limit is out of bounds")
@@ -1840,14 +1853,14 @@ class OwnedWorkspaceAuthority:
             self._close_resources_after_error_locked(primary_error)
             raise primary_error.with_traceback(primary_error.__traceback__)
         assert record is not None
-        public_record = TreeFileRecord(
-            path=path,
-            mode=record[1],
-            size=record[2],
-            sha256=record[3],
-        )
         try:
             self._written_files[path] = record
+            public_record = TreeFileRecord(
+                path=path,
+                mode=record[1],
+                size=record[2],
+                sha256=record[3],
+            )
             self._refresh_locked(require_complete=False)
             self._state = "writing"
         except BaseException as transition_error:

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -25,6 +25,8 @@ except ImportError:  # pragma: no cover - Windows fails closed when requested
     _fcntl = None  # type: ignore[assignment]
 
 from ._atomic_directory import (
+    _MAX_OWNERSHIP_ENTRIES,
+    _SAFE_OWNERSHIP_DIRECTORY_FDS,
     DirectoryOrphan,
     PublicationDirectoryReader,
     TreeFileRecord,
@@ -36,6 +38,7 @@ from ._atomic_directory import (
     _publish_staged_directory_with_authority,
     _rename_noreplace_at,
     _require_matching_ownership,
+    _require_rename_noreplace_platform,
     directory_ownership_entry_identities,
     directory_ownership_file_records,
     directory_ownership_inventory,
@@ -46,10 +49,7 @@ from ._atomic_directory import (
     publication_parent_identity,
     publish_staged_directory,
 )
-from ._owned_file_publication import (
-    _CancellationSafeRLock,
-    _DescriptorOwner,
-)
+from ._owned_file_publication import _CancellationSafeRLock, _DescriptorOwner
 from ._owned_file_publication import _file_identity as _owned_file_identity
 
 logger = logging.getLogger(__name__)
@@ -70,7 +70,8 @@ _F_SEAL_GROW = 0x0004
 _F_SEAL_WRITE = 0x0008
 _REQUIRED_SNAPSHOT_SEALS = _F_SEAL_SEAL | _F_SEAL_SHRINK | _F_SEAL_GROW | _F_SEAL_WRITE
 _UNSET_DESTINATION_OWNERSHIP = object()
-_MAX_WORKSPACE_ENTRIES = 500_000
+# Workspace plans must fit the atomic ownership scanner used at seal/publication.
+_MAX_WORKSPACE_ENTRIES = _MAX_OWNERSHIP_ENTRIES
 _MAX_WORKSPACE_FILE_BYTES = 64 * 1024 * 1024 * 1024
 _MAX_WORKSPACE_TOTAL_BYTES = 64 * 1024 * 1024 * 1024
 _WORKSPACE_PLAN_DOMAIN = b"codenib-owned-workspace-plan-v1"
@@ -370,6 +371,25 @@ class WorkspacePlan:
 
 class UnsupportedWorkspaceCreation(RuntimeError):
     """Strict workspace creation is unavailable without a native creator."""
+
+
+def require_owned_workspace_publication_support() -> None:
+    """Fail before provisioning when strict workspace publication is unavailable."""
+
+    if not sys.platform.startswith("linux"):
+        raise UnsupportedWorkspaceCreation(
+            "strict workspace publication requires a supported Linux host"
+        )
+    if not _SAFE_OWNERSHIP_DIRECTORY_FDS:
+        raise UnsupportedWorkspaceCreation(
+            "strict workspace publication requires anchored directory-fd support"
+        )
+    try:
+        _require_rename_noreplace_platform()
+    except (OSError, RuntimeError) as exc:
+        raise UnsupportedWorkspaceCreation(
+            "strict workspace publication requires atomic no-replace rename support"
+        ) from exc
 
 
 @dataclass(slots=True)
@@ -1684,16 +1704,16 @@ class OwnedWorkspaceAuthority:
         self,
         relative: str | Path | PurePosixPath,
         chunks: Iterable[bytes],
-    ) -> None:
+    ) -> TreeFileRecord:
         self._require_owner_pid()
         self._reject_reentrant("write")
-        self._lock.run(lambda: self._write_file_locked(relative, chunks))
+        return self._lock.run(lambda: self._write_file_locked(relative, chunks))
 
     def _write_file_locked(
         self,
         relative: str | Path | PurePosixPath,
         chunks: Iterable[bytes],
-    ) -> None:
+    ) -> TreeFileRecord:
         self._require_owner_pid()
         if self._state not in {"adopted", "writing"}:
             raise RuntimeError(f"owned workspace cannot write while {self._state}")
@@ -1820,6 +1840,12 @@ class OwnedWorkspaceAuthority:
             self._close_resources_after_error_locked(primary_error)
             raise primary_error.with_traceback(primary_error.__traceback__)
         assert record is not None
+        public_record = TreeFileRecord(
+            path=path,
+            mode=record[1],
+            size=record[2],
+            sha256=record[3],
+        )
         try:
             self._written_files[path] = record
             self._refresh_locked(require_complete=False)
@@ -1828,6 +1854,7 @@ class OwnedWorkspaceAuthority:
             self._state = "failed"
             self._close_resources_after_error_locked(transition_error)
             raise
+        return public_record
 
     def seal(self) -> object:
         self._require_owner_pid()
@@ -1864,13 +1891,31 @@ class OwnedWorkspaceAuthority:
         for path in ordered_paths:
             os.fsync(self._directory_descriptors[path])
 
-    def publish_into(self, receipt_owner: PublishedWorkspaceReceiptOwner) -> None:
+    def publish_into(
+        self,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        *,
+        validate_staged_directory: (
+            Callable[[PublicationDirectoryReader], None] | None
+        ) = None,
+        validate_published_destination: (
+            Callable[[PublicationDirectoryReader], None] | None
+        ) = None,
+    ) -> None:
         """Durably publish and install ownership in a pre-created caller slot."""
 
         self._require_owner_pid()
         self._reject_reentrant("publish")
         if not isinstance(receipt_owner, PublishedWorkspaceReceiptOwner):
             raise TypeError("receipt_owner must be a PublishedWorkspaceReceiptOwner")
+        if validate_staged_directory is not None and not callable(
+            validate_staged_directory
+        ):
+            raise TypeError("staged workspace validator must be callable")
+        if validate_published_destination is not None and not callable(
+            validate_published_destination
+        ):
+            raise TypeError("published workspace validator must be callable")
         transfer = _WorkspacePublicationTransfer(self)
         reservation = _WorkspaceReservation(transfer)
         try:
@@ -1879,6 +1924,8 @@ class OwnedWorkspaceAuthority:
                     receipt_owner,
                     transfer,
                     reservation,
+                    validate_staged_directory,
+                    validate_published_destination,
                 )
             )
         except BaseException as primary_error:  # noqa: B036 - reconcile owners
@@ -1895,6 +1942,10 @@ class OwnedWorkspaceAuthority:
         receipt_owner: PublishedWorkspaceReceiptOwner,
         transfer: _WorkspacePublicationTransfer,
         reservation: _WorkspaceReservation,
+        validate_staged_directory: Callable[[PublicationDirectoryReader], None] | None,
+        validate_published_destination: (
+            Callable[[PublicationDirectoryReader], None] | None
+        ),
     ) -> None:
         self._require_owner_pid()
         if self._state != "sealed" or self._sealed_ownership is None:
@@ -1950,6 +2001,8 @@ class OwnedWorkspaceAuthority:
             self._destination,
             expected_stage_root_ownership=sealed_ownership,
             expected_destination_ownership=self._expected_destination,
+            validate_staged_directory=validate_staged_directory,
+            validate_published_destination=validate_published_destination,
             commit_callback=install_receipt,
         )
 
@@ -3135,4 +3188,5 @@ __all__ = [
     "WorkspaceDirectory",
     "WorkspaceFile",
     "WorkspacePlan",
+    "require_owned_workspace_publication_support",
 ]

--- a/codenib/_contained_source.py
+++ b/codenib/_contained_source.py
@@ -6,12 +6,53 @@
 
 from __future__ import annotations
 
+import errno
+import ntpath
 import os
 import stat
+import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
-from typing import Iterator
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Iterator, Sequence
+
+from ._windows_fs_authority import (
+    FILE_ATTRIBUTE_DIRECTORY as _WINDOWS_FILE_ATTRIBUTE_DIRECTORY,
+)
+from ._windows_fs_authority import (
+    FILE_ATTRIBUTE_REPARSE_POINT as _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT,
+)
+from ._windows_fs_authority import FILE_LIST_DIRECTORY as _WINDOWS_FILE_LIST_DIRECTORY
+from ._windows_fs_authority import FILE_READ_ATTRIBUTES as _WINDOWS_FILE_READ_ATTRIBUTES
+from ._windows_fs_authority import FILE_READ_DATA as _WINDOWS_FILE_READ_DATA
+from ._windows_fs_authority import (
+    IO_REPARSE_TAG_SYMLINK as _WINDOWS_IO_REPARSE_TAG_SYMLINK,
+)
+from ._windows_fs_authority import (
+    SYMLINK_FLAG_RELATIVE as _WINDOWS_SYMLINK_FLAG_RELATIVE,
+)
+from ._windows_fs_authority import SYNCHRONIZE as _WINDOWS_SYNCHRONIZE
+from ._windows_fs_authority import (
+    WindowsDirectoryAuthority as _WindowsDirectoryAuthority,
+)
+from ._windows_fs_authority import WindowsDirectoryEntry as _WindowsDirectoryEntry
+from ._windows_fs_authority import WindowsHandleMetadata as _WindowsHandleMetadata
+from ._windows_fs_authority import WindowsKernelApi as _WindowsKernelApi
+from ._windows_fs_authority import WindowsReparsePoint as _WindowsReparsePoint
+from ._windows_fs_authority import (
+    _close_windows_handles,
+    _WindowsHandleCleanup,
+)
+from ._windows_fs_authority import (
+    open_lexical_directory_authority as _open_lexical_windows_authority,
+)
+from ._windows_fs_authority import (
+    windows_file_id_is_reliable as _windows_file_id_is_reliable,
+)
+from ._windows_fs_authority import windows_kernel_api as _shared_windows_kernel_api
+from ._windows_fs_authority import (
+    windows_require_source_api as _shared_windows_require_source_api,
+)
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _MAX_COMPONENTS = 256
@@ -32,6 +73,266 @@ SECURE_CONTAINED_SYMLINKS = (
 
 class ContainedSourceMissingError(ValueError):
     """A lexically present source link has no resolvable regular target."""
+
+
+class _SourceCleanupSlot:
+    """Stable, retryable owner across raw-resource and binding handoffs."""
+
+    __slots__ = ("_resource",)
+
+    def __init__(self) -> None:
+        self._resource: object | None = None
+
+    def own(self, resource: object) -> None:
+        if resource is None:
+            raise TypeError("source cleanup resource must not be null")
+        self._resource = resource
+
+    @property
+    def pending_sources(self) -> tuple[object, ...]:
+        resource = self._resource
+        if resource is None or self.closed:
+            return ()
+        nested = getattr(resource, "pending_sources", None)
+        if nested is not None:
+            return tuple(nested)
+        return (resource,)
+
+    @property
+    def closed(self) -> bool:
+        resource = self._resource
+        if resource is None:
+            return True
+        try:
+            return bool(resource.closed)  # type: ignore[attr-defined]
+        except BaseException:  # noqa: B036 - uncertain ownership stays retained
+            return False
+
+    def close(self) -> None:
+        resource = self._resource
+        if resource is None:
+            return
+        close = getattr(resource, "close", None)
+        if not callable(close):
+            raise TypeError("source cleanup resource has no close method")
+        close()
+        if self.closed:
+            self._resource = None
+
+
+class _PosixDescriptorCleanup:
+    """Retryable owner for descriptors acquired during contained resolution."""
+
+    __slots__ = ("descriptors", "expected_identities")
+
+    def __init__(self) -> None:
+        self.descriptors: list[int] = []
+        self.expected_identities: dict[int, tuple[int, ...]] = {}
+
+    @property
+    def closed(self) -> bool:
+        return not self.descriptors
+
+    def retain(self, descriptor: int) -> int:
+        if descriptor not in self.descriptors:
+            self.descriptors.append(descriptor)
+        return descriptor
+
+    def remember_identity(self, descriptor: int, metadata: os.stat_result) -> None:
+        self.expected_identities[descriptor] = _binding_identity(metadata)
+
+    def open(self, path: str | Path, flags: int, *, dir_fd: int | None = None) -> int:
+        descriptor = -1
+        try:
+            if dir_fd is None:
+                descriptor = os.open(path, flags)
+            else:
+                descriptor = os.open(path, flags, dir_fd=dir_fd)
+            return self.retain(descriptor)
+        except BaseException:  # noqa: B036 - commit native return ownership
+            if descriptor >= 0:
+                try:
+                    self.retain(descriptor)
+                except BaseException:  # noqa: B036 - preserve acquisition failure
+                    pass
+            raise
+
+    def dup(self, descriptor: int) -> int:
+        duplicate = -1
+        try:
+            duplicate = os.dup(descriptor)
+            return self.retain(duplicate)
+        except BaseException:  # noqa: B036 - commit native return ownership
+            if duplicate >= 0:
+                try:
+                    self.retain(duplicate)
+                except BaseException:  # noqa: B036 - preserve acquisition failure
+                    pass
+            raise
+
+    def _close_selected(self, selected: tuple[int, ...]) -> BaseException | None:
+        deferred: BaseException | None = None
+        for descriptor in reversed(selected):
+            if descriptor not in self.descriptors:
+                continue
+            closed = False
+            try:
+                before = os.fstat(descriptor)
+                expected = self.expected_identities.get(descriptor)
+                if expected is not None and _binding_identity(before) != expected:
+                    deferred = deferred or RuntimeError(
+                        "source descriptor ownership changed"
+                    )
+                    closed = True
+                else:
+                    try:
+                        os.close(descriptor)
+                        closed = True
+                    except BaseException as exc:  # noqa: B036 - probe close result
+                        deferred = deferred or exc
+                        try:
+                            visible = os.fstat(descriptor)
+                        except OSError as probe:
+                            if probe.errno == errno.EBADF:
+                                closed = True
+                            else:
+                                deferred = deferred or probe
+                        except BaseException as probe:  # noqa: B036
+                            deferred = deferred or probe
+                        else:
+                            if _binding_identity(visible) != _binding_identity(before):
+                                closed = True
+            except OSError as exc:
+                if exc.errno == errno.EBADF:
+                    closed = True
+                else:
+                    deferred = deferred or exc
+            except BaseException as exc:  # noqa: B036 - visit remaining fds
+                deferred = deferred or exc
+            if closed:
+                while descriptor in self.descriptors:
+                    self.descriptors.remove(descriptor)
+                self.expected_identities.pop(descriptor, None)
+        return deferred
+
+    def close_descriptor(self, descriptor: int) -> None:
+        failure = self._close_selected((descriptor,))
+        if failure is not None:
+            raise failure
+
+    def close(self) -> None:
+        failure = self._close_selected(tuple(self.descriptors))
+        if failure is not None:
+            raise failure
+
+
+class _SourceCleanupGroup:
+    """Retryable cleanup-all owner for independently pending authorities."""
+
+    __slots__ = ("owners",)
+
+    def __init__(self, *owners: object) -> None:
+        self.owners: list[object] = []
+        for owner in owners:
+            self.add(owner)
+
+    def add(self, owner: object) -> None:
+        if owner is self:
+            return
+        if isinstance(owner, _SourceCleanupGroup):
+            for nested in owner.owners:
+                self.add(nested)
+            return
+        if not any(candidate is owner for candidate in self.owners):
+            self.owners.append(owner)
+
+    @property
+    def closed(self) -> bool:
+        for owner in self.owners:
+            try:
+                if not bool(owner.closed):  # type: ignore[attr-defined]
+                    return False
+            except BaseException:  # noqa: B036 - uncertain ownership is pending
+                return False
+        return True
+
+    @property
+    def pending_sources(self) -> tuple[object, ...]:
+        pending: list[object] = []
+        for owner in self.owners:
+            try:
+                if bool(owner.closed):  # type: ignore[attr-defined]
+                    continue
+            except BaseException:  # noqa: B036 - retain uncertain owner
+                pass
+            nested = getattr(owner, "pending_sources", None)
+            if nested is None:
+                pending.append(owner)
+            else:
+                pending.extend(nested)
+        return tuple(pending)
+
+    def close(self) -> None:
+        first_failure: BaseException | None = None
+        for owner in tuple(self.owners):
+            try:
+                owner.close()  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - cleanup every owner
+                first_failure = first_failure or exc
+        if first_failure is not None:
+            raise first_failure
+
+
+def _attach_source_cleanup_owner(failure: BaseException, owner: object) -> None:
+    """Attach all still-live cleanup owners to the propagated exception."""
+
+    try:
+        if bool(owner.closed):  # type: ignore[attr-defined]
+            return
+    except BaseException:  # noqa: B036 - uncertain ownership must stay reachable
+        pass
+    existing = getattr(failure, "source_cleanup_owner", None)
+    if existing is owner:
+        return
+    if existing is None:
+        attached = owner
+    elif isinstance(existing, _SourceCleanupGroup):
+        existing.add(owner)
+        attached = existing
+    else:
+        attached = _SourceCleanupGroup(existing, owner)
+    try:
+        failure.source_cleanup_owner = attached  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - the current frame still retains *owner*
+        pass
+
+
+def _inherit_source_cleanup_owner(
+    failure: BaseException,
+    prior: BaseException,
+) -> None:
+    """Keep a nested retry owner reachable from a translated primary error."""
+
+    owner = getattr(prior, "source_cleanup_owner", None)
+    if owner is not None:
+        _attach_source_cleanup_owner(failure, owner)
+
+
+def _raise_with_cleanup(
+    primary: BaseException,
+    owner: object,
+) -> None:
+    """Prefer *primary* while retaining any failed cleanup for explicit retry."""
+
+    cleanup_failure: BaseException | None = None
+    try:
+        owner.close()  # type: ignore[attr-defined]
+    except BaseException as exc:  # noqa: B036 - primary remains authoritative
+        cleanup_failure = exc
+    _attach_source_cleanup_owner(primary, owner)
+    if cleanup_failure is not None:
+        raise primary from cleanup_failure
+    raise primary
 
 
 def _is_link_or_reparse(metadata: os.stat_result) -> bool:
@@ -112,8 +413,6 @@ def _normalize_link_target(
         resolved.append(part)
         if len(resolved) > _MAX_COMPONENTS:
             raise ValueError("resolved source path exceeds its component limit")
-    if not resolved:
-        raise ValueError("source symlink does not resolve to a file")
     return tuple(resolved)
 
 
@@ -133,7 +432,13 @@ class _BoundRepositoryFile:
     root_descriptor: int
     root_identity: tuple[int, ...]
     observations: list[_PathObservation]
+    cleanup: _PosixDescriptorCleanup
     is_regular = True
+    is_directory = False
+
+    @property
+    def closed(self) -> bool:
+        return self.cleanup.closed
 
     def update_hash(self, hasher: object) -> None:
         update = getattr(hasher, "update", None)
@@ -196,16 +501,17 @@ class _BoundRepositoryFile:
             raise ValueError("source file changed while it was being read")
 
     def close(self) -> None:
-        descriptors = [
-            self.descriptor,
-            self.root_descriptor,
-            *(item.parent_descriptor for item in self.observations),
-        ]
-        for descriptor in descriptors:
-            try:
-                os.close(descriptor)
-            except OSError:
-                pass
+        try:
+            self.cleanup.close()
+        finally:
+            pending = set(self.cleanup.descriptors)
+            if self.descriptor not in pending:
+                self.descriptor = -1
+            if self.root_descriptor not in pending:
+                self.root_descriptor = -1
+            for item in self.observations:
+                if item.parent_descriptor not in pending:
+                    item.parent_descriptor = -1
 
 
 @dataclass(slots=True)
@@ -218,7 +524,13 @@ class _StableUnresolvedRepositoryFile:
     parent_identity: tuple[int, ...]
     name: str
     expected: tuple[int, ...] | None
+    cleanup: _PosixDescriptorCleanup
     is_regular = False
+    is_directory = False
+
+    @property
+    def closed(self) -> bool:
+        return self.cleanup.closed
 
     def verify(self) -> None:
         _verify_stable_unresolved(
@@ -233,16 +545,63 @@ class _StableUnresolvedRepositoryFile:
         )
 
     def close(self) -> None:
-        descriptors = [
+        try:
+            self.cleanup.close()
+        finally:
+            pending = set(self.cleanup.descriptors)
+            if self.root_descriptor not in pending:
+                self.root_descriptor = -1
+            if self.parent_descriptor not in pending:
+                self.parent_descriptor = -1
+            for item in self.observations:
+                if item.parent_descriptor not in pending:
+                    item.parent_descriptor = -1
+
+
+@dataclass(slots=True)
+class _BoundRepositoryDirectory:
+    """Pinned directory outcome for a lexical repository symlink."""
+
+    descriptor: int
+    opened_identity: tuple[int, ...]
+    root: Path
+    root_descriptor: int
+    root_identity: tuple[int, ...]
+    observations: list[_PathObservation]
+    cleanup: _PosixDescriptorCleanup
+    is_regular = False
+    is_directory = True
+
+    @property
+    def closed(self) -> bool:
+        return self.cleanup.closed
+
+    def verify(self) -> None:
+        _verify_resolution_state(
+            self.root,
             self.root_descriptor,
-            self.parent_descriptor,
-            *(item.parent_descriptor for item in self.observations),
-        ]
-        for descriptor in descriptors:
-            try:
-                os.close(descriptor)
-            except OSError:
-                pass
+            self.root_identity,
+            self.observations,
+        )
+        opened = os.fstat(self.descriptor)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or _version_identity(opened) != self.opened_identity
+        ):
+            raise ValueError("source directory changed during contained resolution")
+
+    def close(self) -> None:
+        try:
+            self.cleanup.close()
+        finally:
+            pending = set(self.cleanup.descriptors)
+            if self.descriptor not in pending:
+                self.descriptor = -1
+            if self.root_descriptor not in pending:
+                self.root_descriptor = -1
+            for item in self.observations:
+                if item.parent_descriptor not in pending:
+                    item.parent_descriptor = -1
 
 
 def _directory_flags() -> int:
@@ -335,16 +694,61 @@ def _open_secure(
     *,
     expected_final_identity: tuple[int, ...] | None = None,
     allow_stable_unresolved: bool = False,
-) -> _BoundRepositoryFile | _StableUnresolvedRepositoryFile:
-    try:
-        root_before = root.lstat()
-    except FileNotFoundError as exc:
-        raise ContainedSourceMissingError("repository root does not exist") from exc
+    pinned_root_descriptor: int | None = None,
+    expected_root_identity: tuple[int, ...] | None = None,
+    cleanup_slot: _SourceCleanupSlot | None = None,
+) -> _BoundRepositoryFile | _BoundRepositoryDirectory | _StableUnresolvedRepositoryFile:
+    cleanup = _PosixDescriptorCleanup()
+    if cleanup_slot is not None:
+        cleanup_slot.own(cleanup)
+    if pinned_root_descriptor is None:
+        try:
+            root_before = root.lstat()
+        except FileNotFoundError as exc:
+            raise ContainedSourceMissingError("repository root does not exist") from exc
+        try:
+            root_descriptor = cleanup.open(root, _directory_flags())
+        except BaseException as primary:  # noqa: B036 - retain partial open
+            _raise_with_cleanup(primary, cleanup_slot or cleanup)
+    else:
+        if (
+            isinstance(pinned_root_descriptor, bool)
+            or not isinstance(pinned_root_descriptor, int)
+            or pinned_root_descriptor < 0
+        ):
+            raise ValueError("pinned repository root descriptor is invalid")
+        try:
+            root_descriptor = cleanup.dup(pinned_root_descriptor)
+        except BaseException as primary:  # noqa: B036 - retain partial dup
+            _raise_with_cleanup(primary, cleanup_slot or cleanup)
+        try:
+            root_before = os.fstat(root_descriptor)
+            path_before = root.lstat()
+        except BaseException as primary:  # noqa: B036 - preserve acquisition
+            _raise_with_cleanup(primary, cleanup_slot or cleanup)
+        if _binding_identity(path_before) != _binding_identity(root_before):
+            _raise_with_cleanup(
+                ValueError("repository root changed during source resolution"),
+                cleanup_slot or cleanup,
+            )
     if _is_link_or_reparse(root_before) or not stat.S_ISDIR(root_before.st_mode):
-        raise ValueError("repository root must be a real directory")
+        _raise_with_cleanup(
+            ValueError("repository root must be a real directory"),
+            cleanup_slot or cleanup,
+        )
     if not _identity_is_reliable(root_before):
-        raise ValueError("repository root has no reliable filesystem identity")
-    root_descriptor = os.open(root, _directory_flags())
+        _raise_with_cleanup(
+            ValueError("repository root has no reliable filesystem identity"),
+            cleanup_slot or cleanup,
+        )
+    if (
+        expected_root_identity is not None
+        and _version_identity(root_before) != expected_root_identity
+    ):
+        _raise_with_cleanup(
+            ValueError("repository root changed during source resolution"),
+            cleanup_slot or cleanup,
+        )
     current_descriptor = -1
     source_descriptor = -1
     observations: list[_PathObservation] = []
@@ -377,16 +781,53 @@ def _open_secure(
                 root_descriptor=root_descriptor,
                 root_identity=_version_identity(root_opened),
                 observations=observations,
-                parent_descriptor=os.dup(parent_descriptor),
+                parent_descriptor=cleanup.dup(parent_descriptor),
                 parent_identity=parent_identity,
                 name=name,
                 expected=expected,
+                cleanup=cleanup,
             )
             root_descriptor = -1
             observations = []
+            if cleanup_slot is not None:
+                cleanup_slot.own(retained)
             return retained
 
-        current_descriptor = os.dup(root_descriptor)
+        def retain_directory(
+            directory_descriptor: int,
+            *,
+            expected_binding: tuple[int, ...] | None = None,
+        ) -> _BoundRepositoryDirectory:
+            nonlocal root_descriptor, observations
+            try:
+                opened = os.fstat(directory_descriptor)
+                if (
+                    expected_binding is not None
+                    and _binding_identity(opened) != expected_binding
+                ):
+                    raise ValueError("source directory changed while opening")
+                binding = _BoundRepositoryDirectory(
+                    descriptor=directory_descriptor,
+                    opened_identity=_version_identity(opened),
+                    root=root,
+                    root_descriptor=root_descriptor,
+                    root_identity=_version_identity(root_opened),
+                    observations=observations,
+                    cleanup=cleanup,
+                )
+            except BaseException as primary:  # noqa: B036 - preserve construction
+                _raise_with_cleanup(primary, cleanup_slot or cleanup)
+            root_descriptor = -1
+            observations = []
+            try:
+                binding.verify()
+            except BaseException as primary:  # noqa: B036 - preserve validation
+                _raise_with_cleanup(primary, cleanup_slot or binding)
+            if cleanup_slot is not None:
+                cleanup_slot.own(binding)
+            return binding
+
+        current_descriptor = cleanup.dup(root_descriptor)
         pending = [(name, index == len(parts) - 1) for index, name in enumerate(parts)]
         resolved_prefix: tuple[str, ...] = ()
         symlink_count = 0
@@ -440,7 +881,7 @@ def _open_secure(
                     )
                 observations.append(
                     _PathObservation(
-                        parent_descriptor=os.dup(current_descriptor),
+                        parent_descriptor=cleanup.dup(current_descriptor),
                         name=name,
                         identity=_version_identity(before),
                         link_target=target,
@@ -463,15 +904,28 @@ def _open_secure(
                 target_parts = _normalize_link_target(root, resolved_prefix, target)
                 if len(target_parts) + len(pending) > _MAX_COMPONENTS:
                     raise ValueError("resolved source path exceeds its component limit")
+                if not target_parts and not pending:
+                    expected_is_link = (
+                        expected_final_identity is not None
+                        and stat.S_ISLNK(expected_final_identity[2])
+                    )
+                    if not allow_stable_unresolved or not expected_is_link:
+                        raise ValueError(
+                            "source path resolves to the repository directory"
+                        )
+                    return retain_directory(
+                        cleanup.dup(root_descriptor),
+                        expected_binding=_binding_identity(root_opened),
+                    )
                 pending = [*((part, False) for part in target_parts), *pending]
                 resolved_prefix = ()
-                os.close(current_descriptor)
-                current_descriptor = os.dup(root_descriptor)
+                cleanup.close_descriptor(current_descriptor)
+                current_descriptor = cleanup.dup(root_descriptor)
                 continue
 
             observations.append(
                 _PathObservation(
-                    parent_descriptor=os.dup(current_descriptor),
+                    parent_descriptor=cleanup.dup(current_descriptor),
                     name=name,
                     identity=_version_identity(before),
                 )
@@ -481,7 +935,7 @@ def _open_secure(
                     raise ValueError("source path has a non-directory component")
                 child_descriptor = -1
                 try:
-                    child_descriptor = os.open(
+                    child_descriptor = cleanup.open(
                         name,
                         _directory_flags(),
                         dir_fd=current_descriptor,
@@ -489,11 +943,9 @@ def _open_secure(
                     opened = os.fstat(child_descriptor)
                     if _binding_identity(opened) != _binding_identity(before):
                         raise ValueError("source directory changed while opening")
-                except BaseException:
-                    if child_descriptor >= 0:
-                        os.close(child_descriptor)
-                    raise
-                os.close(current_descriptor)
+                except BaseException as primary:  # noqa: B036 - preserve open error
+                    _raise_with_cleanup(primary, cleanup_slot or cleanup)
+                cleanup.close_descriptor(current_descriptor)
                 current_descriptor = child_descriptor
                 resolved_prefix = (*resolved_prefix, name)
                 continue
@@ -502,6 +954,27 @@ def _open_secure(
                 expected_is_link = expected_final_identity is not None and stat.S_ISLNK(
                     expected_final_identity[2]
                 )
+                if (
+                    allow_stable_unresolved
+                    and expected_is_link
+                    and stat.S_ISDIR(before.st_mode)
+                ):
+                    directory_descriptor = -1
+                    try:
+                        directory_descriptor = cleanup.open(
+                            name,
+                            _directory_flags(),
+                            dir_fd=current_descriptor,
+                        )
+                        retained_descriptor = directory_descriptor
+                        directory_descriptor = -1
+                        return retain_directory(
+                            retained_descriptor,
+                            expected_binding=_binding_identity(before),
+                        )
+                    finally:
+                        if directory_descriptor >= 0:
+                            cleanup.close_descriptor(directory_descriptor)
                 if (
                     allow_stable_unresolved
                     and expected_is_link
@@ -514,7 +987,7 @@ def _open_secure(
                         expected=_version_identity(before),
                     )
                 raise ValueError("source path is not a regular repository file")
-            source_descriptor = os.open(
+            source_descriptor = cleanup.open(
                 name,
                 _regular_flags(),
                 dir_fd=current_descriptor,
@@ -529,14 +1002,16 @@ def _open_secure(
                 root_descriptor=root_descriptor,
                 root_identity=_version_identity(root_opened),
                 observations=observations,
+                cleanup=cleanup,
             )
             source_descriptor = -1
             root_descriptor = -1
             try:
                 binding.verify()
-            except BaseException:
-                binding.close()
-                raise
+            except BaseException as primary:  # noqa: B036 - preserve validation
+                _raise_with_cleanup(primary, cleanup_slot or binding)
+            if cleanup_slot is not None:
+                cleanup_slot.own(binding)
             return binding
         raise ValueError("source path does not resolve to a file")
     except FileNotFoundError as exc:
@@ -546,18 +1021,834 @@ def _open_secure(
     except OSError as exc:
         raise ValueError("source path could not be resolved safely") from exc
     finally:
-        if source_descriptor >= 0:
-            os.close(source_descriptor)
-        if current_descriptor >= 0:
-            os.close(current_descriptor)
-        if root_descriptor >= 0:
-            os.close(root_descriptor)
-        if root_descriptor >= 0 or source_descriptor >= 0:
-            for observation in observations:
-                try:
-                    os.close(observation.parent_descriptor)
-                except OSError:
-                    pass
+        active_failure = sys.exc_info()[1]
+        cleanup_failure: BaseException | None = None
+        try:
+            if root_descriptor < 0 and source_descriptor < 0:
+                if current_descriptor >= 0:
+                    cleanup.close_descriptor(current_descriptor)
+            else:
+                cleanup.close()
+        except BaseException as exc:  # noqa: B036 - preserve primary + owner
+            cleanup_failure = exc
+        owner = cleanup_slot or cleanup
+        if active_failure is not None:
+            _attach_source_cleanup_owner(active_failure, owner)
+            if cleanup_failure is not None:
+                raise active_failure from cleanup_failure
+        elif cleanup_failure is not None:
+            _attach_source_cleanup_owner(cleanup_failure, owner)
+            raise cleanup_failure
+
+
+def _windows_kernel_api() -> _WindowsKernelApi:
+    return _shared_windows_kernel_api()
+
+
+def _windows_lexical_repository_path(value: str | Path) -> Path:
+    expanded = os.path.expanduser(os.fspath(value))
+    return Path(ntpath.abspath(expanded))
+
+
+def _windows_binding_identity(metadata: _WindowsHandleMetadata) -> tuple[object, ...]:
+    return (
+        metadata.st_dev,
+        metadata.file_id_128,
+        metadata.st_mode,
+        metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0,
+        metadata.st_file_attributes,
+        metadata.reparse_tag,
+    )
+
+
+def _windows_version_identity(metadata: _WindowsHandleMetadata) -> tuple[object, ...]:
+    return (
+        *_windows_binding_identity(metadata),
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        metadata.delete_pending,
+    )
+
+
+def _windows_identity_is_reliable(metadata: _WindowsHandleMetadata) -> bool:
+    return (
+        bool(metadata.st_dev)
+        and _windows_file_id_is_reliable(metadata.file_id_128)
+        and not metadata.delete_pending
+    )
+
+
+def _windows_entry_is_reparse(entry: _WindowsDirectoryEntry) -> bool:
+    return bool(entry.attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def _windows_metadata_is_reparse(metadata: _WindowsHandleMetadata) -> bool:
+    return bool(metadata.st_file_attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def _windows_simple_child_name(name: str) -> None:
+    if (
+        not isinstance(name, str)
+        or not name
+        or name in {".", ".."}
+        or "/" in name
+        or "\\" in name
+        or "\x00" in name
+        or len(name.encode("utf-8", errors="strict")) > _MAX_RELATIVE_PATH_BYTES
+    ):
+        raise ValueError("Windows source entry has an invalid child name")
+
+
+def _windows_find_child(
+    api: _WindowsKernelApi,
+    parent_handle: int,
+    name: str,
+) -> _WindowsDirectoryEntry | None:
+    """Find one exact child without imposing unsafe case-folding semantics."""
+
+    _windows_simple_child_name(name)
+    matches = [
+        entry for entry in api.enumerate_directory(parent_handle) if entry.name == name
+    ]
+    if len(matches) > 1:
+        raise ValueError("Windows source directory has duplicate exact child names")
+    return matches[0] if matches else None
+
+
+def _windows_open_child(
+    api: _WindowsKernelApi,
+    parent_handle: int,
+    entry: _WindowsDirectoryEntry,
+    *,
+    cleanup: _WindowsHandleCleanup | None = None,
+) -> tuple[int, _WindowsHandleMetadata]:
+    """Open the enumerated child no-follow and rebind its exact FILE_ID."""
+
+    if not _windows_file_id_is_reliable(entry.file_id_128):
+        raise ValueError("Windows source entry has no reliable 128-bit FILE_ID")
+    is_reparse = _windows_entry_is_reparse(entry)
+    is_directory = bool(entry.attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+    desired_access = _WINDOWS_FILE_READ_ATTRIBUTES | _WINDOWS_SYNCHRONIZE
+    if not is_reparse:
+        desired_access |= (
+            _WINDOWS_FILE_LIST_DIRECTORY if is_directory else _WINDOWS_FILE_READ_DATA
+        )
+    selected_cleanup = cleanup or _WindowsHandleCleanup(api)
+    handle = 0
+    try:
+        handle = api.open_relative(
+            parent_handle,
+            entry.name,
+            desired_access=desired_access,
+            is_directory=is_directory,
+            allow_reparse=is_reparse,
+        )
+        selected_cleanup.retain(handle)
+        opened = api.metadata(handle)
+        selected_cleanup.retain(handle, opened)
+        if (
+            not _windows_identity_is_reliable(opened)
+            or opened.file_id_128 != entry.file_id_128
+            or opened.st_dev != api.metadata(parent_handle).st_dev
+            or bool(opened.st_file_attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+            != is_directory
+            or _windows_metadata_is_reparse(opened) != is_reparse
+            or (is_reparse and opened.reparse_tag != entry.reparse_tag)
+        ):
+            raise ValueError("Windows source entry changed while it was opened")
+        return handle, opened
+    except BaseException as primary:  # noqa: B036 - preserve construction failure
+        _raise_with_cleanup(primary, selected_cleanup)
+
+
+def _strip_windows_namespace(path: str) -> str:
+    if path.startswith("\\??\\UNC\\"):
+        return "\\\\" + path[8:]
+    if path.startswith("\\??\\"):
+        return path[4:]
+    if path.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + path[8:]
+    if path.startswith("\\\\?\\"):
+        return path[4:]
+    return path
+
+
+def _windows_path_parts(path: str) -> tuple[str, ...]:
+    return tuple(PureWindowsPath(ntpath.normpath(path)).parts)
+
+
+def _normalize_windows_link_target(
+    root: Path,
+    prefix: tuple[str, ...],
+    point: _WindowsReparsePoint,
+) -> tuple[str, ...]:
+    """Normalize one Windows SYMLINK payload into pinned-root components."""
+
+    target = point.substitute_name
+    if not isinstance(target, str) or not target or "\x00" in target:
+        raise ValueError("Windows source symlink target must be non-empty")
+    if len(target.encode("utf-8", errors="strict")) > _MAX_SYMLINK_TARGET_BYTES:
+        raise ValueError("Windows source symlink target exceeds its byte limit")
+    relative = bool(point.flags & _WINDOWS_SYMLINK_FLAG_RELATIVE)
+    if point.flags & ~_WINDOWS_SYMLINK_FLAG_RELATIVE:
+        raise ValueError("Windows source symlink has unsupported flags")
+
+    if relative:
+        if ntpath.isabs(target) or ntpath.splitdrive(target)[0]:
+            raise ValueError("Windows relative symlink contains an absolute target")
+        resolved: list[str] = list(prefix)
+        target_parts = target.replace("\\", "/").split("/")
+    else:
+        target = _strip_windows_namespace(target)
+        if not ntpath.isabs(target):
+            raise ValueError("Windows absolute symlink has a relative target")
+        root_parts = _windows_path_parts(str(root))
+        target_parts_absolute = _windows_path_parts(target)
+        if len(target_parts_absolute) < len(root_parts) or any(
+            observed.casefold() != expected.casefold()
+            for observed, expected in zip(
+                target_parts_absolute,
+                root_parts,
+                strict=False,
+            )
+        ):
+            raise ValueError("Windows source symlink resolves outside the repository")
+        resolved = []
+        target_parts = list(target_parts_absolute[len(root_parts) :])
+
+    for part in target_parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if not resolved:
+                raise ValueError(
+                    "Windows source symlink resolves outside the repository"
+                )
+            resolved.pop()
+            continue
+        if ":" in part:
+            raise ValueError("Windows source symlink contains a stream component")
+        _windows_simple_child_name(part)
+        resolved.append(part)
+        if len(resolved) > _MAX_COMPONENTS:
+            raise ValueError("resolved Windows source path exceeds its component limit")
+    return tuple(resolved)
+
+
+def _windows_link_target_text(point: _WindowsReparsePoint) -> str:
+    target = point.print_name or point.substitute_name
+    if not isinstance(target, str) or not target or "\x00" in target:
+        raise ValueError("Windows source symlink has no canonical text target")
+    if len(target.encode("utf-8", errors="strict")) > _MAX_SYMLINK_TARGET_BYTES:
+        raise ValueError("Windows source symlink target exceeds its byte limit")
+    return target
+
+
+@dataclass(slots=True)
+class _WindowsPathObservation:
+    parent_handle: int
+    parent_identity: tuple[object, ...]
+    name: str
+    file_id_128: bytes
+    handle: int
+    identity: tuple[object, ...]
+    reparse_point: _WindowsReparsePoint | None = None
+
+
+def _verify_windows_root_path(
+    api: _WindowsKernelApi,
+    authority: _WindowsDirectoryAuthority,
+    root_handle: int,
+    root_identity: tuple[object, ...],
+) -> None:
+    authority.verify()
+    opened = api.metadata(root_handle)
+    if _windows_version_identity(opened) != root_identity:
+        raise ValueError("Windows repository root changed during source resolution")
+
+
+def _verify_windows_resolution_state(
+    api: _WindowsKernelApi,
+    authority: _WindowsDirectoryAuthority,
+    root_handle: int,
+    root_identity: tuple[object, ...],
+    observations: Sequence[_WindowsPathObservation],
+) -> None:
+    _verify_windows_root_path(api, authority, root_handle, root_identity)
+    for observation in observations:
+        if (
+            _windows_version_identity(api.metadata(observation.parent_handle))
+            != observation.parent_identity
+        ):
+            raise ValueError("Windows source parent changed during resolution")
+        entry = _windows_find_child(api, observation.parent_handle, observation.name)
+        if entry is None or entry.file_id_128 != observation.file_id_128:
+            raise ValueError("Windows source path changed during resolution")
+        if (
+            _windows_version_identity(api.metadata(observation.handle))
+            != observation.identity
+        ):
+            raise ValueError("Windows source object changed during resolution")
+        if observation.reparse_point is not None and (
+            api.query_reparse_point(observation.handle) != observation.reparse_point
+        ):
+            raise ValueError("Windows source symlink changed during resolution")
+    _verify_windows_root_path(api, authority, root_handle, root_identity)
+
+
+class _WindowsResolutionBinding:
+    is_regular = False
+    is_directory = False
+
+    def __init__(
+        self,
+        *,
+        api: _WindowsKernelApi,
+        root: Path,
+        root_authority: _WindowsDirectoryAuthority,
+        owns_root_authority: bool,
+        root_handle: int,
+        root_identity: tuple[object, ...],
+        observations: list[_WindowsPathObservation],
+        handles: list[int],
+        handle_identities: dict[int, tuple[object, ...]],
+    ) -> None:
+        self.api = api
+        self.root = root
+        self.root_authority = root_authority
+        self.owns_root_authority = owns_root_authority
+        self.root_handle = root_handle
+        self.root_identity = root_identity
+        self.observations = observations
+        self.handles = handles
+        self.handle_identities = handle_identities
+        self.closed = False
+        self._cleanup_started = False
+
+    def verify(self) -> None:
+        if self.closed or self._cleanup_started:
+            raise ValueError("Windows source binding is closed")
+        _verify_windows_resolution_state(
+            self.api,
+            self.root_authority,
+            self.root_handle,
+            self.root_identity,
+            self.observations,
+        )
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self._cleanup_started = True
+        failure = _close_windows_handles(
+            self.api,
+            self.handles,
+            self.handle_identities,
+        )
+        if self.root_handle not in self.handles:
+            self.root_handle = 0
+        if self.owns_root_authority:
+            try:
+                self.root_authority.close()
+            except BaseException as exc:  # noqa: B036 - finish all cleanup
+                if failure is None:
+                    failure = exc
+        self.closed = not self.handles and (
+            not self.owns_root_authority or self.root_authority.closed
+        )
+        if failure is not None:
+            raise failure
+
+
+class _WindowsResolutionConstructionCleanup:
+    """Owner spanning partial resolution HANDLEs and an optional root authority."""
+
+    __slots__ = ("handles", "root_authority", "owns_root_authority")
+
+    def __init__(
+        self,
+        api: _WindowsKernelApi,
+        root_authority: _WindowsDirectoryAuthority,
+        *,
+        owns_root_authority: bool,
+    ) -> None:
+        self.handles = _WindowsHandleCleanup(api)
+        self.root_authority = root_authority
+        self.owns_root_authority = owns_root_authority
+
+    @property
+    def closed(self) -> bool:
+        return self.handles.closed and (
+            not self.owns_root_authority or self.root_authority.closed
+        )
+
+    def close(self) -> None:
+        failure: BaseException | None = None
+        try:
+            self.handles.close()
+        except BaseException as exc:  # noqa: B036 - cleanup all authorities
+            failure = exc
+        if self.owns_root_authority:
+            try:
+                self.root_authority.close()
+            except BaseException as exc:  # noqa: B036 - preserve first failure
+                failure = failure or exc
+        if failure is not None:
+            raise failure
+
+
+class _WindowsBoundRepositoryFile(_WindowsResolutionBinding):
+    is_regular = True
+
+    def __init__(
+        self,
+        *,
+        file_handle: int,
+        opened_identity: tuple[object, ...],
+        opened_size: int,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.file_handle = file_handle
+        self.opened_identity = opened_identity
+        self.opened_size = opened_size
+
+    def _opened(self) -> _WindowsHandleMetadata:
+        opened = self.api.metadata(self.file_handle)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or _windows_metadata_is_reparse(opened)
+            or not _windows_identity_is_reliable(opened)
+            or _windows_version_identity(opened) != self.opened_identity
+            or opened.st_size != self.opened_size
+        ):
+            raise ValueError("Windows source file is not a stable regular file")
+        return opened
+
+    def update_hash(self, hasher: object) -> None:
+        update = getattr(hasher, "update", None)
+        if not callable(update):
+            raise TypeError("hasher must provide an update method")
+        opened = self._opened()
+        remaining = opened.st_size
+        while remaining:
+            block = self.api.read(self.file_handle, min(remaining, _READ_CHUNK_BYTES))
+            if not block:
+                raise ValueError("Windows source file was truncated while hashing")
+            update(block)
+            remaining -= len(block)
+        if self.api.read(self.file_handle, 1):
+            raise ValueError("Windows source file grew while hashing")
+        self.verify()
+        self._opened()
+
+    def read_bytes(self, *, max_bytes: int) -> bytes:
+        if (
+            isinstance(max_bytes, bool)
+            or not isinstance(max_bytes, int)
+            or max_bytes <= 0
+        ):
+            raise ValueError("source byte limit must be positive")
+        opened = self._opened()
+        if opened.st_size < 0 or opened.st_size > max_bytes:
+            raise ValueError("Windows source file exceeds its bounded read limit")
+        payload = bytearray()
+        remaining = opened.st_size
+        while remaining:
+            block = self.api.read(self.file_handle, min(remaining, _READ_CHUNK_BYTES))
+            if not block:
+                raise ValueError("Windows source file was truncated while being read")
+            payload.extend(block)
+            remaining -= len(block)
+        if self.api.read(self.file_handle, 1):
+            raise ValueError("Windows source file grew while being read")
+        self.verify()
+        self._opened()
+        return bytes(payload)
+
+
+class _WindowsBoundRepositoryDirectory(_WindowsResolutionBinding):
+    is_directory = True
+
+    def __init__(
+        self,
+        *,
+        directory_handle: int,
+        opened_identity: tuple[object, ...],
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.directory_handle = directory_handle
+        self.opened_identity = opened_identity
+
+    def verify(self) -> None:
+        super().verify()
+        opened = self.api.metadata(self.directory_handle)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or _windows_metadata_is_reparse(opened)
+            or _windows_version_identity(opened) != self.opened_identity
+        ):
+            raise ValueError("Windows source directory changed during resolution")
+
+
+class _WindowsStableUnresolvedRepositoryFile(_WindowsResolutionBinding):
+    def __init__(
+        self,
+        *,
+        parent_handle: int,
+        parent_identity: tuple[object, ...],
+        name: str,
+        expected_file_id: bytes | None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.parent_handle = parent_handle
+        self.parent_identity = parent_identity
+        self.name = name
+        self.expected_file_id = expected_file_id
+
+    def verify(self) -> None:
+        super().verify()
+        if (
+            _windows_version_identity(self.api.metadata(self.parent_handle))
+            != self.parent_identity
+        ):
+            raise ValueError("Windows unresolved source parent changed")
+        entry = _windows_find_child(self.api, self.parent_handle, self.name)
+        observed = None if entry is None else entry.file_id_128
+        if observed != self.expected_file_id:
+            raise ValueError("Windows unresolved source terminal changed")
+
+
+def _open_windows_pinned_repository_root(
+    root: Path,
+    *,
+    api: _WindowsKernelApi | None = None,
+    cleanup_slot: _SourceCleanupSlot | None = None,
+) -> tuple[
+    _WindowsKernelApi,
+    _WindowsDirectoryAuthority,
+    tuple[object, ...],
+]:
+    selected = _windows_kernel_api() if api is None else api
+    if api is None:
+        _shared_windows_require_source_api(selected)
+    authority = _open_lexical_windows_authority(
+        root,
+        api=selected,
+        cleanup_slot=cleanup_slot,
+    )
+    try:
+        opened = selected.metadata(authority.handle)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or _windows_metadata_is_reparse(opened)
+            or not _windows_identity_is_reliable(opened)
+        ):
+            raise ValueError(
+                "Windows repository root must be a real identity-bound directory"
+            )
+        identity = _windows_version_identity(opened)
+        _verify_windows_root_path(selected, authority, authority.handle, identity)
+        return selected, authority, identity
+    except BaseException as primary:  # noqa: B036 - preserve root failure
+        _raise_with_cleanup(primary, cleanup_slot or authority)
+
+
+def _verify_windows_pinned_repository_root(
+    api: _WindowsKernelApi,
+    authority: _WindowsDirectoryAuthority,
+    expected_identity: tuple[object, ...],
+) -> None:
+    _verify_windows_root_path(
+        api,
+        authority,
+        authority.handle,
+        expected_identity,
+    )
+
+
+def _open_windows_resolution_at(
+    root: Path,
+    root_authority: _WindowsDirectoryAuthority,
+    parts: tuple[str, ...],
+    *,
+    expected_root_identity: tuple[object, ...],
+    expected_final_identity: tuple[object, ...] | None,
+    allow_stable_unresolved: bool,
+    api: _WindowsKernelApi,
+    owns_root_authority: bool = False,
+    cleanup_slot: _SourceCleanupSlot | None = None,
+) -> _WindowsResolutionBinding:
+    construction = _WindowsResolutionConstructionCleanup(
+        api,
+        root_authority,
+        owns_root_authority=owns_root_authority,
+    )
+    if cleanup_slot is not None:
+        cleanup_slot.own(construction)
+    cleanup = construction.handles
+    owned_root = 0
+    try:
+        owned_root = api.duplicate_handle(root_authority.handle)
+        cleanup.retain(owned_root)
+    except BaseException as primary:  # noqa: B036 - retain partial duplicate
+        _raise_with_cleanup(primary, cleanup_slot or construction)
+    handles = cleanup.handles
+    handle_identities = cleanup.expected_identities
+    observations: list[_WindowsPathObservation] = []
+    try:
+        root_opened = api.metadata(owned_root)
+        cleanup.retain(owned_root, root_opened)
+        if (
+            _windows_version_identity(root_opened) != expected_root_identity
+            or not stat.S_ISDIR(root_opened.st_mode)
+            or _windows_metadata_is_reparse(root_opened)
+            or not _windows_identity_is_reliable(root_opened)
+        ):
+            raise ValueError("Windows repository root changed before resolution")
+        current_handle = owned_root
+        pending = [(part, index == len(parts) - 1) for index, part in enumerate(parts)]
+        resolved_prefix: tuple[str, ...] = ()
+        seen_links: set[bytes] = set()
+        symlink_count = 0
+        lexical_final_is_link = bool(
+            expected_final_identity is not None
+            and len(expected_final_identity) > 5
+            and expected_final_identity[5] == _WINDOWS_IO_REPARSE_TAG_SYMLINK
+        )
+
+        def common_kwargs() -> dict[str, object]:
+            return {
+                "api": api,
+                "root": root,
+                "root_authority": root_authority,
+                "owns_root_authority": owns_root_authority,
+                "root_handle": owned_root,
+                "root_identity": expected_root_identity,
+                "observations": observations,
+                "handles": handles,
+                "handle_identities": handle_identities,
+            }
+
+        while pending:
+            name, is_lexical_final = pending.pop(0)
+            parent_identity = _windows_version_identity(api.metadata(current_handle))
+            entry = _windows_find_child(api, current_handle, name)
+            if entry is None:
+                if not (allow_stable_unresolved and lexical_final_is_link):
+                    raise FileNotFoundError(name)
+                binding = _WindowsStableUnresolvedRepositoryFile(
+                    parent_handle=current_handle,
+                    parent_identity=parent_identity,
+                    name=name,
+                    expected_file_id=None,
+                    **common_kwargs(),
+                )
+                binding.verify()
+                if cleanup_slot is not None:
+                    cleanup_slot.own(binding)
+                return binding
+            opened_handle, opened = _windows_open_child(
+                api,
+                current_handle,
+                entry,
+                cleanup=cleanup,
+            )
+            opened_identity = _windows_version_identity(opened)
+            if (
+                is_lexical_final
+                and expected_final_identity is not None
+                and opened_identity != expected_final_identity
+            ):
+                raise ValueError("Windows source differs from its initial observation")
+
+            point: _WindowsReparsePoint | None = None
+            if _windows_metadata_is_reparse(opened):
+                if opened.reparse_tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
+                    raise ValueError(
+                        "Windows source contains an unsupported reparse point"
+                    )
+                point = api.query_reparse_point(opened_handle)
+                if point.tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
+                    raise ValueError("Windows source reparse tag changed while opening")
+            observation = _WindowsPathObservation(
+                parent_handle=current_handle,
+                parent_identity=parent_identity,
+                name=name,
+                file_id_128=entry.file_id_128,
+                handle=opened_handle,
+                identity=opened_identity,
+                reparse_point=point,
+            )
+            observations.append(observation)
+
+            if point is not None:
+                symlink_count += 1
+                if symlink_count > _MAX_SYMLINKS:
+                    raise ValueError(
+                        "Windows source symlink resolution exceeds its limit"
+                    )
+                if opened.file_id_128 in seen_links:
+                    if not (allow_stable_unresolved and lexical_final_is_link):
+                        raise ValueError(
+                            "Windows source symlink resolution contains a loop"
+                        )
+                    binding = _WindowsStableUnresolvedRepositoryFile(
+                        parent_handle=current_handle,
+                        parent_identity=parent_identity,
+                        name=name,
+                        expected_file_id=entry.file_id_128,
+                        **common_kwargs(),
+                    )
+                    binding.verify()
+                    if cleanup_slot is not None:
+                        cleanup_slot.own(binding)
+                    return binding
+                seen_links.add(opened.file_id_128)
+                target_parts = _normalize_windows_link_target(
+                    root,
+                    resolved_prefix,
+                    point,
+                )
+                if len(target_parts) + len(pending) > _MAX_COMPONENTS:
+                    raise ValueError(
+                        "resolved Windows source path exceeds its component limit"
+                    )
+                if not target_parts and not pending:
+                    if not (allow_stable_unresolved and lexical_final_is_link):
+                        raise ValueError(
+                            "Windows source path resolves to the repository directory"
+                        )
+                    directory_handle = api.duplicate_handle(owned_root)
+                    cleanup.retain(directory_handle)
+                    directory_metadata = api.metadata(directory_handle)
+                    cleanup.retain(directory_handle, directory_metadata)
+                    binding = _WindowsBoundRepositoryDirectory(
+                        directory_handle=directory_handle,
+                        opened_identity=_windows_version_identity(directory_metadata),
+                        **common_kwargs(),
+                    )
+                    binding.verify()
+                    if cleanup_slot is not None:
+                        cleanup_slot.own(binding)
+                    return binding
+                pending = [*((part, False) for part in target_parts), *pending]
+                resolved_prefix = ()
+                current_handle = owned_root
+                continue
+
+            if pending:
+                if not stat.S_ISDIR(opened.st_mode):
+                    raise ValueError("Windows source has a non-directory component")
+                current_handle = opened_handle
+                resolved_prefix = (*resolved_prefix, name)
+                continue
+
+            if stat.S_ISDIR(opened.st_mode):
+                if not (allow_stable_unresolved and lexical_final_is_link):
+                    raise ValueError("Windows source path is not a regular file")
+                binding = _WindowsBoundRepositoryDirectory(
+                    directory_handle=opened_handle,
+                    opened_identity=opened_identity,
+                    **common_kwargs(),
+                )
+                binding.verify()
+                if cleanup_slot is not None:
+                    cleanup_slot.own(binding)
+                return binding
+            if not stat.S_ISREG(opened.st_mode):
+                if not (allow_stable_unresolved and lexical_final_is_link):
+                    raise ValueError("Windows source path is not a regular file")
+                binding = _WindowsStableUnresolvedRepositoryFile(
+                    parent_handle=current_handle,
+                    parent_identity=parent_identity,
+                    name=name,
+                    expected_file_id=entry.file_id_128,
+                    **common_kwargs(),
+                )
+                binding.verify()
+                if cleanup_slot is not None:
+                    cleanup_slot.own(binding)
+                return binding
+            binding = _WindowsBoundRepositoryFile(
+                file_handle=opened_handle,
+                opened_identity=opened_identity,
+                opened_size=opened.st_size,
+                **common_kwargs(),
+            )
+            binding.verify()
+            if cleanup_slot is not None:
+                cleanup_slot.own(binding)
+            return binding
+        raise ValueError("Windows source path does not resolve to a file")
+    except BaseException as primary:  # noqa: B036 - preserve resolution failure
+        _raise_with_cleanup(primary, cleanup_slot or construction)
+
+
+@contextmanager
+def _resolved_windows_repository_file_at(
+    root: str | Path,
+    root_authority: _WindowsDirectoryAuthority,
+    relative: str,
+    *,
+    expected_root_identity: tuple[object, ...],
+    expected_final_identity: tuple[object, ...],
+    api: _WindowsKernelApi | None = None,
+) -> Iterator[_WindowsResolutionBinding]:
+    """Resolve one source entry through a caller-owned pinned Windows root."""
+
+    selected = _windows_kernel_api() if api is None else api
+    parts = _relative_parts(relative)
+    cleanup_slot = _SourceCleanupSlot()
+    binding = _open_windows_resolution_at(
+        Path(root),
+        root_authority,
+        parts,
+        expected_root_identity=expected_root_identity,
+        expected_final_identity=expected_final_identity,
+        allow_stable_unresolved=True,
+        api=selected,
+        cleanup_slot=cleanup_slot,
+    )
+    try:
+        yield binding
+        binding.verify()
+    except BaseException as primary:  # noqa: B036 - preserve body failure
+        _raise_with_cleanup(primary, cleanup_slot)
+    else:
+        try:
+            cleanup_slot.close()
+        except BaseException as cleanup_failure:  # noqa: B036
+            _attach_source_cleanup_owner(cleanup_failure, cleanup_slot)
+            raise
+
+
+def _open_windows_repository_file(
+    root: Path,
+    parts: tuple[str, ...],
+    *,
+    expected_final_identity: tuple[object, ...] | None = None,
+    allow_stable_unresolved: bool = False,
+) -> _WindowsResolutionBinding:
+    cleanup_slot = _SourceCleanupSlot()
+    api, root_authority, root_identity = _open_windows_pinned_repository_root(
+        root,
+        cleanup_slot=cleanup_slot,
+    )
+    return _open_windows_resolution_at(
+        root,
+        root_authority,
+        parts,
+        expected_root_identity=root_identity,
+        expected_final_identity=expected_final_identity,
+        allow_stable_unresolved=allow_stable_unresolved,
+        api=api,
+        owns_root_authority=True,
+        cleanup_slot=cleanup_slot,
+    )
 
 
 def _static_components(
@@ -623,6 +1914,19 @@ def validate_repository_file(root: str | Path, relative: str) -> None:
     """Require one stable regular source file resolving beneath *root*."""
 
     try:
+        if sys.platform == "win32":
+            repository = _windows_lexical_repository_path(root)
+            binding = _open_windows_repository_file(
+                repository,
+                _relative_parts(relative),
+            )
+            try:
+                if not binding.is_regular:
+                    raise ValueError("source path is not a regular repository file")
+                binding.verify()
+            finally:
+                binding.close()
+            return
         repository = Path(root).expanduser().resolve()
         parts = _relative_parts(relative)
         if SECURE_CONTAINED_SYMLINKS:
@@ -655,6 +1959,18 @@ def read_repository_file(
     if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes <= 0:
         raise ValueError("source byte limit must be positive")
     try:
+        if sys.platform == "win32":
+            repository = _windows_lexical_repository_path(root)
+            binding = _open_windows_repository_file(
+                repository,
+                _relative_parts(relative),
+            )
+            try:
+                if not isinstance(binding, _WindowsBoundRepositoryFile):
+                    raise ValueError("source path is not a regular repository file")
+                return binding.read_bytes(max_bytes=max_bytes)
+            finally:
+                binding.close()
         repository = Path(root).expanduser().resolve()
         parts = _relative_parts(relative)
         if SECURE_CONTAINED_SYMLINKS:
@@ -678,9 +1994,25 @@ def resolved_repository_file(
     relative: str,
     *,
     expected_final_identity: tuple[int, ...],
-) -> Iterator[_BoundRepositoryFile | _StableUnresolvedRepositoryFile]:
+) -> Iterator[
+    _BoundRepositoryFile | _BoundRepositoryDirectory | _StableUnresolvedRepositoryFile
+]:
     """Yield a pinned regular file or a retained stable link-only outcome."""
 
+    if sys.platform == "win32":
+        repository = _windows_lexical_repository_path(root)
+        binding = _open_windows_repository_file(
+            repository,
+            _relative_parts(relative),
+            expected_final_identity=expected_final_identity,
+            allow_stable_unresolved=True,
+        )
+        try:
+            yield binding
+            binding.verify()
+        finally:
+            binding.close()
+        return
     if not SECURE_CONTAINED_SYMLINKS:
         raise ValueError("stable link-only resolution requires directory-fd support")
     repository = Path(root).expanduser().resolve()
@@ -701,6 +2033,48 @@ def resolved_repository_file(
         binding.close()
 
 
+@contextmanager
+def _resolved_repository_file_at(
+    root: str | Path,
+    root_descriptor: int,
+    relative: str,
+    *,
+    expected_root_identity: tuple[int, ...],
+    expected_final_identity: tuple[int, ...],
+) -> Iterator[
+    _BoundRepositoryFile | _BoundRepositoryDirectory | _StableUnresolvedRepositoryFile
+]:
+    """Resolve one entry through a caller-owned, already-pinned root fd."""
+
+    if not SECURE_CONTAINED_SYMLINKS:
+        raise ValueError("pinned source resolution requires directory-fd support")
+    repository = Path(root)
+    if not repository.is_absolute():
+        raise ValueError("pinned repository root must be absolute")
+    parts = _relative_parts(relative)
+    cleanup_slot = _SourceCleanupSlot()
+    binding = _open_secure(
+        repository,
+        parts,
+        expected_final_identity=expected_final_identity,
+        allow_stable_unresolved=True,
+        pinned_root_descriptor=root_descriptor,
+        expected_root_identity=expected_root_identity,
+        cleanup_slot=cleanup_slot,
+    )
+    try:
+        yield binding
+        binding.verify()
+    except BaseException as primary:  # noqa: B036 - preserve body failure
+        _raise_with_cleanup(primary, cleanup_slot)
+    else:
+        try:
+            cleanup_slot.close()
+        except BaseException as cleanup_failure:  # noqa: B036
+            _attach_source_cleanup_owner(cleanup_failure, cleanup_slot)
+            raise
+
+
 def update_repository_file_hash(
     root: str | Path,
     relative: str,
@@ -713,6 +2087,20 @@ def update_repository_file_hash(
     update = getattr(hasher, "update", None)
     if not callable(update):
         raise TypeError("hasher must provide an update method")
+    if sys.platform == "win32":
+        repository = _windows_lexical_repository_path(root)
+        binding = _open_windows_repository_file(
+            repository,
+            _relative_parts(relative),
+            expected_final_identity=expected_final_identity,
+        )
+        try:
+            if not isinstance(binding, _WindowsBoundRepositoryFile):
+                raise ValueError("source path is not a regular repository file")
+            binding.update_hash(hasher)
+        finally:
+            binding.close()
+        return
     repository = Path(root).expanduser().resolve()
     parts = _relative_parts(relative)
     if not SECURE_CONTAINED_SYMLINKS:

--- a/codenib/_contained_source.py
+++ b/codenib/_contained_source.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 
 import os
 import stat
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
+from typing import Iterator
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _MAX_COMPONENTS = 256
+_MAX_RELATIVE_PATH_BYTES = 4_096
 _MAX_SYMLINKS = 40
 _MAX_SYMLINK_TARGET_BYTES = 4_096
 _READ_CHUNK_BYTES = 1024 * 1024
@@ -25,6 +28,10 @@ SECURE_CONTAINED_SYMLINKS = (
     and os.stat in getattr(os, "supports_follow_symlinks", ())
     and os.readlink in getattr(os, "supports_dir_fd", ())
 )
+
+
+class ContainedSourceMissingError(ValueError):
+    """A lexically present source link has no resolvable regular target."""
 
 
 def _is_link_or_reparse(metadata: os.stat_result) -> bool:
@@ -52,8 +59,17 @@ def _version_identity(metadata: os.stat_result) -> tuple[int, ...]:
     )
 
 
+def _identity_is_reliable(metadata: os.stat_result) -> bool:
+    return bool(metadata.st_dev) and bool(metadata.st_ino)
+
+
 def _relative_parts(value: str) -> tuple[str, ...]:
-    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+    if (
+        not isinstance(value, str)
+        or not value
+        or (os.name == "nt" and "\\" in value)
+        or "\x00" in value
+    ):
         raise ValueError("source path must be a repository-relative POSIX path")
     relative = PurePosixPath(value)
     if (
@@ -61,20 +77,30 @@ def _relative_parts(value: str) -> tuple[str, ...]:
         or relative.as_posix() != value
         or any(part in {"", ".", ".."} for part in relative.parts)
         or len(relative.parts) > _MAX_COMPONENTS
+        or len(os.fsencode(value)) > _MAX_RELATIVE_PATH_BYTES
     ):
         raise ValueError("source path must be a repository-relative POSIX path")
     return relative.parts
 
 
 def _normalize_link_target(
+    root: Path,
     prefix: tuple[str, ...],
     target: str,
 ) -> tuple[str, ...]:
-    if not target or "\x00" in target or os.path.isabs(target):
-        raise ValueError("source symlink target must be relative")
+    if not target or "\x00" in target:
+        raise ValueError("source symlink target must be non-empty")
     if len(os.fsencode(target)) > _MAX_SYMLINK_TARGET_BYTES:
         raise ValueError("source symlink target exceeds its byte limit")
-    resolved = list(prefix)
+    if os.path.isabs(target):
+        normalized_target = Path(os.path.normpath(target))
+        try:
+            target = normalized_target.relative_to(root).as_posix()
+        except ValueError as exc:
+            raise ValueError("source symlink resolves outside the repository") from exc
+        resolved: list[str] = []
+    else:
+        resolved = list(prefix)
     for part in target.split("/"):
         if part in {"", "."}:
             continue
@@ -107,6 +133,29 @@ class _BoundRepositoryFile:
     root_descriptor: int
     root_identity: tuple[int, ...]
     observations: list[_PathObservation]
+    is_regular = True
+
+    def update_hash(self, hasher: object) -> None:
+        update = getattr(hasher, "update", None)
+        if not callable(update):
+            raise TypeError("hasher must provide an update method")
+        opened = os.fstat(self.descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or _version_identity(opened) != self.opened_identity
+            or not _identity_is_reliable(opened)
+        ):
+            raise ValueError("source file is not a stable regular file")
+        remaining = opened.st_size
+        while remaining:
+            block = os.read(self.descriptor, min(remaining, _READ_CHUNK_BYTES))
+            if not block:
+                raise ValueError("source file was truncated while hashing")
+            update(block)
+            remaining -= len(block)
+        if os.read(self.descriptor, 1):
+            raise ValueError("source file grew while hashing")
+        self.verify()
 
     def read_bytes(self, *, max_bytes: int) -> bytes:
         if (
@@ -137,33 +186,12 @@ class _BoundRepositoryFile:
         return bytes(payload)
 
     def verify(self) -> None:
-        if _version_identity(os.fstat(self.root_descriptor)) != self.root_identity:
-            raise ValueError("repository root changed during source resolution")
-        root_after = self.root.lstat()
-        if _binding_identity(root_after) != _binding_identity(
-            os.fstat(self.root_descriptor)
-        ):
-            raise ValueError("repository root changed during source resolution")
-        for observation in self.observations:
-            current = os.stat(
-                observation.name,
-                dir_fd=observation.parent_descriptor,
-                follow_symlinks=False,
-            )
-            if _version_identity(current) != observation.identity:
-                raise ValueError("source path changed during contained resolution")
-            if observation.link_target is not None:
-                if (
-                    not stat.S_ISLNK(current.st_mode)
-                    or os.readlink(
-                        observation.name,
-                        dir_fd=observation.parent_descriptor,
-                    )
-                    != observation.link_target
-                ):
-                    raise ValueError(
-                        "source symlink changed during contained resolution"
-                    )
+        _verify_resolution_state(
+            self.root,
+            self.root_descriptor,
+            self.root_identity,
+            self.observations,
+        )
         if _version_identity(os.fstat(self.descriptor)) != self.opened_identity:
             raise ValueError("source file changed while it was being read")
 
@@ -171,6 +199,43 @@ class _BoundRepositoryFile:
         descriptors = [
             self.descriptor,
             self.root_descriptor,
+            *(item.parent_descriptor for item in self.observations),
+        ]
+        for descriptor in descriptors:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+@dataclass(slots=True)
+class _StableUnresolvedRepositoryFile:
+    root: Path
+    root_descriptor: int
+    root_identity: tuple[int, ...]
+    observations: list[_PathObservation]
+    parent_descriptor: int
+    parent_identity: tuple[int, ...]
+    name: str
+    expected: tuple[int, ...] | None
+    is_regular = False
+
+    def verify(self) -> None:
+        _verify_stable_unresolved(
+            root=self.root,
+            root_descriptor=self.root_descriptor,
+            root_identity=self.root_identity,
+            observations=self.observations,
+            parent_descriptor=self.parent_descriptor,
+            parent_identity=self.parent_identity,
+            name=self.name,
+            expected=self.expected,
+        )
+
+    def close(self) -> None:
+        descriptors = [
+            self.root_descriptor,
+            self.parent_descriptor,
             *(item.parent_descriptor for item in self.observations),
         ]
         for descriptor in descriptors:
@@ -200,10 +265,85 @@ def _regular_flags() -> int:
     )
 
 
-def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
-    root_before = root.lstat()
+def _verify_resolution_state(
+    root: Path,
+    root_descriptor: int,
+    root_identity: tuple[int, ...],
+    observations: list[_PathObservation],
+) -> None:
+    root_opened = os.fstat(root_descriptor)
+    if _version_identity(root_opened) != root_identity:
+        raise ValueError("repository root changed during source resolution")
+    root_after = root.lstat()
+    if _binding_identity(root_after) != _binding_identity(root_opened):
+        raise ValueError("repository root changed during source resolution")
+    for observation in observations:
+        current = os.stat(
+            observation.name,
+            dir_fd=observation.parent_descriptor,
+            follow_symlinks=False,
+        )
+        if _version_identity(current) != observation.identity:
+            raise ValueError("source path changed during contained resolution")
+        if observation.link_target is not None and (
+            not stat.S_ISLNK(current.st_mode)
+            or os.readlink(
+                observation.name,
+                dir_fd=observation.parent_descriptor,
+            )
+            != observation.link_target
+        ):
+            raise ValueError("source symlink changed during contained resolution")
+
+
+def _verify_stable_unresolved(
+    *,
+    root: Path,
+    root_descriptor: int,
+    root_identity: tuple[int, ...],
+    observations: list[_PathObservation],
+    parent_descriptor: int,
+    parent_identity: tuple[int, ...],
+    name: str,
+    expected: tuple[int, ...] | None,
+) -> None:
+    """Prove a missing or nonregular terminal outcome without opening it."""
+
+    _verify_resolution_state(root, root_descriptor, root_identity, observations)
+    if _version_identity(os.fstat(parent_descriptor)) != parent_identity:
+        raise ValueError("source parent changed during contained resolution")
+    try:
+        observed = os.stat(
+            name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        observed_identity = None
+    else:
+        observed_identity = _version_identity(observed)
+    if observed_identity != expected:
+        raise ValueError("source terminal changed during contained resolution")
+    _verify_resolution_state(root, root_descriptor, root_identity, observations)
+    if _version_identity(os.fstat(parent_descriptor)) != parent_identity:
+        raise ValueError("source parent changed during contained resolution")
+
+
+def _open_secure(
+    root: Path,
+    parts: tuple[str, ...],
+    *,
+    expected_final_identity: tuple[int, ...] | None = None,
+    allow_stable_unresolved: bool = False,
+) -> _BoundRepositoryFile | _StableUnresolvedRepositoryFile:
+    try:
+        root_before = root.lstat()
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError("repository root does not exist") from exc
     if _is_link_or_reparse(root_before) or not stat.S_ISDIR(root_before.st_mode):
         raise ValueError("repository root must be a real directory")
+    if not _identity_is_reliable(root_before):
+        raise ValueError("repository root has no reliable filesystem identity")
     root_descriptor = os.open(root, _directory_flags())
     current_descriptor = -1
     source_descriptor = -1
@@ -213,13 +353,72 @@ def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
         root_opened = os.fstat(root_descriptor)
         if _binding_identity(root_opened) != _binding_identity(root_before):
             raise ValueError("repository root changed during source resolution")
+
+        def retain_unresolved(
+            *,
+            parent_descriptor: int,
+            parent_identity: tuple[int, ...],
+            name: str,
+            expected: tuple[int, ...] | None,
+        ) -> _StableUnresolvedRepositoryFile:
+            nonlocal root_descriptor, observations
+            _verify_stable_unresolved(
+                root=root,
+                root_descriptor=root_descriptor,
+                root_identity=_version_identity(root_opened),
+                observations=observations,
+                parent_descriptor=parent_descriptor,
+                parent_identity=parent_identity,
+                name=name,
+                expected=expected,
+            )
+            retained = _StableUnresolvedRepositoryFile(
+                root=root,
+                root_descriptor=root_descriptor,
+                root_identity=_version_identity(root_opened),
+                observations=observations,
+                parent_descriptor=os.dup(parent_descriptor),
+                parent_identity=parent_identity,
+                name=name,
+                expected=expected,
+            )
+            root_descriptor = -1
+            observations = []
+            return retained
+
         current_descriptor = os.dup(root_descriptor)
-        pending = list(parts)
+        pending = [(name, index == len(parts) - 1) for index, name in enumerate(parts)]
         resolved_prefix: tuple[str, ...] = ()
         symlink_count = 0
         while pending:
-            name = pending.pop(0)
-            before = os.stat(name, dir_fd=current_descriptor, follow_symlinks=False)
+            name, is_lexical_final = pending.pop(0)
+            parent_identity = _version_identity(os.fstat(current_descriptor))
+            try:
+                before = os.stat(
+                    name,
+                    dir_fd=current_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                expected_is_link = expected_final_identity is not None and stat.S_ISLNK(
+                    expected_final_identity[2]
+                )
+                if not allow_stable_unresolved or not expected_is_link:
+                    raise
+                return retain_unresolved(
+                    parent_descriptor=current_descriptor,
+                    parent_identity=parent_identity,
+                    name=name,
+                    expected=None,
+                )
+            if not _identity_is_reliable(before):
+                raise ValueError("source path has no reliable filesystem identity")
+            if (
+                is_lexical_final
+                and expected_final_identity is not None
+                and _version_identity(before) != expected_final_identity
+            ):
+                raise ValueError("source path differs from its initial observation")
             if bool(
                 getattr(before, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
             ):
@@ -229,9 +428,6 @@ def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
                 if symlink_count > _MAX_SYMLINKS:
                     raise ValueError("source symlink resolution exceeds its limit")
                 link_identity = (before.st_dev, before.st_ino)
-                if link_identity in seen_links:
-                    raise ValueError("source symlink resolution contains a loop")
-                seen_links.add(link_identity)
                 target = os.readlink(name, dir_fd=current_descriptor)
                 after = os.stat(
                     name,
@@ -250,10 +446,24 @@ def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
                         link_target=target,
                     )
                 )
-                target_parts = _normalize_link_target(resolved_prefix, target)
+                if link_identity in seen_links:
+                    expected_is_link = (
+                        expected_final_identity is not None
+                        and stat.S_ISLNK(expected_final_identity[2])
+                    )
+                    if not allow_stable_unresolved or not expected_is_link:
+                        raise ValueError("source symlink resolution contains a loop")
+                    return retain_unresolved(
+                        parent_descriptor=current_descriptor,
+                        parent_identity=parent_identity,
+                        name=name,
+                        expected=_version_identity(before),
+                    )
+                seen_links.add(link_identity)
+                target_parts = _normalize_link_target(root, resolved_prefix, target)
                 if len(target_parts) + len(pending) > _MAX_COMPONENTS:
                     raise ValueError("resolved source path exceeds its component limit")
-                pending = [*target_parts, *pending]
+                pending = [*((part, False) for part in target_parts), *pending]
                 resolved_prefix = ()
                 os.close(current_descriptor)
                 current_descriptor = os.dup(root_descriptor)
@@ -269,21 +479,40 @@ def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
             if pending:
                 if not stat.S_ISDIR(before.st_mode):
                     raise ValueError("source path has a non-directory component")
-                child_descriptor = os.open(
-                    name,
-                    _directory_flags(),
-                    dir_fd=current_descriptor,
-                )
-                opened = os.fstat(child_descriptor)
-                if _binding_identity(opened) != _binding_identity(before):
-                    os.close(child_descriptor)
-                    raise ValueError("source directory changed while opening")
+                child_descriptor = -1
+                try:
+                    child_descriptor = os.open(
+                        name,
+                        _directory_flags(),
+                        dir_fd=current_descriptor,
+                    )
+                    opened = os.fstat(child_descriptor)
+                    if _binding_identity(opened) != _binding_identity(before):
+                        raise ValueError("source directory changed while opening")
+                except BaseException:
+                    if child_descriptor >= 0:
+                        os.close(child_descriptor)
+                    raise
                 os.close(current_descriptor)
                 current_descriptor = child_descriptor
                 resolved_prefix = (*resolved_prefix, name)
                 continue
 
             if not stat.S_ISREG(before.st_mode):
+                expected_is_link = expected_final_identity is not None and stat.S_ISLNK(
+                    expected_final_identity[2]
+                )
+                if (
+                    allow_stable_unresolved
+                    and expected_is_link
+                    and not stat.S_ISDIR(before.st_mode)
+                ):
+                    return retain_unresolved(
+                        parent_descriptor=current_descriptor,
+                        parent_identity=parent_identity,
+                        name=name,
+                        expected=_version_identity(before),
+                    )
                 raise ValueError("source path is not a regular repository file")
             source_descriptor = os.open(
                 name,
@@ -310,6 +539,10 @@ def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
                 raise
             return binding
         raise ValueError("source path does not resolve to a file")
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError(
+            "source path has no resolvable regular target"
+        ) from exc
     except OSError as exc:
         raise ValueError("source path could not be resolved safely") from exc
     finally:
@@ -337,9 +570,13 @@ def _static_components(
     if _is_link_or_reparse(root_metadata) or not stat.S_ISDIR(root_metadata.st_mode):
         raise ValueError("repository root must be a real directory")
     identities.append(_version_identity(root_metadata))
+    if not _identity_is_reliable(root_metadata):
+        raise ValueError("repository root has no reliable filesystem identity")
     for index, part in enumerate(parts):
         current /= part
         metadata = current.lstat()
+        if not _identity_is_reliable(metadata):
+            raise ValueError("source path has no reliable filesystem identity")
         if _is_link_or_reparse(metadata):
             raise ValueError(
                 "safe contained symlink resolution requires directory-fd support"
@@ -385,19 +622,26 @@ def _read_static(root: Path, parts: tuple[str, ...], *, max_bytes: int) -> bytes
 def validate_repository_file(root: str | Path, relative: str) -> None:
     """Require one stable regular source file resolving beneath *root*."""
 
-    repository = Path(root).expanduser().resolve()
-    parts = _relative_parts(relative)
-    if SECURE_CONTAINED_SYMLINKS:
-        binding = _open_secure(repository, parts)
-        try:
+    try:
+        repository = Path(root).expanduser().resolve()
+        parts = _relative_parts(relative)
+        if SECURE_CONTAINED_SYMLINKS:
+            binding = _open_secure(repository, parts)
+            if not isinstance(binding, _BoundRepositoryFile):  # pragma: no cover
+                raise AssertionError("regular source resolver returned no binding")
             try:
-                binding.verify()
-            except OSError as exc:
-                raise ValueError("source path could not be resolved safely") from exc
-        finally:
-            binding.close()
-        return
-    _static_components(repository, parts)
+                try:
+                    binding.verify()
+                except OSError as exc:
+                    raise ValueError(
+                        "source path could not be resolved safely"
+                    ) from exc
+            finally:
+                binding.close()
+            return
+        _static_components(repository, parts)
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError("source path does not exist") from exc
 
 
 def read_repository_file(
@@ -410,23 +654,59 @@ def read_repository_file(
 
     if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes <= 0:
         raise ValueError("source byte limit must be positive")
+    try:
+        repository = Path(root).expanduser().resolve()
+        parts = _relative_parts(relative)
+        if SECURE_CONTAINED_SYMLINKS:
+            binding = _open_secure(repository, parts)
+            if not isinstance(binding, _BoundRepositoryFile):  # pragma: no cover
+                raise AssertionError("regular source resolver returned no binding")
+            try:
+                return binding.read_bytes(max_bytes=max_bytes)
+            except OSError as exc:
+                raise ValueError("source path could not be read safely") from exc
+            finally:
+                binding.close()
+        return _read_static(repository, parts, max_bytes=max_bytes)
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError("source path does not exist") from exc
+
+
+@contextmanager
+def resolved_repository_file(
+    root: str | Path,
+    relative: str,
+    *,
+    expected_final_identity: tuple[int, ...],
+) -> Iterator[_BoundRepositoryFile | _StableUnresolvedRepositoryFile]:
+    """Yield a pinned regular file or a retained stable link-only outcome."""
+
+    if not SECURE_CONTAINED_SYMLINKS:
+        raise ValueError("stable link-only resolution requires directory-fd support")
     repository = Path(root).expanduser().resolve()
     parts = _relative_parts(relative)
-    if SECURE_CONTAINED_SYMLINKS:
-        binding = _open_secure(repository, parts)
-        try:
-            return binding.read_bytes(max_bytes=max_bytes)
-        except OSError as exc:
-            raise ValueError("source path could not be read safely") from exc
-        finally:
-            binding.close()
-    return _read_static(repository, parts, max_bytes=max_bytes)
+    try:
+        binding = _open_secure(
+            repository,
+            parts,
+            expected_final_identity=expected_final_identity,
+            allow_stable_unresolved=True,
+        )
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError("source path does not exist") from exc
+    try:
+        yield binding
+        binding.verify()
+    finally:
+        binding.close()
 
 
 def update_repository_file_hash(
     root: str | Path,
     relative: str,
     hasher: object,
+    *,
+    expected_final_identity: tuple[int, ...] | None = None,
 ) -> None:
     """Stream one stable contained source file into a hashlib-compatible hash."""
 
@@ -436,7 +716,15 @@ def update_repository_file_hash(
     repository = Path(root).expanduser().resolve()
     parts = _relative_parts(relative)
     if not SECURE_CONTAINED_SYMLINKS:
-        source, identities = _static_components(repository, parts)
+        try:
+            source, identities = _static_components(repository, parts)
+        except FileNotFoundError as exc:
+            raise ContainedSourceMissingError("source path does not exist") from exc
+        if (
+            expected_final_identity is not None
+            and identities[-1] != expected_final_identity
+        ):
+            raise ValueError("source path differs from its initial observation")
         descriptor = -1
         try:
             descriptor = os.open(source, _regular_flags())
@@ -462,19 +750,18 @@ def update_repository_file_hash(
             if descriptor >= 0:
                 os.close(descriptor)
 
-    binding = _open_secure(repository, parts)
     try:
-        opened = os.fstat(binding.descriptor)
-        remaining = opened.st_size
-        while remaining:
-            block = os.read(binding.descriptor, min(remaining, _READ_CHUNK_BYTES))
-            if not block:
-                raise ValueError("source file was truncated while hashing")
-            update(block)
-            remaining -= len(block)
-        if os.read(binding.descriptor, 1):
-            raise ValueError("source file grew while hashing")
-        binding.verify()
+        binding = _open_secure(
+            repository,
+            parts,
+            expected_final_identity=expected_final_identity,
+        )
+    except FileNotFoundError as exc:
+        raise ContainedSourceMissingError("source path does not exist") from exc
+    if not isinstance(binding, _BoundRepositoryFile):  # pragma: no cover
+        raise AssertionError("regular source resolver returned no binding")
+    try:
+        binding.update_hash(hasher)
     except OSError as exc:
         raise ValueError("source path could not be hashed safely") from exc
     finally:
@@ -482,8 +769,10 @@ def update_repository_file_hash(
 
 
 __all__ = [
+    "ContainedSourceMissingError",
     "SECURE_CONTAINED_SYMLINKS",
     "read_repository_file",
+    "resolved_repository_file",
     "update_repository_file_hash",
     "validate_repository_file",
 ]

--- a/codenib/_contained_source.py
+++ b/codenib/_contained_source.py
@@ -1,0 +1,489 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Race-resistant reads of repository files, including contained symlinks."""
+
+from __future__ import annotations
+
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+_MAX_COMPONENTS = 256
+_MAX_SYMLINKS = 40
+_MAX_SYMLINK_TARGET_BYTES = 4_096
+_READ_CHUNK_BYTES = 1024 * 1024
+SECURE_CONTAINED_SYMLINKS = (
+    os.name == "posix"
+    and hasattr(os, "O_DIRECTORY")
+    and hasattr(os, "O_NOFOLLOW")
+    and os.open in getattr(os, "supports_dir_fd", ())
+    and os.stat in getattr(os, "supports_dir_fd", ())
+    and os.stat in getattr(os, "supports_follow_symlinks", ())
+    and os.readlink in getattr(os, "supports_dir_fd", ())
+)
+
+
+def _is_link_or_reparse(metadata: os.stat_result) -> bool:
+    return stat.S_ISLNK(metadata.st_mode) or bool(
+        getattr(metadata, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def _binding_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _version_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        *_binding_identity(metadata),
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+    )
+
+
+def _relative_parts(value: str) -> tuple[str, ...]:
+    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+        raise ValueError("source path must be a repository-relative POSIX path")
+    relative = PurePosixPath(value)
+    if (
+        relative.is_absolute()
+        or relative.as_posix() != value
+        or any(part in {"", ".", ".."} for part in relative.parts)
+        or len(relative.parts) > _MAX_COMPONENTS
+    ):
+        raise ValueError("source path must be a repository-relative POSIX path")
+    return relative.parts
+
+
+def _normalize_link_target(
+    prefix: tuple[str, ...],
+    target: str,
+) -> tuple[str, ...]:
+    if not target or "\x00" in target or os.path.isabs(target):
+        raise ValueError("source symlink target must be relative")
+    if len(os.fsencode(target)) > _MAX_SYMLINK_TARGET_BYTES:
+        raise ValueError("source symlink target exceeds its byte limit")
+    resolved = list(prefix)
+    for part in target.split("/"):
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if not resolved:
+                raise ValueError("source symlink resolves outside the repository")
+            resolved.pop()
+            continue
+        resolved.append(part)
+        if len(resolved) > _MAX_COMPONENTS:
+            raise ValueError("resolved source path exceeds its component limit")
+    if not resolved:
+        raise ValueError("source symlink does not resolve to a file")
+    return tuple(resolved)
+
+
+@dataclass(slots=True)
+class _PathObservation:
+    parent_descriptor: int
+    name: str
+    identity: tuple[int, ...]
+    link_target: str | None = None
+
+
+@dataclass(slots=True)
+class _BoundRepositoryFile:
+    descriptor: int
+    opened_identity: tuple[int, ...]
+    root: Path
+    root_descriptor: int
+    root_identity: tuple[int, ...]
+    observations: list[_PathObservation]
+
+    def read_bytes(self, *, max_bytes: int) -> bytes:
+        if (
+            isinstance(max_bytes, bool)
+            or not isinstance(max_bytes, int)
+            or max_bytes <= 0
+        ):
+            raise ValueError("source byte limit must be positive")
+        opened = os.fstat(self.descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or _version_identity(opened) != self.opened_identity
+            or opened.st_size < 0
+            or opened.st_size > max_bytes
+        ):
+            raise ValueError("source file is not a stable bounded regular file")
+        payload = bytearray()
+        remaining = opened.st_size
+        while remaining:
+            chunk = os.read(self.descriptor, min(remaining, _READ_CHUNK_BYTES))
+            if not chunk:
+                raise ValueError("source file was truncated while being read")
+            payload.extend(chunk)
+            remaining -= len(chunk)
+        if os.read(self.descriptor, 1):
+            raise ValueError("source file grew while being read")
+        self.verify()
+        return bytes(payload)
+
+    def verify(self) -> None:
+        if _version_identity(os.fstat(self.root_descriptor)) != self.root_identity:
+            raise ValueError("repository root changed during source resolution")
+        root_after = self.root.lstat()
+        if _binding_identity(root_after) != _binding_identity(
+            os.fstat(self.root_descriptor)
+        ):
+            raise ValueError("repository root changed during source resolution")
+        for observation in self.observations:
+            current = os.stat(
+                observation.name,
+                dir_fd=observation.parent_descriptor,
+                follow_symlinks=False,
+            )
+            if _version_identity(current) != observation.identity:
+                raise ValueError("source path changed during contained resolution")
+            if observation.link_target is not None:
+                if (
+                    not stat.S_ISLNK(current.st_mode)
+                    or os.readlink(
+                        observation.name,
+                        dir_fd=observation.parent_descriptor,
+                    )
+                    != observation.link_target
+                ):
+                    raise ValueError(
+                        "source symlink changed during contained resolution"
+                    )
+        if _version_identity(os.fstat(self.descriptor)) != self.opened_identity:
+            raise ValueError("source file changed while it was being read")
+
+    def close(self) -> None:
+        descriptors = [
+            self.descriptor,
+            self.root_descriptor,
+            *(item.parent_descriptor for item in self.observations),
+        ]
+        for descriptor in descriptors:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _directory_flags() -> int:
+    return (
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | os.O_NOFOLLOW
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+
+def _regular_flags() -> int:
+    return (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+
+
+def _open_secure(root: Path, parts: tuple[str, ...]) -> _BoundRepositoryFile:
+    root_before = root.lstat()
+    if _is_link_or_reparse(root_before) or not stat.S_ISDIR(root_before.st_mode):
+        raise ValueError("repository root must be a real directory")
+    root_descriptor = os.open(root, _directory_flags())
+    current_descriptor = -1
+    source_descriptor = -1
+    observations: list[_PathObservation] = []
+    seen_links: set[tuple[int, int]] = set()
+    try:
+        root_opened = os.fstat(root_descriptor)
+        if _binding_identity(root_opened) != _binding_identity(root_before):
+            raise ValueError("repository root changed during source resolution")
+        current_descriptor = os.dup(root_descriptor)
+        pending = list(parts)
+        resolved_prefix: tuple[str, ...] = ()
+        symlink_count = 0
+        while pending:
+            name = pending.pop(0)
+            before = os.stat(name, dir_fd=current_descriptor, follow_symlinks=False)
+            if bool(
+                getattr(before, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+            ):
+                raise ValueError("source path contains a reparse point")
+            if stat.S_ISLNK(before.st_mode):
+                symlink_count += 1
+                if symlink_count > _MAX_SYMLINKS:
+                    raise ValueError("source symlink resolution exceeds its limit")
+                link_identity = (before.st_dev, before.st_ino)
+                if link_identity in seen_links:
+                    raise ValueError("source symlink resolution contains a loop")
+                seen_links.add(link_identity)
+                target = os.readlink(name, dir_fd=current_descriptor)
+                after = os.stat(
+                    name,
+                    dir_fd=current_descriptor,
+                    follow_symlinks=False,
+                )
+                if _version_identity(after) != _version_identity(before):
+                    raise ValueError(
+                        "source symlink changed during contained resolution"
+                    )
+                observations.append(
+                    _PathObservation(
+                        parent_descriptor=os.dup(current_descriptor),
+                        name=name,
+                        identity=_version_identity(before),
+                        link_target=target,
+                    )
+                )
+                target_parts = _normalize_link_target(resolved_prefix, target)
+                if len(target_parts) + len(pending) > _MAX_COMPONENTS:
+                    raise ValueError("resolved source path exceeds its component limit")
+                pending = [*target_parts, *pending]
+                resolved_prefix = ()
+                os.close(current_descriptor)
+                current_descriptor = os.dup(root_descriptor)
+                continue
+
+            observations.append(
+                _PathObservation(
+                    parent_descriptor=os.dup(current_descriptor),
+                    name=name,
+                    identity=_version_identity(before),
+                )
+            )
+            if pending:
+                if not stat.S_ISDIR(before.st_mode):
+                    raise ValueError("source path has a non-directory component")
+                child_descriptor = os.open(
+                    name,
+                    _directory_flags(),
+                    dir_fd=current_descriptor,
+                )
+                opened = os.fstat(child_descriptor)
+                if _binding_identity(opened) != _binding_identity(before):
+                    os.close(child_descriptor)
+                    raise ValueError("source directory changed while opening")
+                os.close(current_descriptor)
+                current_descriptor = child_descriptor
+                resolved_prefix = (*resolved_prefix, name)
+                continue
+
+            if not stat.S_ISREG(before.st_mode):
+                raise ValueError("source path is not a regular repository file")
+            source_descriptor = os.open(
+                name,
+                _regular_flags(),
+                dir_fd=current_descriptor,
+            )
+            opened = os.fstat(source_descriptor)
+            if _binding_identity(opened) != _binding_identity(before):
+                raise ValueError("source file changed while opening")
+            binding = _BoundRepositoryFile(
+                descriptor=source_descriptor,
+                opened_identity=_version_identity(opened),
+                root=root,
+                root_descriptor=root_descriptor,
+                root_identity=_version_identity(root_opened),
+                observations=observations,
+            )
+            source_descriptor = -1
+            root_descriptor = -1
+            try:
+                binding.verify()
+            except BaseException:
+                binding.close()
+                raise
+            return binding
+        raise ValueError("source path does not resolve to a file")
+    except OSError as exc:
+        raise ValueError("source path could not be resolved safely") from exc
+    finally:
+        if source_descriptor >= 0:
+            os.close(source_descriptor)
+        if current_descriptor >= 0:
+            os.close(current_descriptor)
+        if root_descriptor >= 0:
+            os.close(root_descriptor)
+        if root_descriptor >= 0 or source_descriptor >= 0:
+            for observation in observations:
+                try:
+                    os.close(observation.parent_descriptor)
+                except OSError:
+                    pass
+
+
+def _static_components(
+    root: Path,
+    parts: tuple[str, ...],
+) -> tuple[Path, tuple[tuple[int, ...], ...]]:
+    current = root
+    identities: list[tuple[int, ...]] = []
+    root_metadata = root.lstat()
+    if _is_link_or_reparse(root_metadata) or not stat.S_ISDIR(root_metadata.st_mode):
+        raise ValueError("repository root must be a real directory")
+    identities.append(_version_identity(root_metadata))
+    for index, part in enumerate(parts):
+        current /= part
+        metadata = current.lstat()
+        if _is_link_or_reparse(metadata):
+            raise ValueError(
+                "safe contained symlink resolution requires directory-fd support"
+            )
+        expected = stat.S_ISREG if index == len(parts) - 1 else stat.S_ISDIR
+        if not expected(metadata.st_mode):
+            raise ValueError("source path is not a regular repository file")
+        identities.append(_version_identity(metadata))
+    return current, tuple(identities)
+
+
+def _read_static(root: Path, parts: tuple[str, ...], *, max_bytes: int) -> bytes:
+    source, identities = _static_components(root, parts)
+    descriptor = -1
+    try:
+        descriptor = os.open(source, _regular_flags())
+        opened = os.fstat(descriptor)
+        if _version_identity(opened) != identities[-1] or opened.st_size > max_bytes:
+            raise ValueError("source file is not a stable bounded regular file")
+        payload = bytearray()
+        remaining = opened.st_size
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, _READ_CHUNK_BYTES))
+            if not chunk:
+                raise ValueError("source file was truncated while being read")
+            payload.extend(chunk)
+            remaining -= len(chunk)
+        if os.read(descriptor, 1):
+            raise ValueError("source file grew while being read")
+        _source, after_identities = _static_components(root, parts)
+        if after_identities != identities or _version_identity(
+            os.fstat(descriptor)
+        ) != (identities[-1]):
+            raise ValueError("source path changed while it was being read")
+        return bytes(payload)
+    except OSError as exc:
+        raise ValueError("source path could not be read safely") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def validate_repository_file(root: str | Path, relative: str) -> None:
+    """Require one stable regular source file resolving beneath *root*."""
+
+    repository = Path(root).expanduser().resolve()
+    parts = _relative_parts(relative)
+    if SECURE_CONTAINED_SYMLINKS:
+        binding = _open_secure(repository, parts)
+        try:
+            try:
+                binding.verify()
+            except OSError as exc:
+                raise ValueError("source path could not be resolved safely") from exc
+        finally:
+            binding.close()
+        return
+    _static_components(repository, parts)
+
+
+def read_repository_file(
+    root: str | Path,
+    relative: str,
+    *,
+    max_bytes: int,
+) -> bytes:
+    """Read a bounded source file through the contained-symlink contract."""
+
+    if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes <= 0:
+        raise ValueError("source byte limit must be positive")
+    repository = Path(root).expanduser().resolve()
+    parts = _relative_parts(relative)
+    if SECURE_CONTAINED_SYMLINKS:
+        binding = _open_secure(repository, parts)
+        try:
+            return binding.read_bytes(max_bytes=max_bytes)
+        except OSError as exc:
+            raise ValueError("source path could not be read safely") from exc
+        finally:
+            binding.close()
+    return _read_static(repository, parts, max_bytes=max_bytes)
+
+
+def update_repository_file_hash(
+    root: str | Path,
+    relative: str,
+    hasher: object,
+) -> None:
+    """Stream one stable contained source file into a hashlib-compatible hash."""
+
+    update = getattr(hasher, "update", None)
+    if not callable(update):
+        raise TypeError("hasher must provide an update method")
+    repository = Path(root).expanduser().resolve()
+    parts = _relative_parts(relative)
+    if not SECURE_CONTAINED_SYMLINKS:
+        source, identities = _static_components(repository, parts)
+        descriptor = -1
+        try:
+            descriptor = os.open(source, _regular_flags())
+            opened = os.fstat(descriptor)
+            if _version_identity(opened) != identities[-1]:
+                raise ValueError("source file changed while opening")
+            remaining = opened.st_size
+            while remaining:
+                block = os.read(descriptor, min(remaining, _READ_CHUNK_BYTES))
+                if not block:
+                    raise ValueError("source file was truncated while hashing")
+                update(block)
+                remaining -= len(block)
+            if os.read(descriptor, 1):
+                raise ValueError("source file grew while hashing")
+            _source, after_identities = _static_components(repository, parts)
+            if after_identities != identities:
+                raise ValueError("source path changed while hashing")
+            return
+        except OSError as exc:
+            raise ValueError("source path could not be hashed safely") from exc
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+
+    binding = _open_secure(repository, parts)
+    try:
+        opened = os.fstat(binding.descriptor)
+        remaining = opened.st_size
+        while remaining:
+            block = os.read(binding.descriptor, min(remaining, _READ_CHUNK_BYTES))
+            if not block:
+                raise ValueError("source file was truncated while hashing")
+            update(block)
+            remaining -= len(block)
+        if os.read(binding.descriptor, 1):
+            raise ValueError("source file grew while hashing")
+        binding.verify()
+    except OSError as exc:
+        raise ValueError("source path could not be hashed safely") from exc
+    finally:
+        binding.close()
+
+
+__all__ = [
+    "SECURE_CONTAINED_SYMLINKS",
+    "read_repository_file",
+    "update_repository_file_hash",
+    "validate_repository_file",
+]

--- a/codenib/_owned_file_publication.py
+++ b/codenib/_owned_file_publication.py
@@ -1,0 +1,2293 @@
+# SPDX-FileCopyrightText: 2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Descriptor-bound no-overwrite publication of one regular file.
+
+This module deliberately leaves failed and redundant stages in place for a
+later, quiescent garbage collector.  POSIX has no inode-conditional unlink, so
+online cleanup cannot prove that a name still denotes the file this process
+created.
+
+Publication never returns a descriptor-owning receipt.  The caller creates a
+``PublishedFileReceiptOwner`` first; publication installs a borrowed receipt in
+that owner before returning, closing the return-to-caller cancellation window.
+
+The receipt authenticates an exact retained descriptor at publication and on
+each bounded read.  A normal filesystem writable by another process with the
+same UID cannot guarantee byte immutability across time; that stronger property
+requires a protected object store, fs-verity, or a service ownership boundary.
+
+The descriptor guards cover asynchronous failure after an fd reaches its Python
+owner and cover ordinary fd-number reuse.  One native promotion gate remains:
+``os.open`` and ``os.dup`` return bare integers, so arbitrary opcode injection
+between the C return and the first Python ownership store cannot be closed in
+Python.  Full closure requires a native owning-fd object that installs itself in
+the supplied owner before returning, matching the atomic-directory promotion
+gate.
+
+These guards are not a sandbox against arbitrary code already executing in this
+process; such code can directly close, seek, or reassign any process descriptor.
+In particular, a callback can ``dup2`` an alias of the same open-file
+description onto a just-closed number.  That exact ABA is indistinguishable from
+a close that did not happen.  A retryable receipt owner therefore retains that
+exact alias after an interrupted close.  Its stored offset cookie rejects later
+observable fd reuse before another close, but arbitrary same-process code can
+continually recreate the exact alias and defeats any proof available in Python.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import secrets
+import stat
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Iterator, TypeVar
+
+from . import _atomic_directory as _atomic
+
+_COPY_BYTES = 1 << 20
+_MAX_STAGE_ATTEMPTS = 128
+_CLOSE_COOKIE_FLOOR = 1 << 20
+_CLOSE_COOKIE_SPAN = 1 << 30
+_OWNER_STATE_RECOVERY_LIMIT = 64
+_TERMINAL_DESCRIPTOR_RECOVERY_LIMIT = 8
+_REAL_OS_CLOSE = os.close
+_T = TypeVar("_T")
+_SAFE_POSIX_FILE_FDS = (
+    hasattr(os, "O_NOFOLLOW")
+    and hasattr(os, "O_CLOEXEC")
+    and os.open in os.supports_dir_fd
+    and os.stat in os.supports_dir_fd
+    and os.stat in os.supports_follow_symlinks
+)
+
+
+def require_owned_file_publication_support() -> None:
+    """Fail before mutation when strict regular-file publication is unavailable."""
+
+    # The shared Windows authority does not yet expose a RootDirectory-bound
+    # regular-file create HANDLE.  Keep this gate ahead of every parent or stage
+    # mutation so callers can safely select an unsupported-platform fallback.
+    if sys.platform == "win32":
+        raise RuntimeError("owned regular-file publication is unsupported on Windows")
+    if not (sys.platform.startswith("linux") or sys.platform == "darwin"):
+        raise RuntimeError("owned regular-file publication is unsupported on this host")
+    if not _SAFE_POSIX_FILE_FDS:
+        raise RuntimeError(
+            "owned regular-file publication requires POSIX dir-fd support"
+        )
+    if not _atomic._SAFE_OWNERSHIP_DIRECTORY_FDS:
+        raise RuntimeError(
+            "owned regular-file publication requires anchored directory-fd support"
+        )
+    _atomic._require_rename_noreplace_platform()
+
+
+class _DescriptorOwner:
+    """One shared, invalidatable owner slot for a POSIX descriptor.
+
+    Sharing the slot, rather than copying an fd number between locals and
+    result objects, makes every alias observe cleanup performed after a
+    constructor or return-path ``BaseException``.
+    """
+
+    __slots__ = ("_descriptor", "_identity", "_close_cookie")
+
+    def __init__(self) -> None:
+        self._descriptor = -1
+        self._identity: tuple[int, ...] | None = None
+        self._close_cookie: int | None = None
+
+    @property
+    def descriptor(self) -> int:
+        return self._descriptor
+
+    def open(
+        self,
+        path: str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        if self._descriptor >= 0:
+            raise RuntimeError("descriptor owner is already active")
+        descriptor = -1
+        try:
+            if dir_fd is None:
+                descriptor = os.open(path, flags, mode)
+            else:
+                descriptor = os.open(path, flags, mode, dir_fd=dir_fd)
+            self._descriptor = descriptor
+            self._close_cookie = None
+            return descriptor
+        except BaseException as primary_error:
+            if descriptor >= 0:
+                if self._descriptor == descriptor:
+                    self.close_after_error(primary_error)
+                else:
+                    _cleanup_untransferred_descriptor(descriptor, primary_error)
+            raise
+
+    def duplicate(self, descriptor: int) -> int:
+        if self._descriptor >= 0:
+            raise RuntimeError("descriptor owner is already active")
+        duplicate = -1
+        try:
+            duplicate = os.dup(descriptor)
+            self._descriptor = duplicate
+            self._close_cookie = None
+            return duplicate
+        except BaseException as primary_error:
+            if duplicate >= 0:
+                if self._descriptor == duplicate:
+                    self.close_after_error(primary_error)
+                else:
+                    _cleanup_untransferred_descriptor(duplicate, primary_error)
+            raise
+
+    def bind_identity(self, metadata: os.stat_result) -> None:
+        identity = _file_identity(metadata)
+        if self._descriptor < 0:
+            raise RuntimeError("cannot bind an inactive descriptor owner")
+        self._identity = identity
+
+    def close(
+        self,
+        *,
+        expected_identity: tuple[int, ...],
+        retryable: bool = False,
+    ) -> None:
+        descriptor = self._descriptor
+        if descriptor < 0:
+            return
+        if retryable:
+            self._close_retryable(
+                descriptor,
+                expected_identity=expected_identity,
+            )
+            return
+        close_cookie: int | None = None
+        try:
+            close_cookie = _arm_descriptor_for_close(descriptor)
+            # Clearing the shared slot is the close linearization point.  It is
+            # deliberately before the syscall: if close succeeds and delivery
+            # of an asynchronous exception follows, no alias retains a stale
+            # descriptor number that it could close again after fd reuse.
+            self._descriptor = -1
+            self._identity = None
+            self._close_cookie = None
+            os.close(descriptor)
+        except BaseException as close_error:
+            if self._descriptor < 0:
+                _finish_close_after_error(
+                    descriptor,
+                    expected_identity,
+                    close_error,
+                    close_cookie=close_cookie,
+                )
+            else:
+                # Arming itself, or the tiny arm-to-owner-clear window, can be
+                # interrupted.  This is still unquestionably our descriptor:
+                # invalidate the shared owner and finish one terminal cleanup
+                # attempt while keeping the interruption primary.
+                self._descriptor = -1
+                self._identity = None
+                self._close_cookie = None
+                _cleanup_descriptor_after_error(
+                    descriptor,
+                    expected_identity,
+                    close_error,
+                )
+            raise
+
+    def _close_retryable(
+        self,
+        descriptor: int,
+        *,
+        expected_identity: tuple[int, ...],
+    ) -> None:
+        """Attempt one close while retaining a provably open owner for retry."""
+
+        previous_cookie = self._close_cookie
+        if previous_cookie is not None:
+            try:
+                still_owned = _descriptor_still_exact(
+                    descriptor,
+                    expected_identity,
+                    close_cookie=previous_cookie,
+                )
+            except BaseException as ownership_error:  # noqa: B036
+                self._descriptor = -1
+                self._identity = None
+                self._close_cookie = None
+                raise RuntimeError(
+                    "published receipt descriptor ownership is unknown"
+                ) from ownership_error
+            if not still_owned:
+                self._descriptor = -1
+                self._identity = None
+                self._close_cookie = None
+                raise RuntimeError(
+                    "published receipt descriptor changed before close retry"
+                )
+
+        close_cookie = _arm_descriptor_for_close(
+            descriptor,
+            cookie_owner=self,
+        )
+        try:
+            os.close(descriptor)
+            self._descriptor = -1
+            self._identity = None
+            self._close_cookie = None
+        except BaseException as close_error:  # noqa: B036 - reconcile syscall
+            if self._descriptor < 0:
+                self._identity = None
+                self._close_cookie = None
+                raise
+            try:
+                still_exact = _descriptor_still_exact(
+                    descriptor,
+                    expected_identity,
+                    close_cookie=close_cookie,
+                )
+            except BaseException as reconciliation_error:  # noqa: B036
+                _annotate_error(
+                    close_error,
+                    "descriptor close reconciliation failed",
+                    reconciliation_error,
+                )
+                # Unknown is not sufficient authority for another close.  A
+                # retry is offered only when identity plus the OFD cookie were
+                # positively re-observed after the failed syscall.
+                self._descriptor = -1
+                self._identity = None
+                self._close_cookie = None
+            else:
+                if not still_exact:
+                    self._descriptor = -1
+                    self._identity = None
+                    self._close_cookie = None
+            raise
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        """Terminally clean while retaining ownership across cancellation."""
+
+        deferred: BaseException | None = None
+        for _attempt in range(_TERMINAL_DESCRIPTOR_RECOVERY_LIMIT):
+            descriptor = self._descriptor
+            if descriptor < 0:
+                deferred = self._invalidate_converged(deferred)
+                self._note_deferred_cleanup(primary_error, deferred)
+                return
+
+            identity = self._identity
+            if identity is None:
+                try:
+                    metadata = os.fstat(descriptor)
+                except OSError as error:
+                    if error.errno == errno.EBADF:
+                        deferred = self._invalidate_converged(deferred)
+                        self._note_deferred_cleanup(primary_error, deferred)
+                        return
+                    deferred = _remember_first_cleanup_error(deferred, error)
+                    continue
+                except BaseException as error:  # noqa: B036 - bounded recovery
+                    deferred = _remember_first_cleanup_error(deferred, error)
+                    continue
+                try:
+                    self.bind_identity(metadata)
+                except BaseException as error:  # noqa: B036 - observe next pass
+                    deferred = _remember_first_cleanup_error(deferred, error)
+                continue
+
+            try:
+                self._close_retryable(
+                    descriptor,
+                    expected_identity=identity,
+                )
+            except BaseException as error:  # noqa: B036 - bounded recovery
+                deferred = _remember_first_cleanup_error(deferred, error)
+                if self._descriptor < 0:
+                    deferred = self._invalidate_converged(deferred)
+                    self._note_deferred_cleanup(primary_error, deferred)
+                    return
+                continue
+
+            deferred = self._invalidate_converged(deferred)
+            self._note_deferred_cleanup(primary_error, deferred)
+            return
+
+        descriptor = self._descriptor
+        identity = self._identity
+        if descriptor < 0:
+            deferred = self._invalidate_converged(deferred)
+            self._note_deferred_cleanup(primary_error, deferred)
+            return
+        try:
+            if identity is None:
+                closed = _cleanup_untransferred_descriptor(
+                    descriptor,
+                    primary_error,
+                )
+            else:
+                closed = _cleanup_descriptor_after_error(
+                    descriptor,
+                    identity,
+                    primary_error,
+                    cookie_owner=self,
+                )
+        except BaseException as error:  # noqa: B036 - observe terminal outcome
+            deferred = _remember_first_cleanup_error(deferred, error)
+            closed = self._descriptor < 0
+            if not closed and self._close_cookie is not None and identity is not None:
+                try:
+                    closed = not _descriptor_still_exact(
+                        descriptor,
+                        identity,
+                        close_cookie=self._close_cookie,
+                    )
+                except BaseException as reconciliation_error:  # noqa: B036
+                    deferred = _remember_first_cleanup_error(
+                        deferred,
+                        reconciliation_error,
+                    )
+        if closed:
+            deferred = self._invalidate_converged(deferred)
+        self._note_deferred_cleanup(primary_error, deferred)
+
+    def _invalidate_converged(
+        self,
+        deferred: BaseException | None,
+    ) -> BaseException | None:
+        for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+            try:
+                self._invalidate()
+            except BaseException as error:  # noqa: B036 - converge owner state
+                deferred = _remember_first_cleanup_error(deferred, error)
+                continue
+            if (
+                self._descriptor < 0
+                and self._identity is None
+                and self._close_cookie is None
+            ):
+                return deferred
+        return _remember_first_cleanup_error(
+            deferred,
+            RuntimeError("descriptor owner invalidation did not converge"),
+        )
+
+    def _invalidate(self) -> None:
+        self._descriptor = -1
+        self._identity = None
+        self._close_cookie = None
+
+    @staticmethod
+    def _note_deferred_cleanup(
+        primary_error: BaseException,
+        deferred: BaseException | None,
+    ) -> None:
+        if deferred is not None:
+            _annotate_error(
+                primary_error,
+                "descriptor terminal cleanup was interrupted",
+                deferred,
+            )
+
+
+def _close_posix_resources(
+    resources: _atomic._PosixResourceOwner,
+    *,
+    primary_error: BaseException | None = None,
+) -> None:
+    """Close an independent directory bridge while retaining its first error."""
+
+    first_error = primary_error
+    for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+        if resources.closed:
+            break
+        try:
+            resources.close_all()
+        except BaseException as close_error:  # noqa: B036 - converge ownership
+            if first_error is None:
+                first_error = close_error
+            else:
+                _annotate_error(
+                    first_error,
+                    "borrowed parent bridge cleanup also failed",
+                    close_error,
+                )
+    if not resources.closed:
+        convergence_error = RuntimeError(
+            "borrowed parent bridge cleanup did not converge"
+        )
+        if first_error is None:
+            first_error = convergence_error
+        else:
+            _annotate_error(
+                first_error,
+                "borrowed parent bridge cleanup did not converge",
+                convergence_error,
+            )
+    if primary_error is None and first_error is not None:
+        raise first_error
+
+
+class _PublicationAuthorityOwner:
+    """Owner installed before the shared parent authority is acquired."""
+
+    __slots__ = ("_authority",)
+
+    def __init__(self) -> None:
+        self._authority: _atomic._PublicationAuthority | None = None
+
+    @property
+    def authority(self) -> _atomic._PublicationAuthority | None:
+        return self._authority
+
+    def install(self, authority: _atomic._PublicationAuthority) -> None:
+        """Accept authority ownership before the factory returns to Python."""
+
+        if self._authority is not None:
+            raise RuntimeError("publication authority owner is already active")
+        self._authority = authority
+
+    def acquire(self, path: Path, *, parent_resource: int | None = None) -> None:
+        if self._authority is not None:
+            raise RuntimeError("publication authority owner is already active")
+        bridge_resources = _atomic._PosixResourceOwner()
+        authority_parent: int | None = None
+        if parent_resource is not None:
+            if isinstance(parent_resource, bool) or not isinstance(
+                parent_resource, int
+            ):
+                raise TypeError(
+                    "borrowed publication parent resource must be an integer"
+                )
+            if parent_resource < 0:
+                raise ValueError(
+                    "borrowed publication parent resource must be non-negative"
+                )
+            expected_parent_identity = _atomic.publication_parent_identity(
+                parent_resource
+            )
+        else:
+            expected_parent_identity = None
+        try:
+            if parent_resource is not None:
+                # ``dup(parent_resource)`` would share the caller's open-file
+                # description and therefore its directory offset.  Open "."
+                # relative to the borrowed descriptor to create an independent
+                # OFD before atomic takes its own duplicate.  Close cookies can
+                # then never perturb the caller's offset.
+                flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+                flags |= getattr(os, "O_NONBLOCK", 0)
+                authority_parent = bridge_resources.open(
+                    ".",
+                    flags,
+                    dir_fd=parent_resource,
+                )
+                if (
+                    _atomic.publication_parent_identity(authority_parent)
+                    != expected_parent_identity
+                ):
+                    raise RuntimeError(
+                        "borrowed publication parent resource changed while opened"
+                    )
+            _atomic._open_publication_authority(
+                path,
+                parent_resource=authority_parent,
+                expected_parent_identity=expected_parent_identity,
+                create_missing=False,
+                authority_owner=self,
+            )
+            if self._authority is None:
+                raise RuntimeError("publication authority was not installed")
+            if authority_parent is not None:
+                _close_posix_resources(bridge_resources)
+        except BaseException as primary_error:
+            if self._authority is not None:
+                self.close_after_error(primary_error)
+            _close_posix_resources(
+                bridge_resources,
+                primary_error=primary_error,
+            )
+            raise
+
+    def close(self) -> None:
+        authority = self._authority
+        if authority is None:
+            return
+        try:
+            _close_publication_authority(authority)
+        finally:
+            if authority._closed:
+                self._authority = None
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close()
+        except BaseException as cleanup_error:  # noqa: B036 - keep primary
+            _annotate_error(
+                primary_error,
+                "parent authority cleanup also failed",
+                cleanup_error,
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedFileRecord:
+    """Canonical content and mode authenticated by publication."""
+
+    size: int
+    sha256: str
+    mode: int
+
+
+@dataclass(frozen=True, slots=True)
+class OwnedFileOrphan:
+    """A diagnostic locator for an owned stage that was not published.
+
+    The path is not an authority and this type intentionally has no deletion
+    operation.  Reclamation belongs to a separate cooperative-GC boundary.
+    """
+
+    path: Path
+    parent_identity: tuple[int, ...]
+    file_identity: tuple[int, ...]
+    record: PublishedFileRecord
+
+
+class OwnedFileConflictError(RuntimeError):
+    """The destination is not the requested receipt-time-authenticated object."""
+
+    def __init__(
+        self,
+        destination: Path,
+        expected: PublishedFileRecord,
+        observed: PublishedFileRecord | None,
+        orphan: OwnedFileOrphan,
+    ) -> None:
+        super().__init__(destination, expected, observed, orphan)
+        self.destination = destination
+        self.expected = expected
+        self.observed = observed
+        self.orphan = orphan
+
+    def __str__(self) -> str:
+        return f"owned file publication conflicts at {self.destination}"
+
+
+_RECEIPT_OWNER_CLOSE = object()
+
+
+class PublishedFileReceipt:
+    """A borrowed handle-bound view that re-authenticates each bounded read.
+
+    Retaining the handle prevents path substitution; it does not make a normal
+    same-UID writable filesystem immutable after publication.  Its caller owns
+    the corresponding :class:`PublishedFileReceiptOwner`, which controls close.
+    """
+
+    __slots__ = (
+        "path",
+        "record",
+        "file_identity",
+        "parent_identity",
+        "reused",
+        "orphan",
+        "_descriptor_owner",
+        "_owner_pid",
+        "_version_identity",
+    )
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        record: PublishedFileRecord,
+        file_identity: tuple[int, ...],
+        version_identity: tuple[int, ...],
+        parent_identity: tuple[int, ...],
+        reused: bool,
+        orphan: OwnedFileOrphan | None,
+        descriptor_owner: _DescriptorOwner,
+    ) -> None:
+        # Store the shared owner first.  If any later constructor operation is
+        # interrupted, the publisher can invalidate the same slot seen by a
+        # partially constructed receipt retained by an injected callback.
+        self._descriptor_owner = descriptor_owner
+        self.path = path
+        self.record = record
+        self.file_identity = file_identity
+        self.parent_identity = parent_identity
+        self.reused = reused
+        self.orphan = orphan
+        self._owner_pid = os.getpid()
+        self._version_identity = version_identity
+
+    @property
+    def _descriptor(self) -> int:
+        return self._descriptor_owner.descriptor
+
+    @property
+    def closed(self) -> bool:
+        return self._descriptor < 0
+
+    def read_bytes(self, *, max_bytes: int) -> bytes:
+        """Read and re-authenticate bytes through the retained exact handle."""
+
+        self._require_active()
+        limit = _bounded_size(max_bytes, label="receipt read limit")
+        if self.record.size > limit:
+            raise ValueError("published file exceeds the receipt read limit")
+        before = os.fstat(self._descriptor)
+        _require_exact_regular(
+            before,
+            identity=self.file_identity,
+            version_identity=self._version_identity,
+            mode=self.record.mode,
+            size=self.record.size,
+            label="published file receipt",
+        )
+        payload = bytearray()
+        digest = hashlib.sha256()
+        offset = 0
+        while offset < self.record.size:
+            block = os.pread(
+                self._descriptor,
+                min(_COPY_BYTES, self.record.size - offset),
+                offset,
+            )
+            if not block:
+                raise RuntimeError("published file was truncated")
+            payload.extend(block)
+            digest.update(block)
+            offset += len(block)
+        if os.pread(self._descriptor, 1, offset):
+            raise RuntimeError("published file grew")
+        after = os.fstat(self._descriptor)
+        _require_exact_regular(
+            after,
+            identity=self.file_identity,
+            version_identity=self._version_identity,
+            mode=self.record.mode,
+            size=self.record.size,
+            label="published file receipt",
+        )
+        if digest.hexdigest() != self.record.sha256:
+            raise RuntimeError("published file bytes changed")
+        return bytes(payload)
+
+    def close(self) -> None:
+        """Reject detached cleanup of this borrowed receipt view."""
+
+        raise RuntimeError("close the PublishedFileReceiptOwner, not its receipt")
+
+    def _close_from_owner(self, authority: object) -> None:
+        if authority is not _RECEIPT_OWNER_CLOSE:
+            raise RuntimeError("published file receipt close authority is invalid")
+        if self._descriptor < 0:
+            return
+        owner_changed = os.getpid() != self._owner_pid
+        self._descriptor_owner.close(
+            expected_identity=self.file_identity,
+            retryable=True,
+        )
+        if owner_changed:
+            raise RuntimeError("published file receipt cannot cross a PID boundary")
+
+    def _require_active(self) -> None:
+        if self._descriptor < 0:
+            raise RuntimeError("published file receipt is closed")
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError("published file receipt cannot cross a PID boundary")
+
+
+_RECEIPT_OWNER_EMPTY = object()
+_RECEIPT_OWNER_CLOSED = object()
+
+
+class _CancellationSafeRLock:
+    """RLock whose logical depth makes interrupted transitions recoverable."""
+
+    __slots__ = ("_depth", "_lock")
+
+    _RECOVERY_LIMIT = 64
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._depth = threading.local()
+
+    def run(self, callback: Callable[[], _T]) -> _T:
+        baseline = self._logical_depth()
+        try:
+            acquisition_error = self._acquire_reconciled(baseline)
+        except BaseException as primary_error:  # noqa: B036 - restore baseline
+            self._release_preserving(baseline, primary_error)
+            raise
+        if acquisition_error is not None:
+            self._release_preserving(baseline, acquisition_error)
+            raise acquisition_error
+        try:
+            result = callback()
+        except BaseException as primary_error:  # noqa: B036 - restore then preserve
+            self._release_preserving(baseline, primary_error)
+            raise
+        try:
+            release_error = self._release_reconciled(baseline)
+        except BaseException:
+            raise
+        if release_error is not None:
+            raise release_error
+        return result
+
+    def _acquire(self) -> None:
+        depth = self._logical_depth()
+        if depth:
+            self._set_logical_depth(depth + 1)
+            return
+        if not self._lock.acquire():
+            raise RuntimeError("receipt owner lifecycle lock acquisition failed")
+        self._set_logical_depth(1)
+
+    def _release(self) -> None:
+        depth = self._logical_depth()
+        if depth < 1 or not self._native_is_owned():
+            raise RuntimeError("cannot release an unowned receipt lifecycle lock")
+        if depth > 1:
+            self._set_logical_depth(depth - 1)
+            return
+        self._lock.release()
+        self._set_logical_depth(0)
+
+    def _logical_depth(self) -> int:
+        return int(getattr(self._depth, "value", 0))
+
+    def _set_logical_depth(self, depth: int) -> None:
+        self._depth.value = depth
+
+    def _native_is_owned(self) -> bool:
+        ownership_check = getattr(self._lock, "_is_owned", None)
+        if not callable(ownership_check):
+            raise RuntimeError("receipt lifecycle lock lacks owner tracking")
+        return bool(ownership_check())
+
+    def held_by_current_thread(self) -> bool:
+        """Return whether this thread is already inside a lifecycle lease."""
+
+        return self._logical_depth() > 0 and self._native_is_owned()
+
+    @staticmethod
+    def _defer_failure(
+        deferred: BaseException | None,
+        failure: BaseException,
+    ) -> BaseException:
+        if deferred is None:
+            return failure
+        if failure is not deferred:
+            _annotate_error(
+                deferred,
+                "receipt lifecycle lock recovery also failed",
+                failure,
+            )
+        return deferred
+
+    def _acquire_reconciled(self, baseline: int) -> BaseException | None:
+        """Acquire one logical level without repeating a completed acquire."""
+
+        deferred: BaseException | None = None
+        for _attempt in range(self._RECOVERY_LIMIT):
+            try:
+                depth = self._logical_depth()
+                native_owned = self._native_is_owned()
+            except BaseException as error:  # noqa: B036 - bounded recovery
+                deferred = self._defer_failure(deferred, error)
+                continue
+
+            if native_owned:
+                if depth > baseline:
+                    return deferred
+                try:
+                    # A completed zero-depth acquire, or an interrupted
+                    # reentrant logical acquire, needs no second native call.
+                    self._set_logical_depth(baseline + 1)
+                except BaseException as error:  # noqa: B036
+                    deferred = self._defer_failure(deferred, error)
+                    continue
+                return deferred
+
+            if depth > baseline:
+                try:
+                    self._set_logical_depth(baseline)
+                except BaseException as error:  # noqa: B036
+                    deferred = self._defer_failure(deferred, error)
+                    continue
+
+            if deferred is not None:
+                # A successful ownership probe now proves that an interrupted
+                # acquire did not take the native lock.  This operation will
+                # not execute its callback, so reacquiring would only defer
+                # cancellation behind an unrelated owner.
+                return deferred
+
+            try:
+                self._acquire()
+                return deferred
+            except BaseException as error:  # noqa: B036 - reconcile next
+                deferred = self._defer_failure(deferred, error)
+
+        if deferred is not None:
+            raise deferred
+        raise RuntimeError("receipt lifecycle lock acquisition did not converge")
+
+    def _release_reconciled(self, baseline: int) -> BaseException | None:
+        """Restore the logical baseline without repeating a completed release."""
+
+        deferred: BaseException | None = None
+        for _attempt in range(self._RECOVERY_LIMIT):
+            try:
+                depth = self._logical_depth()
+                native_owned = self._native_is_owned()
+            except BaseException as error:  # noqa: B036 - bounded recovery
+                deferred = self._defer_failure(deferred, error)
+                continue
+
+            if baseline:
+                if not native_owned:
+                    try:
+                        self._set_logical_depth(0)
+                    except BaseException as error:  # noqa: B036
+                        deferred = self._defer_failure(deferred, error)
+                        continue
+                    return self._defer_failure(
+                        deferred,
+                        RuntimeError(
+                            "receipt lifecycle lock lost its outer native owner"
+                        ),
+                    )
+                if depth != baseline:
+                    try:
+                        self._set_logical_depth(baseline)
+                    except BaseException as error:  # noqa: B036
+                        deferred = self._defer_failure(deferred, error)
+                        continue
+                return deferred
+
+            if not native_owned:
+                if depth:
+                    try:
+                        self._set_logical_depth(0)
+                    except BaseException as error:  # noqa: B036
+                        deferred = self._defer_failure(deferred, error)
+                        continue
+                return deferred
+
+            if depth != 1:
+                try:
+                    self._set_logical_depth(1)
+                except BaseException as error:  # noqa: B036
+                    deferred = self._defer_failure(deferred, error)
+                    continue
+
+            try:
+                self._release()
+            except BaseException as error:  # noqa: B036 - reconcile next
+                deferred = self._defer_failure(deferred, error)
+
+        if deferred is not None:
+            raise deferred
+        raise RuntimeError("receipt lifecycle lock release did not converge")
+
+    def _release_preserving(
+        self,
+        baseline: int,
+        primary_error: BaseException,
+    ) -> None:
+        try:
+            release_error = self._release_reconciled(baseline)
+        except BaseException as release_error:  # noqa: B036 - keep primary
+            _annotate_error(
+                primary_error,
+                "receipt lifecycle lock release also failed",
+                release_error,
+            )
+            return
+        if release_error is not None:
+            _annotate_error(
+                primary_error,
+                "receipt lifecycle lock release was interrupted",
+                release_error,
+            )
+
+
+class PublishedFileReceiptOwner:
+    """One-shot caller-owned slot for a borrowed published-file receipt.
+
+    The caller creates this owner before publication.  Publication reserves it
+    before any rename and installs the receipt before returning, so an
+    asynchronous exception at any later Python return/STORE boundary cannot
+    strand the retained descriptor on the evaluation stack.
+    """
+
+    __slots__ = ("_slot", "_lock", "_owner_pid")
+
+    def __init__(self) -> None:
+        self._slot: object = _RECEIPT_OWNER_EMPTY
+        self._lock = _CancellationSafeRLock()
+        self._owner_pid = os.getpid()
+
+    @property
+    def state(self) -> str:
+        self._require_owner_pid()
+
+        def observe() -> str:
+            self._normalize_closed_locked()
+            return self._state_locked()
+
+        deferred: BaseException | None = None
+        for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+            try:
+                observed = self._lock.run(observe)
+            except BaseException as state_error:  # noqa: B036 - converge state
+                deferred = _remember_first_cleanup_error(deferred, state_error)
+                continue
+            if deferred is not None:
+                raise deferred
+            return observed
+        if deferred is not None:
+            raise deferred
+        raise RuntimeError("receipt owner state observation did not converge")
+
+    @property
+    def active(self) -> bool:
+        return self.state == "active"
+
+    @property
+    def closed(self) -> bool:
+        return self.state == "closed"
+
+    @property
+    def receipt(self) -> PublishedFileReceipt:
+        """Return a borrowed receipt while this owner retains its ownership."""
+
+        self._require_owner_pid()
+
+        def borrow() -> PublishedFileReceipt:
+            self._normalize_closed_locked()
+            if not isinstance(self._slot, PublishedFileReceipt):
+                raise RuntimeError(
+                    "published file receipt owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            return self._slot
+
+        return self._lock.run(borrow)
+
+    def consume(self, callback: Callable[[PublishedFileReceipt], object]) -> None:
+        """Run a synchronous callback with a borrowed, never-detached receipt."""
+
+        if not callable(callback):
+            raise TypeError("published file receipt consumer must be callable")
+        self._require_owner_pid()
+        if self._lock.held_by_current_thread():
+            raise RuntimeError("published file receipt owner consume is reentrant")
+
+        def consume_locked() -> None:
+            self._normalize_closed_locked()
+            if not isinstance(self._slot, PublishedFileReceipt):
+                raise RuntimeError(
+                    "published file receipt owner is "
+                    f"{self._state_locked()}, expected active"
+                )
+            receipt = self._slot
+            callback(receipt)
+            self._normalize_closed_locked()
+
+        # Holding the lifecycle lease for the callback makes consume and close
+        # linear: a concurrent close either wins first or waits for the entire
+        # synchronous borrow to finish.
+        self._lock.run(consume_locked)
+
+    def close(self) -> None:
+        owner_changed = os.getpid() != self._owner_pid
+        if self._lock.held_by_current_thread():
+            raise RuntimeError("published file receipt owner close is reentrant")
+
+        def close_locked() -> None:
+            self._normalize_closed_locked()
+            if self._slot is _RECEIPT_OWNER_CLOSED:
+                return
+            if isinstance(self._slot, PublishedFileReceipt):
+                receipt = self._slot
+                # Keep the lifecycle lock across descriptor reconciliation.  A
+                # receipt never moves through a return/store handoff inside
+                # close, and another thread cannot start a competing cleanup.
+                try:
+                    receipt._close_from_owner(_RECEIPT_OWNER_CLOSE)
+                except BaseException as close_error:  # noqa: B036 - settle state
+                    try:
+                        settle_error = self._settle_receipt_locked(receipt)
+                    except BaseException as observation_error:  # noqa: B036
+                        _annotate_error(
+                            close_error,
+                            "receipt owner close-state observation also failed",
+                            observation_error,
+                        )
+                        raise close_error
+                    if settle_error is not None:
+                        _annotate_error(
+                            close_error,
+                            "receipt owner close-state cleanup also failed",
+                            settle_error,
+                        )
+                    raise
+                settle_error = self._settle_receipt_locked(receipt)
+                if settle_error is not None:
+                    raise settle_error
+                return
+            if self._slot is _RECEIPT_OWNER_EMPTY:
+                self._slot = _RECEIPT_OWNER_CLOSED
+                return
+            raise RuntimeError("published file receipt publication is in progress")
+
+        close_error: BaseException | None = None
+        try:
+            self._lock.run(close_locked)
+        except BaseException as exc:  # noqa: B036 - report PID after cleanup
+            close_error = exc
+
+        if owner_changed:
+            boundary_error = RuntimeError(
+                "published file receipt owner cannot cross a PID boundary"
+            )
+            if close_error is not None:
+                raise boundary_error from close_error
+            raise boundary_error
+        if close_error is not None:
+            raise close_error
+
+    def _settle_receipt_locked(
+        self,
+        receipt: PublishedFileReceipt,
+    ) -> BaseException | None:
+        deferred: BaseException | None = None
+        for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+            try:
+                closed = receipt.closed
+            except BaseException as state_error:  # noqa: B036 - bounded recovery
+                deferred = _remember_first_cleanup_error(deferred, state_error)
+                continue
+            if not closed:
+                return deferred
+            try:
+                if self._slot is receipt:
+                    self._slot = _RECEIPT_OWNER_CLOSED
+            except BaseException as state_error:  # noqa: B036 - observe next
+                deferred = _remember_first_cleanup_error(deferred, state_error)
+                continue
+            if self._slot is not receipt:
+                return deferred
+        return _remember_first_cleanup_error(
+            deferred,
+            RuntimeError("receipt owner close state did not converge"),
+        )
+
+    def close_after_error(self, primary_error: BaseException) -> None:
+        try:
+            self.close()
+        except BaseException as cleanup_error:  # noqa: B036 - keep primary
+            _annotate_error(
+                primary_error,
+                "published receipt owner cleanup also failed",
+                cleanup_error,
+            )
+
+    def _reserve(self, reservation: object) -> None:
+        self._require_owner_pid()
+
+        def reserve() -> None:
+            if self._slot is not _RECEIPT_OWNER_EMPTY:
+                raise RuntimeError(
+                    "published file receipt owner is "
+                    f"{self._state_locked()}, expected empty"
+                )
+            self._slot = reservation
+
+        self._lock.run(reserve)
+
+    def _install(
+        self,
+        reservation: object,
+        receipt: PublishedFileReceipt,
+    ) -> None:
+        self._require_owner_pid()
+
+        def install() -> None:
+            if self._slot is not reservation:
+                raise RuntimeError("published file receipt reservation changed")
+            self._slot = receipt
+
+        self._lock.run(install)
+
+    def _owns_descriptor_owner(self, descriptor_owner: _DescriptorOwner) -> bool:
+        def owns() -> bool:
+            return (
+                isinstance(self._slot, PublishedFileReceipt)
+                and self._slot._descriptor_owner is descriptor_owner
+            )
+
+        return self._lock.run(owns)
+
+    def _cancel_reservation(self, reservation: object) -> None:
+        deferred: BaseException | None = None
+        for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+            try:
+                terminal = self._lock.run(
+                    lambda: self._cancel_reservation_locked(reservation)
+                )
+            except BaseException as cleanup_error:  # noqa: B036 - converge state
+                deferred = _remember_first_cleanup_error(deferred, cleanup_error)
+                continue
+            if terminal:
+                if deferred is not None:
+                    raise deferred
+                return
+        if deferred is not None:
+            raise deferred
+        raise RuntimeError("receipt reservation cancellation did not converge")
+
+    def _cancel_reservation_locked(self, reservation: object) -> bool:
+        if self._slot is reservation:
+            self._slot = _RECEIPT_OWNER_CLOSED
+        return self._slot is not reservation
+
+    def _close_terminal_after_error(self, primary_error: BaseException) -> None:
+        """Terminally clean a helper-local owner that cannot escape to retry."""
+
+        deferred: BaseException | None = None
+        for _attempt in range(_OWNER_STATE_RECOVERY_LIMIT):
+            try:
+                terminal = self._lock.run(
+                    lambda: self._close_terminal_locked(primary_error)
+                )
+            except BaseException as cleanup_error:  # noqa: B036 - converge state
+                deferred = _remember_first_cleanup_error(deferred, cleanup_error)
+                continue
+            if terminal:
+                if deferred is not None:
+                    _annotate_error(
+                        primary_error,
+                        "terminal receipt owner cleanup was interrupted",
+                        deferred,
+                    )
+                return
+        convergence_error = RuntimeError(
+            "terminal receipt owner cleanup did not converge"
+        )
+        deferred = _remember_first_cleanup_error(deferred, convergence_error)
+        _annotate_error(
+            primary_error,
+            "terminal receipt owner cleanup also failed",
+            deferred,
+        )
+
+    def _close_terminal_locked(self, primary_error: BaseException) -> bool:
+        self._normalize_closed_locked()
+        if isinstance(self._slot, PublishedFileReceipt):
+            receipt = self._slot
+            receipt._descriptor_owner.close_after_error(primary_error)
+            if receipt.closed and self._slot is receipt:
+                self._slot = _RECEIPT_OWNER_CLOSED
+            return receipt.closed
+        if self._slot is not _RECEIPT_OWNER_CLOSED:
+            self._slot = _RECEIPT_OWNER_CLOSED
+        return self._slot is _RECEIPT_OWNER_CLOSED
+
+    def _normalize_closed_locked(self) -> None:
+        if isinstance(self._slot, PublishedFileReceipt) and self._slot.closed:
+            self._slot = _RECEIPT_OWNER_CLOSED
+
+    def _state_locked(self) -> str:
+        if self._slot is _RECEIPT_OWNER_EMPTY:
+            return "empty"
+        if self._slot is _RECEIPT_OWNER_CLOSED:
+            return "closed"
+        if isinstance(self._slot, PublishedFileReceipt):
+            return "active"
+        return "reserved"
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "published file receipt owner cannot cross a PID boundary"
+            )
+
+    def __enter__(self) -> PublishedFileReceiptOwner:
+        self._require_owner_pid()
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        if exc is None:
+            self.close()
+        else:
+            self.close_after_error(exc)
+
+
+class OwnedFilePublicationAuthority:
+    """Linear, PID-bound authority for producing and publishing one file."""
+
+    __slots__ = (
+        "destination",
+        "max_bytes",
+        "mode",
+        "_authority_owner",
+        "_stage_owner",
+        "_owner_pid",
+        "_stage_name",
+        "_state",
+        "_record",
+        "_stage_identity",
+        "_renamed",
+    )
+
+    def __init__(
+        self,
+        destination: Path,
+        *,
+        max_bytes: int,
+        mode: int = 0o644,
+        parent_resource: int | None = None,
+    ) -> None:
+        self.destination = _atomic.lexical_directory_path(Path(destination))
+        _atomic._simple_child_name(
+            self.destination.name,
+            label="owned file destination",
+        )
+        self.max_bytes = _bounded_size(max_bytes, label="publication byte limit")
+        self.mode = _file_mode(mode)
+        self._authority_owner = _PublicationAuthorityOwner()
+        self._stage_owner = _DescriptorOwner()
+        self._owner_pid = os.getpid()
+        self._stage_name = ""
+        self._state = "opening"
+        self._record: PublishedFileRecord | None = None
+        self._stage_identity: tuple[int, ...] | None = None
+        self._renamed = False
+
+        try:
+            require_owned_file_publication_support()
+        except BaseException:
+            self._state = "closed"
+            raise
+
+        try:
+            if parent_resource is None:
+                self._authority_owner.acquire(self.destination.parent)
+            else:
+                self._authority_owner.acquire(
+                    self.destination.parent,
+                    parent_resource=parent_resource,
+                )
+            self._stage_name = self._create_stage()
+            self._state = "staged"
+        except BaseException as primary_error:
+            self._state = "failed"
+            self._stage_owner.close_after_error(primary_error)
+            self._authority_owner.close_after_error(primary_error)
+            raise
+
+    @property
+    def _authority(self) -> _atomic._PublicationAuthority | None:
+        return self._authority_owner.authority
+
+    @property
+    def _descriptor(self) -> int:
+        return self._stage_owner.descriptor
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def orphan(self) -> OwnedFileOrphan | None:
+        if (
+            self._record is None
+            or self._stage_identity is None
+            or not self._stage_name
+            or self._renamed
+        ):
+            return None
+        assert self._authority is not None
+        return OwnedFileOrphan(
+            path=self.destination.parent / self._stage_name,
+            parent_identity=self._authority.identity,
+            file_identity=self._stage_identity,
+            record=self._record,
+        )
+
+    def write(self, chunks: Iterable[bytes] | bytes) -> PublishedFileRecord:
+        """Consume one bounded producer exactly once, then flush the file.
+
+        A closeable iterator is always closed.  If iteration already failed, a
+        close failure is attached as a note and the iteration error remains the
+        primary exception.
+        """
+
+        self._require_state("staged")
+        self._state = "writing"
+        iterator: Iterator[bytes] | None = None
+        primary_error: BaseException | None = None
+        digest = hashlib.sha256()
+        size = 0
+        try:
+            iterator = iter((chunks,) if isinstance(chunks, bytes) else chunks)
+            for block in iterator:
+                if not isinstance(block, bytes):
+                    raise TypeError("publication producer must yield bytes")
+                if len(block) > self.max_bytes - size:
+                    raise ValueError("publication producer exceeds its byte limit")
+                view = memoryview(block)
+                while view:
+                    written = os.write(self._descriptor, view)
+                    if written <= 0:
+                        raise RuntimeError("publication write made no progress")
+                    digest.update(view[:written])
+                    size += written
+                    view = view[written:]
+        except BaseException as exc:
+            primary_error = exc
+            raise
+        finally:
+            self._record = PublishedFileRecord(
+                size=size,
+                sha256=digest.hexdigest(),
+                mode=self.mode,
+            )
+            if iterator is not None:
+                close = getattr(iterator, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except BaseException as close_error:
+                        if primary_error is None:
+                            self._state = "failed"
+                            raise
+                        _annotate_error(
+                            primary_error,
+                            "publication iterator cleanup also failed",
+                            close_error,
+                        )
+            if primary_error is not None:
+                self._state = "failed"
+
+        record = PublishedFileRecord(
+            size=size,
+            sha256=digest.hexdigest(),
+            mode=self.mode,
+        )
+        self._record = record
+        try:
+            self._bind_stage(record)
+            os.fsync(self._descriptor)
+            self._bind_stage(record)
+        except BaseException:
+            self._state = "failed"
+            raise
+        self._state = "written"
+        return record
+
+    def publish_into(self, receipt_owner: PublishedFileReceiptOwner) -> None:
+        """Publish and install the receipt in a caller-precreated owner.
+
+        The owner is reserved before any rename.  Installation is complete
+        before this method returns, so even an asynchronous exception at the
+        caller's first bytecode cannot lose the descriptor-owning object.
+        """
+
+        self._require_state("written")
+        if not isinstance(receipt_owner, PublishedFileReceiptOwner):
+            raise TypeError("receipt_owner must be a PublishedFileReceiptOwner")
+
+        reservation = object()
+        receipt_descriptor_owner = _DescriptorOwner()
+        try:
+            self._state = "publishing"
+            receipt_owner._reserve(reservation)
+            assert self._authority is not None
+            assert self._record is not None
+            self._bind_stage(self._record)
+            self._authenticate_descriptor(
+                self._descriptor,
+                expected=self._record,
+                identity=self._stage_identity,
+                label="owned file stage",
+            )
+            self._authority.verify_path_binding()
+
+            try:
+                self._authority.rename_noreplace(
+                    self._stage_name,
+                    self.destination.name,
+                )
+                renamed = True
+            except FileExistsError:
+                renamed = False
+            except BaseException as rename_error:
+                # The syscall may have committed before an injected exception.
+                # That outcome is recorded only to avoid mislabelling a final
+                # name as an orphan.  An ambiguous operation never installs a
+                # receipt; a fresh call must authenticate the existing file.
+                self._state = "failed"
+                self._renamed = True
+                try:
+                    self._renamed = self._rename_committed()
+                except BaseException as reconciliation_error:  # noqa: B036
+                    _annotate_error(
+                        rename_error,
+                        "rename outcome reconciliation also failed",
+                        reconciliation_error,
+                    )
+                raise
+            self._renamed = renamed
+
+            if renamed:
+                metadata = self._authenticate_descriptor(
+                    self._descriptor,
+                    expected=self._record,
+                    identity=self._stage_identity,
+                    label="published file",
+                )
+                receipt_descriptor = receipt_descriptor_owner.duplicate(
+                    self._descriptor
+                )
+                receipt_metadata = os.fstat(receipt_descriptor)
+                receipt_descriptor_owner.bind_identity(receipt_metadata)
+                if _file_version_identity(receipt_metadata) != _file_version_identity(
+                    metadata
+                ):
+                    raise RuntimeError("published receipt descriptor changed")
+                os.set_inheritable(receipt_descriptor, False)
+                orphan = None
+                receipt_record = self._record
+            else:
+                try:
+                    metadata, observed = self._authenticate_existing(
+                        receipt_descriptor_owner
+                    )
+                except ValueError as exc:
+                    orphan = self.orphan
+                    assert orphan is not None
+                    self._state = "failed"
+                    raise OwnedFileConflictError(
+                        self.destination,
+                        self._record,
+                        None,
+                        orphan,
+                    ) from exc
+                if (
+                    observed.mode != self._record.mode
+                    or observed.size != self._record.size
+                    or observed.sha256 != self._record.sha256
+                ):
+                    orphan = self.orphan
+                    assert orphan is not None
+                    self._state = "failed"
+                    raise OwnedFileConflictError(
+                        self.destination,
+                        self._record,
+                        observed,
+                        orphan,
+                    )
+                orphan = self.orphan
+                receipt_record = observed
+
+            os.fsync(self._authority.resource)
+            self._authority.verify_path_binding()
+            rebound = os.stat(
+                self.destination.name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+            if _file_version_identity(rebound) != _file_version_identity(metadata):
+                raise RuntimeError("published file binding changed before receipt")
+            self._close_stage_descriptor()
+            parent_identity = self._authority.identity
+            self._close_parent_authority()
+            receipt = PublishedFileReceipt(
+                path=self.destination,
+                record=receipt_record,
+                file_identity=_file_identity(metadata),
+                version_identity=_file_version_identity(metadata),
+                parent_identity=parent_identity,
+                reused=not renamed,
+                orphan=orphan,
+                descriptor_owner=receipt_descriptor_owner,
+            )
+            receipt_owner._install(reservation, receipt)
+            self._state = "published"
+            self._stage_name = ""
+            return None
+        except BaseException as primary_error:
+            try:
+                installed = receipt_owner._owns_descriptor_owner(
+                    receipt_descriptor_owner
+                )
+            except BaseException as ownership_error:  # noqa: B036
+                _annotate_error(
+                    primary_error,
+                    "receipt ownership reconciliation also failed",
+                    ownership_error,
+                )
+                installed = False
+            if installed:
+                receipt_owner.close_after_error(primary_error)
+            else:
+                receipt_descriptor_owner.close_after_error(primary_error)
+                try:
+                    receipt_owner._cancel_reservation(reservation)
+                except BaseException as reservation_error:  # noqa: B036
+                    _annotate_error(
+                        primary_error,
+                        "receipt reservation cleanup also failed",
+                        reservation_error,
+                    )
+            if self._state != "failed":
+                self._state = "failed"
+            raise
+
+    def publish(self, *, receipt_owner: PublishedFileReceiptOwner) -> None:
+        """Compatibility spelling for :meth:`publish_into`, with strict owner."""
+
+        self.publish_into(receipt_owner)
+
+    def close(self) -> None:
+        if self._state == "closed":
+            return
+        owner_changed = os.getpid() != self._owner_pid
+        close_error: BaseException | None = None
+        if self._stage_owner.descriptor >= 0:
+            try:
+                self._close_stage_descriptor()
+            except BaseException as exc:  # noqa: B036 - finish all cleanup
+                close_error = exc
+        if self._authority_owner.authority is not None:
+            try:
+                self._close_parent_authority()
+            except BaseException as exc:  # noqa: B036 - finish all cleanup
+                if close_error is None:
+                    close_error = exc
+                else:
+                    _annotate_error(
+                        close_error,
+                        "parent authority close also failed",
+                        exc,
+                    )
+        cleanup_complete = (
+            self._stage_owner.descriptor < 0 and self._authority_owner.authority is None
+        )
+        if self._state != "published" and cleanup_complete:
+            self._state = "closed"
+        elif not cleanup_complete:
+            self._state = "close-failed"
+        if owner_changed:
+            raise RuntimeError(
+                "owned file publication authority cannot cross a PID boundary"
+            ) from close_error
+        if close_error is not None:
+            raise close_error
+
+    def _create_stage(self) -> str:
+        assert self._authority is not None
+        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC
+        destination_digest = hashlib.sha256(
+            os.fsencode(self.destination.name)
+        ).hexdigest()[:16]
+        for _attempt in range(_MAX_STAGE_ATTEMPTS):
+            name = f".codenib-file-{destination_digest}-{secrets.token_hex(16)}"
+            _atomic._simple_child_name(name, label="owned file stage")
+            try:
+                try:
+                    descriptor = self._stage_owner.open(
+                        name,
+                        flags,
+                        0o600,
+                        dir_fd=self._authority.resource,
+                    )
+                except FileExistsError:
+                    continue
+                created = os.fstat(descriptor)
+                self._stage_owner.bind_identity(created)
+                os.fchmod(descriptor, self.mode)
+                metadata = os.fstat(descriptor)
+                _require_new_regular(metadata, mode=self.mode)
+                self._stage_owner.bind_identity(metadata)
+                self._stage_identity = _file_identity(metadata)
+                return name
+            except BaseException as primary_error:
+                self._stage_owner.close_after_error(primary_error)
+                raise
+        raise RuntimeError("could not reserve a bounded owned file stage")
+
+    def _bind_stage(self, record: PublishedFileRecord) -> None:
+        assert self._authority is not None
+        descriptor_metadata = os.fstat(self._descriptor)
+        _require_exact_regular(
+            descriptor_metadata,
+            identity=self._stage_identity,
+            version_identity=None,
+            mode=record.mode,
+            size=record.size,
+            label="owned file stage",
+        )
+        try:
+            bound = os.stat(
+                self._stage_name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "owned file stage namespace binding disappeared"
+            ) from exc
+        _require_exact_regular(
+            bound,
+            identity=self._stage_identity,
+            version_identity=None,
+            mode=record.mode,
+            size=record.size,
+            label="owned file stage binding",
+        )
+
+    def _open_regular(
+        self,
+        name: str,
+        *,
+        label: str,
+        owner: _DescriptorOwner,
+    ) -> os.stat_result:
+        assert self._authority is not None
+        try:
+            before = os.stat(
+                name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"{label} disappeared") from exc
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            raise ValueError(f"{label} must be an unlinked regular file")
+        flags = (
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC | getattr(os, "O_NONBLOCK", 0)
+        )
+        try:
+            descriptor = owner.open(name, flags, dir_fd=self._authority.resource)
+            opened = os.fstat(descriptor)
+            owner.bind_identity(opened)
+            if _file_identity(opened) != _file_identity(before):
+                raise RuntimeError(f"{label} changed while it was opened")
+            _require_new_regular(opened, mode=stat.S_IMODE(opened.st_mode))
+            return opened
+        except BaseException as primary_error:
+            owner.close_after_error(primary_error)
+            raise
+
+    def _authenticate_existing(
+        self,
+        owner: _DescriptorOwner,
+    ) -> tuple[os.stat_result, PublishedFileRecord]:
+        assert self._authority is not None
+        before = self._open_regular(
+            self.destination.name,
+            label="existing publication",
+            owner=owner,
+        )
+        descriptor = owner.descriptor
+        try:
+            if before.st_size < 0 or before.st_size > self.max_bytes:
+                assert self._record is not None
+                orphan = self.orphan
+                assert orphan is not None
+                raise OwnedFileConflictError(
+                    self.destination,
+                    self._record,
+                    None,
+                    orphan,
+                )
+            digest = hashlib.sha256()
+            offset = 0
+            while offset < before.st_size:
+                block = os.pread(
+                    descriptor,
+                    min(_COPY_BYTES, before.st_size - offset),
+                    offset,
+                )
+                if not block:
+                    raise RuntimeError("existing publication was truncated")
+                digest.update(block)
+                offset += len(block)
+            if os.pread(descriptor, 1, offset):
+                raise RuntimeError("existing publication grew")
+            after = os.fstat(descriptor)
+            if _file_version_identity(after) != _file_version_identity(before):
+                raise RuntimeError("existing publication changed while authenticated")
+            observed_mode = _file_mode(stat.S_IMODE(after.st_mode))
+            rebound = os.stat(
+                self.destination.name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+            if _file_version_identity(rebound) != _file_version_identity(after):
+                raise RuntimeError("existing publication binding changed")
+            return (
+                after,
+                PublishedFileRecord(
+                    size=after.st_size,
+                    sha256=digest.hexdigest(),
+                    mode=observed_mode,
+                ),
+            )
+        except BaseException as primary_error:
+            owner.close_after_error(primary_error)
+            raise
+
+    def _authenticate_descriptor(
+        self,
+        descriptor: int,
+        *,
+        expected: PublishedFileRecord,
+        identity: tuple[int, ...] | None,
+        label: str,
+    ) -> os.stat_result:
+        before = os.fstat(descriptor)
+        _require_exact_regular(
+            before,
+            identity=identity,
+            version_identity=None,
+            mode=expected.mode,
+            size=expected.size,
+            label=label,
+        )
+        digest = hashlib.sha256()
+        offset = 0
+        while offset < expected.size:
+            block = os.pread(
+                descriptor,
+                min(_COPY_BYTES, expected.size - offset),
+                offset,
+            )
+            if not block:
+                raise RuntimeError(f"{label} was truncated")
+            digest.update(block)
+            offset += len(block)
+        if os.pread(descriptor, 1, offset):
+            raise RuntimeError(f"{label} grew")
+        after = os.fstat(descriptor)
+        if _file_version_identity(after) != _file_version_identity(before):
+            raise RuntimeError(f"{label} changed while authenticated")
+        if digest.hexdigest() != expected.sha256:
+            raise RuntimeError(f"{label} bytes differ from the producer digest")
+        return after
+
+    def _rename_committed(self) -> bool:
+        assert self._authority is not None
+        try:
+            source = os.stat(
+                self._stage_name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            source = None
+        try:
+            destination = os.stat(
+                self.destination.name,
+                dir_fd=self._authority.resource,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            destination = None
+        return (
+            source is None
+            and destination is not None
+            and _file_identity(destination) == self._stage_identity
+        )
+
+    def _close_stage_descriptor(self) -> None:
+        assert self._stage_identity is not None
+        self._stage_owner.close(expected_identity=self._stage_identity)
+
+    def _close_parent_authority(self) -> None:
+        assert self._authority_owner.authority is not None
+        self._authority_owner.close()
+
+    def _require_state(self, expected: str) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "owned file publication authority cannot cross a PID boundary"
+            )
+        if self._state != expected:
+            raise RuntimeError(
+                f"owned file publication is {self._state}, expected {expected}"
+            )
+
+    def __enter__(self) -> OwnedFilePublicationAuthority:
+        self._require_state("staged")
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        try:
+            self.close()
+        except BaseException as close_error:
+            if exc is None:
+                raise
+            _annotate_error(exc, "publication cleanup also failed", close_error)
+
+
+def publish_owned_file(
+    destination: Path,
+    chunks: Iterable[bytes] | bytes,
+    *,
+    max_bytes: int,
+    mode: int = 0o644,
+    parent_resource: int | None = None,
+    receipt_owner: PublishedFileReceiptOwner | None = None,
+    consume: Callable[[PublishedFileReceipt], object] | None = None,
+) -> None:
+    """Publish into a caller owner or synchronously consume a borrowed receipt.
+
+    The receipt retains the exact authenticated handle, but a same-UID process
+    can still mutate a normal writable filesystem after publication.  A
+    consumer-only receipt is valid solely for the synchronous callback and is
+    terminally cleaned before this helper returns or propagates an exception.
+    """
+
+    if (receipt_owner is None) == (consume is None):
+        raise TypeError("provide exactly one of receipt_owner or consume")
+    if receipt_owner is not None and not isinstance(
+        receipt_owner, PublishedFileReceiptOwner
+    ):
+        raise TypeError("receipt_owner must be a PublishedFileReceiptOwner")
+    if consume is not None and not callable(consume):
+        raise TypeError("published file receipt consumer must be callable")
+
+    if receipt_owner is not None:
+        with OwnedFilePublicationAuthority(
+            destination,
+            max_bytes=max_bytes,
+            mode=mode,
+            parent_resource=parent_resource,
+        ) as publication:
+            publication.write(chunks)
+            publication.publish_into(receipt_owner)
+        return None
+
+    local_owner = PublishedFileReceiptOwner()
+    try:
+        with OwnedFilePublicationAuthority(
+            destination,
+            max_bytes=max_bytes,
+            mode=mode,
+            parent_resource=parent_resource,
+        ) as publication:
+            publication.write(chunks)
+            publication.publish_into(local_owner)
+        assert consume is not None
+        local_owner.consume(consume)
+    except BaseException as primary_error:
+        try:
+            local_owner._close_terminal_after_error(primary_error)
+        except BaseException as cleanup_error:  # noqa: B036 - keep primary
+            _annotate_error(
+                primary_error,
+                "helper-local receipt owner cleanup also failed",
+                cleanup_error,
+            )
+        raise
+    try:
+        local_owner.close()
+    except BaseException as close_error:
+        try:
+            local_owner._close_terminal_after_error(close_error)
+        except BaseException as cleanup_error:  # noqa: B036 - keep close error
+            _annotate_error(
+                close_error,
+                "helper-local terminal cleanup also failed",
+                cleanup_error,
+            )
+        raise
+    return None
+
+
+def _bounded_size(value: int, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{label} must be an integer")
+    if value < 0 or value > (64 << 30):
+        raise ValueError(f"{label} is out of bounds")
+    return value
+
+
+def _file_mode(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("publication mode must be an integer")
+    if value < 0 or value > 0o777 or value & 0o022:
+        raise ValueError("publication mode must be a non-writable-group POSIX mode")
+    return value
+
+
+def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (metadata.st_dev, metadata.st_ino, stat.S_IFMT(metadata.st_mode))
+
+
+def _file_version_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _annotate_error(
+    primary_error: BaseException,
+    label: str,
+    cleanup_error: BaseException,
+) -> None:
+    message = f"{label}: {cleanup_error!r}"
+    if hasattr(primary_error, "add_note"):
+        primary_error.add_note(message)
+        return
+    notes = list(getattr(primary_error, "_codenib_cleanup_notes", ()))
+    notes.append(message)
+    primary_error._codenib_cleanup_notes = tuple(notes)  # type: ignore[attr-defined]
+    if primary_error.__cause__ is None:
+        primary_error.__cause__ = cleanup_error
+
+
+def _remember_first_cleanup_error(
+    deferred: BaseException | None,
+    failure: BaseException,
+) -> BaseException:
+    if deferred is None:
+        return failure
+    if failure is not deferred:
+        _annotate_error(deferred, "additional cleanup interruption", failure)
+    return deferred
+
+
+def _arm_descriptor_for_close(
+    descriptor: int,
+    *,
+    cookie_owner: _DescriptorOwner | None = None,
+) -> int:
+    """Place an unguessable cookie on this open-file description before close."""
+
+    cookie = _CLOSE_COOKIE_FLOOR + secrets.randbelow(_CLOSE_COOKIE_SPAN)
+    observed = os.lseek(descriptor, cookie, os.SEEK_SET)
+    if observed != cookie or os.lseek(descriptor, 0, os.SEEK_CUR) != cookie:
+        raise RuntimeError("could not arm descriptor close ownership")
+    if cookie_owner is not None:
+        if cookie_owner.descriptor != descriptor:
+            raise RuntimeError("descriptor close-cookie owner changed")
+        # Install before returning so interruption at the caller's first
+        # bytecode still leaves a proof for any later retry.
+        cookie_owner._close_cookie = cookie
+    return cookie
+
+
+def _descriptor_still_exact(
+    descriptor: int,
+    identity: tuple[int, ...],
+    *,
+    close_cookie: int | None,
+) -> bool:
+    """Best-effort recognition of the pre-close open-file description.
+
+    A same-process ``dup2`` of an alias sharing both inode and file offset is an
+    intentionally documented, unprovable ABA boundary.
+    """
+
+    if close_cookie is None:
+        return False
+
+    try:
+        metadata = os.fstat(descriptor)
+    except OSError as exc:
+        if exc.errno == errno.EBADF:
+            return False
+        raise
+    if _file_identity(metadata) != identity:
+        return False
+    try:
+        return os.lseek(descriptor, 0, os.SEEK_CUR) == close_cookie
+    except OSError as exc:
+        if exc.errno == errno.EBADF:
+            return False
+        raise
+
+
+def _finish_close_after_error(
+    descriptor: int,
+    identity: tuple[int, ...],
+    close_error: BaseException,
+    *,
+    close_cookie: int | None,
+) -> bool:
+    """Finish an ambiguous close unless the descriptor is observably reused."""
+
+    try:
+        still_exact = _descriptor_still_exact(
+            descriptor,
+            identity,
+            close_cookie=close_cookie,
+        )
+    except BaseException as reconciliation_error:  # noqa: B036 - keep close error
+        _annotate_error(
+            close_error,
+            "descriptor close reconciliation failed",
+            reconciliation_error,
+        )
+        return False
+    if not still_exact:
+        return True
+    try:
+        _REAL_OS_CLOSE(descriptor)
+    except BaseException as cleanup_error:  # noqa: B036 - keep close error
+        _annotate_error(
+            close_error,
+            "descriptor fallback close failed",
+            cleanup_error,
+        )
+        try:
+            return not _descriptor_still_exact(
+                descriptor,
+                identity,
+                close_cookie=close_cookie,
+            )
+        except BaseException as reconciliation_error:  # noqa: B036 - keep primary
+            _annotate_error(
+                close_error,
+                "descriptor fallback reconciliation failed",
+                reconciliation_error,
+            )
+            return False
+    return True
+
+
+def _cleanup_descriptor_after_error(
+    descriptor: int,
+    identity: tuple[int, ...] | None,
+    primary_error: BaseException,
+    *,
+    cookie_owner: _DescriptorOwner | None = None,
+) -> bool:
+    if identity is None:
+        return _cleanup_untransferred_descriptor(descriptor, primary_error)
+    close_cookie: int | None = None
+    try:
+        close_cookie = _arm_descriptor_for_close(
+            descriptor,
+            cookie_owner=cookie_owner,
+        )
+    except BaseException as ownership_error:  # noqa: B036 - keep primary error
+        _annotate_error(
+            primary_error,
+            "descriptor cleanup ownership check failed",
+            ownership_error,
+        )
+    try:
+        os.close(descriptor)
+    except BaseException as close_error:  # noqa: B036 - keep primary error
+        closed = _finish_close_after_error(
+            descriptor,
+            identity,
+            close_error,
+            close_cookie=close_cookie,
+        )
+        _annotate_error(primary_error, "descriptor cleanup also failed", close_error)
+        if not closed:
+            _annotate_error(
+                primary_error,
+                "owned descriptor close outcome remains unknown",
+                close_error,
+            )
+        return closed
+    return True
+
+
+def _cleanup_untransferred_descriptor(
+    descriptor: int,
+    primary_error: BaseException,
+) -> bool:
+    try:
+        metadata = os.fstat(descriptor)
+    except OSError as exc:
+        if exc.errno == errno.EBADF:
+            return True
+        _annotate_error(primary_error, "descriptor cleanup identity failed", exc)
+        try:
+            os.close(descriptor)
+        except BaseException as close_error:  # noqa: B036 - keep primary error
+            _annotate_error(
+                primary_error,
+                "unidentified descriptor cleanup also failed",
+                close_error,
+            )
+            return False
+        return True
+    except BaseException as identity_error:  # noqa: B036 - keep primary error
+        _annotate_error(
+            primary_error,
+            "descriptor cleanup identity was interrupted",
+            identity_error,
+        )
+        try:
+            os.close(descriptor)
+        except BaseException as close_error:  # noqa: B036 - keep primary error
+            _annotate_error(
+                primary_error,
+                "unidentified descriptor cleanup also failed",
+                close_error,
+            )
+            return False
+        return True
+    return _cleanup_descriptor_after_error(
+        descriptor,
+        _file_identity(metadata),
+        primary_error,
+    )
+
+
+def _close_publication_authority(
+    authority: _atomic._PublicationAuthority,
+) -> None:
+    """Close a shared authority while retaining the first BaseException."""
+
+    resource = authority._resource
+    resource_identity: tuple[int, ...] | None = None
+    close_cookie: int | None = None
+    primary_error: BaseException | None = None
+    try:
+        resource_identity = _file_identity(os.fstat(resource))
+        close_cookie = _arm_descriptor_for_close(resource)
+    except BaseException as ownership_error:  # noqa: B036 - cleanup must continue
+        primary_error = ownership_error
+
+    try:
+        authority.close()
+    except BaseException as close_error:  # noqa: B036 - finish all cleanup
+        if primary_error is None:
+            primary_error = close_error
+        else:
+            _annotate_error(
+                primary_error,
+                "parent authority close also failed",
+                close_error,
+            )
+        try:
+            # The callback owns the complete lexical walk.  It is deliberately
+            # resumed after an interrupt even though the authority is closed.
+            authority._close_callback(resource)
+        except BaseException as cleanup_error:  # noqa: B036 - keep first error
+            _annotate_error(
+                primary_error,
+                "parent authority cleanup also failed",
+                cleanup_error,
+            )
+
+    if resource_identity is not None:
+        try:
+            still_open = _descriptor_still_exact(
+                resource,
+                resource_identity,
+                close_cookie=close_cookie,
+            )
+        except BaseException as reconciliation_error:  # noqa: B036
+            if primary_error is None:
+                primary_error = reconciliation_error
+            else:
+                _annotate_error(
+                    primary_error,
+                    "parent descriptor reconciliation failed",
+                    reconciliation_error,
+                )
+        else:
+            if still_open:
+                try:
+                    _REAL_OS_CLOSE(resource)
+                except BaseException as cleanup_error:  # noqa: B036
+                    if primary_error is None:
+                        primary_error = cleanup_error
+                    else:
+                        _annotate_error(
+                            primary_error,
+                            "parent descriptor cleanup failed",
+                            cleanup_error,
+                        )
+
+    if primary_error is not None:
+        raise primary_error
+
+
+def _require_new_regular(metadata: os.stat_result, *, mode: int) -> None:
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_nlink != 1
+        or stat.S_IMODE(metadata.st_mode) != mode
+    ):
+        raise RuntimeError("owned file must be one exact regular inode")
+
+
+def _require_exact_regular(
+    metadata: os.stat_result,
+    *,
+    identity: tuple[int, ...] | None,
+    version_identity: tuple[int, ...] | None,
+    mode: int,
+    size: int,
+    label: str,
+) -> None:
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_nlink != 1
+        or stat.S_IMODE(metadata.st_mode) != mode
+        or metadata.st_size != size
+        or (identity is not None and _file_identity(metadata) != identity)
+        or (
+            version_identity is not None
+            and _file_version_identity(metadata) != version_identity
+        )
+    ):
+        raise RuntimeError(f"{label} identity changed")
+
+
+__all__ = [
+    "OwnedFileConflictError",
+    "OwnedFileOrphan",
+    "OwnedFilePublicationAuthority",
+    "PublishedFileReceipt",
+    "PublishedFileReceiptOwner",
+    "PublishedFileRecord",
+    "publish_owned_file",
+    "require_owned_file_publication_support",
+]

--- a/codenib/_secret_fields.py
+++ b/codenib/_secret_fields.py
@@ -69,38 +69,82 @@ class SecretFieldError(ValueError):
     """A decoded value contains credential-shaped publication data."""
 
 
+def _trim_bounds(value: str) -> tuple[int, int]:
+    start = 0
+    end = len(value)
+    while start < end and value[start].isspace():
+        start += 1
+    while end > start and value[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
+def _authority_contains_userinfo(value: str, start: int, end: int) -> bool:
+    """Check a URL authority without copying a potentially huge document."""
+
+    position = start
+    while position < end:
+        char = value[position]
+        if char in "/?#" or char.isspace():
+            break
+        if char == "@":
+            return True
+        position += 1
+    return False
+
+
+def _string_contains_url_credentials(value: str, start: int, end: int) -> bool:
+    if end - start <= 8_192:
+        candidate = value[start:end]
+        if "://" not in candidate and not candidate.startswith("//"):
+            return False
+        try:
+            parsed = urlsplit(candidate)
+        except ValueError as exc:
+            raise SecretFieldError("value contains an invalid URL") from exc
+        return parsed.username is not None or parsed.password is not None
+
+    if value.startswith("//", start) and _authority_contains_userinfo(
+        value, start + 2, end
+    ):
+        return True
+    search_from = start
+    while (separator := value.find("://", search_from, end)) >= 0:
+        if _authority_contains_userinfo(value, separator + 3, end):
+            return True
+        search_from = separator + 3
+    return False
+
+
 def assert_no_secret_fields(value: Any, *, source: str = "value") -> None:
     """Reject decoded credential keys, URL userinfo, and auth header values."""
 
-    if isinstance(value, Mapping):
-        for key, child in value.items():
-            normalized = re.sub(r"[^a-z0-9]", "", str(key).casefold())
-            if (
-                normalized in _NORMALIZED_SECRET_FIELD_NAMES
-                or normalized.endswith(_NORMALIZED_SECRET_FIELD_SUFFIXES)
-                or normalized.startswith(_NORMALIZED_SECRET_HEADER_PREFIXES)
-            ):
-                raise SecretFieldError(
-                    f"{source} contains a credential field or secret field: {key}"
-                )
-            assert_no_secret_fields(child, source=source)
-    elif isinstance(value, (list, tuple)):
-        for child in value:
-            assert_no_secret_fields(child, source=source)
-    elif isinstance(value, str):
-        stripped = value.strip()
-        if "://" in stripped or stripped.startswith("//"):
-            try:
-                parsed = urlsplit(stripped)
-            except ValueError as exc:
-                raise SecretFieldError(f"{source} contains an invalid URL") from exc
-            if parsed.username is not None or parsed.password is not None:
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            for key, child in current.items():
+                normalized = re.sub(r"[^a-z0-9]", "", str(key).casefold())
+                if (
+                    normalized in _NORMALIZED_SECRET_FIELD_NAMES
+                    or normalized.endswith(_NORMALIZED_SECRET_FIELD_SUFFIXES)
+                    or normalized.startswith(_NORMALIZED_SECRET_HEADER_PREFIXES)
+                ):
+                    raise SecretFieldError(
+                        f"{source} contains a credential field or secret field: {key}"
+                    )
+                stack.append(child)
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+        elif isinstance(current, str):
+            start, end = _trim_bounds(current)
+            if _string_contains_url_credentials(current, start, end):
                 raise SecretFieldError(f"{source} must not contain URL credentials")
-        normalized = stripped.casefold()
-        if normalized.startswith(("bearer ", "basic ")):
-            raise SecretFieldError(
-                f"{source} must not contain authorization credentials"
-            )
+            prefix = current[start : min(end, start + 7)].casefold()
+            if prefix.startswith(("bearer ", "basic ")):
+                raise SecretFieldError(
+                    f"{source} must not contain authorization credentials"
+                )
 
 
 __all__ = ["SecretFieldError", "assert_no_secret_fields"]

--- a/codenib/_secret_fields.py
+++ b/codenib/_secret_fields.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-neutral credential-field and credential-value classification."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+_SECRET_FIELD_NAMES = frozenset(
+    {
+        "access_key",
+        "access_token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "bearer_token",
+        "client_secret",
+        "cookie",
+        "credential",
+        "credentials",
+        "headers",
+        "password",
+        "passwd",
+        "private_key",
+        "proxy_authorization",
+        "refresh_token",
+        "secret",
+        "secret_key",
+        "token",
+        "x_api_key",
+        "x_auth_token",
+    }
+)
+_NORMALIZED_SECRET_FIELD_NAMES = frozenset(
+    re.sub(r"[^a-z0-9]", "", name.casefold()) for name in _SECRET_FIELD_NAMES
+)
+_NORMALIZED_SECRET_FIELD_SUFFIXES = tuple(
+    re.sub(r"[^a-z0-9]", "", name.casefold())
+    for name in (
+        "api_key",
+        "access_key",
+        "access_token",
+        "auth_token",
+        "bearer_token",
+        "client_secret",
+        "credential",
+        "credentials",
+        "password",
+        "passwd",
+        "private_key",
+        "refresh_token",
+        "secret",
+        "secret_key",
+        "token",
+        "authorization",
+    )
+)
+_NORMALIZED_SECRET_HEADER_PREFIXES = tuple(
+    re.sub(r"[^a-z0-9]", "", name.casefold())
+    for name in ("proxy_authorization", "x_api_key", "x_auth_token")
+)
+
+
+class SecretFieldError(ValueError):
+    """A decoded value contains credential-shaped publication data."""
+
+
+def assert_no_secret_fields(value: Any, *, source: str = "value") -> None:
+    """Reject decoded credential keys, URL userinfo, and auth header values."""
+
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            normalized = re.sub(r"[^a-z0-9]", "", str(key).casefold())
+            if (
+                normalized in _NORMALIZED_SECRET_FIELD_NAMES
+                or normalized.endswith(_NORMALIZED_SECRET_FIELD_SUFFIXES)
+                or normalized.startswith(_NORMALIZED_SECRET_HEADER_PREFIXES)
+            ):
+                raise SecretFieldError(
+                    f"{source} contains a credential field or secret field: {key}"
+                )
+            assert_no_secret_fields(child, source=source)
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            assert_no_secret_fields(child, source=source)
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if "://" in stripped or stripped.startswith("//"):
+            try:
+                parsed = urlsplit(stripped)
+            except ValueError as exc:
+                raise SecretFieldError(f"{source} contains an invalid URL") from exc
+            if parsed.username is not None or parsed.password is not None:
+                raise SecretFieldError(f"{source} must not contain URL credentials")
+        normalized = stripped.casefold()
+        if normalized.startswith(("bearer ", "basic ")):
+            raise SecretFieldError(
+                f"{source} must not contain authorization credentials"
+            )
+
+
+__all__ = ["SecretFieldError", "assert_no_secret_fields"]

--- a/codenib/_secret_fields.py
+++ b/codenib/_secret_fields.py
@@ -85,7 +85,9 @@ def _authority_contains_userinfo(value: str, start: int, end: int) -> bool:
     position = start
     while position < end:
         char = value[position]
-        if char in "/?#" or char.isspace():
+        # urllib.parse treats whitespace inside the netloc as part of the
+        # authority. Do not stop early and miss a later userinfo delimiter.
+        if char in "/?#":
             break
         if char == "@":
             return True

--- a/codenib/_windows_fs_authority.py
+++ b/codenib/_windows_fs_authority.py
@@ -1,0 +1,1424 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared Win32 HANDLE and FILE_ID filesystem primitives.
+
+This module owns only kernel bindings and handle-level metadata operations.
+Publication, source-containment, and staging policy remain in their respective
+callers.  Child paths are deliberately absent from this interface: callers
+enumerate an already-open parent and reopen entries by filesystem identity.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import ntpath
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+from typing import Callable, Iterator
+
+INVALID_HANDLE_VALUE = -1
+FILE_LIST_DIRECTORY = 0x0001
+FILE_READ_DATA = 0x0001
+FILE_READ_ATTRIBUTES = 0x0080
+DELETE = 0x00010000
+SYNCHRONIZE = 0x00100000
+FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+OPEN_EXISTING = 3
+FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+FILE_ATTRIBUTE_DIRECTORY = 0x00000010
+FILE_ATTRIBUTE_READONLY = 0x00000001
+FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+FILE_ID_BOTH_DIRECTORY_INFO = 10
+FILE_ID_BOTH_DIRECTORY_RESTART_INFO = 11
+FILE_STANDARD_INFO = 1
+FILE_ATTRIBUTE_TAG_INFO = 9
+FILE_ID_INFO = 18
+FILE_ID_EXTD_DIRECTORY_INFO = 19
+FILE_ID_EXTD_DIRECTORY_RESTART_INFO = 20
+FILE_RENAME_INFO = 3
+FILE_ID_TYPE = 0
+EXTENDED_FILE_ID_TYPE = 2
+FSCTL_GET_REPARSE_POINT = 0x000900A8
+IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003
+IO_REPARSE_TAG_SYMLINK = 0xA000000C
+SYMLINK_FLAG_RELATIVE = 0x00000001
+MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 16 * 1024
+OBJ_DONT_REPARSE = 0x00001000
+FILE_OPEN = 0x00000001
+FILE_DIRECTORY_FILE = 0x00000001
+FILE_NON_DIRECTORY_FILE = 0x00000040
+FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020
+FILE_OPEN_REPARSE_POINT = 0x00200000
+ERROR_FILE_NOT_FOUND = 2
+ERROR_PATH_NOT_FOUND = 3
+ERROR_NO_MORE_FILES = 18
+ERROR_FILE_EXISTS = 80
+ERROR_ALREADY_EXISTS = 183
+ERROR_INVALID_FUNCTION = 1
+ERROR_NOT_SUPPORTED = 50
+DIRECTORY_QUERY_BYTES = 64 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsFileId:
+    """One volume-scoped 128-bit Windows filesystem identity."""
+
+    volume_serial: int
+    value: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsHandleMetadata:
+    """Windows-native metadata retained by handle-bound policy layers."""
+
+    st_dev: int
+    st_ino: int
+    st_mode: int
+    st_size: int
+    st_mtime_ns: int
+    st_ctime_ns: int
+    st_nlink: int
+    st_file_attributes: int
+    file_id_128: bytes = b""
+    reparse_tag: int = 0
+    delete_pending: bool = False
+
+    @property
+    def file_identity(self) -> WindowsFileId:
+        """Return the exact volume-scoped identity reported for this handle."""
+
+        return WindowsFileId(self.st_dev, self.file_id_128)
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsDirectoryEntry:
+    """One enumerated child name and its filesystem identity."""
+
+    name: str
+    file_id: int
+    attributes: int
+    file_id_128: bytes = b""
+    reparse_tag: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsReparsePoint:
+    """Parsed data for one no-follow reparse-point handle."""
+
+    tag: int
+    substitute_name: str | None
+    print_name: str | None
+    flags: int = 0
+
+
+def parse_windows_reparse_data(payload: bytes) -> WindowsReparsePoint:
+    """Strictly decode one FSCTL_GET_REPARSE_POINT response buffer."""
+
+    if not isinstance(payload, bytes) or len(payload) < 8:
+        raise RuntimeError("Windows reparse-point data is truncated")
+    tag = int.from_bytes(payload[0:4], "little")
+    data_length = int.from_bytes(payload[4:6], "little")
+    data_end = 8 + data_length
+    if data_end > len(payload) or data_end > MAXIMUM_REPARSE_DATA_BUFFER_SIZE:
+        raise RuntimeError("Windows reparse-point data length is invalid")
+    if tag != IO_REPARSE_TAG_SYMLINK:
+        return WindowsReparsePoint(tag, None, None)
+    if data_length < 12 or data_end < 20:
+        raise RuntimeError("Windows symbolic-link reparse data is truncated")
+    substitute_offset = int.from_bytes(payload[8:10], "little")
+    substitute_length = int.from_bytes(payload[10:12], "little")
+    print_offset = int.from_bytes(payload[12:14], "little")
+    print_length = int.from_bytes(payload[14:16], "little")
+    flags = int.from_bytes(payload[16:20], "little")
+    path_start = 20
+
+    def decode_name(offset: int, length: int) -> str:
+        if offset % 2 or length % 2:
+            raise RuntimeError("Windows symbolic-link name is misaligned")
+        start = path_start + offset
+        end = start + length
+        if start < path_start or end > data_end:
+            raise RuntimeError("Windows symbolic-link name is out of bounds")
+        try:
+            return payload[start:end].decode("utf-16-le", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise RuntimeError(
+                "Windows symbolic-link name is not valid UTF-16"
+            ) from exc
+
+    return WindowsReparsePoint(
+        tag=tag,
+        substitute_name=decode_name(substitute_offset, substitute_length),
+        print_name=decode_name(print_offset, print_length),
+        flags=flags,
+    )
+
+
+def windows_file_id_is_reliable(value: object) -> bool:
+    """Return whether *value* is one non-zero 128-bit FILE_ID."""
+
+    return isinstance(value, bytes) and len(value) == 16 and any(value)
+
+
+def windows_metadata_identity(
+    metadata: WindowsHandleMetadata,
+) -> tuple[object, ...]:
+    """Return the exact version token used by HANDLE authority checks."""
+
+    return (
+        metadata.st_dev,
+        metadata.file_id_128,
+        metadata.st_mode,
+        metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0,
+        metadata.st_file_attributes,
+        metadata.reparse_tag,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        metadata.delete_pending,
+    )
+
+
+def windows_handle_ownership_identity(
+    metadata: WindowsHandleMetadata,
+) -> tuple[object, ...]:
+    """Return the stable kernel-object identity used only for HANDLE cleanup.
+
+    Directory timestamps, link counts, attributes, and delete-pending state are
+    version/authentication data. They may change while the retained HANDLE still
+    names the same kernel object and therefore must not decide close ownership.
+    """
+
+    return (metadata.st_dev, metadata.file_id_128)
+
+
+def windows_extended_path(path: Path) -> str:
+    """Return one canonical extended-length path for opening a root authority."""
+
+    absolute = str(path.absolute())
+    if absolute.startswith("\\\\?\\"):
+        return absolute
+    if absolute.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + absolute[2:]
+    return "\\\\?\\" + absolute
+
+
+def windows_mode_from_attributes(attributes: int) -> int:
+    """Mirror Windows readonly semantics without inventing execute bits."""
+
+    readonly = bool(attributes & FILE_ATTRIBUTE_READONLY)
+    if attributes & FILE_ATTRIBUTE_DIRECTORY:
+        permissions = 0o555 if readonly else 0o777
+        return stat.S_IFDIR | permissions
+    permissions = 0o444 if readonly else 0o666
+    return stat.S_IFREG | permissions
+
+
+class WindowsKernelApi:
+    """Small HANDLE API shared by filesystem authority policy layers.
+
+    The higher-level methods make the ABI replaceable in simulation tests.
+    Future source-containment and staging work can extend this class with
+    reparse queries and root-relative opens without duplicating ctypes.
+    """
+
+    __slots__ = (
+        "kernel32",
+        "ntdll",
+        "wintypes",
+        "BY_HANDLE_FILE_INFORMATION",
+        "FILE_BASIC_INFO",
+        "FILE_STANDARD_INFO",
+        "FILE_ATTRIBUTE_TAG_INFO",
+        "FILE_ID_128",
+        "FILE_ID_INFO",
+        "FILE_ID_DESCRIPTOR",
+        "FILE_ID_BOTH_DIR_INFO",
+        "FILE_ID_EXTD_DIR_INFO",
+        "FILE_RENAME_INFO",
+        "UNICODE_STRING",
+        "OBJECT_ATTRIBUTES",
+        "IO_STATUS_BLOCK",
+        "invalid_handle",
+    )
+
+    def __init__(self) -> None:
+        if sys.platform != "win32" or not hasattr(ctypes, "WinDLL"):
+            raise RuntimeError("Windows HANDLE filesystem API is unavailable")
+        import ctypes.wintypes as wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        ntdll = ctypes.WinDLL("ntdll", use_last_error=True)
+
+        class BY_HANDLE_FILE_INFORMATION(ctypes.Structure):
+            _fields_ = [
+                ("dwFileAttributes", wintypes.DWORD),
+                ("ftCreationTime", wintypes.FILETIME),
+                ("ftLastAccessTime", wintypes.FILETIME),
+                ("ftLastWriteTime", wintypes.FILETIME),
+                ("dwVolumeSerialNumber", wintypes.DWORD),
+                ("nFileSizeHigh", wintypes.DWORD),
+                ("nFileSizeLow", wintypes.DWORD),
+                ("nNumberOfLinks", wintypes.DWORD),
+                ("nFileIndexHigh", wintypes.DWORD),
+                ("nFileIndexLow", wintypes.DWORD),
+            ]
+
+        class FILE_BASIC_INFO(ctypes.Structure):
+            _fields_ = [
+                ("CreationTime", ctypes.c_longlong),
+                ("LastAccessTime", ctypes.c_longlong),
+                ("LastWriteTime", ctypes.c_longlong),
+                ("ChangeTime", ctypes.c_longlong),
+                ("FileAttributes", wintypes.DWORD),
+            ]
+
+        class FILE_STANDARD_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("AllocationSize", ctypes.c_longlong),
+                ("EndOfFile", ctypes.c_longlong),
+                ("NumberOfLinks", wintypes.DWORD),
+                ("DeletePending", wintypes.BOOLEAN),
+                ("Directory", wintypes.BOOLEAN),
+            ]
+
+        class FILE_ATTRIBUTE_TAG_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("FileAttributes", wintypes.DWORD),
+                ("ReparseTag", wintypes.DWORD),
+            ]
+
+        class FILE_ID_128_STRUCT(ctypes.Structure):
+            _fields_ = [("Identifier", ctypes.c_ubyte * 16)]
+
+        class FILE_ID_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("VolumeSerialNumber", ctypes.c_ulonglong),
+                ("FileId", FILE_ID_128_STRUCT),
+            ]
+
+        class FILE_ID_VALUE(ctypes.Union):
+            _fields_ = [
+                ("FileId", ctypes.c_longlong),
+                ("ObjectId", ctypes.c_ubyte * 16),
+                ("ExtendedFileId", ctypes.c_ubyte * 16),
+            ]
+
+        class FILE_ID_DESCRIPTOR(ctypes.Structure):
+            _anonymous_ = ("value",)
+            _fields_ = [
+                ("dwSize", wintypes.DWORD),
+                ("Type", ctypes.c_int),
+                ("value", FILE_ID_VALUE),
+            ]
+
+        class FILE_ID_EXTD_DIR_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("NextEntryOffset", wintypes.DWORD),
+                ("FileIndex", wintypes.DWORD),
+                ("CreationTime", ctypes.c_longlong),
+                ("LastAccessTime", ctypes.c_longlong),
+                ("LastWriteTime", ctypes.c_longlong),
+                ("ChangeTime", ctypes.c_longlong),
+                ("EndOfFile", ctypes.c_longlong),
+                ("AllocationSize", ctypes.c_longlong),
+                ("FileAttributes", wintypes.DWORD),
+                ("FileNameLength", wintypes.DWORD),
+                ("EaSize", wintypes.DWORD),
+                ("ReparsePointTag", wintypes.DWORD),
+                ("FileId", FILE_ID_128_STRUCT),
+                ("FileName", wintypes.WCHAR * 1),
+            ]
+
+        class FILE_ID_BOTH_DIR_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("NextEntryOffset", wintypes.DWORD),
+                ("FileIndex", wintypes.DWORD),
+                ("CreationTime", ctypes.c_longlong),
+                ("LastAccessTime", ctypes.c_longlong),
+                ("LastWriteTime", ctypes.c_longlong),
+                ("ChangeTime", ctypes.c_longlong),
+                ("EndOfFile", ctypes.c_longlong),
+                ("AllocationSize", ctypes.c_longlong),
+                ("FileAttributes", wintypes.DWORD),
+                ("FileNameLength", wintypes.DWORD),
+                ("EaSize", wintypes.DWORD),
+                ("ShortNameLength", ctypes.c_byte),
+                ("ShortName", wintypes.WCHAR * 12),
+                ("FileId", ctypes.c_longlong),
+                ("FileName", wintypes.WCHAR * 1),
+            ]
+
+        class FILE_RENAME_INFO_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("ReplaceIfExists", wintypes.BOOLEAN),
+                ("RootDirectory", wintypes.HANDLE),
+                ("FileNameLength", wintypes.DWORD),
+                ("FileName", wintypes.WCHAR * 1),
+            ]
+
+        class UNICODE_STRING_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("Length", wintypes.USHORT),
+                ("MaximumLength", wintypes.USHORT),
+                ("Buffer", wintypes.LPWSTR),
+            ]
+
+        class OBJECT_ATTRIBUTES_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("Length", wintypes.ULONG),
+                ("RootDirectory", wintypes.HANDLE),
+                ("ObjectName", ctypes.POINTER(UNICODE_STRING_STRUCT)),
+                ("Attributes", wintypes.ULONG),
+                ("SecurityDescriptor", wintypes.LPVOID),
+                ("SecurityQualityOfService", wintypes.LPVOID),
+            ]
+
+        class IO_STATUS_BLOCK_STRUCT(ctypes.Structure):
+            _fields_ = [
+                ("Status", ctypes.c_void_p),
+                ("Information", ctypes.c_size_t),
+            ]
+
+        kernel32.CreateFileW.argtypes = (
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        )
+        kernel32.CreateFileW.restype = wintypes.HANDLE
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        kernel32.GetFileInformationByHandle.argtypes = (
+            wintypes.HANDLE,
+            ctypes.POINTER(BY_HANDLE_FILE_INFORMATION),
+        )
+        kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+        kernel32.GetFileInformationByHandleEx.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        )
+        kernel32.GetFileInformationByHandleEx.restype = wintypes.BOOL
+        kernel32.OpenFileById.argtypes = (
+            wintypes.HANDLE,
+            ctypes.POINTER(FILE_ID_DESCRIPTOR),
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        )
+        kernel32.OpenFileById.restype = wintypes.HANDLE
+        kernel32.ReadFile.argtypes = (
+            wintypes.HANDLE,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+            wintypes.LPVOID,
+        )
+        kernel32.ReadFile.restype = wintypes.BOOL
+        kernel32.DeviceIoControl.argtypes = (
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+            wintypes.LPVOID,
+        )
+        kernel32.DeviceIoControl.restype = wintypes.BOOL
+        kernel32.SetFileInformationByHandle.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        )
+        kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+        kernel32.GetCurrentProcess.argtypes = ()
+        kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        kernel32.DuplicateHandle.argtypes = (
+            wintypes.HANDLE,
+            wintypes.HANDLE,
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.HANDLE),
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        )
+        kernel32.DuplicateHandle.restype = wintypes.BOOL
+
+        ntdll.NtCreateFile.argtypes = (
+            ctypes.POINTER(wintypes.HANDLE),
+            wintypes.DWORD,
+            ctypes.POINTER(OBJECT_ATTRIBUTES_STRUCT),
+            ctypes.POINTER(IO_STATUS_BLOCK_STRUCT),
+            ctypes.c_void_p,
+            wintypes.ULONG,
+            wintypes.ULONG,
+            wintypes.ULONG,
+            wintypes.ULONG,
+            ctypes.c_void_p,
+            wintypes.ULONG,
+        )
+        ntdll.NtCreateFile.restype = ctypes.c_long
+        ntdll.RtlNtStatusToDosError.argtypes = (wintypes.ULONG,)
+        ntdll.RtlNtStatusToDosError.restype = wintypes.ULONG
+
+        self.kernel32 = kernel32
+        self.ntdll = ntdll
+        self.wintypes = wintypes
+        self.BY_HANDLE_FILE_INFORMATION = BY_HANDLE_FILE_INFORMATION
+        self.FILE_BASIC_INFO = FILE_BASIC_INFO
+        self.FILE_STANDARD_INFO = FILE_STANDARD_INFO_STRUCT
+        self.FILE_ATTRIBUTE_TAG_INFO = FILE_ATTRIBUTE_TAG_INFO_STRUCT
+        self.FILE_ID_128 = FILE_ID_128_STRUCT
+        self.FILE_ID_INFO = FILE_ID_INFO_STRUCT
+        self.FILE_ID_DESCRIPTOR = FILE_ID_DESCRIPTOR
+        self.FILE_ID_BOTH_DIR_INFO = FILE_ID_BOTH_DIR_INFO_STRUCT
+        self.FILE_ID_EXTD_DIR_INFO = FILE_ID_EXTD_DIR_INFO_STRUCT
+        self.FILE_RENAME_INFO = FILE_RENAME_INFO_STRUCT
+        self.UNICODE_STRING = UNICODE_STRING_STRUCT
+        self.OBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES_STRUCT
+        self.IO_STATUS_BLOCK = IO_STATUS_BLOCK_STRUCT
+        self.invalid_handle = ctypes.c_void_p(INVALID_HANDLE_VALUE).value
+
+    def _raise_last_error(self, context: str) -> None:
+        error = ctypes.get_last_error()
+        if error in {ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND}:
+            raise FileNotFoundError(error, context)
+        if error in {ERROR_FILE_EXISTS, ERROR_ALREADY_EXISTS}:
+            raise FileExistsError(error, context)
+        if error in {ERROR_INVALID_FUNCTION, ERROR_NOT_SUPPORTED}:
+            raise RuntimeError(
+                "filesystem does not support HANDLE-bound directory authority"
+            )
+        raise ctypes.WinError(error)
+
+    def _raise_ntstatus(self, status: int, context: str) -> None:
+        error = int(self.ntdll.RtlNtStatusToDosError(status & 0xFFFFFFFF))
+        ctypes.set_last_error(error)
+        self._raise_last_error(context)
+
+    @staticmethod
+    def _handle_value(handle: object) -> int:
+        value = getattr(handle, "value", handle)
+        return 0 if value is None else int(value)
+
+    def create_directory_handle(self, path: Path) -> int:
+        handle = self.kernel32.CreateFileW(
+            windows_extended_path(path),
+            FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            None,
+        )
+        value = self._handle_value(handle)
+        if value == self.invalid_handle:
+            self._raise_last_error(f"could not open filesystem authority: {path}")
+        return value
+
+    def duplicate_handle(self, handle: int) -> int:
+        duplicate = self.wintypes.HANDLE()
+        process = self.kernel32.GetCurrentProcess()
+        if not self.kernel32.DuplicateHandle(
+            process,
+            handle,
+            process,
+            ctypes.byref(duplicate),
+            0,
+            False,
+            0x00000002,  # DUPLICATE_SAME_ACCESS
+        ):
+            self._raise_last_error("could not duplicate filesystem authority handle")
+        return self._handle_value(duplicate)
+
+    def close(self, handle: int) -> None:
+        if handle not in {0, self.invalid_handle}:
+            if not self.kernel32.CloseHandle(handle):
+                self._raise_last_error("could not close filesystem authority HANDLE")
+
+    def metadata(self, handle: int) -> WindowsHandleMetadata:
+        information = self.BY_HANDLE_FILE_INFORMATION()
+        if not self.kernel32.GetFileInformationByHandle(
+            handle,
+            ctypes.byref(information),
+        ):
+            self._raise_last_error("could not read HANDLE identity")
+        basic = self.FILE_BASIC_INFO()
+        if not self.kernel32.GetFileInformationByHandleEx(
+            handle,
+            0,  # FileBasicInfo
+            ctypes.byref(basic),
+            ctypes.sizeof(basic),
+        ):
+            self._raise_last_error("could not read HANDLE version metadata")
+        standard = self.FILE_STANDARD_INFO()
+        if not self.kernel32.GetFileInformationByHandleEx(
+            handle,
+            FILE_STANDARD_INFO,
+            ctypes.byref(standard),
+            ctypes.sizeof(standard),
+        ):
+            self._raise_last_error("could not read HANDLE standard metadata")
+        identity = self.FILE_ID_INFO()
+        if not self.kernel32.GetFileInformationByHandleEx(
+            handle,
+            FILE_ID_INFO,
+            ctypes.byref(identity),
+            ctypes.sizeof(identity),
+        ):
+            self._raise_last_error("could not read HANDLE 128-bit identity")
+        tag = self.FILE_ATTRIBUTE_TAG_INFO()
+        if not self.kernel32.GetFileInformationByHandleEx(
+            handle,
+            FILE_ATTRIBUTE_TAG_INFO,
+            ctypes.byref(tag),
+            ctypes.sizeof(tag),
+        ):
+            self._raise_last_error("could not read HANDLE reparse metadata")
+        attributes = int(tag.FileAttributes)
+        file_id_128 = bytes(identity.FileId.Identifier)
+        legacy_file_id = (int(information.nFileIndexHigh) << 32) | int(
+            information.nFileIndexLow
+        )
+        return WindowsHandleMetadata(
+            st_dev=int(identity.VolumeSerialNumber),
+            st_ino=legacy_file_id,
+            st_mode=windows_mode_from_attributes(attributes),
+            st_size=int(standard.EndOfFile),
+            st_mtime_ns=int(basic.LastWriteTime) * 100,
+            st_ctime_ns=int(basic.ChangeTime) * 100,
+            st_nlink=int(standard.NumberOfLinks),
+            st_file_attributes=attributes,
+            file_id_128=file_id_128,
+            reparse_tag=(
+                int(tag.ReparseTag) if attributes & FILE_ATTRIBUTE_REPARSE_POINT else 0
+            ),
+            delete_pending=bool(standard.DeletePending),
+        )
+
+    def iter_directory(self, handle: int) -> Iterator[WindowsDirectoryEntry]:
+        """Yield children incrementally from an already-open directory HANDLE."""
+
+        information_class = FILE_ID_EXTD_DIRECTORY_RESTART_INFO
+        while True:
+            buffer = ctypes.create_string_buffer(DIRECTORY_QUERY_BYTES)
+            if not self.kernel32.GetFileInformationByHandleEx(
+                handle,
+                information_class,
+                buffer,
+                len(buffer),
+            ):
+                error = ctypes.get_last_error()
+                if error == ERROR_NO_MORE_FILES:
+                    break
+                self._raise_last_error("could not enumerate directory HANDLE")
+            information_class = FILE_ID_EXTD_DIRECTORY_INFO
+            offset = 0
+            while True:
+                entry = self.FILE_ID_EXTD_DIR_INFO.from_buffer(buffer, offset)
+                name_offset = offset + self.FILE_ID_EXTD_DIR_INFO.FileName.offset
+                name_bytes = bytes(
+                    buffer[name_offset : name_offset + int(entry.FileNameLength)]
+                )
+                try:
+                    name = name_bytes.decode("utf-16-le", errors="strict")
+                except UnicodeDecodeError as exc:
+                    raise RuntimeError(
+                        "Windows directory name is not valid UTF-16"
+                    ) from exc
+                if name not in {".", ".."}:
+                    file_id_128 = bytes(entry.FileId.Identifier)
+                    yield WindowsDirectoryEntry(
+                        name=name,
+                        file_id=int.from_bytes(file_id_128[:8], "little"),
+                        attributes=int(entry.FileAttributes),
+                        file_id_128=file_id_128,
+                        reparse_tag=(
+                            int(entry.ReparsePointTag)
+                            if int(entry.FileAttributes) & FILE_ATTRIBUTE_REPARSE_POINT
+                            else 0
+                        ),
+                    )
+                next_offset = int(entry.NextEntryOffset)
+                if not next_offset:
+                    break
+                offset += next_offset
+                if offset >= len(buffer):
+                    raise RuntimeError("Windows directory enumeration is malformed")
+
+    def enumerate_directory(self, handle: int) -> tuple[WindowsDirectoryEntry, ...]:
+        """Return all children for compatibility with publication callers."""
+
+        output: list[WindowsDirectoryEntry] = []
+        information_class = FILE_ID_BOTH_DIRECTORY_RESTART_INFO
+        while True:
+            buffer = ctypes.create_string_buffer(DIRECTORY_QUERY_BYTES)
+            if not self.kernel32.GetFileInformationByHandleEx(
+                handle,
+                information_class,
+                buffer,
+                len(buffer),
+            ):
+                error = ctypes.get_last_error()
+                if error == ERROR_NO_MORE_FILES:
+                    break
+                self._raise_last_error("could not enumerate directory HANDLE")
+            information_class = FILE_ID_BOTH_DIRECTORY_INFO
+            offset = 0
+            while True:
+                entry = self.FILE_ID_BOTH_DIR_INFO.from_buffer(buffer, offset)
+                name_offset = offset + self.FILE_ID_BOTH_DIR_INFO.FileName.offset
+                name_bytes = bytes(
+                    buffer[name_offset : name_offset + int(entry.FileNameLength)]
+                )
+                try:
+                    name = name_bytes.decode("utf-16-le", errors="strict")
+                except UnicodeDecodeError as exc:
+                    raise RuntimeError(
+                        "Windows directory name is not valid UTF-16"
+                    ) from exc
+                if name not in {".", ".."}:
+                    output.append(
+                        WindowsDirectoryEntry(
+                            name=name,
+                            file_id=int(entry.FileId) & ((1 << 64) - 1),
+                            attributes=int(entry.FileAttributes),
+                        )
+                    )
+                next_offset = int(entry.NextEntryOffset)
+                if not next_offset:
+                    break
+                offset += next_offset
+                if offset >= len(buffer):
+                    raise RuntimeError("Windows directory enumeration is malformed")
+        return tuple(output)
+
+    def open_by_extended_id(
+        self,
+        volume_hint: int,
+        file_id_128: bytes,
+        *,
+        desired_access: int,
+        is_directory: bool,
+    ) -> int:
+        """Open one object by its exact 128-bit FILE_ID without following it."""
+
+        if not windows_file_id_is_reliable(file_id_128):
+            raise ValueError("Windows extended FILE_ID is not reliable")
+        descriptor = self.FILE_ID_DESCRIPTOR()
+        descriptor.dwSize = ctypes.sizeof(descriptor)
+        descriptor.Type = EXTENDED_FILE_ID_TYPE
+        ctypes.memmove(
+            ctypes.addressof(descriptor.ExtendedFileId),
+            file_id_128,
+            len(file_id_128),
+        )
+        flags = FILE_FLAG_OPEN_REPARSE_POINT
+        if is_directory:
+            flags |= FILE_FLAG_BACKUP_SEMANTICS
+        handle = self.kernel32.OpenFileById(
+            volume_hint,
+            ctypes.byref(descriptor),
+            desired_access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            flags,
+        )
+        value = self._handle_value(handle)
+        if value == self.invalid_handle:
+            self._raise_last_error("could not open directory entry by extended FILE_ID")
+        return value
+
+    def open_relative(
+        self,
+        parent_handle: int,
+        name: str,
+        *,
+        desired_access: int,
+        is_directory: bool,
+        allow_reparse: bool,
+    ) -> int:
+        """Open one simple child relative to a retained directory HANDLE."""
+
+        if (
+            not isinstance(name, str)
+            or not name
+            or name in {".", ".."}
+            or "\\" in name
+            or "/" in name
+            or "\x00" in name
+        ):
+            raise ValueError("Windows relative open requires one simple child name")
+        encoded = name.encode("utf-16-le", errors="strict")
+        if len(encoded) > 0xFFFE:
+            raise ValueError("Windows relative child name is too long")
+        name_buffer = ctypes.create_unicode_buffer(name)
+        unicode_name = self.UNICODE_STRING()
+        unicode_name.Length = len(encoded)
+        unicode_name.MaximumLength = len(encoded) + 2
+        unicode_name.Buffer = ctypes.cast(name_buffer, self.wintypes.LPWSTR)
+        attributes = self.OBJECT_ATTRIBUTES()
+        attributes.Length = ctypes.sizeof(attributes)
+        attributes.RootDirectory = parent_handle
+        attributes.ObjectName = ctypes.pointer(unicode_name)
+        attributes.Attributes = 0 if allow_reparse else OBJ_DONT_REPARSE
+        attributes.SecurityDescriptor = None
+        attributes.SecurityQualityOfService = None
+        io_status = self.IO_STATUS_BLOCK()
+        opened = self.wintypes.HANDLE()
+        options = FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT
+        options |= FILE_DIRECTORY_FILE if is_directory else FILE_NON_DIRECTORY_FILE
+        status = int(
+            self.ntdll.NtCreateFile(
+                ctypes.byref(opened),
+                desired_access,
+                ctypes.byref(attributes),
+                ctypes.byref(io_status),
+                None,
+                0,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                FILE_OPEN,
+                options,
+                None,
+                0,
+            )
+        )
+        if status < 0:
+            self._raise_ntstatus(status, "could not open HANDLE-relative child")
+        return self._handle_value(opened)
+
+    def query_reparse_point(self, handle: int) -> WindowsReparsePoint:
+        """Read and strictly parse one already-open reparse point."""
+
+        buffer = ctypes.create_string_buffer(MAXIMUM_REPARSE_DATA_BUFFER_SIZE)
+        returned = self.wintypes.DWORD()
+        if not self.kernel32.DeviceIoControl(
+            handle,
+            FSCTL_GET_REPARSE_POINT,
+            None,
+            0,
+            buffer,
+            len(buffer),
+            ctypes.byref(returned),
+            None,
+        ):
+            self._raise_last_error("could not read HANDLE reparse-point data")
+        payload = bytes(buffer[: int(returned.value)])
+        return parse_windows_reparse_data(payload)
+
+    def open_by_id(
+        self,
+        volume_hint: int,
+        file_id: int,
+        *,
+        desired_access: int,
+        is_directory: bool,
+    ) -> int:
+        descriptor = self.FILE_ID_DESCRIPTOR()
+        descriptor.dwSize = ctypes.sizeof(descriptor)
+        descriptor.Type = FILE_ID_TYPE
+        signed_id = file_id if file_id < (1 << 63) else file_id - (1 << 64)
+        descriptor.FileId = signed_id
+        flags = FILE_FLAG_OPEN_REPARSE_POINT
+        if is_directory:
+            flags |= FILE_FLAG_BACKUP_SEMANTICS
+        handle = self.kernel32.OpenFileById(
+            volume_hint,
+            ctypes.byref(descriptor),
+            desired_access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            flags,
+        )
+        value = self._handle_value(handle)
+        if value == self.invalid_handle:
+            self._raise_last_error("could not open directory entry by FILE_ID")
+        return value
+
+    def read(self, handle: int, size: int) -> bytes:
+        if size <= 0:
+            return b""
+        buffer = ctypes.create_string_buffer(size)
+        read = self.wintypes.DWORD()
+        if not self.kernel32.ReadFile(
+            handle,
+            buffer,
+            size,
+            ctypes.byref(read),
+            None,
+        ):
+            self._raise_last_error("could not read FILE_ID-bound file")
+        return bytes(buffer[: int(read.value)])
+
+    def rename_noreplace(
+        self,
+        source_handle: int,
+        parent_handle: int,
+        destination: str,
+    ) -> None:
+        encoded = destination.encode("utf-16-le", errors="strict")
+        structure_type = self.FILE_RENAME_INFO
+        size = structure_type.FileName.offset + len(encoded)
+        buffer = ctypes.create_string_buffer(size)
+        information = structure_type.from_buffer(buffer)
+        information.ReplaceIfExists = False
+        information.RootDirectory = parent_handle
+        information.FileNameLength = len(encoded)
+        ctypes.memmove(
+            ctypes.addressof(buffer) + structure_type.FileName.offset,
+            encoded,
+            len(encoded),
+        )
+        if not self.kernel32.SetFileInformationByHandle(
+            source_handle,
+            FILE_RENAME_INFO,
+            buffer,
+            size,
+        ):
+            self._raise_last_error("could not perform no-replace HANDLE rename")
+
+
+@dataclass(frozen=True, slots=True)
+class _WindowsAuthorityObservation:
+    parent_handle: int
+    parent_identity: tuple[object, ...]
+    name: str
+    child_handle: int
+    child_identity: tuple[object, ...]
+    child_file_id: bytes
+
+
+class WindowsDirectoryAuthority:
+    """Retained no-follow HANDLE chain for one lexical Windows directory."""
+
+    __slots__ = (
+        "api",
+        "path",
+        "handles",
+        "observations",
+        "anchor_identity",
+        "closed",
+    )
+
+    def __init__(
+        self,
+        *,
+        api: WindowsKernelApi,
+        path: Path,
+        handles: list[int],
+        observations: list[_WindowsAuthorityObservation],
+        anchor_identity: tuple[object, ...],
+    ) -> None:
+        self.api = api
+        self.path = path
+        self.handles = handles
+        self.observations = observations
+        self.anchor_identity = anchor_identity
+        self.closed = False
+
+    @property
+    def handle(self) -> int:
+        if self.closed or not self.handles:
+            raise RuntimeError("Windows directory authority is closed")
+        return self.handles[-1]
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return windows_metadata_identity(self.api.metadata(self.handle))
+
+    def _find_exact_child(
+        self,
+        parent_handle: int,
+        name: str,
+    ) -> WindowsDirectoryEntry | None:
+        iterator = getattr(self.api, "iter_directory", None)
+        entries = (
+            iterator(parent_handle)
+            if callable(iterator)
+            else self.api.enumerate_directory(parent_handle)
+        )
+        matches = [entry for entry in entries if entry.name == name]
+        if len(matches) > 1:
+            raise RuntimeError(
+                "Windows authority directory has duplicate exact child names"
+            )
+        return matches[0] if matches else None
+
+    def verify(self) -> None:
+        if self.closed or not self.handles:
+            raise RuntimeError("Windows directory authority is closed")
+        anchor = self.api.metadata(self.handles[0])
+        if (
+            windows_metadata_identity(anchor) != self.anchor_identity
+            or not stat.S_ISDIR(anchor.st_mode)
+            or anchor.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+            or not anchor.st_dev
+            or not windows_file_id_is_reliable(anchor.file_id_128)
+            or anchor.delete_pending
+        ):
+            raise RuntimeError("Windows lexical anchor changed")
+        for observation in self.observations:
+            if (
+                windows_metadata_identity(self.api.metadata(observation.parent_handle))
+                != observation.parent_identity
+            ):
+                raise RuntimeError("Windows lexical parent changed")
+            entry = self._find_exact_child(
+                observation.parent_handle,
+                observation.name,
+            )
+            if entry is None or entry.file_id_128 != observation.child_file_id:
+                raise RuntimeError("Windows lexical directory binding changed")
+            opened = self.api.metadata(observation.child_handle)
+            if (
+                windows_metadata_identity(opened) != observation.child_identity
+                or not stat.S_ISDIR(opened.st_mode)
+                or opened.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+                or not windows_file_id_is_reliable(opened.file_id_128)
+                or opened.delete_pending
+            ):
+                raise RuntimeError("Windows lexical directory component changed")
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        # A cancellation may land after the final HANDLE was confirmed closed
+        # but before the prior call could publish ``closed``.  Empty ownership
+        # is authoritative and makes the retry a finite state transition.
+        if not self.handles:
+            self.closed = True
+            return
+        expected = {self.handles[0]: self.anchor_identity[:2]}
+        expected.update(
+            {
+                observation.child_handle: observation.child_identity[:2]
+                for observation in self.observations
+            }
+        )
+        failure = _close_windows_handles(self.api, self.handles, expected)
+        self.closed = not self.handles
+        if failure is not None:
+            raise failure
+
+
+def _close_windows_handles(
+    api: WindowsKernelApi,
+    handles: list[int],
+    expected_identities: dict[int, tuple[object, ...]],
+) -> BaseException | None:
+    """Visit every HANDLE and retain the first delayed close failure."""
+
+    deferred: BaseException | None = None
+    for handle in reversed(tuple(handles)):
+        closed = False
+        while True:
+            try:
+                observed = api.metadata(handle)
+                expected = expected_identities.get(handle)
+                if (
+                    expected is not None
+                    and windows_handle_ownership_identity(observed) != expected
+                ):
+                    deferred = deferred or RuntimeError(
+                        "Windows HANDLE ownership changed"
+                    )
+                    closed = True
+                    break
+            except KeyError:
+                closed = True
+                break
+            except OSError as exc:
+                if exc.errno == errno.EBADF or getattr(exc, "winerror", None) == 6:
+                    closed = True
+                    break
+                deferred = deferred or exc
+                break
+            except BaseException as exc:  # noqa: B036 - confirm close result
+                if isinstance(exc, Exception):
+                    deferred = deferred or exc
+                    break
+                deferred = deferred or exc
+                continue
+
+            expected_at_close = windows_handle_ownership_identity(observed)
+            try:
+                api.close(handle)
+                closed = True
+            except BaseException as exc:  # noqa: B036 - confirm close result
+                deferred = deferred or exc
+                while True:
+                    try:
+                        visible = api.metadata(handle)
+                    except KeyError:
+                        closed = True
+                        break
+                    except OSError as probe_error:
+                        if (
+                            probe_error.errno == errno.EBADF
+                            or getattr(probe_error, "winerror", None) == 6
+                        ):
+                            closed = True
+                        else:
+                            deferred = deferred or probe_error
+                        break
+                    except BaseException as probe_error:  # noqa: B036
+                        if isinstance(probe_error, Exception):
+                            deferred = deferred or probe_error
+                            break
+                        deferred = deferred or probe_error
+                        continue
+                    if windows_handle_ownership_identity(visible) != expected_at_close:
+                        # The owned HANDLE closed and its numeric value was
+                        # reused. Never close the replacement authority.
+                        closed = True
+                    break
+                if closed or isinstance(exc, Exception):
+                    break
+                continue
+            break
+
+        if closed:
+            while handle in handles:
+                try:
+                    handles.pop(handles.index(handle))
+                except BaseException as exc:
+                    if isinstance(exc, Exception):
+                        raise
+                    deferred = deferred or exc
+            while handle in expected_identities:
+                try:
+                    expected_identities.pop(handle, None)
+                except BaseException as exc:
+                    if isinstance(exc, Exception):
+                        raise
+                    deferred = deferred or exc
+    return deferred
+
+
+class _WindowsHandleCleanup:
+    """Retryable owner installed before the first Windows HANDLE acquisition."""
+
+    __slots__ = ("api", "handles", "expected_identities")
+
+    def __init__(self, api: WindowsKernelApi) -> None:
+        self.api = api
+        self.handles: list[int] = []
+        self.expected_identities: dict[int, tuple[object, ...]] = {}
+
+    @property
+    def closed(self) -> bool:
+        return not self.handles
+
+    def retain(
+        self,
+        handle: int,
+        metadata: WindowsHandleMetadata | None = None,
+    ) -> int:
+        deferred = _append_owned_windows_handle(self.handles, handle)
+        if deferred is not None:
+            raise deferred
+        if metadata is not None:
+            self.expected_identities[handle] = windows_handle_ownership_identity(
+                metadata
+            )
+        return handle
+
+    def close(self) -> None:
+        failure = _close_windows_handles(
+            self.api,
+            self.handles,
+            self.expected_identities,
+        )
+        if failure is not None:
+            raise failure
+
+
+def _install_cleanup_resource(slot: object | None, resource: object) -> None:
+    if slot is None:
+        return
+    own = getattr(slot, "own", None)
+    if not callable(own):
+        raise TypeError("source cleanup slot must provide own()")
+    own(resource)
+
+
+def _attach_cleanup_resource(failure: BaseException, resource: object) -> None:
+    try:
+        if bool(resource.closed):  # type: ignore[attr-defined]
+            return
+    except BaseException:  # noqa: B036 - uncertain ownership stays reachable
+        pass
+    try:
+        failure.source_cleanup_owner = resource  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - local ownership remains authoritative
+        pass
+
+
+def _append_owned_windows_handle(
+    handles: list[int],
+    handle: int,
+    deferred: BaseException | None = None,
+) -> BaseException | None:
+    while handle not in handles:
+        try:
+            handles.append(handle)
+        except BaseException as exc:
+            if isinstance(exc, Exception):
+                raise
+            deferred = deferred or exc
+    return deferred
+
+
+def _open_owned_windows_handle(
+    operation: Callable[[], int],
+    handles: list[int],
+) -> int:
+    """Open and register a HANDLE at the first Python-owned opportunity.
+
+    A raw integer can still be lost if arbitrary opcode injection lands between
+    the native API return and Python's result store. Full coverage of that
+    interpreter boundary requires a native helper returning an owning object.
+    """
+
+    handle = 0
+    try:
+        handle = operation()
+        deferred = _append_owned_windows_handle(handles, handle)
+        if deferred is not None:
+            raise deferred
+        return handle
+    except BaseException:  # noqa: B036 - commit HANDLE ownership
+        if handle:
+            try:
+                _append_owned_windows_handle(handles, handle)
+            except BaseException:  # noqa: B036 - preserve primary failure
+                pass
+        raise
+
+
+def open_lexical_directory_authority(
+    path: str | Path,
+    *,
+    api: WindowsKernelApi | None = None,
+    cleanup_slot: object | None = None,
+) -> WindowsDirectoryAuthority:
+    """Pin every component of an absolute lexical Windows directory path."""
+
+    selected = windows_kernel_api() if api is None else api
+    if api is None:
+        windows_require_source_api(selected)
+    raw = str(path)
+    if not raw or "\x00" in raw:
+        raise ValueError("Windows lexical directory path is invalid")
+    normalized = ntpath.normpath(ntpath.abspath(raw))
+    pure = PureWindowsPath(normalized)
+    if not pure.is_absolute() or not pure.anchor:
+        raise ValueError("Windows lexical directory path must be absolute")
+    components = pure.parts[1:]
+    if (
+        len(components) > 256
+        or len(normalized.encode("utf-8", errors="strict")) > 4_096
+    ):
+        raise ValueError("Windows lexical directory path exceeds its limits")
+    for component in components:
+        if (
+            not component
+            or component in {".", ".."}
+            or "\\" in component
+            or "/" in component
+            or "\x00" in component
+        ):
+            raise ValueError("Windows lexical directory component is invalid")
+
+    cleanup = _WindowsHandleCleanup(selected)
+    _install_cleanup_resource(cleanup_slot, cleanup)
+    handles = cleanup.handles
+    handle_identities = cleanup.expected_identities
+    observations: list[_WindowsAuthorityObservation] = []
+    try:
+        anchor_handle = _open_owned_windows_handle(
+            lambda: selected.create_directory_handle(Path(pure.anchor)),
+            handles,
+        )
+        anchor = selected.metadata(anchor_handle)
+        if (
+            not stat.S_ISDIR(anchor.st_mode)
+            or anchor.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+            or not anchor.st_dev
+            or not windows_file_id_is_reliable(anchor.file_id_128)
+            or anchor.delete_pending
+        ):
+            raise RuntimeError("Windows lexical anchor is not identity-bound")
+        handle_identities[anchor_handle] = windows_handle_ownership_identity(anchor)
+        current_handle = anchor_handle
+        for component in components:
+            parent_identity = windows_metadata_identity(
+                selected.metadata(current_handle)
+            )
+
+            def open_component(
+                current_handle: int = current_handle,
+                component: str = component,
+            ) -> int:
+                return selected.open_relative(
+                    current_handle,
+                    component,
+                    desired_access=(
+                        FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE
+                    ),
+                    is_directory=True,
+                    allow_reparse=False,
+                )
+
+            child_handle = _open_owned_windows_handle(
+                open_component,
+                handles,
+            )
+            child = selected.metadata(child_handle)
+            if (
+                not stat.S_ISDIR(child.st_mode)
+                or child.st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+                or child.st_dev != anchor.st_dev
+                or not windows_file_id_is_reliable(child.file_id_128)
+                or child.delete_pending
+            ):
+                raise RuntimeError(
+                    "Windows lexical directory component is not identity-bound"
+                )
+            handle_identities[child_handle] = windows_handle_ownership_identity(child)
+            iterator = getattr(selected, "iter_directory", None)
+            entries = (
+                iterator(current_handle)
+                if callable(iterator)
+                else selected.enumerate_directory(current_handle)
+            )
+            matches = [entry for entry in entries if entry.name == component]
+            if len(matches) != 1 or matches[0].file_id_128 != child.file_id_128:
+                raise RuntimeError("Windows lexical directory changed while opening")
+            observations.append(
+                _WindowsAuthorityObservation(
+                    parent_handle=current_handle,
+                    parent_identity=parent_identity,
+                    name=component,
+                    child_handle=child_handle,
+                    child_identity=windows_metadata_identity(child),
+                    child_file_id=child.file_id_128,
+                )
+            )
+            current_handle = child_handle
+        authority = WindowsDirectoryAuthority(
+            api=selected,
+            path=Path(normalized),
+            handles=handles,
+            observations=observations,
+            anchor_identity=windows_metadata_identity(anchor),
+        )
+        authority.verify()
+        _install_cleanup_resource(cleanup_slot, authority)
+        return authority
+    except BaseException as primary:  # noqa: B036 - preserve acquisition failure
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup.close()
+        except BaseException as exc:  # noqa: B036 - retain explicit retry owner
+            cleanup_failure = exc
+        _attach_cleanup_resource(primary, cleanup_slot or cleanup)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+
+
+_KERNEL_API: WindowsKernelApi | None = None
+
+
+def windows_kernel_api() -> WindowsKernelApi:
+    """Return the process-wide Win32 filesystem binding."""
+
+    global _KERNEL_API
+    if _KERNEL_API is None:
+        try:
+            _KERNEL_API = WindowsKernelApi()
+        except (AttributeError, OSError) as exc:
+            raise RuntimeError(
+                "Windows FILE_ID HANDLE filesystem APIs are unavailable"
+            ) from exc
+    return _KERNEL_API
+
+
+def windows_require_publication_api(api: WindowsKernelApi | None = None) -> None:
+    """Fail closed unless the no-replace publication primitives are callable."""
+
+    selected = windows_kernel_api() if api is None else api
+    required = (
+        "GetFileInformationByHandleEx",
+        "OpenFileById",
+        "SetFileInformationByHandle",
+    )
+    if any(not hasattr(selected.kernel32, name) for name in required):
+        raise RuntimeError(
+            "atomic directory publication requires Windows FILE_ID HANDLE APIs"
+        )
+
+
+def windows_require_source_api(api: WindowsKernelApi | None = None) -> None:
+    """Fail closed unless the Windows source-authority primitives are callable."""
+
+    selected = windows_kernel_api() if api is None else api
+    kernel_required = (
+        "DeviceIoControl",
+        "GetFileInformationByHandleEx",
+        "OpenFileById",
+    )
+    if any(not hasattr(selected.kernel32, name) for name in kernel_required) or not (
+        hasattr(selected.ntdll, "NtCreateFile")
+        and hasattr(selected.ntdll, "RtlNtStatusToDosError")
+    ):
+        raise RuntimeError(
+            "secure source reads require Windows 128-bit FILE_ID, relative-open, "
+            "and reparse-point APIs"
+        )
+
+
+__all__ = [
+    "DELETE",
+    "FILE_ATTRIBUTE_DIRECTORY",
+    "FILE_ATTRIBUTE_READONLY",
+    "FILE_ATTRIBUTE_REPARSE_POINT",
+    "FILE_LIST_DIRECTORY",
+    "FILE_READ_ATTRIBUTES",
+    "FILE_READ_DATA",
+    "IO_REPARSE_TAG_MOUNT_POINT",
+    "IO_REPARSE_TAG_SYMLINK",
+    "SYNCHRONIZE",
+    "WindowsDirectoryAuthority",
+    "WindowsDirectoryEntry",
+    "WindowsFileId",
+    "WindowsHandleMetadata",
+    "WindowsKernelApi",
+    "WindowsReparsePoint",
+    "parse_windows_reparse_data",
+    "windows_extended_path",
+    "windows_file_id_is_reliable",
+    "windows_handle_ownership_identity",
+    "windows_kernel_api",
+    "windows_metadata_identity",
+    "windows_mode_from_attributes",
+    "open_lexical_directory_authority",
+    "windows_require_publication_api",
+    "windows_require_source_api",
+]

--- a/codenib/agent/runner.py
+++ b/codenib/agent/runner.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     List,
     Mapping,
@@ -66,6 +67,8 @@ from .tools.defaults import (
 from .tools.spec import ToolRegistry
 
 if TYPE_CHECKING:
+    from ..compiler.manifest import IndexEntry
+    from ..native_index_authorization import NativeIndexAuthorization
     from ..sandbox.protocol import SandboxSession
 
 logger = get_logger(__name__)
@@ -1623,6 +1626,12 @@ class CodeNibAgentOptions:
     bm25-only, even when ``embedding_search`` is in ``allowed_skills`` —
     CAR couldn't route to it at runtime anyway. (In ``manifest`` mode
     this rule is moot — the manifest dictates what exists.)
+
+    Native vector parsers are fail-closed. Pass either an already-bound
+    ``native_index_authorization`` or a
+    ``native_index_authorization_resolver`` that receives the exact manifest
+    ``IndexEntry`` about to be loaded. The two options are mutually exclusive;
+    neither can be derived from manifest fields by the agent runtime.
     """
 
     # --- index source: exactly one of these three must be set ---
@@ -1641,6 +1650,10 @@ class CodeNibAgentOptions:
     default_level: str = "l2"
     rebuild_indexes: bool = False
     skills_dir: Optional[str] = None
+    native_index_authorization: Optional["NativeIndexAuthorization"] = None
+    native_index_authorization_resolver: Optional[
+        Callable[["IndexEntry"], Optional["NativeIndexAuthorization"]]
+    ] = None
 
     # --- skill gating ---
     allowed_skills: Optional[List[str]] = None
@@ -1692,6 +1705,22 @@ def query(
     opts = options or CodeNibAgentOptions()
 
     _check_exactly_one_mode(opts)
+    if opts.contexts is not None and (
+        opts.native_index_authorization is not None
+        or opts.native_index_authorization_resolver is not None
+    ):
+        raise ValueError(
+            "native-index authorization options are not accepted in contexts "
+            "mode because its pre-built objects are not loaded by query()"
+        )
+    if (
+        opts.native_index_authorization is not None
+        and opts.native_index_authorization_resolver is not None
+    ):
+        raise ValueError(
+            "provide either native_index_authorization or "
+            "native_index_authorization_resolver, not both"
+        )
     if opts.sandbox is not None and opts.manifest is None:
         raise ValueError(
             "query() sandbox execution requires a trusted, revision-matched "
@@ -1788,6 +1817,10 @@ def query(
             skill_registry=registry,
             default_top_k=opts.default_top_k,
             default_level=opts.default_level,
+            native_index_authorization=opts.native_index_authorization,
+            native_index_authorization_resolver=(
+                opts.native_index_authorization_resolver
+            ),
         )
         SkillRegistry.reset()
         registry = SkillRegistry()
@@ -2041,6 +2074,8 @@ def _build_contexts(
         default_top_k=opts.default_top_k,
         default_level=opts.default_level,
         rebuild=opts.rebuild_indexes,
+        native_index_authorization=opts.native_index_authorization,
+        native_index_authorization_resolver=(opts.native_index_authorization_resolver),
     )
 
 

--- a/codenib/agent/runner.py
+++ b/codenib/agent/runner.py
@@ -37,6 +37,7 @@ from ..llm.litellm_chat import LiteLLMChat, RetryConfig
 from ..llm.usage import UsageTracker
 from ..log_utils import get_logger
 from ..paths import repo_index_dir
+from ..source_fingerprint import is_secure_source_fingerprint_v2
 from .agent_types import AgentResult, ToolCallRecord
 from .boundary import from_agent_repr_arg, is_line_bearing, to_agent_repr
 from .history import PlainChatHistory, TokenBudgetedChatHistory
@@ -250,6 +251,14 @@ class AgentRunner:
                 raise ValueError(
                     "sandbox execution requires matching source fingerprints in "
                     "the manifest and sandbox metadata"
+                )
+            if not (
+                is_secure_source_fingerprint_v2(manifest_fingerprint)
+                and is_secure_source_fingerprint_v2(sandbox_fingerprint)
+            ):
+                raise ValueError(
+                    "sandbox execution requires matching secure source "
+                    "fingerprint v2 identities"
                 )
             if manifest_fingerprint != sandbox_fingerprint:
                 raise ValueError(
@@ -1721,6 +1730,14 @@ def query(
             raise ValueError(
                 "sandbox execution requires matching source fingerprints in the "
                 "manifest and sandbox metadata"
+            )
+        if not (
+            is_secure_source_fingerprint_v2(manifest_fingerprint)
+            and is_secure_source_fingerprint_v2(sandbox_fingerprint)
+        ):
+            raise ValueError(
+                "sandbox execution requires matching secure source fingerprint "
+                "v2 identities"
             )
         if manifest_fingerprint != sandbox_fingerprint:
             raise ValueError(

--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -28,6 +28,7 @@ from .runtime import (
     ContextArtifactBinding,
     VerifiedContextArtifact,
     bind_context_artifact,
+    query_context_artifact,
     verify_context_artifact,
 )
 
@@ -46,6 +47,7 @@ __all__ = [
     "extract_context_artifact_archive",
     "fetch_github_context_artifact",
     "normalize_owned_query_view",
+    "query_context_artifact",
     "validate_portable_query_view",
     "resolve_github_context_artifact",
     "render_artifact_mcp_config",

--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -19,7 +19,11 @@ from .github import (
     resolve_github_context_artifact,
 )
 from .mcp_config import MCP_CONFIG_HOSTS, render_artifact_mcp_config
-from .portable_views import SourceTrust, normalize_owned_query_view
+from .portable_views import (
+    SourceTrust,
+    normalize_owned_query_view,
+    validate_portable_query_view,
+)
 from .runtime import (
     ContextArtifactBinding,
     VerifiedContextArtifact,
@@ -42,6 +46,7 @@ __all__ = [
     "extract_context_artifact_archive",
     "fetch_github_context_artifact",
     "normalize_owned_query_view",
+    "validate_portable_query_view",
     "resolve_github_context_artifact",
     "render_artifact_mcp_config",
     "stage_context_artifact",

--- a/codenib/artifacts/archive.py
+++ b/codenib/artifacts/archive.py
@@ -6,29 +6,236 @@
 
 from __future__ import annotations
 
-import json
+import os
 import stat
-import tempfile
 import zipfile
+from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
+from typing import BinaryIO, Iterator
 
 from .._atomic_directory import (
     PublicationDirectoryReader,
-    _annotate_secondary_error,
-    capture_directory_ownership,
-    directory_ownership_root_identity,
-    discard_owned_directory,
     lexical_directory_path,
-    publish_staged_directory,
+)
+from .._captured_directory import (
+    OwnedDirectoryStage,
+    _create_sealable_memfd,
+    _seal_snapshot_descriptor,
+    _SnapshotUnavailable,
+    _write_all,
 )
 from .context import CONTEXT_ARTIFACT_MANIFEST
-from .runtime import VerifiedContextArtifact, verify_context_artifact
+from .runtime import VerifiedContextArtifact, verify_context_artifact_reader
 
 DEFAULT_MAX_ARCHIVE_FILES = 100_000
 DEFAULT_MAX_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
 _COPY_CHUNK_BYTES = 1024 * 1024
-_MAX_CONTEXT_METADATA_BYTES = 16 * 1024 * 1024
+_MAX_ARCHIVE_PATH_BYTES = 4_096
+_MAX_ARCHIVE_PATH_COMPONENTS = 256
+_MAX_ARCHIVE_ENVELOPE_BYTES = 16 * 1024 * 1024
+_MAX_ARCHIVE_MEMBER_OVERHEAD = 4_096
+
+
+def _read_archive(descriptor: int, size: int) -> bytes:
+    return os.read(descriptor, size)
+
+
+def _create_archive_snapshot() -> int:
+    try:
+        return _create_sealable_memfd()
+    except _SnapshotUnavailable as exc:
+        raise ValueError(
+            "secure context archive parsing requires immutable sealed snapshots"
+        ) from exc
+
+
+def _write_snapshot(descriptor: int, block: bytes) -> None:
+    _write_all(descriptor, block)
+
+
+def _seal_archive_snapshot(descriptor: int) -> None:
+    try:
+        _seal_snapshot_descriptor(descriptor)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(
+            "context artifact archive snapshot could not be sealed"
+        ) from exc
+
+
+def _stable_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _directory_binding_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    """Identify one retained lexical ancestor without mutable directory times."""
+
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0) & 0x400,
+    )
+
+
+@contextmanager
+def _authenticated_archive_snapshot(
+    value: str | Path,
+    *,
+    max_files: int,
+    max_bytes: int,
+) -> Iterator[tuple[Path, BinaryIO]]:
+    """Copy one lexical no-follow regular file into a verified snapshot."""
+
+    if os.name != "posix" or not (
+        hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and os.open in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.stat in os.supports_follow_symlinks
+    ):
+        raise ValueError(
+            "secure context archive reads require no-follow directory handles"
+        )
+    candidate = Path(value).expanduser()
+    lexical = Path(os.path.abspath(os.fspath(candidate)))
+    encoded = os.fsencode(lexical)
+    if (
+        lexical.name in {"", ".", ".."}
+        or len(encoded) > _MAX_ARCHIVE_PATH_BYTES
+        or len(lexical.parts) > _MAX_ARCHIVE_PATH_COMPONENTS
+    ):
+        raise ValueError("context artifact archive path is invalid or too long")
+    physical_limit = (
+        max_bytes
+        + max_files * _MAX_ARCHIVE_MEMBER_OVERHEAD
+        + _MAX_ARCHIVE_ENVELOPE_BYTES
+    )
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    directory_flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+    file_flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    file_flags |= getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_BINARY", 0)
+    descriptors: list[int] = []
+    bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
+    source = -1
+    snapshot_descriptor = -1
+    snapshot: BinaryIO | None = None
+    try:
+        descriptor = os.open(lexical.anchor, directory_flags)
+        descriptors.append(descriptor)
+        root = os.fstat(descriptor)
+        if not root.st_dev or not root.st_ino or not stat.S_ISDIR(root.st_mode):
+            raise ValueError("context artifact archive root has no stable identity")
+        for part in lexical.parts[1:-1]:
+            before = os.stat(part, dir_fd=descriptor, follow_symlinks=False)
+            if (
+                not stat.S_ISDIR(before.st_mode)
+                or stat.S_ISLNK(before.st_mode)
+                or not before.st_dev
+                or not before.st_ino
+            ):
+                raise ValueError(
+                    "context artifact archive parent is not a real directory"
+                )
+            child = os.open(part, directory_flags, dir_fd=descriptor)
+            opened = os.fstat(child)
+            if _directory_binding_identity(opened) != _directory_binding_identity(
+                before
+            ):
+                os.close(child)
+                raise ValueError("context artifact archive parent changed")
+            bindings.append(
+                (descriptor, part, child, _directory_binding_identity(opened))
+            )
+            descriptors.append(child)
+            descriptor = child
+
+        before = os.stat(
+            lexical.name,
+            dir_fd=descriptor,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or stat.S_ISLNK(before.st_mode)
+            or not before.st_dev
+            or not before.st_ino
+            or before.st_size < 0
+            or before.st_size > physical_limit
+        ):
+            raise ValueError(
+                f"context artifact archive is not a bounded regular file: {lexical}"
+            )
+        source = os.open(lexical.name, file_flags, dir_fd=descriptor)
+        opened = os.fstat(source)
+        expected = _stable_identity(before)
+        if _stable_identity(opened) != expected:
+            raise ValueError("context artifact archive changed while opening")
+
+        snapshot_descriptor = _create_archive_snapshot()
+        remaining = opened.st_size
+        while remaining:
+            block = _read_archive(source, min(remaining, _COPY_CHUNK_BYTES))
+            if not block:
+                raise ValueError("context artifact archive was truncated")
+            _write_snapshot(snapshot_descriptor, block)
+            remaining -= len(block)
+        if _read_archive(source, 1):
+            raise ValueError("context artifact archive grew while reading")
+
+        def verify_binding() -> None:
+            if (
+                _stable_identity(os.fstat(source)) != expected
+                or _stable_identity(
+                    os.stat(
+                        lexical.name,
+                        dir_fd=descriptor,
+                        follow_symlinks=False,
+                    )
+                )
+                != expected
+            ):
+                raise ValueError("context artifact archive changed while reading")
+            for parent, name, child, identity in bindings:
+                if (
+                    _directory_binding_identity(os.fstat(child)) != identity
+                    or _directory_binding_identity(
+                        os.stat(name, dir_fd=parent, follow_symlinks=False)
+                    )
+                    != identity
+                ):
+                    raise ValueError("context artifact archive parent changed")
+
+        verify_binding()
+        _seal_archive_snapshot(snapshot_descriptor)
+        snapshot = os.fdopen(snapshot_descriptor, "rb")
+        snapshot_descriptor = -1
+        yield lexical, snapshot
+        verify_binding()
+    except FileNotFoundError as exc:
+        raise ValueError(f"context artifact archive does not exist: {lexical}") from exc
+    except OSError as exc:
+        raise ValueError(
+            f"context artifact archive could not be opened safely: {lexical}"
+        ) from exc
+    finally:
+        if snapshot is not None:
+            snapshot.close()
+        if snapshot_descriptor >= 0:
+            os.close(snapshot_descriptor)
+        if source >= 0:
+            os.close(source)
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
 
 
 def _member_path(value: str) -> PurePosixPath:
@@ -121,24 +328,28 @@ def _extract_member(
     archive: zipfile.ZipFile,
     info: zipfile.ZipInfo,
     relative: PurePosixPath,
-    root: Path,
+    stage: OwnedDirectoryStage,
 ) -> None:
-    output = root.joinpath(*relative.parts)
     if info.is_dir():
-        output.mkdir(parents=True, exist_ok=True)
         return
-    output.parent.mkdir(parents=True, exist_ok=True)
-    written = 0
-    with archive.open(info, "r") as source, output.open("xb") as destination:
-        while chunk := source.read(_COPY_CHUNK_BYTES):
-            written += len(chunk)
-            if written > info.file_size:
-                raise ValueError(
-                    f"context artifact archive member exceeded declared size: {relative}"
-                )
-            destination.write(chunk)
-    if written != info.file_size:
-        raise ValueError(f"context artifact archive member size mismatch: {relative}")
+
+    def chunks():
+        written = 0
+        with archive.open(info, "r") as source:
+            while chunk := source.read(_COPY_CHUNK_BYTES):
+                written += len(chunk)
+                if written > info.file_size:
+                    raise ValueError(
+                        "context artifact archive member exceeded declared size: "
+                        f"{relative}"
+                    )
+                yield chunk
+        if written != info.file_size:
+            raise ValueError(
+                f"context artifact archive member size mismatch: {relative}"
+            )
+
+    stage.write_file(relative, chunks(), max_bytes=info.file_size)
 
 
 def extract_context_artifact_archive(
@@ -152,174 +363,88 @@ def extract_context_artifact_archive(
 ) -> VerifiedContextArtifact:
     """Extract and verify an artifact ZIP before publishing it."""
 
-    archive_candidate = Path(archive_path).expanduser()
-    if archive_candidate.is_symlink():
-        raise ValueError(
-            f"context artifact archive must not be a symbolic link: {archive_candidate}"
-        )
-    archive_path = archive_candidate.resolve()
-    if not archive_path.is_file():
-        raise ValueError(f"context artifact archive does not exist: {archive_path}")
+    if (
+        isinstance(max_files, bool)
+        or not isinstance(max_files, int)
+        or max_files <= 0
+        or isinstance(max_bytes, bool)
+        or not isinstance(max_bytes, int)
+        or max_bytes <= 0
+    ):
+        raise ValueError("context artifact archive limits must be positive integers")
     output = lexical_directory_path(Path(output_dir))
-    if output.is_symlink():
-        raise ValueError(
-            f"context artifact output must not be a symbolic link: {output}"
-        )
-    if output.exists() and not output.is_dir():
-        raise ValueError(f"context artifact output is not a directory: {output}")
     try:
-        expected_output_ownership = (
-            capture_directory_ownership(
-                output,
-                required_root_file=CONTEXT_ARTIFACT_MANIFEST,
-                allow_empty_root=True,
-            )
-            if output.exists()
-            else None
+        stage = OwnedDirectoryStage.prepare(
+            output,
+            required_destination_file=CONTEXT_ARTIFACT_MANIFEST,
+            allow_empty_destination=True,
         )
-    except RuntimeError as exc:
+    except (OSError, RuntimeError) as exc:
         raise ValueError(
             "refusing to replace a non-empty directory that is not a "
             f"CodeNib context artifact: {output}"
         ) from exc
 
-    output.parent.mkdir(parents=True, exist_ok=True)
-    stage = lexical_directory_path(
-        Path(
-            tempfile.mkdtemp(
-                prefix=f".{output.name}.extract-",
-                dir=str(output.parent),
-            )
-        )
-    )
-    stage_root_ownership = capture_directory_ownership(stage)
-    initial_stage_root_identity = directory_ownership_root_identity(
-        stage_root_ownership
-    )
+    published: list[VerifiedContextArtifact] = []
     try:
-        with zipfile.ZipFile(archive_path) as archive:
-            members = _validated_members(
-                archive,
+        with _authenticated_archive_snapshot(
+            archive_path,
+            max_files=max_files,
+            max_bytes=max_bytes,
+        ) as (archive_display, snapshot):
+            with zipfile.ZipFile(snapshot) as archive:
+                members = _validated_members(
+                    archive,
+                    max_files=max_files,
+                    max_bytes=max_bytes,
+                )
+                for info, relative in members:
+                    _extract_member(archive, info, relative, stage)
+
+        def validate_staged_artifact(candidate: PublicationDirectoryReader) -> None:
+            verify_context_artifact_reader(
+                candidate,
+                expected_repository=expected_repository,
+                expected_commit=expected_commit,
                 max_files=max_files,
                 max_bytes=max_bytes,
             )
-            for info, relative in members:
-                _extract_member(archive, info, relative, stage)
 
-        verified = verify_context_artifact(
-            stage,
-            expected_repository=expected_repository,
-            expected_commit=expected_commit,
-            max_files=max_files,
-            max_bytes=max_bytes,
-        )
-        publication_ownership = capture_directory_ownership(stage)
-        if (
-            directory_ownership_root_identity(publication_ownership)
-            != initial_stage_root_identity
-        ):
-            raise RuntimeError("context artifact stage root changed during extraction")
-        stage_root_ownership = publication_ownership
-        expected_files = {
-            item["path"]: (item["bytes"], item["sha256"])
-            for item in verified.metadata["files"]
-        }
+        def validate_published_artifact(
+            candidate: PublicationDirectoryReader,
+        ) -> None:
+            verified = verify_context_artifact_reader(
+                candidate,
+                expected_repository=expected_repository,
+                expected_commit=expected_commit,
+                max_files=max_files,
+                max_bytes=max_bytes,
+            )
+            published.append(
+                replace(
+                    verified,
+                    root=output,
+                    metadata_path=output / CONTEXT_ARTIFACT_MANIFEST,
+                    manifest_path=output / verified.manifest_path.name,
+                )
+            )
 
-        def validate_artifact(candidate: PublicationDirectoryReader) -> None:
-            records = {record.path: record for record in candidate.file_records()}
-            metadata_record = records.pop(CONTEXT_ARTIFACT_MANIFEST, None)
-            if (
-                metadata_record is None
-                or metadata_record.size > _MAX_CONTEXT_METADATA_BYTES
-                or set(records) != set(expected_files)
-                or any(
-                    (record.size, record.sha256) != expected_files[path]
-                    for path, record in records.items()
-                )
-            ):
-                raise ValueError(
-                    "published context artifact differs from its verified identity"
-                )
-            try:
-                metadata = json.loads(
-                    candidate.read_bytes(
-                        CONTEXT_ARTIFACT_MANIFEST,
-                        max_bytes=_MAX_CONTEXT_METADATA_BYTES,
-                    ).decode("utf-8", errors="strict")
-                )
-            except (UnicodeError, json.JSONDecodeError) as exc:
-                raise ValueError(
-                    "published context artifact metadata is invalid"
-                ) from exc
-            if metadata != verified.metadata:
-                raise ValueError(
-                    "published context artifact metadata changed after verification"
-                )
-
-        publish_staged_directory(
-            stage,
-            output,
-            expected_stage_root_ownership=stage_root_ownership,
-            expected_destination_ownership=expected_output_ownership,
-            validate_staged_directory=validate_artifact,
-            validate_published_destination=validate_artifact,
+        stage.publish(
+            validate_staged_directory=validate_staged_artifact,
+            validate_published_destination=validate_published_artifact,
         )
     except zipfile.BadZipFile as exc:
-        primary_error = ValueError(
-            f"context artifact archive is not a valid ZIP: {archive_path}"
-        )
-        try:
-            observed_stage_ownership = capture_directory_ownership(stage)
-            if (
-                directory_ownership_root_identity(observed_stage_ownership)
-                == initial_stage_root_identity
-            ):
-                stage_root_ownership = observed_stage_ownership
-        except BaseException as capture_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "context archive stage cleanup capture also failed",
-                capture_error,
-            )
-        try:
-            discard_owned_directory(stage, stage_root_ownership)
-        except BaseException as discard_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "context archive stage discard also failed",
-                discard_error,
-            )
-        raise primary_error from exc
-    except BaseException as primary_error:
-        try:
-            observed_stage_ownership = capture_directory_ownership(stage)
-            if (
-                directory_ownership_root_identity(observed_stage_ownership)
-                == initial_stage_root_identity
-            ):
-                stage_root_ownership = observed_stage_ownership
-        except BaseException as capture_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "context archive stage cleanup capture also failed",
-                capture_error,
-            )
-        try:
-            discard_owned_directory(stage, stage_root_ownership)
-        except BaseException as discard_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "context archive stage discard also failed",
-                discard_error,
-            )
+        stage.discard()
+        raise ValueError(
+            f"context artifact archive is not a valid ZIP: {archive_display}"
+        ) from exc
+    except BaseException:
+        stage.discard()
         raise
 
-    return replace(
-        verified,
-        root=output,
-        metadata_path=output / CONTEXT_ARTIFACT_MANIFEST,
-        manifest_path=output / verified.manifest_path.relative_to(stage),
-    )
+    if len(published) != 1:
+        raise RuntimeError("published context artifact was not authority-verified")
+    return published[0]
 
 
 __all__ = [

--- a/codenib/artifacts/archive.py
+++ b/codenib/artifacts/archive.py
@@ -6,13 +6,18 @@
 
 from __future__ import annotations
 
+import json
 import stat
 import tempfile
 import zipfile
+from dataclasses import replace
 from pathlib import Path, PurePosixPath
 
 from .._atomic_directory import (
+    PublicationDirectoryReader,
+    _annotate_secondary_error,
     capture_directory_ownership,
+    directory_ownership_root_identity,
     discard_owned_directory,
     lexical_directory_path,
     publish_staged_directory,
@@ -23,6 +28,7 @@ from .runtime import VerifiedContextArtifact, verify_context_artifact
 DEFAULT_MAX_ARCHIVE_FILES = 100_000
 DEFAULT_MAX_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
 _COPY_CHUNK_BYTES = 1024 * 1024
+_MAX_CONTEXT_METADATA_BYTES = 16 * 1024 * 1024
 
 
 def _member_path(value: str) -> PurePosixPath:
@@ -187,6 +193,9 @@ def extract_context_artifact_archive(
         )
     )
     stage_root_ownership = capture_directory_ownership(stage)
+    initial_stage_root_identity = directory_ownership_root_identity(
+        stage_root_ownership
+    )
     try:
         with zipfile.ZipFile(archive_path) as archive:
             members = _validated_members(
@@ -197,16 +206,56 @@ def extract_context_artifact_archive(
             for info, relative in members:
                 _extract_member(archive, info, relative, stage)
 
-        def validate_artifact(candidate: Path) -> None:
-            verify_context_artifact(
-                candidate,
-                expected_repository=expected_repository,
-                expected_commit=expected_commit,
-                max_files=max_files,
-                max_bytes=max_bytes,
-            )
+        verified = verify_context_artifact(
+            stage,
+            expected_repository=expected_repository,
+            expected_commit=expected_commit,
+            max_files=max_files,
+            max_bytes=max_bytes,
+        )
+        publication_ownership = capture_directory_ownership(stage)
+        if (
+            directory_ownership_root_identity(publication_ownership)
+            != initial_stage_root_identity
+        ):
+            raise RuntimeError("context artifact stage root changed during extraction")
+        stage_root_ownership = publication_ownership
+        expected_files = {
+            item["path"]: (item["bytes"], item["sha256"])
+            for item in verified.metadata["files"]
+        }
 
-        validate_artifact(stage)
+        def validate_artifact(candidate: PublicationDirectoryReader) -> None:
+            records = {record.path: record for record in candidate.file_records()}
+            metadata_record = records.pop(CONTEXT_ARTIFACT_MANIFEST, None)
+            if (
+                metadata_record is None
+                or metadata_record.size > _MAX_CONTEXT_METADATA_BYTES
+                or set(records) != set(expected_files)
+                or any(
+                    (record.size, record.sha256) != expected_files[path]
+                    for path, record in records.items()
+                )
+            ):
+                raise ValueError(
+                    "published context artifact differs from its verified identity"
+                )
+            try:
+                metadata = json.loads(
+                    candidate.read_bytes(
+                        CONTEXT_ARTIFACT_MANIFEST,
+                        max_bytes=_MAX_CONTEXT_METADATA_BYTES,
+                    ).decode("utf-8", errors="strict")
+                )
+            except (UnicodeError, json.JSONDecodeError) as exc:
+                raise ValueError(
+                    "published context artifact metadata is invalid"
+                ) from exc
+            if metadata != verified.metadata:
+                raise ValueError(
+                    "published context artifact metadata changed after verification"
+                )
+
         publish_staged_directory(
             stage,
             output,
@@ -216,20 +265,60 @@ def extract_context_artifact_archive(
             validate_published_destination=validate_artifact,
         )
     except zipfile.BadZipFile as exc:
-        discard_owned_directory(stage, stage_root_ownership)
-        raise ValueError(
+        primary_error = ValueError(
             f"context artifact archive is not a valid ZIP: {archive_path}"
-        ) from exc
-    except BaseException:
-        discard_owned_directory(stage, stage_root_ownership)
+        )
+        try:
+            observed_stage_ownership = capture_directory_ownership(stage)
+            if (
+                directory_ownership_root_identity(observed_stage_ownership)
+                == initial_stage_root_identity
+            ):
+                stage_root_ownership = observed_stage_ownership
+        except BaseException as capture_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context archive stage cleanup capture also failed",
+                capture_error,
+            )
+        try:
+            discard_owned_directory(stage, stage_root_ownership)
+        except BaseException as discard_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context archive stage discard also failed",
+                discard_error,
+            )
+        raise primary_error from exc
+    except BaseException as primary_error:
+        try:
+            observed_stage_ownership = capture_directory_ownership(stage)
+            if (
+                directory_ownership_root_identity(observed_stage_ownership)
+                == initial_stage_root_identity
+            ):
+                stage_root_ownership = observed_stage_ownership
+        except BaseException as capture_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context archive stage cleanup capture also failed",
+                capture_error,
+            )
+        try:
+            discard_owned_directory(stage, stage_root_ownership)
+        except BaseException as discard_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context archive stage discard also failed",
+                discard_error,
+            )
         raise
 
-    return verify_context_artifact(
-        output,
-        expected_repository=expected_repository,
-        expected_commit=expected_commit,
-        max_files=max_files,
-        max_bytes=max_bytes,
+    return replace(
+        verified,
+        root=output,
+        metadata_path=output / CONTEXT_ARTIFACT_MANIFEST,
+        manifest_path=output / verified.manifest_path.relative_to(stage),
     )
 
 

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -32,7 +32,7 @@ from ..index.embedding.artifact_integrity import (
     validate_vector_config_artifact,
 )
 from ..provider_routes import resolve_embedding_artifact_route
-from .portable_views import normalize_owned_query_view
+from .portable_views import normalize_owned_query_view, validate_portable_query_view
 from .security import assert_no_credential_fields, assert_publishable_tree, file_sha256
 
 CONTEXT_ARTIFACT_SCHEMA = "codenib.context-artifact.v1"
@@ -269,6 +269,7 @@ def stage_context_artifact(
         portable = manifest.to_dict()
         portable["repo"]["path"] = "source"
         portable_indexes: dict[str, Any] = {}
+        portable_validation: dict[str, tuple[str, dict[str, Any]]] = {}
         for view in selected:
             entry = manifest.indexes[view]
             assert_no_credential_fields(entry.config, source=f"view {view!r} config")
@@ -305,6 +306,15 @@ def stage_context_artifact(
             entry_data["path"] = relative
             for section in ("config", "metadata"):
                 entry_data[section].update(adjustments)
+            validate_portable_query_view(
+                stage.joinpath(*PurePosixPath(relative).parts),
+                repo_path=repo_path,
+                view_type=view,
+                view_config=entry_data["config"],
+                forbidden_paths=(manifest_root,),
+                environ=environment,
+            )
+            portable_validation[view] = (relative, dict(entry_data["config"]))
             portable_indexes[view] = entry_data
         portable["indexes"] = portable_indexes
         portable["capabilities"] = _portable_capabilities(
@@ -359,6 +369,15 @@ def stage_context_artifact(
         expected_metadata_bytes = _json_bytes(metadata)
 
         def validate_artifact(candidate: Path) -> None:
+            for view, (relative, config) in portable_validation.items():
+                validate_portable_query_view(
+                    candidate.joinpath(*PurePosixPath(relative).parts),
+                    repo_path=repo_path,
+                    view_type=view,
+                    view_config=config,
+                    forbidden_paths=(manifest_root,),
+                    environ=environment,
+                )
             assert_publishable_tree(
                 candidate,
                 forbidden_paths=(repo_path, manifest_root),

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -34,6 +34,7 @@ from ..index.embedding.artifact_integrity import (
     require_complete_vector_view,
     validate_vector_config_artifact,
 )
+from ..native_index_authorization import _mint_trusted_local_admin_authorization
 from ..provider_routes import resolve_embedding_artifact_route
 from .portable_views import normalize_owned_query_view, validate_portable_query_view
 from .security import assert_no_credential_fields, assert_publishable_tree, file_sha256
@@ -250,6 +251,15 @@ def stage_context_artifact(
             artifact_root=manifest_root,
         )
     selected = _selected_views(manifest, views)
+    if "vector" in selected and not validate_checkout:
+        # Native parsing is an administrative action.  Even callers that have
+        # already performed a broader publication check must bind this exact
+        # manifest to the current source tree before this function may mint.
+        validate_checkout_identity(
+            repo_path,
+            manifest,
+            artifact_root=manifest_root,
+        )
     unsupported = sorted(set(selected) - PORTABLE_CONTEXT_VIEWS)
     if unsupported:
         raise ValueError(
@@ -289,24 +299,41 @@ def stage_context_artifact(
             if view == "vector":
                 require_complete_vector_view(source)
                 expected_config = entry.config.get("persistence_config_fingerprint")
-                if expected_config is not None:
-                    validate_vector_config_artifact(
-                        source,
-                        route.model.replace("/", "__"),
-                        expected_config,
+                if expected_config is None:
+                    raise ValueError(
+                        "portable vector staging requires its config fingerprint"
                     )
+                validate_vector_config_artifact(
+                    source,
+                    route.model.replace("/", "__"),
+                    expected_config,
+                )
             elif view == "bm25":
                 # Validate the committed source generation before copying and
                 # rewriting its machine-local metadata. Otherwise staging
                 # could bless a torn or tampered source with fresh hashes.
                 require_bm25_manifest_artifact(entry)
             relative = _copy_view(source, stage, view)
+            owned_view = stage.joinpath(*PurePosixPath(relative).parts)
+            native_authorization = None
+            if view == "vector":
+                copied_ownership = capture_directory_ownership(owned_view)
+                native_authorization = _mint_trusted_local_admin_authorization(
+                    copied_ownership,
+                    view_type="vector",
+                    semantic_contract=entry.config,
+                    evidence=(
+                        "context-stage-local-admin",
+                        "manifest-and-checkout-validated",
+                    ),
+                )
             adjustments = normalize_owned_query_view(
-                stage.joinpath(*PurePosixPath(relative).parts),
+                owned_view,
                 repo_path=repo_path,
                 view_type=view,
                 view_config=entry.config,
                 source_trust="trusted-local",
+                native_index_authorization=native_authorization,
             )
             entry_data = entry.to_dict()
             entry_data["path"] = relative

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -17,7 +17,10 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping, Sequence
 
 from .._atomic_directory import (
+    PublicationDirectoryReader,
+    _annotate_secondary_error,
     capture_directory_ownership,
+    directory_ownership_root_identity,
     discard_owned_directory,
     lexical_directory_path,
     publish_staged_directory,
@@ -265,6 +268,9 @@ def stage_context_artifact(
         )
     )
     stage_root_ownership = capture_directory_ownership(stage)
+    initial_stage_root_identity = directory_ownership_root_identity(
+        stage_root_ownership
+    )
     try:
         portable = manifest.to_dict()
         portable["repo"]["path"] = "source"
@@ -368,7 +374,7 @@ def stage_context_artifact(
 
         expected_metadata_bytes = _json_bytes(metadata)
 
-        def validate_artifact(candidate: Path) -> None:
+        def validate_artifact_path(candidate: Path) -> None:
             for view, (relative, config) in portable_validation.items():
                 validate_portable_query_view(
                     candidate.joinpath(*PurePosixPath(relative).parts),
@@ -399,6 +405,57 @@ def stage_context_artifact(
                     "published context artifact differs from its staged identity"
                 )
 
+        # The path-based validators run before the final ownership capture.
+        # Publication callbacks receive a descriptor-bound reader, never a Path;
+        # the exact captured tree then carries those validation results across
+        # both the staged and published callbacks.
+        validate_artifact_path(stage)
+        publication_ownership = capture_directory_ownership(stage)
+        if (
+            directory_ownership_root_identity(publication_ownership)
+            != initial_stage_root_identity
+        ):
+            raise RuntimeError("context artifact stage root changed during build")
+        stage_root_ownership = publication_ownership
+        expected_metadata_size, expected_metadata_digest = file_sha256(metadata_path)
+
+        def validate_artifact(candidate: PublicationDirectoryReader) -> None:
+            records = candidate.file_records()
+            candidate_metadata = next(
+                (
+                    record
+                    for record in records
+                    if record.path == CONTEXT_ARTIFACT_MANIFEST
+                ),
+                None,
+            )
+            actual_files = [
+                {
+                    "path": record.path,
+                    "bytes": record.size,
+                    "sha256": record.sha256,
+                }
+                for record in sorted(
+                    records,
+                    key=lambda item: PurePosixPath(item.path),
+                )
+                if record.path != CONTEXT_ARTIFACT_MANIFEST
+            ]
+            if (
+                candidate_metadata is None
+                or candidate_metadata.size != expected_metadata_size
+                or candidate_metadata.sha256 != expected_metadata_digest
+                or candidate.read_bytes(
+                    CONTEXT_ARTIFACT_MANIFEST,
+                    max_bytes=expected_metadata_size,
+                )
+                != expected_metadata_bytes
+                or actual_files != files
+            ):
+                raise ValueError(
+                    "published context artifact differs from its staged identity"
+                )
+
         publish_staged_directory(
             stage,
             output_dir,
@@ -407,8 +464,28 @@ def stage_context_artifact(
             validate_staged_directory=validate_artifact,
             validate_published_destination=validate_artifact,
         )
-    except BaseException:
-        discard_owned_directory(stage, stage_root_ownership)
+    except BaseException as primary_error:
+        try:
+            observed_stage_ownership = capture_directory_ownership(stage)
+            if (
+                directory_ownership_root_identity(observed_stage_ownership)
+                == initial_stage_root_identity
+            ):
+                stage_root_ownership = observed_stage_ownership
+        except BaseException as capture_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context artifact stage cleanup capture also failed",
+                capture_error,
+            )
+        try:
+            discard_owned_directory(stage, stage_root_ownership)
+        except BaseException as discard_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "context artifact stage discard also failed",
+                discard_error,
+            )
         raise
 
     byte_count = sum(int(item["bytes"]) for item in files)

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -18,7 +18,9 @@ from typing import Any, Iterable, Literal, Mapping
 
 from .. import compat_pickle
 from .._atomic_directory import (
+    _annotate_secondary_error,
     capture_directory_ownership,
+    directory_ownership_file_records,
     directory_ownership_inventory,
     directory_ownership_root_identity,
 )
@@ -29,6 +31,12 @@ from ..index.embedding.artifact_integrity import (
     VECTOR_VIEW_UPDATE_MARKER,
 )
 from ..index.embedding.model_policy import resolve_embedding_load_policy_from_options
+from ..native_index_authorization import (
+    MissingNativeIndexAuthorizationError,
+    NativeIndexAuthorization,
+    require_native_index_authorization,
+    require_native_index_authorization_preflight,
+)
 from ..provider_routes import normalize_provider, resolve_embedding_artifact_route
 from .security import assert_publishable_json_value
 
@@ -53,6 +61,7 @@ _PICKLE_SUFFIXES = frozenset({".pkl", ".pickle"})
 _WINDOWS_REPARSE_POINT = 0x400
 _MAX_CONFIG_JSON_BYTES = 16 * 1024 * 1024
 _MAX_DOCUMENTS_JSON_BYTES = 256 * 1024 * 1024
+_MAX_FAISS_INDEX_BYTES = 8 * 1024 * 1024 * 1024
 _JSON_READ_CHUNK_BYTES = 1024 * 1024
 SourceTrust = Literal["portable-inert", "trusted-local"]
 
@@ -317,6 +326,9 @@ class _OwnedViewReader:
                 self._cached_payloads[relative] = payload
             if keep_descriptor:
                 os.lseek(descriptor, 0, os.SEEK_SET)
+                previous = self._authenticated_files.pop(relative, None)
+                if previous is not None:
+                    os.close(previous[0])
                 self._authenticated_files[relative] = (descriptor, opened)
                 descriptor = -1
         except OSError as exc:
@@ -664,6 +676,38 @@ def _owned_inventory_paths(root: Path, ownership: object, *, kind: str) -> set[P
     }
 
 
+def _authenticate_initial_file(
+    reader: _OwnedViewReader,
+    root: Path,
+    ownership: object,
+    path: Path,
+    *,
+    max_bytes: int,
+    cache_bytes: bool = False,
+    keep_descriptor: bool = False,
+) -> None:
+    """Bind one later read/parser to the bytes in the initial tree capture."""
+
+    relative = path.relative_to(root).as_posix()
+    record = next(
+        (
+            item
+            for item in directory_ownership_file_records(ownership)
+            if item.path == relative
+        ),
+        None,
+    )
+    if record is None:
+        raise ValueError(f"portable vector artifact is missing: {relative}")
+    reader.authenticate(
+        path,
+        {"size": record.size, "sha256": record.sha256},
+        cache_bytes=cache_bytes,
+        max_bytes=max_bytes,
+        keep_descriptor=keep_descriptor,
+    )
+
+
 def _pickle_paths(root: Path, ownership: object) -> list[Path]:
     return sorted(
         path
@@ -802,7 +846,7 @@ def _validate_vector_model_policy(
     *,
     ownership: object,
     model_suffix: str,
-    source_trust: SourceTrust,
+    native_authorized: bool,
 ) -> None:
     """Reject ambiguous multi-model trees and untrusted serialized objects."""
 
@@ -833,7 +877,7 @@ def _validate_vector_model_policy(
         )
 
     pickles = _pickle_paths(root, ownership)
-    if source_trust == "portable-inert":
+    if not native_authorized:
         _reject_inert_pickles(root, ownership)
         return
 
@@ -995,17 +1039,13 @@ def _validate_vector_semantics(
 def _faiss_contract(
     path: Path,
     *,
-    reader: _OwnedViewReader | None = None,
+    reader: _OwnedViewReader,
 ) -> tuple[int, int, str, str, bool]:
     """Read the persisted index contract, importing FAISS on demand."""
 
     try:
         faiss = importlib.import_module("faiss")
-        index = (
-            faiss.read_index(str(path))
-            if reader is None
-            else reader.faiss_index(path, faiss)
-        )
+        index = reader.faiss_index(path, faiss)
         dimension = int(index.d)
         total = int(index.ntotal)
         is_trained = bool(index.is_trained)
@@ -1038,10 +1078,11 @@ def _validate_level_semantics(
     metric: object,
     index_type: str,
     count: int,
+    present: bool,
+    reader: _OwnedViewReader,
     canonicalize: bool = True,
-    reader: _OwnedViewReader | None = None,
 ) -> None:
-    if not path.exists():
+    if not present:
         return
     config = _load_json_object(
         path,
@@ -1108,9 +1149,9 @@ def _validate_vector_layout(
     expected_dimension: int,
     expected_metric: str,
     expected_index_type: str,
-    source_trust: SourceTrust,
+    native_authorized: bool,
+    reader: _OwnedViewReader,
     canonicalize_level_configs: bool = True,
-    reader: _OwnedViewReader | None = None,
 ) -> tuple[
     str,
     dict[Path, list[dict[str, Any]]],
@@ -1190,14 +1231,19 @@ def _validate_vector_layout(
         path = present[0]
         document_format = path.suffix.removeprefix(".")
         if document_format == "pkl":
-            if source_trust != "trusted-local":
-                raise ValueError(
-                    "portable-inert vector view must not deserialize documents"
+            if not native_authorized:
+                raise MissingNativeIndexAuthorizationError(
+                    "vector pickle deserialization requires external native "
+                    "authorization"
                 )
-            if reader is None:
-                raise RuntimeError(
-                    "trusted-local vector normalization requires an owned reader"
-                )
+            _authenticate_initial_file(
+                reader,
+                root,
+                ownership,
+                path,
+                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+                cache_bytes=True,
+            )
             payload = _normalize_pickle_documents(path, repo_path, reader=reader)
         else:
             payload = _normalize_json_documents(path, repo_path, reader=reader)
@@ -1207,22 +1253,14 @@ def _validate_vector_layout(
                 f"expected {count}, found {len(payload)}"
             )
         count = len(payload)
-        if reader is not None:
-            reader.pin_file(index_path)
-        dimension, total, metric, index_type, is_trained = _faiss_contract(
+        _authenticate_initial_file(
+            reader,
+            root,
+            ownership,
             index_path,
-            reader=reader,
+            max_bytes=_MAX_FAISS_INDEX_BYTES,
+            keep_descriptor=native_authorized,
         )
-        if dimension != expected_dimension:
-            raise ValueError(
-                f"portable vector FAISS dimension mismatch in {level}: "
-                f"expected {expected_dimension}, found {dimension}"
-            )
-        if total != count:
-            raise ValueError(
-                f"portable vector FAISS count mismatch in {level}: "
-                f"expected {count}, found {total}"
-            )
         derived_counts[level] = count
         if legacy_counts and count == 0:
             stale_paths.update(
@@ -1236,22 +1274,38 @@ def _validate_vector_layout(
                 if candidate in inventory_files
             )
             continue
-        if metric != expected_metric:
-            raise ValueError(
-                f"portable vector FAISS metric mismatch in {level}: "
-                f"expected {expected_metric}, found {metric}"
+        if native_authorized:
+            dimension, total, metric, index_type, is_trained = _faiss_contract(
+                index_path,
+                reader=reader,
             )
-        if index_type != expected_index_type:
-            raise ValueError(
-                f"portable vector FAISS index type mismatch in {level}: "
-                f"expected {expected_index_type}, found {index_type}"
-            )
-        if index_type == "ivf" and not is_trained:
-            raise ValueError(
-                f"portable vector active IVF index is untrained in {level}"
-            )
+            if dimension != expected_dimension:
+                raise ValueError(
+                    f"portable vector FAISS dimension mismatch in {level}: "
+                    f"expected {expected_dimension}, found {dimension}"
+                )
+            if total != count:
+                raise ValueError(
+                    f"portable vector FAISS count mismatch in {level}: "
+                    f"expected {count}, found {total}"
+                )
+            if metric != expected_metric:
+                raise ValueError(
+                    f"portable vector FAISS metric mismatch in {level}: "
+                    f"expected {expected_metric}, found {metric}"
+                )
+            if index_type != expected_index_type:
+                raise ValueError(
+                    f"portable vector FAISS index type mismatch in {level}: "
+                    f"expected {expected_index_type}, found {index_type}"
+                )
+            if index_type == "ivf" and not is_trained:
+                raise ValueError(
+                    f"portable vector active IVF index is untrained in {level}"
+                )
+        level_config_path = level_path / f"config_{model_suffix}.json"
         _validate_level_semantics(
-            level_path / f"config_{model_suffix}.json",
+            level_config_path,
             level=level,
             model=expected_model,
             provider=expected_provider,
@@ -1260,6 +1314,7 @@ def _validate_vector_layout(
             metric=expected_metric,
             index_type=expected_index_type,
             count=count,
+            present=level_config_path in inventory_files,
             canonicalize=canonicalize_level_configs,
             reader=reader,
         )
@@ -1484,7 +1539,7 @@ def _normalize_vector_view(
     initial_tree: object,
     reader: _OwnedViewReader,
     view_config: Mapping[str, Any],
-    source_trust: SourceTrust,
+    native_authorized: bool,
 ) -> dict[str, Any]:
     assert_no_secret_fields(view_config, source="portable vector view config")
     initial_files = _owned_inventory_paths(root, initial_tree, kind="file")
@@ -1512,7 +1567,7 @@ def _normalize_vector_view(
         root,
         ownership=initial_tree,
         model_suffix=model_suffix,
-        source_trust=source_trust,
+        native_authorized=native_authorized,
     )
     expected_config = view_config.get("persistence_config_fingerprint")
     config_path = root / f"config_{model_suffix}.json"
@@ -1561,7 +1616,7 @@ def _normalize_vector_view(
         expected_dimension=expected_dimension,
         expected_metric=expected_metric,
         expected_index_type=expected_index_type,
-        source_trust=source_trust,
+        native_authorized=native_authorized,
         reader=reader,
     )
     _validate_view_document_count(view_config, counts)
@@ -1735,12 +1790,14 @@ def normalize_owned_query_view(
     view_type: str,
     view_config: Mapping[str, Any],
     source_trust: SourceTrust = "portable-inert",
+    native_index_authorization: NativeIndexAuthorization | None = None,
 ) -> dict[str, Any]:
     """Normalize one copied view and return its portable identity adjustments.
 
     ``root`` must be a caller-owned copy that can be safely rewritten.
-    ``source_trust`` defaults to inert portable data; only ``trusted-local`` may
-    deserialize the exact legacy vector pickle names owned by this program.
+    ``source_trust`` is descriptive compatibility metadata, not authority.
+    Native FAISS or legacy pickle parsing requires a process-local authorization
+    bound to the initial captured tree and this exact view config.
     """
 
     if not isinstance(source_trust, str) or source_trust not in {
@@ -1748,12 +1805,55 @@ def normalize_owned_query_view(
         "trusted-local",
     }:
         raise ValueError(f"invalid portable query view source trust: {source_trust!r}")
+    if not isinstance(view_config, Mapping):
+        raise ValueError(f"portable {view_type} normalization requires its view config")
+    try:
+        view_config_snapshot = json.loads(
+            _json_bytes(dict(view_config)),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "portable query view config is not canonical JSON data"
+        ) from exc
+    if not isinstance(view_config_snapshot, dict):  # pragma: no cover - dict encoded
+        raise ValueError("portable query view config must be a JSON object")
+    if native_index_authorization is not None:
+        if view_type != "vector":
+            raise ValueError(
+                "native index authorization is only valid for vector views"
+            )
+        require_native_index_authorization_preflight(
+            native_index_authorization,
+            view_type="vector",
+        )
     normalized_root, repository = _owned_view_root(root, repo_path)
     try:
         initial_tree = capture_directory_ownership(normalized_root)
         reader = _OwnedViewReader(normalized_root, initial_tree)
     except (OSError, RuntimeError, ValueError) as exc:
         raise RuntimeError("portable query view could not be captured safely") from exc
+    native_authorized = False
+    if native_index_authorization is not None:
+        try:
+            require_native_index_authorization(
+                native_index_authorization,
+                initial_tree,
+                view_type="vector",
+                semantic_contract=view_config_snapshot,
+            )
+        except BaseException as primary_error:
+            try:
+                reader.close()
+            except BaseException as cleanup_error:  # noqa: B036 - preserve primary
+                _annotate_secondary_error(
+                    primary_error,
+                    "portable query view reader cleanup also failed",
+                    cleanup_error,
+                )
+            raise
+        native_authorized = True
     try:
         if view_type == "vector":
             return _normalize_vector_view(
@@ -1761,8 +1861,8 @@ def normalize_owned_query_view(
                 repository,
                 initial_tree=initial_tree,
                 reader=reader,
-                view_config=view_config,
-                source_trust=source_trust,
+                view_config=view_config_snapshot,
+                native_authorized=native_authorized,
             )
         if view_type == "bm25":
             return _normalize_bm25_view(
@@ -1923,6 +2023,7 @@ def _authenticate_vector_generation(
             root / level / index_name,
             index_record,
             cache_bytes=False,
+            max_bytes=_MAX_FAISS_INDEX_BYTES,
             keep_descriptor=True,
         )
     return config
@@ -2037,7 +2138,7 @@ def _validate_portable_vector_view(
         root,
         ownership=initial_tree,
         model_suffix=model_suffix,
-        source_trust="portable-inert",
+        native_authorized=False,
     )
     expected_config = view_config.get("persistence_config_fingerprint")
     if expected_config is None:
@@ -2076,7 +2177,7 @@ def _validate_portable_vector_view(
         expected_dimension=expected_dimension,
         expected_metric=expected_metric,
         expected_index_type=expected_index_type,
-        source_trust="portable-inert",
+        native_authorized=False,
         canonicalize_level_configs=False,
         reader=reader,
     )

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -6,27 +6,31 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
+import io
 import json
+import os
 import re
+import stat
 from pathlib import Path, PurePosixPath
-from typing import Any, Literal, Mapping
+from typing import Any, Iterable, Literal, Mapping
 
 from .. import compat_pickle
-from ..compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
+from .._atomic_directory import (
+    capture_directory_ownership,
+    directory_ownership_inventory,
+    directory_ownership_root_identity,
+)
+from .._contained_source import validate_repository_file
+from .._secret_fields import assert_no_secret_fields
 from ..index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
     VECTOR_VIEW_UPDATE_MARKER,
-    require_complete_vector_view,
-    validate_vector_config_artifact,
-    validate_vector_generation_artifacts,
-    vector_config_artifact_record,
-    vector_level_artifact_records,
 )
-from ..index.embedding.model_policy import (
-    resolve_embedding_load_policy_from_options,
-)
+from ..index.embedding.model_policy import resolve_embedding_load_policy_from_options
 from ..provider_routes import normalize_provider, resolve_embedding_artifact_route
+from .security import assert_publishable_json_value
 
 _VECTOR_LEVELS = ("l0", "l2")
 _REMOVABLE_MUTABLE_VECTOR_FILES = frozenset(
@@ -46,7 +50,368 @@ _MUTABLE_VECTOR_PREFIXES = (
 )
 _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
 _PICKLE_SUFFIXES = frozenset({".pkl", ".pickle"})
+_WINDOWS_REPARSE_POINT = 0x400
+_MAX_CONFIG_JSON_BYTES = 16 * 1024 * 1024
+_MAX_DOCUMENTS_JSON_BYTES = 256 * 1024 * 1024
+_JSON_READ_CHUNK_BYTES = 1024 * 1024
 SourceTrust = Literal["portable-inert", "trusted-local"]
+
+
+def _view_file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+class _OwnedViewReader:
+    """Read one captured view through a pinned no-follow root descriptor."""
+
+    def __init__(self, root: Path, ownership: object) -> None:
+        if not hasattr(os, "O_DIRECTORY") or not hasattr(os, "O_NOFOLLOW"):
+            raise RuntimeError(
+                "portable view validation requires no-follow directory descriptors"
+            )
+        self.root = root
+        self.ownership = ownership
+        self._descriptor = -1
+        self._cached_payloads: dict[PurePosixPath, bytearray] = {}
+        self._authenticated_files: dict[PurePosixPath, tuple[int, os.stat_result]] = {}
+        try:
+            flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            self._descriptor = os.open(root, flags)
+            opened = os.fstat(self._descriptor)
+            root_identity = (
+                opened.st_dev,
+                opened.st_ino,
+                stat.S_IFMT(opened.st_mode),
+                getattr(opened, "st_file_attributes", 0),
+            )
+            if root_identity != directory_ownership_root_identity(ownership):
+                raise RuntimeError("portable view root changed after capture")
+            self._root_identity = _view_file_identity(opened)
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        for descriptor, _metadata in self._authenticated_files.values():
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        self._authenticated_files.clear()
+        if self._descriptor >= 0:
+            try:
+                os.close(self._descriptor)
+            except OSError:
+                pass
+            self._descriptor = -1
+
+    def verify_root(self) -> None:
+        try:
+            current = os.fstat(self._descriptor)
+            path_current = self.root.lstat()
+        except OSError as exc:
+            raise RuntimeError("portable view root changed during validation") from exc
+        if _view_file_identity(current) != self._root_identity or (
+            current.st_dev,
+            current.st_ino,
+            stat.S_IFMT(current.st_mode),
+            getattr(current, "st_file_attributes", 0),
+        ) != (
+            path_current.st_dev,
+            path_current.st_ino,
+            stat.S_IFMT(path_current.st_mode),
+            getattr(path_current, "st_file_attributes", 0),
+        ):
+            raise RuntimeError("portable view root changed during validation")
+
+    @staticmethod
+    def _relative(value: Path) -> PurePosixPath:
+        relative = PurePosixPath(value.as_posix())
+        if (
+            relative.is_absolute()
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or len(relative.parts) > 256
+        ):
+            raise ValueError(f"portable view path is invalid: {value}")
+        return relative
+
+    def _open_file(self, relative: PurePosixPath) -> tuple[int, os.stat_result]:
+        directory_descriptor = os.dup(self._descriptor)
+        source_descriptor = -1
+        try:
+            directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            directory_flags |= getattr(os, "O_CLOEXEC", 0)
+            for part in relative.parts[:-1]:
+                before = os.stat(
+                    part,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if not stat.S_ISDIR(before.st_mode) or bool(
+                    getattr(before, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT
+                ):
+                    raise ValueError(
+                        f"portable view path is not a real directory: {relative}"
+                    )
+                child = os.open(part, directory_flags, dir_fd=directory_descriptor)
+                opened = os.fstat(child)
+                if (
+                    opened.st_dev != before.st_dev
+                    or opened.st_ino != before.st_ino
+                    or stat.S_IFMT(opened.st_mode) != stat.S_IFMT(before.st_mode)
+                ):
+                    os.close(child)
+                    raise ValueError(f"portable view directory changed: {relative}")
+                os.close(directory_descriptor)
+                directory_descriptor = child
+
+            name = relative.parts[-1]
+            before = os.stat(
+                name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or before.st_nlink != 1
+                or bool(
+                    getattr(before, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT
+                )
+            ):
+                raise ValueError(
+                    f"portable view path is not a private file: {relative}"
+                )
+            flags = os.O_RDONLY | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+            source_descriptor = os.open(name, flags, dir_fd=directory_descriptor)
+            opened = os.fstat(source_descriptor)
+            if _view_file_identity(opened) != _view_file_identity(before):
+                raise ValueError(
+                    f"portable view file changed while opening: {relative}"
+                )
+            owned = source_descriptor
+            source_descriptor = -1
+            return owned, opened
+        except OSError as exc:
+            raise ValueError(
+                f"portable view file is not safely readable: {relative}"
+            ) from exc
+        finally:
+            if source_descriptor >= 0:
+                os.close(source_descriptor)
+            os.close(directory_descriptor)
+
+    @staticmethod
+    def _read_exact(
+        descriptor: int,
+        opened: os.stat_result,
+        *,
+        relative: PurePosixPath,
+        max_bytes: int | None,
+    ) -> bytearray:
+        if max_bytes is not None and opened.st_size > max_bytes:
+            raise ValueError(
+                f"portable view file exceeds its {max_bytes}-byte limit: {relative}"
+            )
+        payload = bytearray()
+        remaining = opened.st_size
+        while remaining:
+            block = os.read(descriptor, min(remaining, _JSON_READ_CHUNK_BYTES))
+            if not block:
+                raise ValueError(f"portable view file was truncated: {relative}")
+            payload.extend(block)
+            remaining -= len(block)
+        if os.read(descriptor, 1):
+            raise ValueError(f"portable view file grew while being read: {relative}")
+        if _view_file_identity(os.fstat(descriptor)) != _view_file_identity(opened):
+            raise ValueError(f"portable view file changed while being read: {relative}")
+        return payload
+
+    def read_bytes(self, path: Path, *, max_bytes: int) -> bytearray:
+        relative = self._relative(path.relative_to(self.root))
+        cached = self._cached_payloads.get(relative)
+        if cached is not None:
+            if len(cached) > max_bytes:
+                raise ValueError(
+                    f"portable view file exceeds its {max_bytes}-byte limit: {relative}"
+                )
+            return cached
+        descriptor, opened = self._open_file(relative)
+        try:
+            return self._read_exact(
+                descriptor,
+                opened,
+                relative=relative,
+                max_bytes=max_bytes,
+            )
+        except OSError as exc:
+            raise ValueError(f"portable view file is not readable: {relative}") from exc
+        finally:
+            os.close(descriptor)
+
+    def authenticate(
+        self,
+        path: Path,
+        expected: object,
+        *,
+        cache_bytes: bool,
+        max_bytes: int | None = None,
+        keep_descriptor: bool = False,
+    ) -> None:
+        relative = self._relative(path.relative_to(self.root))
+        if not isinstance(expected, Mapping):
+            raise ValueError(f"portable view fingerprint is invalid: {relative}")
+        expected_fields = {"size", "sha256"}
+        if "file" in expected:
+            expected_fields.add("file")
+        if set(expected) != expected_fields:
+            raise ValueError(f"portable view fingerprint is invalid: {relative}")
+        if "file" in expected and expected.get("file") != relative.name:
+            raise ValueError(
+                f"portable view fingerprint filename is invalid: {relative}"
+            )
+        size = expected.get("size")
+        digest = expected.get("sha256")
+        if (
+            not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+            or not isinstance(digest, str)
+            or not re.fullmatch(r"[0-9a-f]{64}", digest)
+        ):
+            raise ValueError(f"portable view fingerprint is invalid: {relative}")
+        descriptor, opened = self._open_file(relative)
+        try:
+            if opened.st_size != size or (
+                max_bytes is not None and opened.st_size > max_bytes
+            ):
+                raise ValueError(f"portable view fingerprint size mismatch: {relative}")
+            hasher = hashlib.sha256()
+            payload = bytearray() if cache_bytes else None
+            remaining = opened.st_size
+            while remaining:
+                block = os.read(descriptor, min(remaining, _JSON_READ_CHUNK_BYTES))
+                if not block:
+                    raise ValueError(f"portable view file was truncated: {relative}")
+                hasher.update(block)
+                if payload is not None:
+                    payload.extend(block)
+                remaining -= len(block)
+            if os.read(descriptor, 1):
+                raise ValueError(f"portable view file grew while hashing: {relative}")
+            if hasher.hexdigest() != digest or _view_file_identity(
+                os.fstat(descriptor)
+            ) != _view_file_identity(opened):
+                raise ValueError(f"portable view fingerprint mismatch: {relative}")
+            if payload is not None:
+                self._cached_payloads[relative] = payload
+            if keep_descriptor:
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                self._authenticated_files[relative] = (descriptor, opened)
+                descriptor = -1
+        except OSError as exc:
+            raise ValueError(f"portable view file is not readable: {relative}") from exc
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+
+    def pin_file(self, path: Path, *, max_bytes: int | None = None) -> None:
+        """Retain a stable file descriptor for a later parser."""
+
+        relative = self._relative(path.relative_to(self.root))
+        if relative in self._authenticated_files:
+            return
+        descriptor, opened = self._open_file(relative)
+        try:
+            if max_bytes is not None and opened.st_size > max_bytes:
+                raise ValueError(
+                    f"portable view file exceeds its {max_bytes}-byte limit: "
+                    f"{relative}"
+                )
+            self._authenticated_files[relative] = (descriptor, opened)
+            descriptor = -1
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+
+    def fingerprint(
+        self, path: Path, *, max_bytes: int | None = None
+    ) -> dict[str, Any]:
+        """Hash a stable regular file through the pinned view root."""
+
+        relative = self._relative(path.relative_to(self.root))
+        descriptor, opened = self._open_file(relative)
+        try:
+            if max_bytes is not None and opened.st_size > max_bytes:
+                raise ValueError(
+                    f"portable view file exceeds its {max_bytes}-byte limit: "
+                    f"{relative}"
+                )
+            hasher = hashlib.sha256()
+            remaining = opened.st_size
+            while remaining:
+                block = os.read(descriptor, min(remaining, _JSON_READ_CHUNK_BYTES))
+                if not block:
+                    raise ValueError(f"portable view file was truncated: {relative}")
+                hasher.update(block)
+                remaining -= len(block)
+            if os.read(descriptor, 1):
+                raise ValueError(f"portable view file grew while hashing: {relative}")
+            if _view_file_identity(os.fstat(descriptor)) != _view_file_identity(opened):
+                raise ValueError(
+                    f"portable view file changed while hashing: {relative}"
+                )
+            return {"size": opened.st_size, "sha256": hasher.hexdigest()}
+        except OSError as exc:
+            raise ValueError(f"portable view file is not readable: {relative}") from exc
+        finally:
+            os.close(descriptor)
+
+    def faiss_index(self, path: Path, faiss: Any) -> Any:
+        relative = self._relative(path.relative_to(self.root))
+        authenticated = self._authenticated_files.get(relative)
+        if authenticated is None:
+            raise ValueError(f"portable FAISS index is not authenticated: {relative}")
+        descriptor, opened = authenticated
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        remaining = opened.st_size
+
+        def read_bytes(requested: int) -> bytes:
+            nonlocal remaining
+            if requested <= 0 or remaining <= 0:
+                return b""
+            block = os.read(descriptor, min(requested, remaining, 8 * 1024 * 1024))
+            remaining -= len(block)
+            return block
+
+        reader = faiss.PyCallbackIOReader(read_bytes)
+        index = faiss.read_index(reader)
+        if _view_file_identity(os.fstat(descriptor)) != _view_file_identity(opened):
+            raise ValueError(f"portable FAISS index changed while parsing: {relative}")
+        return index
+
+
+def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_number(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
 
 
 def _json_bytes(value: Any) -> bytes:
@@ -63,17 +428,109 @@ def _json_bytes(value: Any) -> bytes:
     ).encode("utf-8")
 
 
-def _load_json(path: Path, *, label: str) -> Any:
-    if path.is_symlink() or not path.is_file():
-        raise ValueError(f"{label} is not a regular file: {path}")
+def _json_file_signature(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _read_bounded_json(path: Path, *, label: str, max_bytes: int) -> bytearray:
+    if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes <= 0:
+        raise ValueError(f"{label} byte limit must be positive")
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        before_path = path.lstat()
+        if (
+            stat.S_ISLNK(before_path.st_mode)
+            or not stat.S_ISREG(before_path.st_mode)
+            or before_path.st_nlink != 1
+            or bool(
+                getattr(before_path, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT
+            )
+        ):
+            raise ValueError(f"{label} is not a private regular file: {path}")
+        if before_path.st_size > max_bytes:
+            raise ValueError(f"{label} exceeds its {max_bytes}-byte limit: {path}")
+
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        descriptor = os.open(path, flags)
+        try:
+            opened = os.fstat(descriptor)
+            if not stat.S_ISREG(opened.st_mode) or _json_file_signature(
+                opened
+            ) != _json_file_signature(before_path):
+                raise ValueError(f"{label} changed while opening: {path}")
+            payload = bytearray()
+            while True:
+                chunk = os.read(descriptor, _JSON_READ_CHUNK_BYTES)
+                if not chunk:
+                    break
+                payload.extend(chunk)
+                if len(payload) > max_bytes:
+                    raise ValueError(
+                        f"{label} exceeds its {max_bytes}-byte limit: {path}"
+                    )
+            after_open = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+        after_path = path.lstat()
+        if _json_file_signature(after_open) != _json_file_signature(
+            opened
+        ) or _json_file_signature(after_path) != _json_file_signature(opened):
+            raise ValueError(f"{label} changed while reading: {path}")
+        return payload
+    except OSError as exc:
+        raise ValueError(f"{label} is not readable: {path}") from exc
+
+
+def _load_json(
+    path: Path,
+    *,
+    label: str,
+    max_bytes: int,
+    require_canonical: bool = False,
+    reader: _OwnedViewReader | None = None,
+) -> Any:
+    payload = (
+        _read_bounded_json(path, label=label, max_bytes=max_bytes)
+        if reader is None
+        else reader.read_bytes(path, max_bytes=max_bytes)
+    )
+    try:
+        value = json.loads(
+            payload,
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+        )
+    except ValueError as exc:
         raise ValueError(f"{label} is invalid JSON: {path}") from exc
+    if require_canonical and payload != _json_bytes(value):
+        raise ValueError(f"{label} is not canonical JSON: {path}")
+    return value
 
 
-def _load_json_object(path: Path, *, label: str) -> dict[str, Any]:
-    value = _load_json(path, label=label)
+def _load_json_object(
+    path: Path,
+    *,
+    label: str,
+    max_bytes: int = _MAX_CONFIG_JSON_BYTES,
+    require_canonical: bool = False,
+    reader: _OwnedViewReader | None = None,
+) -> dict[str, Any]:
+    value = _load_json(
+        path,
+        label=label,
+        max_bytes=max_bytes,
+        require_canonical=require_canonical,
+        reader=reader,
+    )
     if not isinstance(value, dict):
         raise ValueError(f"{label} must be a JSON object: {path}")
     return value
@@ -99,14 +556,6 @@ def _owned_view_root(root: Path, repo_path: Path) -> tuple[Path, Path]:
             "portable query view must not overlap the source repository: " f"{resolved}"
         )
 
-    for path in sorted(resolved.rglob("*")):
-        relative = path.relative_to(resolved)
-        if path.is_symlink():
-            raise ValueError(f"portable query view contains a symlink: {relative}")
-        if not path.is_dir() and not path.is_file():
-            raise ValueError(
-                f"portable query view contains a non-regular entry: {relative}"
-            )
     return resolved, repository
 
 
@@ -122,8 +571,8 @@ def _portable_source_path(value: object, repo_path: Path, *, source: str) -> str
     path = Path(raw).expanduser()
     if path.is_absolute():
         try:
-            path = path.resolve().relative_to(repo_path)
-        except (OSError, RuntimeError, ValueError) as exc:
+            path = path.relative_to(repo_path)
+        except ValueError as exc:
             raise ValueError(f"{source} points outside the repository: {raw}") from exc
         raw = path.as_posix()
     else:
@@ -146,17 +595,26 @@ def _portable_source_path(value: object, repo_path: Path, *, source: str) -> str
         or raw != normalized.as_posix()
     ):
         raise ValueError(f"{source} is not repository-relative: {raw}")
+    try:
+        validate_repository_file(repo_path, normalized.as_posix())
+    except ValueError as exc:
+        raise ValueError(
+            f"{source} is not a stable contained source file: {raw}"
+        ) from exc
     return normalized.as_posix()
 
 
 def _normalize_pickle_documents(
     path: Path,
     repo_path: Path,
+    *,
+    reader: _OwnedViewReader,
 ) -> list[dict[str, Any]]:
     """Load documents from an explicitly trusted, machine-local pickle."""
 
     try:
-        with path.open("rb") as handle:
+        payload = reader.read_bytes(path, max_bytes=_MAX_DOCUMENTS_JSON_BYTES)
+        with io.BytesIO(payload) as handle:
             documents = compat_pickle.load(handle)
     except Exception as exc:
         raise ValueError(
@@ -177,6 +635,10 @@ def _normalize_pickle_documents(
             raise ValueError(
                 f"portable vector document {index} has invalid metadata: {path.name}"
             )
+        assert_no_secret_fields(
+            metadata,
+            source=f"portable vector document {index} metadata",
+        )
         normalized_metadata = dict(metadata)
         normalized_metadata["file"] = _portable_source_path(
             metadata.get("file"),
@@ -194,16 +656,24 @@ def _normalize_pickle_documents(
     return payload
 
 
-def _pickle_paths(root: Path) -> list[Path]:
+def _owned_inventory_paths(root: Path, ownership: object, *, kind: str) -> set[Path]:
+    return {
+        root.joinpath(*PurePosixPath(relative).parts)
+        for relative, observed_kind in directory_ownership_inventory(ownership)
+        if observed_kind == kind
+    }
+
+
+def _pickle_paths(root: Path, ownership: object) -> list[Path]:
     return sorted(
         path
-        for path in root.rglob("*")
-        if path.is_file() and path.suffix.casefold() in _PICKLE_SUFFIXES
+        for path in _owned_inventory_paths(root, ownership, kind="file")
+        if path.suffix.casefold() in _PICKLE_SUFFIXES
     )
 
 
-def _reject_inert_pickles(root: Path) -> None:
-    pickles = _pickle_paths(root)
+def _reject_inert_pickles(root: Path, ownership: object) -> None:
+    pickles = _pickle_paths(root, ownership)
     if pickles:
         raise ValueError(
             "portable-inert query view must not contain pickle: "
@@ -214,8 +684,15 @@ def _reject_inert_pickles(root: Path) -> None:
 def _normalize_json_documents(
     path: Path,
     repo_path: Path,
+    *,
+    reader: _OwnedViewReader | None = None,
 ) -> list[dict[str, Any]]:
-    documents = _load_json(path, label="portable vector documents")
+    documents = _load_json(
+        path,
+        label="portable vector documents",
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        reader=reader,
+    )
     if not isinstance(documents, list):
         raise ValueError(f"portable vector documents must be a JSON list: {path}")
 
@@ -235,6 +712,10 @@ def _normalize_json_documents(
                 "portable vector document "
                 f"{index} has invalid content or metadata: {path.name}"
             )
+        assert_no_secret_fields(
+            metadata,
+            source=f"portable vector document {index} metadata",
+        )
         raw_file = metadata.get("file")
         if raw_file is not None and not isinstance(raw_file, str):
             raise ValueError(
@@ -255,6 +736,58 @@ def _normalize_json_documents(
     return payload
 
 
+def _normalize_bm25_documents(
+    path: Path,
+    repo_path: Path,
+    *,
+    reader: _OwnedViewReader,
+) -> None:
+    documents = _load_json(
+        path,
+        label="portable BM25 documents",
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        reader=reader,
+    )
+    if not isinstance(documents, list):
+        raise ValueError(f"portable BM25 documents must be a JSON list: {path}")
+
+    normalized: list[dict[str, Any]] = []
+    for index, document in enumerate(documents):
+        if not isinstance(document, dict) or set(document) != {
+            "page_content",
+            "metadata",
+        }:
+            raise ValueError(
+                f"portable BM25 document {index} has invalid shape: {path.name}"
+            )
+        page_content = document["page_content"]
+        metadata = document["metadata"]
+        if not isinstance(page_content, str) or not isinstance(metadata, dict):
+            raise ValueError(
+                f"portable BM25 document {index} has invalid content or metadata"
+            )
+        assert_no_secret_fields(
+            metadata,
+            source=f"portable BM25 document {index} metadata",
+        )
+        raw_file = metadata.get("file")
+        if raw_file is not None and not isinstance(raw_file, str):
+            raise ValueError(
+                f"portable BM25 document {index} has an invalid source path"
+            )
+        normalized_metadata = dict(metadata)
+        if raw_file is not None:
+            normalized_metadata["file"] = _portable_source_path(
+                raw_file,
+                repo_path,
+                source=f"BM25 document {index} file",
+            )
+        normalized.append(
+            {"page_content": page_content, "metadata": normalized_metadata}
+        )
+    path.write_bytes(_json_bytes(normalized))
+
+
 def _is_mutable_vector_state(path: Path) -> bool:
     name = path.name.lower()
     return (
@@ -267,6 +800,7 @@ def _is_mutable_vector_state(path: Path) -> bool:
 def _validate_vector_model_policy(
     root: Path,
     *,
+    ownership: object,
     model_suffix: str,
     source_trust: SourceTrust,
 ) -> None:
@@ -285,9 +819,10 @@ def _validate_vector_model_policy(
                 root / level / f"index_{model_suffix}.pkl",
             }
         )
+    inventory_files = _owned_inventory_paths(root, ownership, kind="file")
     unexpected_model_artifacts = sorted(
         path
-        for path in root.rglob("*")
+        for path in inventory_files
         if path.name.casefold().startswith(("config_", "documents_", "index_"))
         and path not in allowed_model_artifacts
     )
@@ -297,9 +832,9 @@ def _validate_vector_model_policy(
             f"{unexpected_model_artifacts[0].relative_to(root)}"
         )
 
-    pickles = _pickle_paths(root)
+    pickles = _pickle_paths(root, ownership)
     if source_trust == "portable-inert":
-        _reject_inert_pickles(root)
+        _reject_inert_pickles(root, ownership)
         return
 
     allowed_pickles = {
@@ -457,12 +992,20 @@ def _validate_vector_semantics(
     )
 
 
-def _faiss_contract(path: Path) -> tuple[int, int, str, str, bool]:
+def _faiss_contract(
+    path: Path,
+    *,
+    reader: _OwnedViewReader | None = None,
+) -> tuple[int, int, str, str, bool]:
     """Read the persisted index contract, importing FAISS on demand."""
 
     try:
         faiss = importlib.import_module("faiss")
-        index = faiss.read_index(str(path))
+        index = (
+            faiss.read_index(str(path))
+            if reader is None
+            else reader.faiss_index(path, faiss)
+        )
         dimension = int(index.d)
         total = int(index.ntotal)
         is_trained = bool(index.is_trained)
@@ -495,10 +1038,35 @@ def _validate_level_semantics(
     metric: object,
     index_type: str,
     count: int,
+    canonicalize: bool = True,
+    reader: _OwnedViewReader | None = None,
 ) -> None:
     if not path.exists():
         return
-    config = _load_json_object(path, label=f"portable vector {level} config")
+    config = _load_json_object(
+        path,
+        label=f"portable vector {level} config",
+        require_canonical=not canonicalize,
+        reader=reader,
+    )
+    assert_no_secret_fields(
+        config,
+        source=f"portable vector {level} config",
+    )
+    expected_fields = {
+        "embedding_model",
+        "embedding_provider",
+        "embedding_revision",
+        "dimension",
+        "index_type",
+        "index_metric",
+        "level",
+        "num_documents",
+    }
+    if set(config) != expected_fields:
+        raise ValueError(
+            f"portable vector {level} persistence config has an invalid shape"
+        )
     checks: tuple[tuple[str, object], ...] = (
         ("embedding_model", model),
         ("embedding_revision", revision),
@@ -523,12 +1091,15 @@ def _validate_level_semantics(
         ) from exc
     if persisted_provider != provider:
         raise ValueError(f"portable vector {level} persistence provider does not match")
+    if canonicalize:
+        path.write_bytes(_json_bytes(config))
 
 
 def _validate_vector_layout(
     root: Path,
     repo_path: Path,
     *,
+    ownership: object,
     model_suffix: str,
     config: Mapping[str, Any],
     expected_model: str,
@@ -538,6 +1109,8 @@ def _validate_vector_layout(
     expected_metric: str,
     expected_index_type: str,
     source_trust: SourceTrust,
+    canonicalize_level_configs: bool = True,
+    reader: _OwnedViewReader | None = None,
 ) -> tuple[
     str,
     dict[Path, list[dict[str, Any]]],
@@ -561,6 +1134,7 @@ def _validate_vector_layout(
 
     derived_counts: dict[str, int] = {}
     stale_paths: set[Path] = set()
+    inventory_files = _owned_inventory_paths(root, ownership, kind="file")
 
     for level in _VECTOR_LEVELS:
         count = config.get(f"{level}_documents") if not legacy_counts else None
@@ -573,7 +1147,7 @@ def _validate_vector_layout(
         level_path = root / level
         pickle_path = level_path / f"documents_{model_suffix}.pkl"
         json_path = level_path / f"documents_{model_suffix}.json"
-        present = [path for path in (pickle_path, json_path) if path.is_file()]
+        present = [path for path in (pickle_path, json_path) if path in inventory_files]
         expected_documents.update(present)
         index_path = level_path / f"index_{model_suffix}.faiss"
 
@@ -590,7 +1164,7 @@ def _validate_vector_layout(
                     level_path / f"index_{model_suffix}.pkl",
                     level_path / f"config_{model_suffix}.json",
                 )
-                if path.is_file()
+                if path in inventory_files
             )
             derived_counts[level] = 0
             continue
@@ -604,13 +1178,13 @@ def _validate_vector_layout(
             )
         if not present and count is None:
             if (
-                index_path.exists()
-                or (level_path / f"config_{model_suffix}.json").exists()
+                index_path in inventory_files
+                or (level_path / f"config_{model_suffix}.json") in inventory_files
             ):
                 raise ValueError(f"portable legacy vector {level} level is incomplete")
             derived_counts[level] = 0
             continue
-        if index_path.is_symlink() or not index_path.is_file():
+        if index_path not in inventory_files:
             raise ValueError(f"portable vector view is missing its index: {index_path}")
 
         path = present[0]
@@ -620,16 +1194,25 @@ def _validate_vector_layout(
                 raise ValueError(
                     "portable-inert vector view must not deserialize documents"
                 )
-            payload = _normalize_pickle_documents(path, repo_path)
+            if reader is None:
+                raise RuntimeError(
+                    "trusted-local vector normalization requires an owned reader"
+                )
+            payload = _normalize_pickle_documents(path, repo_path, reader=reader)
         else:
-            payload = _normalize_json_documents(path, repo_path)
+            payload = _normalize_json_documents(path, repo_path, reader=reader)
         if count is not None and len(payload) != count:
             raise ValueError(
                 f"portable vector {level} count differs from {path.name}: "
                 f"expected {count}, found {len(payload)}"
             )
         count = len(payload)
-        dimension, total, metric, index_type, is_trained = _faiss_contract(index_path)
+        if reader is not None:
+            reader.pin_file(index_path)
+        dimension, total, metric, index_type, is_trained = _faiss_contract(
+            index_path,
+            reader=reader,
+        )
         if dimension != expected_dimension:
             raise ValueError(
                 f"portable vector FAISS dimension mismatch in {level}: "
@@ -650,7 +1233,7 @@ def _validate_vector_layout(
                     level_path / f"index_{model_suffix}.pkl",
                     level_path / f"config_{model_suffix}.json",
                 )
-                if candidate.is_file()
+                if candidate in inventory_files
             )
             continue
         if metric != expected_metric:
@@ -677,6 +1260,8 @@ def _validate_vector_layout(
             metric=expected_metric,
             index_type=expected_index_type,
             count=count,
+            canonicalize=canonicalize_level_configs,
+            reader=reader,
         )
         formats.add(document_format)
         selected[path] = payload
@@ -688,8 +1273,9 @@ def _validate_vector_layout(
 
     candidates = {
         path
-        for path in root.rglob("documents_*")
+        for path in inventory_files
         if path.suffix.casefold() in {".json", ".pkl", ".pickle"}
+        and path.name.startswith("documents_")
     }
     unexpected_documents = sorted(candidates - expected_documents)
     if unexpected_documents:
@@ -703,16 +1289,20 @@ def _validate_vector_layout(
         path for path in stale_paths if path.suffix.casefold() in _PICKLE_SUFFIXES
     )
     allowed_pickles.update(
-        path for path in root.glob("l[02]/index_*.pkl") if path.is_file()
+        path
+        for path in inventory_files
+        if path.parent.name in _VECTOR_LEVELS
+        and path.name.startswith("index_")
+        and path.suffix.casefold() == ".pkl"
     )
     allowed_pickles.update(
         root / name
         for name in _REMOVABLE_MUTABLE_VECTOR_FILES
-        if name.endswith(".pkl") and (root / name).is_file()
+        if name.endswith(".pkl") and (root / name) in inventory_files
     )
     residual_pickles = sorted(
         path
-        for path in root.rglob("*")
+        for path in inventory_files
         if path.suffix.casefold() in _PICKLE_SUFFIXES and path not in allowed_pickles
     )
     if residual_pickles:
@@ -724,9 +1314,8 @@ def _validate_vector_layout(
     removable_mutable = {root / name for name in _REMOVABLE_MUTABLE_VECTOR_FILES}
     residual_mutable = sorted(
         path
-        for path in root.rglob("*")
-        if _is_mutable_vector_state(path)
-        and (path not in removable_mutable or not path.is_file())
+        for path in inventory_files
+        if _is_mutable_vector_state(path) and path not in removable_mutable
     )
     if residual_mutable:
         raise ValueError(
@@ -743,23 +1332,54 @@ def _refresh_vector_persistence_records(
     model_suffix: str,
 ) -> None:
     config_path = root / f"config_{model_suffix}.json"
-    config = _load_json_object(config_path, label="portable vector config")
-    level_artifacts: dict[str, dict[str, dict[str, Any]]] = {}
-    for level in _VECTOR_LEVELS:
-        count = config.get(f"{level}_documents")
-        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
-            raise ValueError(
-                f"portable vector config has invalid {level} count: {count!r}"
-            )
-        if count == 0:
-            continue
-        level_path = root / level
-        documents_path = level_path / f"documents_{model_suffix}.json"
-        level_artifacts[level] = vector_level_artifact_records(
-            level_path,
-            model_suffix,
-            documents_file=documents_path.name,
+    try:
+        ownership = capture_directory_ownership(root)
+        reader = _OwnedViewReader(root, ownership)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            "portable vector view could not be captured before refreshing records"
+        ) from exc
+    try:
+        config = _load_json_object(
+            config_path,
+            label="portable vector config",
+            reader=reader,
         )
+        assert_no_secret_fields(config, source="portable vector config")
+        level_artifacts: dict[str, dict[str, dict[str, Any]]] = {}
+        for level in _VECTOR_LEVELS:
+            count = config.get(f"{level}_documents")
+            if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+                raise ValueError(
+                    f"portable vector config has invalid {level} count: {count!r}"
+                )
+            if count == 0:
+                continue
+            level_path = root / level
+            documents_path = level_path / f"documents_{model_suffix}.json"
+            index_path = level_path / f"index_{model_suffix}.faiss"
+            index_record = reader.fingerprint(index_path)
+            index_record["file"] = index_path.name
+            documents_record = reader.fingerprint(
+                documents_path,
+                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+            )
+            documents_record["file"] = documents_path.name
+            level_artifacts[level] = {
+                "index": index_record,
+                "documents": documents_record,
+            }
+        reader.verify_root()
+        try:
+            recorded_tree = capture_directory_ownership(root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(
+                "portable vector view changed while refreshing records"
+            ) from exc
+        if recorded_tree != ownership:
+            raise RuntimeError("portable vector view changed while refreshing records")
+    finally:
+        reader.close()
     config["persistence_schema"] = VECTOR_PERSISTENCE_SCHEMA
     config["level_artifacts"] = level_artifacts
     config_path.write_bytes(_json_bytes(config))
@@ -795,29 +1415,91 @@ def _validate_view_document_count(
             )
 
 
-def _assert_normalized_vector_tree(root: Path) -> None:
-    for path in sorted(root.rglob("*")):
-        if path.suffix.casefold() in _PICKLE_SUFFIXES:
-            raise ValueError(
-                "portable vector normalization left a pickle behind: "
-                f"{path.relative_to(root)}"
-            )
-        if _is_mutable_vector_state(path):
-            raise ValueError(
-                "portable vector normalization left mutable state behind: "
-                f"{path.relative_to(root)}"
-            )
+def _assert_exact_view_tree(
+    *,
+    ownership: object,
+    allowed_files: set[PurePosixPath],
+    required_files: set[PurePosixPath],
+    label: str,
+) -> None:
+    allowed_directories = {
+        parent
+        for path in allowed_files
+        for parent in path.parents
+        if parent != PurePosixPath(".")
+    }
+    observed_files: set[PurePosixPath] = set()
+    for raw_relative, kind in directory_ownership_inventory(ownership):
+        relative = PurePosixPath(raw_relative)
+        if kind == "directory":
+            if relative not in allowed_directories:
+                raise ValueError(
+                    f"{label} contains an unexpected directory: {relative}"
+                )
+            continue
+        if relative not in allowed_files:
+            raise ValueError(f"{label} contains an unexpected file: {relative}")
+        observed_files.add(relative)
+
+    missing = sorted(required_files - observed_files, key=str)
+    if missing:
+        raise ValueError(f"{label} is missing a required file: {missing[0]}")
+
+
+def _assert_normalized_vector_tree(
+    *,
+    ownership: object,
+    model_suffix: str,
+    counts: Mapping[str, int],
+) -> None:
+    root_config = PurePosixPath(f"config_{model_suffix}.json")
+    allowed_files = {root_config}
+    required_files = {root_config}
+    for level in _VECTOR_LEVELS:
+        if counts[level] <= 0:
+            continue
+        level_path = PurePosixPath(level)
+        documents = level_path / f"documents_{model_suffix}.json"
+        index = level_path / f"index_{model_suffix}.faiss"
+        allowed_files.update(
+            {
+                level_path / f"config_{model_suffix}.json",
+                documents,
+                index,
+            }
+        )
+        required_files.update({documents, index})
+    _assert_exact_view_tree(
+        ownership=ownership,
+        allowed_files=allowed_files,
+        required_files=required_files,
+        label="portable vector view",
+    )
 
 
 def _normalize_vector_view(
     root: Path,
     repo_path: Path,
     *,
+    initial_tree: object,
+    reader: _OwnedViewReader,
     view_config: Mapping[str, Any],
     source_trust: SourceTrust,
 ) -> dict[str, Any]:
-    require_complete_vector_view(root)
-    interrupted = sorted(root.glob(".config_*.json.save-in-progress"))
+    assert_no_secret_fields(view_config, source="portable vector view config")
+    initial_files = _owned_inventory_paths(root, initial_tree, kind="file")
+    if root / VECTOR_VIEW_UPDATE_MARKER in initial_files:
+        raise ValueError(
+            "portable vector view has an incomplete update marker: "
+            f"{VECTOR_VIEW_UPDATE_MARKER}"
+        )
+    interrupted = sorted(
+        path
+        for path in initial_files
+        if path.parent == root
+        and path.name.startswith(".config_")
+        and path.name.endswith(".json.save-in-progress")
+    )
     if interrupted:
         raise ValueError(
             "portable vector view contains an interrupted save marker: "
@@ -828,21 +1510,35 @@ def _normalize_vector_view(
     model_suffix = route.model.replace("/", "__")
     _validate_vector_model_policy(
         root,
+        ownership=initial_tree,
         model_suffix=model_suffix,
         source_trust=source_trust,
     )
     expected_config = view_config.get("persistence_config_fingerprint")
-    if expected_config is not None:
-        validate_vector_config_artifact(
-            root,
-            model_suffix,
-            expected_config,
-        )
-    # Validate the committed source generation before replacing any trusted-local
-    # pickle or refreshing records. Otherwise normalization could bless torn files.
-    validate_vector_generation_artifacts(root, model_suffix)
     config_path = root / f"config_{model_suffix}.json"
-    config = _load_json_object(config_path, label="portable vector config")
+    if expected_config is not None:
+        config = _authenticate_vector_generation(
+            reader,
+            root,
+            model_suffix=model_suffix,
+            expected_config=expected_config,
+            require_canonical=False,
+        )
+    else:
+        config = _load_json_object(
+            config_path,
+            label="portable vector config",
+            reader=reader,
+        )
+        if config.get("persistence_schema") is not None:
+            config = _authenticate_vector_generation(
+                reader,
+                root,
+                model_suffix=model_suffix,
+                expected_config=None,
+                require_canonical=False,
+            )
+    assert_no_secret_fields(config, source="portable vector config")
     (
         semantic_suffix,
         expected_dimension,
@@ -856,6 +1552,7 @@ def _normalize_vector_view(
     document_format, documents, counts, stale_paths = _validate_vector_layout(
         root,
         repo_path,
+        ownership=initial_tree,
         model_suffix=model_suffix,
         config=config,
         expected_model=route.model,
@@ -865,8 +1562,11 @@ def _normalize_vector_view(
         expected_metric=expected_metric,
         expected_index_type=expected_index_type,
         source_trust=source_trust,
+        reader=reader,
     )
     _validate_view_document_count(view_config, counts)
+    reader.verify_root()
+    reader.close()
 
     for path, payload in documents.items():
         output = path.with_suffix(".json")
@@ -891,20 +1591,141 @@ def _normalize_vector_view(
     # mutable state was rejected before mutation.
     for name in _REMOVABLE_MUTABLE_VECTOR_FILES:
         (root / name).unlink(missing_ok=True)
-    for legacy in root.glob("l[02]/index_*.pkl"):
-        legacy.unlink()
+    for legacy in sorted(
+        path
+        for path in initial_files
+        if path.parent.parent == root
+        and path.parent.name in _VECTOR_LEVELS
+        and path.name.startswith("index_")
+        and path.suffix.casefold() == ".pkl"
+    ):
+        legacy.unlink(missing_ok=True)
 
     _refresh_vector_persistence_records(root, model_suffix=model_suffix)
-    _assert_normalized_vector_tree(root)
-    validate_vector_generation_artifacts(root, model_suffix)
+    try:
+        final_tree = capture_directory_ownership(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            "portable vector view could not be captured after normalization"
+        ) from exc
+    _assert_normalized_vector_tree(
+        ownership=final_tree,
+        model_suffix=model_suffix,
+        counts=counts,
+    )
+    try:
+        fingerprint_reader = _OwnedViewReader(root, final_tree)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            "portable vector view could not be opened after normalization"
+        ) from exc
+    try:
+        config_record = fingerprint_reader.fingerprint(
+            config_path,
+            max_bytes=_MAX_CONFIG_JSON_BYTES,
+        )
+        config_record["file"] = config_path.name
+        fingerprint_reader.verify_root()
+        try:
+            fingerprint_tree = capture_directory_ownership(root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(
+                "portable vector view changed while recording its fingerprint"
+            ) from exc
+        if fingerprint_tree != final_tree:
+            raise RuntimeError(
+                "portable vector view changed while recording its fingerprint"
+            )
+    finally:
+        fingerprint_reader.close()
     return {
         "artifact_scope": "query-serving",
         "portable_document_format": "codenib.vector-documents.v1",
-        "persistence_config_fingerprint": vector_config_artifact_record(
-            root,
-            model_suffix,
-        ),
+        "persistence_config_fingerprint": config_record,
     }
+
+
+def _normalize_bm25_view(
+    root: Path,
+    repo_path: Path,
+    *,
+    initial_tree: object,
+    reader: _OwnedViewReader,
+) -> dict[str, Any]:
+    _reject_inert_pickles(root, initial_tree)
+    documents_path = root / "documents.json"
+    _normalize_bm25_documents(documents_path, repo_path, reader=reader)
+    metadata_path = root / "bm25_metadata.json"
+    metadata = _load_json_object(
+        metadata_path,
+        label="portable BM25 metadata",
+        reader=reader,
+    )
+    assert_no_secret_fields(metadata, source="portable BM25 metadata")
+    if not set(metadata) <= {"project_root", "max_k", "language"}:
+        raise ValueError("portable BM25 metadata has an invalid shape")
+    max_k = metadata.get("max_k", 10)
+    if isinstance(max_k, bool) or not isinstance(max_k, int) or max_k <= 0:
+        raise ValueError("portable BM25 metadata max_k must be positive")
+    language = metadata.get("language", "english")
+    if (
+        not isinstance(language, str)
+        or not language.strip()
+        or "\x00" in language
+        or len(language) > 256
+    ):
+        raise ValueError("portable BM25 metadata language is invalid")
+    if metadata.get("project_root") is not None and not isinstance(
+        metadata.get("project_root"), str
+    ):
+        raise ValueError("portable BM25 metadata project_root is invalid")
+    metadata.update({"project_root": "source", "max_k": max_k, "language": language})
+    reader.verify_root()
+    reader.close()
+
+    metadata_path.write_bytes(_json_bytes(metadata))
+    expected_files = {
+        PurePosixPath("documents.json"),
+        PurePosixPath("bm25_metadata.json"),
+    }
+    try:
+        normalized_tree = capture_directory_ownership(root)
+        fingerprint_reader = _OwnedViewReader(root, normalized_tree)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            "portable BM25 view could not be captured after normalization"
+        ) from exc
+    try:
+        _assert_exact_view_tree(
+            ownership=normalized_tree,
+            allowed_files=expected_files,
+            required_files=expected_files,
+            label="portable BM25 view",
+        )
+        fingerprints = {
+            "documents.json": fingerprint_reader.fingerprint(
+                documents_path,
+                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+            ),
+            "bm25_metadata.json": fingerprint_reader.fingerprint(
+                metadata_path,
+                max_bytes=_MAX_CONFIG_JSON_BYTES,
+            ),
+        }
+        fingerprint_reader.verify_root()
+        try:
+            final_tree = capture_directory_ownership(root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(
+                "portable BM25 view changed while recording its fingerprints"
+            ) from exc
+        if final_tree != normalized_tree:
+            raise RuntimeError(
+                "portable BM25 view changed while recording its fingerprints"
+            )
+    finally:
+        fingerprint_reader.close()
+    return {"artifact_file_fingerprints": fingerprints}
 
 
 def normalize_owned_query_view(
@@ -928,27 +1749,435 @@ def normalize_owned_query_view(
     }:
         raise ValueError(f"invalid portable query view source trust: {source_trust!r}")
     normalized_root, repository = _owned_view_root(root, repo_path)
-    if view_type == "vector":
-        return _normalize_vector_view(
-            normalized_root,
-            repository,
-            view_config=view_config,
-            source_trust=source_trust,
-        )
-    if view_type != "bm25":
+    try:
+        initial_tree = capture_directory_ownership(normalized_root)
+        reader = _OwnedViewReader(normalized_root, initial_tree)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError("portable query view could not be captured safely") from exc
+    try:
+        if view_type == "vector":
+            return _normalize_vector_view(
+                normalized_root,
+                repository,
+                initial_tree=initial_tree,
+                reader=reader,
+                view_config=view_config,
+                source_trust=source_trust,
+            )
+        if view_type == "bm25":
+            return _normalize_bm25_view(
+                normalized_root,
+                repository,
+                initial_tree=initial_tree,
+                reader=reader,
+            )
         raise ValueError(
             f"view {view_type!r} is not yet supported by portable query views; "
             "select bm25 and/or vector"
         )
+    finally:
+        reader.close()
 
-    _reject_inert_pickles(normalized_root)
-    metadata_path = normalized_root / "bm25_metadata.json"
-    metadata = _load_json_object(metadata_path, label="portable BM25 metadata")
-    metadata["project_root"] = "source"
-    metadata_path.write_bytes(_json_bytes(metadata))
-    return {
-        "artifact_file_fingerprints": bm25_artifact_file_fingerprints(normalized_root)
+
+def _validate_normalized_document_sources(
+    path: Path,
+    repo_path: Path,
+    *,
+    view_type: str,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+    reader: _OwnedViewReader | None = None,
+) -> None:
+    documents = _load_json(
+        path,
+        label=f"portable {view_type} documents",
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        require_canonical=True,
+        reader=reader,
+    )
+    if not isinstance(documents, list):
+        raise ValueError(f"portable {view_type} documents must be a JSON list: {path}")
+    for index, document in enumerate(documents):
+        if not isinstance(document, dict) or set(document) != {
+            "page_content",
+            "metadata",
+        }:
+            raise ValueError(
+                f"portable {view_type} document {index} has an invalid shape"
+            )
+        if not isinstance(document["page_content"], str) or not isinstance(
+            document["metadata"], dict
+        ):
+            raise ValueError(
+                f"portable {view_type} document {index} has invalid content or metadata"
+            )
+        metadata = document["metadata"]
+        assert_no_secret_fields(
+            metadata,
+            source=f"portable {view_type} document {index} metadata",
+        )
+        assert_publishable_json_value(
+            metadata,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+            label=f"portable {view_type} document {index} metadata",
+        )
+        raw_file = metadata.get("file")
+        if raw_file is not None and not isinstance(raw_file, str):
+            raise ValueError(
+                f"portable {view_type} document {index} has an invalid source path"
+            )
+        if raw_file is not None:
+            normalized_file = _portable_source_path(
+                raw_file,
+                repo_path,
+                source=f"portable {view_type} document {index} file",
+            )
+            if raw_file != normalized_file:
+                raise ValueError(
+                    f"portable {view_type} document {index} file is not normalized"
+                )
+
+
+def _authenticate_vector_generation(
+    reader: _OwnedViewReader,
+    root: Path,
+    *,
+    model_suffix: str,
+    expected_config: object | None,
+    require_canonical: bool = True,
+) -> dict[str, Any]:
+    config_path = root / f"config_{model_suffix}.json"
+    if expected_config is not None:
+        try:
+            reader.authenticate(
+                config_path,
+                expected_config,
+                cache_bytes=True,
+                max_bytes=_MAX_CONFIG_JSON_BYTES,
+            )
+        except ValueError as exc:
+            raise ValueError(
+                "portable vector config does not match its manifest fingerprint"
+            ) from exc
+    config = _load_json_object(
+        config_path,
+        label="portable vector config",
+        require_canonical=require_canonical,
+        reader=reader,
+    )
+    if config.get("persistence_schema") != VECTOR_PERSISTENCE_SCHEMA:
+        raise ValueError("portable vector generation has an invalid persistence schema")
+    committed = config.get("level_artifacts")
+    if not isinstance(committed, Mapping) or not set(committed) <= set(_VECTOR_LEVELS):
+        raise ValueError("portable vector generation has invalid committed levels")
+    for level in _VECTOR_LEVELS:
+        count = config.get(f"{level}_documents")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError(f"portable vector generation has invalid {level} count")
+        records = committed.get(level)
+        if count == 0:
+            if records is not None:
+                raise ValueError(
+                    f"portable vector generation commits empty {level} artifacts"
+                )
+            continue
+        if not isinstance(records, Mapping) or set(records) != {
+            "index",
+            "documents",
+        }:
+            raise ValueError(
+                f"portable vector generation has invalid {level} artifacts"
+            )
+        index_name = f"index_{model_suffix}.faiss"
+        json_documents_name = f"documents_{model_suffix}.json"
+        allowed_documents_names = {json_documents_name}
+        if not require_canonical:
+            allowed_documents_names.add(f"documents_{model_suffix}.pkl")
+        index_record = records["index"]
+        documents_record = records["documents"]
+        if (
+            not isinstance(index_record, Mapping)
+            or index_record.get("file") != index_name
+        ):
+            raise ValueError(f"portable vector generation has invalid {level} index")
+        if (
+            not isinstance(documents_record, Mapping)
+            or documents_record.get("file") not in allowed_documents_names
+        ):
+            raise ValueError(
+                f"portable vector generation has invalid {level} documents"
+            )
+        try:
+            reader.authenticate(
+                root / level / str(documents_record["file"]),
+                documents_record,
+                cache_bytes=True,
+                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"committed documents vector artifact is invalid in {level}"
+            ) from exc
+        reader.authenticate(
+            root / level / index_name,
+            index_record,
+            cache_bytes=False,
+            keep_descriptor=True,
+        )
+    return config
+
+
+def _validate_portable_bm25_view(
+    root: Path,
+    repository: Path,
+    *,
+    view_config: Mapping[str, Any],
+    forbidden: tuple[Path, ...],
+    environment: Mapping[str, str],
+    initial_tree: object,
+    reader: _OwnedViewReader,
+) -> None:
+    assert_no_secret_fields(view_config, source="portable BM25 view config")
+    fingerprints = view_config.get("artifact_file_fingerprints")
+    if not isinstance(fingerprints, Mapping) or set(fingerprints) != {
+        "documents.json",
+        "bm25_metadata.json",
+    }:
+        raise ValueError(
+            "portable BM25 validation requires complete artifact file fingerprints"
+        )
+    expected_files = {
+        PurePosixPath("documents.json"),
+        PurePosixPath("bm25_metadata.json"),
     }
+    _assert_exact_view_tree(
+        ownership=initial_tree,
+        allowed_files=expected_files,
+        required_files=expected_files,
+        label="portable BM25 view",
+    )
+    reader.authenticate(
+        root / "documents.json",
+        fingerprints["documents.json"],
+        cache_bytes=True,
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+    )
+    reader.authenticate(
+        root / "bm25_metadata.json",
+        fingerprints["bm25_metadata.json"],
+        cache_bytes=True,
+        max_bytes=_MAX_CONFIG_JSON_BYTES,
+    )
+    metadata = _load_json_object(
+        root / "bm25_metadata.json",
+        label="portable BM25 metadata",
+        require_canonical=True,
+        reader=reader,
+    )
+    assert_no_secret_fields(metadata, source="portable BM25 metadata")
+    assert_publishable_json_value(
+        metadata,
+        forbidden_paths=forbidden,
+        environ=environment,
+        label="portable BM25 metadata",
+    )
+    if set(metadata) != {"project_root", "max_k", "language"}:
+        raise ValueError("portable BM25 metadata has an invalid normalized shape")
+    if metadata.get("project_root") != "source":
+        raise ValueError("portable BM25 metadata project_root is not normalized")
+    if (
+        isinstance(metadata.get("max_k"), bool)
+        or not isinstance(metadata.get("max_k"), int)
+        or metadata["max_k"] <= 0
+        or not isinstance(metadata.get("language"), str)
+        or not metadata["language"].strip()
+        or "\x00" in metadata["language"]
+        or len(metadata["language"]) > 256
+    ):
+        raise ValueError("portable BM25 metadata is invalid")
+    _validate_normalized_document_sources(
+        root / "documents.json",
+        repository,
+        view_type="BM25",
+        forbidden_paths=forbidden,
+        environ=environment,
+        reader=reader,
+    )
 
 
-__all__ = ["SourceTrust", "normalize_owned_query_view"]
+def _validate_portable_vector_view(
+    root: Path,
+    repository: Path,
+    *,
+    view_config: Mapping[str, Any],
+    forbidden: tuple[Path, ...],
+    environment: Mapping[str, str],
+    initial_tree: object,
+    reader: _OwnedViewReader,
+) -> None:
+    assert_no_secret_fields(view_config, source="portable vector view config")
+    route = resolve_embedding_artifact_route(view_config)
+    expected_suffix = route.model.replace("/", "__")
+    inventory_files = _owned_inventory_paths(root, initial_tree, kind="file")
+    root_configs = sorted(
+        path
+        for path in inventory_files
+        if path.parent == root
+        and path.name.startswith("config_")
+        and path.name.endswith(".json")
+    )
+    if len(root_configs) != 1:
+        raise ValueError("portable vector view must contain one root config")
+    config_path = root_configs[0]
+    model_suffix = config_path.name[len("config_") : -len(".json")]
+    if not model_suffix or model_suffix != expected_suffix:
+        raise ValueError("portable vector root config does not match its view model")
+    _validate_vector_model_policy(
+        root,
+        ownership=initial_tree,
+        model_suffix=model_suffix,
+        source_trust="portable-inert",
+    )
+    expected_config = view_config.get("persistence_config_fingerprint")
+    if expected_config is None:
+        raise ValueError("portable vector validation requires its config fingerprint")
+    config = _authenticate_vector_generation(
+        reader,
+        root,
+        model_suffix=model_suffix,
+        expected_config=expected_config,
+    )
+    assert_no_secret_fields(config, source="portable vector config")
+    assert_publishable_json_value(
+        config,
+        forbidden_paths=forbidden,
+        environ=environment,
+        label="portable vector config",
+    )
+    (
+        semantic_suffix,
+        expected_dimension,
+        expected_revision,
+        expected_metric,
+        expected_index_type,
+    ) = _validate_vector_semantics(config, view_config)
+    if semantic_suffix != model_suffix:
+        raise ValueError("portable vector config embedding model does not match")
+    document_format, _documents, counts, stale_paths = _validate_vector_layout(
+        root,
+        repository,
+        ownership=initial_tree,
+        model_suffix=model_suffix,
+        config=config,
+        expected_model=route.model,
+        expected_provider=route.provider,
+        expected_revision=expected_revision,
+        expected_dimension=expected_dimension,
+        expected_metric=expected_metric,
+        expected_index_type=expected_index_type,
+        source_trust="portable-inert",
+        canonicalize_level_configs=False,
+        reader=reader,
+    )
+    if document_format != "json" or stale_paths:
+        raise ValueError("portable vector view is not in its normalized final form")
+    _validate_view_document_count(view_config, counts)
+    _assert_normalized_vector_tree(
+        ownership=initial_tree,
+        model_suffix=model_suffix,
+        counts=counts,
+    )
+    for level in _VECTOR_LEVELS:
+        if counts[level] <= 0:
+            continue
+        level_root = root / level
+        level_config = level_root / f"config_{model_suffix}.json"
+        if level_config in inventory_files:
+            assert_publishable_json_value(
+                _load_json_object(
+                    level_config,
+                    label=f"portable vector {level} config",
+                    require_canonical=True,
+                    reader=reader,
+                ),
+                forbidden_paths=forbidden,
+                environ=environment,
+                label=f"portable vector {level} config",
+            )
+        _validate_normalized_document_sources(
+            level_root / f"documents_{model_suffix}.json",
+            repository,
+            view_type=f"vector {level}",
+            forbidden_paths=forbidden,
+            environ=environment,
+            reader=reader,
+        )
+
+
+def validate_portable_query_view(
+    root: Path,
+    *,
+    repo_path: Path,
+    view_type: str,
+    view_config: Mapping[str, Any] | None = None,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    """Revalidate a normalized query view without mutating its bytes."""
+
+    normalized_root, repository = _owned_view_root(root, repo_path)
+    if view_type not in {"bm25", "vector"}:
+        raise ValueError(f"unsupported portable query view: {view_type!r}")
+    if not isinstance(view_config, Mapping):
+        raise ValueError(f"portable {view_type} validation requires its view config")
+    try:
+        initial_tree = capture_directory_ownership(normalized_root)
+        reader = _OwnedViewReader(normalized_root, initial_tree)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            f"portable {view_type} view could not be captured safely"
+        ) from exc
+    environment = os.environ if environ is None else environ
+    forbidden = (repository, *tuple(forbidden_paths))
+    try:
+        if view_type == "bm25":
+            _validate_portable_bm25_view(
+                normalized_root,
+                repository,
+                view_config=view_config,
+                forbidden=forbidden,
+                environment=environment,
+                initial_tree=initial_tree,
+                reader=reader,
+            )
+        else:
+            _validate_portable_vector_view(
+                normalized_root,
+                repository,
+                view_config=view_config,
+                forbidden=forbidden,
+                environment=environment,
+                initial_tree=initial_tree,
+                reader=reader,
+            )
+        reader.verify_root()
+        try:
+            final_tree = capture_directory_ownership(normalized_root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(
+                f"portable {view_type} view changed during semantic validation"
+            ) from exc
+        if final_tree != initial_tree:
+            raise RuntimeError(
+                f"portable {view_type} view changed during semantic validation"
+            )
+    finally:
+        reader.close()
+
+
+__all__ = [
+    "SourceTrust",
+    "normalize_owned_query_view",
+    "validate_portable_query_view",
+]

--- a/codenib/artifacts/runtime.py
+++ b/codenib/artifacts/runtime.py
@@ -7,26 +7,45 @@
 from __future__ import annotations
 
 import json
+import math
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from pathlib import Path, PurePosixPath
-from typing import Any, Mapping
+from typing import Any, Callable, Iterator, Mapping, NoReturn
 
-from .._contained_source import validate_repository_file
+from .._atomic_directory import (
+    PublicationAuthenticatedFile,
+    PublicationDirectoryReader,
+    TreeFileRecord,
+    capture_directory_ownership,
+    directory_ownership_file_records,
+    lexical_directory_path,
+    reopen_authenticated_directory,
+)
+from .._bounded_json import iter_bounded_json_array
+from .._contained_source import _attach_source_cleanup_owner
 from ..compiler.checkout_identity import checkout_commit
 from ..compiler.manifest import MANIFEST_FILENAME, MANIFEST_VERSION, RepoManifest
 from ..compiler.snapshot_store import normalize_repo
-from ..source_fingerprint import fingerprint_repository
+from ..source_fingerprint import (
+    RepositorySourceBinding,
+    _SourceLifecycleRLock,
+    _SourceLockLease,
+    capture_repository_source,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
+)
 from .context import (
     CONTEXT_ARTIFACT_MANIFEST,
     CONTEXT_ARTIFACT_SCHEMA,
     PORTABLE_CONTEXT_VIEWS,
 )
-from .security import file_sha256
 
 _COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 _DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
-_SOURCE_FINGERPRINT_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_SOURCE_FINGERPRINT_RE = re.compile(r"^(?:sha256|sha256-v2):[0-9a-f]{64}$")
 _REPOSITORY_RE = re.compile(r"^[a-z0-9_.-]+(?:/[a-z0-9_.-]+)*$")
 _DEFAULT_MAX_FILES = 100_000
 _DEFAULT_MAX_BYTES = 64 * 1024 * 1024 * 1024
@@ -34,11 +53,40 @@ _MAX_METADATA_BYTES = 16 * 1024 * 1024
 _MAX_DOCUMENTS_BYTES = 256 * 1024 * 1024
 
 
+def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate context artifact JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _bounded_json_int(value: str) -> int:
+    if len(value) > 1_024:
+        raise ValueError("context artifact JSON integer is too large")
+    return int(value)
+
+
+def _bounded_json_float(value: str) -> float:
+    if len(value) > 1_024:
+        raise ValueError("context artifact JSON number is too large")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("context artifact JSON number is not finite")
+    return parsed
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"context artifact JSON constant is not finite: {value}")
+
+
 @dataclass(frozen=True, slots=True)
 class VerifiedContextArtifact:
     """Integrity-checked, still-unbound portable context artifact."""
 
     root: Path
+    ownership: object = dataclass_field(repr=False, compare=False)
     metadata_path: Path
     manifest_path: Path
     metadata: Mapping[str, Any]
@@ -52,28 +100,356 @@ class VerifiedContextArtifact:
     byte_count: int
 
 
-@dataclass(frozen=True, slots=True)
+class SourceBindingCleanupOwner:
+    """Explicit, retryable owner for source bindings awaiting cleanup."""
+
+    def __init__(self) -> None:
+        self._sources: list[object] = []
+
+    def retain(self, source: object) -> None:
+        close = getattr(source, "close", None)
+        if not callable(close):
+            raise TypeError("source cleanup resource must provide close()")
+        if not any(candidate is source for candidate in self._sources):
+            self._sources.append(source)
+
+    @property
+    def pending_sources(self) -> tuple[RepositorySourceBinding, ...]:
+        pending: list[RepositorySourceBinding] = []
+        for source in self._sources:
+            nested = getattr(source, "pending_sources", None)
+            if nested is None:
+                pending.append(source)  # type: ignore[arg-type]
+            else:
+                pending.extend(nested)
+        return tuple(pending)
+
+    @property
+    def closed(self) -> bool:
+        return not self._sources
+
+    def close(self) -> None:
+        """Visit every source and retain only authorities that remain open."""
+
+        first_failure: BaseException | None = None
+        pending: list[object] = []
+        for source in tuple(self._sources):
+            try:
+                source.close()  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - cleanup all sources
+                if first_failure is None:
+                    first_failure = exc
+            try:
+                fully_closed = bool(source.closed)  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - retain uncertain owner
+                fully_closed = False
+                if first_failure is None:
+                    first_failure = exc
+            if not fully_closed:
+                pending.append(source)
+        self._sources[:] = pending
+        if first_failure is not None:
+            raise first_failure
+
+
+def _source_cleanup_owner_is_pending(owner: object | None) -> bool:
+    """Treat uncertain cleanup ownership as pending and therefore non-degradable."""
+
+    if owner is None:
+        return False
+    try:
+        return not bool(owner.closed)  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - uncertain ownership is pending
+        return True
+
+
+def _raise_source_cleanup_failure(
+    primary: BaseException,
+    cleanup_failure: BaseException | None,
+    pending_owner: object | None,
+) -> NoReturn:
+    """Apply source cleanup priority and retain every still-pending owner."""
+
+    actual = primary
+    if (
+        cleanup_failure is not None
+        and isinstance(primary, Exception)
+        and not isinstance(cleanup_failure, Exception)
+    ):
+        actual = cleanup_failure
+
+    prior_owner = getattr(primary, "source_cleanup_owner", None)
+    if _source_cleanup_owner_is_pending(prior_owner):
+        _attach_source_cleanup_owner(actual, prior_owner)
+    if _source_cleanup_owner_is_pending(pending_owner):
+        _attach_source_cleanup_owner(actual, pending_owner)
+
+    if actual is cleanup_failure:
+        raise actual from primary
+    if cleanup_failure is not None:
+        raise actual from cleanup_failure
+    raise actual
+
+
+_SOURCE_BINDING_AVAILABLE = object()
+_SOURCE_BINDING_CLEANUP_PENDING = object()
+_SOURCE_BINDING_CONSUMED = object()
+
+
+@dataclass(slots=True)
 class ContextArtifactBinding:
-    """Verified artifact rebound in memory to one exact source checkout."""
+    """Verified artifact rebound to exact source bytes, not mutable Git state."""
 
     artifact: VerifiedContextArtifact
-    repo_path: Path
+    repo_path: Path | None
     manifest: RepoManifest
+    checkout_commit_observed: str | None = None
+    _source_binding: RepositorySourceBinding | None = dataclass_field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _transfer_lock: _SourceLifecycleRLock = dataclass_field(
+        default_factory=_SourceLifecycleRLock,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _source_state: tuple[object, RepositorySourceBinding | None] = dataclass_field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        self._source_state = (_SOURCE_BINDING_AVAILABLE, self._source_binding)
+        self._source_binding = None
+
+    @property
+    def source_binding(self) -> RepositorySourceBinding | None:
+        """Return a non-owning snapshot for diagnostics only."""
+
+        with self._transfer_lease():
+            state, source = self._source_state
+            return source if state is _SOURCE_BINDING_AVAILABLE else None
+
+    @property
+    def source_bound(self) -> bool:
+        with self._transfer_lease():
+            state, source = self._source_state
+            return state is _SOURCE_BINDING_AVAILABLE and source is not None
+
+    @contextmanager
+    def _transfer_lease(self) -> Iterator[None]:
+        with _SourceLockLease(self._transfer_lock) as acquisition_failure:
+            if acquisition_failure is not None:
+                raise acquisition_failure
+            yield
+
+    @property
+    def source_verification_scope(self) -> str | None:
+        """Describe the authority retained for later source reads."""
+
+        return "content-bytes" if self.source_bound else None
+
+    @property
+    def commit_verified(self) -> bool:
+        """Mutable Git HEAD is not attested by an M1 content binding."""
+
+        return False
+
+    def install_source_binding(
+        self,
+        install: Callable[[RepositorySourceBinding | None], None],
+        *,
+        expected: RepositorySourceBinding | None = None,
+        require_expected: bool = False,
+    ) -> None:
+        """Install the one-shot source into an already-stable runtime owner.
+
+        The callback must publish its argument in the destination owner before
+        returning.  Unlike returning the capability, this keeps the destination
+        reachable if cancellation lands between this method's return and the
+        caller's next bytecode.
+        """
+
+        source: RepositorySourceBinding | None = None
+        try:
+            with self._transfer_lease():
+                state, candidate = self._source_state
+                if state is not _SOURCE_BINDING_AVAILABLE:
+                    raise RuntimeError(
+                        "context artifact source authority was already transferred"
+                    )
+                if require_expected and candidate is not expected:
+                    raise ValueError(
+                        "artifact source authority does not match its binding"
+                    )
+                source = candidate
+                # Retain an explicit cleanup owner while the callback installs
+                # the source. A failed or interrupted installation remains
+                # retryable through close().
+                self._source_state = (_SOURCE_BINDING_CLEANUP_PENDING, source)
+                install(source)
+                self._source_state = (_SOURCE_BINDING_CONSUMED, None)
+        except BaseException:  # noqa: B036 - close unreturned capability
+            self._recover_source_install(source)
+            raise
+
+    def _recover_source_install(
+        self,
+        source: RepositorySourceBinding | None,
+    ) -> None:
+        """Close or retain a source whose destination install did not finish."""
+
+        try:
+            with _SourceLockLease(self._transfer_lock):
+                state, owned = self._source_state
+                if state is not _SOURCE_BINDING_CLEANUP_PENDING or owned is not source:
+                    return
+                if source is not None:
+                    try:
+                        source.close()
+                    except BaseException:  # noqa: B036 - preserve primary
+                        pass
+                self._source_state = (
+                    (_SOURCE_BINDING_CONSUMED, None)
+                    if source is None or source.closed
+                    else (_SOURCE_BINDING_CLEANUP_PENDING, source)
+                )
+        except BaseException:  # noqa: B036 - binding still retains pending owner
+            return
+
+    def close(self) -> None:
+        """Close an unconsumed live-source authority; query bindings are no-op."""
+
+        deferred: BaseException | None = None
+        try:
+            with _SourceLockLease(self._transfer_lock) as acquisition_failure:
+                if acquisition_failure is not None:
+                    deferred = acquisition_failure
+                state, source = self._source_state
+                if state in {
+                    _SOURCE_BINDING_AVAILABLE,
+                    _SOURCE_BINDING_CLEANUP_PENDING,
+                }:
+                    if source is None:
+                        self._source_state = (_SOURCE_BINDING_CONSUMED, None)
+                    else:
+                        try:
+                            source.close()
+                        except BaseException as exc:  # noqa: B036 - retain owner
+                            if deferred is None:
+                                deferred = exc
+                        self._source_state = (
+                            (_SOURCE_BINDING_CONSUMED, None)
+                            if source.closed
+                            else (_SOURCE_BINDING_CLEANUP_PENDING, source)
+                        )
+        except BaseException as exc:  # noqa: B036 - state retains retry owner
+            if deferred is None:
+                deferred = exc
+        if deferred is not None:
+            raise deferred
+
+    def __enter__(self) -> ContextArtifactBinding:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
 
 
-def _load_json_object(path: Path, *, label: str, max_bytes: int) -> dict[str, Any]:
+class _PublicationContextReader:
+    """Context-artifact facade over an authority-bound publication reader."""
+
+    def __init__(
+        self,
+        publication: PublicationDirectoryReader,
+        ownership: object,
+        *,
+        entry_policy_factory: Callable[[], Callable[[str, str, int, int], None]],
+    ) -> None:
+        self._publication = publication
+        self._ownership = ownership
+        self._entry_policy_factory = entry_policy_factory
+        self._records = {
+            record.path: record
+            for record in directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+        }
+
+    def _record(self, relative: str | PurePosixPath) -> TreeFileRecord:
+        normalized = PurePosixPath(relative) if isinstance(relative, str) else relative
+        try:
+            return self._records[normalized.as_posix()]
+        except KeyError as exc:
+            raise ValueError(
+                f"context artifact has no initial file record: {normalized}"
+            ) from exc
+
+    @contextmanager
+    def open_file(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> Iterator[PublicationAuthenticatedFile]:
+        normalized = PurePosixPath(relative) if isinstance(relative, str) else relative
+        expected = self._record(normalized)
+        with self._publication.open_authenticated_file(
+            normalized,
+            max_bytes=max_bytes,
+        ) as source:
+            yield source
+        if source.record != expected:
+            raise ValueError(
+                f"context artifact file differs from its initial record: {normalized}"
+            )
+
+    def read_bytes(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        payload = bytearray()
+        with self.open_file(relative, max_bytes=max_bytes) as source:
+            for chunk in source.iter_bytes():
+                payload.extend(chunk)
+        return bytes(payload)
+
+    def verify_root(self) -> None:
+        observed = self._publication.capture_ownership(
+            entry_policy=self._entry_policy_factory(),
+        )
+        if observed != self._ownership:
+            raise ValueError("context artifact changed during verification")
+
+    def close(self) -> None:
+        return None
+
+
+_ContextReader = _PublicationContextReader
+
+
+def _load_json_object(
+    reader: _ContextReader,
+    relative: str | PurePosixPath,
+    *,
+    label: str,
+    max_bytes: int,
+) -> dict[str, Any]:
     try:
-        size = path.stat().st_size
-    except OSError as exc:
-        raise ValueError(f"{label} is not readable: {path}") from exc
-    if size > max_bytes:
-        raise ValueError(f"{label} exceeds {max_bytes} bytes: {path}")
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-        raise ValueError(f"{label} is not valid UTF-8 JSON: {path}") from exc
+        value = json.loads(
+            reader.read_bytes(relative, max_bytes=max_bytes),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_json_constant,
+            parse_int=_bounded_json_int,
+            parse_float=_bounded_json_float,
+        )
+    except ValueError as exc:
+        raise ValueError(f"{label} is not valid UTF-8 JSON: {relative}") from exc
     if not isinstance(value, dict):
-        raise ValueError(f"{label} must be a JSON object: {path}")
+        raise ValueError(f"{label} must be a JSON object: {relative}")
     return value
 
 
@@ -92,29 +468,7 @@ def _relative_path(value: object, *, label: str) -> PurePosixPath:
 
 def _artifact_path(root: Path, value: object, *, label: str) -> Path:
     relative = _relative_path(value, label=label)
-    path = root.joinpath(*relative.parts)
-    resolved = path.resolve()
-    if root != resolved and root not in resolved.parents:
-        raise ValueError(f"{label} escapes the context artifact")
-    return resolved
-
-
-def _actual_files(root: Path, *, max_files: int) -> set[str]:
-    files: set[str] = set()
-    for path in sorted(root.rglob("*")):
-        relative = path.relative_to(root).as_posix()
-        if path.is_symlink():
-            raise ValueError(f"context artifact contains a symbolic link: {relative}")
-        if path.is_file():
-            files.add(relative)
-            # The metadata file is intentionally outside its own inventory.
-            if len(files) > max_files + 1:
-                raise ValueError(
-                    f"context artifact contains more than {max_files} inventoried files"
-                )
-        elif not path.is_dir():
-            raise ValueError(f"context artifact contains a special file: {relative}")
-    return files
+    return root.joinpath(*relative.parts)
 
 
 def _inventory(
@@ -204,64 +558,60 @@ def _artifact_views(metadata: Mapping[str, Any]) -> tuple[str, ...]:
 def _source_path(value: object, *, label: str) -> str:
     if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
         raise ValueError(f"{label} must be a repository-relative POSIX path")
+    try:
+        encoded = value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{label} must be a repository-relative POSIX path") from exc
     path = PurePosixPath(value)
     if (
         path.is_absolute()
         or value != path.as_posix()
         or any(part in {"", ".", ".."} for part in path.parts)
+        or len(path.parts) > 256
+        or len(encoded) > 4_096
     ):
         raise ValueError(f"{label} must be a repository-relative POSIX path")
     return path.as_posix()
 
 
 def _document_source_paths(
-    path: Path,
+    reader: _ContextReader,
+    relative: str | PurePosixPath,
     *,
     label: str,
     max_bytes: int,
 ) -> set[str]:
-    try:
-        size = path.stat().st_size
-    except OSError as exc:
-        raise ValueError(f"{label} is not readable: {path}") from exc
-    if size > max_bytes:
-        raise ValueError(f"{label} exceeds {max_bytes} bytes: {path}")
-    try:
-        documents = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-        raise ValueError(f"{label} is not valid UTF-8 JSON: {path}") from exc
-    if not isinstance(documents, list):
-        raise ValueError(f"{label} must be a JSON list: {path}")
-
     result: set[str] = set()
-    for index, document in enumerate(documents):
-        if not isinstance(document, dict):
-            raise ValueError(f"{label} document {index} must be an object")
-        page_content = document.get("page_content")
-        metadata = document.get("metadata")
-        if not isinstance(page_content, str) or not isinstance(metadata, dict):
-            raise ValueError(
-                f"{label} document {index} has invalid content or metadata"
-            )
-        raw_file = metadata.get("file")
-        if raw_file is not None and raw_file != "":
-            result.add(
-                _source_path(
-                    raw_file,
-                    label=f"{label} document {index} file",
+    with reader.open_file(relative, max_bytes=max_bytes) as source:
+        for index, document in enumerate(iter_bounded_json_array(source, label=label)):
+            if not isinstance(document, dict):
+                raise ValueError(f"{label} document {index} must be an object")
+            page_content = document.get("page_content")
+            metadata = document.get("metadata")
+            if not isinstance(page_content, str) or not isinstance(metadata, dict):
+                raise ValueError(
+                    f"{label} document {index} has invalid content or metadata"
                 )
-            )
-        for field in ("start_line", "end_line"):
-            value = metadata.get(field)
-            if value is not None and (
-                not isinstance(value, int) or isinstance(value, bool) or value < 0
-            ):
-                raise ValueError(f"{label} document {index} has invalid {field}")
+            raw_file = metadata.get("file")
+            if raw_file is not None and raw_file != "":
+                result.add(
+                    _source_path(
+                        raw_file,
+                        label=f"{label} document {index} file",
+                    )
+                )
+            for field in ("start_line", "end_line"):
+                value = metadata.get(field)
+                if value is not None and (
+                    not isinstance(value, int) or isinstance(value, bool) or value < 0
+                ):
+                    raise ValueError(f"{label} document {index} has invalid {field}")
     return result
 
 
 def _validate_view_payloads(
     root: Path,
+    reader: _ContextReader,
     inventory: Mapping[str, tuple[int, str]],
     *,
     views: tuple[str, ...],
@@ -276,7 +626,8 @@ def _validate_view_payloads(
         if not required <= inventory_paths:
             raise ValueError("portable BM25 view is missing its serving files")
         metadata = _load_json_object(
-            root / metadata_relative,
+            reader,
+            metadata_relative,
             label="portable BM25 metadata",
             max_bytes=_MAX_METADATA_BYTES,
         )
@@ -284,7 +635,8 @@ def _validate_view_payloads(
             raise ValueError("portable BM25 project root must be 'source'")
         source_paths.update(
             _document_source_paths(
-                root / documents_relative,
+                reader,
+                documents_relative,
                 label="portable BM25 documents",
                 max_bytes=_MAX_DOCUMENTS_BYTES,
             )
@@ -311,7 +663,8 @@ def _validate_view_payloads(
                 )
             source_paths.update(
                 _document_source_paths(
-                    root.joinpath(*path.parts),
+                    reader,
+                    path,
                     label=f"portable vector documents {relative}",
                     max_bytes=_MAX_DOCUMENTS_BYTES,
                 )
@@ -321,6 +674,7 @@ def _validate_view_payloads(
 
 def _validate_manifest(
     root: Path,
+    reader: _ContextReader,
     metadata: Mapping[str, Any],
     *,
     commit: str,
@@ -346,8 +700,14 @@ def _validate_manifest(
     if manifest_relative not in inventoried_paths:
         raise ValueError("context artifact manifest is absent from its inventory")
     try:
-        manifest = RepoManifest.load(manifest_path)
-    except (KeyError, OSError, TypeError, ValueError) as exc:
+        manifest_payload = _load_json_object(
+            reader,
+            manifest_relative,
+            label="context artifact repository manifest",
+            max_bytes=_MAX_METADATA_BYTES,
+        )
+        manifest = RepoManifest.from_dict(manifest_payload)
+    except (KeyError, TypeError, ValueError) as exc:
         raise ValueError("context artifact repository manifest is invalid") from exc
     if manifest.version != MANIFEST_VERSION:
         raise ValueError(
@@ -418,8 +778,6 @@ def _validate_manifest(
             entry.path,
             label=f"context artifact {view} view path",
         )
-        if not view_path.is_dir():
-            raise ValueError(f"context artifact view is missing: {view}")
         view_relative = view_path.relative_to(root).as_posix()
         if not any(
             relative == view_relative or relative.startswith(f"{view_relative}/")
@@ -433,96 +791,146 @@ def _validate_manifest(
     return manifest_path, manifest
 
 
-def verify_context_artifact(
-    root: str | Path,
+def _validate_context_limits(max_files: int, max_bytes: int) -> None:
+    if (
+        isinstance(max_files, bool)
+        or not isinstance(max_files, int)
+        or max_files <= 0
+        or isinstance(max_bytes, bool)
+        or not isinstance(max_bytes, int)
+        or max_bytes <= 0
+    ):
+        raise ValueError("context artifact limits must be positive integers")
+
+
+def _context_entry_policy(
     *,
-    expected_repository: str | None = None,
-    expected_commit: str | None = None,
-    max_files: int = _DEFAULT_MAX_FILES,
-    max_bytes: int = _DEFAULT_MAX_BYTES,
+    max_files: int,
+    max_bytes: int,
+) -> Callable[[str, str, int, int], None]:
+    file_count = [0]
+    captured_bytes = [0]
+
+    def policy(relative: str, kind: str, mode: int, size: int) -> None:
+        del mode
+        if kind != "file":
+            return
+        file_count[0] += 1
+        if file_count[0] > max_files + 1:
+            raise ValueError(
+                f"context artifact contains more than {max_files} inventoried files"
+            )
+        name = PurePosixPath(relative).name
+        if name.startswith("documents") and name.endswith(".json"):
+            per_file_limit = _MAX_DOCUMENTS_BYTES
+        elif relative == CONTEXT_ARTIFACT_MANIFEST or name.endswith(".json"):
+            per_file_limit = _MAX_METADATA_BYTES
+        else:
+            per_file_limit = max_bytes
+        if size < 0 or size > per_file_limit:
+            raise ValueError(
+                f"context artifact file exceeds its {per_file_limit}-byte limit: "
+                f"{relative}"
+            )
+        captured_bytes[0] += size
+        if captured_bytes[0] > max_bytes + _MAX_METADATA_BYTES:
+            raise ValueError("context artifact exceeds its captured byte limit")
+
+    return policy
+
+
+def _verify_context_artifact_reader(
+    root: Path,
+    ownership: object,
+    reader: _ContextReader,
+    *,
+    expected_repository: str | None,
+    expected_commit: str | None,
+    max_files: int,
+    max_bytes: int,
+    capture_final: Callable[[], object],
 ) -> VerifiedContextArtifact:
-    """Verify an artifact completely without opening any persisted index."""
-
-    candidate = Path(root).expanduser()
-    if candidate.is_symlink():
-        raise ValueError(
-            f"context artifact root must not be a symbolic link: {candidate}"
+    metadata_path = root / CONTEXT_ARTIFACT_MANIFEST
+    try:
+        metadata = _load_json_object(
+            reader,
+            CONTEXT_ARTIFACT_MANIFEST,
+            label="context artifact metadata",
+            max_bytes=_MAX_METADATA_BYTES,
         )
-    resolved = candidate.resolve()
-    if not resolved.is_dir():
-        raise ValueError(f"context artifact directory does not exist: {resolved}")
-    metadata_path = resolved / CONTEXT_ARTIFACT_MANIFEST
-    if metadata_path.is_symlink() or not metadata_path.is_file():
-        raise ValueError(f"context artifact metadata is missing: {metadata_path}")
-    metadata = _load_json_object(
-        metadata_path,
-        label="context artifact metadata",
-        max_bytes=_MAX_METADATA_BYTES,
-    )
-    if metadata.get("schema") != CONTEXT_ARTIFACT_SCHEMA:
-        raise ValueError(
-            "context artifact schema is incompatible: "
-            f"expected {CONTEXT_ARTIFACT_SCHEMA}, found {metadata.get('schema')!r}"
-        )
-    repository, commit, source_fingerprint = _repository_identity(metadata)
-    views = _artifact_views(metadata)
-    inventory, byte_count = _inventory(
-        metadata,
-        max_files=max_files,
-        max_bytes=max_bytes,
-    )
-
-    expected_files = set(inventory) | {CONTEXT_ARTIFACT_MANIFEST}
-    actual_files = _actual_files(resolved, max_files=max_files)
-    if actual_files != expected_files:
-        missing = sorted(expected_files - actual_files)
-        extra = sorted(actual_files - expected_files)
-        raise ValueError(
-            "context artifact file set differs from its inventory: "
-            f"missing={missing}, extra={extra}"
-        )
-    for relative, (expected_size, expected_digest) in inventory.items():
-        path = _artifact_path(
-            resolved,
-            relative,
-            label=f"context artifact inventory path {relative!r}",
-        )
-        size, digest = file_sha256(path)
-        if size != expected_size or digest != expected_digest:
-            raise ValueError(f"context artifact file digest mismatch: {relative}")
-
-    manifest_path, manifest = _validate_manifest(
-        resolved,
-        metadata,
-        commit=commit,
-        source_fingerprint=source_fingerprint,
-        views=views,
-        inventoried_paths=set(inventory),
-    )
-    source_paths = _validate_view_payloads(
-        resolved,
-        inventory,
-        views=views,
-    )
-    if expected_repository is not None:
-        expected = normalize_repo(expected_repository)
-        if repository != expected:
+        if metadata.get("schema") != CONTEXT_ARTIFACT_SCHEMA:
             raise ValueError(
-                "context artifact repository mismatch: "
-                f"expected {expected}, found {repository}"
+                "context artifact schema is incompatible: "
+                f"expected {CONTEXT_ARTIFACT_SCHEMA}, "
+                f"found {metadata.get('schema')!r}"
             )
-    if expected_commit is not None:
-        expected = expected_commit.strip().lower()
-        if not _COMMIT_RE.fullmatch(expected):
-            raise ValueError("expected context artifact commit must be a full Git SHA")
-        if commit != expected:
+        repository, commit, source_fingerprint = _repository_identity(metadata)
+        views = _artifact_views(metadata)
+        inventory, byte_count = _inventory(
+            metadata,
+            max_files=max_files,
+            max_bytes=max_bytes,
+        )
+        records = {
+            record.path: record
+            for record in directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+        }
+        expected_files = set(inventory) | {CONTEXT_ARTIFACT_MANIFEST}
+        actual_files = set(records)
+        if actual_files != expected_files:
+            missing = sorted(expected_files - actual_files)
+            extra = sorted(actual_files - expected_files)
             raise ValueError(
-                "context artifact commit mismatch: "
-                f"expected {expected[:12]}, found {commit[:12]}"
+                "context artifact file set differs from its inventory: "
+                f"missing={missing}, extra={extra}"
             )
+        for relative, (expected_size, expected_digest) in inventory.items():
+            record = records[relative]
+            if record.size != expected_size or record.sha256 != expected_digest:
+                raise ValueError(f"context artifact file digest mismatch: {relative}")
+
+        manifest_path, manifest = _validate_manifest(
+            root,
+            reader,
+            metadata,
+            commit=commit,
+            source_fingerprint=source_fingerprint,
+            views=views,
+            inventoried_paths=set(inventory),
+        )
+        source_paths = _validate_view_payloads(
+            root,
+            reader,
+            inventory,
+            views=views,
+        )
+        if expected_repository is not None:
+            expected = normalize_repo(expected_repository)
+            if repository != expected:
+                raise ValueError(
+                    "context artifact repository mismatch: "
+                    f"expected {expected}, found {repository}"
+                )
+        if expected_commit is not None:
+            expected = expected_commit.strip().lower()
+            if not _COMMIT_RE.fullmatch(expected):
+                raise ValueError(
+                    "expected context artifact commit must be a full Git SHA"
+                )
+            if commit != expected:
+                raise ValueError(
+                    "context artifact commit mismatch: "
+                    f"expected {expected[:12]}, found {commit[:12]}"
+                )
+        reader.verify_root()
+        if capture_final() != ownership:
+            raise ValueError("context artifact changed during verification")
+    finally:
+        reader.close()
 
     return VerifiedContextArtifact(
-        root=resolved,
+        root=root,
+        ownership=ownership,
         metadata_path=metadata_path,
         manifest_path=manifest_path,
         metadata=metadata,
@@ -537,6 +945,101 @@ def verify_context_artifact(
     )
 
 
+def verify_context_artifact_reader(
+    publication: PublicationDirectoryReader,
+    *,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+    max_files: int = _DEFAULT_MAX_FILES,
+    max_bytes: int = _DEFAULT_MAX_BYTES,
+) -> VerifiedContextArtifact:
+    """Verify an artifact through a publication authority without a path reopen."""
+
+    _validate_context_limits(max_files, max_bytes)
+    policy_factory = lambda: _context_entry_policy(  # noqa: E731
+        max_files=max_files,
+        max_bytes=max_bytes,
+    )
+    ownership = publication.capture_ownership(entry_policy=policy_factory())
+    reader = _PublicationContextReader(
+        publication,
+        ownership,
+        entry_policy_factory=policy_factory,
+    )
+    return _verify_context_artifact_reader(
+        Path("/__codenib_context_artifact__"),
+        ownership,
+        reader,
+        expected_repository=expected_repository,
+        expected_commit=expected_commit,
+        max_files=max_files,
+        max_bytes=max_bytes,
+        capture_final=lambda: publication.capture_ownership(
+            entry_policy=policy_factory(),
+        ),
+    )
+
+
+def verify_context_artifact(
+    root: str | Path,
+    *,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+    max_files: int = _DEFAULT_MAX_FILES,
+    max_bytes: int = _DEFAULT_MAX_BYTES,
+) -> VerifiedContextArtifact:
+    """Verify an artifact completely without opening any persisted index."""
+
+    _validate_context_limits(max_files, max_bytes)
+    resolved = lexical_directory_path(Path(root))
+    policy_factory = lambda: _context_entry_policy(  # noqa: E731
+        max_files=max_files,
+        max_bytes=max_bytes,
+    )
+
+    try:
+        ownership = capture_directory_ownership(
+            resolved,
+            entry_policy=policy_factory(),
+        )
+    except ValueError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(
+            "context artifact directory could not be captured safely; it may "
+            f"contain a symbolic link or unstable content: {resolved}"
+        ) from exc
+
+    def verify(publication: PublicationDirectoryReader) -> VerifiedContextArtifact:
+        reader = _PublicationContextReader(
+            publication,
+            ownership,
+            entry_policy_factory=policy_factory,
+        )
+        return _verify_context_artifact_reader(
+            resolved,
+            ownership,
+            reader,
+            expected_repository=expected_repository,
+            expected_commit=expected_commit,
+            max_files=max_files,
+            max_bytes=max_bytes,
+            capture_final=lambda: publication.capture_ownership(
+                entry_policy=policy_factory(),
+            ),
+        )
+
+    try:
+        return reopen_authenticated_directory(resolved, ownership, verify)
+    except ValueError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(
+            "context artifact directory could not be reopened safely; it may "
+            f"contain a symbolic link or unstable content: {resolved}"
+        ) from exc
+
+
 def bind_context_artifact(
     root: str | Path,
     repo_path: str | Path,
@@ -544,65 +1047,117 @@ def bind_context_artifact(
     expected_repository: str | None = None,
     expected_commit: str | None = None,
 ) -> ContextArtifactBinding:
-    """Verify an artifact and bind it to an exact, unchanged checkout."""
+    """Bind an artifact to retained, v2-authenticated repository content."""
 
     artifact = verify_context_artifact(
         root,
         expected_repository=expected_repository,
         expected_commit=expected_commit,
     )
-    repo = Path(repo_path).expanduser().resolve()
-    if not repo.is_dir():
-        raise ValueError(f"repository checkout does not exist: {repo}")
-    actual_commit = checkout_commit(repo)
-    if actual_commit != artifact.commit:
-        actual_label = actual_commit[:12] if actual_commit else "not-a-git-checkout"
-        raise ValueError(
-            "repository checkout commit does not match the context artifact: "
-            f"checkout={actual_label}, artifact={artifact.commit[:12]}"
-        )
-    source = fingerprint_repository(
-        repo,
-        exclude_roots=(artifact.root,),
-    )
-    if source.value != artifact.source_fingerprint:
-        raise ValueError(
-            "repository source files do not match the context artifact fingerprint"
-        )
-    if source.file_count != artifact.manifest.file_count:
-        raise ValueError(
-            "repository file count does not match the context artifact manifest"
-        )
-    for relative in artifact.source_paths:
-        try:
-            validate_repository_file(repo, relative)
-        except ValueError as exc:
-            raise ValueError(
-                "context artifact source path is not a stable file inside "
-                f"the repository checkout: {relative}"
-            ) from exc
+    cleanup_owner = SourceBindingCleanupOwner()
 
-    manifest_data = artifact.manifest.to_dict()
-    manifest_data["repo"]["path"] = str(repo)
-    for view, entry in manifest_data["indexes"].items():
-        entry["path"] = str(
-            _artifact_path(
-                artifact.root,
-                entry["path"],
-                label=f"context artifact {view} view path",
+    def bind(_publication: PublicationDirectoryReader) -> ContextArtifactBinding:
+        if not is_secure_source_fingerprint_v2(artifact.source_fingerprint):
+            raise ValueError(
+                "legacy context artifact source fingerprints are query-only; "
+                "rebuild with source fingerprint v2 before binding a live checkout"
             )
+        repo = lexical_repository_path(repo_path)
+        source = capture_repository_source(
+            repo,
+            exclude_roots=(artifact.root,),
+            _source_owner=cleanup_owner.retain,
         )
-    manifest = RepoManifest.from_dict(manifest_data)
+        # This is diagnostic provenance only. A mutable Git HEAD cannot be
+        # attested by any finite sequence of path reads, so it never gates the
+        # retained content authority or native trust.
+        actual_commit = checkout_commit(repo)
+        source.verify_snapshot()
+        if source.fingerprint != artifact.source_fingerprint:
+            raise ValueError(
+                "repository source files do not match the context artifact fingerprint"
+            )
+        if source.file_count != artifact.manifest.file_count:
+            raise ValueError(
+                "repository file count does not match the context artifact manifest"
+            )
+        source_records = {record.path for record in source.file_records}
+        missing_source_paths = sorted(set(artifact.source_paths) - source_records)
+        if missing_source_paths:
+            raise ValueError(
+                "context artifact source paths are absent from the authenticated "
+                "repository: " + ", ".join(missing_source_paths)
+            )
+
+        manifest_data = artifact.manifest.to_dict()
+        manifest_data["repo"]["path"] = str(repo)
+        for view, entry in manifest_data["indexes"].items():
+            entry["path"] = str(
+                _artifact_path(
+                    artifact.root,
+                    entry["path"],
+                    label=f"context artifact {view} view path",
+                )
+            )
+        manifest = RepoManifest.from_dict(manifest_data)
+        return ContextArtifactBinding(
+            artifact=artifact,
+            repo_path=repo,
+            manifest=manifest,
+            checkout_commit_observed=actual_commit or None,
+            _source_binding=source,
+        )
+
+    try:
+        return reopen_authenticated_directory(
+            artifact.root,
+            artifact.ownership,  # type: ignore[arg-type]
+            bind,
+        )
+    except BaseException as exc:  # noqa: B036 - cleanup before propagation
+        try:
+            cleanup_owner.close()
+        except BaseException:  # noqa: B036 - preserve primary, retain owner
+            _attach_source_cleanup_owner(exc, cleanup_owner)
+        if isinstance(exc, ValueError):
+            raise
+        if not isinstance(exc, (OSError, RuntimeError)):
+            raise
+        translated = ValueError(
+            "context artifact changed between verification and source binding"
+        )
+        _attach_source_cleanup_owner(translated, cleanup_owner)
+        raise translated from exc
+
+
+def query_context_artifact(
+    root: str | Path,
+    *,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+) -> ContextArtifactBinding:
+    """Create an authority-bound, source-disabled portable query binding."""
+
+    artifact = verify_context_artifact(
+        root,
+        expected_repository=expected_repository,
+        expected_commit=expected_commit,
+    )
     return ContextArtifactBinding(
         artifact=artifact,
-        repo_path=repo,
-        manifest=manifest,
+        repo_path=None,
+        manifest=artifact.manifest,
+        checkout_commit_observed=None,
+        _source_binding=None,
     )
 
 
 __all__ = [
     "ContextArtifactBinding",
+    "SourceBindingCleanupOwner",
     "VerifiedContextArtifact",
     "bind_context_artifact",
+    "query_context_artifact",
     "verify_context_artifact",
+    "verify_context_artifact_reader",
 ]

--- a/codenib/artifacts/runtime.py
+++ b/codenib/artifacts/runtime.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
 
+from .._contained_source import validate_repository_file
 from ..compiler.checkout_identity import checkout_commit
 from ..compiler.manifest import MANIFEST_FILENAME, MANIFEST_VERSION, RepoManifest
 from ..compiler.snapshot_store import normalize_repo
@@ -30,6 +31,7 @@ _REPOSITORY_RE = re.compile(r"^[a-z0-9_.-]+(?:/[a-z0-9_.-]+)*$")
 _DEFAULT_MAX_FILES = 100_000
 _DEFAULT_MAX_BYTES = 64 * 1024 * 1024 * 1024
 _MAX_METADATA_BYTES = 16 * 1024 * 1024
+_MAX_DOCUMENTS_BYTES = 256 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -276,7 +278,7 @@ def _validate_view_payloads(
         metadata = _load_json_object(
             root / metadata_relative,
             label="portable BM25 metadata",
-            max_bytes=inventory[metadata_relative][0],
+            max_bytes=_MAX_METADATA_BYTES,
         )
         if metadata.get("project_root") != "source":
             raise ValueError("portable BM25 project root must be 'source'")
@@ -284,7 +286,7 @@ def _validate_view_payloads(
             _document_source_paths(
                 root / documents_relative,
                 label="portable BM25 documents",
-                max_bytes=inventory[documents_relative][0],
+                max_bytes=_MAX_DOCUMENTS_BYTES,
             )
         )
 
@@ -311,7 +313,7 @@ def _validate_view_payloads(
                 _document_source_paths(
                     root.joinpath(*path.parts),
                     label=f"portable vector documents {relative}",
-                    max_bytes=inventory[relative][0],
+                    max_bytes=_MAX_DOCUMENTS_BYTES,
                 )
             )
     return tuple(sorted(source_paths))
@@ -572,15 +574,13 @@ def bind_context_artifact(
             "repository file count does not match the context artifact manifest"
         )
     for relative in artifact.source_paths:
-        candidate = repo.joinpath(*PurePosixPath(relative).parts)
-        resolved_source = candidate.resolve()
-        if not resolved_source.is_file() or (
-            resolved_source != repo and repo not in resolved_source.parents
-        ):
+        try:
+            validate_repository_file(repo, relative)
+        except ValueError as exc:
             raise ValueError(
-                "context artifact source path does not resolve to a file inside "
+                "context artifact source path is not a stable file inside "
                 f"the repository checkout: {relative}"
-            )
+            ) from exc
 
     manifest_data = artifact.manifest.to_dict()
     manifest_data["repo"]["path"] = str(repo)

--- a/codenib/artifacts/security.py
+++ b/codenib/artifacts/security.py
@@ -11,6 +11,8 @@ import json
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+from .._secret_fields import assert_no_secret_fields
+
 _SENSITIVE_ENV_NAMES = {
     "ANTHROPIC_API_KEY",
     "AWS_SECRET_ACCESS_KEY",
@@ -26,33 +28,42 @@ _SENSITIVE_ENV_NAMES = {
 }
 _SENSITIVE_ENV_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET")
 _SCAN_CHUNK_BYTES = 1024 * 1024
-_CREDENTIAL_FIELDS = {
-    "access_token",
-    "api_key",
-    "apikey",
-    "authorization",
-    "bearer_token",
-    "client_secret",
-    "headers",
-    "password",
-    "private_key",
-    "secret_key",
-    "token",
-}
 
 
 def assert_no_credential_fields(value: Any, *, source: str) -> None:
     """Reject credential-shaped keys in metadata intended for publication."""
 
-    if isinstance(value, Mapping):
-        for key, item in value.items():
-            name = str(key).strip().lower().replace("-", "_")
-            if name in _CREDENTIAL_FIELDS:
-                raise ValueError(f"{source} contains a credential field: {key}")
-            assert_no_credential_fields(item, source=source)
-    elif isinstance(value, (list, tuple)):
-        for item in value:
-            assert_no_credential_fields(item, source=source)
+    assert_no_secret_fields(value, source=source)
+
+
+def assert_publishable_json_value(
+    value: Any,
+    *,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+    label: str,
+) -> None:
+    """Scan decoded JSON semantics without depending on their source encoding."""
+
+    assert_no_credential_fields(value, source=label)
+    payload = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    forbidden_values: list[str] = []
+    for path in forbidden_paths:
+        resolved = path.expanduser().resolve()
+        forbidden_values.extend((str(resolved), resolved.as_posix()))
+    if any(
+        pattern and pattern in payload
+        for pattern in _serialized_patterns(forbidden_values)
+    ):
+        raise ValueError(f"{label} contains an absolute build-machine path")
+    if any(pattern and pattern in payload for pattern in _secret_values(environ)):
+        raise ValueError(f"{label} contains a configured credential")
 
 
 def _serialized_patterns(values: Iterable[str]) -> tuple[bytes, ...]:
@@ -168,6 +179,7 @@ def assert_publishable_tree(
 
 __all__ = [
     "assert_no_credential_fields",
+    "assert_publishable_json_value",
     "assert_publishable_tree",
     "file_sha256",
 ]

--- a/codenib/artifacts/security.py
+++ b/codenib/artifacts/security.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
@@ -46,24 +47,49 @@ def assert_publishable_json_value(
     """Scan decoded JSON semantics without depending on their source encoding."""
 
     assert_no_credential_fields(value, source=label)
-    payload = json.dumps(
-        value,
-        allow_nan=False,
-        ensure_ascii=True,
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("ascii")
     forbidden_values: list[str] = []
     for path in forbidden_paths:
         resolved = path.expanduser().resolve()
         forbidden_values.extend((str(resolved), resolved.as_posix()))
-    if any(
-        pattern and pattern in payload
-        for pattern in _serialized_patterns(forbidden_values)
-    ):
-        raise ValueError(f"{label} contains an absolute build-machine path")
-    if any(pattern and pattern in payload for pattern in _secret_values(environ)):
-        raise ValueError(f"{label} contains a configured credential")
+    forbidden = tuple(item for item in forbidden_values if item)
+    secrets = tuple(
+        value
+        for name, value in environ.items()
+        if isinstance(value, str)
+        and len(value) >= 8
+        and (
+            name.upper() in _SENSITIVE_ENV_NAMES
+            or name.upper().endswith(_SENSITIVE_ENV_SUFFIXES)
+        )
+    )
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            for key, child in current.items():
+                if not isinstance(key, str):
+                    raise ValueError(f"{label} contains a non-text JSON object key")
+                if any(pattern in key for pattern in forbidden):
+                    raise ValueError(f"{label} contains an absolute build-machine path")
+                if any(pattern in key for pattern in secrets):
+                    raise ValueError(f"{label} contains a configured credential")
+                stack.append(child)
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+        elif isinstance(current, str):
+            if any(pattern in current for pattern in forbidden):
+                raise ValueError(f"{label} contains an absolute build-machine path")
+            if any(pattern in current for pattern in secrets):
+                raise ValueError(f"{label} contains a configured credential")
+        elif current is None or isinstance(current, (bool, int)):
+            continue
+        elif isinstance(current, float):
+            if not math.isfinite(current):
+                raise ValueError(f"{label} contains a non-finite JSON number")
+        else:
+            raise ValueError(
+                f"{label} contains unsupported JSON value: " f"{type(current).__name__}"
+            )
 
 
 def _serialized_patterns(values: Iterable[str]) -> tuple[bytes, ...]:

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -882,6 +882,7 @@ def _audit_local_wiki(local) -> dict[str, object]:
 
     from .llm.litellm_chat import LiteLLMChat
     from .web.config import load_config
+    from .web.native_authority import authorize_local_manifest_vector
     from .web.repo_registry import RepoRegistry
     from .wiki.agent_wiki import AgentWiki
     from .wiki.quality import audit_wiki
@@ -896,7 +897,10 @@ def _audit_local_wiki(local) -> dict[str, object]:
     if local.runtime_env.get("CODENIB_EMBEDDING_API_KEY"):
         config.embedding_api_key = local.runtime_env["CODENIB_EMBEDDING_API_KEY"]
 
-    registry = RepoRegistry(config)
+    registry = RepoRegistry(
+        config,
+        native_index_authorization_resolver=authorize_local_manifest_vector,
+    )
     registry.load_all()
     bundle = registry.get(local.repo_id)
     if bundle is None:

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -13,6 +13,7 @@ import os
 import re
 import shlex
 import shutil
+import stat
 import sys
 from collections import Counter
 from dataclasses import dataclass, field
@@ -218,8 +219,9 @@ def _split_values(values: Iterable[str] | None) -> list[str]:
 def detect_languages(repo_path: str | os.PathLike[str]) -> list[str]:
     """Detect supported source languages, ordered by source-file count."""
     from .languages import extension_to_language_map
+    from .source_fingerprint import lexical_repository_path
 
-    root = Path(repo_path).expanduser().resolve()
+    root = lexical_repository_path(repo_path)
     extension_map = extension_to_language_map("chunker")
     counts: Counter[str] = Counter()
 
@@ -260,8 +262,18 @@ def normalize_languages(values: Iterable[str]) -> list[str]:
 
 
 def resolve_repo_path(value: str) -> Path:
-    path = Path(value).expanduser().resolve()
-    if not path.is_dir():
+    from .source_fingerprint import lexical_repository_path
+
+    path = lexical_repository_path(value)
+    try:
+        metadata = path.lstat()
+    except OSError:
+        metadata = None
+    if (
+        metadata is None
+        or stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+    ):
         raise CLIError(f"repository directory does not exist: {path}")
     return path
 
@@ -271,22 +283,40 @@ def resolve_manifest_path(value: str) -> Path:
     from .compiler.manifest import MANIFEST_FILENAME
     from .paths import legacy_repo_index_dir, repo_index_dir
 
-    path = Path(value).expanduser().resolve()
-    if path.is_dir():
+    path = Path(os.path.abspath(os.fspath(Path(value).expanduser())))
+    try:
+        metadata = path.lstat()
+    except OSError:
+        metadata = None
+    if metadata is not None and stat.S_ISLNK(metadata.st_mode):
+        raise CLIError(f"manifest path must not be a symbolic link: {path}")
+    if metadata is not None and stat.S_ISDIR(metadata.st_mode):
         candidates = (
             repo_index_dir(path) / MANIFEST_FILENAME,
             legacy_repo_index_dir(path) / MANIFEST_FILENAME,
         )
         path = next(
-            (candidate for candidate in candidates if candidate.is_file()),
+            (
+                candidate
+                for candidate in candidates
+                if _is_regular_file_nofollow(candidate)
+            ),
             candidates[0],
         )
-    if not path.is_file():
+    if not _is_regular_file_nofollow(path):
         raise CLIError(
             f"manifest not found: {path}\n"
             "Run `codenib index <repo>` before starting this command."
         )
     return path
+
+
+def _is_regular_file_nofollow(path: Path) -> bool:
+    try:
+        metadata = path.lstat()
+    except OSError:
+        return False
+    return stat.S_ISREG(metadata.st_mode)
 
 
 def _selected_languages(repo_path: Path, explicit: Iterable[str]) -> list[str]:
@@ -484,15 +514,14 @@ def _run_mcp(args: argparse.Namespace) -> int:
     from .mcp.server import main as mcp_main
 
     if args.artifact:
-        repo_path = resolve_repo_path(args.repo)
         command = [
             "--artifact",
-            str(Path(args.artifact).expanduser().resolve()),
-            "--repo",
-            str(repo_path),
+            str(Path(os.path.abspath(os.fspath(Path(args.artifact).expanduser())))),
             "--log-level",
             args.log_level,
         ]
+        if args.repo is not None:
+            command.extend(("--repo", str(resolve_repo_path(args.repo))))
         if args.repository:
             command.extend(("--repository", args.repository))
         mcp_main(command)
@@ -506,7 +535,7 @@ def _run_export(args: argparse.Namespace) -> int:
     repo_path = resolve_repo_path(args.repo)
     manifest_path = resolve_manifest_path(str(repo_path))
     output_dir = (
-        Path(args.output).expanduser().resolve()
+        Path(os.path.abspath(os.fspath(Path(args.output).expanduser())))
         if args.output
         else manifest_path.parent / "static-wiki"
     )
@@ -580,7 +609,14 @@ def _validate_publish_outputs(
 
     protected = (
         (repo_path, "repository"),
-        (repo_index_dir(repo_path).expanduser().resolve(), "index state"),
+        (
+            Path(
+                os.path.abspath(
+                    os.fspath(repo_index_dir(repo_path).expanduser()),
+                )
+            ),
+            "index state",
+        ),
     )
     for output, output_name in (
         (site_output, "Wiki"),
@@ -605,7 +641,7 @@ def _run_artifact_pack(args: argparse.Namespace) -> int:
 
     manifest = RepoManifest.load(manifest_path)
     output_dir = (
-        Path(args.output).expanduser().resolve()
+        Path(os.path.abspath(os.fspath(Path(args.output).expanduser())))
         if args.output
         else _default_distribution_dir(
             manifest_path,
@@ -735,10 +771,12 @@ def _run_artifact_mcp_config(args: argparse.Namespace) -> int:
 def _run_publish(args: argparse.Namespace) -> int:
     repo_path = resolve_repo_path(args.repo)
     site_output = (
-        Path(args.site_output).expanduser().resolve() if args.site_output else None
+        Path(os.path.abspath(os.fspath(Path(args.site_output).expanduser())))
+        if args.site_output
+        else None
     )
     context_output = (
-        Path(args.context_output).expanduser().resolve()
+        Path(os.path.abspath(os.fspath(Path(args.context_output).expanduser())))
         if args.context_output
         else None
     )
@@ -1979,8 +2017,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     mcp_parser.add_argument(
         "--repo",
-        default=".",
-        help="exact checkout bound to --artifact",
+        help="optional exact checkout bound to --artifact",
     )
     mcp_parser.add_argument(
         "--repository",

--- a/codenib/clients/_manifest.py
+++ b/codenib/clients/_manifest.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from typing import Callable
@@ -14,7 +15,8 @@ from codenib.compiler.manifest import MANIFEST_FILENAME, RepoManifest
 from codenib.paths import legacy_repo_index_dir, repo_index_dir
 from codenib.source_fingerprint import (
     fingerprint_repository,
-    repository_source_is_dirty,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
 )
 
 ManifestResolver = Callable[[Path], str | Path]
@@ -58,39 +60,25 @@ def _validate_source_identity(
             f"manifest: {head} != {expected_commit}"
         )
 
-    excluded = (repo_index_dir(repo), legacy_repo_index_dir(repo))
-    if expected_commit and head == expected_commit:
-        if not repository_source_is_dirty(repo, exclude_roots=excluded):
-            return
-        if not manifest.source_fingerprint:
-            raise ValueError(
-                f"{integration_name} checkout has source changes that the CodeNib "
-                "manifest cannot validate"
-            )
-
-    if manifest.source_fingerprint:
-        observed = fingerprint_repository(repo, exclude_roots=excluded).value
-        if observed != manifest.source_fingerprint:
-            raise ValueError(
-                f"{integration_name} checkout source fingerprint does not match the "
-                "CodeNib manifest"
-            )
-        return
-
-    if expected_commit:
+    if not is_secure_source_fingerprint_v2(manifest.source_fingerprint):
         raise ValueError(
-            f"{integration_name} cannot read the checkout revision required by the "
+            f"{integration_name} CodeNib manifest has no secure v2 source "
+            "fingerprint; rebuild the index"
+        )
+
+    excluded = (repo_index_dir(repo), legacy_repo_index_dir(repo))
+    observed = fingerprint_repository(repo, exclude_roots=excluded).value
+    if observed != manifest.source_fingerprint:
+        raise ValueError(
+            f"{integration_name} checkout source fingerprint does not match the "
             "CodeNib manifest"
         )
-    raise ValueError(
-        f"{integration_name} CodeNib manifest has no commit or source fingerprint"
-    )
 
 
 def resolve_checkout_manifest(repo_path: str | Path) -> Path:
     """Resolve the canonical or legacy CodeNib manifest for one checkout."""
 
-    repo = Path(repo_path).expanduser().resolve()
+    repo = lexical_repository_path(repo_path)
     candidates = (
         repo_index_dir(repo) / MANIFEST_FILENAME,
         legacy_repo_index_dir(repo) / MANIFEST_FILENAME,
@@ -104,7 +92,7 @@ def resolve_checkout_manifest(repo_path: str | Path) -> Path:
             f"CodeNib manifest not found for {repo}: {manifest_path}. "
             "Run `codenib index <repo> --preset graph` first."
         )
-    return manifest_path.resolve()
+    return manifest_path
 
 
 def select_checkout_manifest(
@@ -116,13 +104,15 @@ def select_checkout_manifest(
 ) -> Path:
     """Select and validate the manifest bound to an external-policy request."""
 
-    repo = Path(repo_path).expanduser().resolve()
+    repo = lexical_repository_path(repo_path)
     if manifest_path is not None and manifest_resolver is not None:
         raise ValueError("Specify either manifest_path or manifest_resolver, not both")
     if manifest_path is not None:
-        selected = Path(manifest_path).expanduser().resolve()
+        selected = Path(os.path.abspath(os.fspath(Path(manifest_path).expanduser())))
     elif manifest_resolver is not None:
-        selected = Path(manifest_resolver(repo)).expanduser().resolve()
+        selected = Path(
+            os.path.abspath(os.fspath(Path(manifest_resolver(repo)).expanduser()))
+        )
     else:
         selected = resolve_checkout_manifest(repo)
 
@@ -130,7 +120,7 @@ def select_checkout_manifest(
         raise FileNotFoundError(f"CodeNib manifest not found: {selected}")
     manifest = RepoManifest.load(selected)
     if manifest.repo_path:
-        manifest_repo = Path(manifest.repo_path).expanduser().resolve()
+        manifest_repo = lexical_repository_path(manifest.repo_path)
         if manifest_repo != repo:
             raise ValueError(
                 f"{integration_name} repo_path does not match the CodeNib manifest: "

--- a/codenib/clients/agentless_agent.py
+++ b/codenib/clients/agentless_agent.py
@@ -25,6 +25,7 @@ from codenib.eval.benchmarks.agentless import (
 )
 from codenib.integrations._repository import RepositoryEntity
 from codenib.integrations.agentless import AgentlessRepositoryProvider
+from codenib.source_fingerprint import lexical_repository_path
 from codenib.types import NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
 
 
@@ -198,7 +199,7 @@ class AgentlessAgent:
     ) -> BaselineRunResult:
         """Localize one issue through the shared baseline interface."""
 
-        repo = Path(repo_path).expanduser().resolve()
+        repo = lexical_repository_path(repo_path)
         if not repo.is_dir():
             return BaselineRunResult(
                 success=False,

--- a/codenib/clients/cosil_agent.py
+++ b/codenib/clients/cosil_agent.py
@@ -23,6 +23,7 @@ from codenib.eval.benchmarks.cosil import (
     parse_cosil_locations,
 )
 from codenib.integrations.cosil import CoSILRepositoryProvider, get_cosil_tool_schemas
+from codenib.source_fingerprint import lexical_repository_path
 
 _FALSE_OBSERVATION = (
     "I have already checked this function/class and it is not related to the bug. "
@@ -157,7 +158,7 @@ class CoSILAgent:
         repo_path: str,
         context: Optional[Mapping[str, Any]] = None,
     ) -> BaselineRunResult:
-        repo = Path(repo_path).expanduser().resolve()
+        repo = lexical_repository_path(repo_path)
         if not repo.is_dir():
             return BaselineRunResult(
                 success=False,

--- a/codenib/clients/locagent_agent.py
+++ b/codenib/clients/locagent_agent.py
@@ -19,6 +19,7 @@ from codenib.eval.baseline import BaselineLocation, BaselineRunResult
 from codenib.eval.benchmarks.locagent import LocAgentLocation, parse_locagent_locations
 from codenib.integrations._repository import RepositoryAdapter, RepositoryEntity
 from codenib.integrations.locagent import LocAgentToolProvider
+from codenib.source_fingerprint import lexical_repository_path
 from codenib.types import (
     NODE_TYPE_CLASS,
     NODE_TYPE_FUNCTION,
@@ -280,7 +281,7 @@ class LocAgentAgent:
     ) -> BaselineRunResult:
         """Localize one task through the shared external-agent interface."""
 
-        repo = Path(repo_path).expanduser().resolve()
+        repo = lexical_repository_path(repo_path)
         if not repo.is_dir():
             return BaselineRunResult(
                 success=False,

--- a/codenib/clients/orcaloca_agent.py
+++ b/codenib/clients/orcaloca_agent.py
@@ -24,6 +24,7 @@ from codenib.clients._manifest import (
 )
 from codenib.eval.baseline import BaselineLocation, BaselineRunResult
 from codenib.eval.benchmarks.orcaloca import OrcaLocaLocation, parse_orcaloca_locations
+from codenib.source_fingerprint import lexical_repository_path
 
 OrcaLocaPayload = str | Mapping[str, Any] | Sequence[Mapping[str, Any]]
 
@@ -151,7 +152,7 @@ class OrcaLocaAgent:
     ) -> BaselineRunResult:
         """Localize one task using the shared external-agent interface."""
 
-        repo = Path(repo_path).expanduser().resolve()
+        repo = lexical_repository_path(repo_path)
         if not repo.is_dir():
             return BaselineRunResult(
                 success=False,

--- a/codenib/compiler/artifact_fingerprints.py
+++ b/codenib/compiler/artifact_fingerprints.py
@@ -7,20 +7,71 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import stat
 from pathlib import Path
 from typing import Any, Mapping
 
 _BM25_ARTIFACT_PATHS = (Path("documents.json"), Path("bm25_metadata.json"))
+_READ_BYTES = 1024 * 1024
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+
+
+def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
 
 
 def _file_fingerprint(path: Path) -> dict[str, Any]:
-    digest = hashlib.sha256()
-    size = 0
-    with path.open("rb") as handle:
-        while block := handle.read(1024 * 1024):
+    descriptor = -1
+    try:
+        before = path.lstat()
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or bool(
+                getattr(before, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+            )
+        ):
+            raise ValueError(f"invalid BM25 artifact file: {path}")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or _file_identity(opened) != _file_identity(
+            before
+        ):
+            raise ValueError(f"BM25 artifact file changed while opening: {path}")
+        digest = hashlib.sha256()
+        remaining = opened.st_size
+        while remaining:
+            block = os.read(descriptor, min(remaining, _READ_BYTES))
+            if not block:
+                raise ValueError(f"BM25 artifact file was truncated: {path}")
             digest.update(block)
-            size += len(block)
-    return {"size": size, "sha256": digest.hexdigest()}
+            remaining -= len(block)
+        if os.read(descriptor, 1):
+            raise ValueError(f"BM25 artifact file grew while hashing: {path}")
+        after_open = os.fstat(descriptor)
+        after_path = path.lstat()
+        if _file_identity(after_open) != _file_identity(opened) or _file_identity(
+            after_path
+        ) != _file_identity(opened):
+            raise ValueError(f"BM25 artifact file changed while hashing: {path}")
+        return {"size": opened.st_size, "sha256": digest.hexdigest()}
+    except OSError as exc:
+        raise ValueError(f"invalid BM25 artifact file: {path}") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
 
 
 def bm25_artifact_file_fingerprints(
@@ -32,8 +83,6 @@ def bm25_artifact_file_fingerprints(
     fingerprints: dict[str, dict[str, Any]] = {}
     for relative in _BM25_ARTIFACT_PATHS:
         path = artifact_root / relative
-        if path.is_symlink() or not path.is_file():
-            raise ValueError(f"invalid BM25 artifact file: {path}")
         fingerprints[relative.as_posix()] = _file_fingerprint(path)
     return fingerprints
 

--- a/codenib/compiler/artifact_quality.py
+++ b/codenib/compiler/artifact_quality.py
@@ -12,8 +12,15 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
 from .. import compat_pickle
+from .._captured_directory import AuthenticatedSnapshotReader
 from ..git_snapshot import GitSourceSurface, normalize_repository_path
 from ..graph.code_graph import CodeGraph
+from ..index.embedding.artifact_integrity import AuthenticatedVectorView
+from ..native_index_authorization import (
+    NativeIndexAuthorization,
+    require_native_index_authorization,
+    require_native_index_authorization_preflight,
+)
 from ..types import NODE_TYPE_DIRECTORY, NODE_TYPE_FILE, ROOT_NODE, is_symbol_node
 
 ARTIFACT_QUALITY_SCHEMA_VERSION = 1
@@ -242,32 +249,37 @@ def constrain_and_assess_graph_artifact(
 
 
 def _load_vector_level(
-    root: Path,
+    view: AuthenticatedVectorView,
     level: str,
     model_suffix: str,
 ) -> tuple[list[Any], int, list[str], bool]:
     import faiss
 
     failures = []
-    level_root = root / level
-    config_path = level_root / f"config_{model_suffix}.json"
-    index_path = level_root / f"index_{model_suffix}.faiss"
-    documents_path = level_root / f"documents_{model_suffix}.pkl"
-    for path in (config_path, index_path, documents_path):
-        if not path.is_file():
-            failures.append(f"missing:{path.name}")
+    config_relative = f"{level}/config_{model_suffix}.json"
+    index_relative = f"{level}/index_{model_suffix}.faiss"
+    documents_relative = f"{level}/documents_{model_suffix}.pkl"
+    for relative in (config_relative, index_relative, documents_relative):
+        if not view.has_file(relative):
+            failures.append(f"missing:{Path(relative).name}")
     if failures:
         return [], 0, failures, False
 
     try:
-        config = json.loads(config_path.read_text(encoding="utf-8"))
-        with documents_path.open("rb") as handle:
-            documents = list(compat_pickle.load(handle))
-        index = faiss.read_index(str(index_path))
+        config = view.load_json_object(
+            config_relative,
+            label=f"vector {level} quality config",
+        )
+        with view.authenticated_snapshot(documents_relative) as (snapshot, _record):
+            documents = list(compat_pickle.load(AuthenticatedSnapshotReader(snapshot)))
+        with view.authenticated_snapshot(index_relative) as (snapshot, _record):
+            source = AuthenticatedSnapshotReader(snapshot)
+            callback_reader = faiss.PyCallbackIOReader(  # type: ignore[attr-defined]
+                source.read
+            )
+            index = faiss.read_index(callback_reader)
     except Exception as exc:
         return [], 0, [f"unreadable_level:{type(exc).__name__}"], False
-    if not isinstance(config, Mapping):
-        return [], 0, ["invalid_level_config"], False
     expected = config.get("num_documents")
     if not isinstance(expected, int) or isinstance(expected, bool) or expected < 0:
         failures.append("invalid_document_config_count")
@@ -350,38 +362,55 @@ def vector_artifact_files_match(
     ) == dict(expected_fingerprints)
 
 
-def assess_vector_artifact(
-    root: str | Path,
+def _captured_vector_artifact_file_fingerprints(
+    view: AuthenticatedVectorView,
+    *,
+    model_suffix: str,
+    build_levels: Sequence[str],
+) -> dict[str, dict[str, Any]]:
+    """Return fingerprints from the exact tree authorized for assessment."""
+
+    fingerprints: dict[str, dict[str, Any]] = {}
+    for relative_path in _vector_artifact_relative_paths(model_suffix, build_levels):
+        relative = relative_path.as_posix()
+        if not view.has_file(relative):
+            continue
+        record = view.record(relative)
+        fingerprints[relative] = {
+            "size": record.size,
+            "sha256": record.sha256,
+        }
+    return fingerprints
+
+
+def _assess_captured_vector_artifact(
     *,
     embedding_model: str,
     build_levels: Sequence[str],
     surface: GitSourceSurface,
     expected_artifact: Mapping[str, Any],
     required_l0_files: Sequence[str] = (),
+    authenticated_view: AuthenticatedVectorView,
 ) -> dict[str, Any]:
-    """Validate vector files, provenance, commit paths, and L0 GT coverage."""
-
-    artifact_root = Path(root)
     model_suffix = embedding_model.replace("/", "__")
-    top_config_path = artifact_root / f"config_{model_suffix}.json"
+    top_config_relative = f"config_{model_suffix}.json"
     failures: list[str] = []
     top_config: Mapping[str, Any] = {}
-    if not top_config_path.is_file():
+    if not authenticated_view.has_file(top_config_relative):
         failures.append("missing_top_config")
     else:
         try:
-            top_config = json.loads(top_config_path.read_text(encoding="utf-8"))
+            top_config = authenticated_view.load_json_object(
+                top_config_relative,
+                label="vector quality top-level config",
+            )
         except Exception as exc:
             failures.append(f"unreadable_top_config:{type(exc).__name__}")
         else:
-            if not isinstance(top_config, Mapping):
-                failures.append("invalid_top_config")
-                top_config = {}
-            else:
-                if top_config.get("embedding_model") != embedding_model:
-                    failures.append("embedding_model_mismatch")
-                if top_config.get("artifact") != dict(expected_artifact):
-                    failures.append("artifact_identity_mismatch")
+            if top_config.get("embedding_model") != embedding_model:
+                failures.append("embedding_model_mismatch")
+            if top_config.get("artifact") != dict(expected_artifact):
+                failures.append("artifact_identity_mismatch")
 
     levels: dict[str, Any] = {}
     all_paths: set[str] = set()
@@ -391,9 +420,8 @@ def assess_vector_artifact(
     normalized_levels = tuple(dict.fromkeys(level.lower() for level in build_levels))
     unexpected_levels = []
     for level in sorted({"l0", "l2"} - set(normalized_levels)):
-        level_root = artifact_root / level
         if any(
-            (level_root / name).exists()
+            authenticated_view.has_file(f"{level}/{name}")
             for name in (
                 f"config_{model_suffix}.json",
                 f"index_{model_suffix}.faiss",
@@ -405,7 +433,7 @@ def assess_vector_artifact(
             failures.append(f"unexpected_level:{level}")
     for level in normalized_levels:
         documents, vector_count, level_failures, loaded = _load_vector_level(
-            artifact_root, level, model_suffix
+            authenticated_view, level, model_suffix
         )
         paths = set()
         for document_index, document in enumerate(documents):
@@ -447,9 +475,9 @@ def assess_vector_artifact(
     missing = tuple(path for path in required if path not in l0_paths)
     if missing:
         failures.append("missing_required_l0_files")
-    file_fingerprints = vector_artifact_file_fingerprints(
-        artifact_root,
-        embedding_model=embedding_model,
+    file_fingerprints = _captured_vector_artifact_file_fingerprints(
+        authenticated_view,
+        model_suffix=model_suffix,
         build_levels=normalized_levels,
     )
     expected_file_count = len(
@@ -479,6 +507,68 @@ def assess_vector_artifact(
         "failure_names": sorted(set(failures)),
         "passed": not failures,
     }
+
+
+def assess_vector_artifact(
+    root: str | Path,
+    *,
+    embedding_model: str,
+    build_levels: Sequence[str],
+    surface: GitSourceSurface,
+    expected_artifact: Mapping[str, Any],
+    required_l0_files: Sequence[str] = (),
+    authenticated_view: AuthenticatedVectorView,
+    native_index_authorization: NativeIndexAuthorization | None,
+) -> dict[str, Any]:
+    """Validate one externally authorized, already-captured vector artifact.
+
+    The assessor is a generic artifact consumer, not an administrative trust
+    boundary: callers must supply both the exact captured view and an
+    out-of-band capability bound to that view and ``expected_artifact``.  No
+    artifact field can authorize the pickle or FAISS parsers used below.
+    """
+
+    from .._atomic_directory import lexical_directory_path
+
+    require_native_index_authorization_preflight(
+        native_index_authorization,
+        view_type="vector",
+    )
+    artifact_root = lexical_directory_path(Path(root))
+    if authenticated_view.root != artifact_root:
+        raise ValueError("authenticated vector view does not match assessment root")
+    require_native_index_authorization(
+        native_index_authorization,
+        authenticated_view.ownership,
+        view_type="vector",
+        semantic_contract=expected_artifact,
+    )
+
+    primary_error: BaseException | None = None
+    try:
+        return _assess_captured_vector_artifact(
+            embedding_model=embedding_model,
+            build_levels=build_levels,
+            surface=surface,
+            expected_artifact=expected_artifact,
+            required_l0_files=required_l0_files,
+            authenticated_view=authenticated_view,
+        )
+    except BaseException as exc:
+        primary_error = exc
+        raise
+    finally:
+        try:
+            authenticated_view.verify_final()
+        except BaseException as verification_error:
+            if primary_error is None:
+                raise
+            add_note = getattr(primary_error, "add_note", None)
+            if callable(add_note):
+                add_note(
+                    "secondary authenticated-vector final verification failure: "
+                    f"{type(verification_error).__name__}: {verification_error}"
+                )
 
 
 def write_artifact_quality(path: str | Path, report: Mapping[str, Any]) -> None:

--- a/codenib/compiler/cache_lock.py
+++ b/codenib/compiler/cache_lock.py
@@ -109,6 +109,55 @@ def _remember_cleanup_interruption(
     return deferred if deferred is not None else interruption
 
 
+def _annotate_secondary_cleanup_error(
+    primary_error: BaseException,
+    label: str,
+    cleanup_error: BaseException,
+) -> None:
+    """Keep cleanup diagnostics reachable without replacing the first fault."""
+
+    message = f"{label}: {cleanup_error!r}"
+    try:
+        add_note = getattr(primary_error, "add_note", None)
+        if callable(add_note):
+            add_note(message)
+            return
+    except BaseException:  # noqa: B036 - annotation must not mask primary
+        pass
+    try:
+        notes = list(getattr(primary_error, "_codenib_cleanup_notes", ()))
+        notes.append(message)
+        primary_error._codenib_cleanup_notes = tuple(notes)  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - primary still remains authoritative
+        pass
+    try:
+        if primary_error.__cause__ is None:
+            primary_error.__cause__ = cleanup_error
+    except BaseException:  # noqa: B036 - primary still remains authoritative
+        pass
+
+
+def _finish_cleanup_preserving_primary(
+    primary_error: BaseException | None,
+    label: str,
+    cleanup: Callable[[], BaseException | None],
+) -> None:
+    """Finish cleanup, propagating it only when no earlier failure exists."""
+
+    try:
+        deferred = cleanup()
+        if deferred is not None:
+            raise deferred
+    except BaseException as cleanup_error:  # noqa: B036 - preserve first fault
+        if primary_error is None:
+            raise
+        _annotate_secondary_cleanup_error(
+            primary_error,
+            label,
+            cleanup_error,
+        )
+
+
 def _posix_lifecycle_guard_is_owned() -> bool:
     """Return whether the current CPython thread owns the lifecycle RLock."""
 
@@ -467,14 +516,22 @@ def _open_posix_cache_directory(cache_dir: str | Path) -> Iterator[tuple[Path, i
         descriptor = os.open(cache, _directory_open_flags())
     except OSError as exc:
         raise RuntimeError(f"could not open compiler cache directory: {cache}") from exc
+    primary_error: BaseException | None = None
     try:
         metadata = os.fstat(descriptor)
         if not stat.S_ISDIR(metadata.st_mode) or _is_reparse_point(metadata):
             raise RuntimeError(f"compiler cache path is not a real directory: {cache}")
         os.set_inheritable(descriptor, False)
         yield cache, descriptor
+    except BaseException as exc:  # noqa: B036 - cleanup preserves first fault
+        primary_error = exc
+        raise
     finally:
-        os.close(descriptor)
+        _finish_cleanup_preserving_primary(
+            primary_error,
+            "compiler cache directory cleanup also failed",
+            lambda: _close_descriptor_for_cleanup(descriptor, None),
+        )
 
 
 def _posix_lock_flags(*, create: bool) -> int:
@@ -585,25 +642,29 @@ def _open_posix_lock_file(
                     raise RuntimeError(
                         f"could not open compiler cache lock: {lock_path}"
                     ) from exc
-                deferred = _close_owned_descriptor_for_cleanup(
-                    descriptor,
-                    descriptor_owner,
-                    None,
-                    active_registry=_ACTIVE_POSIX_LOCK_DESCRIPTORS,
-                )
-                if deferred is not None:
-                    raise deferred
-                raise
-            except BaseException:
-                if descriptor is not None:
-                    deferred = _close_owned_descriptor_for_cleanup(
+                _finish_cleanup_preserving_primary(
+                    exc,
+                    "compiler cache lock acquisition cleanup also failed",
+                    lambda descriptor=descriptor: _close_owned_descriptor_for_cleanup(
                         descriptor,
                         descriptor_owner,
                         None,
                         active_registry=_ACTIVE_POSIX_LOCK_DESCRIPTORS,
+                    ),
+                )
+                raise
+            except BaseException as exc:
+                if descriptor is not None:
+                    _finish_cleanup_preserving_primary(
+                        exc,
+                        "compiler cache lock acquisition cleanup also failed",
+                        lambda descriptor=descriptor: _close_owned_descriptor_for_cleanup(
+                            descriptor,
+                            descriptor_owner,
+                            None,
+                            active_registry=_ACTIVE_POSIX_LOCK_DESCRIPTORS,
+                        ),
                     )
-                    if deferred is not None:
-                        raise deferred
                 raise
             return descriptor, identity
         raise RuntimeError(f"compiler cache lock changed repeatedly: {lock_path}")
@@ -643,6 +704,7 @@ def _posix_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
         lock_path = cache / COMPILER_CACHE_LOCK_FILENAME
         descriptor_owner: list[int] = []
         locked = False
+        primary_error: BaseException | None = None
         try:
             descriptor, identity = _open_posix_lock_file(
                 cache,
@@ -659,11 +721,21 @@ def _posix_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
                 expected_identity=identity,
             )
             yield
+        except BaseException as exc:  # noqa: B036 - cleanup preserves first fault
+            primary_error = exc
+            raise
         finally:
             # The child-side at-fork callback already closed its inherited
             # descriptor.  The generation guard prevents closing a reused fd.
             if descriptor_owner and _POSIX_FORK_GENERATION == owner_generation:
-                _close_posix_lock_file(descriptor_owner, locked=locked)
+                _finish_cleanup_preserving_primary(
+                    primary_error,
+                    "compiler cache lock cleanup also failed",
+                    lambda: _close_posix_lock_file(
+                        descriptor_owner,
+                        locked=locked,
+                    ),
+                )
 
 
 def _windows_identity(metadata: os.stat_result, path: Path) -> tuple[int, ...]:
@@ -764,23 +836,27 @@ def _open_windows_lock_file(
                 raise RuntimeError(
                     f"could not open compiler cache lock: {lock_path}"
                 ) from exc
-            deferred = _close_owned_descriptor_for_cleanup(
-                descriptor,
-                owner,
-                None,
-            )
-            if deferred is not None:
-                raise deferred
-            raise
-        except BaseException:
-            if descriptor is not None:
-                deferred = _close_owned_descriptor_for_cleanup(
+            _finish_cleanup_preserving_primary(
+                exc,
+                "compiler cache lock acquisition cleanup also failed",
+                lambda descriptor=descriptor: _close_owned_descriptor_for_cleanup(
                     descriptor,
                     owner,
                     None,
+                ),
+            )
+            raise
+        except BaseException as exc:
+            if descriptor is not None:
+                _finish_cleanup_preserving_primary(
+                    exc,
+                    "compiler cache lock acquisition cleanup also failed",
+                    lambda descriptor=descriptor: _close_owned_descriptor_for_cleanup(
+                        descriptor,
+                        owner,
+                        None,
+                    ),
                 )
-                if deferred is not None:
-                    raise deferred
             raise
         return descriptor, identity
     raise RuntimeError(f"compiler cache lock changed repeatedly: {lock_path}")
@@ -848,6 +924,7 @@ def _windows_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
     cache_identity = _validate_windows_cache(cache)
     descriptor_owner: list[int] = []
     locked = False
+    primary_error: BaseException | None = None
     try:
         descriptor, lock_identity = _open_windows_lock_file(
             cache,
@@ -863,9 +940,19 @@ def _windows_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
             expected_identity=lock_identity,
         )
         yield
+    except BaseException as exc:  # noqa: B036 - cleanup preserves first fault
+        primary_error = exc
+        raise
     finally:
         if descriptor_owner:
-            _close_windows_lock_file(descriptor_owner, locked=locked)
+            _finish_cleanup_preserving_primary(
+                primary_error,
+                "compiler cache lock cleanup also failed",
+                lambda: _close_windows_lock_file(
+                    descriptor_owner,
+                    locked=locked,
+                ),
+            )
 
 
 @contextmanager

--- a/codenib/compiler/checkout_identity.py
+++ b/codenib/compiler/checkout_identity.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-from ..source_fingerprint import fingerprint_repository
+from ..source_fingerprint import (
+    fingerprint_repository,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
+)
 from .manifest import RepoManifest
 
 
@@ -33,25 +37,30 @@ def validate_checkout_identity(
 ) -> None:
     """Reject source or commit drift between a checkout and its manifest."""
 
-    repo_path = repo_path.expanduser().resolve()
-    artifact_root = artifact_root.expanduser().resolve()
+    repo_path = lexical_repository_path(repo_path)
+    artifact_root = lexical_repository_path(artifact_root)
     excluded_roots = (
         (artifact_root,)
         if artifact_root != repo_path and repo_path in artifact_root.parents
         else ()
     )
     expected_source = (manifest.source_fingerprint or "").strip()
-    if expected_source:
-        actual_source = fingerprint_repository(
-            repo_path,
-            exclude_roots=excluded_roots,
-        ).value
-        if actual_source != expected_source:
-            raise ValueError(
-                "repository source files do not match the indexed content. "
-                "Rebuild the index for the current working tree before serving "
-                "or publishing context."
-            )
+    if not is_secure_source_fingerprint_v2(expected_source):
+        raise ValueError(
+            "repository manifest uses a legacy or unsupported source fingerprint "
+            "(including a missing value). Rebuild the index before serving or "
+            "publishing context."
+        )
+    actual_source = fingerprint_repository(
+        repo_path,
+        exclude_roots=excluded_roots,
+    ).value
+    if actual_source != expected_source:
+        raise ValueError(
+            "repository source files do not match the indexed content. "
+            "Rebuild the index for the current working tree before serving "
+            "or publishing context."
+        )
 
     expected = (manifest.commit or "").strip()
     actual = checkout_commit(repo_path)

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -453,6 +453,18 @@ class VectorIndexBuilder:
         Missing or incompatible state propagates to :meth:`incremental_update`,
         which rebuilds conservatively exactly once.
         """
+        from ..native_index_authorization import (
+            require_native_index_authorization_preflight,
+        )
+
+        native_index_authorization = kwargs.get("native_index_authorization")
+        # Reject before constructing an embedding backend. The public wrapper
+        # catches this and performs one source-derived full rebuild.
+        require_native_index_authorization_preflight(
+            native_index_authorization,
+            view_type="vector",
+        )
+
         from pathlib import Path
 
         from ..code_chunker import CodeChunker, RepoChunkingConfig
@@ -535,7 +547,10 @@ class VectorIndexBuilder:
             **self._embedding_call_kwargs(),
         )
         self._validate_vector_dimension(vector_store)
-        vector_store.load(output_dir)
+        vector_store.load(
+            output_dir,
+            native_index_authorization=native_index_authorization,
+        )
 
         chunk_store = IncrementalChunkStore.load(chunk_store_path)
         embeddings_cache = EmbeddingsCache.load(embeddings_cache_path)

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -46,6 +46,10 @@ from .verification import NullVerifier, UpdateVerifier, VerificationResult
 logger = logging.getLogger(__name__)
 
 
+class _AtomicIncrementalRebuildRequired(RuntimeError):
+    """Signal that vector deltas must use the complete-generation builder."""
+
+
 def _git_output(repo_path: str, *args: str) -> str:
     """Run git in *repo_path* and return stripped stdout ("" on any failure)."""
     try:
@@ -270,52 +274,122 @@ class VectorIndexBuilder:
         return vector_config_artifact_record(output_dir, model_suffix)
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
+        from pathlib import Path, PurePosixPath
+
+        from .._atomic_directory import (
+            PublicationDirectoryReader,
+            reopen_authenticated_directory,
+        )
+        from .._captured_directory import OwnedDirectoryStage
         from ..index.embedding.artifact_integrity import (
             begin_vector_view_update,
             finish_vector_view_update,
         )
+        from ..index.embedding.builders import _PrivateBuildDirectory
 
-        output_dir: str = kwargs["output_dir"]
-        begin_vector_view_update(output_dir)
-        status = self._build_once(scope, **kwargs)
-        finish_vector_view_update(output_dir)
+        output_path = Path(kwargs["output_dir"])
+        publication_stage = OwnedDirectoryStage.prepare(
+            output_path,
+            allow_empty_destination=True,
+        )
+
+        def copy_generation(reader: PublicationDirectoryReader) -> None:
+            for record in reader.file_records():
+                relative = PurePosixPath(record.path)
+                with reader.iter_authenticated_chunks(
+                    relative,
+                    max_bytes=record.size,
+                ) as chunks:
+                    publication_stage.write_file(
+                        relative,
+                        chunks,
+                        mode=record.mode,
+                        max_bytes=record.size,
+                    )
+
+        try:
+            with _PrivateBuildDirectory(
+                prefix=f".{output_path.name}.generation-build-",
+                parent=output_path.parent,
+            ) as build_root:
+                build_path = build_root.path
+                writer_path = build_root.writer_path
+                with build_root.path_operation("vector update marker begin"):
+                    begin_vector_view_update(writer_path)
+                build_kwargs = dict(kwargs)
+                build_kwargs["output_dir"] = str(writer_path)
+                build_kwargs["_published_output_dir"] = str(output_path)
+                build_kwargs["_build_root_guard"] = build_root
+                status = self._build_once(scope, **build_kwargs)
+                with build_root.path_operation("vector update marker finish"):
+                    finish_vector_view_update(writer_path)
+
+                model_suffix = self._embedding_route().model.replace("/", "__")
+                generation_ownership = build_root.capture_ownership(
+                    required_root_file=f"config_{model_suffix}.json",
+                )
+                reopen_authenticated_directory(
+                    build_path,
+                    generation_ownership,
+                    copy_generation,
+                )
+
+            publication_stage.publish()
+        except BaseException:  # noqa: B036 - preserve publication interruptions
+            try:
+                publication_stage.discard()
+            except BaseException:  # noqa: B036 - retain the generation failure
+                logger.exception("Could not isolate failed vector generation stage")
+            raise
         return status
 
     def _build_once(self, scope: str, **kwargs: Any) -> IndexStatus:
         repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
+        published_output_dir: str = kwargs.get("_published_output_dir", output_dir)
+        build_root_guard = kwargs.get("_build_root_guard")
 
         from pathlib import Path
 
-        from ..index.embedding.builders import build_hierarchical_vector_store
+        from ..index.embedding.builders import (
+            _PrivateBuildDirectory,
+            build_hierarchical_vector_store,
+        )
         from ..index.incremental import (
             EmbeddingsCache,
             IncrementalChunkStore,
             IncrementalState,
         )
 
-        os.makedirs(output_dir, exist_ok=True)
+        if not isinstance(build_root_guard, _PrivateBuildDirectory):
+            raise RuntimeError("full vector build requires its private root owner")
+        build_root_guard.require_writer_path(Path(output_dir))
+        build_root_guard.verify("full vector build entry")
         artifact_identity = self.artifact_identity()
-        vs = build_hierarchical_vector_store(
-            repo_path=repo_path,
-            index_path=output_dir,
-            plan_name=None,
-            languages=self.languages,
-            max_lines_per_chunk=self.max_lines_per_chunk,
-            build_levels=self.build_levels,
-            embedding_model=artifact_identity["embedding_model"],
-            embedding_provider=artifact_identity["embedding_provider"],
-            embedding_dimension=self.embedding_dimension,
-            embedding_kwargs=self._embedding_call_kwargs(),
-            index_metric=self.index_metric,
-            artifact_metadata=artifact_identity,
-            # ``build`` is the compiler's full-materialization path. Reusing an
-            # artifact merely because its model config exists would let stale
-            # vectors be stamped with the current source fingerprint. Cross-
-            # commit reuse belongs to ``incremental_update`` instead.
-            force_rebuild=True,
-            strict_chunking=True,
-        )
+        with build_root_guard.path_operation("hierarchical vector build"):
+            vs = build_hierarchical_vector_store(
+                repo_path=repo_path,
+                index_path=output_dir,
+                plan_name=None,
+                languages=self.languages,
+                max_lines_per_chunk=self.max_lines_per_chunk,
+                build_levels=self.build_levels,
+                embedding_model=artifact_identity["embedding_model"],
+                embedding_provider=artifact_identity["embedding_provider"],
+                embedding_dimension=self.embedding_dimension,
+                embedding_kwargs=self._embedding_call_kwargs(),
+                index_metric=self.index_metric,
+                artifact_metadata=artifact_identity,
+                # ``build`` is the compiler's full-materialization path.
+                # Reusing an artifact merely because its model config exists
+                # would stamp stale vectors with the current source identity.
+                force_rebuild=True,
+                strict_chunking=True,
+                # ``build`` owns the complete private generation tree.  Its
+                # outer OwnedDirectoryStage is the publication boundary.
+                _atomic_publish=False,
+                _build_root_guard=build_root_guard,
+            )
         self._validate_vector_dimension(vs)
 
         doc_count = {}
@@ -382,23 +456,27 @@ class VectorIndexBuilder:
             for content_hash, vec in hash_to_vec.items():
                 emb_cache.put(content_hash, vec)
 
-        chunk_store.save(Path(output_dir) / "chunk_store.pkl")
+        with build_root_guard.path_operation("incremental chunk seed save"):
+            chunk_store.save(Path(output_dir) / "chunk_store.pkl")
         logger.info(
             "Seeded embeddings cache with %d vectors from initial build.",
             emb_cache.size(),
         )
-        emb_cache.save(Path(output_dir) / "embeddings_cache.pkl")
+        with build_root_guard.path_operation("embedding cache seed save"):
+            emb_cache.save(Path(output_dir) / "embeddings_cache.pkl")
 
         # Persist incremental state so callers don't need to track last_commit
         inc_state = IncrementalState(
             last_commit=head_commit,
             chunk_store_path="chunk_store.pkl",
             embeddings_cache_path="embeddings_cache.pkl",
-            index_path=str(Path(output_dir).expanduser().resolve()),
+            index_path=str(Path(published_output_dir).expanduser().resolve()),
             build_levels=list(self.build_levels),
         )
-        inc_state.save(Path(output_dir))
-        persistence_config = self._persistence_config_fingerprint(output_dir)
+        with build_root_guard.path_operation("incremental state seed save"):
+            inc_state.save(Path(output_dir))
+        with build_root_guard.path_operation("persistence fingerprint read"):
+            persistence_config = self._persistence_config_fingerprint(output_dir)
 
         return IndexStatus(
             index_type="vector",
@@ -406,7 +484,7 @@ class VectorIndexBuilder:
             last_built=time.time(),
             age_seconds=0.0,
             scope=scope,
-            path=output_dir,
+            path=published_output_dir,
             metadata={
                 **artifact_identity,
                 "persistence_config_fingerprint": persistence_config,
@@ -416,25 +494,44 @@ class VectorIndexBuilder:
         )
 
     def incremental_update(self, scope: str, **kwargs: Any) -> IndexStatus:
-        """Update the vector view, rebuilding on any incremental-path failure."""
+        """Update the vector view, rebuilding on recoverable path failures."""
+
+        from ..native_index_authorization import (
+            MissingNativeIndexAuthorizationError,
+            NativeIndexAuthorizationError,
+        )
 
         try:
             return self._incremental_update_once(scope, **kwargs)
+        except MissingNativeIndexAuthorizationError as exc:
+            return self._rebuild_after_incremental_failure(scope, kwargs, exc)
+        except NativeIndexAuthorizationError:
+            # An explicit capability is caller-supplied authority.  Never turn
+            # a malformed, foreign-process, or mismatched token into a source
+            # rebuild that appears to have accepted it.
+            raise
         except Exception as exc:  # noqa: BLE001 - failed deltas must not publish
-            logger.warning("vector: incremental update failed (%s); rebuilding", exc)
-            build_kwargs = {
-                key: value
-                for key, value in kwargs.items()
-                if key not in {"last_commit", "previous_artifact_config"}
-            }
-            status = self.build(scope, **build_kwargs)
-            status.metadata["update_mode"] = "full_rebuild"
-            status.metadata["incremental_fallback_reason"] = type(exc).__name__
-            return status
+            return self._rebuild_after_incremental_failure(scope, kwargs, exc)
+
+    def _rebuild_after_incremental_failure(
+        self,
+        scope: str,
+        kwargs: Dict[str, Any],
+        exc: Exception,
+    ) -> IndexStatus:
+        logger.warning("vector: incremental update failed (%s); rebuilding", exc)
+        build_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key not in {"last_commit", "previous_artifact_config"}
+        }
+        status = self.build(scope, **build_kwargs)
+        status.metadata["update_mode"] = "full_rebuild"
+        status.metadata["incremental_fallback_reason"] = type(exc).__name__
+        return status
 
     def _incremental_update_once(self, scope: str, **kwargs: Any) -> IndexStatus:
-        """
-        Attempt one vector-index update using git diff detection.
+        """Validate one delta request and route it to an atomic full rebuild.
 
         Required kwargs
         ---------------
@@ -446,12 +543,10 @@ class VectorIndexBuilder:
             The git SHA recorded when the index was last fully built.
             Pass an empty string to force a full rebuild.
 
-        The method loads the existing ``CodeVectorStore``, ``IncrementalChunkStore``,
-        and ``EmbeddingsCache`` from *output_dir*, runs the incremental update
-        pipeline, then saves all state back to disk.
-
-        Missing or incompatible state propagates to :meth:`incremental_update`,
-        which rebuilds conservatively exactly once.
+        Path-based vector persistence cannot safely update the live generation
+        in place.  After exact authorization and state validation, this method
+        therefore raises a private recoverable signal.  The public wrapper
+        rebuilds one complete private generation and switches it atomically.
         """
         from ..native_index_authorization import (
             require_native_index_authorization_preflight,
@@ -459,7 +554,7 @@ class VectorIndexBuilder:
 
         native_index_authorization = kwargs.get("native_index_authorization")
         # Reject before constructing an embedding backend. The public wrapper
-        # catches this and performs one source-derived full rebuild.
+        # rebuilds only for a missing token and propagates explicit bad tokens.
         require_native_index_authorization_preflight(
             native_index_authorization,
             view_type="vector",
@@ -467,27 +562,32 @@ class VectorIndexBuilder:
 
         from pathlib import Path
 
-        from ..code_chunker import CodeChunker, RepoChunkingConfig
-        from ..index.embedding.vector_store import CodeVectorStore
-        from ..index.incremental import (
-            EmbeddingsCache,
-            GitDiffDetector,
-            IncrementalChunkStore,
-            IncrementalIndexUpdater,
-            IncrementalState,
-        )
+        from ..index.incremental import IncrementalState
 
-        repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
         last_commit: str = kwargs.get("last_commit", "")
 
         from ..index.embedding.artifact_integrity import (
-            begin_vector_view_update,
-            finish_vector_view_update,
+            require_authorized_vector_view,
             require_complete_vector_view,
         )
 
         require_complete_vector_view(output_dir)
+        artifact_identity = self.artifact_identity()
+        previous_artifact = kwargs.get("previous_artifact_config")
+        if previous_artifact is not None and not isinstance(previous_artifact, dict):
+            raise ValueError("previous vector artifact config must be a mapping")
+        load_identity = (
+            dict(previous_artifact)
+            if previous_artifact is not None
+            else artifact_identity
+        )
+        require_authorized_vector_view(
+            output_dir,
+            native_index_authorization,
+            load_identity,
+        )
+
         inc_state = IncrementalState.load(Path(output_dir))
         if inc_state is None:
             raise ValueError("incremental state is missing")
@@ -526,113 +626,9 @@ class VectorIndexBuilder:
 
         if not has_chunk_store or not has_emb_cache:
             raise ValueError("incremental chunk or embedding state is missing")
-
-        # Load existing artifacts
-        artifact_identity = self.artifact_identity()
-        previous_artifact = kwargs.get("previous_artifact_config")
-        if previous_artifact is not None and not isinstance(previous_artifact, dict):
-            raise ValueError("previous vector artifact config must be a mapping")
-        load_identity = (
-            dict(previous_artifact)
-            if previous_artifact is not None
-            else artifact_identity
-        )
-        vector_store = CodeVectorStore(
-            embedding_model=artifact_identity["embedding_model"],
-            embedding_provider=artifact_identity["embedding_provider"],
-            dimension=self.embedding_dimension,
-            index_metric=self.index_metric,
-            store_path=output_dir,
-            artifact_metadata=load_identity,
-            **self._embedding_call_kwargs(),
-        )
-        self._validate_vector_dimension(vector_store)
-        vector_store.load(
-            output_dir,
-            native_index_authorization=native_index_authorization,
-        )
-
-        chunk_store = IncrementalChunkStore.load(chunk_store_path)
-        embeddings_cache = EmbeddingsCache.load(embeddings_cache_path)
-
-        # Build chunkers matching the original build config
-        primary = self.languages[0] if self.languages else "python"
-        repo_cfg = RepoChunkingConfig(languages=self.languages)
-        chunker = CodeChunker(
-            language=primary,
-            repo_config=repo_cfg,
-            max_lines_per_chunk=self.max_lines_per_chunk,
-        )
-
-        # L0 chunker for file skeletons (only if L0 was part of the build)
-        l0_chunker = None
-        if "l0" in self.build_levels:
-            l0_chunker = CodeChunker(
-                language=primary,
-                repo_config=repo_cfg,
-                max_lines_per_chunk=self.max_lines_per_chunk,
-                chunk_depth=0,
-                skeleton_mode=True,
-            )
-
-        diff_detector = GitDiffDetector()
-        updater = IncrementalIndexUpdater(
-            chunker=chunker,
-            embedding_model=vector_store.embedding,
-            diff_detector=diff_detector,
-            l0_chunker=l0_chunker,
-        )
-
-        result = updater.update(
-            repo_path=repo_path,
-            vector_store=vector_store,
-            chunk_store=chunk_store,
-            embeddings_cache=embeddings_cache,
-            last_commit=last_commit,
-        )
-        if not result.new_commit:
-            raise ValueError("incremental update did not resolve a target commit")
-
-        # Persist updated state
-        begin_vector_view_update(output_dir)
-        vector_store.save(output_dir)
-        chunk_store.save(chunk_store_path)
-        embeddings_cache.save(embeddings_cache_path)
-
-        # Update incremental state with the new commit.
-        new_state = IncrementalState(
-            last_commit=result.new_commit,
-            chunk_store_path="chunk_store.pkl",
-            embeddings_cache_path="embeddings_cache.pkl",
-            index_path=str(expected_index_path),
-            build_levels=list(self.build_levels),
-        )
-        new_state.save(Path(output_dir))
-        persistence_config = self._persistence_config_fingerprint(output_dir)
-        finish_vector_view_update(output_dir)
-
-        doc_count = {}
-        if vector_store.l0_documents:
-            doc_count["l0"] = len(vector_store.l0_documents)
-        if vector_store.l2_documents:
-            doc_count["l2"] = len(vector_store.l2_documents)
-
-        return IndexStatus(
-            index_type="vector",
-            state=IndexState.FRESH,
-            last_built=time.time(),
-            age_seconds=0.0,
-            scope=scope,
-            path=output_dir,
-            metadata={
-                **self.artifact_identity(),
-                "persistence_config_fingerprint": persistence_config,
-                "document_count": doc_count,
-                "chunks_reembedded": result.chunks_reembedded,
-                "chunks_from_cache": result.chunks_from_cache,
-                "cache_hit_rate": result.cache_hit_rate,
-                "new_commit": result.new_commit,
-            },
+        raise _AtomicIncrementalRebuildRequired(
+            "in-place vector delta publication is disabled; rebuild one "
+            "complete generation"
         )
 
 

--- a/codenib/compiler/index_compiler.py
+++ b/codenib/compiler/index_compiler.py
@@ -33,7 +33,7 @@ from ..paths import REPO_INDEX_DIRNAME
 from ..source_fingerprint import (
     SourceFingerprint,
     fingerprint_repository,
-    repository_source_is_dirty,
+    is_secure_source_fingerprint_v2,
 )
 from .cache_lock import compiler_cache_lock
 from .index_builders import IndexBuilderRegistry
@@ -124,9 +124,12 @@ class IndexCompiler:
         """
         Advance an existing manifest to the repo's current HEAD.
 
-        Each builder is asked for an incremental update rather than a full
-        build. Builders without a real delta path fall back to a rebuild
-        internally, so the result is always correct -- only the cost differs.
+        Requested views are rebuilt from the captured source generation.  An
+        incremental delta is unsafe until the Git cleanliness/HEAD observation
+        can be bound to the same pinned repository authority as the source
+        fingerprint; a path-based status check can otherwise observe a
+        temporary replacement repository and authorize reuse for different
+        bytes.
 
         Falls back to a full :meth:`compile_repo` when there is no existing
         manifest, or when the previously indexed commit cannot be determined.
@@ -256,10 +259,6 @@ class IndexCompiler:
 
         head_commit = self._get_head_commit(repo_path)
         source = source or fingerprint_repository(repo_path, exclude_roots=(cache,))
-        source_is_dirty = repository_source_is_dirty(
-            repo_path,
-            exclude_roots=(cache,),
-        )
         existing = existing_manifest
         languages = list(self._config.languages)
         if existing is not None:
@@ -327,23 +326,23 @@ class IndexCompiler:
             previous_entry_compatible = (
                 previous_entry is not None
                 and previous_entry.status in {"fresh", "stale"}
+                and existing is not None
+                and is_secure_source_fingerprint_v2(existing.source_fingerprint)
+                and is_secure_source_fingerprint_v2(previous_entry.source_fingerprint)
                 and self._entry_matches_builder(previous_entry, builder)
             )
             if previous_entry_compatible:
                 previous_commit = previous_entry.commit
                 if not previous_commit and existing is not None:
                     previous_commit = existing.last_indexed_commit
-            incremental_from = (
-                previous_commit
-                if (
-                    not force_rebuild
-                    and previous_commit
-                    and head_commit
-                    and previous_commit != head_commit
-                    and not source_is_dirty
-                )
-                else None
-            )
+            # Do not seed an incremental builder from a Git status/HEAD check
+            # performed through a separately resolved path.  A repository can
+            # be A for both source fingerprints, B (clean) only for that check,
+            # and A again before the build.  Until Git observations share the
+            # pinned source authority, a full rebuild is the only safe reuse
+            # policy.  ``previous_commit`` is still retained below so a failed
+            # rebuild can preserve the last known generation in the manifest.
+            incremental_from = None
 
             output_dir = os.path.join(cache, idx_type)
             result = self._build_one(
@@ -485,7 +484,8 @@ class IndexCompiler:
         if commit and entry.commit != commit:
             return False
         return (
-            bool(source_fingerprint) and entry.source_fingerprint == source_fingerprint
+            is_secure_source_fingerprint_v2(source_fingerprint)
+            and entry.source_fingerprint == source_fingerprint
         )
 
     @staticmethod

--- a/codenib/compiler/skill_context.py
+++ b/codenib/compiler/skill_context.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, Set
 
 from ..agent.skills.core import SkillType
 from ..agent.skills.registry import SkillRegistry
@@ -46,7 +46,10 @@ from ..provider_routes import resolve_embedding_artifact_route
 from .artifact_fingerprints import require_bm25_manifest_artifact
 from .index_builders import IndexBuilderRegistry, register_default_builders
 from .index_compiler import IndexCompiler, IndexCompilerConfig
-from .manifest import RepoManifest
+from .manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
+
+if TYPE_CHECKING:
+    from ..native_index_authorization import NativeIndexAuthorization
 
 logger = logging.getLogger(__name__)
 
@@ -280,6 +283,34 @@ def _looks_built(cache_dir: str, index_type: str) -> bool:
     return any(p.iterdir())
 
 
+def _current_cached_vector_entry(
+    cache_dir: str,
+    vector_path: str,
+) -> IndexEntry | None:
+    """Return trusted caller metadata for a current conventional cache entry."""
+
+    manifest_path = Path(cache_dir) / MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return None
+    try:
+        manifest = RepoManifest.load(manifest_path)
+    except Exception as exc:  # noqa: BLE001 - unusable metadata cannot bind a token
+        logger.warning("Ignoring unusable cache manifest %s: %s", manifest_path, exc)
+        return None
+    entry = manifest.indexes.get("vector")
+    if entry is None or not manifest.index_is_current("vector"):
+        return None
+    expected = os.path.abspath(os.path.expanduser(vector_path))
+    recorded = os.path.abspath(os.path.expanduser(entry.path))
+    if recorded != expected:
+        logger.warning(
+            "Ignoring vector metadata for a different cache path: %s",
+            entry.path,
+        )
+        return None
+    return entry
+
+
 def _load_bm25(index_path: str):
     """Load a BM25 index from an arbitrary directory path.
 
@@ -306,9 +337,21 @@ def _load_vector(
     artifact_metadata: Optional[Dict[str, Any]] = None,
     trust_remote_code: bool = False,
     default_batch_size: Optional[int] = None,
+    native_index_authorization: NativeIndexAuthorization | None = None,
 ):
     """Load a FAISS vector store from an arbitrary directory path."""
     from ..index.embedding.vector_store import CodeVectorStore
+    from ..native_index_authorization import (
+        require_native_index_authorization_preflight,
+    )
+
+    # Reject absent or malformed authority before initializing an embedding
+    # model or client. The exact tree and semantic contract are checked again
+    # by ``CodeVectorStore.load`` after it captures the view.
+    require_native_index_authorization_preflight(
+        native_index_authorization,
+        view_type="vector",
+    )
 
     kwargs = dict(embedding_kwargs or {})
     if embedding_revision is not None:
@@ -325,7 +368,10 @@ def _load_vector(
         trust_remote_code=trust_remote_code,
         **kwargs,
     )
-    store.load(index_path)
+    store.load(
+        index_path,
+        native_index_authorization=native_index_authorization,
+    )
     return store
 
 
@@ -344,16 +390,16 @@ def _run_compiler(
     *,
     languages: Sequence[str],
     builder_registry: IndexBuilderRegistry,
-) -> None:
+) -> RepoManifest | None:
     if not index_types:
-        return
+        return None
     cfg = IndexCompilerConfig(
         cache_dir_name=Path(cache_dir).name,
         index_types=list(index_types),
         languages=list(languages),
     )
     compiler = IndexCompiler(builder_registry, cfg)
-    compiler.compile_repo(
+    return compiler.compile_repo(
         repo_path,
         index_types=list(index_types),
         cache_dir=cache_dir,
@@ -378,6 +424,7 @@ def build_skill_contexts(
     trust_remote_code: Optional[bool] = None,
     embedding_batch_size: Optional[int] = None,
     embedding_max_seq_length: Optional[int] = None,
+    native_index_authorization: NativeIndexAuthorization | None = None,
 ) -> Dict[str, Any]:
     """Build the union of indexes required by *skill_ids* and package them.
 
@@ -428,8 +475,15 @@ def build_skill_contexts(
         trust_remote_code=trust_remote_code,
     )
 
+    compiled_manifest: RepoManifest | None = None
+    compiled_types: Set[str] = set()
     if needed:
         missing = _missing_index_types(needed, cache_dir, rebuild=rebuild)
+        # An existing native vector cache is not self-authorizing. Without a
+        # caller-issued capability, rebuild it from the repository source so
+        # this compiler invocation owns the bytes it will authorize below.
+        if "vector" in needed and native_index_authorization is None:
+            missing = sorted(set(missing) | {"vector"})
         if missing:
             registry = builder_registry
             if registry is None:
@@ -445,27 +499,67 @@ def build_skill_contexts(
                     embedding_max_seq_length=embedding_max_seq_length,
                 )
             logger.info("Building missing indexes %s under %s", missing, cache_dir)
-            _run_compiler(
+            compiled_manifest = _run_compiler(
                 repo_path,
                 missing,
                 cache_dir,
                 languages=languages,
                 builder_registry=registry,
             )
+            compiled_types.update(missing)
 
     # Load required types plus any optional type already present on disk
     # (optional types are never built here — used-if-present only).
     loadable: Set[str] = set(needed)
     for t in optional:
         if _looks_built(cache_dir, t):
+            if t == "vector" and native_index_authorization is None:
+                logger.warning(
+                    "Skipping optional native vector cache without external "
+                    "authorization"
+                )
+                continue
             loadable.add(t)
 
     loaded: Dict[str, Any] = {}
     if "bm25" in loadable:
         loaded["bm25"] = _load_bm25(_index_dir(cache_dir, "bm25"))
     if "vector" in loadable:
+        vector_path = _index_dir(cache_dir, "vector")
+        vector_artifact_metadata: Dict[str, Any] | None = None
+        vector_authorization = native_index_authorization
+        if "vector" in compiled_types and compiled_manifest is not None:
+            vector_entry = compiled_manifest.indexes.get("vector")
+            if (
+                vector_entry is not None
+                and vector_entry.status == "fresh"
+                and compiled_manifest.index_is_current("vector")
+            ):
+                from ..index.embedding.artifact_integrity import (
+                    capture_authenticated_vector_view,
+                )
+                from ..native_index_authorization import (
+                    _mint_trusted_local_admin_authorization,
+                )
+
+                vector_path = vector_entry.path
+                vector_artifact_metadata = dict(vector_entry.config)
+                with capture_authenticated_vector_view(vector_path) as vector_view:
+                    vector_authorization = _mint_trusted_local_admin_authorization(
+                        vector_view.ownership,
+                        view_type="vector",
+                        semantic_contract=vector_artifact_metadata,
+                        evidence=(
+                            "skill-context-compiler-owned-build",
+                            "captured-vector-tree-subject",
+                        ),
+                    )
+        elif vector_authorization is not None:
+            cached_entry = _current_cached_vector_entry(cache_dir, vector_path)
+            if cached_entry is not None:
+                vector_artifact_metadata = dict(cached_entry.config)
         loaded["vector"] = _load_vector(
-            _index_dir(cache_dir, "vector"),
+            vector_path,
             embedding_model=embedding_model,
             embedding_provider="huggingface",
             embedding_dimension=embedding_dimension,
@@ -477,6 +571,8 @@ def build_skill_contexts(
             ),
             trust_remote_code=load_policy.trust_remote_code,
             default_batch_size=embedding_batch_size,
+            artifact_metadata=vector_artifact_metadata,
+            native_index_authorization=vector_authorization,
         )
     if "symbol_graph" in loadable:
         try:
@@ -519,6 +615,7 @@ def load_contexts_from_manifest(
     skill_registry: Optional[SkillRegistry] = None,
     default_top_k: int = 10,
     default_level: str = "l2",
+    native_index_authorization: NativeIndexAuthorization | None = None,
 ) -> Dict[str, Any]:
     """Load index artifacts directly from a pre-built ``RepoManifest``.
 
@@ -556,6 +653,16 @@ def load_contexts_from_manifest(
             entry = manifest.indexes.get(req.index_type)
             fresh = entry is not None and manifest.index_is_current(req.index_type)
             if fresh:
+                if (
+                    req.index_type == "vector"
+                    and not getattr(req, "required", True)
+                    and native_index_authorization is None
+                ):
+                    logger.warning(
+                        "Skipping optional manifest vector view without external "
+                        "native-index authorization"
+                    )
+                    continue
                 needed.add(req.index_type)
             elif getattr(req, "required", True):
                 raise ValueError(
@@ -585,6 +692,7 @@ def load_contexts_from_manifest(
             index_metric=vec_entry.config.get("index_metric", "ip"),
             embedding_kwargs=embedding_kwargs,
             artifact_metadata=vec_entry.config,
+            native_index_authorization=native_index_authorization,
         )
     if "symbol_graph" in needed:
         loaded["symbol_graph"] = _load_symbol_graph(

--- a/codenib/compiler/skill_context.py
+++ b/codenib/compiler/skill_context.py
@@ -32,10 +32,21 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, Set
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+)
 
 from ..agent.skills.core import SkillType
 from ..agent.skills.registry import SkillRegistry
+from ..index.embedding.artifact_integrity import require_authorized_vector_view
 from ..index.embedding.model_policy import (
     DEFAULT_EMBEDDING_DIMENSION,
     DEFAULT_EMBEDDING_MODEL,
@@ -50,6 +61,10 @@ from .manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
 
 if TYPE_CHECKING:
     from ..native_index_authorization import NativeIndexAuthorization
+
+NativeIndexAuthorizationResolver = Callable[
+    [IndexEntry], "NativeIndexAuthorization | None"
+]
 
 logger = logging.getLogger(__name__)
 
@@ -311,6 +326,21 @@ def _current_cached_vector_entry(
     return entry
 
 
+def _resolve_native_vector_authorization(
+    entry: IndexEntry,
+    resolver: NativeIndexAuthorizationResolver,
+):
+    """Resolve external authority from the exact entry about to be loaded."""
+
+    authorization = resolver(entry)
+    if authorization is None:
+        raise ValueError(
+            "native-index authorization resolver returned no authorization "
+            "for a required vector view"
+        )
+    return authorization
+
+
 def _load_bm25(index_path: str):
     """Load a BM25 index from an arbitrary directory path.
 
@@ -341,16 +371,14 @@ def _load_vector(
 ):
     """Load a FAISS vector store from an arbitrary directory path."""
     from ..index.embedding.vector_store import CodeVectorStore
-    from ..native_index_authorization import (
-        require_native_index_authorization_preflight,
-    )
 
-    # Reject absent or malformed authority before initializing an embedding
-    # model or client. The exact tree and semantic contract are checked again
-    # by ``CodeVectorStore.load`` after it captures the view.
-    require_native_index_authorization_preflight(
+    # Bind the capability to the exact tree and semantic contract before the
+    # constructor can initialize an embedding model or remote client. The
+    # store repeats the exact check around its native parser load.
+    require_authorized_vector_view(
+        index_path,
         native_index_authorization,
-        view_type="vector",
+        artifact_metadata or {},
     )
 
     kwargs = dict(embedding_kwargs or {})
@@ -425,6 +453,7 @@ def build_skill_contexts(
     embedding_batch_size: Optional[int] = None,
     embedding_max_seq_length: Optional[int] = None,
     native_index_authorization: NativeIndexAuthorization | None = None,
+    native_index_authorization_resolver: NativeIndexAuthorizationResolver | None = None,
 ) -> Dict[str, Any]:
     """Build the union of indexes required by *skill_ids* and package them.
 
@@ -451,8 +480,21 @@ def build_skill_contexts(
     ``config.yaml`` on disk, so callers no longer have to pre-populate the
     ``SkillRegistry`` before calling this (see #154). The registry is only
     consulted for skills that are not present on disk.
+
+    Existing native vector views require either a capability already bound to
+    the intended cache or a resolver that receives its current manifest entry.
+    When this function itself compiles new bytes, it may mint only for that
+    compiler-owned captured output.
     """
     skill_ids = list(skill_ids)
+    if (
+        native_index_authorization is not None
+        and native_index_authorization_resolver is not None
+    ):
+        raise ValueError(
+            "provide either native_index_authorization or "
+            "native_index_authorization_resolver, not both"
+        )
     skill_registry = skill_registry or SkillRegistry()
 
     cache_dir = cache_dir or os.path.join(
@@ -482,7 +524,11 @@ def build_skill_contexts(
         # An existing native vector cache is not self-authorizing. Without a
         # caller-issued capability, rebuild it from the repository source so
         # this compiler invocation owns the bytes it will authorize below.
-        if "vector" in needed and native_index_authorization is None:
+        if (
+            "vector" in needed
+            and native_index_authorization is None
+            and native_index_authorization_resolver is None
+        ):
             missing = sorted(set(missing) | {"vector"})
         if missing:
             registry = builder_registry
@@ -513,7 +559,11 @@ def build_skill_contexts(
     loadable: Set[str] = set(needed)
     for t in optional:
         if _looks_built(cache_dir, t):
-            if t == "vector" and native_index_authorization is None:
+            if (
+                t == "vector"
+                and native_index_authorization is None
+                and native_index_authorization_resolver is None
+            ):
                 logger.warning(
                     "Skipping optional native vector cache without external "
                     "authorization"
@@ -544,36 +594,58 @@ def build_skill_contexts(
 
                 vector_path = vector_entry.path
                 vector_artifact_metadata = dict(vector_entry.config)
-                with capture_authenticated_vector_view(vector_path) as vector_view:
-                    vector_authorization = _mint_trusted_local_admin_authorization(
-                        vector_view.ownership,
-                        view_type="vector",
-                        semantic_contract=vector_artifact_metadata,
-                        evidence=(
-                            "skill-context-compiler-owned-build",
-                            "captured-vector-tree-subject",
-                        ),
+                if native_index_authorization_resolver is not None:
+                    vector_authorization = _resolve_native_vector_authorization(
+                        vector_entry,
+                        native_index_authorization_resolver,
                     )
+                else:
+                    with capture_authenticated_vector_view(vector_path) as vector_view:
+                        vector_authorization = _mint_trusted_local_admin_authorization(
+                            vector_view.ownership,
+                            view_type="vector",
+                            semantic_contract=vector_artifact_metadata,
+                            evidence=(
+                                "skill-context-compiler-owned-build",
+                                "captured-vector-tree-subject",
+                            ),
+                        )
         elif vector_authorization is not None:
             cached_entry = _current_cached_vector_entry(cache_dir, vector_path)
             if cached_entry is not None:
                 vector_artifact_metadata = dict(cached_entry.config)
-        loaded["vector"] = _load_vector(
-            vector_path,
-            embedding_model=embedding_model,
-            embedding_provider="huggingface",
-            embedding_dimension=embedding_dimension,
-            embedding_revision=load_policy.revision,
-            embedding_kwargs=(
-                {"max_seq_length": embedding_max_seq_length}
-                if embedding_max_seq_length is not None
-                else None
-            ),
-            trust_remote_code=load_policy.trust_remote_code,
-            default_batch_size=embedding_batch_size,
-            artifact_metadata=vector_artifact_metadata,
-            native_index_authorization=vector_authorization,
-        )
+        elif native_index_authorization_resolver is not None:
+            cached_entry = _current_cached_vector_entry(cache_dir, vector_path)
+            if cached_entry is None:
+                raise ValueError(
+                    "cannot resolve native-index authorization without a current "
+                    "vector manifest entry"
+                )
+            vector_artifact_metadata = dict(cached_entry.config)
+            vector_authorization = _resolve_native_vector_authorization(
+                cached_entry,
+                native_index_authorization_resolver,
+            )
+        # Required vectors always reach the fail-closed loader, even when a
+        # broken compiler result omitted its authority. Optional vectors may
+        # still degrade when no external capability was supplied.
+        if vector_authorization is not None or "vector" in needed:
+            loaded["vector"] = _load_vector(
+                vector_path,
+                embedding_model=embedding_model,
+                embedding_provider="huggingface",
+                embedding_dimension=embedding_dimension,
+                embedding_revision=load_policy.revision,
+                embedding_kwargs=(
+                    {"max_seq_length": embedding_max_seq_length}
+                    if embedding_max_seq_length is not None
+                    else None
+                ),
+                trust_remote_code=load_policy.trust_remote_code,
+                default_batch_size=embedding_batch_size,
+                artifact_metadata=vector_artifact_metadata,
+                native_index_authorization=vector_authorization,
+            )
     if "symbol_graph" in loadable:
         try:
             loaded["symbol_graph"] = _load_symbol_graph(
@@ -616,6 +688,7 @@ def load_contexts_from_manifest(
     default_top_k: int = 10,
     default_level: str = "l2",
     native_index_authorization: NativeIndexAuthorization | None = None,
+    native_index_authorization_resolver: NativeIndexAuthorizationResolver | None = None,
 ) -> Dict[str, Any]:
     """Load index artifacts directly from a pre-built ``RepoManifest``.
 
@@ -633,6 +706,10 @@ def load_contexts_from_manifest(
     model/dimension are read from ``manifest.indexes["vector"].config``
     when present.
 
+    ``native_index_authorization_resolver``, when supplied, is invoked with
+    that exact vector ``IndexEntry`` and must return an out-of-band capability
+    bound to the same tree and config. Manifest data never mints authority.
+
     Raises:
         ValueError: if any ``skill_ids`` *requires* an ``index_type`` that
             isn't present in the manifest or whose ``status != "fresh"``.
@@ -641,6 +718,14 @@ def load_contexts_from_manifest(
             beats the deferred "Skill not available" at tool-call time.
     """
     skill_ids = list(skill_ids)
+    if (
+        native_index_authorization is not None
+        and native_index_authorization_resolver is not None
+    ):
+        raise ValueError(
+            "provide either native_index_authorization or "
+            "native_index_authorization_resolver, not both"
+        )
     registry = skill_registry or SkillRegistry()
 
     # Map skill_id → list of index_types to load, validating required ones.
@@ -657,6 +742,7 @@ def load_contexts_from_manifest(
                     req.index_type == "vector"
                     and not getattr(req, "required", True)
                     and native_index_authorization is None
+                    and native_index_authorization_resolver is None
                 ):
                     logger.warning(
                         "Skipping optional manifest vector view without external "
@@ -681,6 +767,12 @@ def load_contexts_from_manifest(
         loaded["bm25"] = _load_bm25(bm25_entry.path)
     if "vector" in needed:
         vec_entry = manifest.indexes["vector"]
+        vector_authorization = native_index_authorization
+        if native_index_authorization_resolver is not None:
+            vector_authorization = _resolve_native_vector_authorization(
+                vec_entry,
+                native_index_authorization_resolver,
+            )
         route = resolve_embedding_artifact_route(vec_entry.config)
         embedding_kwargs = route.embedding_backend_kwargs()
         embedding_kwargs.update(route.client_kwargs())
@@ -692,7 +784,7 @@ def load_contexts_from_manifest(
             index_metric=vec_entry.config.get("index_metric", "ip"),
             embedding_kwargs=embedding_kwargs,
             artifact_metadata=vec_entry.config,
-            native_index_authorization=native_index_authorization,
+            native_index_authorization=vector_authorization,
         )
     if "symbol_graph" in needed:
         loaded["symbol_graph"] = _load_symbol_graph(

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -16,6 +16,7 @@ from typing import Any, Mapping
 
 from ..._atomic_directory import (
     TreeFileRecord,
+    _annotate_secondary_error,
     capture_directory_ownership,
     directory_ownership_file_records,
     directory_ownership_inventory,
@@ -23,6 +24,11 @@ from ..._atomic_directory import (
 )
 from ..._bounded_json import iter_bounded_json_array
 from ..._captured_directory import AuthenticatedFile, CapturedDirectoryReader
+from ...native_index_authorization import (
+    NativeIndexAuthorization,
+    require_native_index_authorization,
+    require_native_index_authorization_preflight,
+)
 
 VECTOR_PERSISTENCE_SCHEMA = 1
 VECTOR_VIEW_UPDATE_MARKER = ".vector-view.update-in-progress"
@@ -255,6 +261,46 @@ def capture_authenticated_vector_view(root: str | Path) -> AuthenticatedVectorVi
         return AuthenticatedVectorView.capture(root)
     except (OSError, RuntimeError, ValueError) as exc:
         raise ValueError(f"vector view could not be captured safely: {root}") from exc
+
+
+def require_authorized_vector_view(
+    root: str | Path,
+    authorization: NativeIndexAuthorization | None,
+    semantic_contract: Mapping[str, Any],
+) -> None:
+    """Require exact authority for a vector tree without loading its model.
+
+    This gate is intended for callers whose vector-store constructor may load
+    an embedding model or initialize a remote client. It binds the supplied
+    capability to one freshly captured tree and semantic contract, verifies
+    that the tree remained stable, and closes the captured view before the
+    caller performs any expensive initialization.
+    """
+
+    require_native_index_authorization_preflight(
+        authorization,
+        view_type="vector",
+    )
+    view = capture_authenticated_vector_view(root)
+    try:
+        require_native_index_authorization(
+            authorization,
+            view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+        )
+        view.verify_final()
+    except BaseException as primary_error:  # noqa: B036 - preserve first failure
+        try:
+            view.close()
+        except BaseException as cleanup_error:  # noqa: B036 - preserve first failure
+            _annotate_secondary_error(
+                primary_error,
+                "authenticated vector view cleanup also failed",
+                cleanup_error,
+            )
+        raise
+    view.close()
 
 
 def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -577,6 +623,7 @@ __all__ = [
     "begin_vector_view_update",
     "capture_authenticated_vector_view",
     "finish_vector_view_update",
+    "require_authorized_vector_view",
     "require_complete_vector_view",
     "validate_vector_config_artifact",
     "validate_vector_generation_artifacts",

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -9,25 +9,137 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import stat
 from pathlib import Path
 from typing import Any, Mapping
 
 VECTOR_PERSISTENCE_SCHEMA = 1
 VECTOR_VIEW_UPDATE_MARKER = ".vector-view.update-in-progress"
 _DIGEST_BYTES = 1024 * 1024
+_MAX_CONFIG_BYTES = 16 * 1024 * 1024
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _UPDATE_MARKER_PAYLOAD = b'{"schema":"codenib.vector-view-update.v1"}\n'
 
 
+def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _open_stable_regular(path: Path) -> tuple[int, os.stat_result]:
+    descriptor = -1
+    try:
+        before = path.lstat()
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or bool(
+                getattr(before, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+            )
+        ):
+            raise ValueError(f"invalid vector artifact file: {path}")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or _file_identity(opened) != _file_identity(
+            before
+        ):
+            raise ValueError(f"vector artifact changed while opening: {path}")
+        return descriptor, opened
+    except ValueError:
+        if descriptor >= 0:
+            os.close(descriptor)
+        raise
+    except OSError as exc:
+        if descriptor >= 0:
+            os.close(descriptor)
+        raise ValueError(f"invalid vector artifact file: {path}") from exc
+
+
+def _read_exact(descriptor: int, size: int, path: Path) -> bytearray:
+    payload = bytearray()
+    remaining = size
+    while remaining:
+        block = os.read(descriptor, min(remaining, _DIGEST_BYTES))
+        if not block:
+            raise ValueError(f"vector artifact was truncated: {path}")
+        payload.extend(block)
+        remaining -= len(block)
+    if os.read(descriptor, 1):
+        raise ValueError(f"vector artifact grew while reading: {path}")
+    return payload
+
+
+def _verify_open_file(
+    descriptor: int,
+    opened: os.stat_result,
+    path: Path,
+) -> None:
+    try:
+        after_open = os.fstat(descriptor)
+        after_path = path.lstat()
+    except OSError as exc:
+        raise ValueError(f"vector artifact changed while reading: {path}") from exc
+    if _file_identity(after_open) != _file_identity(opened) or _file_identity(
+        after_path
+    ) != _file_identity(opened):
+        raise ValueError(f"vector artifact changed while reading: {path}")
+
+
 def _file_record(path: Path) -> dict[str, Any]:
-    if path.is_symlink() or not path.is_file():
-        raise ValueError(f"invalid vector artifact file: {path}")
-    digest = hashlib.sha256()
-    size = 0
-    with path.open("rb") as handle:
-        while block := handle.read(_DIGEST_BYTES):
+    descriptor, opened = _open_stable_regular(path)
+    try:
+        digest = hashlib.sha256()
+        remaining = opened.st_size
+        while remaining:
+            block = os.read(descriptor, min(remaining, _DIGEST_BYTES))
+            if not block:
+                raise ValueError(f"vector artifact was truncated: {path}")
             digest.update(block)
-            size += len(block)
-    return {"file": path.name, "size": size, "sha256": digest.hexdigest()}
+            remaining -= len(block)
+        if os.read(descriptor, 1):
+            raise ValueError(f"vector artifact grew while hashing: {path}")
+        _verify_open_file(descriptor, opened, path)
+        return {
+            "file": path.name,
+            "size": opened.st_size,
+            "sha256": digest.hexdigest(),
+        }
+    except OSError as exc:
+        raise ValueError(f"vector artifact could not be read: {path}") from exc
+    finally:
+        os.close(descriptor)
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    descriptor, opened = _open_stable_regular(path)
+    try:
+        if opened.st_size > _MAX_CONFIG_BYTES:
+            raise ValueError(f"vector generation config exceeds its byte limit: {path}")
+        payload = _read_exact(descriptor, opened.st_size, path)
+        _verify_open_file(descriptor, opened, path)
+        try:
+            config = json.loads(payload)
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise ValueError(
+                f"vector generation config is invalid JSON: {path}"
+            ) from exc
+    except OSError as exc:
+        raise ValueError(f"vector generation config could not be read: {path}") from exc
+    finally:
+        os.close(descriptor)
+    if not isinstance(config, dict):
+        raise ValueError(f"vector generation config must be an object: {path}")
+    return config
 
 
 def vector_level_artifact_records(
@@ -180,12 +292,7 @@ def validate_vector_generation_artifacts(
     """Validate every file committed by one modern top-level vector config."""
 
     config_path = Path(root) / f"config_{model_suffix}.json"
-    if config_path.is_symlink() or not config_path.is_file():
-        raise ValueError(f"invalid vector generation config: {config_path}")
-    with config_path.open(encoding="utf-8") as handle:
-        config = json.load(handle)
-    if not isinstance(config, dict):
-        raise ValueError(f"vector generation config must be an object: {config_path}")
+    config = _load_config(config_path)
 
     persistence_schema = config.get("persistence_schema")
     committed_levels = config.get("level_artifacts")

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -10,15 +10,251 @@ import hashlib
 import json
 import os
 import stat
-from pathlib import Path
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
+
+from ..._atomic_directory import (
+    TreeFileRecord,
+    capture_directory_ownership,
+    directory_ownership_file_records,
+    directory_ownership_inventory,
+    lexical_directory_path,
+)
+from ..._bounded_json import iter_bounded_json_array
+from ..._captured_directory import AuthenticatedFile, CapturedDirectoryReader
 
 VECTOR_PERSISTENCE_SCHEMA = 1
 VECTOR_VIEW_UPDATE_MARKER = ".vector-view.update-in-progress"
 _DIGEST_BYTES = 1024 * 1024
 _MAX_CONFIG_BYTES = 16 * 1024 * 1024
+_MAX_DOCUMENT_BYTES = 256 * 1024 * 1024
+_MAX_FAISS_BYTES = 8 * 1024 * 1024 * 1024
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _UPDATE_MARKER_PAYLOAD = b'{"schema":"codenib.vector-view-update.v1"}\n'
+_VECTOR_LEVELS = frozenset({"l0", "l2"})
+_MUTABLE_ROOT_FILES = frozenset(
+    {
+        "chunk_store.json",
+        "chunk_store.pkl",
+        "embeddings_cache.json",
+        "embeddings_cache.npz",
+        "embeddings_cache.pkl",
+        "incremental_state.json",
+    }
+)
+
+
+def _vector_entry_policy(relative: str, kind: str, mode: int, size: int) -> None:
+    del mode
+    path = PurePosixPath(relative)
+    if kind == "directory":
+        if len(path.parts) != 1 or path.name not in _VECTOR_LEVELS:
+            raise ValueError(f"vector view has an invalid directory: {relative}")
+        return
+    if len(path.parts) == 1:
+        name = path.name
+        if name.startswith("config_") and name.endswith(".json"):
+            limit = _MAX_CONFIG_BYTES
+        elif name == "config.json":
+            limit = _MAX_CONFIG_BYTES
+        elif name == VECTOR_VIEW_UPDATE_MARKER or (
+            name.startswith(".config_") and name.endswith(".save-in-progress")
+        ):
+            limit = _MAX_CONFIG_BYTES
+        elif name in _MUTABLE_ROOT_FILES:
+            limit = _MAX_DOCUMENT_BYTES
+        else:
+            raise ValueError(f"vector view has an invalid file: {relative}")
+    elif len(path.parts) == 2 and path.parts[0] in _VECTOR_LEVELS:
+        name = path.name
+        suffix = path.suffix.casefold()
+        if name.startswith("config_") and suffix == ".json":
+            limit = _MAX_CONFIG_BYTES
+        elif name.startswith("documents_") and suffix in {
+            ".json",
+            ".pkl",
+            ".pickle",
+        }:
+            limit = _MAX_DOCUMENT_BYTES
+        elif name.startswith("index_") and suffix == ".faiss":
+            limit = _MAX_FAISS_BYTES
+        elif name.startswith("index_") and suffix in {".pkl", ".pickle"}:
+            limit = _MAX_DOCUMENT_BYTES
+        else:
+            raise ValueError(f"vector view has an invalid file: {relative}")
+    else:
+        raise ValueError(f"vector view has an invalid entry: {relative}")
+    if size < 0 or size > limit:
+        raise ValueError(f"vector artifact exceeds its {limit}-byte limit: {relative}")
+
+
+class _WrappedValueReader:
+    """Expose one bytes payload as a synthetic one-item JSON array."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._parts = iter((b"[", payload, b"]"))
+        self._pending = b""
+
+    def read(self, size: int = -1) -> bytes:
+        if not self._pending:
+            self._pending = next(self._parts, b"")
+        if size is None or size < 0 or len(self._pending) <= size:
+            block = self._pending
+            self._pending = b""
+            return block
+        block = self._pending[:size]
+        self._pending = self._pending[size:]
+        return block
+
+
+@dataclass(slots=True)
+class AuthenticatedVectorView:
+    """One captured vector tree whose consumers never reopen trusted paths."""
+
+    root: Path
+    ownership: object
+    reader: CapturedDirectoryReader
+    records: dict[str, TreeFileRecord]
+    inventory: tuple[tuple[str, str], ...]
+
+    @classmethod
+    def capture(cls, root: str | Path) -> AuthenticatedVectorView:
+        lexical = lexical_directory_path(Path(root))
+        ownership = capture_directory_ownership(
+            lexical,
+            entry_policy=_vector_entry_policy,
+        )
+        try:
+            reader = CapturedDirectoryReader(lexical, ownership)
+        except BaseException:
+            raise
+        return cls(
+            root=lexical,
+            ownership=ownership,
+            reader=reader,
+            records={
+                record.path: record
+                for record in directory_ownership_file_records(ownership)
+            },
+            inventory=directory_ownership_inventory(ownership),
+        )
+
+    def close(self) -> None:
+        self.reader.close()
+
+    def __enter__(self) -> AuthenticatedVectorView:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def has_file(self, relative: str | PurePosixPath) -> bool:
+        value = relative.as_posix() if isinstance(relative, PurePosixPath) else relative
+        return value in self.records
+
+    def record(self, relative: str | PurePosixPath) -> TreeFileRecord:
+        value = relative.as_posix() if isinstance(relative, PurePosixPath) else relative
+        try:
+            return self.records[value]
+        except KeyError as exc:
+            raise ValueError(f"vector artifact file is missing: {value}") from exc
+
+    def open_file(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> AuthenticatedFile:
+        return self.reader.open_file(relative, max_bytes=max_bytes)
+
+    def authenticated_descriptor(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ):
+        """Return a context manager yielding an immutable authenticated fd."""
+
+        return self.reader.authenticated_descriptor(relative, max_bytes=max_bytes)
+
+    def authenticated_snapshot(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ):
+        """Return a context manager yielding immutable authenticated bytes."""
+
+        return self.reader.authenticated_snapshot(relative, max_bytes=max_bytes)
+
+    def load_json_object(
+        self,
+        relative: str | PurePosixPath,
+        *,
+        label: str,
+        max_bytes: int = _MAX_CONFIG_BYTES,
+    ) -> dict[str, Any]:
+        payload = self.reader.read_bytes(relative, max_bytes=max_bytes)
+        values = iter_bounded_json_array(
+            _WrappedValueReader(payload),
+            label=label,
+            max_items=1,
+            max_element_bytes=max_bytes,
+        )
+        try:
+            value = next(values)
+        except StopIteration as exc:
+            raise ValueError(f"{label} is empty") from exc
+        try:
+            next(values)
+        except StopIteration:
+            pass
+        else:  # pragma: no cover - the synthetic wrapper has exactly one item
+            raise ValueError(f"{label} contains multiple JSON values")
+        if not isinstance(value, dict):
+            raise ValueError(f"{label} must be a JSON object")
+        return value
+
+    def require_record(
+        self,
+        relative: str | PurePosixPath,
+        expected: object,
+    ) -> TreeFileRecord:
+        record = self.record(relative)
+        if not isinstance(expected, Mapping) or set(expected) != {
+            "file",
+            "size",
+            "sha256",
+        }:
+            raise ValueError("invalid vector artifact fingerprint")
+        if dict(expected) != {
+            "file": PurePosixPath(record.path).name,
+            "size": record.size,
+            "sha256": record.sha256,
+        }:
+            raise ValueError(
+                f"vector artifact does not match its fingerprint: {record.path}"
+            )
+        return record
+
+    def verify_final(self) -> None:
+        self.reader.verify_root()
+        observed = capture_directory_ownership(
+            self.root,
+            entry_policy=_vector_entry_policy,
+        )
+        if observed != self.ownership:
+            raise ValueError("vector view changed during authenticated loading")
+
+
+def capture_authenticated_vector_view(root: str | Path) -> AuthenticatedVectorView:
+    """Capture a bounded no-follow vector tree before native authorization."""
+
+    try:
+        return AuthenticatedVectorView.capture(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError(f"vector view could not be captured safely: {root}") from exc
 
 
 def _file_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -335,9 +571,11 @@ def validate_vector_generation_artifacts(
 
 
 __all__ = [
+    "AuthenticatedVectorView",
     "VECTOR_PERSISTENCE_SCHEMA",
     "VECTOR_VIEW_UPDATE_MARKER",
     "begin_vector_view_update",
+    "capture_authenticated_vector_view",
     "finish_vector_view_update",
     "require_complete_vector_view",
     "validate_vector_config_artifact",

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -8,13 +8,26 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
-from pathlib import Path
+import os
+import stat
+import tempfile
+from contextlib import contextmanager, nullcontext
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from ..._atomic_directory import (
+    PublicationDirectoryReader,
+    capture_directory_ownership,
+    directory_ownership_root_identity,
+    discard_owned_directory,
+    lexical_directory_path,
+    reopen_authenticated_directory,
+)
+from ..._captured_directory import OwnedDirectoryStage
 from ...code_chunker import CodeChunker, RepoChunkingConfig
 from ...log_utils import get_logger
 from ...profiler import Profiler
+from .artifact_integrity import VECTOR_VIEW_UPDATE_MARKER
 from .vector_store import CodeVectorStore
 
 if TYPE_CHECKING:
@@ -22,29 +35,277 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_MODEL_LEVEL_FILE_TEMPLATES = (
+    "config_{model_suffix}.json",
+    "index_{model_suffix}.faiss",
+    "documents_{model_suffix}.pkl",
+    "documents_{model_suffix}.json",
+    "index_{model_suffix}.pkl",
+)
+_GENERATION_STATE_ROOT_FILES = frozenset(
+    {
+        VECTOR_VIEW_UPDATE_MARKER,
+        "chunk_store.json",
+        "chunk_store.pkl",
+        "embeddings_cache.json",
+        "embeddings_cache.npz",
+        "embeddings_cache.pkl",
+        "incremental_state.json",
+    }
+)
 
-def _remove_unrequested_model_levels(
-    store_path: Path,
-    embedding_model: str,
-    build_levels: List[str],
-) -> None:
-    model_suffix = embedding_model.replace("/", "__")
-    requested = frozenset(build_levels)
-    for level in ("l0", "l2"):
-        if level in requested:
-            continue
-        level_path = store_path / level
-        for name in (
-            f"config_{model_suffix}.json",
-            f"index_{model_suffix}.faiss",
-            f"documents_{model_suffix}.pkl",
-            f"index_{model_suffix}.pkl",
-        ):
-            (level_path / name).unlink(missing_ok=True)
+
+def _metadata_root_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+class _PrivateBuildDirectory:
+    """Retain and continuously verify one private path-based build root.
+
+    Model/index libraries still require a filesystem path.  Capturing only
+    after those libraries return is insufficient: a callback can rename the
+    private root and recreate its old name.  This owner captures the empty root
+    before the first callback, retains its directory descriptor where the host
+    supports it, and brackets every path-based operation with a no-follow root
+    binding check.
+    """
+
+    def __init__(self, *, parent: Path, prefix: str) -> None:
+        self.path = lexical_directory_path(
+            Path(tempfile.mkdtemp(prefix=prefix, dir=str(parent)))
+        )
+        self._descriptor = -1
+        self._closed = False
+        self._dirty = False
+        self._writer_path: Path | None = None
+        self._cleanup_ownership = capture_directory_ownership(self.path)
+        self._root_identity = directory_ownership_root_identity(self._cleanup_ownership)
+        flags = os.O_RDONLY
+        flags |= getattr(os, "O_DIRECTORY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        flags |= getattr(os, "O_CLOEXEC", 0)
         try:
-            level_path.rmdir()
-        except OSError:
-            pass
+            try:
+                self._descriptor = os.open(self.path, flags)
+            except OSError:
+                if os.name != "nt":
+                    raise
+            self.verify("private build root initialization")
+            if self._descriptor >= 0:
+                for descriptor_root in (Path("/proc/self/fd"), Path("/dev/fd")):
+                    candidate = descriptor_root / str(self._descriptor)
+                    try:
+                        if (
+                            _metadata_root_identity(os.stat(candidate))
+                            == self._root_identity
+                        ):
+                            self._writer_path = candidate
+                            break
+                    except OSError:
+                        continue
+        except BaseException as primary_error:
+            if self._descriptor >= 0:
+                os.close(self._descriptor)
+                self._descriptor = -1
+            try:
+                discard_owned_directory(self.path, self._cleanup_ownership)
+            except BaseException as cleanup_error:  # noqa: B036 - retain primary
+                add_note = getattr(primary_error, "add_note", None)
+                if callable(add_note):
+                    add_note(
+                        "private build initialization cleanup also failed: "
+                        f"{cleanup_error}"
+                    )
+            raise
+
+    @property
+    def writer_path(self) -> Path:
+        """Return a path whose resolution is anchored to the retained root fd."""
+
+        self.verify("descriptor-anchored writer path selection")
+        if self._writer_path is None:
+            raise RuntimeError(
+                "safe path-based vector builds require a descriptor-anchored "
+                "directory path on this platform"
+            )
+        try:
+            if (
+                _metadata_root_identity(os.stat(self._writer_path))
+                != self._root_identity
+            ):
+                raise RuntimeError("descriptor-anchored private build path changed")
+        except OSError as exc:
+            raise RuntimeError(
+                "descriptor-anchored private build path changed"
+            ) from exc
+        return self._writer_path
+
+    def require_writer_path(self, path: Path) -> None:
+        if lexical_directory_path(path) != self.writer_path:
+            raise RuntimeError(
+                "path-based vector writer is not anchored to its private root"
+            )
+
+    def verify(self, operation: str) -> None:
+        if self._closed:
+            raise RuntimeError("private build root owner is closed")
+        try:
+            if self._descriptor >= 0:
+                path_metadata = os.stat(self.path, follow_symlinks=False)
+                path_identity = _metadata_root_identity(path_metadata)
+                descriptor_identity = _metadata_root_identity(
+                    os.fstat(self._descriptor)
+                )
+            else:
+                ownership = capture_directory_ownership(
+                    self.path,
+                    allow_empty_root=True,
+                )
+                path_identity = directory_ownership_root_identity(ownership)
+                descriptor_identity = path_identity
+                path_metadata = os.stat(self.path, follow_symlinks=False)
+        except OSError as exc:
+            raise RuntimeError(
+                f"private build root changed during {operation}"
+            ) from exc
+        if (
+            not stat.S_ISDIR(path_metadata.st_mode)
+            or path_identity != self._root_identity
+            or descriptor_identity != self._root_identity
+        ):
+            raise RuntimeError(f"private build root changed during {operation}")
+
+    @contextmanager
+    def path_operation(self, operation: str):
+        """Require the same retained root immediately before and after a call."""
+
+        self.verify(f"before {operation}")
+        self._dirty = True
+        try:
+            yield
+        except BaseException as primary_error:  # noqa: B036 - retain interrupt
+            try:
+                self.verify(f"after failed {operation}")
+            except BaseException as continuity_error:  # noqa: B036
+                add_note = getattr(primary_error, "add_note", None)
+                if callable(add_note):
+                    add_note(
+                        "private build root verification also failed: "
+                        f"{continuity_error}"
+                    )
+            raise
+        self.verify(f"after {operation}")
+
+    def capture_ownership(self, *, required_root_file: str) -> object:
+        self.verify("before final ownership capture")
+        ownership = capture_directory_ownership(
+            self.path,
+            required_root_file=required_root_file,
+        )
+        if directory_ownership_root_identity(ownership) != self._root_identity:
+            raise RuntimeError("private build root changed during final capture")
+        self.verify("after final ownership capture")
+        self._cleanup_ownership = ownership
+        self._dirty = False
+        return ownership
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        cleanup_error: BaseException | None = None
+        try:
+            if self._dirty:
+                self.verify("cleanup capture")
+                ownership = capture_directory_ownership(
+                    self.path,
+                    allow_empty_root=True,
+                )
+                if directory_ownership_root_identity(ownership) != self._root_identity:
+                    raise RuntimeError("private build root changed during cleanup")
+                self._cleanup_ownership = ownership
+        except BaseException as exc:  # noqa: B036 - close the retained handle
+            cleanup_error = exc
+        finally:
+            if self._descriptor >= 0:
+                try:
+                    os.close(self._descriptor)
+                except OSError as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+                self._descriptor = -1
+            self._closed = True
+        try:
+            discard_owned_directory(self.path, self._cleanup_ownership)
+        except BaseException as exc:  # noqa: B036 - report safe orphaning
+            if cleanup_error is None:
+                cleanup_error = exc
+        if cleanup_error is not None:
+            raise cleanup_error
+
+    def __enter__(self) -> _PrivateBuildDirectory:
+        return self
+
+    def __exit__(self, _exc_type, exc, _traceback) -> None:
+        try:
+            self.close()
+        except BaseException as cleanup_error:  # noqa: B036 - retain primary
+            if exc is None:
+                raise
+            add_note = getattr(exc, "add_note", None)
+            if callable(add_note):
+                add_note(f"private build root cleanup also failed: {cleanup_error}")
+
+
+def _model_level_file_names(model_suffix: str) -> tuple[str, ...]:
+    return tuple(
+        template.format(model_suffix=model_suffix)
+        for template in _MODEL_LEVEL_FILE_TEMPLATES
+    )
+
+
+def _replaced_generation_paths(
+    model_suffix: str,
+) -> frozenset[str]:
+    paths = {
+        f"config_{model_suffix}.json",
+        f".config_{model_suffix}.json.save-in-progress",
+        *_GENERATION_STATE_ROOT_FILES,
+    }
+    paths.update(
+        f"{level}/{name}"
+        for level in ("l0", "l2")
+        for name in _model_level_file_names(model_suffix)
+    )
+    return frozenset(paths)
+
+
+def _copy_captured_tree(
+    reader: PublicationDirectoryReader,
+    stage: OwnedDirectoryStage,
+    *,
+    excluded: frozenset[str] = frozenset(),
+) -> None:
+    """Copy authenticated regular files into an authority-owned private stage."""
+
+    for record in reader.file_records():
+        relative = PurePosixPath(record.path)
+        if relative.as_posix() in excluded:
+            continue
+        with reader.iter_authenticated_chunks(
+            relative,
+            max_bytes=record.size,
+        ) as chunks:
+            stage.write_file(
+                relative,
+                chunks,
+                mode=record.mode,
+                max_bytes=record.size,
+            )
 
 
 def _profiler_section(profiler, label, metadata=None):
@@ -76,13 +337,17 @@ def build_hierarchical_vector_store(
     strict_chunking: bool = False,
     artifact_metadata: Optional[Dict[str, Any]] = None,
     native_index_authorization: NativeIndexAuthorization | None = None,
+    _atomic_publish: bool = True,
+    _build_root_guard: _PrivateBuildDirectory | None = None,
 ) -> CodeVectorStore:
     """Build (or load) a hierarchical vector store (L0/L2) for a repository.
 
     When ``force_rebuild=False`` (the default) and a saved index for the
     requested ``embedding_model`` already exists at ``index_path``, the store
     is loaded from disk instead of re-chunking and re-embedding the repository.
-    Pass ``force_rebuild=True`` to unconditionally rebuild.
+    Pass ``force_rebuild=True`` to unconditionally rebuild. Rebuilds compose a
+    complete private tree and atomically switch the directory only after save
+    and ownership verification succeed.
     """
     store_path = Path(index_path)
     if plan_name:
@@ -102,19 +367,19 @@ def build_hierarchical_vector_store(
             "repo_path is required to rebuild a vector index when no authorized "
             "cache can be loaded"
         )
-    if effective_force_rebuild:
-        _remove_unrequested_model_levels(
-            store_path,
-            embedding_model,
-            normalized_levels,
-        )
-
     if not effective_force_rebuild:
         if config_path.exists():
             logger.info(
                 "Pre-built index found at %s — loading instead of rebuilding "
                 "(pass force_rebuild=True to override).",
                 store_path,
+            )
+            from .artifact_integrity import require_authorized_vector_view
+
+            require_authorized_vector_view(
+                store_path,
+                native_index_authorization,
+                artifact_metadata or {},
             )
             vector_store = CodeVectorStore(
                 embedding_model=embedding_model,
@@ -221,32 +486,94 @@ def build_hierarchical_vector_store(
         "avg_chunk_loc": round(total_loc / max(total_chunks, 1), 1),
     }
 
-    store_path.mkdir(parents=True, exist_ok=True)
-    vector_store = CodeVectorStore(
-        embedding_model=embedding_model,
-        embedding_provider=embedding_provider,
-        dimension=embedding_dimension,
-        index_metric=index_metric,
-        index_type=index_type,
-        ivf_nlist=ivf_nlist,
-        ivf_nprobe=ivf_nprobe,
-        store_path=str(store_path),
-        profiler=profiler,
-        embedding=embedding,
-        artifact_metadata=artifact_metadata,
-        **(embedding_kwargs or {}),
-    )
+    def materialize(
+        build_path: Path,
+        build_root: _PrivateBuildDirectory,
+    ) -> CodeVectorStore:
+        with build_root.path_operation("vector store initialization"):
+            vector_store = CodeVectorStore(
+                embedding_model=embedding_model,
+                embedding_provider=embedding_provider,
+                dimension=embedding_dimension,
+                index_metric=index_metric,
+                index_type=index_type,
+                ivf_nlist=ivf_nlist,
+                ivf_nprobe=ivf_nprobe,
+                store_path=str(build_path),
+                profiler=profiler,
+                embedding=embedding,
+                artifact_metadata=artifact_metadata,
+                **(embedding_kwargs or {}),
+            )
 
-    if l0_chunks:
-        vector_store.add_code_chunks(
-            [chunk._asdict() for chunk in l0_chunks], level="l0"
-        )
-    if l2_chunks:
-        vector_store.add_code_chunks(
-            [chunk._asdict() for chunk in l2_chunks], level="l2"
-        )
+        if l0_chunks:
+            with build_root.path_operation("L0 vector materialization"):
+                vector_store.add_code_chunks(
+                    [chunk._asdict() for chunk in l0_chunks], level="l0"
+                )
+        if l2_chunks:
+            with build_root.path_operation("L2 vector materialization"):
+                vector_store.add_code_chunks(
+                    [chunk._asdict() for chunk in l2_chunks], level="l2"
+                )
+        with build_root.path_operation("vector store save"):
+            vector_store.save(str(build_path))
+        return vector_store
 
-    vector_store.save(str(store_path))
+    if _atomic_publish:
+        publication_stage = OwnedDirectoryStage.prepare(
+            store_path,
+            allow_empty_destination=True,
+        )
+        try:
+            previous_ownership = publication_stage.expected_destination_ownership
+            if previous_ownership is not None:
+                reopen_authenticated_directory(
+                    store_path,
+                    previous_ownership,  # type: ignore[arg-type]
+                    lambda reader: _copy_captured_tree(
+                        reader,
+                        publication_stage,
+                        excluded=_replaced_generation_paths(model_suffix),
+                    ),
+                )
+
+            with _PrivateBuildDirectory(
+                prefix=f".{store_path.name}.vector-build-",
+                parent=store_path.parent,
+            ) as build_root:
+                build_path = build_root.path
+                vector_store = materialize(build_root.writer_path, build_root)
+                build_ownership = build_root.capture_ownership(
+                    required_root_file=f"config_{model_suffix}.json",
+                )
+                reopen_authenticated_directory(
+                    build_path,
+                    build_ownership,
+                    lambda reader: _copy_captured_tree(reader, publication_stage),
+                )
+
+            publication_stage.publish()
+        except BaseException:  # noqa: B036 - preserve interrupts across rollback
+            try:
+                publication_stage.discard()
+            except BaseException:  # noqa: B036 - retain the publication failure
+                logger.exception("Could not isolate failed vector publication stage")
+            raise
+    else:
+        # The compiler uses this only inside its private full-generation tree;
+        # the outer OwnedDirectoryStage is the sole publication transaction.
+        if _build_root_guard is None or not isinstance(
+            _build_root_guard, _PrivateBuildDirectory
+        ):
+            raise RuntimeError(
+                "non-atomic vector materialization requires its private root owner"
+            )
+        _build_root_guard.require_writer_path(store_path)
+        _build_root_guard.verify("non-atomic vector materialization entry")
+        vector_store = materialize(store_path, _build_root_guard)
+
+    vector_store.store_path = store_path
     vector_store.chunk_stats = chunk_stats
     return vector_store
 

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -6,14 +6,19 @@
 
 """Reusable embedding builders for hierarchical pipelines."""
 
+from __future__ import annotations
+
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ...code_chunker import CodeChunker, RepoChunkingConfig
 from ...log_utils import get_logger
 from ...profiler import Profiler
 from .vector_store import CodeVectorStore
+
+if TYPE_CHECKING:
+    from ...native_index_authorization import NativeIndexAuthorization
 
 logger = get_logger(__name__)
 
@@ -70,6 +75,7 @@ def build_hierarchical_vector_store(
     force_rebuild: bool = False,
     strict_chunking: bool = False,
     artifact_metadata: Optional[Dict[str, Any]] = None,
+    native_index_authorization: NativeIndexAuthorization | None = None,
 ) -> CodeVectorStore:
     """Build (or load) a hierarchical vector store (L0/L2) for a repository.
 
@@ -83,16 +89,27 @@ def build_hierarchical_vector_store(
         store_path = store_path / plan_name
 
     normalized_levels = [level.lower() for level in (build_levels or ["l0", "l2"])]
-    if force_rebuild:
+    model_suffix = embedding_model.replace("/", "__")
+    config_path = store_path / f"config_{model_suffix}.json"
+    cache_without_authority = (
+        not force_rebuild
+        and config_path.exists()
+        and native_index_authorization is None
+    )
+    effective_force_rebuild = force_rebuild or cache_without_authority
+    if effective_force_rebuild and not repo_path:
+        raise ValueError(
+            "repo_path is required to rebuild a vector index when no authorized "
+            "cache can be loaded"
+        )
+    if effective_force_rebuild:
         _remove_unrequested_model_levels(
             store_path,
             embedding_model,
             normalized_levels,
         )
 
-    if not force_rebuild:
-        model_suffix = embedding_model.replace("/", "__")
-        config_path = store_path / f"config_{model_suffix}.json"
+    if not effective_force_rebuild:
         if config_path.exists():
             logger.info(
                 "Pre-built index found at %s — loading instead of rebuilding "
@@ -113,8 +130,23 @@ def build_hierarchical_vector_store(
                 artifact_metadata=artifact_metadata,
                 **(embedding_kwargs or {}),
             )
-            vector_store.load(str(store_path))
+            vector_store.load(
+                str(store_path),
+                native_index_authorization=native_index_authorization,
+            )
             return vector_store
+    elif cache_without_authority:
+        logger.warning(
+            "Pre-built index found at %s but no external native-index "
+            "authorization was supplied; rebuilding from repository source.",
+            store_path,
+        )
+
+    if not repo_path:
+        raise ValueError(
+            "repo_path is required to build a vector index when no authorized "
+            "cache can be loaded"
+        )
 
     languages = languages or ["python"]
     build_levels = normalized_levels

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -16,22 +16,29 @@ import pickle
 import tempfile
 from collections.abc import Mapping
 from contextlib import contextmanager, nullcontext
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 
 import faiss
 import numpy as np
 
 from ... import compat_pickle
+from ..._bounded_json import iter_bounded_json_array
+from ..._captured_directory import AuthenticatedSnapshotReader
 from ...log_utils import get_logger
+from ...native_index_authorization import (
+    NativeIndexAuthorization,
+    require_native_index_authorization,
+    require_native_index_authorization_preflight,
+)
 from ...profiler import Profiler
 from ...provider_routes import normalize_provider
 from ...types import NodeInfo
 from .artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
-    require_complete_vector_view,
-    validate_vector_config_artifact,
-    validate_vector_level_artifacts,
+    VECTOR_VIEW_UPDATE_MARKER,
+    AuthenticatedVectorView,
+    capture_authenticated_vector_view,
     vector_level_artifact_records,
 )
 from .model_policy import (
@@ -57,6 +64,28 @@ _HUGGINGFACE_ONLY_OPTIONS = frozenset(
         "trust_remote_code",
     }
 )
+
+
+@contextmanager
+def _authenticated_binary_file(
+    view: AuthenticatedVectorView,
+    relative: str,
+):
+    """Yield a file object backed only by an immutable authenticated snapshot."""
+
+    with view.authenticated_snapshot(relative) as (snapshot, _record):
+        yield AuthenticatedSnapshotReader(snapshot)
+
+
+def _read_authenticated_faiss(
+    view: AuthenticatedVectorView,
+    relative: str,
+) -> Any:
+    """Give FAISS only a fixed-chunk reader over an authenticated snapshot."""
+
+    with view.authenticated_snapshot(relative) as (snapshot, _record):
+        source = AuthenticatedSnapshotReader(snapshot)
+        return faiss.read_index(faiss.PyCallbackIOReader(source.read))
 
 
 def _pop_compatible_model_option(
@@ -785,14 +814,22 @@ class CodeVectorStore:
                 results.append((documents[idx], float(dist)))
         return results
 
-    def swap_index(self, path: str) -> None:
+    def swap_index(
+        self,
+        path: str,
+        *,
+        native_index_authorization: NativeIndexAuthorization | None = None,
+    ) -> None:
         """Hot-swap the FAISS index without reloading the embedding model.
 
         The replacement is fully loaded and validated before the current
         L0/L2 state is released. The embedding model is left intact so the
         caller can reuse the same model across many instances.
         """
-        self.load(path)
+        self.load(
+            path,
+            native_index_authorization=native_index_authorization,
+        )
 
     def close(self) -> None:
         """Release embeddings and FAISS resources to free memory."""
@@ -1321,32 +1358,60 @@ class CodeVectorStore:
         logger.info(f"Saved {level.upper()} store with {len(documents)} documents")
         return artifacts
 
-    def load(self, path: Optional[str] = None) -> None:
+    def load(
+        self,
+        path: Optional[str] = None,
+        *,
+        native_index_authorization: NativeIndexAuthorization | None = None,
+    ) -> None:
         """
         Load the vector store from disk.
 
         Args:
             path: Path to load the store from (uses self.store_path if not provided)
+            native_index_authorization: Process-local authorization bound to the
+                exact captured tree and semantic view contract. Artifact fields
+                cannot provide this capability.
         """
         load_path = Path(path) if path else self.store_path
         if load_path is None:
             raise ValueError("No load path provided")
+        require_native_index_authorization_preflight(
+            native_index_authorization,
+            view_type="vector",
+        )
+        view = capture_authenticated_vector_view(load_path)
+        try:
+            require_native_index_authorization(
+                native_index_authorization,
+                view.ownership,
+                view_type="vector",
+                semantic_contract=self.artifact_metadata,
+            )
+            self._load_captured(view)
+            view.verify_final()
+        finally:
+            view.close()
 
-        load_path = Path(load_path)
-        if not load_path.exists():
-            raise FileNotFoundError(f"Vector store not found at {load_path}")
+    def _load_captured(self, view: AuthenticatedVectorView) -> None:
+        """Load native state only through one already-authorized captured tree."""
 
-        logger.info(f"Loading vector store from {load_path}")
-        require_complete_vector_view(load_path)
+        load_path = view.root
+        logger.info("Loading authenticated vector store from %s", load_path)
+        if view.has_file(VECTOR_VIEW_UPDATE_MARKER):
+            raise ValueError(
+                "vector view has an incomplete update marker: "
+                f"{VECTOR_VIEW_UPDATE_MARKER}"
+            )
 
         model_suffix = self.embedding_model.replace("/", "__")
 
         # Load top-level configuration
-        config_path = load_path / f"config_{model_suffix}.json"
-        if not config_path.exists():
-            config_path = load_path / "config.json"
-        save_marker = load_path / f".config_{model_suffix}.json.save-in-progress"
-        if save_marker.exists():
+        config_relative = f"config_{model_suffix}.json"
+        if not view.has_file(config_relative):
+            config_relative = "config.json"
+        save_marker = f".config_{model_suffix}.json.save-in-progress"
+        if view.has_file(save_marker):
             raise ValueError(
                 f"Vector store has an interrupted save marker: {save_marker}"
             )
@@ -1354,17 +1419,19 @@ class CodeVectorStore:
         expected_artifact = dict(self.artifact_metadata)
         expected_config = expected_artifact.get("persistence_config_fingerprint")
         if expected_config is not None:
-            config_path = validate_vector_config_artifact(
-                load_path,
-                model_suffix,
+            config_relative = f"config_{model_suffix}.json"
+            view.require_record(
+                config_relative,
                 expected_config,
             )
         loaded_artifact = expected_artifact
         expected_counts: Dict[str, Optional[int]] = {"l0": None, "l2": None}
         committed_levels: Optional[dict[str, object]] = None
-        if config_path.exists():
-            with open(config_path, "r") as f:
-                config = json.load(f)
+        if view.has_file(config_relative):
+            config = view.load_json_object(
+                config_relative,
+                label="vector generation config",
+            )
 
             saved_model = config.get("embedding_model")
             if saved_model is not None and saved_model != self.embedding_model:
@@ -1453,8 +1520,7 @@ class CodeVectorStore:
         loaded_levels = {}
         for level in ("l0", "l2"):
             expected_count = expected_counts[level]
-            level_path = load_path / level
-            faiss_path = level_path / f"index_{model_suffix}.faiss"
+            faiss_relative = f"{level}/index_{model_suffix}.faiss"
             committed_artifacts = (
                 committed_levels.get(level) if committed_levels is not None else None
             )
@@ -1479,16 +1545,17 @@ class CodeVectorStore:
                     f"Vector config is missing committed artifacts for {level}"
                 )
 
-            if committed_artifacts is not None or faiss_path.exists():
+            if committed_artifacts is not None or view.has_file(faiss_relative):
                 index, documents = self._load_level(
-                    level_path,
+                    view,
+                    level,
                     model_suffix,
                     committed_artifacts=committed_artifacts,
                 )
             elif expected_count is not None and expected_count > 0:
                 raise FileNotFoundError(
                     f"Vector config expects {expected_count} {level} documents, "
-                    f"but {faiss_path} is missing"
+                    f"but {faiss_relative} is missing"
                 )
             else:
                 index, documents = self._build_faiss_index(), []
@@ -1536,7 +1603,8 @@ class CodeVectorStore:
 
     def _load_level(
         self,
-        level_path: Path,
+        view: AuthenticatedVectorView,
+        level: str,
         model_suffix: str,
         *,
         committed_artifacts: object = None,
@@ -1546,72 +1614,96 @@ class CodeVectorStore:
         Handles both the new format (raw FAISS + _Document list) and the
         legacy LangChain format (FAISS + docstore pkl) transparently.
         """
+        level_path = view.root / level
         index_name = f"index_{model_suffix}"
-        committed_documents_path = None
+        faiss_relative = f"{level}/{index_name}.faiss"
+        committed_documents_relative = None
         if committed_artifacts is not None:
-            faiss_path, committed_documents_path = validate_vector_level_artifacts(
-                level_path,
-                model_suffix,
-                committed_artifacts,
+            if not isinstance(committed_artifacts, Mapping) or set(
+                committed_artifacts
+            ) != {"index", "documents"}:
+                raise ValueError(f"invalid committed vector artifacts for {level_path}")
+            view.require_record(faiss_relative, committed_artifacts["index"])
+            documents_record = committed_artifacts["documents"]
+            if not isinstance(documents_record, Mapping):
+                raise ValueError(
+                    f"invalid documents vector artifact record for {level_path}"
+                )
+            documents_name = documents_record.get("file")
+            if documents_name not in {
+                f"documents_{model_suffix}.json",
+                f"documents_{model_suffix}.pkl",
+            }:
+                raise ValueError(
+                    f"invalid documents vector artifact filename for {level_path}"
+                )
+            committed_documents_relative = f"{level}/{documents_name}"
+            view.require_record(
+                committed_documents_relative,
+                documents_record,
             )
-        else:
-            faiss_path = level_path / f"{index_name}.faiss"
 
-        if not faiss_path.exists():
-            raise FileNotFoundError(f"FAISS index not found at {faiss_path}")
+        if not view.has_file(faiss_relative):
+            raise FileNotFoundError(f"FAISS index not found at {faiss_relative}")
 
         try:
-            index = faiss.read_index(str(faiss_path))
+            index = _read_authenticated_faiss(view, faiss_relative)
         except Exception as e:
             raise ValueError(
-                f"Could not load FAISS index from {faiss_path}: {e}"
+                f"Could not load FAISS index from {faiss_relative}: {e}"
             ) from e
         if int(index.d) != self.dimension:
             raise ValueError(
-                f"FAISS dimension mismatch at {faiss_path}: "
+                f"FAISS dimension mismatch at {faiss_relative}: "
                 f"expected {self.dimension}, found {int(index.d)}"
             )
 
         # Portable artifacts use inert JSON so a downloaded document store is
         # never unpickled. Local indexes retain the pickle fallback for
         # compatibility with previously built artifacts.
-        json_path = level_path / f"documents_{model_suffix}.json"
-        if committed_documents_path is not None:
-            if committed_documents_path.suffix == ".json":
-                documents = self._load_documents_json(committed_documents_path)
+        json_relative = f"{level}/documents_{model_suffix}.json"
+        if committed_documents_relative is not None:
+            if PurePosixPath(committed_documents_relative).suffix == ".json":
+                documents = self._load_documents_json(
+                    view,
+                    committed_documents_relative,
+                )
             else:
                 try:
-                    with committed_documents_path.open("rb") as handle:
+                    with _authenticated_binary_file(
+                        view,
+                        committed_documents_relative,
+                    ) as handle:
                         raw_docs = compat_pickle.load(handle)
                     documents = [_to_document(document) for document in raw_docs]
                 except Exception as exc:
                     raise ValueError(
                         "Could not load committed vector documents from "
-                        f"{committed_documents_path}: {exc}"
+                        f"{committed_documents_relative}: {exc}"
                     ) from exc
-        elif json_path.exists():
-            documents = self._load_documents_json(json_path)
+        elif view.has_file(json_relative):
+            documents = self._load_documents_json(view, json_relative)
         else:
             documents = None
 
             # Try loading the local documents pickle (works for both new
             # _Document and legacy LangChain Document objects).
-            docs_path = level_path / f"documents_{model_suffix}.pkl"
-            if docs_path.exists():
+            docs_relative = f"{level}/documents_{model_suffix}.pkl"
+            if view.has_file(docs_relative):
                 try:
-                    with open(docs_path, "rb") as f:
-                        raw_docs = compat_pickle.load(f)
+                    with _authenticated_binary_file(view, docs_relative) as source:
+                        raw_docs = compat_pickle.load(source)
                     documents = [_to_document(d) for d in raw_docs]
                 except Exception as exc:
                     logger.warning(
-                        "Could not load documents from %s: %s", docs_path, exc
+                        "Could not load documents from %s: %s", docs_relative, exc
                     )
 
             # Fallback: LangChain stores use index_name.pkl for their docstore.
-            lc_pkl_path = level_path / f"{index_name}.pkl"
-            if documents is None and lc_pkl_path.exists():
+            lc_pkl_relative = f"{level}/{index_name}.pkl"
+            if documents is None and view.has_file(lc_pkl_relative):
                 try:
-                    documents = self._load_langchain_pkl(lc_pkl_path)
+                    documents = self._load_langchain_pkl(view, lc_pkl_relative)
                     logger.info(
                         "Loaded %d documents from legacy LangChain format",
                         len(documents),
@@ -1619,7 +1711,7 @@ class CodeVectorStore:
                 except Exception as exc:
                     logger.warning(
                         "Could not load legacy LangChain pkl from %s: %s",
-                        lc_pkl_path,
+                        lc_pkl_relative,
                         exc,
                     )
 
@@ -1636,44 +1728,107 @@ class CodeVectorStore:
                 f"Misaligned vector level {level_path}: {int(index.ntotal)} vectors "
                 f"for {len(documents)} documents"
             )
+        self._validate_loaded_faiss_index(
+            index,
+            relative=faiss_relative,
+            document_count=len(documents),
+        )
+        level_config_relative = f"{level}/config_{model_suffix}.json"
+        if view.has_file(level_config_relative):
+            level_config = view.load_json_object(
+                level_config_relative,
+                label=f"vector {level} config",
+            )
+            expected_level_config = {
+                "embedding_model": self.embedding_model,
+                "embedding_provider": self.embedding_provider,
+                "embedding_revision": self.embedding_revision,
+                "dimension": self.dimension,
+                "index_type": self.index_type,
+                "index_metric": self.index_metric,
+                "level": level,
+                "num_documents": len(documents),
+            }
+            for field, expected in expected_level_config.items():
+                if level_config.get(field) != expected:
+                    raise ValueError(
+                        f"vector {level} config {field} mismatch: "
+                        f"expected {expected!r}, found {level_config.get(field)!r}"
+                    )
         return index, documents
 
+    def _validate_loaded_faiss_index(
+        self,
+        index: faiss.Index,
+        *,
+        relative: str,
+        document_count: int,
+    ) -> None:
+        expected_metric = self._faiss_metric()
+        if int(index.metric_type) != int(expected_metric):
+            raise ValueError(
+                f"FAISS metric mismatch at {relative}: expected "
+                f"{self.index_metric}, found {int(index.metric_type)}"
+            )
+        if self.index_type == "flat":
+            valid_type = isinstance(index, faiss.IndexFlat)
+        else:
+            valid_type = isinstance(index, faiss.IndexIVF)
+        if not valid_type:
+            raise ValueError(
+                f"FAISS index type mismatch at {relative}: expected {self.index_type}"
+            )
+        if document_count > 0 and not bool(index.is_trained):
+            raise ValueError(f"FAISS index is not trained at {relative}")
+
     @staticmethod
-    def _load_documents_json(path: Path) -> List[_Document]:
+    def _load_documents_json(
+        view: AuthenticatedVectorView,
+        relative: str,
+    ) -> List[_Document]:
         """Load the non-executable portable vector document format."""
 
-        with path.open(encoding="utf-8") as handle:
-            payload = json.load(handle)
-        if not isinstance(payload, list):
-            raise ValueError(f"vector documents must be a JSON list: {path}")
-
         documents: List[_Document] = []
-        for index, item in enumerate(payload):
-            if not isinstance(item, dict):
-                raise ValueError(
-                    f"vector document {index} must be a JSON object: {path}"
+        with view.open_file(relative) as source:
+            for index, item in enumerate(
+                iter_bounded_json_array(
+                    source,
+                    label=f"vector documents {relative}",
                 )
-            page_content = item.get("page_content")
-            metadata = item.get("metadata")
-            if not isinstance(page_content, str) or not isinstance(metadata, dict):
-                raise ValueError(
-                    f"vector document {index} has invalid content or metadata: {path}"
+            ):
+                if not isinstance(item, dict) or set(item) != {
+                    "page_content",
+                    "metadata",
+                }:
+                    raise ValueError(
+                        f"vector document {index} must have canonical shape: "
+                        f"{relative}"
+                    )
+                page_content = item.get("page_content")
+                metadata = item.get("metadata")
+                if not isinstance(page_content, str) or not isinstance(metadata, dict):
+                    raise ValueError(
+                        f"vector document {index} has invalid content or metadata: "
+                        f"{relative}"
+                    )
+                documents.append(
+                    _Document(page_content=page_content, metadata=dict(metadata))
                 )
-            documents.append(
-                _Document(page_content=page_content, metadata=dict(metadata))
-            )
         return documents
 
     @staticmethod
-    def _load_langchain_pkl(pkl_path: Path) -> List[_Document]:
+    def _load_langchain_pkl(
+        view: AuthenticatedVectorView,
+        relative: str,
+    ) -> List[_Document]:
         """Extract documents from a LangChain FAISS pkl file.
 
         The pkl file contains ``(InMemoryDocstore, index_to_docstore_id)``
         where ``index_to_docstore_id`` maps integer FAISS indices to
         docstore string IDs.
         """
-        with open(pkl_path, "rb") as f:
-            docstore, index_to_docstore_id = compat_pickle.load(f)
+        with _authenticated_binary_file(view, relative) as source:
+            docstore, index_to_docstore_id = compat_pickle.load(source)
 
         documents: List[_Document] = []
         for i in sorted(index_to_docstore_id.keys()):

--- a/codenib/index/sparse_idx/bm25_index.py
+++ b/codenib/index/sparse_idx/bm25_index.py
@@ -9,7 +9,7 @@ import os
 import re
 import stat
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional
 
 from rank_bm25 import BM25Okapi
 
@@ -21,11 +21,20 @@ from ...utils import is_test_file, wrap_code_snippet
 
 if TYPE_CHECKING:
     from ...graph.code_graph import CodeGraph
+    from ...source_fingerprint import RepositorySourceBinding
 
 logger = get_logger(__name__)
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _MAX_RUNTIME_SOURCE_BYTES = 64 * 1024 * 1024
+SOURCE_MODE_LEGACY_DIRECT = "legacy-direct"
+SOURCE_MODE_BOUND_REPOSITORY = "bound-repository"
+SOURCE_MODE_PERSISTED_ONLY = "persisted-only"
+_SOURCE_MODES = {
+    SOURCE_MODE_LEGACY_DIRECT,
+    SOURCE_MODE_BOUND_REPOSITORY,
+    SOURCE_MODE_PERSISTED_ONLY,
+}
 _SECURE_SOURCE_DIRECTORY_FDS = (
     os.name == "posix"
     and hasattr(os, "O_DIRECTORY")
@@ -427,6 +436,8 @@ class BM25CodeIndexer:
         self.retriever = None
         self.code_graph: CodeGraph = None
         self.project_root = project_root
+        self.source_mode = SOURCE_MODE_LEGACY_DIRECT
+        self._source_binding: RepositorySourceBinding | None = None
         self.nodes: List[str] = []
 
         # Build the index immediately if a code_graph is provided
@@ -447,6 +458,8 @@ class BM25CodeIndexer:
         self.nodes = []
         self.code_graph = code_graph
         self.project_root = code_graph.project_root
+        self.source_mode = SOURCE_MODE_LEGACY_DIRECT
+        self._source_binding = None
 
         # Convert graph nodes to documents
         for vertex in code_graph.graph.vs:
@@ -483,6 +496,8 @@ class BM25CodeIndexer:
         self.nodes = []
         self.code_graph = None
         self.project_root = project_root
+        self.source_mode = SOURCE_MODE_LEGACY_DIRECT
+        self._source_binding = None
 
         # Keep each bounded source span independently searchable. Overloads and
         # split large definitions can share a node_id, but merging them widens
@@ -715,6 +730,33 @@ class BM25CodeIndexer:
         wrap_with_ln: bool = True,
         filter_test: bool = False,
     ) -> List[NodeInfo]:
+        if self.source_mode == SOURCE_MODE_BOUND_REPOSITORY:
+            if self._source_binding is None:  # pragma: no cover - invariant
+                raise RuntimeError("BM25 bound source mode has no source authority")
+            with self._source_binding.read_session():
+                return self._search(
+                    query,
+                    top_k=top_k,
+                    return_code_content=return_code_content,
+                    wrap_with_ln=wrap_with_ln,
+                    filter_test=filter_test,
+                )
+        return self._search(
+            query,
+            top_k=top_k,
+            return_code_content=return_code_content,
+            wrap_with_ln=wrap_with_ln,
+            filter_test=filter_test,
+        )
+
+    def _search(
+        self,
+        query: str,
+        top_k: Optional[int] = None,
+        return_code_content: bool = False,
+        wrap_with_ln: bool = True,
+        filter_test: bool = False,
+    ) -> List[NodeInfo]:
         """
         Search the index for nodes matching the query.
 
@@ -747,6 +789,7 @@ class BM25CodeIndexer:
 
         # Convert results to NodeInfo objects and apply filtering
         processed_results = []
+        source_cache: dict[str, Optional[str]] = {}
         for doc in results:
             # Extract all metadata directly from the document
             metadata = doc.metadata
@@ -765,7 +808,18 @@ class BM25CodeIndexer:
             # Handle code content if requested
             content = None
             if return_code_content and file_path:
-                source_text = _read_source_text(self.project_root, file_path)
+                source_text = None
+                if self.source_mode != SOURCE_MODE_PERSISTED_ONLY:
+                    try:
+                        source_key = os.fspath(file_path)
+                    except TypeError:
+                        source_key = None
+                    if isinstance(source_key, str):
+                        if source_key not in source_cache:
+                            source_cache[source_key] = self._read_result_source(
+                                source_key
+                            )
+                        source_text = source_cache[source_key]
                 if source_text is not None:
                     if node_type == NODE_TYPE_FILE:
                         # For file nodes, return entire file content.
@@ -823,6 +877,34 @@ class BM25CodeIndexer:
         return processed_results
 
     def search_identifier_occurrences(
+        self,
+        identifier: str,
+        *,
+        context_query: Optional[str] = None,
+        top_k: int = 20,
+        wrap_with_ln: bool = True,
+        filter_test: bool = False,
+    ) -> List[NodeInfo]:
+        if self.source_mode == SOURCE_MODE_BOUND_REPOSITORY:
+            if self._source_binding is None:  # pragma: no cover - invariant
+                raise RuntimeError("BM25 bound source mode has no source authority")
+            with self._source_binding.read_session():
+                return self._search_identifier_occurrences(
+                    identifier,
+                    context_query=context_query,
+                    top_k=top_k,
+                    wrap_with_ln=wrap_with_ln,
+                    filter_test=filter_test,
+                )
+        return self._search_identifier_occurrences(
+            identifier,
+            context_query=context_query,
+            top_k=top_k,
+            wrap_with_ln=wrap_with_ln,
+            filter_test=filter_test,
+        )
+
+    def _search_identifier_occurrences(
         self,
         identifier: str,
         *,
@@ -891,18 +973,23 @@ class BM25CodeIndexer:
                 continue
             if not isinstance(source_key, str):
                 continue
-            if source_key not in files:
-                source_text = _read_source_text(self.project_root, source_key)
-                files[source_key] = (
-                    _split_source_lines(source_text) if source_text is not None else []
-                )
-            lines = files[source_key]
-            if not lines:
-                continue
-
-            start_idx = max(0, start_line)
-            end_idx = min(len(lines), end_line + 1)
-            selected = lines[start_idx:end_idx]
+            if self.source_mode == SOURCE_MODE_PERSISTED_ONLY:
+                selected = _split_source_lines(doc.page_content)
+                start_idx = max(0, start_line)
+            else:
+                if source_key not in files:
+                    source_text = self._read_result_source(source_key)
+                    files[source_key] = (
+                        _split_source_lines(source_text)
+                        if source_text is not None
+                        else []
+                    )
+                lines = files[source_key]
+                if not lines:
+                    continue
+                start_idx = max(0, start_line)
+                end_idx = min(len(lines), end_line + 1)
+                selected = lines[start_idx:end_idx]
             code_content = "".join(selected)
             if not occurrence.search(code_content):
                 continue
@@ -941,6 +1028,40 @@ class BM25CodeIndexer:
 
         matches.sort(key=lambda item: (item[0], item[1], item[2]))
         return [node for _, _, _, node in matches[:top_k]]
+
+    def bind_repository_source(self, binding: RepositorySourceBinding) -> None:
+        """Attach a retained source authority chosen by the runtime caller."""
+
+        if binding.fingerprint is None:  # pragma: no cover - structural contract
+            raise TypeError("repository source binding is invalid")
+        binding.verify_snapshot()
+        self._source_binding = binding
+        self.project_root = str(binding.root)
+        self.source_mode = SOURCE_MODE_BOUND_REPOSITORY
+
+    def _read_result_source(self, file_path: object) -> Optional[str]:
+        if self.source_mode == SOURCE_MODE_BOUND_REPOSITORY:
+            if self._source_binding is None:  # pragma: no cover - invariant
+                raise RuntimeError("BM25 bound source mode has no source authority")
+            try:
+                relative = os.fspath(file_path)
+            except TypeError:
+                return None
+            if not isinstance(relative, str):
+                return None
+            try:
+                payload = self._source_binding.read_bytes(
+                    relative,
+                    max_bytes=_MAX_RUNTIME_SOURCE_BYTES,
+                )
+            except ValueError:
+                return None
+            return (
+                payload.decode("utf-8", errors="replace")
+                .replace("\r\n", "\n")
+                .replace("\r", "\n")
+            )
+        return _read_source_text(self.project_root, file_path)
 
     def save_index(self, directory_path: str):
         """
@@ -998,13 +1119,70 @@ class BM25CodeIndexer:
         with open(documents_file, "r", encoding="utf-8") as f:
             documents_data = json.load(f)
 
-        # Reconstruct Document objects
+        metadata_file = os.path.join(directory_path, "bm25_metadata.json")
+        if os.path.exists(metadata_file):
+            with open(metadata_file, "r", encoding="utf-8") as f:
+                metadata = json.load(f)
+        else:
+            metadata = {
+                "project_root": None,
+                "max_k": self.max_k,
+                "language": self.language,
+            }
+        self.load_index_values(documents_data, metadata)
+
+    def load_index_values(
+        self,
+        documents_data: Iterable[object],
+        metadata: Mapping[str, Any] | None,
+        *,
+        source_mode: str = SOURCE_MODE_LEGACY_DIRECT,
+    ) -> None:
+        """Load already-decoded BM25 values from an authenticated reader.
+
+        Artifact runtimes use this entry point so persisted bytes can be read
+        through a pinned directory authority instead of being reopened by path.
+        """
+
+        if metadata is not None and not isinstance(metadata, Mapping):
+            raise ValueError("BM25 metadata must be an object")
+        metadata = {} if metadata is None else metadata
+        max_k = metadata.get("max_k", 10)
+        language = metadata.get("language", "english")
+        project_root = metadata.get("project_root")
+        if isinstance(max_k, bool) or not isinstance(max_k, int) or max_k <= 0:
+            raise ValueError("BM25 max_k must be a positive integer")
+        if not isinstance(language, str) or not language:
+            raise ValueError("BM25 language must be a non-empty string")
+        if project_root is not None and not isinstance(project_root, str):
+            raise ValueError("BM25 project_root must be a string or null")
+        if source_mode not in _SOURCE_MODES:
+            raise ValueError(f"unsupported BM25 source mode: {source_mode!r}")
+
+        # Restore serving configuration before creating the retriever.  Its k
+        # value is fixed at construction time.
+        self.project_root = project_root
+        self.source_mode = source_mode
+        self._source_binding = None
+        self.max_k = max_k
+        self.language = language
+
+        # Reconstruct Document objects one decoded element at a time.
         self.documents = []
         self.nodes = []
         seen_nodes = set()
         for doc_data in documents_data:
+            if not isinstance(doc_data, Mapping):
+                raise ValueError("BM25 document must be an object")
+            page_content = doc_data.get("page_content")
+            document_metadata = doc_data.get("metadata")
+            if not isinstance(page_content, str) or not isinstance(
+                document_metadata, Mapping
+            ):
+                raise ValueError("BM25 document content or metadata is invalid")
             doc = Document(
-                page_content=doc_data["page_content"], metadata=doc_data["metadata"]
+                page_content=page_content,
+                metadata=dict(document_metadata),
             )
             self.documents.append(doc)
             node_name = doc.metadata.get("node_id") or doc.metadata.get("name")
@@ -1012,19 +1190,4 @@ class BM25CodeIndexer:
                 self.nodes.append(node_name)
                 seen_nodes.add(node_name)
 
-        # Load additional metadata including project_root
-        metadata_file = os.path.join(directory_path, "bm25_metadata.json")
-        if os.path.exists(metadata_file):
-            with open(metadata_file, "r", encoding="utf-8") as f:
-                metadata = json.load(f)
-                self.project_root = metadata.get("project_root")
-                self.max_k = metadata.get("max_k", 10)
-                self.language = metadata.get("language", "english")
-        else:
-            # For backward compatibility with indices saved without metadata
-            self.project_root = None
-
-        # Recreate only after restoring ``max_k``. Reversing this order silently
-        # capped loaded artifacts at the constructor default (15), even when
-        # the persisted compiler contract requested 128 candidates.
         self.retriever = BM25Retriever.from_documents(self.documents, k=self.max_k)

--- a/codenib/index/sparse_idx/bm25_index.py
+++ b/codenib/index/sparse_idx/bm25_index.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 from rank_bm25 import BM25Okapi
 
+from ..._contained_source import read_repository_file
 from ...code_chunker import CodeChunk
 from ...log_utils import get_logger
 from ...types import NODE_TYPE_DIRECTORY, NODE_TYPE_FILE, NodeInfo, is_symbol_node
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+_MAX_RUNTIME_SOURCE_BYTES = 64 * 1024 * 1024
 _SECURE_SOURCE_DIRECTORY_FDS = (
     os.name == "posix"
     and hasattr(os, "O_DIRECTORY")
@@ -325,10 +327,19 @@ def _read_source_text(project_root: object, file_path: object) -> Optional[str]:
         return None
     root, _source_path, parts = contained
     if _SECURE_SOURCE_DIRECTORY_FDS:
-        descriptor = _open_regular_file_beneath(root, parts)
-        if descriptor is None:
+        try:
+            payload = read_repository_file(
+                root,
+                "/".join(parts),
+                max_bytes=_MAX_RUNTIME_SOURCE_BYTES,
+            )
+        except ValueError:
             return None
-        return _read_open_descriptor(descriptor)
+        return (
+            payload.decode("utf-8", errors="replace")
+            .replace("\r\n", "\n")
+            .replace("\r", "\n")
+        )
     return _read_static_contained_source(root, parts)
 
 

--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -78,7 +78,7 @@ also remain available. All forms accept
 | `lsp_definition` | runtime LSP provider or `symbol_graph` | location | static graph analogue of go-to-definition |
 | `lsp_references` | runtime LSP provider or `symbol_graph` | locations | static graph analogue of find-references |
 | `lsp_route` | runtime LSP provider or `symbol_graph` | locations | compact route anchors for related symbols |
-| `read_source` | verified checkout | source window | bounded source inspection after retrieval/navigation |
+| `read_source` | content-authenticated source binding | source window | bounded source inspection after retrieval/navigation |
 | `get_manifest` | — | — | repo metadata: path, commit, languages, capabilities |
 
 All source locations returned by MCP use 1-based line numbers. Internal indexes
@@ -175,8 +175,10 @@ Static LSP-shaped navigation through the server's selected runtime provider.
 A source-verified local C/C++-only checkout can reuse an existing project-local
 clangd index for symbol definition and reference queries without generating a
 new index. Position and route calls lazily load the compatible complete graph
-once. Portable artifacts, mixed-language repositories, unverified checkouts,
-and disabled or unavailable native support use the persisted `symbol_graph`.
+once. Portable artifacts expose only their supported portable views and never
+attach a project-local native provider. Mixed-language repositories, unverified
+checkouts, and disabled or unavailable native support use the persisted
+`symbol_graph` when that view is eligible and loaded.
 Result rows expose provider backend, fallback, capability, and snapshot metadata
 when available; `get_manifest.runtime.lsp_provider` exposes the selection before
 the first result. These tools return compact locations only; clients should read
@@ -199,8 +201,9 @@ entry budget before normalization.
   matches and 512 expanded candidates, and stops after 100 milliseconds.
 
 ### `read_source`
-Reads source only when server startup verified the checkout against the direct
-manifest or a rebound portable artifact.
+Reads source only while a retained repository authority authenticates the live
+bytes against the v2 content fingerprint and per-file records from a direct
+manifest or rebound portable artifact.
 
 - `file_path` (str): canonical repository-relative POSIX path; absolute paths,
   traversal, symlinks, and special files are rejected.
@@ -211,8 +214,10 @@ manifest or a rebound portable artifact.
 The response includes at most 16,000 content characters plus the indexed
 commit/source fingerprint. `content_projection` reports whether the requested
 window was shortened and, when truncation ended on a complete line, the next
-`start_line`. Source identity is checked at startup under the server's
-quiescent-checkout assumption; restart or rebind after modifying the checkout.
+`start_line`. Each read session revalidates the retained whole-tree authority
+and exact file record. The commit is display provenance only: mutable Git HEAD
+is not attested by this content binding. Any source drift permanently disables
+the binding until the server is restarted or rebound.
 
 ### `get_manifest`
 Returns the manifest version; a nested `repo` object containing path, commit,

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -28,6 +28,7 @@ from .._atomic_directory import (
 from .._bounded_json import iter_bounded_json_array
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
+from ..index.embedding.artifact_integrity import require_authorized_vector_view
 from ..provider_routes import resolve_embedding_artifact_route
 
 if TYPE_CHECKING:
@@ -274,11 +275,11 @@ class ServerContext:
         ctx: ServerContext | None = None
         try:
             selected = _resolve_views(views)
-            if artifact_binding is not None and native_index_authorization is not None:
-                raise ValueError(
-                    "portable artifact bindings cannot authorize native vector parsing"
-                )
             artifact_origin = artifact is not None or artifact_binding is not None
+            if artifact_origin and native_index_authorization is not None:
+                raise ValueError(
+                    "portable artifact contexts cannot authorize native vector parsing"
+                )
             if artifact_origin:
                 disallowed = selected - _PORTABLE_ARTIFACT_RUNTIME_VIEWS
                 if views is not None and disallowed:
@@ -425,18 +426,24 @@ class ServerContext:
 
         selected = _resolve_views(views)
         with self._view_lock:
-            if self.artifact is not None or self._artifact_binding is not None:
+            artifact_origin = (
+                self.artifact is not None or self._artifact_binding is not None
+            )
+            if artifact_origin:
                 disallowed = selected - _PORTABLE_ARTIFACT_RUNTIME_VIEWS
                 if disallowed:
                     raise ValueError(
                         "portable artifact contexts cannot load native views: "
                         + ", ".join(sorted(disallowed))
                     )
-            if native_index_authorization is not None:
-                if self._artifact_binding is not None:
+                if (
+                    native_index_authorization is not None
+                    or self._native_index_authorization is not None
+                ):
                     raise ValueError(
-                        "portable artifact bindings cannot authorize native parsing"
+                        "portable artifact contexts cannot authorize native parsing"
                     )
+            if native_index_authorization is not None:
                 self._native_index_authorization = native_index_authorization
             for view, loader_name in _VIEW_LOADERS:
                 if view not in selected or getattr(self, view, None) is not None:
@@ -678,6 +685,13 @@ class ServerContext:
         entry = self.manifest.indexes.get("vector")
         if not entry or not self.manifest.index_is_current("vector"):
             return
+        if self.artifact is not None or self._artifact_binding is not None:
+            self.errors["vector"] = (
+                "portable artifact contexts cannot use external authorization "
+                "for native vector parsing"
+            )
+            logger.warning("Portable vector view remains native-parser inert")
+            return
         if self._native_index_authorization is None:
             self.errors["vector"] = (
                 "native vector parsing requires external authorization; "
@@ -691,6 +705,11 @@ class ServerContext:
             from ..index.embedding.vector_store import CodeVectorStore
 
             cfg = entry.config
+            require_authorized_vector_view(
+                entry.path,
+                self._native_index_authorization,
+                cfg,
+            )
             route = resolve_embedding_artifact_route(cfg)
             kwargs = route.embedding_backend_kwargs()
             if probe:

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -12,23 +12,33 @@ call time rather than blocking server startup.
 
 from __future__ import annotations
 
+import json
 import logging
+import math
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import RLock
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
 
+from .._atomic_directory import (
+    PublicationDirectoryReader,
+    reopen_authenticated_directory,
+)
+from .._bounded_json import iter_bounded_json_array
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
 from ..provider_routes import resolve_embedding_artifact_route
 
 if TYPE_CHECKING:
+    from ..artifacts.runtime import ContextArtifactBinding
     from ..graph.code_graph import CodeGraph
     from ..index.embedding.vector_store import CodeVectorStore
     from ..index.regex_idx import RegexNodeIndex
     from ..index.sparse_idx import BM25CodeIndexer
     from ..index.trigram import ZoektSearcher
+    from ..native_index_authorization import NativeIndexAuthorization
+    from ..source_fingerprint import RepositorySourceBinding
 
 logger = logging.getLogger(__name__)
 
@@ -40,9 +50,55 @@ _VIEW_LOADERS = (
     ("vector", "_load_vector"),
 )
 RUNTIME_VIEW_NAMES = frozenset(name for name, _ in _VIEW_LOADERS)
+_PORTABLE_ARTIFACT_RUNTIME_VIEWS = frozenset({"bm25", "vector"})
+_MAX_ARTIFACT_METADATA_BYTES = 16 * 1024 * 1024
+_MAX_ARTIFACT_DOCUMENTS_BYTES = 256 * 1024 * 1024
 _VIEW_DEPENDENCIES = {
     "regex_index": frozenset({"symbol_graph"}),
 }
+
+
+def _reject_duplicate_json_object(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate artifact BM25 JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _bounded_json_int(value: str) -> int:
+    if len(value) > 1_024:
+        raise ValueError("artifact BM25 JSON integer is too large")
+    return int(value)
+
+
+def _bounded_json_float(value: str) -> float:
+    if len(value) > 1_024:
+        raise ValueError("artifact BM25 JSON number is too large")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError("artifact BM25 JSON number is not finite")
+    return result
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"artifact BM25 JSON constant is not finite: {value}")
+
+
+def _load_artifact_bm25_metadata(payload: bytes) -> Mapping[str, Any]:
+    value = json.loads(
+        payload,
+        object_pairs_hook=_reject_duplicate_json_object,
+        parse_int=_bounded_json_int,
+        parse_float=_bounded_json_float,
+        parse_constant=_reject_json_constant,
+    )
+    if not isinstance(value, dict):
+        raise ValueError("artifact BM25 metadata must be a JSON object")
+    return value
 
 
 class _DimensionProbeEmbedding:
@@ -126,13 +182,76 @@ class ServerContext:
     lsp_provider_selection: Dict[str, Any] = field(default_factory=dict)
     errors: Dict[str, str] = field(default_factory=dict)
     artifact: Optional[Mapping[str, Any]] = None
-    source_verified: bool = False
     source_error: Optional[str] = "source binding has not been verified"
     _lsp_allow_native: bool = field(default=False, init=False, repr=False)
     _lsp_native_disabled_reason: str = field(
         default="local_source_not_verified", init=False, repr=False
     )
     _view_lock: RLock = field(default_factory=RLock, init=False, repr=False)
+    _native_index_authorization: Optional[NativeIndexAuthorization] = field(
+        default=None,
+        repr=False,
+    )
+    _artifact_binding: Optional[ContextArtifactBinding] = field(
+        default=None,
+        repr=False,
+    )
+    _source_binding: Optional[RepositorySourceBinding] = field(
+        default=None,
+        repr=False,
+    )
+
+    @property
+    def source_verified(self) -> bool:
+        """Return whether live reads retain exact content-byte authority."""
+
+        return self._source_binding is not None and self._source_binding.usable
+
+    @property
+    def source_verification_scope(self) -> str | None:
+        """M1 authenticates v2 content bytes, never mutable Git HEAD state."""
+
+        return "content-bytes" if self.source_verified else None
+
+    @property
+    def commit_verified(self) -> bool:
+        """Mutable checkout commit provenance requires an M2 source snapshot."""
+
+        return False
+
+    def _install_repository_source(
+        self,
+        source: RepositorySourceBinding | None,
+    ) -> None:
+        """Publish a transferred source in this already-reachable owner."""
+
+        self._source_binding = source
+
+    def read_source_bytes(self, relative: str, *, max_bytes: int) -> bytes:
+        """Read one repository file through the retained source authority."""
+
+        if self._source_binding is None:
+            raise RuntimeError(
+                f"source reads are unavailable: {self.source_error or 'unverified'}"
+            )
+        try:
+            return self._source_binding.read_bytes(relative, max_bytes=max_bytes)
+        except Exception as exc:
+            self.source_error = str(exc)
+            raise
+
+    def verify_source_status(self) -> bool:
+        """Refresh whole-tree source truth before publishing verified status."""
+
+        if self._source_binding is None:
+            return False
+        try:
+            self._source_binding.verify_snapshot()
+        except Exception as exc:
+            self.source_error = self._source_binding.failure_reason or str(exc)
+            return False
+        self.source_error = None
+        return True
 
     @classmethod
     def load(
@@ -141,6 +260,9 @@ class ServerContext:
         *,
         views: Iterable[str] | None = None,
         artifact: Mapping[str, Any] | None = None,
+        artifact_binding: ContextArtifactBinding | None = None,
+        native_index_authorization: NativeIndexAuthorization | None = None,
+        source_binding: RepositorySourceBinding | None = None,
     ) -> ServerContext:
         """Load a manifest and the selected runtime views.
 
@@ -149,39 +271,133 @@ class ServerContext:
         selected view is loaded independently; a failure in one does not block
         the others. Failed views are recorded in ``errors``.
         """
-        selected = _resolve_views(views)
-        manifest = (
-            manifest_path
-            if isinstance(manifest_path, RepoManifest)
-            else RepoManifest.load(manifest_path)
-        )
-        ctx = cls(manifest=manifest, artifact=dict(artifact) if artifact else None)
+        ctx: ServerContext | None = None
+        try:
+            selected = _resolve_views(views)
+            if artifact_binding is not None and native_index_authorization is not None:
+                raise ValueError(
+                    "portable artifact bindings cannot authorize native vector parsing"
+                )
+            artifact_origin = artifact is not None or artifact_binding is not None
+            if artifact_origin:
+                disallowed = selected - _PORTABLE_ARTIFACT_RUNTIME_VIEWS
+                if views is not None and disallowed:
+                    raise ValueError(
+                        "portable artifact contexts cannot load native views: "
+                        + ", ".join(sorted(disallowed))
+                    )
+                selected &= _PORTABLE_ARTIFACT_RUNTIME_VIEWS
+            if artifact_binding is not None:
+                if (
+                    not isinstance(manifest_path, RepoManifest)
+                    or manifest_path.to_dict() != artifact_binding.manifest.to_dict()
+                ):
+                    raise ValueError(
+                        "artifact runtime manifest must come from its verified binding"
+                    )
+                manifest = artifact_binding.manifest
+            else:
+                manifest = (
+                    manifest_path
+                    if isinstance(manifest_path, RepoManifest)
+                    else RepoManifest.load(manifest_path)
+                )
 
-        ctx.load_views(selected)
-        ctx.configure_lsp_provider(
-            allow_native=False,
-            native_disabled_reason=(
-                "portable_artifact_uses_persisted_graph"
-                if ctx.artifact is not None
-                else "local_source_not_verified"
-            ),
-        )
+            ctx = cls(
+                manifest=manifest,
+                artifact=dict(artifact) if artifact is not None else None,
+                _native_index_authorization=native_index_authorization,
+                _artifact_binding=artifact_binding,
+                _source_binding=None,
+            )
+            if artifact_binding is not None:
+                artifact_binding.install_source_binding(
+                    ctx._install_repository_source,
+                    expected=source_binding,
+                    require_expected=source_binding is not None,
+                )
+            else:
+                ctx._install_repository_source(source_binding)
+            owned_source = ctx._source_binding
 
-        cap_summary = {k: v for k, v in manifest.capabilities.items() if v}
-        loaded = [
-            view for view, _ in _VIEW_LOADERS if getattr(ctx, view, None) is not None
-        ]
-        logger.info(
-            "ServerContext ready  repo=%s  commit=%s  requested=%s  loaded=%s  "
-            "capabilities=%s  errors=%s",
-            manifest.repo_path,
-            manifest.commit[:8] if manifest.commit else "N/A",
-            sorted(selected),
-            loaded or "none",
-            cap_summary or "none",
-            list(ctx.errors) or "none",
-        )
-        return ctx
+            if owned_source is not None:
+                from ..source_fingerprint import (
+                    is_secure_source_fingerprint_v2,
+                    lexical_repository_path,
+                )
+
+                if (
+                    not owned_source.usable
+                    or not is_secure_source_fingerprint_v2(manifest.source_fingerprint)
+                    or owned_source.fingerprint != manifest.source_fingerprint
+                    or owned_source.file_count != manifest.file_count
+                    or owned_source.root != lexical_repository_path(manifest.repo_path)
+                ):
+                    raise ValueError(
+                        "repository source authority does not match the manifest"
+                    )
+                owned_source.verify_snapshot()
+
+            ctx.source_error = (
+                None
+                if owned_source is not None
+                else "source binding has not been verified"
+            )
+
+            ctx.load_views(selected)
+            ctx.configure_lsp_provider(
+                allow_native=False,
+                native_disabled_reason=(
+                    "portable_artifact_uses_persisted_graph"
+                    if artifact_origin
+                    else "local_source_not_verified"
+                ),
+            )
+
+            cap_summary = {k: v for k, v in manifest.capabilities.items() if v}
+            loaded = [
+                view
+                for view, _ in _VIEW_LOADERS
+                if getattr(ctx, view, None) is not None
+            ]
+            logger.info(
+                "ServerContext ready  repo=%s  commit=%s  requested=%s  loaded=%s  "
+                "capabilities=%s  errors=%s",
+                manifest.repo_path,
+                manifest.commit[:8] if manifest.commit else "N/A",
+                sorted(selected),
+                loaded or "none",
+                cap_summary or "none",
+                list(ctx.errors) or "none",
+            )
+            return ctx
+        except BaseException as primary:  # noqa: B036 - preserve primary
+            from ..artifacts.runtime import (
+                _raise_source_cleanup_failure,
+                _source_cleanup_owner_is_pending,
+            )
+
+            cleanup_source = (
+                ctx._source_binding
+                if ctx is not None and ctx._source_binding is not None
+                else source_binding if artifact_binding is None else None
+            )
+            cleanup_failure: BaseException | None = None
+            if cleanup_source is not None:
+                try:
+                    cleanup_source.close()
+                except BaseException as exc:  # noqa: B036 - apply shared priority
+                    cleanup_failure = exc
+            pending_owner = (
+                cleanup_source
+                if _source_cleanup_owner_is_pending(cleanup_source)
+                else None
+            )
+            _raise_source_cleanup_failure(
+                primary,
+                cleanup_failure,
+                pending_owner,
+            )
 
     @property
     def loaded_views(self) -> frozenset[str]:
@@ -193,7 +409,12 @@ class ServerContext:
             if getattr(self, view, None) is not None
         )
 
-    def load_views(self, views: Iterable[str]) -> Dict[str, str]:
+    def load_views(
+        self,
+        views: Iterable[str],
+        *,
+        native_index_authorization: NativeIndexAuthorization | None = None,
+    ) -> Dict[str, str]:
         """Load additional manifest views without disturbing loaded resources.
 
         View dependencies are resolved in the same way as :meth:`load`. The
@@ -204,6 +425,19 @@ class ServerContext:
 
         selected = _resolve_views(views)
         with self._view_lock:
+            if self.artifact is not None or self._artifact_binding is not None:
+                disallowed = selected - _PORTABLE_ARTIFACT_RUNTIME_VIEWS
+                if disallowed:
+                    raise ValueError(
+                        "portable artifact contexts cannot load native views: "
+                        + ", ".join(sorted(disallowed))
+                    )
+            if native_index_authorization is not None:
+                if self._artifact_binding is not None:
+                    raise ValueError(
+                        "portable artifact bindings cannot authorize native parsing"
+                    )
+                self._native_index_authorization = native_index_authorization
             for view, loader_name in _VIEW_LOADERS:
                 if view not in selected or getattr(self, view, None) is not None:
                     continue
@@ -232,6 +466,10 @@ class ServerContext:
             if self.vector is not None:
                 _close_vector(self.vector)
                 self.vector = None
+            if self._source_binding is not None:
+                self._source_binding.close()
+                self._source_binding = None
+                self.source_error = "source binding is closed"
 
     def configure_lsp_provider(
         self,
@@ -262,6 +500,7 @@ class ServerContext:
         manifest: RepoManifest | str | Path,
         *,
         views: Iterable[str],
+        native_index_authorization: NativeIndexAuthorization | None = None,
     ) -> Dict[str, str]:
         """Open selected artifacts without initializing a vector query model.
 
@@ -277,7 +516,10 @@ class ServerContext:
             if isinstance(manifest, RepoManifest)
             else RepoManifest.load(manifest)
         )
-        ctx = cls(manifest=resolved_manifest)
+        ctx = cls(
+            manifest=resolved_manifest,
+            _native_index_authorization=native_index_authorization,
+        )
         available: set[str] = set()
         try:
             for view, loader_name in _VIEW_LOADERS:
@@ -328,12 +570,51 @@ class ServerContext:
             return
         try:
             from ..index.sparse_idx import BM25CodeIndexer
+            from ..index.sparse_idx.bm25_index import SOURCE_MODE_PERSISTED_ONLY
 
-            require_bm25_manifest_artifact(entry)
             indexer = BM25CodeIndexer()
-            indexer.load_index(entry.path)
-            if indexer.project_root == "source":
-                indexer.project_root = self.manifest.repo_path
+            if self._artifact_binding is None:
+                if self.artifact is not None:
+                    raise ValueError(
+                        "portable BM25 loading requires a verified artifact binding"
+                    )
+                require_bm25_manifest_artifact(entry)
+                indexer.load_index(entry.path)
+            else:
+                artifact = self._artifact_binding.artifact
+
+                def load_portable_bm25(
+                    reader: PublicationDirectoryReader,
+                ) -> None:
+                    metadata = _load_artifact_bm25_metadata(
+                        reader.read_bytes(
+                            "views/bm25/bm25_metadata.json",
+                            max_bytes=_MAX_ARTIFACT_METADATA_BYTES,
+                        )
+                    )
+                    with reader.open_authenticated_file(
+                        "views/bm25/documents.json",
+                        max_bytes=_MAX_ARTIFACT_DOCUMENTS_BYTES,
+                    ) as documents:
+                        indexer.load_index_values(
+                            iter_bounded_json_array(
+                                documents,
+                                label="portable artifact BM25 documents",
+                            ),
+                            metadata,
+                            source_mode=SOURCE_MODE_PERSISTED_ONLY,
+                        )
+
+                reopen_authenticated_directory(
+                    artifact.root,
+                    artifact.ownership,  # type: ignore[arg-type]
+                    load_portable_bm25,
+                )
+            if self._source_binding is not None:
+                indexer.bind_repository_source(self._source_binding)
+            else:
+                indexer.project_root = None
+                indexer.source_mode = SOURCE_MODE_PERSISTED_ONLY
             self.bm25 = indexer
             logger.info("Loaded BM25 index from %s", entry.path)
         except Exception as exc:
@@ -397,6 +678,13 @@ class ServerContext:
         entry = self.manifest.indexes.get("vector")
         if not entry or not self.manifest.index_is_current("vector"):
             return
+        if self._native_index_authorization is None:
+            self.errors["vector"] = (
+                "native vector parsing requires external authorization; "
+                "portable artifacts remain inert by default"
+            )
+            logger.warning("Vector view is inert without external authorization")
+            return
 
         vector = None
         try:
@@ -421,7 +709,9 @@ class ServerContext:
             )
 
             # Load FAISS index from disk
-            vector.load()
+            vector.load(
+                native_index_authorization=self._native_index_authorization,
+            )
 
             # Validate model consistency
             loaded_model = vector.embedding_model

--- a/codenib/mcp/prompts.py
+++ b/codenib/mcp/prompts.py
@@ -14,7 +14,8 @@ Use the lower-level tools when you need to force one operation.
 Search responses keep every ranked location but may project large source bodies
 under a shared content budget. A truncated hit includes ``content_projection``
 metadata; use ``read_source`` with its file and 1-based line range to inspect
-the exact checkout before finalizing an answer.
+content authenticated against the indexed v2 source fingerprint before
+finalizing an answer. The displayed commit is not a mutable-HEAD attestation.
 
 ## When to use each tool
 
@@ -68,9 +69,11 @@ Examples:
 ### read_source
 Use after search or static navigation identifies a source location. It accepts
 only a repository-relative POSIX path and at most 200 lines per call. The
-server enables reads only when the checkout matched the manifest or a verified
-portable-artifact binding at startup, and each response carries that commit and
-source fingerprint.
+server enables reads only while a retained source authority matches the v2
+content fingerprint and per-file records from a manifest or portable-artifact
+binding. Each response carries the indexed commit as display provenance and the
+content fingerprint used by that authority; it does not claim that mutable Git
+HEAD is attested.
 
 ### Choosing between them
 | Scenario | Tool |

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -22,8 +22,9 @@ import argparse
 import asyncio
 import logging
 import sys
+from contextlib import nullcontext
 from pathlib import Path
-from typing import Annotated, Any, Literal, Optional
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional
 
 from mcp.server import MCPServer
 from pydantic import Field
@@ -51,6 +52,10 @@ from .tools.search import search_bm25_impl, search_context_impl, search_regex_im
 from .tools.search import search_semantic as _search_semantic_impl
 from .tools.search import search_zoekt_impl
 from .tools.source import read_source_impl
+
+if TYPE_CHECKING:
+    from ..artifacts.runtime import ContextArtifactBinding
+    from ..source_fingerprint import RepositorySourceBinding
 
 logger = logging.getLogger(__name__)
 
@@ -396,9 +401,10 @@ async def lsp_route(
 @mcp.tool(
     name="read_source",
     description=(
-        "Read up to 200 lines from the verified repository checkout using a "
+        "Read up to 200 lines authenticated by the retained source-content "
+        "binding using a "
         "repository-relative POSIX path and 1-based inclusive line range. "
-        "Responses are bounded and retain commit/source provenance."
+        "Responses are bounded; commit is display provenance, not attested."
     ),
 )
 async def read_source(
@@ -406,7 +412,7 @@ async def read_source(
     start_line: _PositiveLine = 1,
     end_line: _PositiveLine | None = None,
 ) -> dict[str, Any]:
-    """Return one bounded source window from the verified checkout."""
+    """Return one bounded window from content-authenticated source bytes."""
     if _ctx is None:
         raise RuntimeError("Server not initialized")
     return await asyncio.to_thread(
@@ -429,13 +435,17 @@ async def get_manifest() -> dict[str, Any]:
     """Return the repo manifest as a dict."""
     if _ctx is None:
         raise RuntimeError("Server not initialized")
+    source_verified = _ctx.verify_source_status()
     result = _ctx.manifest.to_dict()
     result["runtime"] = {
         "loaded_views": sorted(_ctx.loaded_views),
         "view_errors": dict(sorted(_ctx.errors.items())),
         "source_read": {
-            "verified": _ctx.source_verified,
+            "verified": source_verified,
             "error": _ctx.source_error,
+            "verification_scope": _ctx.source_verification_scope,
+            "commit_verified": False,
+            "checkout_state": "not-attested",
         },
         "lsp_provider": dict(_ctx.lsp_provider_selection),
     }
@@ -505,8 +515,11 @@ def server_status() -> str:
         else:
             lines.append("  ✗ zoekt: not_loaded")
 
+        source_verified = ctx.verify_source_status()
         source_status = (
-            "verified" if ctx.source_verified else (ctx.source_error or "unverified")
+            "verified(content-bytes; commit=not-attested)"
+            if source_verified
+            else (ctx.source_error or "unverified")
         )
         lines.append(f"  source_read: {source_status}")
 
@@ -580,7 +593,8 @@ def init_server(
     manifest_path: RepoManifest | str | Path,
     *,
     artifact: dict[str, Any] | None = None,
-    source_verified: bool = False,
+    artifact_binding: ContextArtifactBinding | None = None,
+    source_binding: RepositorySourceBinding | None = None,
 ) -> None:
     """Initialize the global ServerContext from a manifest file.
 
@@ -600,49 +614,186 @@ def init_server(
             manifest.repo_path,
             (manifest.commit or "")[:12],
         )
+        compiler_lock = nullcontext()
     else:
         resolved = Path(manifest_path).resolve()
         if not resolved.exists():
             raise FileNotFoundError(f"Manifest not found: {resolved}")
         logger.info("Loading manifest from %s", resolved)
-        manifest = RepoManifest.load(resolved)
         resolved_manifest_path = resolved
-    if _ctx is not None:
-        _ctx.close()
-    _ctx = ServerContext.load(manifest, artifact=artifact)
-    if source_verified:
-        _ctx.source_verified = True
-        _ctx.source_error = None
-    elif resolved_manifest_path is not None:
-        from ..compiler.checkout_identity import validate_checkout_identity
+        # A local manifest is an explicit administrator boundary. Serialize
+        # capture and native loading with the same cache lock as IndexCompiler.
+        # Artifact bindings intentionally skip this branch and remain inert.
+        from filelock import FileLock
 
-        repo_path = Path(manifest.repo_path).expanduser().resolve()
-        if not manifest.source_fingerprint:
-            _ctx.source_error = "manifest has no source fingerprint"
-        elif not repo_path.is_dir():
-            _ctx.source_error = "manifest repository checkout does not exist"
-        else:
+        compiler_lock = FileLock(str(resolved.parent / ".index-compiler.lock"))
+
+    from ..artifacts.runtime import (
+        SourceBindingCleanupOwner,
+        _raise_source_cleanup_failure,
+        _source_cleanup_owner_is_pending,
+    )
+
+    capture_cleanup_owner: SourceBindingCleanupOwner | None = None
+    new_context: ServerContext | None = None
+
+    def close_capture_owner(
+        primary: BaseException,
+    ) -> tuple[BaseException | None, object | None]:
+        """Close the preinstalled owner and identify any retry authority."""
+
+        cleanup_failure: BaseException | None = None
+        if capture_cleanup_owner is not None:
             try:
-                validate_checkout_identity(
-                    repo_path,
-                    manifest,
-                    artifact_root=resolved_manifest_path.parent,
-                )
-            except (OSError, ValueError) as exc:
-                _ctx.source_error = str(exc)
-            else:
-                _ctx.source_verified = True
-                _ctx.source_error = None
+                capture_cleanup_owner.close()
+            except BaseException as exc:  # noqa: B036 - caller selects priority
+                cleanup_failure = exc
+        pending_owner: object | None = None
+        if _source_cleanup_owner_is_pending(capture_cleanup_owner):
+            pending_owner = capture_cleanup_owner
+        nested_owner = getattr(primary, "source_cleanup_owner", None)
+        if pending_owner is None and _source_cleanup_owner_is_pending(nested_owner):
+            pending_owner = nested_owner
+        return cleanup_failure, pending_owner
+
+    try:
+        with compiler_lock:
+            if resolved_manifest_path is not None:
+                manifest = RepoManifest.load(resolved_manifest_path)
+
+            from ..source_fingerprint import (
+                capture_repository_source,
+                is_secure_source_fingerprint_v2,
+            )
+
+            source_error: str | None = "source binding has not been verified"
+            retained_source = (
+                artifact_binding.source_binding
+                if artifact_binding is not None
+                else source_binding
+            )
+            verified = retained_source is not None and is_secure_source_fingerprint_v2(
+                manifest.source_fingerprint
+            )
+            native_authorization = None
+            if verified:
+                source_error = None
+            elif resolved_manifest_path is not None:
+                from ..source_fingerprint import lexical_repository_path
+
+                repo_path = lexical_repository_path(manifest.repo_path)
+                if not is_secure_source_fingerprint_v2(manifest.source_fingerprint):
+                    source_error = (
+                        "manifest has no trust-eligible source fingerprint v2"
+                    )
+                else:
+                    capture_cleanup_owner = SourceBindingCleanupOwner()
+                    try:
+                        retained_source = capture_repository_source(
+                            repo_path,
+                            exclude_roots=(resolved_manifest_path.parent,),
+                            _source_owner=capture_cleanup_owner.retain,
+                        )
+                        if (
+                            retained_source.fingerprint != manifest.source_fingerprint
+                            or retained_source.file_count != manifest.file_count
+                        ):
+                            raise ValueError(
+                                "repository source bytes do not match the indexed "
+                                "content"
+                            )
+                    except BaseException as exc:  # noqa: B036 - preserve primary
+                        cleanup_failure, pending_owner = close_capture_owner(exc)
+                        retained_source = None
+                        if (
+                            not isinstance(exc, Exception)
+                            or cleanup_failure is not None
+                            or pending_owner is not None
+                        ):
+                            _raise_source_cleanup_failure(
+                                exc,
+                                cleanup_failure,
+                                pending_owner,
+                            )
+                        source_error = str(exc)
+                    else:
+                        verified = True
+                        source_error = None
+
+                if verified and manifest.index_is_current("vector"):
+                    from ..index.embedding.artifact_integrity import (
+                        capture_authenticated_vector_view,
+                    )
+                    from ..native_index_authorization import (
+                        _mint_trusted_local_admin_authorization,
+                    )
+
+                    entry = manifest.indexes["vector"]
+                    with capture_authenticated_vector_view(entry.path) as vector_view:
+                        native_authorization = _mint_trusted_local_admin_authorization(
+                            vector_view.ownership,
+                            view_type="vector",
+                            semantic_contract=entry.config,
+                            evidence=(
+                                "local-admin-cli-intent",
+                                "source-content-fingerprint-v2-bound",
+                                "captured-vector-tree-subject",
+                            ),
+                        )
+
+            new_context = ServerContext.load(
+                manifest,
+                artifact=artifact,
+                artifact_binding=artifact_binding,
+                native_index_authorization=native_authorization,
+                source_binding=retained_source,
+            )
+            new_context.source_error = source_error
+            portable_artifact = artifact is not None or artifact_binding is not None
+            new_context.configure_lsp_provider(
+                allow_native=new_context.source_verified and not portable_artifact,
+                native_disabled_reason=(
+                    "portable_artifact_uses_persisted_graph"
+                    if portable_artifact
+                    else "local_source_not_verified"
+                ),
+            )
+
+        if _ctx is not None:
+            _ctx.close()
+        _ctx = new_context
         if not _ctx.source_verified:
             logger.warning("Source reads disabled: %s", _ctx.source_error)
-    _ctx.configure_lsp_provider(
-        allow_native=_ctx.source_verified and _ctx.artifact is None,
-        native_disabled_reason=(
-            "portable_artifact_uses_persisted_graph"
-            if _ctx.artifact is not None
-            else "local_source_not_verified"
-        ),
-    )
+    except BaseException as primary:  # noqa: B036 - retain capture owner
+        # Once the new context is globally reachable it is the stable owner.
+        # Before that point, the preinstalled capture owner must close or retain
+        # the source across any return-handoff or startup cancellation.
+        if not (new_context is not None and _ctx is new_context):
+            cleanup_failure: BaseException | None = None
+            pending_owner: object | None = None
+            context_source = (
+                new_context._source_binding if new_context is not None else None
+            )
+            if new_context is not None:
+                try:
+                    new_context.close()
+                except BaseException as exc:  # noqa: B036 - apply shared priority
+                    cleanup_failure = exc
+            if _source_cleanup_owner_is_pending(context_source):
+                pending_owner = context_source
+            if capture_cleanup_owner is not None:
+                owner_failure, owner_pending = close_capture_owner(primary)
+                if cleanup_failure is None:
+                    cleanup_failure = owner_failure
+                if pending_owner is None:
+                    pending_owner = owner_pending
+            if cleanup_failure is not None or pending_owner is not None:
+                _raise_source_cleanup_failure(
+                    primary,
+                    cleanup_failure,
+                    pending_owner,
+                )
+        raise
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -654,37 +805,51 @@ def main(argv: list[str] | None = None) -> None:
     if args.artifact and manifest_path:
         logger.error("Choose either a manifest or --artifact, not both")
         sys.exit(1)
-    if args.artifact and not args.repo:
-        logger.error("--artifact requires --repo with the exact checkout")
-        sys.exit(1)
     if not args.artifact and not manifest_path:
         logger.error(
-            "No context provided. Use: %s <manifest> or --artifact <dir> --repo <dir>",
+            "No context provided. Use: %s <manifest> or --artifact <dir> "
+            "[--repo <dir>]",
             program_name,
         )
         sys.exit(1)
 
     try:
         if args.artifact:
-            from ..artifacts import bind_context_artifact
+            if args.repo:
+                from ..artifacts import bind_context_artifact
 
-            binding = bind_context_artifact(
-                args.artifact,
-                args.repo,
-                expected_repository=args.repository,
-            )
+                binding = bind_context_artifact(
+                    args.artifact,
+                    args.repo,
+                    expected_repository=args.repository,
+                )
+            else:
+                from ..artifacts import query_context_artifact
+
+                binding = query_context_artifact(
+                    args.artifact,
+                    expected_repository=args.repository,
+                )
             artifact = binding.artifact
-            init_server(
-                binding.manifest,
-                artifact={
-                    "verified": True,
-                    "schema": artifact.metadata["schema"],
-                    "repository": artifact.repository,
-                    "commit": artifact.commit,
-                    "views": list(artifact.views),
-                },
-                source_verified=True,
-            )
+            try:
+                init_server(
+                    binding.manifest,
+                    artifact={
+                        "verified": True,
+                        "schema": artifact.metadata["schema"],
+                        "repository": artifact.repository,
+                        "commit": artifact.commit,
+                        "views": list(artifact.views),
+                    },
+                    artifact_binding=binding,
+                )
+            except BaseException:  # noqa: B036 - preserve startup failure
+                try:
+                    binding.close()
+                except BaseException:  # noqa: B036 - preserve primary failure
+                    pass
+                raise
+            binding.close()
         else:
             init_server(manifest_path)
         logger.info("Starting MCP server on stdio...")

--- a/codenib/mcp/tools/source.py
+++ b/codenib/mcp/tools/source.py
@@ -39,11 +39,6 @@ def _repository_relative_source(ctx: ServerContext, value: str) -> str:
         raise ValueError("file_path must be a repository-relative POSIX path.")
 
     root = Path(ctx.manifest.repo_path).expanduser().resolve()
-    candidate = root
-    for part in path.parts:
-        candidate = candidate / part
-        if candidate.is_symlink():
-            raise ValueError("file_path must not traverse a symbolic link.")
     relative = safe_repo_relative_path(str(root), path_text)
     if relative != path_text:
         raise ValueError("file_path must resolve inside the repository checkout.")

--- a/codenib/mcp/tools/source.py
+++ b/codenib/mcp/tools/source.py
@@ -7,10 +7,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import Any
 
-from ...web.repository_files import live_source_slice, safe_repo_relative_path
 from ..context import ServerContext
 from ._validation import (
     MAX_LSP_POSITION,
@@ -20,6 +19,8 @@ from ._validation import (
     bounded_integer,
     required_text,
 )
+
+_MAX_SOURCE_FILE_BYTES = 64 * 1024 * 1024
 
 
 def _repository_relative_source(ctx: ServerContext, value: str) -> str:
@@ -38,11 +39,7 @@ def _repository_relative_source(ctx: ServerContext, value: str) -> str:
     ):
         raise ValueError("file_path must be a repository-relative POSIX path.")
 
-    root = Path(ctx.manifest.repo_path).expanduser().resolve()
-    relative = safe_repo_relative_path(str(root), path_text)
-    if relative != path_text:
-        raise ValueError("file_path must resolve inside the repository checkout.")
-    return relative
+    return path_text
 
 
 def _bounded_source_content(payload: dict[str, Any]) -> dict[str, Any]:
@@ -99,7 +96,7 @@ def read_source_impl(
     start_line: int = 1,
     end_line: int | None = None,
 ) -> dict[str, Any]:
-    """Read one verified repository-relative source window."""
+    """Read one content-authenticated repository-relative source window."""
 
     if getattr(ctx, "source_verified", False) is not True:
         detail = getattr(ctx, "source_error", None) or "source binding is unverified"
@@ -126,14 +123,23 @@ def read_source_impl(
             f"source windows may contain at most {MAX_SOURCE_WINDOW_LINES} lines."
         )
 
-    payload = live_source_slice(
-        ctx.manifest.repo_path,
-        relative,
-        first,
-        last,
-    )
-    if payload is None:
-        raise ValueError("file_path is not a readable regular repository file.")
+    try:
+        source_bytes = ctx.read_source_bytes(
+            relative,
+            max_bytes=_MAX_SOURCE_FILE_BYTES,
+        )
+    except ValueError as exc:
+        raise ValueError(
+            "file_path is not a readable regular repository file."
+        ) from exc
+    all_lines = source_bytes.decode("utf-8", errors="replace").splitlines(keepends=True)
+    selected = all_lines[first - 1 : last]
+    payload = {
+        "file": relative,
+        "start_line": first,
+        "end_line": first + len(selected) - 1,
+        "content": "".join(selected),
+    }
     if int(payload["end_line"]) < first:
         raise ValueError("start_line exceeds the source file length.")
     payload = _bounded_source_content(payload)
@@ -143,6 +149,9 @@ def read_source_impl(
         "commit": ctx.manifest.commit,
         "source_fingerprint": ctx.manifest.source_fingerprint,
         "verified": True,
+        "verification_scope": "content-bytes",
+        "commit_verified": False,
+        "checkout_state": "not-attested",
     }
     return payload
 

--- a/codenib/model/embedding_retrieve_pipeline.py
+++ b/codenib/model/embedding_retrieve_pipeline.py
@@ -4,13 +4,16 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
 from ..log_utils import get_logger
 from ..types import QueriedNode
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from ..native_index_authorization import NativeIndexAuthorization
 
 
 class EmbeddingRetrievePipeline:
@@ -76,6 +79,7 @@ class EmbeddingRetrievePipeline:
         index_type: str = "flat",
         ivf_nlist: int = 100,
         ivf_nprobe: int = 8,
+        native_index_authorization: NativeIndexAuthorization | None = None,
     ) -> None:
         self.top_k = top_k
         _embedding_kwargs = dict(embedding_kwargs or {})
@@ -121,9 +125,15 @@ class EmbeddingRetrievePipeline:
                 ivf_nlist=ivf_nlist,
                 ivf_nprobe=ivf_nprobe,
                 force_rebuild=force_rebuild,
+                native_index_authorization=native_index_authorization,
             )
 
-    def load_index(self, index_path: str) -> None:
+    def load_index(
+        self,
+        index_path: str,
+        *,
+        native_index_authorization: NativeIndexAuthorization | None = None,
+    ) -> None:
         """Hot-swap the FAISS index without reloading the embedding model.
 
         Validates the pre-built index at *index_path* before releasing the
@@ -131,7 +141,10 @@ class EmbeddingRetrievePipeline:
         faster than creating a new :class:`EmbeddingRetrievePipeline` for each
         instance, and a failed replacement leaves the current index available.
         """
-        self.vector_store.swap_index(index_path)
+        self.vector_store.swap_index(
+            index_path,
+            native_index_authorization=native_index_authorization,
+        )
 
     def query(self, query: str, top_k: Optional[int] = None) -> List[QueriedNode]:
         """Retrieve top-K nodes using embedding similarity search.

--- a/codenib/model/graph_retrieve_pipeline.py
+++ b/codenib/model/graph_retrieve_pipeline.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..graph.roi_subgraph import ROISubgraph
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
@@ -15,6 +15,9 @@ from ..log_utils import get_logger
 from ..ls_router import build_graph_for_languages
 from ..profiler import Profiler
 from ..types import QueriedNode
+
+if TYPE_CHECKING:
+    from ..native_index_authorization import NativeIndexAuthorization
 
 logger = get_logger(__name__)
 
@@ -85,6 +88,7 @@ class SparseSeededGraphRetrievePipeline:
         max_lines_per_chunk: int = 300,
         project_name: Optional[str] = None,
         profiler: Optional[Profiler] = None,
+        native_index_authorization: NativeIndexAuthorization | None = None,
     ) -> None:
         self.stage1_topk = stage1_topk
         self.stage2_topk = stage2_topk
@@ -152,6 +156,7 @@ class SparseSeededGraphRetrievePipeline:
                     embedding_kwargs=embedding_kwargs,
                     index_metric="ip",
                     profiler=profiler,
+                    native_index_authorization=native_index_authorization,
                 )
 
     def query(

--- a/codenib/model/hybrid_retrieve_pipeline.py
+++ b/codenib/model/hybrid_retrieve_pipeline.py
@@ -78,11 +78,14 @@ References
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence
+from typing import TYPE_CHECKING, List, Optional, Sequence
 
 from ..compiler import build_skill_contexts
 from ..log_utils import get_logger
 from ..types import QueriedNode
+
+if TYPE_CHECKING:
+    from ..native_index_authorization import NativeIndexAuthorization
 
 logger = get_logger(__name__)
 
@@ -126,6 +129,7 @@ class HybridRetrievePipeline:
         trust_remote_code: Optional[bool] = None,
         languages: Sequence[str] = ("python",),
         embedding_batch_size: int = 8,
+        native_index_authorization: NativeIndexAuthorization | None = None,
     ):
         self.repo_path = repo_path
         self.stage1_topk = stage1_topk
@@ -163,6 +167,7 @@ class HybridRetrievePipeline:
             default_level="l2",  # embedding level
             trust_remote_code=trust_remote_code,
             embedding_batch_size=embedding_batch_size,  # Avoid CUDA OOM
+            native_index_authorization=native_index_authorization,
         )
 
         retrieve_ctx = contexts.get("retrieve")

--- a/codenib/model/retrieve_rerank_pipeline.py
+++ b/codenib/model/retrieve_rerank_pipeline.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Set
 from ..code_chunker import CodeChunker, RepoChunkingConfig
 from ..graph.code_graph import CodeGraph
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
+from ..index.embedding.artifact_integrity import require_authorized_vector_view
 from ..index.embedding.model_policy import resolve_embedding_load_policy_from_options
 from ..index.rerank.cross_encoder import build_reranker
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
@@ -809,13 +810,6 @@ class RetrieveRerankPipeline:
         embedding_dimension: int,
         embedding_kwargs: Dict[str, object],
     ) -> CodeVectorStore:
-        vector_store = CodeVectorStore(
-            embedding_model=embedding_model,
-            embedding_provider=embedding_provider,
-            dimension=embedding_dimension,
-            store_path=str(self.index_path),
-            **embedding_kwargs,
-        )
         model_suffix = embedding_model.replace("/", "__")
         config_file = self.index_path / f"config_{model_suffix}.json"
         l0_path = self.index_path / "l0"
@@ -824,6 +818,20 @@ class RetrieveRerankPipeline:
         cache_exists = config_file.exists() or (l0_path.exists() and l2_path.exists())
         force_rebuild = False
         authorization = getattr(self, "_native_index_authorization", None)
+        if cache_exists and authorization is not None:
+            require_authorized_vector_view(
+                self.index_path,
+                authorization,
+                {},
+            )
+
+        vector_store = CodeVectorStore(
+            embedding_model=embedding_model,
+            embedding_provider=embedding_provider,
+            dimension=embedding_dimension,
+            store_path=str(self.index_path),
+            **embedding_kwargs,
+        )
         if cache_exists and authorization is not None:
             logger.info(
                 "Loading hierarchical vector store from cache.",

--- a/codenib/model/retrieve_rerank_pipeline.py
+++ b/codenib/model/retrieve_rerank_pipeline.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Set
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Set
 
 from ..code_chunker import CodeChunker, RepoChunkingConfig
 from ..graph.code_graph import CodeGraph
@@ -38,6 +38,9 @@ from .retrieval_planner import (
 )
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from ..native_index_authorization import NativeIndexAuthorization
 
 SUPPORTED_ENGINES = {"dense", "sparse"}
 RETRIEVAL_TOP_K = 100
@@ -185,6 +188,7 @@ class RetrieveRerankPipeline:
         enable_rerank: bool = True,
         vector_masks: Optional[Dict[str, Set[str]]] = None,
         rerank_candidate_top_k: Optional[int] = None,
+        native_index_authorization: NativeIndexAuthorization | None = None,
     ) -> None:
         self.repo_path = self._validate_repo(repo_path)
         self.index_path = Path(index_path)
@@ -195,6 +199,7 @@ class RetrieveRerankPipeline:
         self.enable_rerank = enable_rerank
         self.index_metric = "ip"
         self.profiler = None
+        self._native_index_authorization = native_index_authorization
         self.retrieval_mode = (retrieval_mode or "dense").strip().lower()
         self.retrieval_planner = retrieval_planner
         if self.retrieval_planner is None and self.retrieval_mode == "auto":
@@ -817,12 +822,17 @@ class RetrieveRerankPipeline:
         l2_path = self.index_path / "l2"
 
         cache_exists = config_file.exists() or (l0_path.exists() and l2_path.exists())
-        if cache_exists:
+        force_rebuild = False
+        authorization = getattr(self, "_native_index_authorization", None)
+        if cache_exists and authorization is not None:
             logger.info(
                 "Loading hierarchical vector store from cache.",
                 extra={"index_path": str(self.index_path)},
             )
-            vector_store.load(str(self.index_path))
+            vector_store.load(
+                str(self.index_path),
+                native_index_authorization=authorization,
+            )
             missing_levels = []
             if not vector_store.l0_documents:
                 missing_levels.append("l0")
@@ -838,6 +848,14 @@ class RetrieveRerankPipeline:
                 extra={"index_path": str(self.index_path)},
             )
             vector_store.clear()
+            force_rebuild = True
+        elif cache_exists:
+            logger.warning(
+                "Cached vector store at %s has no external native-index "
+                "authorization; rebuilding from repository source.",
+                self.index_path,
+            )
+            force_rebuild = True
 
         logger.info("Building hierarchical vector store index.")
         vector_store = build_hierarchical_vector_store(
@@ -854,6 +872,8 @@ class RetrieveRerankPipeline:
             embedding=vector_store.embedding,
             index_metric=self.index_metric,
             profiler=self.profiler,
+            force_rebuild=force_rebuild,
+            native_index_authorization=authorization,
         )
         return vector_store
 

--- a/codenib/native_index_authorization.py
+++ b/codenib/native_index_authorization.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Out-of-band authorization for native index parsers.
+
+Artifact bytes and manifests can describe an index, but they can never mint this
+capability.  A trusted caller first binds a captured tree and semantic contract,
+then passes the resulting process-local token to the exact native consumer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+from ._atomic_directory import (
+    directory_ownership_digest,
+    directory_ownership_file_records,
+    directory_ownership_root_identity,
+)
+
+NATIVE_INDEX_SUBJECT_SCHEMA = "codenib.native-index-subject.v1"
+FAISS_PARSER_CONTRACT = "codenib.faiss-read-index.v1"
+NativeTrustClass = Literal["trusted-local"]
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_TOKEN_SEAL = object()
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _semantic_digest(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class NativeIndexSubject:
+    parser_contract: str
+    view_type: str
+    tree_digest: str
+    semantic_contract_digest: str
+    files: tuple[tuple[str, int, int, str], ...]
+
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json(
+            {
+                "schema": NATIVE_INDEX_SUBJECT_SCHEMA,
+                "parser_contract": self.parser_contract,
+                "view_type": self.view_type,
+                "tree_digest": self.tree_digest,
+                "semantic_contract_digest": self.semantic_contract_digest,
+                "files": [
+                    {
+                        "path": path,
+                        "mode": mode,
+                        "size": size,
+                        "sha256": digest,
+                    }
+                    for path, mode, size, digest in self.files
+                ],
+            }
+        )
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.canonical_bytes()).hexdigest()
+
+
+class NativeIndexAuthorization:
+    """Non-serializable, process-local capability for one native subject."""
+
+    __slots__ = (
+        "_seal",
+        "trust_class",
+        "view_type",
+        "subject_digest",
+        "root_identity",
+        "evidence",
+    )
+
+    def __init__(
+        self,
+        seal: object,
+        *,
+        trust_class: NativeTrustClass,
+        view_type: str,
+        subject_digest: str,
+        root_identity: tuple[int, ...] | None,
+        evidence: tuple[str, ...],
+    ) -> None:
+        if seal is not _TOKEN_SEAL:
+            raise TypeError("native index authorization cannot be constructed directly")
+        self._seal = seal
+        self.trust_class = trust_class
+        self.view_type = view_type
+        self.subject_digest = subject_digest
+        self.root_identity = root_identity
+        self.evidence = evidence
+
+    def __reduce__(self):
+        raise TypeError(
+            "native index authorization is process-local and not serializable"
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "NativeIndexAuthorization("
+            f"trust_class={self.trust_class!r}, view_type={self.view_type!r}, "
+            f"subject_digest={self.subject_digest[:12]}...)"
+        )
+
+
+def native_index_subject(
+    ownership: object,
+    *,
+    view_type: str,
+    semantic_contract: Mapping[str, Any],
+    parser_contract: str = FAISS_PARSER_CONTRACT,
+) -> NativeIndexSubject:
+    if not isinstance(view_type, str) or not view_type:
+        raise ValueError("native index view type must be non-empty")
+    if not isinstance(semantic_contract, Mapping):
+        raise TypeError("native index semantic contract must be a mapping")
+    records = directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+    return NativeIndexSubject(
+        parser_contract=parser_contract,
+        view_type=view_type,
+        tree_digest=directory_ownership_digest(ownership),  # type: ignore[arg-type]
+        semantic_contract_digest=_semantic_digest(dict(semantic_contract)),
+        files=tuple(
+            (record.path, record.mode, record.size, record.sha256) for record in records
+        ),
+    )
+
+
+def mint_trusted_local_authorization(
+    ownership: object,
+    *,
+    view_type: str,
+    semantic_contract: Mapping[str, Any],
+    evidence: Sequence[str] = (),
+) -> NativeIndexAuthorization:
+    """Mint after the caller's local lock/source/config checks have succeeded."""
+
+    subject = native_index_subject(
+        ownership,
+        view_type=view_type,
+        semantic_contract=semantic_contract,
+    )
+    normalized_evidence = tuple(evidence)
+    if any(not isinstance(item, str) or not item for item in normalized_evidence):
+        raise ValueError(
+            "native index authorization evidence must be non-empty strings"
+        )
+    return NativeIndexAuthorization(
+        _TOKEN_SEAL,
+        trust_class="trusted-local",
+        view_type=view_type,
+        subject_digest=subject.digest,
+        root_identity=directory_ownership_root_identity(ownership),  # type: ignore[arg-type]
+        evidence=normalized_evidence,
+    )
+
+
+def require_native_index_authorization(
+    authorization: NativeIndexAuthorization | None,
+    ownership: object,
+    *,
+    view_type: str,
+    semantic_contract: Mapping[str, Any],
+) -> NativeIndexSubject:
+    if (
+        not isinstance(authorization, NativeIndexAuthorization)
+        or authorization._seal is not _TOKEN_SEAL
+    ):
+        raise ValueError("native index parsing requires external authorization")
+    subject = native_index_subject(
+        ownership,
+        view_type=view_type,
+        semantic_contract=semantic_contract,
+    )
+    if (
+        authorization.view_type != view_type
+        or authorization.subject_digest != subject.digest
+        or not _DIGEST_RE.fullmatch(authorization.subject_digest)
+    ):
+        raise ValueError("native index authorization does not match captured bytes")
+    if (
+        authorization.trust_class == "trusted-local"
+        and authorization.root_identity
+        != (directory_ownership_root_identity(ownership))  # type: ignore[arg-type]
+    ):
+        raise ValueError("trusted-local authorization does not match the root identity")
+    if authorization.trust_class != "trusted-local":
+        raise ValueError("native index authorization has an unsupported trust class")
+    return subject
+
+
+__all__ = [
+    "FAISS_PARSER_CONTRACT",
+    "NATIVE_INDEX_SUBJECT_SCHEMA",
+    "NativeIndexAuthorization",
+    "NativeIndexSubject",
+    "mint_trusted_local_authorization",
+    "native_index_subject",
+    "require_native_index_authorization",
+]

--- a/codenib/native_index_authorization.py
+++ b/codenib/native_index_authorization.py
@@ -31,6 +31,18 @@ _DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _TOKEN_SEAL = object()
 
 
+class NativeIndexAuthorizationError(ValueError):
+    """Base error for a supplied native-index capability that cannot be used."""
+
+
+class MissingNativeIndexAuthorizationError(NativeIndexAuthorizationError):
+    """Raised when a native parser was invoked without an external capability."""
+
+
+class InvalidNativeIndexAuthorizationError(NativeIndexAuthorizationError):
+    """Raised when an explicitly supplied capability is malformed or mismatched."""
+
+
 def _canonical_json(value: Any) -> bytes:
     return json.dumps(
         value,
@@ -221,13 +233,21 @@ def require_native_index_authorization(
     view_type: str,
     semantic_contract: Mapping[str, Any],
 ) -> NativeIndexSubject:
+    if authorization is None:
+        raise MissingNativeIndexAuthorizationError(
+            "native index parsing requires external authorization"
+        )
     if (
         not isinstance(authorization, NativeIndexAuthorization)
         or authorization._seal is not _TOKEN_SEAL
     ):
-        raise ValueError("native index parsing requires external authorization")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization is malformed"
+        )
     if authorization.process_id != os.getpid():
-        raise ValueError("native index authorization belongs to another process")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization belongs to another process"
+        )
     subject = native_index_subject(
         ownership,
         view_type=view_type,
@@ -238,15 +258,21 @@ def require_native_index_authorization(
         or authorization.subject_digest != subject.digest
         or not _DIGEST_RE.fullmatch(authorization.subject_digest)
     ):
-        raise ValueError("native index authorization does not match captured bytes")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization does not match captured bytes"
+        )
     if (
         authorization.trust_class == "trusted-local"
         and authorization.root_identity
         != (directory_ownership_root_identity(ownership))  # type: ignore[arg-type]
     ):
-        raise ValueError("trusted-local authorization does not match the root identity")
+        raise InvalidNativeIndexAuthorizationError(
+            "trusted-local authorization does not match the root identity"
+        )
     if authorization.trust_class != "trusted-local":
-        raise ValueError("native index authorization has an unsupported trust class")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization has an unsupported trust class"
+        )
     return subject
 
 
@@ -257,26 +283,39 @@ def require_native_index_authorization_preflight(
 ) -> None:
     """Reject malformed or foreign-process tokens before expensive capture."""
 
+    if authorization is None:
+        raise MissingNativeIndexAuthorizationError(
+            "native index parsing requires external authorization"
+        )
     if (
         not isinstance(authorization, NativeIndexAuthorization)
         or authorization._seal is not _TOKEN_SEAL
     ):
-        raise ValueError("native index parsing requires external authorization")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization is malformed"
+        )
     if authorization.process_id != os.getpid():
-        raise ValueError("native index authorization belongs to another process")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization belongs to another process"
+        )
     if (
         authorization.trust_class != "trusted-local"
         or authorization.view_type != view_type
         or not _DIGEST_RE.fullmatch(authorization.subject_digest)
         or authorization.root_identity is None
     ):
-        raise ValueError("native index authorization has an invalid preliminary scope")
+        raise InvalidNativeIndexAuthorizationError(
+            "native index authorization has an invalid preliminary scope"
+        )
 
 
 __all__ = [
     "FAISS_PARSER_CONTRACT",
+    "InvalidNativeIndexAuthorizationError",
+    "MissingNativeIndexAuthorizationError",
     "NATIVE_INDEX_SUBJECT_SCHEMA",
     "NativeIndexAuthorization",
+    "NativeIndexAuthorizationError",
     "NativeIndexSubject",
     "native_index_subject",
     "require_native_index_authorization",

--- a/codenib/native_index_authorization.py
+++ b/codenib/native_index_authorization.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping, Sequence
@@ -80,14 +81,7 @@ class NativeIndexSubject:
 class NativeIndexAuthorization:
     """Non-serializable, process-local capability for one native subject."""
 
-    __slots__ = (
-        "_seal",
-        "trust_class",
-        "view_type",
-        "subject_digest",
-        "root_identity",
-        "evidence",
-    )
+    __slots__ = ("_state",)
 
     def __init__(
         self,
@@ -98,15 +92,55 @@ class NativeIndexAuthorization:
         subject_digest: str,
         root_identity: tuple[int, ...] | None,
         evidence: tuple[str, ...],
+        process_id: int,
     ) -> None:
         if seal is not _TOKEN_SEAL:
             raise TypeError("native index authorization cannot be constructed directly")
-        self._seal = seal
-        self.trust_class = trust_class
-        self.view_type = view_type
-        self.subject_digest = subject_digest
-        self.root_identity = root_identity
-        self.evidence = evidence
+        object.__setattr__(
+            self,
+            "_state",
+            (
+                seal,
+                trust_class,
+                view_type,
+                subject_digest,
+                root_identity,
+                evidence,
+                process_id,
+            ),
+        )
+
+    def __setattr__(self, name: str, value: object) -> None:
+        del name, value
+        raise AttributeError("native index authorization is immutable")
+
+    @property
+    def _seal(self) -> object:
+        return self._state[0]
+
+    @property
+    def trust_class(self) -> NativeTrustClass:
+        return self._state[1]
+
+    @property
+    def view_type(self) -> str:
+        return self._state[2]
+
+    @property
+    def subject_digest(self) -> str:
+        return self._state[3]
+
+    @property
+    def root_identity(self) -> tuple[int, ...] | None:
+        return self._state[4]
+
+    @property
+    def evidence(self) -> tuple[str, ...]:
+        return self._state[5]
+
+    @property
+    def process_id(self) -> int:
+        return self._state[6]
 
     def __reduce__(self):
         raise TypeError(
@@ -144,14 +178,18 @@ def native_index_subject(
     )
 
 
-def mint_trusted_local_authorization(
+def _mint_trusted_local_admin_authorization(
     ownership: object,
     *,
     view_type: str,
     semantic_contract: Mapping[str, Any],
-    evidence: Sequence[str] = (),
+    evidence: Sequence[str],
 ) -> NativeIndexAuthorization:
-    """Mint after the caller's local lock/source/config checks have succeeded."""
+    """Issue only after the caller's local lock/source/config checks succeed.
+
+    The module seal prevents artifact self-authorization and accidental direct
+    construction. It is not a sandbox against malicious in-process Python.
+    """
 
     subject = native_index_subject(
         ownership,
@@ -159,7 +197,9 @@ def mint_trusted_local_authorization(
         semantic_contract=semantic_contract,
     )
     normalized_evidence = tuple(evidence)
-    if any(not isinstance(item, str) or not item for item in normalized_evidence):
+    if not normalized_evidence or any(
+        not isinstance(item, str) or not item for item in normalized_evidence
+    ):
         raise ValueError(
             "native index authorization evidence must be non-empty strings"
         )
@@ -170,6 +210,7 @@ def mint_trusted_local_authorization(
         subject_digest=subject.digest,
         root_identity=directory_ownership_root_identity(ownership),  # type: ignore[arg-type]
         evidence=normalized_evidence,
+        process_id=os.getpid(),
     )
 
 
@@ -185,6 +226,8 @@ def require_native_index_authorization(
         or authorization._seal is not _TOKEN_SEAL
     ):
         raise ValueError("native index parsing requires external authorization")
+    if authorization.process_id != os.getpid():
+        raise ValueError("native index authorization belongs to another process")
     subject = native_index_subject(
         ownership,
         view_type=view_type,
@@ -207,12 +250,35 @@ def require_native_index_authorization(
     return subject
 
 
+def require_native_index_authorization_preflight(
+    authorization: NativeIndexAuthorization | None,
+    *,
+    view_type: str,
+) -> None:
+    """Reject malformed or foreign-process tokens before expensive capture."""
+
+    if (
+        not isinstance(authorization, NativeIndexAuthorization)
+        or authorization._seal is not _TOKEN_SEAL
+    ):
+        raise ValueError("native index parsing requires external authorization")
+    if authorization.process_id != os.getpid():
+        raise ValueError("native index authorization belongs to another process")
+    if (
+        authorization.trust_class != "trusted-local"
+        or authorization.view_type != view_type
+        or not _DIGEST_RE.fullmatch(authorization.subject_digest)
+        or authorization.root_identity is None
+    ):
+        raise ValueError("native index authorization has an invalid preliminary scope")
+
+
 __all__ = [
     "FAISS_PARSER_CONTRACT",
     "NATIVE_INDEX_SUBJECT_SCHEMA",
     "NativeIndexAuthorization",
     "NativeIndexSubject",
-    "mint_trusted_local_authorization",
     "native_index_subject",
     "require_native_index_authorization",
+    "require_native_index_authorization_preflight",
 ]

--- a/codenib/sandbox/docker.py
+++ b/codenib/sandbox/docker.py
@@ -108,50 +108,147 @@ root = pathlib.Path('/workspace')
 ignored = set(json.loads(sys.argv[1]))
 fingerprint_version = int(sys.argv[2])
 filter_version = int(sys.argv[3])
+source_root = pathlib.Path(sys.argv[4])
+if fingerprint_version != 2:
+    raise SystemExit('unsupported source fingerprint version')
 hasher = hashlib.sha256()
-hasher.update(
-    (
-        f'codenib-source-fingerprint:{fingerprint_version}:'
-        f'{filter_version}\0'
-    ).encode('ascii')
-)
+hasher.update(b'codenib-source-fingerprint\0\x02')
+def frame_header(domain, payload_size):
+    if not domain or len(domain) > 0xffff or not 0 <= payload_size < 1 << 64:
+        raise SystemExit('source fingerprint frame exceeds its limits')
+    hasher.update(len(domain).to_bytes(2, 'big'))
+    hasher.update(domain)
+    hasher.update(payload_size.to_bytes(8, 'big'))
+def frame(domain, payload):
+    frame_header(domain, len(payload))
+    hasher.update(payload)
+def hash_content(path, metadata, domain):
+    frame_header(domain, metadata.st_size)
+    with path.open('rb') as handle:
+        remaining = metadata.st_size
+        while remaining:
+            block = handle.read(min(remaining, 1024 * 1024))
+            if not block:
+                raise SystemExit('source file was truncated while hashing')
+            hasher.update(block)
+            remaining -= len(block)
+        if handle.read(1):
+            raise SystemExit('source file grew while hashing')
+def normalize_target(prefix, target):
+    if not target or '\0' in target or len(os.fsencode(target)) > 4096:
+        raise SystemExit('source symlink target is invalid')
+    if os.path.isabs(target):
+        try:
+            relative_target = pathlib.Path(os.path.normpath(target)).relative_to(
+                source_root
+            )
+        except ValueError:
+            raise SystemExit('source symlink resolves outside the repository')
+        target = relative_target.as_posix()
+        resolved = []
+    else:
+        resolved = list(prefix)
+    for part in target.split('/'):
+        if part in {'', '.'}:
+            continue
+        if part == '..':
+            if not resolved:
+                raise SystemExit('source symlink resolves outside the repository')
+            resolved.pop()
+        else:
+            resolved.append(part)
+        if len(resolved) > 256:
+            raise SystemExit('resolved source path is too deep')
+    return tuple(resolved)
+def resolve_link(relative_parts):
+    pending = list(relative_parts)
+    resolved = []
+    seen_links = set()
+    symlink_count = 0
+    while pending:
+        name = pending.pop(0)
+        candidate = root.joinpath(*resolved, name)
+        try:
+            metadata = candidate.lstat()
+        except FileNotFoundError:
+            return 'unresolved', None, None
+        if stat.S_ISLNK(metadata.st_mode):
+            symlink_count += 1
+            if symlink_count > 40:
+                return 'unresolved', None, None
+            identity = (metadata.st_dev, metadata.st_ino)
+            if identity in seen_links:
+                return 'unresolved', None, None
+            seen_links.add(identity)
+            target_parts = normalize_target(tuple(resolved), os.readlink(candidate))
+            pending = [*target_parts, *pending]
+            resolved = []
+            continue
+        if pending:
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise SystemExit('source path has a non-directory component')
+            resolved.append(name)
+            continue
+        if stat.S_ISREG(metadata.st_mode):
+            return 'regular', candidate, metadata
+        if stat.S_ISDIR(metadata.st_mode):
+            return 'directory', candidate, metadata
+        return 'unresolved', None, None
+    root_metadata = root.lstat()
+    if not stat.S_ISDIR(root_metadata.st_mode):
+        raise SystemExit('source root is not a directory')
+    return 'directory', root, root_metadata
+frame(b'filter-policy-version', str(filter_version).encode('ascii'))
 file_count = 0
-for current_root, directories, files in os.walk(root):
-    directories[:] = sorted(
-        name for name in directories
-        if name not in ignored and not name.startswith('.codenib')
-    )
-    current = pathlib.Path(current_root)
-    for filename in sorted(files):
-        path = current / filename
-        relative_path = path.relative_to(root)
-        if any(
-            part in ignored or part.startswith('.codenib')
-            for part in relative_path.parts
-        ):
+def scan_directory(current, prefix):
+    global file_count
+    with os.scandir(current) as iterator:
+        names = sorted(child.name for child in iterator)
+    child_directories = []
+    for name in names:
+        if name in ignored or name.startswith('.codenib'):
             continue
-        mode = path.lstat().st_mode
+        relative_parts = (*prefix, name)
+        path = current / name
+        metadata = path.lstat()
+        mode = metadata.st_mode
+        relative = os.fsencode('/'.join(relative_parts))
         if stat.S_ISLNK(mode):
-            raise SystemExit('source fingerprint does not permit symlinks')
-        if not stat.S_ISREG(mode):
+            target = os.readlink(path)
+            target_state, target_path, target_metadata = resolve_link(
+                relative_parts
+            )
+            if target_state == 'directory':
+                continue
+            frame(b'entry-kind', b'link')
+            frame(b'entry-path', relative)
+            frame(b'link-target', os.fsencode(target))
+            if target_state == 'unresolved':
+                frame(b'link-target-state', b'unresolved')
+            else:
+                frame(b'link-target-state', b'regular')
+                hash_content(
+                    target_path,
+                    target_metadata,
+                    b'link-target-content',
+                )
+        elif stat.S_ISREG(mode):
+            frame(b'entry-kind', b'file')
+            frame(b'entry-path', relative)
+            hash_content(path, metadata, b'file-content')
+        elif stat.S_ISDIR(mode):
+            child_directories.append((path, relative_parts))
             continue
-        relative = relative_path.as_posix().encode(
-            'utf-8', errors='surrogateescape'
-        )
-        hasher.update(b'F\0')
-        hasher.update(relative)
-        hasher.update(b'\0')
-        with path.open('rb') as handle:
-            while True:
-                block = handle.read(1024 * 1024)
-                if not block:
-                    break
-                hasher.update(block)
-        hasher.update(b'\0')
+        else:
+            continue
         file_count += 1
+    for child, child_parts in child_directories:
+        scan_directory(child, child_parts)
+scan_directory(root, ())
+frame(b'entry-count', file_count.to_bytes(8, 'big'))
 print(json.dumps({
     'file_count': file_count,
-    'source_fingerprint': 'sha256:' + hasher.hexdigest(),
+    'source_fingerprint': 'sha256-v2:' + hasher.hexdigest(),
 }, sort_keys=True, separators=(',', ':')))
 """.strip()
 
@@ -924,6 +1021,7 @@ class DockerSandboxProvider:
                 json.dumps(sorted(DEFAULT_IGNORED_DIRS), separators=(",", ":")),
                 str(SOURCE_FINGERPRINT_VERSION),
                 str(REPOSITORY_FILTER_POLICY_VERSION),
+                os.path.abspath(os.path.expanduser(os.fspath(spec.source_dir))),
             ]
         )
         completed = self._run_control_container(name, args)
@@ -935,7 +1033,7 @@ class DockerSandboxProvider:
             raise SandboxUnavailableError(
                 "sandbox source fingerprint helper returned invalid output"
             ) from exc
-        if not re.fullmatch(r"sha256:[0-9a-f]{64}", fingerprint) or file_count < 0:
+        if not re.fullmatch(r"sha256-v2:[0-9a-f]{64}", fingerprint) or file_count < 0:
             raise SandboxUnavailableError(
                 "sandbox source fingerprint helper returned invalid identity"
             )

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from ._contained_source import update_repository_file_hash
 from .repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     repository_path_is_visible,
@@ -73,11 +74,8 @@ def fingerprint_repository(
     file_count = 0
 
     for path in walk_repository_files(root_path, exclude_roots=exclude_roots):
-        relative = (
-            path.relative_to(root_path)
-            .as_posix()
-            .encode("utf-8", errors="surrogateescape")
-        )
+        relative_text = path.relative_to(root_path).as_posix()
+        relative = relative_text.encode("utf-8", errors="surrogateescape")
         try:
             mode = path.lstat().st_mode
         except OSError as exc:
@@ -87,7 +85,9 @@ def fingerprint_repository(
 
         if stat.S_ISLNK(mode):
             try:
-                target = os.readlink(path).encode("utf-8", errors="surrogateescape")
+                before_link = path.lstat()
+                raw_target = os.readlink(path)
+                target = raw_target.encode("utf-8", errors="surrogateescape")
             except OSError as exc:
                 raise RepositoryChangedError(
                     f"repository link changed while it was being inspected: {path}"
@@ -97,16 +97,28 @@ def fingerprint_repository(
             hasher.update(b"\0")
             hasher.update(target)
             hasher.update(b"\0")
-            if path.is_file():
-                hasher.update(b"C\0")
-                try:
-                    _update_file(hasher, path)
-                except OSError as exc:
-                    raise RepositoryChangedError(
-                        "repository link target could not be read consistently: "
-                        f"{path}"
-                    ) from exc
-                hasher.update(b"\0")
+            hasher.update(b"C\0")
+            try:
+                update_repository_file_hash(root_path, relative_text, hasher)
+                after_link = path.lstat()
+                after_target = os.readlink(path)
+            except (OSError, ValueError) as exc:
+                raise RepositoryChangedError(
+                    "repository link target could not be read consistently: " f"{path}"
+                ) from exc
+            if (
+                before_link.st_dev != after_link.st_dev
+                or before_link.st_ino != after_link.st_ino
+                or before_link.st_mode != after_link.st_mode
+                or before_link.st_size != after_link.st_size
+                or before_link.st_mtime_ns != after_link.st_mtime_ns
+                or before_link.st_ctime_ns != after_link.st_ctime_ns
+                or raw_target != after_target
+            ):
+                raise RepositoryChangedError(
+                    f"repository link changed while it was being read: {path}"
+                )
+            hasher.update(b"\0")
             file_count += 1
             continue
 

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -14,7 +14,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-from ._contained_source import update_repository_file_hash
+from ._contained_source import (
+    _version_identity,
+    resolved_repository_file,
+    update_repository_file_hash,
+)
 from .repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     repository_path_is_visible,
@@ -22,7 +26,6 @@ from .repository_filters import (
 )
 
 SOURCE_FINGERPRINT_VERSION = 1
-_READ_SIZE = 1024 * 1024
 
 
 class RepositoryChangedError(RuntimeError):
@@ -37,20 +40,20 @@ class SourceFingerprint:
     file_count: int
 
 
-def _update_file(hasher: "hashlib._Hash", path: Path) -> None:
-    before = path.stat()
-    with path.open("rb") as handle:
-        while block := handle.read(_READ_SIZE):
-            hasher.update(block)
-    after = path.stat()
-    if (
-        before.st_size != after.st_size
-        or before.st_mtime_ns != after.st_mtime_ns
-        or before.st_ino != after.st_ino
-    ):
-        raise RepositoryChangedError(
-            f"repository file changed while it was being read: {path}"
-        )
+def _link_matches(
+    path: Path,
+    *,
+    initial: os.stat_result,
+    target: str,
+) -> bool:
+    try:
+        observed = path.lstat()
+        observed_target = os.readlink(path)
+    except OSError:
+        return False
+    return _version_identity(observed) == _version_identity(initial) and (
+        observed_target == target
+    )
 
 
 def fingerprint_repository(
@@ -77,15 +80,15 @@ def fingerprint_repository(
         relative_text = path.relative_to(root_path).as_posix()
         relative = relative_text.encode("utf-8", errors="surrogateescape")
         try:
-            mode = path.lstat().st_mode
+            initial_metadata = path.lstat()
         except OSError as exc:
             raise RepositoryChangedError(
                 f"repository file disappeared while it was being inspected: {path}"
             ) from exc
 
+        mode = initial_metadata.st_mode
         if stat.S_ISLNK(mode):
             try:
-                before_link = path.lstat()
                 raw_target = os.readlink(path)
                 target = raw_target.encode("utf-8", errors="surrogateescape")
             except OSError as exc:
@@ -97,28 +100,25 @@ def fingerprint_repository(
             hasher.update(b"\0")
             hasher.update(target)
             hasher.update(b"\0")
-            hasher.update(b"C\0")
             try:
-                update_repository_file_hash(root_path, relative_text, hasher)
-                after_link = path.lstat()
-                after_target = os.readlink(path)
+                with resolved_repository_file(
+                    root_path,
+                    relative_text,
+                    expected_final_identity=_version_identity(initial_metadata),
+                ) as binding:
+                    if binding.is_regular:
+                        hasher.update(b"C\0")
+                        binding.update_hash(hasher)
             except (OSError, ValueError) as exc:
                 raise RepositoryChangedError(
                     "repository link target could not be read consistently: " f"{path}"
                 ) from exc
-            if (
-                before_link.st_dev != after_link.st_dev
-                or before_link.st_ino != after_link.st_ino
-                or before_link.st_mode != after_link.st_mode
-                or before_link.st_size != after_link.st_size
-                or before_link.st_mtime_ns != after_link.st_mtime_ns
-                or before_link.st_ctime_ns != after_link.st_ctime_ns
-                or raw_target != after_target
-            ):
+            if not _link_matches(path, initial=initial_metadata, target=raw_target):
                 raise RepositoryChangedError(
                     f"repository link changed while it was being read: {path}"
                 )
-            hasher.update(b"\0")
+            if binding.is_regular:
+                hasher.update(b"\0")
             file_count += 1
             continue
 
@@ -129,8 +129,13 @@ def fingerprint_repository(
         hasher.update(relative)
         hasher.update(b"\0")
         try:
-            _update_file(hasher, path)
-        except OSError as exc:
+            update_repository_file_hash(
+                root_path,
+                relative_text,
+                hasher,
+                expected_final_identity=_version_identity(initial_metadata),
+            )
+        except (OSError, ValueError) as exc:
             raise RepositoryChangedError(
                 f"repository file could not be read consistently: {path}"
             ) from exc

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -6,30 +6,266 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
+import ntpath
 import os
+import re
 import stat
 import subprocess
+import sys
+import threading
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Callable, Iterable, Iterator
 
 from ._contained_source import (
+    SECURE_CONTAINED_SYMLINKS,
+    _attach_source_cleanup_owner,
+    _binding_identity,
+    _identity_is_reliable,
+    _inherit_source_cleanup_owner,
+    _open_windows_pinned_repository_root,
+    _resolved_repository_file_at,
+    _resolved_windows_repository_file_at,
+    _SourceCleanupSlot,
+    _verify_windows_pinned_repository_root,
     _version_identity,
-    resolved_repository_file,
-    update_repository_file_hash,
+    _windows_entry_is_reparse,
+    _windows_find_child,
+    _windows_identity_is_reliable,
+    _windows_link_target_text,
+    _windows_metadata_is_reparse,
+    _windows_open_child,
+    _windows_version_identity,
+)
+from ._windows_fs_authority import (
+    IO_REPARSE_TAG_SYMLINK as _WINDOWS_IO_REPARSE_TAG_SYMLINK,
+)
+from ._windows_fs_authority import WindowsDirectoryEntry as _WindowsDirectoryEntry
+from ._windows_fs_authority import WindowsHandleMetadata as _WindowsHandleMetadata
+from ._windows_fs_authority import WindowsKernelApi as _WindowsKernelApi
+from ._windows_fs_authority import (
+    _WindowsHandleCleanup,
 )
 from .repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     repository_path_is_visible,
-    walk_repository_files,
 )
 
-SOURCE_FINGERPRINT_VERSION = 1
+SOURCE_FINGERPRINT_VERSION = 2
+
+_SOURCE_FINGERPRINT_V1_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_SOURCE_FINGERPRINT_V2_RE = re.compile(r"^sha256-v2:[0-9a-f]{64}$")
+_V2_MAGIC = b"codenib-source-fingerprint\x00\x02"
+_MAX_FRAME_BYTES = (1 << 64) - 1
+_MAX_SOURCE_COMPONENTS = 256
+_MAX_SOURCE_PATH_BYTES = 4_096
+_MAX_SOURCE_ENTRIES = 500_000
+_MAX_SOURCE_METADATA_BYTES = 128 * 1024 * 1024
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 
 
 class RepositoryChangedError(RuntimeError):
     """Raised when repository contents change while they are being inspected."""
+
+
+def _remember_interruption(
+    deferred: BaseException | None,
+    interruption: BaseException,
+) -> BaseException:
+    return deferred if deferred is not None else interruption
+
+
+class _SourceLifecycleRLock:
+    """RLock with an owner-depth token visible after interrupted acquisition."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._depth = threading.local()
+
+    def depth(self) -> int:
+        return int(getattr(self._depth, "value", 0))
+
+    def _set_depth(self, depth: int) -> None:
+        self._depth.value = depth
+
+    def _native_is_owned(self) -> bool:
+        runtime: Any = self._lock
+        ownership_check = getattr(runtime, "_is_owned", None)
+        if not callable(ownership_check):
+            raise RuntimeError("source lifecycle lock lacks owner tracking")
+        return bool(ownership_check())
+
+    def acquire(self) -> bool:
+        depth = self.depth()
+        if depth:
+            self._set_depth(depth + 1)
+            return True
+        acquired = self._lock.acquire()
+        if acquired:
+            self._set_depth(1)
+        return acquired
+
+    def release(self) -> None:
+        depth = self.depth()
+        if depth < 1 or not self._native_is_owned():
+            raise RuntimeError("cannot release an unowned source lifecycle lock")
+        if depth > 1:
+            self._set_depth(depth - 1)
+            return
+        self._lock.release()
+        self._set_depth(0)
+
+
+_SOURCE_LOCK_RECOVERY_LIMIT = 64
+
+
+def _defer_source_lock_failure(
+    deferred: BaseException | None,
+    failure: BaseException,
+) -> BaseException:
+    """Retain the first lock interruption while reconciliation completes."""
+
+    return _remember_interruption(deferred, failure)
+
+
+def _acquire_source_lock(
+    lock: _SourceLifecycleRLock,
+    baseline: int,
+    deferred: BaseException | None = None,
+) -> BaseException | None:
+    """Acquire exactly one logical lease without repeating a native acquire.
+
+    Once a native acquire may have run, ownership is reconciled before another
+    acquire is attempted.  This prevents a second cancellation in the recovery
+    probe from adding an untracked native RLock recursion level.
+    """
+
+    for _attempt in range(_SOURCE_LOCK_RECOVERY_LIMIT):
+        try:
+            depth = lock.depth()
+            native_owned = lock._native_is_owned()
+        except BaseException as exc:  # noqa: B036 - bounded reconciliation
+            deferred = _defer_source_lock_failure(deferred, exc)
+            continue
+
+        if native_owned:
+            if depth > baseline:
+                return deferred
+            try:
+                # Native ownership already proves that a zero-depth acquire
+                # completed, or that this is a reentrant logical acquisition.
+                # Publish the one logical level without touching the RLock.
+                lock._set_depth(baseline + 1)
+            except BaseException as exc:  # noqa: B036 - confirm publication
+                deferred = _defer_source_lock_failure(deferred, exc)
+                continue
+            return deferred
+
+        if depth > baseline:
+            try:
+                # A prior attempt changed only the logical token.  Roll that
+                # unowned token back before attempting the native lock.
+                lock._set_depth(baseline)
+            except BaseException as exc:  # noqa: B036 - confirm rollback
+                deferred = _defer_source_lock_failure(deferred, exc)
+                continue
+
+        try:
+            if lock.acquire():
+                return deferred
+        except BaseException as exc:  # noqa: B036 - reconcile before retry
+            deferred = _defer_source_lock_failure(deferred, exc)
+
+    if deferred is not None:
+        raise deferred
+    raise RuntimeError("source lifecycle lock acquisition recovery did not converge")
+
+
+def _release_source_lock(
+    lock: _SourceLifecycleRLock,
+    baseline: int,
+    deferred: BaseException | None = None,
+) -> BaseException | None:
+    """Restore the lease baseline without repeating a completed native release."""
+
+    for _attempt in range(_SOURCE_LOCK_RECOVERY_LIMIT):
+        try:
+            depth = lock.depth()
+            native_owned = lock._native_is_owned()
+        except BaseException as exc:  # noqa: B036 - bounded reconciliation
+            deferred = _defer_source_lock_failure(deferred, exc)
+            continue
+
+        if baseline:
+            if not native_owned:
+                # An outer logical lease must retain the collapsed native lock.
+                # Reacquiring here could block behind a replacement owner, so
+                # fail explicitly after making the lost-ownership state visible.
+                try:
+                    lock._set_depth(0)
+                except BaseException as exc:  # noqa: B036 - confirm publication
+                    deferred = _defer_source_lock_failure(deferred, exc)
+                    continue
+                return _defer_source_lock_failure(
+                    deferred,
+                    RuntimeError("source lifecycle lock lost its outer native owner"),
+                )
+            if depth != baseline:
+                try:
+                    lock._set_depth(baseline)
+                except BaseException as exc:  # noqa: B036 - confirm publication
+                    deferred = _defer_source_lock_failure(deferred, exc)
+                    continue
+            return deferred
+
+        if not native_owned:
+            if depth:
+                try:
+                    lock._set_depth(0)
+                except BaseException as exc:  # noqa: B036 - confirm publication
+                    deferred = _defer_source_lock_failure(deferred, exc)
+                    continue
+            return deferred
+
+        if depth != 1:
+            try:
+                lock._set_depth(1)
+            except BaseException as exc:  # noqa: B036 - confirm publication
+                deferred = _defer_source_lock_failure(deferred, exc)
+                continue
+
+        try:
+            lock.release()
+        except BaseException as exc:  # noqa: B036 - probe before another release
+            deferred = _defer_source_lock_failure(deferred, exc)
+
+    if deferred is not None:
+        raise deferred
+    raise RuntimeError("source lifecycle lock release recovery did not converge")
+
+
+class _SourceLockLease:
+    """Pair one cancellation-safe lock acquisition with one release."""
+
+    def __init__(self, lock: _SourceLifecycleRLock) -> None:
+        self._lock = lock
+        self._baseline = lock.depth()
+
+    def __enter__(self) -> BaseException | None:
+        return _acquire_source_lock(self._lock, self._baseline)
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        exc_value: object,
+        _traceback: object,
+    ) -> None:
+        deferred = _release_source_lock(self._lock, self._baseline)
+        if deferred is not None and exc_value is None:
+            raise deferred
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,20 +276,1878 @@ class SourceFingerprint:
     file_count: int
 
 
-def _link_matches(
-    path: Path,
-    *,
-    initial: os.stat_result,
-    target: str,
-) -> bool:
-    try:
-        observed = path.lstat()
-        observed_target = os.readlink(path)
-    except OSError:
-        return False
-    return _version_identity(observed) == _version_identity(initial) and (
-        observed_target == target
+@dataclass(frozen=True, slots=True)
+class _RepositoryEntry:
+    relative: str
+    metadata: os.stat_result | _WindowsHandleMetadata
+    link_target: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _RepositoryScan:
+    entries: tuple[_RepositoryEntry, ...]
+    inventory_digest: str
+    inventory_entries: int
+
+
+@dataclass(slots=True)
+class _RepositoryScanBudget:
+    entries: int = 0
+    metadata_bytes: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class RepositorySourceFileRecord:
+    """One regular source payload authenticated by a repository binding."""
+
+    path: str
+    size: int
+    sha256: str
+    lexical_identity: tuple[object, ...]
+
+
+class _HashFanout:
+    __slots__ = ("_targets",)
+
+    def __init__(self, *targets: object) -> None:
+        self._targets = targets
+
+    def update(self, payload: bytes) -> None:
+        for target in self._targets:
+            target.update(payload)
+
+
+class RepositorySourceBinding:
+    """Retained root authority and exact records for verified live reads."""
+
+    __slots__ = (
+        "root",
+        "fingerprint",
+        "file_count",
+        "file_records",
+        "_records",
+        "_inventory_digest",
+        "_inventory_entries",
+        "_excluded",
+        "_root_descriptor",
+        "_posix_authority",
+        "_root_identity",
+        "_windows_api",
+        "_windows_authority",
+        "_pid",
+        "_lock",
+        "_closed",
+        "_poisoned",
+        "_session_depth",
+        "_failure_reason",
     )
+
+    def __init__(
+        self,
+        *,
+        root: Path,
+        fingerprint: SourceFingerprint,
+        file_records: Iterable[RepositorySourceFileRecord],
+        inventory_digest: str,
+        inventory_entries: int,
+        excluded: tuple[tuple[str, ...], ...],
+        root_identity: tuple[object, ...],
+        root_descriptor: int = -1,
+        posix_authority: object | None = None,
+        windows_api: _WindowsKernelApi | None = None,
+        windows_authority: object | None = None,
+    ) -> None:
+        records = tuple(file_records)
+        self.root = root
+        self.fingerprint = fingerprint.value
+        self.file_count = fingerprint.file_count
+        self.file_records = records
+        self._records = {record.path: record for record in records}
+        if len(self._records) != len(records):
+            raise ValueError("repository source binding contains duplicate records")
+        self._inventory_digest = inventory_digest
+        self._inventory_entries = inventory_entries
+        self._excluded = excluded
+        self._root_descriptor = root_descriptor
+        self._posix_authority = posix_authority
+        self._root_identity = root_identity
+        self._windows_api = windows_api
+        self._windows_authority = windows_authority
+        self._pid = os.getpid()
+        self._lock = _SourceLifecycleRLock()
+        self._closed = False
+        self._poisoned = False
+        self._session_depth = 0
+        self._failure_reason: str | None = None
+
+    def __enter__(self) -> RepositorySourceBinding:
+        self._require_open()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    @property
+    def usable(self) -> bool:
+        """Return whether this process may still attempt authenticated reads."""
+
+        with self._state_lease():
+            return not self._closed and not self._poisoned and self._pid == os.getpid()
+
+    @property
+    def closed(self) -> bool:
+        """Return whether every retained filesystem authority is closed."""
+
+        with self._state_lease():
+            return self._closed
+
+    @property
+    def failure_reason(self) -> str | None:
+        """Return the first authentication failure retained for diagnostics."""
+
+        with self._state_lease():
+            return self._failure_reason
+
+    @contextmanager
+    def _state_lease(self) -> Iterator[None]:
+        with _SourceLockLease(self._lock) as acquisition_failure:
+            if acquisition_failure is not None:
+                raise acquisition_failure
+            yield
+
+    def _poison(self, reason: object) -> None:
+        try:
+            with _SourceLockLease(self._lock) as deferred:
+                if self._failure_reason is None:
+                    self._failure_reason = str(reason) or "repository source changed"
+                self._poisoned = True
+                try:
+                    self.close()
+                except BaseException as exc:  # noqa: B036 - defer cleanup
+                    deferred = _remember_interruption(deferred, exc)
+                if deferred is not None:
+                    raise deferred
+        except BaseException:  # noqa: B036 - preserve auth failure
+            # Authentication failures retain the operation's original
+            # exception after cleanup has visited every authority.
+            pass
+
+    def _require_open(self) -> None:
+        if self._poisoned:
+            raise RepositoryChangedError("repository source binding is poisoned")
+        if self._closed:
+            raise RuntimeError("repository source binding is closed")
+        if self._pid != os.getpid():
+            raise RuntimeError("repository source binding cannot cross processes")
+
+    @contextmanager
+    def _authentication_lease(self) -> Iterator[None]:
+        """Hold the reentrant lock and poison on every interrupted operation."""
+
+        try:
+            with _SourceLockLease(self._lock) as acquisition_failure:
+                if acquisition_failure is not None:
+                    raise acquisition_failure
+                yield
+        except BaseException as exc:
+            self._poison(exc)
+            raise
+
+    def _verify_inventory(self) -> None:
+        self._require_open()
+        if self._windows_authority is not None:
+            api = self._windows_api
+            if api is None:  # pragma: no cover - constructor invariant
+                raise AssertionError("Windows repository binding has no API")
+            authority = self._windows_authority
+            scan = _scan_pinned_windows_repository(
+                api,
+                authority.handle,
+                excluded=self._excluded,
+                collect_entries=False,
+            )
+            if (
+                scan.inventory_digest != self._inventory_digest
+                or scan.inventory_entries != self._inventory_entries
+            ):
+                raise RepositoryChangedError("repository source inventory changed")
+            _verify_windows_pinned_repository_root(
+                api,
+                authority,
+                self._root_identity,
+            )
+            return
+        scan = _scan_pinned_repository(
+            self._root_descriptor,
+            excluded=self._excluded,
+            collect_entries=False,
+        )
+        if (
+            scan.inventory_digest != self._inventory_digest
+            or scan.inventory_entries != self._inventory_entries
+        ):
+            raise RepositoryChangedError("repository source inventory changed")
+        authority = self._posix_authority
+        if authority is None:  # pragma: no cover - constructor invariant
+            raise AssertionError("POSIX repository binding has no root authority")
+        _verify_pinned_repository_root(
+            authority,
+            self._root_identity,  # type: ignore[arg-type]
+        )
+
+    def verify_snapshot(self) -> None:
+        """Revalidate the whole retained v2 inventory or poison this binding."""
+
+        with self._authentication_lease():
+            try:
+                self._verify_inventory()
+            except BaseException as exc:  # noqa: B036 - preserve body failure
+                self._poison(exc)
+                if isinstance(exc, RepositoryChangedError):
+                    raise
+                if not isinstance(exc, (OSError, RuntimeError, ValueError)):
+                    raise
+                raise RepositoryChangedError(
+                    "repository source changed after it was authenticated"
+                ) from exc
+
+    @contextmanager
+    def read_session(self) -> Iterator[RepositorySourceBinding]:
+        """Gate exact reads with one whole-tree check per side.
+
+        Cancellation is recovered once execution is inside this generator. The
+        outer ``contextlib`` yield/enter handoff remains Python's context-manager
+        protocol boundary; security-sensitive callers must use the temporary
+        form ``with binding.read_session():`` and must not retain or manually
+        enter the returned generator manager.
+        """
+
+        with self._authentication_lease():
+            if self._session_depth == 0:
+                try:
+                    self._verify_inventory()
+                except BaseException as exc:
+                    self._poison(exc)
+                    if isinstance(exc, RepositoryChangedError):
+                        raise
+                    if not isinstance(exc, (OSError, RuntimeError, ValueError)):
+                        raise
+                    raise RepositoryChangedError(
+                        "repository source changed before a read session"
+                    ) from exc
+            self._session_depth += 1
+            primary_failure: BaseException | None = None
+            try:
+                yield self
+            except BaseException as exc:  # noqa: B036 - preserve body failure
+                primary_failure = exc
+            finally:
+                self._session_depth -= 1
+                exit_failure: BaseException | None = None
+                if self._session_depth == 0 and not self._closed and not self._poisoned:
+                    try:
+                        self._verify_inventory()
+                    except BaseException as exc:  # noqa: B036 - defer exit fault
+                        self._poison(exc)
+                        exit_failure = exc
+                if primary_failure is not None:
+                    if exit_failure is not None:
+                        raise primary_failure from exit_failure
+                    raise primary_failure
+                if exit_failure is not None:
+                    if isinstance(exit_failure, RepositoryChangedError):
+                        raise exit_failure
+                    if not isinstance(
+                        exit_failure,
+                        (OSError, RuntimeError, ValueError),
+                    ):
+                        raise exit_failure
+                    raise RepositoryChangedError(
+                        "repository source changed during a read session"
+                    ) from exit_failure
+
+    def _read_record(
+        self,
+        relative: str,
+        record: RepositorySourceFileRecord,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        if self._windows_authority is not None:
+            api = self._windows_api
+            if api is None:  # pragma: no cover - constructor invariant
+                raise AssertionError("Windows repository binding has no API")
+            resolver = _resolved_windows_repository_file_at(
+                self.root,
+                self._windows_authority,
+                relative,
+                expected_root_identity=self._root_identity,
+                expected_final_identity=record.lexical_identity,
+                api=api,
+            )
+        else:
+            resolver = _resolved_repository_file_at(
+                self.root,
+                self._root_descriptor,
+                relative,
+                expected_root_identity=self._root_identity,  # type: ignore[arg-type]
+                expected_final_identity=record.lexical_identity,  # type: ignore[arg-type]
+            )
+        with resolver as source:
+            if not source.is_regular:
+                raise ValueError("source path is no longer a regular file")
+            payload = source.read_bytes(max_bytes=max_bytes)
+        if (
+            len(payload) != record.size
+            or hashlib.sha256(payload).hexdigest() != record.sha256
+        ):
+            raise RepositoryChangedError(
+                "repository source file differs from its authenticated record"
+            )
+        return payload
+
+    def read_bytes(self, relative: str, *, max_bytes: int) -> bytes:
+        """Read one exact captured regular file and rebind the whole inventory."""
+
+        if (
+            isinstance(max_bytes, bool)
+            or not isinstance(max_bytes, int)
+            or max_bytes <= 0
+        ):
+            raise ValueError("source byte limit must be positive")
+        if not isinstance(relative, str):
+            raise TypeError("repository source path must be text")
+        record = self._records.get(relative)
+        if record is None:
+            raise ValueError("source path is not in the authenticated repository")
+        if record.size > max_bytes:
+            raise ValueError("source file exceeds its bounded read limit")
+
+        with self._authentication_lease():
+            try:
+                if self._session_depth == 0:
+                    self._verify_inventory()
+                payload = self._read_record(
+                    relative,
+                    record,
+                    max_bytes=max_bytes,
+                )
+                if self._session_depth == 0:
+                    self._verify_inventory()
+                return payload
+            except BaseException as exc:
+                self._poison(exc)
+                if isinstance(exc, RepositoryChangedError):
+                    raise
+                if not isinstance(exc, (OSError, RuntimeError, ValueError)):
+                    raise
+                raise RepositoryChangedError(
+                    "repository source changed while it was being read"
+                ) from exc
+
+    def close(self) -> None:
+        with _SourceLockLease(self._lock) as first_failure:
+            if not self._closed:
+                # Closing may finish only part of an authority chain before an
+                # operational error. Never permit reads through that partially
+                # dismantled authority; a later close call may still retry the
+                # retained resource owners.
+                self._poisoned = True
+                posix_authority = self._posix_authority
+                if posix_authority is not None:
+                    try:
+                        posix_authority.close()
+                    except BaseException as exc:  # noqa: B036 - finish cleanup
+                        first_failure = _remember_interruption(first_failure, exc)
+                    if posix_authority.closed:
+                        self._posix_authority = None
+                        self._root_descriptor = -1
+                authority = self._windows_authority
+                if authority is not None:
+                    try:
+                        authority.close()
+                    except BaseException as exc:  # noqa: B036 - finish cleanup
+                        first_failure = _remember_interruption(first_failure, exc)
+                    if authority.closed:
+                        self._windows_authority = None
+                self._closed = (
+                    self._posix_authority is None and self._windows_authority is None
+                )
+            if first_failure is not None:
+                raise first_failure
+
+
+def source_fingerprint_version(value: object) -> int | None:
+    """Return the recognized canonical source-fingerprint version."""
+
+    if not isinstance(value, str):
+        return None
+    if _SOURCE_FINGERPRINT_V2_RE.fullmatch(value):
+        return 2
+    if _SOURCE_FINGERPRINT_V1_RE.fullmatch(value):
+        return 1
+    return None
+
+
+def is_secure_source_fingerprint_v2(value: object) -> bool:
+    """Return whether *value* is a canonical, trust-eligible v2 identity."""
+
+    return source_fingerprint_version(value) == SOURCE_FINGERPRINT_VERSION
+
+
+def is_legacy_source_fingerprint_v1(value: object) -> bool:
+    """Return whether *value* is a canonical legacy diagnostic identity."""
+
+    return source_fingerprint_version(value) == 1
+
+
+def lexical_repository_path(value: str | Path) -> Path:
+    """Return an absolute repository path without following replaceable links."""
+
+    return Path(os.path.abspath(os.path.expanduser(os.fspath(value))))
+
+
+def _lexical_windows_repository_path(value: str | Path) -> Path:
+    """Return Windows lexical absolute syntax even in platform-neutral fakes."""
+
+    expanded = os.path.expanduser(os.fspath(value))
+    return Path(ntpath.abspath(expanded))
+
+
+def _entry_version_identity(
+    metadata: os.stat_result | _WindowsHandleMetadata,
+) -> tuple[object, ...]:
+    if isinstance(metadata, _WindowsHandleMetadata):
+        return _windows_version_identity(metadata)
+    return _version_identity(metadata)
+
+
+def _update_frame_header(hasher: object, domain: bytes, payload_size: int) -> None:
+    """Write one unambiguous v2 frame header before a buffered or streamed value."""
+
+    if (
+        not domain
+        or len(domain) > 0xFFFF
+        or payload_size < 0
+        or payload_size > _MAX_FRAME_BYTES
+    ):
+        raise ValueError("source fingerprint frame is outside its encoding limits")
+    update = getattr(hasher, "update", None)
+    if not callable(update):  # pragma: no cover - internal hashlib contract
+        raise TypeError("hasher must provide an update method")
+    update(len(domain).to_bytes(2, "big"))
+    update(domain)
+    update(payload_size.to_bytes(8, "big"))
+
+
+def _update_frame(hasher: object, domain: bytes, payload: bytes) -> None:
+    _update_frame_header(hasher, domain, len(payload))
+    hasher.update(payload)
+
+
+def _directory_flags() -> int:
+    return (
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | os.O_NOFOLLOW
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+
+def _is_link_or_reparse(metadata: os.stat_result) -> bool:
+    return stat.S_ISLNK(metadata.st_mode) or bool(
+        getattr(metadata, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def _excluded_relative_roots(
+    root: Path,
+    exclude_roots: Iterable[str | Path],
+) -> tuple[tuple[str, ...], ...]:
+    excluded: list[tuple[str, ...]] = []
+    for value in exclude_roots:
+        candidate = lexical_repository_path(value)
+        try:
+            relative = candidate.relative_to(root)
+        except ValueError:
+            continue
+        excluded.append(relative.parts)
+    return tuple(excluded)
+
+
+def _excluded_windows_relative_roots(
+    root: Path,
+    exclude_roots: Iterable[str | Path],
+) -> tuple[tuple[str, ...], ...]:
+    root_parts = tuple(
+        part.casefold() for part in ntpath.normpath(str(root)).split("\\")
+    )
+    excluded: list[tuple[str, ...]] = []
+    for value in exclude_roots:
+        candidate = ntpath.normpath(str(_lexical_windows_repository_path(value)))
+        candidate_parts = tuple(candidate.split("\\"))
+        if len(candidate_parts) < len(root_parts) or any(
+            observed.casefold() != expected
+            for observed, expected in zip(
+                candidate_parts,
+                root_parts,
+                strict=False,
+            )
+        ):
+            continue
+        excluded.append(candidate_parts[len(root_parts) :])
+    return tuple(excluded)
+
+
+def _relative_is_excluded(
+    parts: tuple[str, ...],
+    excluded: tuple[tuple[str, ...], ...],
+) -> bool:
+    return any(parts[: len(prefix)] == prefix for prefix in excluded)
+
+
+def _reserve_scan_entry(
+    budget: _RepositoryScanBudget,
+    relative: str,
+) -> None:
+    encoded = os.fsencode(relative)
+    if (
+        len(relative.split("/")) > _MAX_SOURCE_COMPONENTS
+        or len(encoded) > _MAX_SOURCE_PATH_BYTES
+    ):
+        raise ValueError("repository source path exceeds its structural limit")
+    budget.entries += 1
+    budget.metadata_bytes += 256 + len(encoded)
+    if budget.entries > _MAX_SOURCE_ENTRIES:
+        raise ValueError("repository source scan exceeds its entry limit")
+    if budget.metadata_bytes > _MAX_SOURCE_METADATA_BYTES:
+        raise ValueError("repository source scan exceeds its metadata limit")
+
+
+def _reserve_link_target(
+    budget: _RepositoryScanBudget,
+    link_target: str,
+) -> None:
+    budget.metadata_bytes += len(os.fsencode(link_target))
+    if budget.metadata_bytes > _MAX_SOURCE_METADATA_BYTES:
+        raise ValueError("repository source scan exceeds its metadata limit")
+
+
+def _update_inventory_record(
+    hasher: object,
+    *,
+    relative: str,
+    kind: bytes,
+    metadata: os.stat_result | _WindowsHandleMetadata,
+    link_target: str | None,
+) -> None:
+    _update_frame(hasher, b"inventory-kind", kind)
+    _update_frame(hasher, b"inventory-path", os.fsencode(relative))
+    identity = b",".join(
+        repr(value).encode("ascii") for value in _entry_version_identity(metadata)
+    )
+    _update_frame(hasher, b"inventory-identity", identity)
+    if link_target is not None:
+        _update_frame(hasher, b"inventory-link-target", os.fsencode(link_target))
+
+
+def _scan_pinned_repository(
+    root_descriptor: int,
+    *,
+    excluded: tuple[tuple[str, ...], ...],
+    collect_entries: bool,
+) -> _RepositoryScan:
+    """Enumerate one stable view through an already-open repository root."""
+
+    inventory = hashlib.sha256()
+    entries: list[_RepositoryEntry] = []
+    budget = _RepositoryScanBudget()
+    cleanup = _PosixPartialCleanup()
+
+    def scan_directory(
+        descriptor: int,
+        parts: tuple[str, ...],
+    ) -> None:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISDIR(before.st_mode)
+            or _is_link_or_reparse(before)
+            or not _identity_is_reliable(before)
+        ):
+            raise ValueError("repository source directory is not stably bound")
+
+        names: list[str] = []
+        with _owned_scan_descriptor(
+            cleanup,
+            lambda: os.open(".", _directory_flags(), dir_fd=descriptor),
+        ) as scan_descriptor:
+            with os.scandir(scan_descriptor) as children:
+                for child in children:
+                    child_parts = (*parts, child.name)
+                    relative = "/".join(child_parts)
+                    if _relative_is_excluded(child_parts, excluded) or not (
+                        repository_path_is_visible(relative)
+                    ):
+                        continue
+                    # Charge the name before retaining it. A hostile wide
+                    # directory therefore stops at the first over-budget
+                    # entry rather than being materialized before limits run.
+                    _reserve_scan_entry(budget, relative)
+                    names.append(child.name)
+        names.sort()
+
+        directories: list[tuple[str, os.stat_result, tuple[str, ...]]] = []
+        for name in names:
+            child_parts = (*parts, name)
+            relative = "/".join(child_parts)
+            metadata = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+            if not _identity_is_reliable(metadata):
+                raise ValueError(
+                    f"repository source entry has no reliable identity: {relative}"
+                )
+
+            link_target: str | None = None
+            mode = metadata.st_mode
+            if _is_link_or_reparse(metadata):
+                if not stat.S_ISLNK(mode):
+                    raise ValueError(
+                        f"repository source contains a reparse point: {relative}"
+                    )
+                link_target = os.readlink(name, dir_fd=descriptor)
+                _reserve_link_target(budget, link_target)
+                link_after = os.stat(
+                    name,
+                    dir_fd=descriptor,
+                    follow_symlinks=False,
+                )
+                if _version_identity(link_after) != _version_identity(metadata):
+                    raise ValueError(
+                        f"repository source link changed while scanning: {relative}"
+                    )
+                # Never follow a source link from the inventory pass.  Safe
+                # regular/unresolved/directory classification happens through
+                # the pinned contained resolver in the content pass.
+                kind = b"link"
+            elif stat.S_ISDIR(mode):
+                kind = b"directory"
+            elif stat.S_ISREG(mode):
+                kind = b"file"
+            else:
+                kind = f"special-{stat.S_IFMT(mode):o}".encode("ascii")
+
+            _update_inventory_record(
+                inventory,
+                relative=relative,
+                kind=kind,
+                metadata=metadata,
+                link_target=link_target,
+            )
+            if kind == b"directory":
+                directories.append((name, metadata, child_parts))
+            elif collect_entries and kind in {b"file", b"link"}:
+                entries.append(
+                    _RepositoryEntry(
+                        relative=relative,
+                        metadata=metadata,
+                        link_target=link_target,
+                    )
+                )
+
+        del names
+
+        for name, metadata, child_parts in directories:
+            with _owned_scan_descriptor(
+                cleanup,
+                lambda name=name, descriptor=descriptor: os.open(
+                    name,
+                    _directory_flags(),
+                    dir_fd=descriptor,
+                ),
+            ) as child_descriptor:
+                opened = os.fstat(child_descriptor)
+                if _binding_identity(opened) != _binding_identity(metadata):
+                    raise ValueError(
+                        "repository source directory changed while opening: "
+                        + "/".join(child_parts)
+                    )
+                scan_directory(child_descriptor, child_parts)
+                after = os.fstat(child_descriptor)
+                rebound = os.stat(
+                    name,
+                    dir_fd=descriptor,
+                    follow_symlinks=False,
+                )
+                if _version_identity(after) != _version_identity(
+                    opened
+                ) or _version_identity(rebound) != _version_identity(metadata):
+                    raise ValueError(
+                        "repository source directory changed while scanning: "
+                        + "/".join(child_parts)
+                    )
+
+        after = os.fstat(descriptor)
+        if _version_identity(after) != _version_identity(before):
+            label = "/".join(parts) or "."
+            raise ValueError(
+                f"repository source directory changed while scanning: {label}"
+            )
+
+    scan_directory(root_descriptor, ())
+    return _RepositoryScan(
+        entries=tuple(entries),
+        inventory_digest=inventory.hexdigest(),
+        inventory_entries=budget.entries,
+    )
+
+
+def _windows_relative_is_excluded(
+    parts: tuple[str, ...],
+    excluded: tuple[tuple[str, ...], ...],
+) -> bool:
+    folded = tuple(part.casefold() for part in parts)
+    return any(
+        folded[: len(prefix)] == tuple(part.casefold() for part in prefix)
+        for prefix in excluded
+    )
+
+
+def _iter_windows_directory(
+    api: _WindowsKernelApi,
+    handle: int,
+) -> Iterable[_WindowsDirectoryEntry]:
+    iterator = getattr(api, "iter_directory", None)
+    if callable(iterator):
+        return iterator(handle)
+    return api.enumerate_directory(handle)
+
+
+def _scan_pinned_windows_repository(
+    api: _WindowsKernelApi,
+    root_handle: int,
+    *,
+    excluded: tuple[tuple[str, ...], ...],
+    collect_entries: bool,
+) -> _RepositoryScan:
+    """Enumerate through one retained Windows root without following reparses."""
+
+    inventory = hashlib.sha256()
+    entries: list[_RepositoryEntry] = []
+    budget = _RepositoryScanBudget()
+    cleanup = _WindowsHandleCleanup(api)
+
+    def scan_directory(handle: int, parts: tuple[str, ...]) -> None:
+        before = api.metadata(handle)
+        if (
+            not stat.S_ISDIR(before.st_mode)
+            or _windows_metadata_is_reparse(before)
+            or not _windows_identity_is_reliable(before)
+        ):
+            raise ValueError("Windows repository directory is not stably bound")
+
+        children: list[tuple[str, _WindowsDirectoryEntry]] = []
+        for child in _iter_windows_directory(api, handle):
+            child_parts = (*parts, child.name)
+            relative = "/".join(child_parts)
+            if _windows_relative_is_excluded(child_parts, excluded) or not (
+                repository_path_is_visible(relative)
+            ):
+                continue
+            _reserve_scan_entry(budget, relative)
+            children.append((child.name, child))
+        children.sort(key=lambda item: item[0])
+
+        directories: list[
+            tuple[_WindowsDirectoryEntry, tuple[object, ...], tuple[str, ...]]
+        ] = []
+        for name, child in children:
+            child_parts = (*parts, name)
+            relative = "/".join(child_parts)
+            with _owned_scan_handle(
+                cleanup,
+                lambda handle=handle, child=child: _windows_open_child(
+                    api,
+                    handle,
+                    child,
+                    cleanup=cleanup,
+                ),
+            ) as (child_handle, metadata):
+                if metadata.st_dev != before.st_dev:
+                    raise ValueError("Windows repository scan crosses a volume")
+                link_target: str | None = None
+                if _windows_entry_is_reparse(child):
+                    if metadata.reparse_tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
+                        raise ValueError(
+                            f"Windows repository contains unsupported reparse: {relative}"
+                        )
+                    point = api.query_reparse_point(child_handle)
+                    if point.tag != _WINDOWS_IO_REPARSE_TAG_SYMLINK:
+                        raise ValueError(
+                            f"Windows repository reparse tag changed: {relative}"
+                        )
+                    link_target = _windows_link_target_text(point)
+                    _reserve_link_target(budget, link_target)
+                    kind = b"link"
+                elif stat.S_ISDIR(metadata.st_mode):
+                    kind = b"directory"
+                elif stat.S_ISREG(metadata.st_mode):
+                    kind = b"file"
+                else:
+                    kind = f"special-{stat.S_IFMT(metadata.st_mode):o}".encode("ascii")
+
+                after = api.metadata(child_handle)
+                if _windows_version_identity(after) != _windows_version_identity(
+                    metadata
+                ):
+                    raise ValueError(
+                        f"Windows repository entry changed while scanning: {relative}"
+                    )
+                rebound = _windows_find_child(api, handle, name)
+                if rebound is None or rebound.file_id_128 != child.file_id_128:
+                    raise ValueError(
+                        f"Windows repository entry changed while scanning: {relative}"
+                    )
+                _update_inventory_record(
+                    inventory,
+                    relative=relative,
+                    kind=kind,
+                    metadata=metadata,
+                    link_target=link_target,
+                )
+                if kind == b"directory":
+                    directories.append(
+                        (child, _windows_version_identity(metadata), child_parts)
+                    )
+                elif collect_entries and kind in {b"file", b"link"}:
+                    entries.append(
+                        _RepositoryEntry(
+                            relative=relative,
+                            metadata=metadata,
+                            link_target=link_target,
+                        )
+                    )
+
+        del children
+        for child, expected_identity, child_parts in directories:
+            with _owned_scan_handle(
+                cleanup,
+                lambda handle=handle, child=child: _windows_open_child(
+                    api,
+                    handle,
+                    child,
+                    cleanup=cleanup,
+                ),
+            ) as (child_handle, opened):
+                if _windows_version_identity(opened) != expected_identity:
+                    raise ValueError(
+                        "Windows repository directory changed while reopening: "
+                        + "/".join(child_parts)
+                    )
+                scan_directory(child_handle, child_parts)
+                after = api.metadata(child_handle)
+                rebound = _windows_find_child(api, handle, child.name)
+                if (
+                    _windows_version_identity(after) != expected_identity
+                    or rebound is None
+                    or rebound.file_id_128 != child.file_id_128
+                ):
+                    raise ValueError(
+                        "Windows repository directory changed while scanning: "
+                        + "/".join(child_parts)
+                    )
+
+        after = api.metadata(handle)
+        if _windows_version_identity(after) != _windows_version_identity(before):
+            label = "/".join(parts) or "."
+            raise ValueError(
+                f"Windows repository directory changed while scanning: {label}"
+            )
+
+    scan_directory(root_handle, ())
+    return _RepositoryScan(
+        entries=tuple(entries),
+        inventory_digest=inventory.hexdigest(),
+        inventory_entries=budget.entries,
+    )
+
+
+class _PosixRepositoryRootAuthority:
+    __slots__ = (
+        "root",
+        "descriptor",
+        "root_identity",
+        "_resources",
+        "_resource_identities",
+        "_anchor_identity",
+        "_bindings",
+        "_closed",
+    )
+
+    def __init__(
+        self,
+        *,
+        root: Path,
+        descriptor: int,
+        root_identity: tuple[int, ...],
+        resources: list[int],
+        resource_identities: dict[int, tuple[int, ...]],
+        anchor_identity: tuple[int, ...],
+        bindings: list[tuple[int, str, int, tuple[int, ...]]],
+    ) -> None:
+        self.root = root
+        self.descriptor = descriptor
+        self.root_identity = root_identity
+        self._resources = resources
+        self._resource_identities = resource_identities
+        self._anchor_identity = anchor_identity
+        self._bindings = bindings
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def verify(self, expected_root_identity: tuple[int, ...]) -> None:
+        if self._closed:
+            raise ValueError("repository root authority is closed")
+        anchor = self._resources[0]
+        if _binding_identity(os.fstat(anchor)) != self._anchor_identity:
+            raise ValueError("repository root anchor changed")
+        for parent, name, child, expected_binding in self._bindings:
+            observed = os.stat(name, dir_fd=parent, follow_symlinks=False)
+            opened = os.fstat(child)
+            if (
+                _is_link_or_reparse(observed)
+                or not stat.S_ISDIR(observed.st_mode)
+                or _binding_identity(observed) != expected_binding
+                or _binding_identity(opened) != expected_binding
+            ):
+                raise ValueError("repository root path changed")
+        if _version_identity(os.fstat(self.descriptor)) != expected_root_identity:
+            raise ValueError("repository root changed while it was retained")
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        failure = _close_posix_descriptors(
+            self._resources,
+            self._resource_identities,
+        )
+        self._closed = not self._resources
+        self.descriptor = -1
+        if failure is not None:
+            raise failure
+
+
+def _close_posix_descriptors(
+    descriptors: list[int],
+    expected_identities: dict[int, tuple[int, ...]],
+) -> BaseException | None:
+    """Visit every descriptor and retain the first delayed close failure."""
+
+    deferred: BaseException | None = None
+    for descriptor in reversed(tuple(descriptors)):
+        closed = False
+        while True:
+            try:
+                observed = os.fstat(descriptor)
+                expected = expected_identities.get(descriptor)
+                if expected is not None and _binding_identity(observed) != expected:
+                    deferred = _remember_interruption(
+                        deferred,
+                        RuntimeError("repository descriptor ownership changed"),
+                    )
+                    closed = True
+                    break
+            except OSError as exc:
+                if exc.errno == errno.EBADF:
+                    closed = True
+                    break
+                deferred = _remember_interruption(deferred, exc)
+                break
+            except BaseException as exc:  # noqa: B036 - defer cancellation
+                if isinstance(exc, Exception):
+                    deferred = _remember_interruption(deferred, exc)
+                    break
+                deferred = _remember_interruption(deferred, exc)
+                continue
+
+            expected_at_close = _binding_identity(observed)
+            try:
+                os.close(descriptor)
+                closed = True
+            except BaseException as exc:  # noqa: B036 - confirm close result
+                deferred = _remember_interruption(deferred, exc)
+                while True:
+                    try:
+                        visible = os.fstat(descriptor)
+                    except OSError as probe_error:
+                        if probe_error.errno == errno.EBADF:
+                            closed = True
+                        else:
+                            deferred = _remember_interruption(
+                                deferred,
+                                probe_error,
+                            )
+                        break
+                    except BaseException as probe_error:  # noqa: B036
+                        if isinstance(probe_error, Exception):
+                            deferred = _remember_interruption(
+                                deferred,
+                                probe_error,
+                            )
+                            break
+                        deferred = _remember_interruption(deferred, probe_error)
+                        continue
+                    if _binding_identity(visible) != expected_at_close:
+                        # The owned fd closed and its number was reused. Never
+                        # close the replacement descriptor.
+                        closed = True
+                    break
+                if closed or isinstance(exc, Exception):
+                    break
+                continue
+            break
+
+        if closed:
+            while descriptor in descriptors:
+                try:
+                    descriptors.pop(descriptors.index(descriptor))
+                except BaseException as exc:
+                    if isinstance(exc, Exception):
+                        raise
+                    deferred = _remember_interruption(deferred, exc)
+            while descriptor in expected_identities:
+                try:
+                    expected_identities.pop(descriptor, None)
+                except BaseException as exc:
+                    if isinstance(exc, Exception):
+                        raise
+                    deferred = _remember_interruption(deferred, exc)
+    return deferred
+
+
+class _PosixPartialCleanup:
+    """Retryable owner installed before temporary descriptor acquisition."""
+
+    __slots__ = ("descriptors", "expected_identities")
+
+    def __init__(self) -> None:
+        self.descriptors: list[int] = []
+        self.expected_identities: dict[int, tuple[int, ...]] = {}
+
+    @property
+    def closed(self) -> bool:
+        return not self.descriptors
+
+    def retain(self, descriptor: int, metadata: os.stat_result | None = None) -> int:
+        deferred = _append_owned_descriptor(self.descriptors, descriptor)
+        if deferred is not None:
+            raise deferred
+        if metadata is not None:
+            self.expected_identities[descriptor] = _binding_identity(metadata)
+        return descriptor
+
+    def close_descriptor(self, descriptor: int) -> None:
+        selected = [descriptor] if descriptor in self.descriptors else []
+        identities = {
+            descriptor: self.expected_identities[descriptor]
+            for descriptor in selected
+            if descriptor in self.expected_identities
+        }
+        failure = _close_posix_descriptors(selected, identities)
+        if descriptor not in selected:
+            while descriptor in self.descriptors:
+                self.descriptors.remove(descriptor)
+            self.expected_identities.pop(descriptor, None)
+        if failure is not None:
+            raise failure
+
+    def close(self) -> None:
+        failure = _close_posix_descriptors(
+            self.descriptors,
+            self.expected_identities,
+        )
+        if failure is not None:
+            raise failure
+
+
+@contextmanager
+def _owned_scan_descriptor(
+    cleanup: _PosixPartialCleanup,
+    operation: Callable[[], int],
+) -> Iterator[int]:
+    """Acquire one scan fd and preserve a primary across failed cleanup."""
+
+    descriptor = -1
+    try:
+        descriptor = operation()
+        cleanup.retain(descriptor)
+    except BaseException as primary:  # noqa: B036 - retain partial native return
+        if descriptor >= 0:
+            try:
+                cleanup.retain(descriptor)
+            except BaseException:  # noqa: B036 - preserve acquisition primary
+                pass
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup.close()
+        except BaseException as exc:  # noqa: B036
+            cleanup_failure = exc
+        _attach_source_cleanup_owner(primary, cleanup)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+    try:
+        yield descriptor
+    except BaseException as primary:  # noqa: B036 - preserve scan primary
+        cleanup_failure = None
+        try:
+            cleanup.close_descriptor(descriptor)
+        except BaseException as exc:  # noqa: B036
+            cleanup_failure = exc
+        _attach_source_cleanup_owner(primary, cleanup)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+    else:
+        try:
+            cleanup.close_descriptor(descriptor)
+        except BaseException as cleanup_failure:  # noqa: B036
+            _attach_source_cleanup_owner(cleanup_failure, cleanup)
+            raise
+
+
+@contextmanager
+def _owned_scan_handle(
+    cleanup: _WindowsHandleCleanup,
+    operation: Callable[[], tuple[int, _WindowsHandleMetadata]],
+) -> Iterator[tuple[int, _WindowsHandleMetadata]]:
+    """Retain one scan HANDLE and preserve primary/cleanup priority."""
+
+    try:
+        handle, metadata = operation()
+        cleanup.retain(handle, metadata)
+    except BaseException as primary:  # noqa: B036 - helper may carry an owner
+        nested = getattr(primary, "source_cleanup_owner", None)
+        if nested is not None:
+            _attach_source_cleanup_owner(primary, nested)
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup.close()
+        except BaseException as exc:  # noqa: B036
+            cleanup_failure = exc
+        _attach_source_cleanup_owner(primary, cleanup)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+    try:
+        yield handle, metadata
+    except BaseException as primary:  # noqa: B036 - preserve scan primary
+        selected = _WindowsHandleCleanup(cleanup.api)
+        if handle in cleanup.handles:
+            selected.handles.append(handle)
+            if handle in cleanup.expected_identities:
+                selected.expected_identities[handle] = cleanup.expected_identities[
+                    handle
+                ]
+        cleanup_failure = None
+        try:
+            selected.close()
+        except BaseException as exc:  # noqa: B036
+            cleanup_failure = exc
+        if selected.closed:
+            while handle in cleanup.handles:
+                cleanup.handles.remove(handle)
+            cleanup.expected_identities.pop(handle, None)
+        _attach_source_cleanup_owner(primary, cleanup)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+    else:
+        selected = _WindowsHandleCleanup(cleanup.api)
+        if handle in cleanup.handles:
+            selected.handles.append(handle)
+            if handle in cleanup.expected_identities:
+                selected.expected_identities[handle] = cleanup.expected_identities[
+                    handle
+                ]
+        try:
+            selected.close()
+        except BaseException as cleanup_failure:  # noqa: B036
+            _attach_source_cleanup_owner(cleanup_failure, cleanup)
+            raise
+        finally:
+            if selected.closed:
+                while handle in cleanup.handles:
+                    cleanup.handles.remove(handle)
+                cleanup.expected_identities.pop(handle, None)
+
+
+def _append_owned_descriptor(
+    descriptors: list[int],
+    descriptor: int,
+    deferred: BaseException | None = None,
+) -> BaseException | None:
+    while descriptor not in descriptors:
+        try:
+            descriptors.append(descriptor)
+        except BaseException as exc:
+            if isinstance(exc, Exception):
+                raise
+            deferred = _remember_interruption(deferred, exc)
+    return deferred
+
+
+def _open_owned_posix_directory(
+    path: str,
+    *,
+    descriptors: list[int],
+    dir_fd: int | None = None,
+) -> int:
+    """Open and register a directory fd at the first Python-owned opportunity.
+
+    A raw integer can still be lost if arbitrary opcode injection lands between
+    the native ``os.open`` return and Python's result store. Covering that
+    interpreter boundary requires a native helper that returns an owning object.
+    """
+
+    descriptor = -1
+    try:
+        if dir_fd is None:
+            descriptor = os.open(path, _directory_flags())
+        else:
+            descriptor = os.open(path, _directory_flags(), dir_fd=dir_fd)
+        deferred = _append_owned_descriptor(descriptors, descriptor)
+        if deferred is not None:
+            raise deferred
+        return descriptor
+    except BaseException:  # noqa: B036 - commit descriptor ownership
+        if descriptor >= 0:
+            try:
+                _append_owned_descriptor(descriptors, descriptor)
+            except BaseException:  # noqa: B036 - preserve primary failure
+                pass
+        raise
+
+
+def _open_pinned_repository_root(
+    root: Path,
+    *,
+    cleanup_slot: _SourceCleanupSlot | None = None,
+) -> _PosixRepositoryRootAuthority:
+    if not (SECURE_CONTAINED_SYMLINKS and os.scandir in getattr(os, "supports_fd", ())):
+        raise ValueError(
+            "secure source fingerprints require directory-fd traversal support"
+        )
+    if not root.is_absolute() or root.anchor != os.path.sep:
+        raise ValueError("repository root must be an absolute lexical path")
+    cleanup = _PosixPartialCleanup()
+    if cleanup_slot is not None:
+        cleanup_slot.own(cleanup)
+    resources = cleanup.descriptors
+    resource_identities = cleanup.expected_identities
+    try:
+        anchor = _open_owned_posix_directory(
+            root.anchor,
+            descriptors=resources,
+        )
+        anchor_metadata = os.fstat(anchor)
+        if not _identity_is_reliable(anchor_metadata):
+            raise ValueError("repository root anchor has no reliable identity")
+        anchor_identity = _binding_identity(anchor_metadata)
+        resource_identities[anchor] = anchor_identity
+        bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
+        descriptor = anchor
+        for part in root.parts[1:]:
+            before = os.stat(part, dir_fd=descriptor, follow_symlinks=False)
+            if (
+                _is_link_or_reparse(before)
+                or not stat.S_ISDIR(before.st_mode)
+                or not _identity_is_reliable(before)
+            ):
+                raise ValueError(
+                    "repository root ancestors must be real directories with identity"
+                )
+            child = _open_owned_posix_directory(
+                part,
+                descriptors=resources,
+                dir_fd=descriptor,
+            )
+            opened = os.fstat(child)
+            expected_binding = _binding_identity(before)
+            if _binding_identity(opened) != expected_binding:
+                raise ValueError("repository root changed while it was being pinned")
+            resource_identities[child] = expected_binding
+            bindings.append((descriptor, part, child, expected_binding))
+            descriptor = child
+        root_identity = _version_identity(os.fstat(descriptor))
+        authority = _PosixRepositoryRootAuthority(
+            root=root,
+            descriptor=descriptor,
+            root_identity=root_identity,
+            resources=resources,
+            resource_identities=resource_identities,
+            anchor_identity=anchor_identity,
+            bindings=bindings,
+        )
+        authority.verify(root_identity)
+        if cleanup_slot is not None:
+            cleanup_slot.own(authority)
+        return authority
+    except BaseException as primary:  # noqa: B036 - preserve root failure
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup.close()
+        except BaseException as exc:  # noqa: B036 - retain retry owner
+            cleanup_failure = exc
+        owner = cleanup_slot or cleanup
+        _attach_source_cleanup_owner(primary, owner)
+        if cleanup_failure is not None:
+            raise primary from cleanup_failure
+        raise
+
+
+def _verify_pinned_repository_root(
+    authority: _PosixRepositoryRootAuthority,
+    expected_identity: tuple[int, ...],
+) -> None:
+    authority.verify(expected_identity)
+
+
+def _fingerprint_windows_repository(
+    root: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path],
+    version: int,
+    api: _WindowsKernelApi | None = None,
+    retain_binding: bool = False,
+    source_owner: Callable[[object], None] | None = None,
+    cleanup_slot: _SourceCleanupSlot | None = None,
+) -> SourceFingerprint | RepositorySourceBinding:
+    """Hash a Windows repository through one retained HANDLE authority."""
+
+    if retain_binding and cleanup_slot is None:
+        cleanup_slot = _SourceCleanupSlot()
+        if source_owner is not None:
+            source_owner(cleanup_slot)
+    root_path = _lexical_windows_repository_path(root)
+    hasher = hashlib.sha256()
+    if version == 1:
+        hasher.update(
+            (
+                "codenib-source-fingerprint:1:" f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
+            ).encode("ascii")
+        )
+    else:
+        hasher.update(_V2_MAGIC)
+        _update_frame(
+            hasher,
+            b"filter-policy-version",
+            str(REPOSITORY_FILTER_POLICY_VERSION).encode("ascii"),
+        )
+    excluded = _excluded_windows_relative_roots(root_path, exclude_roots)
+    file_count = 0
+    file_records: list[RepositorySourceFileRecord] = []
+    root_authority = None
+    selected: _WindowsKernelApi | None = None
+    completed = False
+    try:
+        selected, root_authority, root_identity = _open_windows_pinned_repository_root(
+            root_path,
+            api=api,
+            cleanup_slot=cleanup_slot,
+        )
+        initial_scan = _scan_pinned_windows_repository(
+            selected,
+            root_authority.handle,
+            excluded=excluded,
+            collect_entries=True,
+        )
+        for entry in initial_scan.entries:
+            metadata = entry.metadata
+            if not isinstance(metadata, _WindowsHandleMetadata):
+                raise AssertionError("Windows source scan returned POSIX metadata")
+            relative_text = entry.relative
+            relative = relative_text.encode("utf-8", errors="strict")
+            path = root_path.joinpath(*relative_text.split("/"))
+
+            if _windows_metadata_is_reparse(metadata):
+                raw_target = entry.link_target
+                if raw_target is None:
+                    raise AssertionError("Windows source link has no captured target")
+                target = raw_target.encode("utf-8", errors="strict")
+                try:
+                    with _resolved_windows_repository_file_at(
+                        root_path,
+                        root_authority,
+                        relative_text,
+                        expected_root_identity=root_identity,
+                        expected_final_identity=_windows_version_identity(metadata),
+                        api=selected,
+                    ) as binding:
+                        if binding.is_directory:
+                            continue
+                        if version == 1:
+                            hasher.update(b"L\0")
+                            hasher.update(relative)
+                            hasher.update(b"\0")
+                            hasher.update(target)
+                            hasher.update(b"\0")
+                        else:
+                            _update_frame(hasher, b"entry-kind", b"link")
+                            _update_frame(hasher, b"entry-path", relative)
+                            _update_frame(hasher, b"link-target", target)
+                        link_is_regular = binding.is_regular
+                        if link_is_regular:
+                            if not hasattr(binding, "opened_size"):
+                                raise AssertionError(
+                                    "Windows regular binding has no opened size"
+                                )
+                            if version == 1:
+                                hasher.update(b"C\0")
+                            else:
+                                _update_frame(
+                                    hasher,
+                                    b"link-target-state",
+                                    b"regular",
+                                )
+                                _update_frame_header(
+                                    hasher,
+                                    b"link-target-content",
+                                    binding.opened_size,
+                                )
+                            content_digest = hashlib.sha256()
+                            binding.update_hash(_HashFanout(hasher, content_digest))
+                            file_records.append(
+                                RepositorySourceFileRecord(
+                                    path=relative_text,
+                                    size=binding.opened_size,
+                                    sha256=content_digest.hexdigest(),
+                                    lexical_identity=_windows_version_identity(
+                                        metadata
+                                    ),
+                                )
+                            )
+                        elif version != 1:
+                            _update_frame(
+                                hasher,
+                                b"link-target-state",
+                                b"unresolved",
+                            )
+                except (OSError, ValueError) as exc:
+                    raise RepositoryChangedError(
+                        "repository link target could not be read consistently: "
+                        f"{path}"
+                    ) from exc
+                if version == 1 and link_is_regular:
+                    hasher.update(b"\0")
+                file_count += 1
+                continue
+
+            if not stat.S_ISREG(metadata.st_mode):
+                continue
+            if version == 1:
+                hasher.update(b"F\0")
+                hasher.update(relative)
+                hasher.update(b"\0")
+            else:
+                _update_frame(hasher, b"entry-kind", b"file")
+                _update_frame(hasher, b"entry-path", relative)
+                _update_frame_header(hasher, b"file-content", metadata.st_size)
+            try:
+                with _resolved_windows_repository_file_at(
+                    root_path,
+                    root_authority,
+                    relative_text,
+                    expected_root_identity=root_identity,
+                    expected_final_identity=_windows_version_identity(metadata),
+                    api=selected,
+                ) as binding:
+                    if not binding.is_regular:
+                        raise ValueError("Windows repository file became nonregular")
+                    content_digest = hashlib.sha256()
+                    binding.update_hash(_HashFanout(hasher, content_digest))
+                    file_records.append(
+                        RepositorySourceFileRecord(
+                            path=relative_text,
+                            size=metadata.st_size,
+                            sha256=content_digest.hexdigest(),
+                            lexical_identity=_windows_version_identity(metadata),
+                        )
+                    )
+            except (OSError, ValueError) as exc:
+                raise RepositoryChangedError(
+                    f"repository file could not be read consistently: {path}"
+                ) from exc
+            if version == 1:
+                hasher.update(b"\0")
+            file_count += 1
+
+        final_scan = _scan_pinned_windows_repository(
+            selected,
+            root_authority.handle,
+            excluded=excluded,
+            collect_entries=False,
+        )
+        if (
+            final_scan.inventory_digest != initial_scan.inventory_digest
+            or final_scan.inventory_entries != initial_scan.inventory_entries
+        ):
+            raise RepositoryChangedError(
+                "repository entries changed while they were being fingerprinted"
+            )
+        _verify_windows_pinned_repository_root(
+            selected,
+            root_authority,
+            root_identity,
+        )
+        completed = True
+    except RepositoryChangedError as exc:
+        if isinstance(exc.__cause__, BaseException):
+            _inherit_source_cleanup_owner(exc, exc.__cause__)
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        failure = RepositoryChangedError(
+            "repository changed while it was being fingerprinted"
+        )
+        _inherit_source_cleanup_owner(failure, exc)
+        raise failure from exc
+    finally:
+        if root_authority is not None and (not retain_binding or not completed):
+            active_failure = sys.exc_info()[1]
+            owner = cleanup_slot or root_authority
+            try:
+                owner.close()  # type: ignore[attr-defined]
+            except BaseException as cleanup_failure:  # noqa: B036
+                if active_failure is not None:
+                    _attach_source_cleanup_owner(active_failure, owner)
+                    raise active_failure from cleanup_failure
+                _attach_source_cleanup_owner(cleanup_failure, owner)
+                raise
+
+    if version != 1:
+        _update_frame(hasher, b"entry-count", file_count.to_bytes(8, "big"))
+    fingerprint = SourceFingerprint(
+        value=(
+            f"sha256:{hasher.hexdigest()}"
+            if version == 1
+            else f"sha256-v2:{hasher.hexdigest()}"
+        ),
+        file_count=file_count,
+    )
+    if retain_binding:
+        if version != SOURCE_FINGERPRINT_VERSION:
+            raise ValueError("only source fingerprint v2 can retain read authority")
+        if selected is None or root_authority is None:  # pragma: no cover - invariant
+            raise AssertionError("Windows source authority was not retained")
+        retained = root_authority
+        binding: RepositorySourceBinding | None = None
+        try:
+            binding = RepositorySourceBinding(
+                root=root_path,
+                fingerprint=fingerprint,
+                file_records=file_records,
+                inventory_digest=initial_scan.inventory_digest,
+                inventory_entries=initial_scan.inventory_entries,
+                excluded=excluded,
+                root_identity=root_identity,
+                windows_api=selected,
+                windows_authority=retained,
+            )
+            if cleanup_slot is not None:
+                cleanup_slot.own(binding)
+            root_authority = None
+            return binding
+        except BaseException as primary:  # noqa: B036 - preserve construction
+            owner = cleanup_slot or binding or retained
+            cleanup_failure: BaseException | None = None
+            try:
+                owner.close()  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - expose retry owner
+                cleanup_failure = exc
+            _attach_source_cleanup_owner(primary, owner)
+            if cleanup_failure is not None:
+                raise primary from cleanup_failure
+            raise
+    return fingerprint
+
+
+def _fingerprint_repository(
+    root: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path],
+    version: int,
+    retain_binding: bool = False,
+    source_owner: Callable[[object], None] | None = None,
+) -> SourceFingerprint | RepositorySourceBinding:
+    """Hash visible repository contents with v2 or the diagnostic v1 format."""
+
+    if version not in {1, SOURCE_FINGERPRINT_VERSION}:
+        raise ValueError(f"unsupported source fingerprint version: {version}")
+    cleanup_slot: _SourceCleanupSlot | None = None
+    if retain_binding:
+        cleanup_slot = _SourceCleanupSlot()
+        if source_owner is not None:
+            source_owner(cleanup_slot)
+    if sys.platform == "win32":
+        return _fingerprint_windows_repository(
+            root,
+            exclude_roots=exclude_roots,
+            version=version,
+            retain_binding=retain_binding,
+            cleanup_slot=cleanup_slot,
+        )
+
+    # Do not call Path.resolve() here. A reversible root-to-symlink swap during
+    # resolution could permanently redirect the rest of this operation to a
+    # foreign tree. The lexical path remains the rebind target for the pinned
+    # no-follow descriptor throughout the operation.
+    root_path = lexical_repository_path(root)
+
+    hasher = hashlib.sha256()
+    if version == 1:
+        hasher.update(
+            (
+                "codenib-source-fingerprint:1:" f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
+            ).encode("ascii")
+        )
+    else:
+        hasher.update(_V2_MAGIC)
+        _update_frame(
+            hasher,
+            b"filter-policy-version",
+            str(REPOSITORY_FILTER_POLICY_VERSION).encode("ascii"),
+        )
+    file_count = 0
+    file_records: list[RepositorySourceFileRecord] = []
+    excluded = _excluded_relative_roots(root_path, exclude_roots)
+    root_descriptor = -1
+    root_authority: _PosixRepositoryRootAuthority | None = None
+    completed = False
+    try:
+        root_authority = _open_pinned_repository_root(
+            root_path,
+            cleanup_slot=cleanup_slot,
+        )
+        root_descriptor = root_authority.descriptor
+        root_identity = root_authority.root_identity
+        initial_scan = _scan_pinned_repository(
+            root_descriptor,
+            excluded=excluded,
+            collect_entries=True,
+        )
+
+        for entry in initial_scan.entries:
+            relative_text = entry.relative
+            relative = os.fsencode(relative_text)
+            initial_metadata = entry.metadata
+            path = root_path.joinpath(*relative_text.split("/"))
+
+            mode = initial_metadata.st_mode
+            if stat.S_ISLNK(mode):
+                raw_target = entry.link_target
+                if raw_target is None:  # pragma: no cover - scan invariant
+                    raise AssertionError("source link has no captured target")
+                target = os.fsencode(raw_target)
+                try:
+                    with _resolved_repository_file_at(
+                        root_path,
+                        root_descriptor,
+                        relative_text,
+                        expected_root_identity=root_identity,
+                        expected_final_identity=_version_identity(initial_metadata),
+                    ) as binding:
+                        if binding.is_directory:
+                            # Preserve v1's directory-link exclusion and keep
+                            # v2 host/container identities byte-for-byte equal.
+                            continue
+                        if version == 1:
+                            hasher.update(b"L\0")
+                            hasher.update(relative)
+                            hasher.update(b"\0")
+                            hasher.update(target)
+                            hasher.update(b"\0")
+                        else:
+                            _update_frame(hasher, b"entry-kind", b"link")
+                            _update_frame(hasher, b"entry-path", relative)
+                            _update_frame(hasher, b"link-target", target)
+                        link_is_regular = binding.is_regular
+                        if link_is_regular:
+                            if version == 1:
+                                hasher.update(b"C\0")
+                            else:
+                                opened = os.fstat(binding.descriptor)
+                                _update_frame(
+                                    hasher,
+                                    b"link-target-state",
+                                    b"regular",
+                                )
+                                _update_frame_header(
+                                    hasher,
+                                    b"link-target-content",
+                                    opened.st_size,
+                                )
+                            opened = os.fstat(binding.descriptor)
+                            content_digest = hashlib.sha256()
+                            binding.update_hash(_HashFanout(hasher, content_digest))
+                            file_records.append(
+                                RepositorySourceFileRecord(
+                                    path=relative_text,
+                                    size=opened.st_size,
+                                    sha256=content_digest.hexdigest(),
+                                    lexical_identity=_version_identity(
+                                        initial_metadata
+                                    ),
+                                )
+                            )
+                        elif version != 1:
+                            _update_frame(
+                                hasher,
+                                b"link-target-state",
+                                b"unresolved",
+                            )
+                except (OSError, ValueError) as exc:
+                    raise RepositoryChangedError(
+                        "repository link target could not be read consistently: "
+                        f"{path}"
+                    ) from exc
+                if version == 1 and link_is_regular:
+                    hasher.update(b"\0")
+                file_count += 1
+                continue
+
+            if not stat.S_ISREG(mode):  # pragma: no cover - scan invariant
+                continue
+
+            if version == 1:
+                hasher.update(b"F\0")
+                hasher.update(relative)
+                hasher.update(b"\0")
+            else:
+                _update_frame(hasher, b"entry-kind", b"file")
+                _update_frame(hasher, b"entry-path", relative)
+                _update_frame_header(
+                    hasher,
+                    b"file-content",
+                    initial_metadata.st_size,
+                )
+            try:
+                with _resolved_repository_file_at(
+                    root_path,
+                    root_descriptor,
+                    relative_text,
+                    expected_root_identity=root_identity,
+                    expected_final_identity=_version_identity(initial_metadata),
+                ) as binding:
+                    if not binding.is_regular:  # pragma: no cover - expected regular
+                        raise ValueError("repository file became nonregular")
+                    content_digest = hashlib.sha256()
+                    binding.update_hash(_HashFanout(hasher, content_digest))
+                    file_records.append(
+                        RepositorySourceFileRecord(
+                            path=relative_text,
+                            size=initial_metadata.st_size,
+                            sha256=content_digest.hexdigest(),
+                            lexical_identity=_version_identity(initial_metadata),
+                        )
+                    )
+            except (OSError, ValueError) as exc:
+                raise RepositoryChangedError(
+                    f"repository file could not be read consistently: {path}"
+                ) from exc
+            if version == 1:
+                hasher.update(b"\0")
+            file_count += 1
+
+        final_scan = _scan_pinned_repository(
+            root_descriptor,
+            excluded=excluded,
+            collect_entries=False,
+        )
+        if (
+            final_scan.inventory_digest != initial_scan.inventory_digest
+            or final_scan.inventory_entries != initial_scan.inventory_entries
+        ):
+            raise RepositoryChangedError(
+                "repository entries changed while they were being fingerprinted"
+            )
+        _verify_pinned_repository_root(root_authority, root_identity)
+        completed = True
+    except RepositoryChangedError as exc:
+        if isinstance(exc.__cause__, BaseException):
+            _inherit_source_cleanup_owner(exc, exc.__cause__)
+        raise
+    except (OSError, ValueError) as exc:
+        failure = RepositoryChangedError(
+            "repository changed while it was being fingerprinted"
+        )
+        _inherit_source_cleanup_owner(failure, exc)
+        raise failure from exc
+    finally:
+        if root_authority is not None and (not retain_binding or not completed):
+            active_failure = sys.exc_info()[1]
+            owner = cleanup_slot or root_authority
+            try:
+                owner.close()  # type: ignore[attr-defined]
+            except BaseException as cleanup_failure:  # noqa: B036
+                if active_failure is not None:
+                    _attach_source_cleanup_owner(active_failure, owner)
+                    raise active_failure from cleanup_failure
+                _attach_source_cleanup_owner(cleanup_failure, owner)
+                raise
+
+    if version != 1:
+        _update_frame(
+            hasher,
+            b"entry-count",
+            file_count.to_bytes(8, "big"),
+        )
+    fingerprint = SourceFingerprint(
+        value=(
+            f"sha256:{hasher.hexdigest()}"
+            if version == 1
+            else f"sha256-v2:{hasher.hexdigest()}"
+        ),
+        file_count=file_count,
+    )
+    if retain_binding:
+        if version != SOURCE_FINGERPRINT_VERSION:
+            raise ValueError("only source fingerprint v2 can retain read authority")
+        if root_authority is None:  # pragma: no cover - invariant
+            raise AssertionError("POSIX source authority was not retained")
+        retained_authority = root_authority
+        retained_descriptor = retained_authority.descriptor
+        binding: RepositorySourceBinding | None = None
+        try:
+            binding = RepositorySourceBinding(
+                root=root_path,
+                fingerprint=fingerprint,
+                file_records=file_records,
+                inventory_digest=initial_scan.inventory_digest,
+                inventory_entries=initial_scan.inventory_entries,
+                excluded=excluded,
+                root_identity=root_identity,
+                root_descriptor=retained_descriptor,
+                posix_authority=retained_authority,
+            )
+            if cleanup_slot is not None:
+                cleanup_slot.own(binding)
+            root_authority = None
+            root_descriptor = -1
+            return binding
+        except BaseException as primary:  # noqa: B036 - preserve construction
+            owner = cleanup_slot or binding or retained_authority
+            cleanup_failure: BaseException | None = None
+            try:
+                owner.close()  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: B036 - expose retry owner
+                cleanup_failure = exc
+            _attach_source_cleanup_owner(primary, owner)
+            if cleanup_failure is not None:
+                raise primary from cleanup_failure
+            raise
+    return fingerprint
 
 
 def fingerprint_repository(
@@ -61,91 +2155,60 @@ def fingerprint_repository(
     *,
     exclude_roots: Iterable[str | Path] = (),
 ) -> SourceFingerprint:
-    """Hash the paths and contents exposed by the shared repository filter."""
+    """Hash visible paths and contents with the canonical v2 framing."""
 
-    root_path = Path(root).expanduser().resolve()
-    if not root_path.is_dir():
-        raise ValueError(f"repository path is not a directory: {root_path}")
-
-    hasher = hashlib.sha256()
-    hasher.update(
-        (
-            f"codenib-source-fingerprint:{SOURCE_FINGERPRINT_VERSION}:"
-            f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
-        ).encode("ascii")
+    result = _fingerprint_repository(
+        root,
+        exclude_roots=exclude_roots,
+        version=SOURCE_FINGERPRINT_VERSION,
     )
-    file_count = 0
+    if not isinstance(result, SourceFingerprint):  # pragma: no cover - invariant
+        result.close()
+        raise AssertionError("fingerprint unexpectedly retained source authority")
+    return result
 
-    for path in walk_repository_files(root_path, exclude_roots=exclude_roots):
-        relative_text = path.relative_to(root_path).as_posix()
-        relative = relative_text.encode("utf-8", errors="surrogateescape")
-        try:
-            initial_metadata = path.lstat()
-        except OSError as exc:
-            raise RepositoryChangedError(
-                f"repository file disappeared while it was being inspected: {path}"
-            ) from exc
 
-        mode = initial_metadata.st_mode
-        if stat.S_ISLNK(mode):
-            try:
-                raw_target = os.readlink(path)
-                target = raw_target.encode("utf-8", errors="surrogateescape")
-            except OSError as exc:
-                raise RepositoryChangedError(
-                    f"repository link changed while it was being inspected: {path}"
-                ) from exc
-            hasher.update(b"L\0")
-            hasher.update(relative)
-            hasher.update(b"\0")
-            hasher.update(target)
-            hasher.update(b"\0")
-            try:
-                with resolved_repository_file(
-                    root_path,
-                    relative_text,
-                    expected_final_identity=_version_identity(initial_metadata),
-                ) as binding:
-                    if binding.is_regular:
-                        hasher.update(b"C\0")
-                        binding.update_hash(hasher)
-            except (OSError, ValueError) as exc:
-                raise RepositoryChangedError(
-                    "repository link target could not be read consistently: " f"{path}"
-                ) from exc
-            if not _link_matches(path, initial=initial_metadata, target=raw_target):
-                raise RepositoryChangedError(
-                    f"repository link changed while it was being read: {path}"
-                )
-            if binding.is_regular:
-                hasher.update(b"\0")
-            file_count += 1
-            continue
+def capture_repository_source(
+    root: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path] = (),
+    _source_owner: Callable[[object], None] | None = None,
+) -> RepositorySourceBinding:
+    """Capture source fingerprint v2 and retain its exact read authority.
 
-        if not stat.S_ISREG(mode):
-            continue
+    ``_source_owner`` is an internal handoff sink used by callers that must own
+    a stable cleanup slot before acquisition and the completed binding before
+    this Python frame returns.
+    """
 
-        hasher.update(b"F\0")
-        hasher.update(relative)
-        hasher.update(b"\0")
-        try:
-            update_repository_file_hash(
-                root_path,
-                relative_text,
-                hasher,
-                expected_final_identity=_version_identity(initial_metadata),
-            )
-        except (OSError, ValueError) as exc:
-            raise RepositoryChangedError(
-                f"repository file could not be read consistently: {path}"
-            ) from exc
-        hasher.update(b"\0")
-        file_count += 1
-
-    return SourceFingerprint(
-        value=f"sha256:{hasher.hexdigest()}",
-        file_count=file_count,
+    result = _fingerprint_repository(
+        root,
+        exclude_roots=exclude_roots,
+        version=SOURCE_FINGERPRINT_VERSION,
+        retain_binding=True,
+        source_owner=_source_owner,
     )
+    if not isinstance(result, RepositorySourceBinding):  # pragma: no cover
+        raise AssertionError("source capture did not retain repository authority")
+    return result
+
+
+def fingerprint_repository_v1_for_diagnostics(
+    root: str | Path,
+    *,
+    exclude_roots: Iterable[str | Path] = (),
+) -> SourceFingerprint:
+    """Reproduce legacy v1 solely for migration diagnostics.
+
+    V1 used delimiter concatenation and is structurally ambiguous.  Its result
+    must never authorize source reads, native indexes, or artifact reuse.
+    """
+
+    result = _fingerprint_repository(root, exclude_roots=exclude_roots, version=1)
+    if not isinstance(result, SourceFingerprint):  # pragma: no cover - invariant
+        result.close()
+        raise AssertionError("diagnostic fingerprint retained source authority")
+    return result
 
 
 def repository_source_is_dirty(
@@ -159,8 +2222,11 @@ def repository_source_is_dirty(
     Git-based incremental update paths.
     """
 
-    root_path = Path(root).expanduser().resolve()
-    excluded = tuple(Path(path).expanduser().resolve() for path in exclude_roots)
+    # Keep the same lexical-root contract as fingerprint_repository().  A
+    # resolve() here would let a reversible root swap redirect Git's status
+    # query and incorrectly authorize an incremental update for another tree.
+    root_path = lexical_repository_path(root)
+    excluded = tuple(lexical_repository_path(path) for path in exclude_roots)
     try:
         result = subprocess.run(
             [
@@ -208,8 +2274,16 @@ def repository_source_is_dirty(
 
 __all__ = [
     "RepositoryChangedError",
+    "RepositorySourceBinding",
+    "RepositorySourceFileRecord",
     "SOURCE_FINGERPRINT_VERSION",
     "SourceFingerprint",
+    "capture_repository_source",
     "fingerprint_repository",
+    "fingerprint_repository_v1_for_diagnostics",
+    "is_legacy_source_fingerprint_v1",
+    "is_secure_source_fingerprint_v2",
+    "lexical_repository_path",
     "repository_source_is_dirty",
+    "source_fingerprint_version",
 ]

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -6,19 +6,24 @@
 
 from __future__ import annotations
 
-import errno
 import hashlib
 import os
 import re
-import secrets
 import stat
 import tempfile
-import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO, Iterator
+from typing import BinaryIO, Iterable, Iterator
 
+from .. import _atomic_directory as _atomic
+from .._owned_file_publication import (
+    OwnedFileConflictError,
+    PublishedFileReceipt,
+    PublishedFileRecord,
+    publish_owned_file,
+    require_owned_file_publication_support,
+)
 from .models import StorageIntegrityError, StorageValidationError
 
 _DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
@@ -30,20 +35,10 @@ _SAFE_DIRECTORY_FDS = (
     and os.stat in os.supports_dir_fd
     and os.stat in os.supports_follow_symlinks
     and os.mkdir in os.supports_dir_fd
-    and os.unlink in os.supports_dir_fd
 )
-_LINK_UNSUPPORTED_ERRNOS = {
-    value
-    for value in (
-        getattr(errno, "ENOSYS", None),
-        getattr(errno, "ENOTSUP", None),
-        getattr(errno, "EOPNOTSUPP", None),
-        getattr(errno, "EPERM", None),
-        getattr(errno, "EXDEV", None),
-    )
-    if value is not None
-}
-_PUBLISH_LOCKS = tuple(threading.Lock() for _ in range(64))
+_CAS_OBJECT_MODE = 0o600
+_SHARD_NAMES = tuple(f"{value:02x}" for value in range(256))
+_DIRECTORY_CLOSE_RECOVERY_LIMIT = 64
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,34 +56,162 @@ class LocalCAS:
     Objects are stored below ``sha256/<first two hex digits>/<remaining hex>``.
     A digest is always the bare, lowercase, 64-character hexadecimal value.
 
-    On platforms with ``dir_fd``, ``O_DIRECTORY``, and ``O_NOFOLLOW`` support,
-    every internal path component is opened relative to its verified parent.
-    Other platforms retain explicit lstat/fstat checks, but cannot eliminate a
-    concurrent directory-replacement race as completely as the anchored path.
+    ``provision()`` plus ``require_preprovisioned=True`` is the strict
+    publication mode. It opens every internal component relative to a held
+    directory descriptor and never creates a directory during ``put``. The
+    default lazy layout remains a cooperative compatibility mode because POSIX
+    cannot bind ``mkdir`` and the following ``open`` into one authority step.
     """
 
-    def __init__(self, root: str | Path) -> None:
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        require_preprovisioned: bool = False,
+    ) -> None:
+        if not isinstance(require_preprovisioned, bool):
+            raise TypeError("require_preprovisioned must be a boolean")
+        # This capability check is deliberately before lstat/mkdir.  In
+        # particular, unsupported Windows publication must not create even the
+        # legacy cooperative layout before it fails.
+        _require_local_cas_support()
         requested_root = Path(root).expanduser()
-        try:
-            requested_metadata = requested_root.lstat()
-        except FileNotFoundError:
-            pass
-        else:
-            if not stat.S_ISDIR(requested_metadata.st_mode):
+        self.root = Path(os.path.abspath(os.fspath(requested_root)))
+        self._require_preprovisioned = require_preprovisioned
+        strict_root_identity: tuple[int, ...] | None = None
+        strict_sha256_identity: tuple[int, ...] | None = None
+        strict_shard_identities: dict[str, tuple[int, ...]] = {}
+        if not require_preprovisioned:
+            try:
+                _ensure_cas_root(self.root)
+            except ValueError as exc:
                 raise StorageValidationError(
-                    f"path is not a real directory: {requested_root}"
-                )
-        self.root = requested_root.resolve()
-        _ensure_directory(self.root)
+                    f"path is not a real directory: {self.root}"
+                ) from exc
         self._sha256_root = self.root / "sha256"
-        with _open_directory_path(self.root, label="CAS root") as root_descriptor:
-            with _open_or_create_child_directory(
-                root_descriptor,
+        try:
+            with _open_directory_path(
                 self.root,
-                "sha256",
-                label="CAS SHA-256 root",
-            ):
-                pass
+                label="CAS root",
+            ) as root_descriptor:
+                if require_preprovisioned:
+                    strict_root_identity = _directory_resource_identity(
+                        root_descriptor,
+                        path=self.root,
+                        label="CAS root",
+                    )
+                open_sha256 = (
+                    _open_child_directory
+                    if require_preprovisioned
+                    else _open_or_create_child_directory
+                )
+                with open_sha256(
+                    root_descriptor,
+                    self.root,
+                    "sha256",
+                    label="CAS SHA-256 root",
+                ) as (sha256_descriptor, sha256_path):
+                    if require_preprovisioned:
+                        strict_sha256_identity = _directory_resource_identity(
+                            sha256_descriptor,
+                            path=sha256_path,
+                            label="CAS SHA-256 root",
+                        )
+                        for shard_name in _SHARD_NAMES:
+                            with _open_child_directory(
+                                sha256_descriptor,
+                                sha256_path,
+                                shard_name,
+                                label="CAS digest shard",
+                            ) as (shard_descriptor, shard_path):
+                                strict_shard_identities[shard_name] = (
+                                    _directory_resource_identity(
+                                        shard_descriptor,
+                                        path=shard_path,
+                                        label="CAS digest shard",
+                                    )
+                                )
+        except FileNotFoundError as exc:
+            if require_preprovisioned:
+                try:
+                    self.root.lstat()
+                except FileNotFoundError:
+                    raise StorageValidationError(
+                        f"preprovisioned CAS root does not exist: {self.root}"
+                    ) from exc
+                raise StorageValidationError(
+                    "preprovisioned CAS layout must contain sha256 and all 256 "
+                    "digest shards"
+                ) from exc
+            raise
+        except ValueError as exc:
+            raise StorageValidationError(
+                f"path is not a real directory: {self.root}"
+            ) from exc
+        self._strict_root_identity = strict_root_identity
+        self._strict_sha256_identity = strict_sha256_identity
+        self._strict_shard_identities = strict_shard_identities
+
+    @classmethod
+    def provision(cls, root: str | Path) -> LocalCAS:
+        """Create the complete layout inside a trusted, quiescent boundary.
+
+        POSIX ``mkdir`` followed by ``open`` cannot prove that a same-UID actor
+        did not replace the new directory in between.  Provisioning therefore
+        creates every shard before strict publication begins; it is not a safe
+        online operation in the adversarial replacement model.
+        """
+
+        _require_local_cas_support()
+        requested_root = Path(root).expanduser()
+        lexical_root = Path(os.path.abspath(os.fspath(requested_root)))
+        root_parent = lexical_root.parent
+        if root_parent == lexical_root or not lexical_root.name:
+            raise StorageValidationError("CAS root must have a lexical parent")
+        try:
+            with _open_directory_path(
+                root_parent,
+                label="CAS root parent",
+            ) as root_parent_descriptor:
+                # Only the final root leaf may be created.  Requiring its
+                # lexical parent to pre-exist makes the unconditional replay
+                # below a complete durability chain, including after an
+                # ambiguous parent-fsync failure on an earlier attempt.
+                with _open_or_create_child_directory(
+                    root_parent_descriptor,
+                    root_parent,
+                    lexical_root.name,
+                    label="CAS root",
+                ) as (root_descriptor, rebound_root):
+                    with _open_or_create_child_directory(
+                        root_descriptor,
+                        rebound_root,
+                        "sha256",
+                        label="CAS SHA-256 root",
+                    ) as (sha256_descriptor, sha256_path):
+                        for shard_name in _SHARD_NAMES:
+                            with _open_or_create_child_directory(
+                                sha256_descriptor,
+                                sha256_path,
+                                shard_name,
+                                label="CAS digest shard",
+                            ):
+                                pass
+                        # Replay the complete durability chain unconditionally.
+                        # A previous mkdir may have committed before its parent
+                        # fsync raised, so an existing entry is not a receipt.
+                        os.fsync(sha256_descriptor)
+                    os.fsync(root_descriptor)
+                os.fsync(root_parent_descriptor)
+        except FileNotFoundError as exc:
+            raise StorageValidationError(
+                f"CAS root parent must already exist: {root_parent}"
+            ) from exc
+        except ValueError as exc:
+            raise StorageValidationError(
+                f"CAS root parent must be a real directory: {root_parent}"
+            ) from exc
+        return cls(lexical_root, require_preprovisioned=True)
 
     def put_bytes(self, data: bytes) -> BlobInfo:
         """Store *data*, deduplicating an already-valid immutable object."""
@@ -96,86 +219,26 @@ class LocalCAS:
         if not isinstance(data, bytes):
             raise TypeError("CAS payload must be bytes")
         digest = hashlib.sha256(data).hexdigest()
-        info = self._blob_info(digest, len(data))
-        with self._open_shard(digest, create=True) as (
-            shard_descriptor,
-            shard_path,
-        ):
-            if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
-                # A concurrent publisher may have linked this entry but not
-                # yet flushed the shard.  A successful deduplicated put is a
-                # durability receipt too, so it must not return before the
-                # canonical directory entry is persistent.
-                _fsync_directory_handle(shard_descriptor, shard_path)
-                return info
-
-            descriptor, temporary_name = _create_temporary_file(
-                shard_descriptor,
-                shard_path,
-                digest[2:],
-            )
-            try:
-                with os.fdopen(descriptor, "wb") as handle:
-                    handle.write(data)
-                    handle.flush()
-                    os.fsync(handle.fileno())
-                self._publish_temporary_at(
-                    shard_descriptor,
-                    shard_path,
-                    temporary_name,
-                    info,
-                )
-                return info
-            finally:
-                _unlink_at(shard_descriptor, shard_path, temporary_name)
-                _fsync_directory_handle(shard_descriptor, shard_path)
+        return self._publish_object(digest, len(data), data)
 
     def put_file(self, source: str | Path) -> BlobInfo:
         """Store a stable snapshot of a regular file.
 
         The source is read twice.  The first pass establishes its digest and
-        destination; the second writes the destination-directory temporary.
+        destination; the second feeds an owned destination-directory stage.
         Identity and metadata checks around both passes reject a source that is
         replaced or modified while it is being stored.
         """
 
         source_path = Path(source)
         digest, byte_size, source_signature = _hash_stable_file(source_path)
-        info = self._blob_info(digest, byte_size)
-        with self._open_shard(digest, create=True) as (
-            shard_descriptor,
-            shard_path,
-        ):
-            if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
-                _fsync_directory_handle(shard_descriptor, shard_path)
-                return info
-
-            descriptor, temporary_name = _create_temporary_file(
-                shard_descriptor,
-                shard_path,
-                digest[2:],
-            )
-            try:
-                with os.fdopen(descriptor, "wb") as target:
-                    copied_digest, copied_size = _copy_stable_file(
-                        source_path,
-                        target,
-                        expected_signature=source_signature,
-                    )
-                    target.flush()
-                    os.fsync(target.fileno())
-                if copied_digest != digest or copied_size != byte_size:
-                    raise OSError(f"source changed while being stored: {source_path}")
-                self._publish_temporary_at(
-                    shard_descriptor,
-                    shard_path,
-                    temporary_name,
-                    info,
-                )
-                return info
-            finally:
-                _unlink_at(shard_descriptor, shard_path, temporary_name)
-                _fsync_directory_handle(shard_descriptor, shard_path)
+        chunks = _stable_file_chunks(
+            source_path,
+            expected_signature=source_signature,
+            expected_digest=digest,
+            expected_size=byte_size,
+        )
+        return self._publish_object(digest, byte_size, chunks)
 
     def has(self, digest: str) -> bool:
         """Return whether a regular object exists for *digest*.
@@ -288,12 +351,24 @@ class LocalCAS:
     ) -> Iterator[tuple[int | None, Path]]:
         digest = _validate_digest(digest)
         with _open_directory_path(self.root, label="CAS root") as root_descriptor:
+            _require_directory_generation(
+                root_descriptor,
+                self._strict_root_identity,
+                path=self.root,
+                label="CAS root",
+            )
             with _open_child_directory(
                 root_descriptor,
                 self.root,
                 "sha256",
                 label="CAS SHA-256 root",
             ) as (sha256_descriptor, sha256_path):
+                _require_directory_generation(
+                    sha256_descriptor,
+                    self._strict_sha256_identity,
+                    path=sha256_path,
+                    label="CAS SHA-256 root",
+                )
                 open_child = (
                     _open_or_create_child_directory if create else _open_child_directory
                 )
@@ -302,8 +377,14 @@ class LocalCAS:
                     sha256_path,
                     digest[:2],
                     label="CAS digest shard",
-                ) as shard:
-                    yield shard
+                ) as (shard_descriptor, shard_path):
+                    _require_directory_generation(
+                        shard_descriptor,
+                        self._strict_shard_identities.get(digest[:2]),
+                        path=shard_path,
+                        label="CAS digest shard",
+                    )
+                    yield shard_descriptor, shard_path
 
     @staticmethod
     def _blob_info(digest: str, byte_size: int) -> BlobInfo:
@@ -314,85 +395,58 @@ class LocalCAS:
             storage_key=f"sha256/{digest[:2]}/{digest[2:]}",
         )
 
-    def _verify_existing_at(
+    def _publish_object(
         self,
-        shard_descriptor: int | None,
-        shard_path: Path,
-        expected: BlobInfo,
-    ) -> BlobInfo | None:
-        path = shard_path / expected.digest[2:]
-        try:
-            with _open_regular_at(
-                shard_descriptor,
-                shard_path,
-                expected.digest[2:],
-                label="existing CAS object",
-            ) as handle:
-                signature = _object_signature(os.fstat(handle.fileno()))
-                observed = hashlib.sha256()
-                byte_size = 0
-                while block := handle.read(_COPY_BUFFER_SIZE):
-                    observed.update(block)
-                    byte_size += len(block)
-                if _object_signature(os.fstat(handle.fileno())) != signature:
+        digest: str,
+        byte_size: int,
+        chunks: Iterable[bytes] | bytes,
+    ) -> BlobInfo:
+        expected = PublishedFileRecord(
+            size=byte_size,
+            sha256=digest,
+            mode=_CAS_OBJECT_MODE,
+        )
+        with self._open_shard(
+            digest,
+            create=not self._require_preprovisioned,
+        ) as (shard_descriptor, shard_path):
+            if shard_descriptor is None:
+                raise RuntimeError(
+                    "strict CAS publication requires an anchored shard descriptor"
+                )
+            destination = shard_path / digest[2:]
+            expected_parent_identity = _atomic.publication_parent_identity(
+                shard_descriptor
+            )
+
+            def consume(receipt: PublishedFileReceipt) -> None:
+                if (
+                    receipt.path != destination
+                    or receipt.record != expected
+                    or receipt.parent_identity != expected_parent_identity
+                ):
                     raise StorageIntegrityError(
-                        f"existing CAS object changed while read: {path}"
+                        f"CAS publication receipt conflicts for {digest}"
                     )
-        except FileNotFoundError:
-            return None
 
-        if byte_size != expected.byte_size or observed.hexdigest() != expected.digest:
-            raise StorageIntegrityError(
-                f"existing CAS object failed integrity validation: {path}"
-            )
-        return expected
-
-    def _publish_temporary_at(
-        self,
-        shard_descriptor: int | None,
-        shard_path: Path,
-        temporary_name: str,
-        info: BlobInfo,
-    ) -> None:
-        destination_name = info.digest[2:]
-        # Another writer may have completed while this writer populated its
-        # temporary.  A valid winner is reused; an invalid one is never healed
-        # silently because that could hide corruption of a published object.
-        if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
-            return
-
-        try:
-            _link_at(
-                shard_descriptor,
-                shard_path,
-                temporary_name,
-                destination_name,
-            )
-            return
-        except FileExistsError:
-            # A concurrent publisher won the no-replace link operation.
-            if self._verify_existing_at(shard_descriptor, shard_path, info) is None:
+            try:
+                publish_owned_file(
+                    destination,
+                    chunks,
+                    max_bytes=byte_size,
+                    mode=_CAS_OBJECT_MODE,
+                    parent_resource=shard_descriptor,
+                    consume=consume,
+                )
+            except OwnedFileConflictError as exc:
                 raise StorageIntegrityError(
-                    f"CAS object disappeared during publication: {info.digest}"
-                ) from None
-            return
-        except OSError as exc:
-            if exc.errno not in _LINK_UNSUPPORTED_ERRNOS:
-                raise
+                    f"existing CAS object failed integrity validation: {destination}"
+                ) from exc
 
-        # Hard links may be unavailable on some filesystems.  Serialize local
-        # writers before the atomic-replace fallback; cross-process writers can
-        # still race here, but they can only publish identical verified bytes.
-        lock = _PUBLISH_LOCKS[int(info.digest[:2], 16) % len(_PUBLISH_LOCKS)]
-        with lock:
-            if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
-                return
-            _replace_at(
-                shard_descriptor,
-                shard_path,
-                temporary_name,
-                destination_name,
-            )
+        # BlobInfo is deliberately created only after the helper has installed,
+        # synchronously consumed, and terminally closed the post-directory-fsync
+        # receipt.  No descriptor-owning resource crosses this return boundary.
+        return self._blob_info(digest, byte_size)
 
     def _consume_object(
         self,
@@ -417,32 +471,134 @@ class LocalCAS:
         return observed.hexdigest(), byte_size
 
 
+def _directory_resource_identity(
+    descriptor: int | None,
+    *,
+    path: Path,
+    label: str,
+) -> tuple[int, ...]:
+    if descriptor is None:
+        raise RuntimeError(f"{label} has no anchored directory descriptor: {path}")
+    try:
+        return _atomic.publication_parent_identity(descriptor)
+    except OSError as exc:
+        raise StorageIntegrityError(
+            f"{label} authority could not be identified: {path}"
+        ) from exc
+
+
+def _require_directory_generation(
+    descriptor: int | None,
+    expected: tuple[int, ...] | None,
+    *,
+    path: Path,
+    label: str,
+) -> None:
+    if expected is None:
+        return
+    if _directory_resource_identity(descriptor, path=path, label=label) != expected:
+        raise StorageIntegrityError(f"{label} generation changed: {path}")
+
+
+def _close_posix_resources(
+    resources: _atomic._PosixResourceOwner,
+    *,
+    primary_error: BaseException | None = None,
+) -> None:
+    """Close every directory fd, retrying while retaining the first error."""
+
+    first_error = primary_error
+    for _attempt in range(_DIRECTORY_CLOSE_RECOVERY_LIMIT):
+        if resources.closed:
+            break
+        try:
+            resources.close_all()
+        except BaseException as close_error:  # noqa: B036 - converge ownership
+            if first_error is None:
+                first_error = close_error
+            else:
+                _atomic._annotate_secondary_error(
+                    first_error,
+                    "directory descriptor cleanup also failed",
+                    close_error,
+                )
+    if not resources.closed:
+        convergence_error = RuntimeError(
+            "directory descriptor cleanup did not converge"
+        )
+        if first_error is None:
+            first_error = convergence_error
+        else:
+            _atomic._annotate_secondary_error(
+                first_error,
+                "directory descriptor cleanup did not converge",
+                convergence_error,
+            )
+    if primary_error is None and first_error is not None:
+        raise first_error
+
+
+def _close_publication_authority_owner(
+    authority_owner: _atomic._PublicationAuthorityOwner,
+    *,
+    primary_error: BaseException | None = None,
+) -> None:
+    """Retry atomic authority cleanup without directory-offset cookies."""
+
+    first_error = primary_error
+    for _attempt in range(_DIRECTORY_CLOSE_RECOVERY_LIMIT):
+        if authority_owner.authority is None:
+            break
+        try:
+            authority_owner.close()
+        except BaseException as close_error:  # noqa: B036 - converge ownership
+            if first_error is None:
+                first_error = close_error
+            else:
+                _atomic._annotate_secondary_error(
+                    first_error,
+                    "directory authority cleanup also failed",
+                    close_error,
+                )
+    if authority_owner.authority is not None:
+        convergence_error = RuntimeError("directory authority cleanup did not converge")
+        if first_error is None:
+            first_error = convergence_error
+        else:
+            _atomic._annotate_secondary_error(
+                first_error,
+                "directory authority cleanup did not converge",
+                convergence_error,
+            )
+    if primary_error is None and first_error is not None:
+        raise first_error
+
+
 @contextmanager
 def _open_directory_path(path: Path, *, label: str) -> Iterator[int | None]:
-    metadata = path.lstat()
-    if not stat.S_ISDIR(metadata.st_mode):
-        raise StorageIntegrityError(f"{label} is not a real directory: {path}")
-
-    if not _SAFE_DIRECTORY_FDS:
-        # The visible component is still rejected when it is a link.  Without
-        # anchored directory descriptors, however, another process can replace
-        # it between this check and a later child operation.
-        yield None
-        return
-
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
-    descriptor = os.open(path, flags)
+    authority_owner = _atomic._PublicationAuthorityOwner()
     try:
-        opened = os.fstat(descriptor)
-        if not stat.S_ISDIR(opened.st_mode):
-            raise StorageIntegrityError(f"{label} is not a directory: {path}")
-        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
-            raise StorageIntegrityError(f"{label} changed while opening: {path}")
-        yield descriptor
-    finally:
-        os.close(descriptor)
+        _atomic._open_publication_authority(
+            path,
+            parent_resource=None,
+            expected_parent_identity=None,
+            create_missing=False,
+            authority_owner=authority_owner,
+        )
+        authority = authority_owner.authority
+        if authority is None:
+            raise RuntimeError(f"{label} authority was not installed: {path}")
+        authority.verify_path_binding()
+        yield authority.resource
+        authority.verify_path_binding()
+    except BaseException as primary_error:
+        _close_publication_authority_owner(
+            authority_owner,
+            primary_error=primary_error,
+        )
+        raise
+    else:
+        _close_publication_authority_owner(authority_owner)
 
 
 @contextmanager
@@ -459,23 +615,29 @@ def _open_child_directory(
             yield descriptor, path
         return
 
-    metadata = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
-    if not stat.S_ISDIR(metadata.st_mode):
-        raise StorageIntegrityError(f"{label} is not a real directory: {path}")
-
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
-    descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+    resources = _atomic._PosixResourceOwner()
     try:
+        metadata = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise StorageIntegrityError(f"{label} is not a real directory: {path}")
+
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+        descriptor = resources.open(name, flags, dir_fd=parent_descriptor)
         opened = os.fstat(descriptor)
         if not stat.S_ISDIR(opened.st_mode):
             raise StorageIntegrityError(f"{label} is not a directory: {path}")
         if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
             raise StorageIntegrityError(f"{label} changed while opening: {path}")
         yield descriptor, path
-    finally:
-        os.close(descriptor)
+        rebound = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        if (rebound.st_dev, rebound.st_ino) != (opened.st_dev, opened.st_ino):
+            raise StorageIntegrityError(f"{label} binding changed: {path}")
+    except BaseException as primary_error:
+        _close_posix_resources(resources, primary_error=primary_error)
+        raise
+    else:
+        _close_posix_resources(resources)
 
 
 @contextmanager
@@ -548,94 +710,46 @@ def _open_regular_at(
         raise
 
 
-def _create_temporary_file(
-    directory_descriptor: int | None,
-    directory_path: Path,
-    object_name: str,
-) -> tuple[int, str]:
-    if directory_descriptor is None:
-        descriptor, temporary_path = tempfile.mkstemp(
-            dir=str(directory_path),
-            prefix=f".{object_name}.",
-            suffix=".tmp",
-        )
-        return descriptor, Path(temporary_path).name
-
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
-    if hasattr(os, "O_BINARY"):
-        flags |= os.O_BINARY
-    if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
-    for _attempt in range(100):
-        name = f".{object_name}.{secrets.token_hex(8)}.tmp"
-        try:
-            descriptor = os.open(
-                name,
-                flags,
-                0o600,
-                dir_fd=directory_descriptor,
-            )
-        except FileExistsError:
-            continue
-        return descriptor, name
-    raise FileExistsError(f"could not allocate CAS temporary in {directory_path}")
-
-
-def _link_at(
-    directory_descriptor: int | None,
-    directory_path: Path,
-    source_name: str,
-    destination_name: str,
-) -> None:
-    if directory_descriptor is not None and os.link in os.supports_dir_fd:
-        os.link(
-            source_name,
-            destination_name,
-            src_dir_fd=directory_descriptor,
-            dst_dir_fd=directory_descriptor,
-            follow_symlinks=False,
-        )
-        return
-    os.link(directory_path / source_name, directory_path / destination_name)
-
-
-def _replace_at(
-    directory_descriptor: int | None,
-    directory_path: Path,
-    source_name: str,
-    destination_name: str,
-) -> None:
-    if directory_descriptor is not None:
-        os.replace(
-            source_name,
-            destination_name,
-            src_dir_fd=directory_descriptor,
-            dst_dir_fd=directory_descriptor,
-        )
-        return
-    os.replace(directory_path / source_name, directory_path / destination_name)
-
-
-def _unlink_at(
-    directory_descriptor: int | None,
-    directory_path: Path,
-    name: str,
-) -> None:
-    try:
-        if directory_descriptor is None:
-            (directory_path / name).unlink()
-        else:
-            os.unlink(name, dir_fd=directory_descriptor)
-    except FileNotFoundError:
-        pass
-
-
 def _validate_digest(digest: str) -> str:
     if not isinstance(digest, str) or _DIGEST_RE.fullmatch(digest) is None:
         raise StorageValidationError(
             "digest must be 64 lowercase hexadecimal characters"
         )
     return digest
+
+
+def _require_local_cas_support() -> None:
+    """Fail before layout mutation unless anchored shard fds are available."""
+
+    require_owned_file_publication_support()
+    if not _SAFE_DIRECTORY_FDS:
+        raise RuntimeError("LocalCAS requires POSIX directory-fd support")
+
+
+def _ensure_cas_root(path: Path) -> None:
+    """Create a cooperative root through one lexical no-follow authority."""
+
+    authority_owner = _atomic._PublicationAuthorityOwner()
+    try:
+        _atomic._open_publication_authority(
+            path,
+            parent_resource=None,
+            expected_parent_identity=None,
+            create_missing=True,
+            authority_owner=authority_owner,
+        )
+        authority = authority_owner.authority
+        if authority is None:
+            raise RuntimeError("CAS root authority was not installed")
+        authority.verify_path_binding()
+    except BaseException as primary_error:
+        _close_publication_authority_owner(
+            authority_owner,
+            primary_error=primary_error,
+        )
+        raise
+    else:
+        _close_publication_authority_owner(authority_owner)
 
 
 def _ensure_directory(path: Path) -> None:
@@ -709,12 +823,15 @@ def _hash_stable_file(path: Path) -> tuple[str, int, tuple[int, ...]]:
     return observed.hexdigest(), byte_size, signature
 
 
-def _copy_stable_file(
+def _stable_file_chunks(
     path: Path,
-    target: BinaryIO,
     *,
     expected_signature: tuple[int, ...],
-) -> tuple[str, int]:
+    expected_digest: str,
+    expected_size: int,
+) -> Iterator[bytes]:
+    """Yield pass-two bytes and reject drift before normal iterator completion."""
+
     observed = hashlib.sha256()
     byte_size = 0
     with _open_regular_file(path, label="CAS source") as source:
@@ -724,11 +841,14 @@ def _copy_stable_file(
         while block := source.read(_COPY_BUFFER_SIZE):
             observed.update(block)
             byte_size += len(block)
-            target.write(block)
+            yield block
         if _file_signature(os.fstat(source.fileno())) != signature:
             raise OSError(f"source changed while being stored: {path}")
     _require_path_signature(path, signature, label="CAS source")
-    return observed.hexdigest(), byte_size
+    if observed.hexdigest() != expected_digest or byte_size != expected_size:
+        # This check runs before StopIteration reaches OwnedFile.write(), so a
+        # pass-two mismatch can leave only an owned stage and is never renamed.
+        raise OSError(f"source changed while being stored: {path}")
 
 
 def _file_signature(metadata: os.stat_result) -> tuple[int, ...]:

--- a/codenib/storage/models.py
+++ b/codenib/storage/models.py
@@ -15,28 +15,14 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, Mapping
 
+from .._secret_fields import (
+    SecretFieldError,
+)
+from .._secret_fields import assert_no_secret_fields as _assert_no_secret_fields
+
 _DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
 _CATALOG_INT64_MAX = 9_223_372_036_854_775_807
 INDEX_JOB_REQUEST_CONTRACT = "codenib.index-job-request.v1"
-_SECRET_FIELD_NAMES = frozenset(
-    {
-        "access_key",
-        "access_token",
-        "api_key",
-        "apikey",
-        "authorization",
-        "client_secret",
-        "cookie",
-        "credential",
-        "credentials",
-        "password",
-        "passwd",
-        "private_key",
-        "refresh_token",
-        "secret",
-        "token",
-    }
-)
 
 
 class StorageError(RuntimeError):
@@ -190,18 +176,21 @@ def _canonical_json_object(value: str, field: str) -> tuple[str, dict[str, Any]]
     return canonical_json(parsed), parsed
 
 
+def assert_no_secret_fields(value: Any, *, source: str = "value") -> None:
+    """Apply the shared credential policy with a storage validation error.
+
+    The classifier lives outside storage so artifacts do not depend on the
+    catalog layer; this wrapper preserves the public storage exception contract.
+    """
+
+    try:
+        _assert_no_secret_fields(value, source=source)
+    except SecretFieldError as exc:
+        raise StorageValidationError(str(exc)) from exc
+
+
 def _reject_secret_fields(value: Any, *, path: str = "request") -> None:
-    if isinstance(value, Mapping):
-        for key, child in value.items():
-            normalized = key.lower().replace("-", "_")
-            if normalized in _SECRET_FIELD_NAMES:
-                raise StorageValidationError(
-                    f"index job request must not contain secret field: {path}.{key}"
-                )
-            _reject_secret_fields(child, path=f"{path}.{key}")
-    elif isinstance(value, list):
-        for index, child in enumerate(value):
-            _reject_secret_fields(child, path=f"{path}[{index}]")
+    assert_no_secret_fields(value, source="index job request")
 
 
 class IndexJobStatus(str, Enum):
@@ -1013,6 +1002,7 @@ __all__ = [
     "StorageValidationError",
     "ViewGeneration",
     "ViewProfile",
+    "assert_no_secret_fields",
     "canonical_json",
     "content_id",
     "normalize_digest",

--- a/codenib/storage/view_bundle.py
+++ b/codenib/storage/view_bundle.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import re
 import stat
@@ -17,14 +18,22 @@ import unicodedata
 import zipfile
 from contextlib import contextmanager
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from pathlib import Path, PurePosixPath
-from typing import Any, BinaryIO, Iterable, Iterator, Mapping
+from typing import Any, BinaryIO, Callable, Iterable, Iterator, Mapping
 
 from .._atomic_directory import (
+    DirectoryOrphan,
+    PublicationDirectoryReader,
     _directory_identity,
     _linux_mount_points,
     _path_is_mount_point,
-    _remove_owned_directory,
+    capture_directory_ownership,
+    directory_ownership_entry_identities,
+    directory_ownership_file_records,
+    directory_ownership_inventory,
+    directory_ownership_root_identity,
+    discard_owned_directory,
     publish_staged_directory,
 )
 from .models import (
@@ -39,6 +48,27 @@ VIEW_BUNDLE_SCHEMA = "codenib.view-bundle.v1"
 VIEW_BUNDLE_MANIFEST = "bundle.json"
 VIEW_BUNDLE_PAYLOAD = "payload"
 VIEW_BUNDLE_MEDIA_TYPE = "application/vnd.codenib.view-bundle.v1+zip"
+logger = logging.getLogger(__name__)
+
+
+def _record_publication_orphan(
+    orphan: DirectoryOrphan | None,
+    *,
+    operation: str,
+) -> None:
+    if orphan is None:
+        return
+    logger.warning(
+        "View-bundle %s retained an orphan for quiescent GC: "
+        "path=%s digest=%s entries=%d bytes=%d verified=%s",
+        operation,
+        orphan.path,
+        orphan.ownership_digest,
+        orphan.entries,
+        orphan.byte_count,
+        orphan.verified_at_isolation,
+    )
+
 
 DEFAULT_MAX_BUNDLE_FILES = 100_000
 DEFAULT_MAX_BUNDLE_BYTES = 64 * 1024 * 1024 * 1024
@@ -94,6 +124,7 @@ class MaterializedViewBundle:
 
     output_dir: Path
     payload_dir: Path
+    ownership: object = dataclass_field(repr=False, compare=False)
     view_type: str
     digest: str
     byte_size: int
@@ -451,6 +482,7 @@ def materialize_view_bundle(
         )
     )
     stage_root_identity = _directory_inode_identity(stage.lstat())
+    published_ownership: list[object] = []
     try:
         with _open_extraction_root(stage, stage_root_identity) as stage_descriptor:
             with _open_stable_regular_file(
@@ -512,9 +544,11 @@ def materialize_view_bundle(
                     "view bundle materialization stage changed before publication"
                 )
 
-        def validate_moved_destination(moved: Path) -> None:
+        def validate_moved_destination(
+            moved: PublicationDirectoryReader,
+        ) -> None:
             try:
-                observed = _validate_materialization_target(
+                observed, _ownership = _validate_materialization_reader(
                     moved,
                     max_files=max_files,
                     max_bytes=max_bytes,
@@ -524,14 +558,19 @@ def materialize_view_bundle(
                 raise StorageIntegrityError(
                     "moved destination failed publication-boundary validation"
                 ) from exc
-            if observed != expected_ownership:
+            if not _same_materialization_semantics(
+                observed,
+                expected_ownership,
+            ):
                 raise StorageIntegrityError(
                     "moved destination failed publication-boundary validation"
                 )
 
-        def validate_published_destination(published: Path) -> None:
+        def validate_published_destination(
+            published: PublicationDirectoryReader,
+        ) -> None:
             try:
-                observed = _validate_materialization_target(
+                observed, ownership = _validate_materialization_reader(
                     published,
                     max_files=max_files,
                     max_bytes=max_bytes,
@@ -541,12 +580,16 @@ def materialize_view_bundle(
                 raise StorageIntegrityError(
                     "published stage failed publication-boundary validation"
                 ) from exc
-            if observed != expected_new_ownership:
+            if not _same_materialization_semantics(
+                observed,
+                expected_new_ownership,
+            ):
                 raise StorageIntegrityError(
                     "published stage failed publication-boundary validation"
                 )
+            published_ownership.append(ownership)
 
-        publish_staged_directory(
+        publication_orphan = publish_staged_directory(
             stage,
             output,
             expected_destination_identity=expected_ownership.root_identity,
@@ -554,9 +597,15 @@ def materialize_view_bundle(
             validate_moved_destination=validate_moved_destination,
             validate_published_destination=validate_published_destination,
         )
+        _record_publication_orphan(publication_orphan, operation="publication")
+        if len(published_ownership) != 1:
+            raise StorageIntegrityError(
+                "published materialized bundle has no authenticated ownership"
+            )
         return MaterializedViewBundle(
             output_dir=output,
             payload_dir=output / VIEW_BUNDLE_PAYLOAD,
+            ownership=published_ownership[0],
             view_type=record.view_type,
             digest=record.digest,
             byte_size=record.byte_size,
@@ -2583,6 +2632,185 @@ def _remove_owned_temporary_file(
         pass
 
 
+def _same_materialization_semantics(
+    left: _MaterializationOwnership,
+    right: _MaterializationOwnership,
+) -> bool:
+    """Compare bundle semantics without reinterpreting filesystem identities.
+
+    PublicationDirectoryReader is already bound to the exact outer ownership
+    token.  Its portable root identity intentionally differs in shape from the
+    legacy path validator's platform-specific identity, so semantic callbacks
+    compare only the authenticated bundle state here.
+    """
+
+    return (
+        left.state,
+        left.manifest_digest,
+        left.members,
+        left.directory_modes,
+    ) == (
+        right.state,
+        right.manifest_digest,
+        right.members,
+        right.directory_modes,
+    )
+
+
+def _materialization_entry_policy(
+    *,
+    max_files: int,
+    max_bytes: int,
+    max_metadata_bytes: int,
+) -> Callable[[str, str, int, int], None]:
+    payload_files = 0
+    payload_bytes = 0
+    payload_directories = 0
+
+    def validate(path: str, kind: str, mode: int, size: int) -> None:
+        nonlocal payload_files, payload_bytes, payload_directories
+        if path == VIEW_BUNDLE_MANIFEST:
+            if kind != "file" or mode != 0o644 or size > max_metadata_bytes:
+                raise StorageValidationError(
+                    "refusing to replace a non-CodeNib directory"
+                )
+            return
+        if path == VIEW_BUNDLE_PAYLOAD:
+            if kind != "directory":
+                raise StorageValidationError(
+                    "refusing to replace a non-CodeNib directory"
+                )
+            payload_directories += 1
+            return
+        prefix = f"{VIEW_BUNDLE_PAYLOAD}/"
+        if not path.startswith(prefix):
+            raise StorageValidationError("refusing to replace a non-CodeNib directory")
+        relative = path[len(prefix) :]
+        _canonical_member_path(relative)
+        if kind == "directory":
+            payload_directories += 1
+            if payload_directories > max_files + 1:
+                raise StorageValidationError(
+                    f"view bundle exceeds {max_files + 1} directories"
+                )
+            return
+        if kind != "file" or mode not in {0o644, 0o755}:
+            raise StorageValidationError("refusing to replace a non-CodeNib directory")
+        payload_files += 1
+        payload_bytes += size
+        if payload_files > max_files or payload_bytes > max_bytes:
+            raise StorageValidationError("refusing to replace a non-CodeNib directory")
+
+    return validate
+
+
+def _validate_materialization_reader(
+    reader: PublicationDirectoryReader,
+    *,
+    max_files: int,
+    max_bytes: int,
+    max_metadata_bytes: int,
+) -> tuple[_MaterializationOwnership, object]:
+    """Validate materialized bundle semantics through one pinned authority."""
+
+    ownership = reader.capture_ownership(
+        allow_empty_root=True,
+        entry_policy=_materialization_entry_policy(
+            max_files=max_files,
+            max_bytes=max_bytes,
+            max_metadata_bytes=max_metadata_bytes,
+        ),
+    )
+    inventory = directory_ownership_inventory(ownership)
+    root_identity = directory_ownership_root_identity(ownership)
+    if not inventory:
+        return (
+            _MaterializationOwnership(
+                "empty",
+                root_identity,
+                None,
+                (),
+                (),
+            ),
+            ownership,
+        )
+
+    inventory_by_path = dict(inventory)
+    if (
+        inventory_by_path.get(VIEW_BUNDLE_MANIFEST) != "file"
+        or inventory_by_path.get(VIEW_BUNDLE_PAYLOAD) != "directory"
+        or any(
+            path not in {VIEW_BUNDLE_MANIFEST, VIEW_BUNDLE_PAYLOAD}
+            and not path.startswith(f"{VIEW_BUNDLE_PAYLOAD}/")
+            for path in inventory_by_path
+        )
+    ):
+        raise StorageValidationError("refusing to replace a non-CodeNib directory")
+
+    records = {
+        record.path: record for record in directory_ownership_file_records(ownership)
+    }
+    manifest_record = records.get(VIEW_BUNDLE_MANIFEST)
+    if (
+        manifest_record is None
+        or manifest_record.mode != 0o644
+        or manifest_record.size > max_metadata_bytes
+    ):
+        raise StorageValidationError("refusing to replace a non-CodeNib directory")
+    metadata_bytes = reader.read_bytes(
+        VIEW_BUNDLE_MANIFEST,
+        max_bytes=max_metadata_bytes,
+    )
+    _view_type, members = _manifest_from_bytes(
+        metadata_bytes,
+        max_files=max_files,
+        max_bytes=max_bytes,
+    )
+
+    prefix = f"{VIEW_BUNDLE_PAYLOAD}/"
+    observed_files = tuple(
+        (
+            record.path[len(prefix) :],
+            record.size,
+            record.mode,
+            record.sha256,
+        )
+        for record in directory_ownership_file_records(ownership)
+        if record.path.startswith(prefix)
+    )
+    expected_files = tuple(
+        (member.path, member.byte_size, member.mode, member.digest)
+        for member in members
+    )
+    if observed_files != expected_files:
+        raise StorageValidationError("refusing to replace a non-CodeNib directory")
+
+    path_trie = _validate_member_paths(members, max_files=max_files)
+    directory_modes: list[tuple[str, int]] = []
+    for path, kind, identity in directory_ownership_entry_identities(ownership):
+        if kind != "directory" or not (
+            path == VIEW_BUNDLE_PAYLOAD or path.startswith(prefix)
+        ):
+            continue
+        relative = "" if path == VIEW_BUNDLE_PAYLOAD else path[len(prefix) :]
+        parts = () if not relative else tuple(PurePosixPath(relative).parts)
+        if not _trie_contains_directory(path_trie, parts):
+            raise StorageValidationError("refusing to replace a non-CodeNib directory")
+        directory_modes.append((relative, stat.S_IMODE(identity[2])))
+    if len(directory_modes) != len(path_trie.directory_nodes):
+        raise StorageValidationError("refusing to replace a non-CodeNib directory")
+    return (
+        _MaterializationOwnership(
+            "bundle",
+            root_identity,
+            manifest_record.sha256,
+            members,
+            tuple(sorted(directory_modes)),
+        ),
+        ownership,
+    )
+
+
 def _validate_materialization_target(
     path: Path,
     *,
@@ -2776,7 +3004,7 @@ def _require_owned_stage_path(
 
 
 def _remove_owned_stage(stage: Path, expected_identity: tuple[int, ...]) -> None:
-    """Remove only the original temporary root, preserving path substitutions."""
+    """Isolate only the original temporary root for cooperative orphan GC."""
 
     try:
         metadata = stage.lstat()
@@ -2788,43 +3016,16 @@ def _remove_owned_stage(stage: Path, expected_identity: tuple[int, ...]) -> None
         or _directory_inode_identity(metadata) != expected_identity
     ):
         return
-    cleanup: Path | None = None
     try:
-        cleanup = Path(
-            tempfile.mkdtemp(
-                prefix=f".{stage.name}.cleanup-",
-                dir=str(stage.parent),
-            )
-        )
-        cleanup.rmdir()
-        os.replace(stage, cleanup)
-    except OSError:
-        if cleanup is not None:
-            try:
-                cleanup.rmdir()
-            except OSError:
-                pass
-        return
-    try:
-        moved_metadata = cleanup.lstat()
-    except FileNotFoundError:
-        return
-    if (
-        _is_link_or_reparse(moved_metadata)
-        or not stat.S_ISDIR(moved_metadata.st_mode)
-        or _directory_inode_identity(moved_metadata) != expected_identity
-    ):
-        try:
-            os.replace(cleanup, stage)
-        except OSError:
-            pass
-        return
-    try:
-        _remove_owned_directory(cleanup, _directory_inode_identity(moved_metadata))
+        ownership = capture_directory_ownership(stage)
     except (OSError, RuntimeError, ValueError):
-        # Cleanup is best effort.  The owned tree remains quarantined under a
-        # unique sibling name rather than following a changed path.
-        pass
+        return
+    if directory_ownership_root_identity(ownership) != expected_identity:
+        return
+    _record_publication_orphan(
+        discard_owned_directory(stage, ownership),
+        operation="discard",
+    )
 
 
 def _reject_forbidden_roots(

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -33,6 +33,7 @@ from ..log_utils import get_logger
 from ..wiki import WikiBuilder
 from ..wiki.narrator import Narrator
 from .config import load_config
+from .native_authority import authorize_local_manifest_vector
 from .ports import argparse_tcp_port
 from .repo_registry import RepoRegistry
 from .repository_files import live_source_slice
@@ -77,7 +78,15 @@ def _wiki_narrator(config):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     config = load_config()
-    registry = RepoRegistry(config)
+    # The production service is the local administrator boundary: it verifies
+    # source fingerprint v2 and the exact captured vector tree through this
+    # injected resolver. RepoRegistry itself remains unable to mint authority.
+    # Sparse mode never invokes the resolver and therefore performs no extra
+    # source capture.
+    registry = RepoRegistry(
+        config,
+        native_index_authorization_resolver=authorize_local_manifest_vector,
+    )
     logger.info("Loading QA repos from %s ...", config.registry_path)
     registry.load_all()
     app.state.registry = registry

--- a/codenib/web/local.py
+++ b/codenib/web/local.py
@@ -16,10 +16,14 @@ from typing import Any, Mapping
 
 import yaml
 
-from ..compiler.checkout_identity import validate_checkout_identity
 from ..compiler.manifest import RepoManifest
 from ..compiler.snapshot_store import normalize_repo
 from ..llm.options import validate_model_options
+from ..source_fingerprint import (
+    capture_repository_source,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
+)
 from .config import RepoEntry, save_registry
 
 
@@ -73,14 +77,39 @@ def prepare_local_wiki(
     model_options: Mapping[str, Any] | None = None,
 ) -> LocalWiki:
     """Write the registry and config consumed by the existing Wiki service."""
-    repo_path = repo_path.expanduser().resolve()
-    manifest_path = manifest_path.expanduser().resolve()
+    repo_path = lexical_repository_path(repo_path)
+    manifest_path = Path(os.path.abspath(os.fspath(manifest_path.expanduser())))
     manifest = RepoManifest.load(str(manifest_path))
-    validate_checkout_identity(
-        repo_path,
-        manifest,
-        artifact_root=manifest_path.parent,
+    if not is_secure_source_fingerprint_v2(manifest.source_fingerprint):
+        raise ValueError("local wiki source reads require source fingerprint v2")
+    from ..artifacts.runtime import (
+        SourceBindingCleanupOwner,
+        _attach_source_cleanup_owner,
     )
+
+    cleanup_owner = SourceBindingCleanupOwner()
+    try:
+        source_binding = capture_repository_source(
+            repo_path,
+            exclude_roots=(manifest_path.parent,),
+            _source_owner=cleanup_owner.retain,
+        )
+        if (
+            source_binding.fingerprint != manifest.source_fingerprint
+            or source_binding.file_count != manifest.file_count
+        ):
+            raise ValueError("repository source content does not match the manifest")
+    except BaseException as primary:  # noqa: B036 - preserve validation fault
+        try:
+            cleanup_owner.close()
+        except BaseException:  # noqa: B036 - expose retry owner on primary
+            _attach_source_cleanup_owner(primary, cleanup_owner)
+        raise
+    try:
+        cleanup_owner.close()
+    except BaseException as cleanup_failure:  # noqa: B036 - retryable owner
+        _attach_source_cleanup_owner(cleanup_failure, cleanup_owner)
+        raise
 
     data_dir = manifest_path.parent / "wiki"
     data_dir.mkdir(parents=True, exist_ok=True)

--- a/codenib/web/native_authority.py
+++ b/codenib/web/native_authority.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trusted local boundary for native vector views served by the Web runtime."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ..artifacts.runtime import (
+    SourceBindingCleanupOwner,
+    _raise_source_cleanup_failure,
+    _source_cleanup_owner_is_pending,
+)
+from ..compiler.cache_lock import compiler_cache_lock
+from ..compiler.manifest import IndexEntry, RepoManifest
+from ..index.embedding.artifact_integrity import capture_authenticated_vector_view
+from ..native_index_authorization import (
+    NativeIndexAuthorization,
+    _mint_trusted_local_admin_authorization,
+)
+from ..source_fingerprint import (
+    capture_repository_source,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
+)
+from .config import RepoEntry
+
+
+def _absolute_manifest_path(value: str) -> Path:
+    lexical = Path(os.path.abspath(os.fspath(Path(value).expanduser())))
+    try:
+        resolved = lexical.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"manifest not found: {lexical}") from exc
+    if not resolved.is_file():
+        raise FileNotFoundError(f"manifest not found: {lexical}")
+    return resolved
+
+
+def _require_same_vector_manifest(
+    expected: RepoManifest,
+    observed: RepoManifest,
+    expected_vector: IndexEntry,
+) -> None:
+    """Reject a manifest or vector entry that changed around authorization."""
+
+    observed_vector = observed.indexes.get("vector")
+    if (
+        observed.repo_path != expected.repo_path
+        or observed.commit != expected.commit
+        or observed.source_fingerprint != expected.source_fingerprint
+        or observed.file_count != expected.file_count
+        or observed_vector != expected_vector
+        or not observed.index_is_current("vector")
+    ):
+        raise ValueError("vector manifest changed before native authorization")
+
+
+def _raise_after_source_cleanup(
+    owner: SourceBindingCleanupOwner,
+    primary: BaseException,
+) -> None:
+    """Close retained source authority without hiding the first failure."""
+
+    cleanup_failure: BaseException | None = None
+    try:
+        owner.close()
+    except BaseException as exc:  # noqa: B036 - shared priority decides
+        cleanup_failure = exc
+    pending_owner = owner if _source_cleanup_owner_is_pending(owner) else None
+    nested_owner = getattr(primary, "source_cleanup_owner", None)
+    if pending_owner is None and _source_cleanup_owner_is_pending(nested_owner):
+        pending_owner = nested_owner
+    _raise_source_cleanup_failure(primary, cleanup_failure, pending_owner)
+
+
+def authorize_local_manifest_vector(
+    repo_entry: RepoEntry,
+    manifest: RepoManifest,
+    vector_entry: IndexEntry,
+) -> NativeIndexAuthorization:
+    """Authorize one exact local vector tree after source-bound admin checks.
+
+    The Web registry is only a consumer and cannot mint from an artifact path.
+    Its production entry points inject this resolver as the trusted boundary.
+    The resolver serializes against the compiler, verifies source fingerprint
+    v2 through retained authority, captures the exact vector tree, and binds
+    the capability to the unmodified manifest config. The later vector loader
+    independently recaptures the tree and checks the same capability subject.
+    """
+
+    recorded_vector = manifest.indexes.get("vector")
+    if recorded_vector is not vector_entry or not manifest.index_is_current("vector"):
+        raise ValueError("resolver did not receive the current manifest vector entry")
+    if not is_secure_source_fingerprint_v2(manifest.source_fingerprint):
+        raise ValueError("native vector authorization requires source fingerprint v2")
+
+    repo_path = lexical_repository_path(repo_entry.repo_dir)
+    manifest_repo_path = lexical_repository_path(manifest.repo_path)
+    if repo_path != manifest_repo_path:
+        raise ValueError("registry repository path does not match the vector manifest")
+    if (
+        repo_entry.base_commit
+        and manifest.commit
+        and repo_entry.base_commit != manifest.commit
+    ):
+        raise ValueError("registry commit does not match the vector manifest")
+
+    manifest_path = _absolute_manifest_path(repo_entry.manifest_path)
+
+    cleanup_owner: SourceBindingCleanupOwner | None = None
+    authorization: NativeIndexAuthorization | None = None
+    with compiler_cache_lock(manifest_path.parent):
+        observed_manifest = RepoManifest.load(str(manifest_path))
+        _require_same_vector_manifest(manifest, observed_manifest, vector_entry)
+
+        cleanup_owner = SourceBindingCleanupOwner()
+        try:
+            source_binding = capture_repository_source(
+                repo_path,
+                exclude_roots=(manifest_path.parent,),
+                _source_owner=cleanup_owner.retain,
+            )
+            if (
+                source_binding.fingerprint != manifest.source_fingerprint
+                or source_binding.file_count != manifest.file_count
+            ):
+                raise ValueError(
+                    "repository source content does not match the vector manifest"
+                )
+
+            with capture_authenticated_vector_view(vector_entry.path) as vector_view:
+                authorization = _mint_trusted_local_admin_authorization(
+                    vector_view.ownership,
+                    view_type="vector",
+                    semantic_contract=dict(vector_entry.config or {}),
+                    evidence=(
+                        "web-local-admin-manifest-intent",
+                        "source-content-fingerprint-v2-bound",
+                        "captured-vector-tree-subject",
+                    ),
+                )
+                vector_view.verify_final()
+
+            source_binding.verify_snapshot()
+            final_manifest = RepoManifest.load(str(manifest_path))
+            _require_same_vector_manifest(manifest, final_manifest, vector_entry)
+        except BaseException as primary:  # noqa: B036 - preserve verification fault
+            _raise_after_source_cleanup(cleanup_owner, primary)
+
+        cleanup_failure: BaseException | None = None
+        try:
+            cleanup_owner.close()
+        except BaseException as exc:  # noqa: B036 - retryable owner
+            cleanup_failure = exc
+        pending_owner = (
+            cleanup_owner if _source_cleanup_owner_is_pending(cleanup_owner) else None
+        )
+        if cleanup_failure is not None:
+            _raise_source_cleanup_failure(
+                cleanup_failure,
+                None,
+                pending_owner,
+            )
+        if pending_owner is not None:
+            _raise_source_cleanup_failure(
+                RuntimeError("repository source cleanup did not finish"),
+                None,
+                pending_owner,
+            )
+
+    if authorization is None:  # pragma: no cover - successful path always mints
+        raise AssertionError("native vector authorization was not minted")
+    return authorization
+
+
+__all__ = ["authorize_local_manifest_vector"]

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -20,7 +20,7 @@ from threading import Lock
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
-from ..compiler.manifest import RepoManifest
+from ..compiler.manifest import IndexEntry, RepoManifest
 from ..log_utils import get_logger
 from ..provider_routes import normalize_endpoint, resolve_embedding_artifact_route
 from ..repository_summary import read_repository_summary
@@ -358,11 +358,32 @@ class RepoRegistry:
         config: QAConfig,
         *,
         native_index_authorization_resolver: (
-            Callable[[Any], NativeIndexAuthorization | None] | None
+            Callable[
+                [RepoEntry, RepoManifest, IndexEntry],
+                NativeIndexAuthorization | None,
+            ]
+            | None
         ) = None,
+        allow_missing_native_index_authorization: bool = False,
     ) -> None:
+        if (
+            "vector" in config.index_types()
+            and native_index_authorization_resolver is None
+            and not allow_missing_native_index_authorization
+        ):
+            from ..native_index_authorization import (
+                MissingNativeIndexAuthorizationError,
+            )
+
+            raise MissingNativeIndexAuthorizationError(
+                "hybrid mode requires an external native-index authorization "
+                "resolver"
+            )
         self._config = config
         self._native_index_authorization_resolver = native_index_authorization_resolver
+        self._allow_missing_native_index_authorization = (
+            allow_missing_native_index_authorization
+        )
         self._bundles: Dict[str, RepoBundle] = {}
         # One embedding model per model name, shared across repos: the GPU model
         # is loaded once instead of once per CodeVectorStore (one per repo).
@@ -410,31 +431,47 @@ class RepoRegistry:
         native_index_authorization: NativeIndexAuthorization,
     ) -> "CodeVectorStore":
         """Load a manifest vector view with the configured embedding backend."""
-        from ..native_index_authorization import (
-            require_native_index_authorization_preflight,
+        from ..index.embedding.artifact_integrity import (
+            require_authorized_vector_view,
         )
 
-        require_native_index_authorization_preflight(
+        # The manifest's exact config is part of the native capability subject.
+        # Legacy route defaults are query-time compatibility inputs only: adding
+        # them to ``artifact_metadata`` would change the semantic contract after
+        # the caller had already bound its token to ``vec_entry.config``.
+        semantic_contract = dict(vec_entry.config or {})
+        # Preliminary token shape checks are intentionally not enough: reject a
+        # valid but wrong-tree or wrong-semantic capability before constructing
+        # an embedding client/model. CodeVectorStore.load recaptures and checks
+        # again, so any drift after this gate also fails before native parsing.
+        require_authorized_vector_view(
+            vec_entry.path,
             native_index_authorization,
-            view_type="vector",
+            semantic_contract,
         )
-        artifact_config = dict(vec_entry.config or {})
-        legacy_route = not artifact_config.get("embedding_route")
+        effective_route_config = dict(semantic_contract)
+        legacy_route = not effective_route_config.get("embedding_route")
         legacy_fallbacks = []
-        if legacy_route and not artifact_config.get("embedding_provider"):
+        if legacy_route and not effective_route_config.get("embedding_provider"):
             # Pre-provider manifests from build_qa_index.py intentionally relied
             # on the QA runtime route. Keep that narrow compatibility path while
             # requiring all newly built artifacts to persist their provider.
-            artifact_config["embedding_provider"] = self._config.embedding_provider
+            effective_route_config["embedding_provider"] = (
+                self._config.embedding_provider
+            )
             legacy_fallbacks.append(f"provider={self._config.embedding_provider}")
             if self._config.embedding_base_url:
-                artifact_config["embedding_endpoint"] = self._config.embedding_base_url
+                effective_route_config["embedding_endpoint"] = (
+                    self._config.embedding_base_url
+                )
         if (
             legacy_route
-            and "dimension" not in artifact_config
-            and "embedding_dimension" not in artifact_config
+            and "dimension" not in effective_route_config
+            and "embedding_dimension" not in effective_route_config
         ):
-            artifact_config["embedding_dimension"] = self._config.embedding_dimension
+            effective_route_config["embedding_dimension"] = (
+                self._config.embedding_dimension
+            )
             legacy_fallbacks.append(f"dimension={self._config.embedding_dimension}")
         if legacy_fallbacks:
             logger.warning(
@@ -444,7 +481,7 @@ class RepoRegistry:
                 vec_entry.path,
                 ", ".join(legacy_fallbacks),
             )
-        route = resolve_embedding_artifact_route(artifact_config)
+        route = resolve_embedding_artifact_route(effective_route_config)
         configured_endpoint = normalize_endpoint(self._config.embedding_base_url)
         if configured_endpoint is not None and configured_endpoint != route.endpoint:
             raise ValueError(
@@ -474,10 +511,10 @@ class RepoRegistry:
             embedding_model=route.model,
             embedding_provider=route.provider,
             dimension=route.dimension,
-            index_metric=artifact_config.get("index_metric", "ip"),
+            index_metric=effective_route_config.get("index_metric", "ip"),
             store_path=vec_entry.path,
             embedding=self._embeddings.get(cache_key),
-            artifact_metadata=artifact_config,
+            artifact_metadata=semantic_contract,
             **embedding_kwargs,
         )
         self._embeddings[cache_key] = vector_store.embedding
@@ -519,40 +556,46 @@ class RepoRegistry:
             bm25_index.load_index(bm25_entry.path)
 
         vec_entry = manifest.indexes.get("vector")
-        if (
-            "vector" in index_types
-            and vec_entry is not None
-            and manifest.index_is_current("vector")
-        ):
+        if "vector" in index_types:
+            if vec_entry is None or not manifest.index_is_current("vector"):
+                if self._allow_missing_native_index_authorization:
+                    logger.warning(
+                        "Skipping missing or stale optional vector view; "
+                        "BM25 remains available"
+                    )
+                else:
+                    raise ValueError(
+                        "hybrid mode requires a current vector manifest entry"
+                    )
+                bundle.vector_store = None
+                bundle.bm25 = bm25_index
+                return
+
             authorization = None
-            if self._native_index_authorization_resolver is not None:
-                try:
-                    authorization = self._native_index_authorization_resolver(vec_entry)
-                except Exception as exc:  # noqa: BLE001 - BM25 remains usable
-                    logger.warning(
-                        "Native vector authorization failed for %s: %s",
-                        vec_entry.path,
-                        exc,
-                    )
+            resolver = self._native_index_authorization_resolver
+            if resolver is not None:
+                authorization = resolver(bundle.entry, manifest, vec_entry)
             if authorization is None:
-                logger.warning(
-                    "Skipping native vector view at %s without external "
-                    "authorization; BM25 remains available",
-                    vec_entry.path,
-                )
-            else:
-                try:
-                    vector_store = self._load_vector_store(
-                        vec_entry,
-                        native_index_authorization=authorization,
-                    )
-                except Exception as exc:  # noqa: BLE001 - BM25 remains usable
+                if self._allow_missing_native_index_authorization:
                     logger.warning(
-                        "Skipping unusable native vector view at %s: %s; "
-                        "BM25 remains available",
+                        "Skipping optional native vector view at %s without "
+                        "external authorization; BM25 remains available",
                         vec_entry.path,
-                        exc,
                     )
+                else:
+                    from ..native_index_authorization import (
+                        MissingNativeIndexAuthorizationError,
+                    )
+
+                    raise MissingNativeIndexAuthorizationError(
+                        "native-index authorization resolver returned no "
+                        "authorization for a required hybrid vector view"
+                    )
+            else:
+                vector_store = self._load_vector_store(
+                    vec_entry,
+                    native_index_authorization=authorization,
+                )
 
         bundle.vector_store = vector_store
         bundle.bm25 = bm25_index

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from ..index.embedding.vector_store import CodeVectorStore
     from ..index.sparse_idx.bm25_index import BM25CodeIndexer
     from ..llm.litellm_chat import LiteLLMChat
+    from ..native_index_authorization import NativeIndexAuthorization
 
 logger = get_logger(__name__)
 
@@ -352,8 +353,16 @@ class RepoBundle:
 class RepoRegistry:
     """Holds the loaded :class:`RepoBundle` objects, keyed by instance id."""
 
-    def __init__(self, config: QAConfig) -> None:
+    def __init__(
+        self,
+        config: QAConfig,
+        *,
+        native_index_authorization_resolver: (
+            Callable[[Any], NativeIndexAuthorization | None] | None
+        ) = None,
+    ) -> None:
         self._config = config
+        self._native_index_authorization_resolver = native_index_authorization_resolver
         self._bundles: Dict[str, RepoBundle] = {}
         # One embedding model per model name, shared across repos: the GPU model
         # is loaded once instead of once per CodeVectorStore (one per repo).
@@ -394,8 +403,21 @@ class RepoRegistry:
             runtime_loader=self._load_repo_runtime,
         )
 
-    def _load_vector_store(self, vec_entry: Any) -> "CodeVectorStore":
+    def _load_vector_store(
+        self,
+        vec_entry: Any,
+        *,
+        native_index_authorization: NativeIndexAuthorization,
+    ) -> "CodeVectorStore":
         """Load a manifest vector view with the configured embedding backend."""
+        from ..native_index_authorization import (
+            require_native_index_authorization_preflight,
+        )
+
+        require_native_index_authorization_preflight(
+            native_index_authorization,
+            view_type="vector",
+        )
         artifact_config = dict(vec_entry.config or {})
         legacy_route = not artifact_config.get("embedding_route")
         legacy_fallbacks = []
@@ -459,7 +481,10 @@ class RepoRegistry:
             **embedding_kwargs,
         )
         self._embeddings[cache_key] = vector_store.embedding
-        vector_store.load(vec_entry.path)
+        vector_store.load(
+            vec_entry.path,
+            native_index_authorization=native_index_authorization,
+        )
         return vector_store
 
     def _create_ask_llm(self) -> "LiteLLMChat":
@@ -499,7 +524,35 @@ class RepoRegistry:
             and vec_entry is not None
             and manifest.index_is_current("vector")
         ):
-            vector_store = self._load_vector_store(vec_entry)
+            authorization = None
+            if self._native_index_authorization_resolver is not None:
+                try:
+                    authorization = self._native_index_authorization_resolver(vec_entry)
+                except Exception as exc:  # noqa: BLE001 - BM25 remains usable
+                    logger.warning(
+                        "Native vector authorization failed for %s: %s",
+                        vec_entry.path,
+                        exc,
+                    )
+            if authorization is None:
+                logger.warning(
+                    "Skipping native vector view at %s without external "
+                    "authorization; BM25 remains available",
+                    vec_entry.path,
+                )
+            else:
+                try:
+                    vector_store = self._load_vector_store(
+                        vec_entry,
+                        native_index_authorization=authorization,
+                    )
+                except Exception as exc:  # noqa: BLE001 - BM25 remains usable
+                    logger.warning(
+                        "Skipping unusable native vector view at %s: %s; "
+                        "BM25 remains available",
+                        vec_entry.path,
+                        exc,
+                    )
 
         bundle.vector_store = vector_store
         bundle.bm25 = bm25_index

--- a/codenib/web/repository_files.py
+++ b/codenib/web/repository_files.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import os
 import re
-import stat
 import subprocess
 from functools import lru_cache
 from typing import Optional
+
+from .._contained_source import read_repository_file
 
 _COMMIT_RE = re.compile(r"[0-9a-fA-F]{7,64}\Z")
 _MAX_SOURCE_BYTES = 8 * 1024 * 1024
@@ -212,24 +213,12 @@ def live_source_slice(
     relative = safe_repo_relative_path(repo_dir, file_path)
     if relative is None:
         return None
-    candidate = os.path.realpath(os.path.join(repo_dir, relative))
-    descriptor = -1
     try:
-        descriptor = os.open(
-            candidate,
-            os.O_RDONLY | getattr(os, "O_NONBLOCK", 0),
+        content = read_repository_file(
+            repo_dir,
+            relative,
+            max_bytes=_MAX_SOURCE_BYTES,
         )
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-            return None
-        handle = os.fdopen(descriptor, "rb")
-        descriptor = -1
-        with handle:
-            content = handle.read(_MAX_SOURCE_BYTES + 1)
-    except OSError:
-        return None
-    finally:
-        if descriptor >= 0:
-            os.close(descriptor)
-    if len(content) > _MAX_SOURCE_BYTES:
+    except ValueError:
         return None
     return _source_slice(relative, content, start, end)

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -18,7 +18,10 @@ from typing import Any, Iterable, Mapping
 from urllib.parse import quote, unquote, urlsplit
 
 from .._atomic_directory import (
+    PublicationDirectoryReader,
+    _annotate_secondary_error,
     capture_directory_ownership,
+    directory_ownership_root_identity,
     discard_owned_directory,
     lexical_directory_path,
     publish_staged_directory,
@@ -825,6 +828,9 @@ def export_static_wiki(
         )
     )
     stage_root_ownership = capture_directory_ownership(stage)
+    initial_stage_root_identity = directory_ownership_root_identity(
+        stage_root_ownership
+    )
     try:
         _copy_frontend(frontend, stage, base_path=base_path)
         _write_bytes(stage, "runtime-config.js", _runtime_config(base_path))
@@ -900,7 +906,7 @@ def export_static_wiki(
 
         expected_manifest_bytes = _json_bytes(export_manifest)
 
-        def validate_export(candidate: Path) -> None:
+        def validate_export_path(candidate: Path) -> None:
             assert_publishable_tree(
                 candidate,
                 forbidden_paths=(repo_path, manifest_path.parent),
@@ -917,6 +923,52 @@ def export_static_wiki(
                     "published static export differs from its staged identity"
                 )
 
+        # Carry the path validators' result across publication with one exact
+        # full-tree token. Publication callbacks receive a retained reader and
+        # must never reopen the staged or published path.
+        validate_export_path(stage)
+        publication_ownership = capture_directory_ownership(stage)
+        if (
+            directory_ownership_root_identity(publication_ownership)
+            != initial_stage_root_identity
+        ):
+            raise RuntimeError("static export stage root changed during build")
+        stage_root_ownership = publication_ownership
+        expected_manifest_size, expected_manifest_digest = file_sha256(manifest_file)
+
+        def validate_export(candidate: PublicationDirectoryReader) -> None:
+            records = candidate.file_records()
+            candidate_manifest = next(
+                (record for record in records if record.path == STATIC_EXPORT_MANIFEST),
+                None,
+            )
+            actual_files = [
+                {
+                    "path": record.path,
+                    "bytes": record.size,
+                    "sha256": record.sha256,
+                }
+                for record in sorted(
+                    records,
+                    key=lambda item: PurePosixPath(item.path),
+                )
+                if record.path != STATIC_EXPORT_MANIFEST
+            ]
+            if (
+                candidate_manifest is None
+                or candidate_manifest.size != expected_manifest_size
+                or candidate_manifest.sha256 != expected_manifest_digest
+                or candidate.read_bytes(
+                    STATIC_EXPORT_MANIFEST,
+                    max_bytes=expected_manifest_size,
+                )
+                != expected_manifest_bytes
+                or actual_files != export_manifest["files"]
+            ):
+                raise ValueError(
+                    "published static export differs from its staged identity"
+                )
+
         publish_staged_directory(
             stage,
             output_dir,
@@ -926,8 +978,28 @@ def export_static_wiki(
             validate_published_destination=validate_export,
         )
         manifest_file = output_dir / manifest_file.relative_to(stage)
-    except BaseException:
-        discard_owned_directory(stage, stage_root_ownership)
+    except BaseException as primary_error:
+        try:
+            observed_stage_ownership = capture_directory_ownership(stage)
+            if (
+                directory_ownership_root_identity(observed_stage_ownership)
+                == initial_stage_root_identity
+            ):
+                stage_root_ownership = observed_stage_ownership
+        except BaseException as capture_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "static export stage cleanup capture also failed",
+                capture_error,
+            )
+        try:
+            discard_owned_directory(stage, stage_root_ownership)
+        except BaseException as discard_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "static export stage discard also failed",
+                discard_error,
+            )
         raise
 
     return StaticExportResult(

--- a/docs/incremental_graph/index.md
+++ b/docs/incremental_graph/index.md
@@ -41,7 +41,7 @@ compiler.update_repo("/path/to/repo")    # incremental advance to HEAD
 - **Nothing to do** — `HEAD` unchanged and every requested index `fresh`: returns the existing manifest untouched.
 - **Retry incomplete builds** — `HEAD` unchanged but some requested index is missing or not `fresh` (a previous run failed partway): re-runs a full `compile_repo()` so the failed indexes are retried instead of staying stale.
 - **Full rebuild fallback** — no manifest, an unreadable manifest, or an empty `last_indexed_commit` (no complete baseline was ever established): falls back to `compile_repo()`.
-- **Incremental advance** — otherwise, each builder's `incremental_update(..., last_commit=<previous>)` runs. Builders without a real delta path (BM25, Zoekt) rebuild internally, the vector builder applies a git-diff-driven embedding update, and the symbol-graph builder runs the LSP patcher described below — the result is always correct, only the cost differs.
+- **Incremental advance** — otherwise, each builder's `incremental_update(..., last_commit=<previous>)` runs. Builders without a safely publishable delta path rebuild internally. BM25 and Zoekt rebuild, and the vector builder validates the existing generation and its native-read authority before publishing one complete private-generation rebuild; it does not mutate the live vector tree in place. The symbol-graph builder runs the LSP patcher described below — the result is always correct, only the cost differs.
 
 ### last_indexed_commit Semantics
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -240,6 +240,26 @@ not depend on the catalog implementation.  These gates close the current
 portable context publication surface; they are a prerequisite for, but do not
 complete, the remaining legacy manifest import/export adapter or a future
 streaming payload revision.
+
+Native vector parsing is now a separate local-authority boundary. Portable
+validation and normalization remain inert: they authenticate the declared
+FAISS bytes and canonical JSON inventory without importing FAISS or
+deserializing pickle, and a descriptive `trusted-local` string cannot grant
+native access. Native consumers must present a process-local authorization
+bound to the exact captured vector tree and semantic configuration before any
+embedding model, remote client, pickle decoder, or FAISS parser is created.
+Compiler rebuilds write the vector files, incremental state, caches, and update
+marker into one descriptor-anchored private generation, then publish the whole
+directory through the owned-directory transaction. The live git-diff vector
+delta is disabled until it can satisfy the same publication boundary; an
+incremental request therefore validates its existing authority and state, then
+performs a complete private-generation rebuild. The Web runtime mints local
+authorization outside the registry only while holding the hardened compiler
+cache lock and revalidating the source-fingerprint-v2 repository, manifest, and
+captured vector tree. These compatibility and publication gates preserve the
+previous complete vector generation on interruption, but they do not complete
+the catalog-backed M2 generation coordinator or durable worker wiring.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -260,6 +260,17 @@ captured vector tree. These compatibility and publication gates preserve the
 previous complete vector generation on interruption, but they do not complete
 the catalog-backed M2 generation coordinator or durable worker wiring.
 
+Strict workspace publication now has a provider-neutral foundation. A caller
+supplies one canonical `WorkspacePlan`; entry count, aggregate path-metadata,
+per-file, and aggregate byte budgets fail before provisioning. A trusted
+provisioner must pre-open and adopt the exact directory skeleton, after which
+descriptor-bound writes, complete-tree sealing, staged/published validation,
+and the retained publication receipt share one ownership boundary. The
+platform capability probe is side-effect free and fails closed where anchored
+directory descriptors or atomic no-replace rename are unavailable. This slice
+does not add a production workspace provider or wire a compiler/context
+producer, so M1 remains in progress.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -218,6 +218,28 @@ path, component, and depth limits.  This avoids relying on directory timestamps,
 which are not reliable on every supported filesystem.  Existing non-empty trees
 fail closed on platforms without safe directory-fd traversal; a first publish
 may proceed only with caller validation and an ownership-checked empty sentinel.
+Portable BM25 and vector normalization now exposes a read-only validation
+boundary for storage publishers.  Retained JSON must be bounded,
+duplicate-safe canonical JSON; decoded metadata and configuration pass the
+shared credential and build-path policy.  BM25 validation binds normalized
+document paths and artifact fingerprints, while vector validation binds the
+provider/model/revision/dimension/metric contract, persistence fingerprints,
+level inventories, document counts, and FAISS type/training semantics inside a
+bounded full-tree ownership sandwich.  Validation holds a no-follow root
+descriptor, authenticates JSON and indexes through descriptor-relative stable
+opens, and gives FAISS a callback over the already authenticated index
+descriptor rather than reopening an attacker-replaceable path.  The M1 JSON
+format has a fixed 16 MiB configuration limit and 256 MiB documents-file limit;
+larger repositories require a future streaming or sharded format rather than a
+manifest-controlled memory override.  Repository-relative source aliases may
+use bounded relative symlinks only when resolution remains inside the pinned
+checkout; absolute, outside, looping, raced, and reparse-point paths fail
+closed in staging, binding, BM25 reads, and MCP reads.  The shared credential
+classifier lives outside both artifacts and storage so the artifact layer does
+not depend on the catalog implementation.  These gates close the current
+portable context publication surface; they are a prerequisite for, but do not
+complete, the remaining legacy manifest import/export adapter or a future
+streaming payload revision.
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/examples/eval_synthesized_queries.py
+++ b/examples/eval_synthesized_queries.py
@@ -44,6 +44,7 @@ Usage:
         --queries-dir synthesized_queries/ \
         --filter-instance "astral-sh__ruff-15309"
 """
+
 from __future__ import annotations
 
 import argparse
@@ -55,7 +56,7 @@ import sys
 import time
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
 if _PROJECT_ROOT not in sys.path:
@@ -74,6 +75,42 @@ from codenib.paths import prebuilt_data_dir, repo_index_dir, user_state_dir
 from codenib.types import QueriedNode
 
 logger = get_logger(__name__)
+
+
+def _load_vector_from_local_admin_boundary(
+    store: Any,
+    path: str | Path,
+    *,
+    semantic_contract: Mapping[str, Any],
+    evidence: str,
+) -> None:
+    """Authorize one compiler-produced local view for this eval process."""
+
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
+
+    if not evidence:
+        raise ValueError("local vector authorization evidence must be non-empty")
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                evidence,
+                "synthesized-query-eval-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Language detection
@@ -414,14 +451,21 @@ def _make_agent(
         bm25_index.load_index(manifest.indexes["bm25"].path)
 
     if "vector" in manifest.indexes and manifest.indexes["vector"].status == "fresh":
-        cfg = manifest.indexes["vector"].config
+        vector_entry = manifest.indexes["vector"]
+        cfg = dict(vector_entry.config)
         vector_store = CodeVectorStore(
             embedding_model=cfg.get("embedding_model", args.embedding_model),
             embedding_provider="huggingface",
             dimension=cfg.get("embedding_dimension", args.embedding_dimension),
-            store_path=manifest.indexes["vector"].path,
+            store_path=vector_entry.path,
+            artifact_metadata=cfg,
         )
-        vector_store.load(manifest.indexes["vector"].path)
+        _load_vector_from_local_admin_boundary(
+            vector_store,
+            vector_entry.path,
+            semantic_contract=cfg,
+            evidence="synthesized-query-eval-compiled-local-manifest",
+        )
 
     ctx: Dict[str, Any] = {
         "retrieve": RetrieveContext(

--- a/examples/skill_agent.py
+++ b/examples/skill_agent.py
@@ -34,7 +34,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Mapping
 
 # ---------------------------------------------------------------------------
 # Ensure the project root is on sys.path when running as a script
@@ -52,6 +52,41 @@ from codenib.ops.rerank import RerankContext
 from codenib.ops.retrieve import RetrieveContext
 from codenib.paths import repo_index_dir
 from codenib.types import QueriedNode
+
+
+def _load_vector_from_local_admin_boundary(
+    store: Any,
+    path: str | Path,
+    *,
+    semantic_contract: Mapping[str, Any],
+    evidence: str,
+) -> None:
+    """Authorize one lexical local cache owned by this example invocation."""
+
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
+
+    if not evidence:
+        raise ValueError("local vector authorization evidence must be non-empty")
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                evidence,
+                "skill-agent-example-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
 
 
 def parse_args() -> argparse.Namespace:
@@ -142,7 +177,12 @@ def build_vector_store(
             dimension=embedding_dimension,
             store_path=str(store_path),
         )
-        vs.load(str(store_path))
+        _load_vector_from_local_admin_boundary(
+            vs,
+            store_path,
+            semantic_contract={},
+            evidence="skill-agent-standalone-local-cache",
+        )
         if vs.l0_documents and vs.l2_documents:
             return vs
         print("  Embedding: cache incomplete, rebuilding")
@@ -374,20 +414,24 @@ def run_agent(args: argparse.Namespace) -> None:
         print(f"  Loaded BM25 from {manifest.indexes['bm25'].path}")
 
     if "vector" in manifest.indexes and manifest.indexes["vector"].status == "fresh":
-        emb_model = manifest.indexes["vector"].config.get(
-            "embedding_model", args.embedding_model
-        )
-        emb_dim = manifest.indexes["vector"].config.get(
-            "embedding_dimension", args.embedding_dimension
-        )
+        vector_entry = manifest.indexes["vector"]
+        vector_contract = dict(vector_entry.config)
+        emb_model = vector_contract.get("embedding_model", args.embedding_model)
+        emb_dim = vector_contract.get("embedding_dimension", args.embedding_dimension)
         vector_store = CodeVectorStore(
             embedding_model=emb_model,
             embedding_provider="huggingface",
             dimension=emb_dim,
-            store_path=manifest.indexes["vector"].path,
+            store_path=vector_entry.path,
+            artifact_metadata=vector_contract,
         )
-        vector_store.load(manifest.indexes["vector"].path)
-        print(f"  Loaded vector store from {manifest.indexes['vector'].path}")
+        _load_vector_from_local_admin_boundary(
+            vector_store,
+            vector_entry.path,
+            semantic_contract=vector_contract,
+            evidence="skill-agent-compiled-local-manifest",
+        )
+        print(f"  Loaded vector store from {vector_entry.path}")
 
     # Create contexts and load skills
     retrieve_ctx = RetrieveContext(

--- a/examples/swerank_retrieve_rerank.py
+++ b/examples/swerank_retrieve_rerank.py
@@ -229,7 +229,7 @@ def resolve_index_dir(
     if commit and not repository_source_is_dirty(repo):
         source_key = f"git-{commit.lower()}"
     else:
-        fingerprint = fingerprint_repository(repo).value.removeprefix("sha256:")
+        fingerprint = fingerprint_repository(repo).value.replace(":", "-", 1)
         source_key = f"source-{fingerprint}"
 
     profile_key = _cache_profile_key(languages, args.max_lines_per_chunk)
@@ -370,7 +370,9 @@ def render_results(
 
 
 def run(args: argparse.Namespace) -> int:
-    repo = Path(args.repo).expanduser().resolve()
+    from codenib.source_fingerprint import lexical_repository_path
+
+    repo = lexical_repository_path(args.repo)
     if not repo.is_dir():
         raise ValueError(f"repository directory does not exist: {repo}")
 

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -45,12 +45,18 @@ from codenib.compiler.snapshot_store import ArtifactProfile  # noqa: E402
 from codenib.compiler.snapshot_store import SnapshotArtifactStore, SourceSnapshot
 from codenib.git_snapshot import GitSourceSurface  # noqa: E402
 from codenib.index.embedding import build_hierarchical_vector_store  # noqa: E402
+from codenib.index.embedding.artifact_integrity import (  # noqa: E402
+    capture_authenticated_vector_view,
+)
 from codenib.index.embedding.model_policy import (  # noqa: E402
     DEFAULT_EMBEDDING_MODEL,
     resolve_embedding_load_policy,
 )
 from codenib.languages import extensions_for_language  # noqa: E402
 from codenib.log_utils import get_logger  # noqa: E402
+from codenib.native_index_authorization import (  # noqa: E402
+    _mint_trusted_local_admin_authorization,
+)
 from codenib.paths import prebuilt_data_dir  # noqa: E402
 from codenib.profiler import Profiler  # noqa: E402
 from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION  # noqa: E402
@@ -410,6 +416,35 @@ def _vector_quality_path(root: Path, embedding_model: str) -> Path:
     return root / f"artifact_quality_{model_suffix}.json"
 
 
+def _assess_vector_artifact_as_local_admin(
+    root: Path,
+    *,
+    artifact_metadata: Mapping[str, Any],
+    evidence: str,
+    **assessment_kwargs: Any,
+) -> dict[str, Any]:
+    """Assess bytes owned by this local build command's lexical boundary."""
+
+    with capture_authenticated_vector_view(root) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=artifact_metadata,
+            evidence=(
+                evidence,
+                "embedding-build-command-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+        return assess_vector_artifact(
+            root,
+            expected_artifact=artifact_metadata,
+            authenticated_view=vector_view,
+            native_index_authorization=authorization,
+            **assessment_kwargs,
+        )
+
+
 def _artifact_metadata(
     *,
     instance: dict[str, Any],
@@ -653,14 +688,21 @@ def build_embeddings(args):
             # Reuse only artifacts that pass identity, file, and coverage checks.
             model_suffix = args.embedding_model.replace("/", "__")
             config_file = artifact_root / f"config_{model_suffix}.json"
-            existing_quality = assess_vector_artifact(
-                artifact_root,
-                embedding_model=args.embedding_model,
-                build_levels=build_levels,
-                surface=surface,
-                expected_artifact=artifact_metadata,
-                required_l0_files=required_l0,
-            )
+            if artifact_root.is_dir():
+                existing_quality = _assess_vector_artifact_as_local_admin(
+                    artifact_root,
+                    artifact_metadata=artifact_metadata,
+                    evidence="embedding-build-existing-local-cache",
+                    embedding_model=args.embedding_model,
+                    build_levels=build_levels,
+                    surface=surface,
+                    required_l0_files=required_l0,
+                )
+            else:
+                existing_quality = {
+                    "passed": False,
+                    "failure_names": ["missing_artifact_root"],
+                }
             if existing_quality["passed"] and not args.force_rebuild:
                 logger.info(
                     "Embedding already exists and passed quality gates at %s; skipping",
@@ -720,12 +762,13 @@ def build_embeddings(args):
                     artifact_metadata=artifact_metadata,
                 )
 
-            artifact_quality = assess_vector_artifact(
+            artifact_quality = _assess_vector_artifact_as_local_admin(
                 artifact_root,
+                artifact_metadata=artifact_metadata,
+                evidence="embedding-build-finished-local-output",
                 embedding_model=args.embedding_model,
                 build_levels=build_levels,
                 surface=surface,
-                expected_artifact=artifact_metadata,
                 required_l0_files=required_l0,
             )
             quality_path = _vector_quality_path(artifact_root, args.embedding_model)

--- a/scripts/mcp_benchmark_codenib_base.py
+++ b/scripts/mcp_benchmark_codenib_base.py
@@ -18,7 +18,7 @@ import json
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List, Mapping
 
 import datasets
 
@@ -48,6 +48,41 @@ LANGUAGE_GROUP_MAP: Dict[str, List[str]] = {
     "Rust": ["rust"],
     "TypeScript/JavaScript": ["typescript", "javascript"],
 }
+
+
+def _load_vector_from_local_admin_boundary(
+    store: CodeVectorStore,
+    path: str | Path,
+    *,
+    semantic_contract: Mapping[str, Any],
+    evidence: str,
+) -> None:
+    """Authorize one prebuilt local benchmark view at the CLI boundary."""
+
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
+
+    if not evidence:
+        raise ValueError("local vector authorization evidence must be non-empty")
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                evidence,
+                "mcp-benchmark-cli-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
 
 
 def _normalize_symbol(s: str) -> str:
@@ -145,6 +180,8 @@ async def benchmark_instance(
 
     ctx = ServerContext(manifest=manifest)
     try:
+        vector_entry = manifest.indexes["vector"]
+        vector_contract = dict(vector_entry.config)
         ctx.vector = CodeVectorStore(
             embedding_model=embedding_model,
             embedding_provider="huggingface",
@@ -157,8 +194,14 @@ async def benchmark_instance(
                 else None
             ),
             trust_remote_code=(embedding_model == DEFAULT_EMBEDDING_MODEL),
+            artifact_metadata=vector_contract,
         )
-        ctx.vector.load()
+        _load_vector_from_local_admin_boundary(
+            ctx.vector,
+            vector_entry.path,
+            semantic_contract=vector_contract,
+            evidence="mcp-benchmark-prebuilt-local-index",
+        )
     except Exception as e:
         return {
             "instance_id": instance_id,

--- a/test/agent/test_embedding_search_e2e.py
+++ b/test/agent/test_embedding_search_e2e.py
@@ -26,6 +26,9 @@ from pathlib import Path
 
 import pytest
 
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
+
 
 def _cuda_available() -> bool:
     try:
@@ -48,6 +51,26 @@ DEFAULT_EMBEDDING_DIM = 768
 DEFAULT_EMBEDDING_PROVIDER = "huggingface"
 
 EMBEDDING_INDEX_PATH = "/tmp/embedding_e2e_index"
+
+
+def _load_test_owned_vector(store, path):
+    """Authorize the session-owned local E2E cache, never artifact input."""
+
+    semantic_contract = dict(store.artifact_metadata)
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "embedding-search-e2e-local-cache",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
 
 
 @pytest.fixture(scope="session")
@@ -77,7 +100,7 @@ def vector_store(httpie_cli_repo):
                 "normalize_embeddings": True,
             },
         )
-        vs.load(EMBEDDING_INDEX_PATH)
+        _load_test_owned_vector(vs, EMBEDDING_INDEX_PATH)
     else:
         print(f"\n[e2e] Building index for {repo_path} into {EMBEDDING_INDEX_PATH}")
         store_root.mkdir(parents=True, exist_ok=True)

--- a/test/agent/test_query.py
+++ b/test/agent/test_query.py
@@ -156,6 +156,34 @@ class TestPreconditions:
         assert result.answer == "ok"
         assert called["n"] == 0
 
+    def test_repo_mode_threads_native_authorization_resolver(self, monkeypatch):
+        from codenib import compiler as compiler_mod
+
+        captured = {}
+
+        def resolver(_entry):
+            return object()
+
+        def fake_build(**kwargs):
+            captured.update(kwargs)
+            return {}
+
+        monkeypatch.setattr(compiler_mod, "build_skill_contexts", fake_build)
+
+        result = query(
+            "hello",
+            options=CodeNibAgentOptions(
+                repo_path="/tmp/repo",
+                llm=_mock_llm_final_answer(answer="ok"),
+                allowed_skills=["bm25_search"],
+                native_index_authorization_resolver=resolver,
+            ),
+        )
+
+        assert result.answer == "ok"
+        assert captured["native_index_authorization"] is None
+        assert captured["native_index_authorization_resolver"] is resolver
+
 
 # ---------------------------------------------------------------------------
 # Compile-table threading

--- a/test/agent/test_query_manifest.py
+++ b/test/agent/test_query_manifest.py
@@ -126,6 +126,39 @@ class TestExactlyOneModeEnforced:
                 ),
             )
 
+    def test_native_token_and_resolver_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="either native_index_authorization"):
+            query(
+                "anything",
+                options=CodeNibAgentOptions(
+                    repo_path="/tmp/x",
+                    llm=_mock_llm_final_answer(),
+                    native_index_authorization=object(),
+                    native_index_authorization_resolver=lambda _entry: object(),
+                ),
+            )
+
+    @pytest.mark.parametrize(
+        "authority_options",
+        [
+            {"native_index_authorization": object()},
+            {"native_index_authorization_resolver": lambda _entry: object()},
+        ],
+    )
+    def test_contexts_mode_rejects_unused_authority_options(
+        self,
+        authority_options,
+    ):
+        with pytest.raises(ValueError, match="not accepted in contexts mode"):
+            query(
+                "anything",
+                options=CodeNibAgentOptions(
+                    contexts={},
+                    llm=_mock_llm_final_answer(),
+                    **authority_options,
+                ),
+            )
+
 
 # ---------------------------------------------------------------------------
 # Manifest mode wiring
@@ -133,6 +166,33 @@ class TestExactlyOneModeEnforced:
 
 
 class TestManifestMode:
+    def test_manifest_mode_threads_native_authorization_resolver(self, monkeypatch):
+        from codenib import compiler as compiler_pkg
+
+        captured = {}
+
+        def resolver(_entry):
+            return object()
+
+        def fake_load(*_args, **kwargs):
+            captured.update(kwargs)
+            return {}
+
+        monkeypatch.setattr(compiler_pkg, "load_contexts_from_manifest", fake_load)
+
+        query(
+            "noop",
+            options=CodeNibAgentOptions(
+                manifest=_fake_manifest(),
+                llm=_mock_llm_final_answer(),
+                allowed_skills=["bm25_search"],
+                native_index_authorization_resolver=resolver,
+            ),
+        )
+
+        assert captured["native_index_authorization"] is None
+        assert captured["native_index_authorization_resolver"] is resolver
+
     def test_manifest_mode_skips_build_skill_contexts(self, monkeypatch):
         """When ``manifest`` is set, the inline build path must never run.
 

--- a/test/agent/test_runner_sandbox.py
+++ b/test/agent/test_runner_sandbox.py
@@ -8,6 +8,7 @@ import base64
 import json
 import subprocess
 import sys
+from dataclasses import replace
 from pathlib import Path
 from types import MappingProxyType, SimpleNamespace
 from unittest.mock import MagicMock
@@ -50,7 +51,7 @@ class FakeSandbox:
             source_revision="c" * 40,
             network="none",
             rootless_runtime=True,
-            source_fingerprint="sha256:" + "e" * 64,
+            source_fingerprint="sha256-v2:" + "e" * 64,
         )
 
     def execute(self, request):
@@ -326,7 +327,10 @@ def test_sandbox_prompt_hides_host_path_and_uses_workspace_root(tmp_path):
 
 
 def test_sandbox_manifest_revision_must_match():
-    manifest = RepoManifest(commit="d" * 40, source_fingerprint="sha256:" + "e" * 64)
+    manifest = RepoManifest(
+        commit="d" * 40,
+        source_fingerprint="sha256-v2:" + "e" * 64,
+    )
     with pytest.raises(ValueError, match="does not match"):
         AgentRunner(
             MagicMock(spec=LiteLLMChat),
@@ -347,13 +351,48 @@ def test_sandbox_manifest_requires_revision():
 
 
 def test_sandbox_manifest_fingerprint_must_match():
-    manifest = RepoManifest(commit="c" * 40, source_fingerprint="sha256:" + "f" * 64)
+    manifest = RepoManifest(
+        commit="c" * 40,
+        source_fingerprint="sha256-v2:" + "f" * 64,
+    )
     with pytest.raises(ValueError, match="fingerprint does not match"):
         AgentRunner(
             MagicMock(spec=LiteLLMChat),
             SkillRegistry(),
             sandbox=FakeSandbox(),
             manifest=manifest,
+        )
+
+
+def test_sandbox_matching_legacy_fingerprint_cannot_authorize_runner():
+    sandbox = FakeSandbox()
+    legacy = "sha256:" + "e" * 64
+    sandbox.metadata = replace(sandbox.metadata, source_fingerprint=legacy)
+    manifest = RepoManifest(commit="c" * 40, source_fingerprint=legacy)
+
+    with pytest.raises(ValueError, match="secure source fingerprint v2"):
+        AgentRunner(
+            MagicMock(spec=LiteLLMChat),
+            SkillRegistry(),
+            sandbox=sandbox,
+            manifest=manifest,
+        )
+
+
+def test_query_matching_legacy_fingerprint_cannot_authorize_context_loading():
+    sandbox = FakeSandbox()
+    legacy = "sha256:" + "e" * 64
+    sandbox.metadata = replace(sandbox.metadata, source_fingerprint=legacy)
+    manifest = RepoManifest(commit="c" * 40, source_fingerprint=legacy)
+
+    with pytest.raises(ValueError, match="secure source fingerprint v2"):
+        query(
+            "noop",
+            options=CodeNibAgentOptions(
+                manifest=manifest,
+                llm=MagicMock(spec=LiteLLMChat),
+                sandbox=sandbox,
+            ),
         )
 
 

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -641,7 +641,15 @@ def test_context_artifact_rejects_source_drift(tmp_path: Path) -> None:
 
 def test_context_artifact_rejects_configured_secret_in_view(tmp_path: Path) -> None:
     repo, manifest_path, view_path = _fixture_manifest(tmp_path)
-    (view_path / "leak.bin").write_bytes(b"runtime-secret-value")
+    documents_path = view_path / "documents.json"
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    documents[0]["metadata"]["note"] = "runtime-secret-value"
+    documents_path.write_text(json.dumps(documents), encoding="utf-8")
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["bm25"].config["artifact_file_fingerprints"] = (
+        bm25_artifact_file_fingerprints(view_path)
+    )
+    manifest.save(manifest_path)
 
     with pytest.raises(ValueError, match="configured credential"):
         stage_context_artifact(
@@ -656,15 +664,54 @@ def test_context_artifact_stream_scan_finds_boundary_spanning_secret(
     tmp_path: Path,
 ) -> None:
     repo, manifest_path, view_path = _fixture_manifest(tmp_path)
-    secret = b"boundary-spanning-secret"
-    (view_path / "large.bin").write_bytes(b"x" * (1024 * 1024 - 5) + secret)
+    secret = "boundary-spanning-secret"
+    documents = [
+        {
+            "page_content": "value",
+            "metadata": {"file": "sample.py", "note": secret},
+        }
+    ]
+    probe = (
+        json.dumps(
+            documents,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    )
+    secret_offset = probe.index(secret)
+    documents[0]["metadata"]["note"] = "x" * (1024 * 1024 - 5 - secret_offset) + secret
+    documents_payload = (
+        json.dumps(
+            documents,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    )
+    assert documents_payload.index(secret) == 1024 * 1024 - 5
+    (view_path / "documents.json").write_text(
+        documents_payload,
+        encoding="utf-8",
+    )
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["bm25"].config["artifact_file_fingerprints"] = (
+        bm25_artifact_file_fingerprints(view_path)
+    )
+    manifest.save(manifest_path)
 
     with pytest.raises(ValueError, match="configured credential"):
         stage_context_artifact(
             repo,
             manifest_path,
             tmp_path / "publish" / "context",
-            environ={"CODENIB_ACTION_EMBEDDING_KEY": secret.decode()},
+            environ={"CODENIB_ACTION_EMBEDDING_KEY": secret},
         )
 
 

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
-import os
 import pickle
 from pathlib import Path
 from types import SimpleNamespace
@@ -294,15 +293,19 @@ def test_context_artifact_restores_previous_output_on_publish_failure(
         bm25_artifact_file_fingerprints(view_path)
     )
     manifest.save(manifest_path)
-    real_replace = os.replace
+    from codenib import _atomic_directory as atomic_module
 
-    def fail_final_publish(source, target):
-        source_path = Path(source)
-        if source_path.name.startswith(".context.tmp-") and Path(target) == output:
+    real_rename = atomic_module._rename_noreplace_at
+
+    def fail_final_publish(source, target, source_parent, target_parent):
+        if source.startswith(".context.tmp-") and target == output.name:
             raise OSError("injected context publish failure")
-        return real_replace(source, target)
+        return real_rename(source, target, source_parent, target_parent)
 
-    monkeypatch.setattr("codenib._atomic_directory.os.replace", fail_final_publish)
+    monkeypatch.setattr(
+        "codenib._atomic_directory._rename_noreplace_at",
+        fail_final_publish,
+    )
 
     with pytest.raises(OSError, match="injected context publish failure"):
         stage_context_artifact(

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -571,6 +571,31 @@ def test_context_artifact_rejects_unpublished_vector_generation(tmp_path: Path) 
         )
 
 
+def test_context_vector_requires_config_authority_before_mint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, manifest_path, _vector = _fixture_vector_manifest(tmp_path)
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["vector"].config.pop("persistence_config_fingerprint")
+    manifest.save(manifest_path)
+    import codenib.artifacts.context as context_module
+
+    monkeypatch.setattr(
+        context_module,
+        "_mint_trusted_local_admin_authorization",
+        lambda *args, **kwargs: pytest.fail(
+            "unanchored vector config must not mint native authorization"
+        ),
+    )
+    with pytest.raises(ValueError, match="requires its config fingerprint"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "publish" / "context",
+        )
+
+
 def test_context_artifact_rejects_tampered_vector_level(tmp_path: Path) -> None:
     repo, manifest_path, vector = _fixture_vector_manifest(tmp_path)
     documents = vector / "l2" / "documents_test__model.pkl"
@@ -639,6 +664,30 @@ def test_context_artifact_rejects_source_drift(tmp_path: Path) -> None:
             repo,
             manifest_path,
             tmp_path / "publish" / "context",
+        )
+
+
+def test_context_vector_never_mints_from_unvalidated_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, manifest_path, _vector = _fixture_vector_manifest(tmp_path)
+    (repo / "sample.py").write_text("VALUE = 2\n")
+    import codenib.artifacts.context as context_module
+
+    monkeypatch.setattr(
+        context_module,
+        "_mint_trusted_local_admin_authorization",
+        lambda *args, **kwargs: pytest.fail(
+            "source drift must be rejected before native authorization"
+        ),
+    )
+    with pytest.raises(ValueError, match="source files do not match"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "publish" / "context",
+            validate_checkout=False,
         )
 
 

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -23,9 +23,7 @@ from codenib.index.embedding.artifact_integrity import (
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
-from codenib.native_index_authorization import (
-    _mint_trusted_local_admin_authorization,
-)
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.provider_routes import resolve_inference_route
 
 _VECTOR_CONFIG = {
@@ -813,6 +811,10 @@ def test_normalize_vector_converts_trusted_pickle_and_strips_build_state(
         view_type="vector",
         view_config=_VECTOR_CONFIG,
         source_trust="trusted-local",
+        native_index_authorization=_authorize_vector_runtime(
+            vector,
+            _VECTOR_CONFIG,
+        ),
     )
 
     documents_path = level / f"documents_{_MODEL_SUFFIX}.json"
@@ -907,8 +909,9 @@ def test_portable_vector_validator_rejects_noncanonical_json_without_mutation(
     } == before_modes
 
 
-def test_portable_vector_validator_rechecks_faiss_semantics_after_records(
+def test_portable_vector_validator_treats_authenticated_faiss_as_inert_bytes(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo, _source = _repository(tmp_path)
     vector = _vector_view(tmp_path, repo, document_format="json")
@@ -937,13 +940,18 @@ def test_portable_vector_validator_rechecks_faiss_semantics_after_records(
         ),
     }
 
-    with pytest.raises(ValueError, match="FAISS dimension mismatch"):
-        validate_portable_query_view(
-            vector,
-            repo_path=repo,
-            view_type="vector",
-            view_config=view_config,
-        )
+    faiss = importlib.import_module("faiss")
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("portable validation must not parse FAISS bytes")
+
+    monkeypatch.setattr(faiss, "read_index", fail_if_called)
+    validate_portable_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=view_config,
+    )
 
 
 @pytest.mark.parametrize("artifact", ["config", "documents", "faiss"])
@@ -1009,36 +1017,35 @@ def test_portable_vector_rejects_fifo_swapped_after_capture_without_blocking(
         target.write_bytes(original)
 
 
-def test_portable_vector_parses_faiss_from_authenticated_callback_reader(
+def test_portable_vector_normalize_and_validate_do_not_parse_faiss(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo, _source = _repository(tmp_path)
     vector = _vector_view(tmp_path, repo, document_format="json")
+    import codenib.artifacts.portable_views as portable_views_module
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("portable normalization must not invoke native parsers")
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "importlib",
+        SimpleNamespace(import_module=fail_if_called),
+    )
+    monkeypatch.setattr(portable_views_module.compat_pickle, "load", fail_if_called)
     adjustments = normalize_owned_query_view(
         vector,
         repo_path=repo,
         view_type="vector",
         view_config=_VECTOR_CONFIG,
     )
-    faiss = importlib.import_module("faiss")
-    real_read_index = faiss.read_index
-    sources: list[object] = []
-
-    def tracking_read_index(source, *args, **kwargs):
-        sources.append(source)
-        return real_read_index(source, *args, **kwargs)
-
-    monkeypatch.setattr(faiss, "read_index", tracking_read_index)
     validate_portable_query_view(
         vector,
         repo_path=repo,
         view_type="vector",
         view_config={**_VECTOR_CONFIG, **adjustments},
     )
-
-    assert len(sources) == 1
-    assert not isinstance(sources[0], (str, Path))
 
 
 def test_portable_vector_rejects_external_symlink_swap_and_restore(
@@ -1312,6 +1319,10 @@ def test_normalize_upgrades_fully_legacy_vector_config(tmp_path: Path) -> None:
         view_type="vector",
         view_config=_VECTOR_CONFIG,
         source_trust="trusted-local",
+        native_index_authorization=_authorize_vector_runtime(
+            vector,
+            _VECTOR_CONFIG,
+        ),
     )
 
     upgraded = json.loads(config_path.read_text(encoding="utf-8"))
@@ -1439,6 +1450,43 @@ def test_normalize_prunes_current_model_files_for_zero_count(tmp_path: Path) -> 
         view_type="vector",
         view_config=_VECTOR_CONFIG,
         source_trust="trusted-local",
+        native_index_authorization=_authorize_vector_runtime(
+            vector,
+            _VECTOR_CONFIG,
+        ),
+    )
+
+    assert not stale.exists()
+
+
+def test_inert_zero_and_nonzero_levels_never_invoke_native_parsers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    stale = vector / "l0"
+    stale.mkdir()
+    (stale / f"documents_{_MODEL_SUFFIX}.json").write_text("[]\n", encoding="utf-8")
+    _write_faiss(stale / f"index_{_MODEL_SUFFIX}.faiss", count=0)
+    (stale / f"config_{_MODEL_SUFFIX}.json").write_text("{}\n", encoding="utf-8")
+    import codenib.artifacts.portable_views as portable_views_module
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("portable-inert levels must not invoke native parsers")
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "importlib",
+        SimpleNamespace(import_module=fail_if_called),
+    )
+    monkeypatch.setattr(portable_views_module.compat_pickle, "load", fail_if_called)
+
+    normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
     )
 
     assert not stale.exists()
@@ -1466,15 +1514,20 @@ def test_normalize_inert_pickle_rejects_before_loading(
 ) -> None:
     repo, _source = _repository(tmp_path)
     vector = _vector_view(tmp_path, repo, document_format="pkl")
+    import codenib.artifacts.portable_views as portable_views_module
+
     called = False
 
-    def fail_if_called(_handle):
+    def fail_if_called(*_args, **_kwargs):
         nonlocal called
         called = True
         raise AssertionError("pickle loader must not run")
 
+    monkeypatch.setattr(portable_views_module.compat_pickle, "load", fail_if_called)
     monkeypatch.setattr(
-        "codenib.artifacts.portable_views.compat_pickle.load", fail_if_called
+        portable_views_module,
+        "importlib",
+        SimpleNamespace(import_module=fail_if_called),
     )
     with pytest.raises(ValueError, match="portable-inert.*pickle"):
         normalize_owned_query_view(
@@ -1482,8 +1535,113 @@ def test_normalize_inert_pickle_rejects_before_loading(
             repo_path=repo,
             view_type="vector",
             view_config=_VECTOR_CONFIG,
+            source_trust="trusted-local",
         )
     assert called is False
+
+
+def test_malformed_native_authorization_rejects_before_parsers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="pkl")
+    faiss = importlib.import_module("faiss")
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("invalid authorization must not reach native parsers")
+
+    monkeypatch.setattr(
+        "codenib.artifacts.portable_views.compat_pickle.load", fail_if_called
+    )
+    monkeypatch.setattr(faiss, "read_index", fail_if_called)
+    with pytest.raises(ValueError, match="authorization.*malformed"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+            native_index_authorization=object(),  # type: ignore[arg-type]
+        )
+
+
+def test_native_authorization_tree_drift_rejects_before_parsers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="pkl")
+    authorization = _authorize_vector_runtime(vector, _VECTOR_CONFIG)
+    index_path = vector / "l2" / f"index_{_MODEL_SUFFIX}.faiss"
+    index_path.write_bytes(index_path.read_bytes() + b"drift")
+    faiss = importlib.import_module("faiss")
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("drifted authorization must not reach native parsers")
+
+    monkeypatch.setattr(
+        "codenib.artifacts.portable_views.compat_pickle.load", fail_if_called
+    )
+    monkeypatch.setattr(faiss, "read_index", fail_if_called)
+    with pytest.raises(ValueError, match="authorization does not match captured bytes"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+            native_index_authorization=authorization,
+        )
+
+
+def test_native_authorization_config_drift_rejects_before_parsers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="pkl")
+    authorization = _authorize_vector_runtime(vector, _VECTOR_CONFIG)
+    changed_config = {**_VECTOR_CONFIG, "index_metric": "l2"}
+    faiss = importlib.import_module("faiss")
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_close = portable_views_module._OwnedViewReader.close
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("config drift must not reach native parsers")
+
+    monkeypatch.setattr(
+        "codenib.artifacts.portable_views.compat_pickle.load", fail_if_called
+    )
+    monkeypatch.setattr(faiss, "read_index", fail_if_called)
+
+    def close_then_fail(reader):
+        real_close(reader)
+        raise RuntimeError("injected reader close failure")
+
+    monkeypatch.setattr(
+        portable_views_module._OwnedViewReader,
+        "close",
+        close_then_fail,
+    )
+    with pytest.raises(
+        ValueError,
+        match="authorization does not match captured bytes",
+    ) as exc_info:
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=changed_config,
+            native_index_authorization=authorization,
+        )
+    notes = (
+        *getattr(exc_info.value, "__notes__", ()),
+        *getattr(exc_info.value, "_codenib_cleanup_notes", ()),
+    )
+    assert any(
+        "reader cleanup also failed" in note and "injected reader close failure" in note
+        for note in notes
+    )
 
 
 def test_portable_views_do_not_import_faiss_eagerly() -> None:
@@ -1711,6 +1869,10 @@ def test_normalize_schema6_rejects_faiss_metric_drift(tmp_path: Path) -> None:
             repo_path=repo,
             view_type="vector",
             view_config=view_config,
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                view_config,
+            ),
         )
 
 
@@ -1729,6 +1891,10 @@ def test_normalize_schema6_rejects_faiss_index_type_drift(tmp_path: Path) -> Non
             repo_path=repo,
             view_type="vector",
             view_config=view_config,
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                view_config,
+            ),
         )
 
 
@@ -1782,6 +1948,10 @@ def test_runtime_and_normalize_reject_untrained_active_ivf_before_first_search(
             repo_path=repo,
             view_type="vector",
             view_config=view_config,
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                view_config,
+            ),
         )
 
 
@@ -1822,6 +1992,10 @@ def test_normalize_vector_rejects_mixed_document_formats(tmp_path: Path) -> None
             repo_path=repo,
             view_type="vector",
             view_config=_VECTOR_CONFIG,
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                _VECTOR_CONFIG,
+            ),
             source_trust="trusted-local",
         )
 
@@ -1866,13 +2040,15 @@ def test_normalize_vector_rejects_malformed_committed_json(tmp_path: Path) -> No
         )
 
 
-def test_normalize_vector_rejects_residual_pickle(tmp_path: Path) -> None:
+def test_trusted_local_string_does_not_authorize_residual_pickle(
+    tmp_path: Path,
+) -> None:
     repo, _source = _repository(tmp_path)
     vector = _vector_view(tmp_path, repo, document_format="json")
     residual = vector / "unexamined.pkl"
     residual.write_bytes(b"must-not-publish")
 
-    with pytest.raises(ValueError, match="unexpected pickle"):
+    with pytest.raises(ValueError, match="portable-inert.*pickle"):
         normalize_owned_query_view(
             vector,
             repo_path=repo,
@@ -2208,6 +2384,10 @@ def test_normalize_rejects_faiss_shape_drift(
             repo_path=repo,
             view_type="vector",
             view_config=_VECTOR_CONFIG,
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                _VECTOR_CONFIG,
+            ),
         )
 
 

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from codenib.artifacts import normalize_owned_query_view
+from codenib.artifacts import normalize_owned_query_view, validate_portable_query_view
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
@@ -45,12 +45,46 @@ def _tree(root: Path) -> dict[str, bytes]:
     }
 
 
+def _canonical_json_bytes(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
 def _repository(root: Path) -> tuple[Path, Path]:
     repo = root / "repo"
     repo.mkdir(parents=True)
     source = repo / "sample.py"
     source.write_text("VALUE = 1\n", encoding="utf-8")
     return repo, source
+
+
+def _bm25_view(
+    root: Path,
+    *,
+    documents: list[dict[str, object]] | None = None,
+    metadata: dict[str, object] | None = None,
+) -> tuple[Path, Path]:
+    repo, _source = _repository(root)
+    bm25 = root / "state" / "bm25"
+    bm25.mkdir(parents=True)
+    (bm25 / "documents.json").write_text(
+        json.dumps(documents or []),
+        encoding="utf-8",
+    )
+    (bm25 / "bm25_metadata.json").write_text(
+        json.dumps(metadata or {}),
+        encoding="utf-8",
+    )
+    return repo, bm25
 
 
 def _write_faiss(
@@ -300,6 +334,443 @@ def test_normalize_bm25_rewrites_project_root_and_refreshes_fingerprints(
     }
 
 
+def test_normalize_bm25_rejects_unicode_escaped_secret_metadata(
+    tmp_path: Path,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    (bm25 / "documents.json").write_text(
+        '[{"page_content":"safe","metadata":{"x\\u002dapi\\u002dkey":"value"}}]',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="secret field"):
+        normalize_owned_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+        )
+
+
+def test_normalize_bm25_does_not_scan_semantic_page_content(tmp_path: Path) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "example Authorization: Bearer documentation-token",
+                "metadata": {"file": "sample.py"},
+            }
+        ],
+    )
+
+    normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+
+
+@pytest.mark.parametrize("extra", ["extra.json", "nested/extra.txt"])
+def test_normalize_bm25_rejects_every_extra_entry(
+    tmp_path: Path,
+    extra: str,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    path = bm25 / extra
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unexpected (file|directory)"):
+        normalize_owned_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+        )
+
+
+def test_normalize_bm25_rejects_source_symlink_component(tmp_path: Path) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "outside",
+                "metadata": {"file": "linked/outside.py"},
+            }
+        ],
+    )
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "outside.py").write_text("OUTSIDE = 1\n", encoding="utf-8")
+    (repo / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="stable contained source"):
+        normalize_owned_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+        )
+
+
+def test_portable_view_validator_detects_source_symlink_swap(tmp_path: Path) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "sample.py"},
+            }
+        ],
+    )
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    outside = tmp_path / "outside.py"
+    outside.write_text("OUTSIDE = 1\n", encoding="utf-8")
+    (repo / "sample.py").unlink()
+    (repo / "sample.py").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="stable contained source"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config=adjustments,
+        )
+
+
+@pytest.mark.parametrize("leak", ["path", "secret"])
+def test_portable_bm25_validator_rejects_decoded_metadata_without_mutation(
+    tmp_path: Path,
+    leak: str,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "sample.py"},
+            }
+        ],
+    )
+    normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    documents_path = bm25 / "documents.json"
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    secret = "decoded-runtime-secret"
+    documents[0]["metadata"]["innocent_note"] = str(repo) if leak == "path" else secret
+    documents_path.write_bytes(_canonical_json_bytes(documents))
+    view_config = {"artifact_file_fingerprints": bm25_artifact_file_fingerprints(bm25)}
+    before = _tree(bm25)
+
+    with pytest.raises(ValueError, match="build-machine path|configured credential"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config=view_config,
+            environ={"MODELS_TOKEN": secret},
+        )
+
+    assert _tree(bm25) == before
+
+
+def test_portable_bm25_accepts_contained_relative_source_symlink(
+    tmp_path: Path,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "alias.py"},
+            }
+        ],
+    )
+    (repo / "alias.py").symlink_to("sample.py")
+
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    validate_portable_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config=adjustments,
+    )
+
+
+def test_portable_bm25_rejects_contained_source_symlink_swap_and_restore(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "alias.py"},
+            }
+        ],
+    )
+    alias = repo / "alias.py"
+    alias.symlink_to("sample.py")
+    outside = tmp_path / "outside.py"
+    outside.write_text("SECRET = 1\n", encoding="utf-8")
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    import codenib._contained_source as contained_source_module
+
+    real_verify = contained_source_module._BoundRepositoryFile.verify
+    calls = 0
+
+    def swap_then_restore(binding) -> None:
+        nonlocal calls
+        calls += 1
+        if calls != 2:
+            return real_verify(binding)
+        alias.unlink()
+        alias.symlink_to("../outside.py")
+        try:
+            return real_verify(binding)
+        finally:
+            alias.unlink()
+            alias.symlink_to("sample.py")
+
+    monkeypatch.setattr(
+        contained_source_module._BoundRepositoryFile,
+        "verify",
+        swap_then_restore,
+    )
+
+    with pytest.raises(ValueError, match="stable contained source"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config=adjustments,
+        )
+
+    assert calls == 2
+
+
+def test_portable_bm25_requires_complete_file_fingerprints(tmp_path: Path) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+
+    for view_config in (None, {}, {"artifact_file_fingerprints": {}}):
+        with pytest.raises(ValueError, match="view config|complete artifact"):
+            validate_portable_query_view(
+                bm25,
+                repo_path=repo,
+                view_type="bm25",
+                view_config=view_config,
+            )
+
+
+def test_portable_bm25_rejects_documents_replaced_after_authentication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "sample.py"},
+            }
+        ],
+    )
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_authenticate = portable_views_module._OwnedViewReader.authenticate
+    replaced = False
+
+    def replace_after_authentication(reader, path, expected, **kwargs):
+        nonlocal replaced
+        result = real_authenticate(reader, path, expected, **kwargs)
+        if Path(path).name == "documents.json" and not replaced:
+            replaced = True
+            Path(path).write_bytes(_canonical_json_bytes([]))
+        return result
+
+    monkeypatch.setattr(
+        portable_views_module._OwnedViewReader,
+        "authenticate",
+        replace_after_authentication,
+    )
+
+    with pytest.raises(RuntimeError, match="changed during semantic validation"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config=adjustments,
+        )
+
+    assert replaced
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX")
+@pytest.mark.timeout(2)
+def test_portable_bm25_rejects_fifo_swapped_after_capture_without_blocking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_capture = portable_views_module.capture_directory_ownership
+    documents = bm25 / "documents.json"
+    original = documents.read_bytes()
+    swapped = False
+
+    def capture_then_swap(path, **kwargs):
+        nonlocal swapped
+        token = real_capture(path, **kwargs)
+        if Path(path) == bm25 and not swapped:
+            swapped = True
+            documents.unlink()
+            os.mkfifo(documents)
+        return token
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "capture_directory_ownership",
+        capture_then_swap,
+    )
+    try:
+        with pytest.raises(ValueError, match="private file|safely readable"):
+            validate_portable_query_view(
+                bm25,
+                repo_path=repo,
+                view_type="bm25",
+                view_config=adjustments,
+            )
+    finally:
+        if documents.exists():
+            documents.unlink()
+        documents.write_bytes(original)
+
+
+def test_portable_validator_does_not_use_path_rglob(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+
+    def forbidden_rglob(*_args, **_kwargs):
+        raise AssertionError("portable validation must use its bounded fd inventory")
+
+    monkeypatch.setattr(Path, "rglob", forbidden_rglob)
+    validate_portable_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config=adjustments,
+    )
+
+
+def test_portable_documents_contract_has_a_fixed_nonconfigurable_cap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    monkeypatch.setattr(
+        "codenib.artifacts.portable_views._MAX_DOCUMENTS_JSON_BYTES",
+        1,
+    )
+
+    with pytest.raises(ValueError, match="size mismatch"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={**adjustments, "max_documents_bytes": 10**12},
+        )
+
+
+def test_normalize_json_disappearance_is_reported_as_value_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    documents = bm25 / "documents.json"
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_capture = portable_views_module.capture_directory_ownership
+    disappeared = False
+
+    def capture_then_disappear(path, **kwargs):
+        nonlocal disappeared
+        token = real_capture(path, **kwargs)
+        if Path(path) == bm25 and not disappeared:
+            disappeared = True
+            documents.unlink()
+        return token
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "capture_directory_ownership",
+        capture_then_disappear,
+    )
+
+    with pytest.raises(ValueError, match="safely readable"):
+        normalize_owned_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+        )
+
+    assert disappeared
+
+
 def test_normalize_vector_converts_trusted_pickle_and_strips_build_state(
     tmp_path: Path,
 ) -> None:
@@ -364,6 +835,418 @@ def test_normalize_committed_json_vector_is_idempotent(tmp_path: Path) -> None:
 
     assert _tree(vector) == first_tree
     assert second_adjustments == first_adjustments
+
+
+def test_portable_vector_validator_rejects_noncanonical_json_without_mutation(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    documents_path = vector / "l2" / f"documents_{_MODEL_SUFFIX}.json"
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    documents_path.write_text(json.dumps(documents), encoding="utf-8")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["level_artifacts"]["l2"] = vector_level_artifact_records(
+        vector / "l2",
+        _MODEL_SUFFIX,
+        documents_file=documents_path.name,
+    )
+    config_path.write_bytes(_canonical_json_bytes(config))
+    view_config = {
+        **_VECTOR_CONFIG,
+        **adjustments,
+        "persistence_config_fingerprint": vector_config_artifact_record(
+            vector,
+            _MODEL_SUFFIX,
+        ),
+    }
+    before = _tree(vector)
+    before_modes = {
+        path.relative_to(vector).as_posix(): path.stat().st_mode
+        for path in vector.rglob("*")
+    }
+
+    with pytest.raises(ValueError, match="not canonical JSON"):
+        validate_portable_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+    assert _tree(vector) == before
+    assert {
+        path.relative_to(vector).as_posix(): path.stat().st_mode
+        for path in vector.rglob("*")
+    } == before_modes
+
+
+def test_portable_vector_validator_rechecks_faiss_semantics_after_records(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    level = vector / "l2"
+    _write_faiss(level / f"index_{_MODEL_SUFFIX}.faiss", dimension=8)
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["level_artifacts"]["l2"] = vector_level_artifact_records(
+        level,
+        _MODEL_SUFFIX,
+        documents_file=f"documents_{_MODEL_SUFFIX}.json",
+    )
+    config_path.write_bytes(_canonical_json_bytes(config))
+    view_config = {
+        **_VECTOR_CONFIG,
+        **adjustments,
+        "persistence_config_fingerprint": vector_config_artifact_record(
+            vector,
+            _MODEL_SUFFIX,
+        ),
+    }
+
+    with pytest.raises(ValueError, match="FAISS dimension mismatch"):
+        validate_portable_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+@pytest.mark.parametrize("artifact", ["config", "documents", "faiss"])
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX")
+@pytest.mark.timeout(2)
+def test_portable_vector_rejects_fifo_swapped_after_capture_without_blocking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    artifact: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    view_config = {**_VECTOR_CONFIG, **adjustments}
+    targets = {
+        "config": vector / f"config_{_MODEL_SUFFIX}.json",
+        "documents": vector / "l2" / f"documents_{_MODEL_SUFFIX}.json",
+        "faiss": vector / "l2" / f"index_{_MODEL_SUFFIX}.faiss",
+    }
+    target = targets[artifact]
+    original = target.read_bytes()
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_capture = portable_views_module.capture_directory_ownership
+    swapped = False
+
+    def capture_then_swap(path, **kwargs):
+        nonlocal swapped
+        token = real_capture(path, **kwargs)
+        if Path(path) == vector and not swapped:
+            swapped = True
+            target.unlink()
+            os.mkfifo(target)
+        return token
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "capture_directory_ownership",
+        capture_then_swap,
+    )
+    try:
+        with pytest.raises(
+            ValueError,
+            match=(
+                "private file|safely readable|manifest fingerprint|"
+                "committed documents"
+            ),
+        ):
+            validate_portable_query_view(
+                vector,
+                repo_path=repo,
+                view_type="vector",
+                view_config=view_config,
+            )
+    finally:
+        if target.exists():
+            target.unlink()
+        target.write_bytes(original)
+
+
+def test_portable_vector_parses_faiss_from_authenticated_callback_reader(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    faiss = importlib.import_module("faiss")
+    real_read_index = faiss.read_index
+    sources: list[object] = []
+
+    def tracking_read_index(source, *args, **kwargs):
+        sources.append(source)
+        return real_read_index(source, *args, **kwargs)
+
+    monkeypatch.setattr(faiss, "read_index", tracking_read_index)
+    validate_portable_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config={**_VECTOR_CONFIG, **adjustments},
+    )
+
+    assert len(sources) == 1
+    assert not isinstance(sources[0], (str, Path))
+
+
+def test_portable_vector_rejects_external_symlink_swap_and_restore(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    target = vector / "l2" / f"documents_{_MODEL_SUFFIX}.json"
+    saved = target.with_name("saved-documents.json")
+    outside = tmp_path / "outside.json"
+    outside.write_text('[{"secret": "outside"}]', encoding="utf-8")
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_open = portable_views_module._OwnedViewReader._open_file
+    swapped = False
+
+    def swap_then_restore(reader, relative):
+        nonlocal swapped
+        if relative.name != target.name or swapped:
+            return real_open(reader, relative)
+        swapped = True
+        target.rename(saved)
+        target.symlink_to(outside)
+        try:
+            return real_open(reader, relative)
+        finally:
+            target.unlink()
+            saved.rename(target)
+
+    monkeypatch.setattr(
+        portable_views_module._OwnedViewReader,
+        "_open_file",
+        swap_then_restore,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="private file|safely readable|committed documents",
+    ):
+        validate_portable_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config={**_VECTOR_CONFIG, **adjustments},
+        )
+
+    assert swapped
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs")
+def test_portable_validator_closes_anchored_descriptors(tmp_path: Path) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    for _ in range(20):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config=adjustments,
+        )
+
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
+
+
+@pytest.mark.parametrize("mutation", ["faiss-dimension", "unicode-secret"])
+def test_portable_vector_validator_rejects_late_synchronized_tree_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    view_config = {**_VECTOR_CONFIG, **adjustments}
+    import codenib.artifacts.portable_views as portable_views_module
+
+    real_validate = portable_views_module._validate_normalized_document_sources
+    validation_calls = 0
+    secret = "晚到的凭据秘密值-12345678"
+
+    def mutate_after_document_validation(path, repo_path, **kwargs):
+        nonlocal validation_calls
+        result = real_validate(path, repo_path, **kwargs)
+        validation_calls += 1
+        if validation_calls == 1:
+            level = vector / "l2"
+            documents_path = level / f"documents_{_MODEL_SUFFIX}.json"
+            if mutation == "faiss-dimension":
+                _write_faiss(
+                    level / f"index_{_MODEL_SUFFIX}.faiss",
+                    dimension=8,
+                )
+            else:
+                documents = json.loads(documents_path.read_text(encoding="utf-8"))
+                documents[0]["metadata"]["innocent_note"] = secret
+                documents_path.write_bytes(_canonical_json_bytes(documents))
+            config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+            config["level_artifacts"]["l2"] = vector_level_artifact_records(
+                level,
+                _MODEL_SUFFIX,
+                documents_file=documents_path.name,
+            )
+            config_path.write_bytes(_canonical_json_bytes(config))
+        return result
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "_validate_normalized_document_sources",
+        mutate_after_document_validation,
+    )
+    with pytest.raises(RuntimeError, match="changed during semantic validation"):
+        validate_portable_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+            environ={"MODELS_TOKEN": secret},
+        )
+
+    assert validation_calls == 1
+
+
+@pytest.mark.parametrize("extra", ["extra.json", "l2/nested/extra.json"])
+def test_normalize_vector_rejects_every_extra_entry(
+    tmp_path: Path,
+    extra: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    path = vector / extra
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unexpected (file|directory)"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_vector_rejects_root_config_url_credentials(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["endpoint"] = "//user:password@example.test/api"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="URL credentials"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_vector_rejects_level_config_authorization_header(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    level_config = vector / "l2" / f"config_{_MODEL_SUFFIX}.json"
+    level_config.write_text(
+        json.dumps(
+            {
+                "embedding_model": "test/model",
+                "embedding_provider": "huggingface",
+                "embedding_revision": None,
+                "dimension": 4,
+                "index_type": "flat",
+                "index_metric": "ip",
+                "level": "l2",
+                "num_documents": 1,
+                "Proxy-Authorization": "Basic dXNlcjpwYXNz",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="secret field"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_vector_rejects_document_metadata_secret(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    documents_path = vector / "l2" / f"documents_{_MODEL_SUFFIX}.json"
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    documents[0]["metadata"]["github_token"] = "value"
+    documents_path.write_text(json.dumps(documents), encoding="utf-8")
+    _refresh_level_record(vector)
+
+    with pytest.raises(ValueError, match="secret field"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
 
 
 def test_normalize_portable_json_is_idempotent_in_a_different_checkout(
@@ -1167,6 +2050,7 @@ def test_normalize_rejects_level_config_semantic_drift(tmp_path: Path) -> None:
             {
                 "embedding_model": "test/model",
                 "embedding_provider": "huggingface",
+                "embedding_revision": None,
                 "dimension": 4,
                 "index_type": "flat",
                 "index_metric": "l2",

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -19,8 +19,12 @@ from codenib.artifacts import normalize_owned_query_view, validate_portable_quer
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    capture_authenticated_vector_view,
     vector_config_artifact_record,
     vector_level_artifact_records,
+)
+from codenib.native_index_authorization import (
+    _mint_trusted_local_admin_authorization,
 )
 from codenib.provider_routes import resolve_inference_route
 
@@ -35,6 +39,21 @@ _VECTOR_CONFIG = {
 }
 _MODEL_SUFFIX = "test__model"
 _REVISION = "a" * 40
+
+
+def _authorize_vector_runtime(path: Path, semantic_contract: dict[str, object]):
+    """Mint the exact process-local capability used by real FAISS load tests."""
+
+    with capture_authenticated_vector_view(path) as view:
+        return _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "portable-vector-runtime-contract-test",
+                "captured-vector-tree-subject",
+            ),
+        )
 
 
 def _tree(root: Path) -> dict[str, bytes]:
@@ -1513,7 +1532,12 @@ def test_normalize_schema6_view_loads_with_runtime_contract(
         trust_remote_code=False,
     )
 
-    store.load()
+    store.load(
+        native_index_authorization=_authorize_vector_runtime(
+            vector,
+            store.artifact_metadata,
+        )
+    )
 
     assert len(store.l2_documents) == 1
     assert int(store.l2_index.ntotal) == 1
@@ -1708,7 +1732,7 @@ def test_normalize_schema6_rejects_faiss_index_type_drift(tmp_path: Path) -> Non
         )
 
 
-def test_normalize_rejects_untrained_active_ivf_before_runtime_first_search(
+def test_runtime_and_normalize_reject_untrained_active_ivf_before_first_search(
     tmp_path: Path,
 ) -> None:
     from codenib.index.embedding.vector_store import CodeVectorStore
@@ -1744,10 +1768,13 @@ def test_normalize_rejects_untrained_active_ivf_before_runtime_first_search(
         revision=_REVISION,
         trust_remote_code=False,
     )
-    store.load()
-    assert store.l2_index.is_trained is False
-    with pytest.raises(RuntimeError, match="is_trained"):
-        store.search("VALUE", top_k=1)
+    with pytest.raises(ValueError, match="FAISS index is not trained"):
+        store.load(
+            native_index_authorization=_authorize_vector_runtime(
+                vector,
+                store.artifact_metadata,
+            )
+        )
 
     with pytest.raises(ValueError, match="active IVF index is untrained"):
         normalize_owned_query_view(

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -49,6 +49,7 @@ from codenib.artifacts import (
 from codenib.cli import run
 from codenib.compiler.index_builders import VectorIndexBuilder
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import vector_config_artifact_record
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.source import read_source_impl
@@ -227,6 +228,11 @@ def _vector_artifact(tmp_path: Path) -> tuple[Path, Path, str]:
             level="l2",
         )
         store.save()
+
+    config["persistence_config_fingerprint"] = vector_config_artifact_record(
+        vector,
+        "test__model",
+    )
 
     source_identity = fingerprint_repository(repo)
     manifest_path = index_root / "repo_manifest.json"

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -9,7 +9,6 @@ import hashlib
 import io
 import json
 import math
-import os
 import shlex
 import shutil
 import stat
@@ -513,18 +512,19 @@ def test_extract_archive_restores_previous_output_on_publish_failure(
     extract_context_artifact_archive(archive, output)
     marker = output / "previous-output.marker"
     marker.write_text("preserve", encoding="utf-8")
-    real_replace = os.replace
+    from codenib import _atomic_directory as atomic_directory
 
-    def fail_final_publish(source, target):
-        source_path = Path(source)
-        if (
-            source_path.name.startswith(".extracted.extract-")
-            and Path(target) == output
-        ):
+    real_rename = atomic_directory._rename_noreplace_at
+
+    def fail_final_publish(source, target, source_dir_fd, target_dir_fd):
+        if source.startswith(".extracted.extract-") and target == output.name:
             raise OSError("injected archive publish failure")
-        return real_replace(source, target)
+        return real_rename(source, target, source_dir_fd, target_dir_fd)
 
-    monkeypatch.setattr("codenib._atomic_directory.os.replace", fail_final_publish)
+    monkeypatch.setattr(
+        "codenib._atomic_directory._rename_noreplace_at",
+        fail_final_publish,
+    )
 
     with pytest.raises(OSError, match="injected archive publish failure"):
         extract_context_artifact_archive(archive, output)

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -5,29 +5,42 @@
 from __future__ import annotations
 
 import asyncio
+import dis
 import hashlib
+import inspect
 import io
 import json
 import math
+import os
 import shlex
 import shutil
 import stat
 import subprocess
+import sys
+import threading
 import urllib.error
 import urllib.request
 import zipfile
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 import codenib.artifacts.github as github_artifacts
+import codenib.artifacts.runtime as runtime_module
+import codenib.index.sparse_idx.bm25_index as bm25_module
 import codenib.mcp.server as server_module
+from codenib._atomic_directory import (
+    PublicationDirectoryReader,
+    reopen_authenticated_directory,
+)
 from codenib.artifacts import (
     CONTEXT_ARTIFACT_MANIFEST,
     bind_context_artifact,
     extract_context_artifact_archive,
     fetch_github_context_artifact,
+    query_context_artifact,
     render_artifact_mcp_config,
     resolve_github_context_artifact,
     stage_context_artifact,
@@ -39,7 +52,11 @@ from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.source import read_source_impl
-from codenib.source_fingerprint import RepositoryChangedError, fingerprint_repository
+from codenib.source_fingerprint import (
+    RepositoryChangedError,
+    capture_repository_source,
+    fingerprint_repository,
+)
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -271,6 +288,21 @@ def _refresh_inventory_file(artifact: Path, metadata: dict, relative: str) -> No
     record["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _rewrite_artifact_source_fingerprint(artifact: Path, fingerprint: str) -> None:
+    metadata = _metadata(artifact)
+    metadata["repository"]["source_fingerprint"] = fingerprint
+    manifest_relative = metadata["manifest"]["path"]
+    manifest_path = artifact / manifest_relative
+    manifest = RepoManifest.load(manifest_path)
+    manifest.source_fingerprint = fingerprint
+    manifest.last_indexed_source_fingerprint = fingerprint
+    for entry in manifest.indexes.values():
+        entry.source_fingerprint = fingerprint
+    manifest.save(manifest_path)
+    _refresh_inventory_file(artifact, metadata, manifest_relative)
+    _write_metadata(artifact, metadata)
+
+
 def _zip_tree(source: Path, output: Path, *, prefix: str = "") -> None:
     with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for path in sorted(source.rglob("*")):
@@ -297,12 +329,547 @@ def test_verify_and_bind_artifact_before_loading_bm25(tmp_path: Path) -> None:
     assert verified.views == ("bm25",)
     assert binding.manifest.repo_path == str(repo)
     assert binding.manifest.indexes["bm25"].path == str(artifact / "views" / "bm25")
-    context = ServerContext.load(binding.manifest, views=["bm25"])
+    context = ServerContext.load(
+        binding.manifest,
+        views=["bm25"],
+        artifact_binding=binding,
+    )
     assert context.bm25 is not None
     assert context.bm25.project_root == str(repo)
     results = context.bm25.search("value", return_code_content=True)
     assert results[0].file == "sample.py"
     assert "VALUE = 1" in (results[0].content or "")
+
+
+def test_bound_source_reads_poison_after_checkout_changes(tmp_path: Path) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(
+        artifact,
+        repo,
+        expected_repository="example/project",
+        expected_commit=commit,
+    )
+    context = ServerContext.load(
+        binding.manifest,
+        views=["bm25"],
+        artifact_binding=binding,
+    )
+    assert context.source_verified is True
+    (repo / "sample.py").write_text("VALUE = 999\n", encoding="utf-8")
+
+    with pytest.raises(RepositoryChangedError):
+        read_source_impl(context, "sample.py", 1, 1)
+    assert context.source_verified is False
+    with pytest.raises(RepositoryChangedError, match="poisoned"):
+        context.bm25.search("value", return_code_content=True)
+
+
+def test_artifact_binding_close_releases_unconsumed_source_authority(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    source = binding.source_binding
+    assert source is not None and source.usable
+
+    binding.close()
+    binding.close()
+
+    assert binding.source_bound is False
+    assert not source.usable
+
+
+@pytest.mark.parametrize(
+    ("timing", "interruption"),
+    [
+        pytest.param(
+            "before",
+            KeyboardInterrupt("context binding close interrupted before source close"),
+            id="before-close",
+        ),
+        pytest.param(
+            "after",
+            SystemExit("context binding close interrupted after source close"),
+            id="after-close",
+        ),
+    ],
+)
+def test_artifact_binding_close_retains_cleanup_owner_through_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    timing: str,
+    interruption: BaseException,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    source = binding.source_binding
+    assert source is not None
+    source_type = type(source)
+    real_close = source_type.close
+    injected = False
+
+    def interrupt_source_close(instance) -> None:
+        nonlocal injected
+        if instance is source and not injected:
+            injected = True
+            if timing == "before":
+                raise interruption
+            real_close(instance)
+            raise interruption
+        real_close(instance)
+
+    monkeypatch.setattr(source_type, "close", interrupt_source_close)
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert injected
+    assert binding.source_bound is False
+    monkeypatch.setattr(source_type, "close", real_close)
+    binding.close()
+    assert source.closed
+
+
+def test_artifact_binding_source_authority_install_is_linear_one_shot(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    barrier = threading.Barrier(3)
+    installed = []
+    failures: list[BaseException] = []
+
+    def install() -> None:
+        target = []
+        barrier.wait()
+        try:
+            binding.install_source_binding(target.append)
+            installed.extend(target)
+        except BaseException as exc:  # noqa: B036 - record thread result
+            failures.append(exc)
+
+    threads = [threading.Thread(target=install) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(installed) == 1
+    assert installed[0] is not None
+    assert len(failures) == 1
+    assert isinstance(failures[0], RuntimeError)
+    assert "already transferred" in str(failures[0])
+    installed[0].close()
+
+
+def test_artifact_binding_rejected_expected_source_retains_original_owner(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    source = binding.source_binding
+    assert source is not None
+    other = capture_repository_source(repo, exclude_roots=(artifact,))
+
+    with pytest.raises(ValueError, match="does not match"):
+        binding.install_source_binding(
+            lambda _source: pytest.fail("mismatched source must not be installed"),
+            expected=other,
+            require_expected=True,
+        )
+
+    assert binding.source_binding is source
+    assert source.usable
+    installed = []
+    binding.install_source_binding(installed.append)
+    assert installed == [source]
+    source.close()
+    other.close()
+
+
+def test_server_context_losing_install_does_not_close_winners_source(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    winner = []
+    binding.install_source_binding(winner.append)
+    source = winner[0]
+    assert source is not None and source.usable
+
+    with pytest.raises(RuntimeError, match="already transferred"):
+        ServerContext.load(
+            binding.manifest,
+            views=[],
+            artifact_binding=binding,
+            source_binding=source,
+        )
+
+    assert source.usable
+    source.close()
+
+
+def test_server_context_expected_witness_mismatch_does_not_close_witness(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = query_context_artifact(artifact, expected_commit=commit)
+    witness = capture_repository_source(repo, exclude_roots=(artifact,))
+
+    with pytest.raises(ValueError, match="does not match"):
+        ServerContext.load(
+            binding.manifest,
+            views=[],
+            artifact_binding=binding,
+            source_binding=witness,
+        )
+
+    assert witness.usable
+    witness.close()
+    binding.close()
+
+
+def test_artifact_binding_install_cancellation_closes_claimed_authority(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    source = binding.source_binding
+    assert source is not None
+    method = type(binding).install_source_binding
+    lines, first_line = inspect.getsourcelines(method)
+    target_line = first_line + next(
+        index for index, line in enumerate(lines) if "install(source)" in line
+    )
+    interruption = KeyboardInterrupt("injected after source authority claim")
+    injected = False
+
+    def interrupt_after_claim(frame, event, _arg):
+        nonlocal injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "line"
+            and frame.f_lineno == target_line
+        ):
+            injected = True
+            raise interruption
+        return interrupt_after_claim
+
+    sys.settrace(interrupt_after_claim)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            binding.install_source_binding(lambda _source: None)
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected
+    assert source.closed
+    assert binding.source_bound is False
+
+
+def test_server_context_install_handoff_cancellation_closes_source(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    source = binding.source_binding
+    assert source is not None
+    method = ServerContext.load.__func__
+    source_lines, first_line = inspect.getsourcelines(method)
+    call_line = first_line + next(
+        index
+        for index, line in enumerate(source_lines)
+        if "artifact_binding.install_source_binding(" in line
+    )
+    current_line = None
+    target_offset = None
+    for instruction in dis.get_instructions(method):
+        if instruction.starts_line is not None:
+            current_line = instruction.starts_line
+        if instruction.opname == "POP_TOP" and current_line in range(
+            call_line, call_line + 5
+        ):
+            target_offset = instruction.offset
+            break
+    assert target_offset is not None
+    interruption = KeyboardInterrupt("injected after destination install")
+    injected = False
+
+    def interrupt_after_install(frame, event, _arg):
+        nonlocal injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "opcode"
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            raise interruption
+        frame.f_trace_opcodes = True
+        return interrupt_after_install
+
+    sys.settrace(interrupt_after_install)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            ServerContext.load(
+                binding.manifest,
+                views=[],
+                artifact_binding=binding,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected
+    assert source.closed
+    assert binding.source_bound is False
+
+
+def test_bind_checkout_cancellation_closes_captured_source_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    captured = []
+    real_capture = runtime_module.capture_repository_source
+    interruption = KeyboardInterrupt("injected checkout cancellation")
+    descriptor_root = Path("/proc/self/fd")
+    before = len(tuple(descriptor_root.iterdir())) if descriptor_root.is_dir() else None
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        return source
+
+    def interrupt_checkout(_repo: Path) -> str:
+        raise interruption
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+    monkeypatch.setattr(runtime_module, "checkout_commit", interrupt_checkout)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        bind_context_artifact(artifact, repo, expected_commit=commit)
+
+    assert caught.value is interruption
+    assert len(captured) == 1
+    assert captured[0].closed
+    if before is not None:
+        assert len(tuple(descriptor_root.iterdir())) <= before + 1
+
+
+def test_bind_capture_return_cancellation_uses_preinstalled_cleanup_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    captured = []
+    real_capture = runtime_module.capture_repository_source
+    interruption = KeyboardInterrupt("injected after capture returned")
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        raise interruption
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        bind_context_artifact(artifact, repo, expected_commit=commit)
+
+    assert caught.value is interruption
+    assert len(captured) == 1
+    assert captured[0].closed
+
+
+def test_bind_persistent_close_failure_exposes_retryable_source_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    captured = []
+    real_capture = runtime_module.capture_repository_source
+    interruption = KeyboardInterrupt("injected bind cancellation")
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        return source
+
+    def interrupt_checkout(_repo: Path) -> str:
+        raise interruption
+
+    monkeypatch.setattr(runtime_module, "capture_repository_source", capture)
+    monkeypatch.setattr(runtime_module, "checkout_commit", interrupt_checkout)
+    probe = capture_repository_source(repo, exclude_roots=(artifact,))
+    source_type = type(probe)
+    probe.close()
+    real_close = source_type.close
+
+    def persistent_close(source) -> None:
+        if source in captured:
+            raise OSError("injected persistent source close failure")
+        real_close(source)
+
+    monkeypatch.setattr(source_type, "close", persistent_close)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        bind_context_artifact(artifact, repo, expected_commit=commit)
+
+    assert caught.value is interruption
+    assert len(captured) == 1
+    owner = caught.value.source_cleanup_owner
+    assert owner.pending_sources == (captured[0],)
+    assert not captured[0].closed
+
+    monkeypatch.setattr(source_type, "close", real_close)
+    owner.close()
+    assert owner.closed
+    assert captured[0].closed
+
+
+def test_bind_rejects_artifact_root_replaced_after_internal_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    saved = tmp_path / "verified-root"
+    real_verify = runtime_module.verify_context_artifact
+
+    def verify_then_replace(*args: object, **kwargs: object):
+        verified = real_verify(*args, **kwargs)
+        artifact.rename(saved)
+        shutil.copytree(saved, artifact)
+        return verified
+
+    monkeypatch.setattr(
+        runtime_module,
+        "verify_context_artifact",
+        verify_then_replace,
+    )
+    with pytest.raises(ValueError, match="changed between verification"):
+        bind_context_artifact(
+            artifact,
+            repo,
+            expected_commit=commit,
+        )
+
+
+def test_bind_rejects_checkout_replaced_after_source_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    foreign = tmp_path / "foreign-repo"
+    shutil.copytree(repo, foreign, symlinks=True)
+    captured = tmp_path / "captured-repo"
+    real_checkout_commit = runtime_module.checkout_commit
+
+    def replace_before_commit(path: Path) -> str:
+        repo.rename(captured)
+        foreign.rename(repo)
+        return real_checkout_commit(path)
+
+    monkeypatch.setattr(runtime_module, "checkout_commit", replace_before_commit)
+    with pytest.raises(ValueError, match="changed between verification"):
+        bind_context_artifact(
+            artifact,
+            repo,
+            expected_repository="example/project",
+            expected_commit=commit,
+        )
+
+    assert repo.is_dir()
+    assert captured.is_dir()
+
+
+def test_artifact_binding_rejects_root_replaced_before_runtime_load(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    saved = tmp_path / "bound-root"
+    artifact.rename(saved)
+    shutil.copytree(saved, artifact)
+    documents = artifact / "views/bm25/documents.json"
+    documents.write_text(
+        '[{"page_content":"FOREIGN","metadata":{"file":"sample.py"}}]',
+        encoding="utf-8",
+    )
+
+    context = ServerContext.load(
+        binding.manifest,
+        views=["bm25"],
+        artifact_binding=binding,
+    )
+
+    assert context.bm25 is None
+    assert "captured ownership" in context.errors["bm25"]
+
+
+def test_artifact_bm25_reader_never_reads_path_swapped_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(tmp_path)
+    binding = bind_context_artifact(artifact, repo, expected_commit=commit)
+    foreign = tmp_path / "foreign-artifact"
+    shutil.copytree(artifact, foreign)
+    (foreign / "views/bm25/documents.json").write_text(
+        '[{"page_content":"FOREIGN","metadata":{"file":"sample.py"}}]',
+        encoding="utf-8",
+    )
+    saved = tmp_path / "authorized-artifact"
+    real_open = PublicationDirectoryReader.open_authenticated_file
+    swapped = False
+    from codenib.index.sparse_idx import BM25CodeIndexer
+
+    real_load_values = BM25CodeIndexer.load_index_values
+    loaded_page_content: list[str] = []
+
+    def record_loaded_values(self, documents, metadata, **kwargs):
+        result = real_load_values(self, documents, metadata, **kwargs)
+        loaded_page_content.extend(document.page_content for document in self.documents)
+        return result
+
+    @contextmanager
+    def open_during_root_aba(self, relative, *, max_bytes=None):
+        nonlocal swapped
+        normalized = Path(relative).as_posix()
+        if normalized != "views/bm25/documents.json":
+            with real_open(self, relative, max_bytes=max_bytes) as source:
+                yield source
+            return
+        swapped = True
+        artifact.rename(saved)
+        foreign.rename(artifact)
+        try:
+            with real_open(self, relative, max_bytes=max_bytes) as source:
+                yield source
+        finally:
+            artifact.rename(foreign)
+            saved.rename(artifact)
+
+    monkeypatch.setattr(
+        PublicationDirectoryReader,
+        "open_authenticated_file",
+        open_during_root_aba,
+    )
+    monkeypatch.setattr(
+        BM25CodeIndexer,
+        "load_index_values",
+        record_loaded_values,
+    )
+    context = ServerContext.load(
+        binding.manifest,
+        views=["bm25"],
+        artifact_binding=binding,
+    )
+
+    assert swapped
+    assert context.bm25 is None
+    assert context.errors["bm25"]
+    assert loaded_page_content == ["sample py value 1"]
 
 
 def test_stage_bind_query_and_mcp_accept_contained_source_symlink(
@@ -322,9 +889,8 @@ def test_stage_bind_query_and_mcp_accept_contained_source_symlink(
         binding.manifest,
         views=["bm25"],
         artifact={"repository": "example/project"},
+        artifact_binding=binding,
     )
-    context.source_verified = True
-    context.source_error = None
 
     assert context.bm25 is not None
     results = context.bm25.search("value", return_code_content=True)
@@ -333,7 +899,7 @@ def test_stage_bind_query_and_mcp_accept_contained_source_symlink(
     assert source["content"] == "VALUE = 1\n"
 
 
-def test_bind_and_query_portable_semantic_artifact_without_pickle(
+def test_bound_portable_semantic_artifact_remains_native_inert_by_default(
     tmp_path: Path,
 ) -> None:
     repo, artifact, commit = _vector_artifact(tmp_path)
@@ -349,13 +915,16 @@ def test_bind_and_query_portable_semantic_artifact_without_pickle(
         CodeVectorStore,
         "_initialize_embedding_model",
         return_value=_PortableEmbedding(),
-    ):
-        context = ServerContext.load(binding.manifest, views=["vector"])
-        assert context.vector is not None
-        results = context.vector.search("locate a symbol", top_k=1)
+    ) as initialize_embedding:
+        context = ServerContext.load(
+            binding.manifest,
+            views=["vector"],
+            artifact_binding=binding,
+        )
+        assert context.vector is None
 
-    assert results[0].node_name == "locate_symbol"
-    assert results[0].file == "search.py"
+    initialize_embedding.assert_not_called()
+    assert "external authorization" in context.errors["vector"]
 
 
 def test_verify_rejects_digest_mismatch(tmp_path: Path) -> None:
@@ -420,6 +989,33 @@ def test_verify_rejects_repository_and_commit_mismatch(tmp_path: Path) -> None:
         )
 
 
+def test_v1_artifact_supports_inert_bm25_query_but_cannot_bind(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, _commit = _bm25_artifact(tmp_path)
+    legacy = f"sha256:{'a' * 64}"
+    _rewrite_artifact_source_fingerprint(artifact, legacy)
+
+    query_binding = query_context_artifact(artifact)
+    verified = query_binding.artifact
+    context = ServerContext.load(
+        query_binding.manifest,
+        views=["bm25"],
+        artifact_binding=query_binding,
+    )
+    try:
+        assert verified.source_fingerprint == legacy
+        assert context.source_verified is False
+        assert context.bm25 is not None
+        assert context.bm25.project_root is None
+        assert context.bm25.search("value", return_code_content=False)
+    finally:
+        context.close()
+
+    with pytest.raises(ValueError, match="query-only"):
+        bind_context_artifact(artifact, repo)
+
+
 def test_verify_rejects_unsafe_bm25_source_contract(tmp_path: Path) -> None:
     _repo, artifact, _commit = _bm25_artifact(tmp_path)
     metadata_path = artifact / "views" / "bm25" / "bm25_metadata.json"
@@ -455,6 +1051,24 @@ def test_verify_rejects_unsafe_bm25_source_contract(tmp_path: Path) -> None:
         verify_context_artifact(artifact)
 
 
+def test_runtime_source_path_budget_has_exact_utf8_and_component_boundaries() -> None:
+    exact_bytes = "a" * 4_096
+    exact_components = "/".join("a" for _ in range(256))
+
+    assert runtime_module._source_path(exact_bytes, label="source") == exact_bytes
+    assert (
+        runtime_module._source_path(exact_components, label="source")
+        == exact_components
+    )
+    for invalid in (
+        "a" * 4_097,
+        "/".join("a" for _ in range(257)),
+        "\ud800.py",
+    ):
+        with pytest.raises(ValueError, match="repository-relative POSIX path"):
+            runtime_module._source_path(invalid, label="source")
+
+
 def test_stage_rejects_source_symlink_outside_checkout(tmp_path: Path) -> None:
     with pytest.raises(
         (ValueError, RepositoryChangedError),
@@ -463,14 +1077,64 @@ def test_stage_rejects_source_symlink_outside_checkout(tmp_path: Path) -> None:
         _bm25_artifact(tmp_path, source_symlink=True)
 
 
-def test_bind_rejects_checkout_commit_drift(tmp_path: Path) -> None:
+def test_bind_rejects_checkout_content_drift_even_after_commit(tmp_path: Path) -> None:
     repo, artifact, _commit = _bm25_artifact(tmp_path)
     (repo / "second.py").write_text("SECOND = 2\n", encoding="utf-8")
     _git(repo, "add", "second.py")
     _git(repo, "commit", "--quiet", "-m", "second")
 
-    with pytest.raises(ValueError, match="checkout commit does not match"):
+    with pytest.raises(ValueError, match="source files do not match"):
         bind_context_artifact(artifact, repo)
+
+
+def test_bind_treats_same_content_new_head_as_unattested_display_provenance(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, indexed_commit = _bm25_artifact(tmp_path)
+    _git(repo, "commit", "--quiet", "--allow-empty", "-m", "same tree, new head")
+    current_commit = _git(repo, "rev-parse", "HEAD")
+    assert current_commit != indexed_commit
+
+    binding = bind_context_artifact(artifact, repo)
+    try:
+        assert binding.source_bound
+        assert binding.source_verification_scope == "content-bytes"
+        assert binding.commit_verified is False
+        assert binding.checkout_commit_observed == current_commit
+        assert binding.manifest.commit == indexed_commit
+    finally:
+        binding.close()
+
+
+def test_bind_never_attests_head_changed_after_diagnostic_observation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, artifact, indexed_commit = _bm25_artifact(tmp_path)
+    _git(repo, "commit", "--quiet", "--allow-empty", "-m", "same tree c2")
+    second_commit = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "reset", "--quiet", "--hard", indexed_commit)
+    real_checkout_commit = runtime_module.checkout_commit
+
+    def observe_then_change_head(path: Path) -> str:
+        observed = real_checkout_commit(path)
+        _git(repo, "reset", "--quiet", "--hard", second_commit)
+        return observed
+
+    monkeypatch.setattr(
+        runtime_module,
+        "checkout_commit",
+        observe_then_change_head,
+    )
+    binding = bind_context_artifact(artifact, repo)
+    try:
+        assert binding.source_bound
+        assert binding.checkout_commit_observed == indexed_commit
+        assert _git(repo, "rev-parse", "HEAD") == second_commit
+        assert binding.commit_verified is False
+        assert binding.source_verification_scope == "content-bytes"
+    finally:
+        binding.close()
 
 
 def test_bind_rejects_checkout_source_drift(tmp_path: Path) -> None:
@@ -501,6 +1165,197 @@ def test_extract_archive_verifies_and_removes_single_root_prefix(
     )
 
 
+def test_extract_archive_rejects_final_symlink_and_fifo(tmp_path: Path) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    archive = tmp_path / "artifact.zip"
+    _zip_tree(artifact, archive)
+    linked = tmp_path / "linked.zip"
+    linked.symlink_to(archive)
+    with pytest.raises(ValueError, match="bounded regular file"):
+        extract_context_artifact_archive(linked, tmp_path / "linked-output")
+
+    if not hasattr(os, "mkfifo"):
+        return
+    fifo = tmp_path / "archive.fifo"
+    os.mkfifo(fifo)
+    with pytest.raises(ValueError, match="bounded regular file"):
+        extract_context_artifact_archive(fifo, tmp_path / "fifo-output")
+
+
+def test_archive_snapshot_allows_sibling_mutation_but_rejects_parent_rebind(
+    tmp_path: Path,
+) -> None:
+    from codenib.artifacts import archive as archive_module
+
+    anchor = tmp_path / "anchor"
+    anchor.mkdir()
+    archive = anchor / "artifact.zip"
+    archive.write_bytes(b"snapshot")
+
+    with archive_module._authenticated_archive_snapshot(
+        archive,
+        max_files=1,
+        max_bytes=1024,
+    ):
+        (anchor / "legitimate-sibling").mkdir()
+
+    held = tmp_path / "held-anchor"
+    foreign = tmp_path / "foreign-anchor"
+    foreign.mkdir()
+    try:
+        with pytest.raises(ValueError, match="archive parent changed"):
+            with archive_module._authenticated_archive_snapshot(
+                archive,
+                max_files=1,
+                max_bytes=1024,
+            ):
+                anchor.rename(held)
+                foreign.rename(anchor)
+    finally:
+        if anchor.exists():
+            anchor.rename(foreign)
+        if held.exists():
+            held.rename(anchor)
+
+
+def test_extract_archive_reads_one_pinned_generation_during_path_aba(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    archive = tmp_path / "artifact.zip"
+    _zip_tree(artifact, archive)
+    foreign = tmp_path / "foreign.zip"
+    foreign.write_bytes(b"not the authorized archive")
+    saved = tmp_path / "saved.zip"
+    from codenib.artifacts import archive as archive_module
+
+    real_read = archive_module._read_archive
+    swapped = False
+
+    def read_during_aba(descriptor: int, size: int) -> bytes:
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            archive.rename(saved)
+            foreign.rename(archive)
+            try:
+                return real_read(descriptor, size)
+            finally:
+                archive.rename(foreign)
+                saved.rename(archive)
+        return real_read(descriptor, size)
+
+    monkeypatch.setattr(archive_module, "_read_archive", read_during_aba)
+    with pytest.raises(ValueError, match="changed while reading"):
+        extract_context_artifact_archive(
+            archive,
+            tmp_path / "output",
+        )
+
+    assert swapped
+    assert foreign.read_bytes() == b"not the authorized archive"
+    assert not (tmp_path / "output").exists()
+
+
+def test_extract_archive_native_parser_consumes_only_sealed_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = tmp_path / "fixture"
+    fixture.mkdir()
+    _repo, artifact, _commit = _bm25_artifact(fixture)
+    archive_a = tmp_path / "artifact-a.zip"
+    _zip_tree(artifact, archive_a)
+
+    artifact_b = tmp_path / "artifact-b"
+    shutil.copytree(artifact, artifact_b)
+    documents = artifact_b / "views" / "bm25" / "documents.json"
+    documents.write_text(
+        documents.read_text(encoding="utf-8").replace("value 1", "value 9"),
+        encoding="utf-8",
+    )
+    metadata = _metadata(artifact_b)
+    _refresh_inventory_file(
+        artifact_b,
+        metadata,
+        "views/bm25/documents.json",
+    )
+    _write_metadata(artifact_b, metadata)
+    archive_b = tmp_path / "artifact-b.zip"
+    _zip_tree(artifact_b, archive_b)
+    replacement = archive_b.read_bytes()
+
+    from codenib.artifacts import archive as archive_module
+
+    real_zip_file = archive_module.zipfile.ZipFile
+    attempted = False
+    replaced = False
+
+    def tamper_before_parse(snapshot, *args, **kwargs):
+        nonlocal attempted, replaced
+        attempted = True
+        descriptor = snapshot.fileno()
+        try:
+            os.ftruncate(descriptor, 0)
+            os.write(descriptor, replacement)
+            os.lseek(descriptor, 0, os.SEEK_SET)
+        except OSError:
+            pass
+        else:  # pragma: no cover - vulnerable writable snapshot implementation
+            replaced = True
+        return real_zip_file(snapshot, *args, **kwargs)
+
+    monkeypatch.setattr(archive_module.zipfile, "ZipFile", tamper_before_parse)
+    output = tmp_path / "output"
+    extract_context_artifact_archive(archive_a, output)
+
+    assert attempted
+    assert not replaced
+    assert b"value 1" in (output / "views/bm25/documents.json").read_bytes()
+    assert b"value 9" not in (output / "views/bm25/documents.json").read_bytes()
+
+
+def test_extract_archive_returns_published_authority_not_refreshed_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_a = tmp_path / "a"
+    fixture_b = tmp_path / "b"
+    fixture_a.mkdir()
+    fixture_b.mkdir()
+    _repo, artifact, commit = _bm25_artifact(fixture_a)
+    _other_repo, foreign_artifact, _other_commit = _bm25_artifact(fixture_b)
+    archive = tmp_path / "artifact.zip"
+    _zip_tree(artifact, archive)
+    output = tmp_path / "output"
+    saved = tmp_path / "published-a"
+    from codenib.artifacts import archive as archive_module
+
+    real_publish = archive_module.OwnedDirectoryStage.publish
+
+    def publish_then_replace(self, **kwargs: object):
+        result = real_publish(self, **kwargs)
+        output.rename(saved)
+        shutil.copytree(foreign_artifact, output)
+        return result
+
+    monkeypatch.setattr(
+        archive_module.OwnedDirectoryStage,
+        "publish",
+        publish_then_replace,
+    )
+    verified = extract_context_artifact_archive(archive, output)
+
+    assert verified.commit == commit
+    with pytest.raises((RuntimeError, ValueError), match="captured ownership"):
+        reopen_authenticated_directory(
+            output,
+            verified.ownership,
+            lambda _reader: None,
+        )
+
+
 def test_extract_archive_restores_previous_output_on_publish_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -517,7 +1372,7 @@ def test_extract_archive_restores_previous_output_on_publish_failure(
     real_rename = atomic_directory._rename_noreplace_at
 
     def fail_final_publish(source, target, source_dir_fd, target_dir_fd):
-        if source.startswith(".extracted.extract-") and target == output.name:
+        if source.startswith(".extracted.normalize-") and target == output.name:
             raise OSError("injected archive publish failure")
         return real_rename(source, target, source_dir_fd, target_dir_fd)
 
@@ -530,8 +1385,7 @@ def test_extract_archive_restores_previous_output_on_publish_failure(
         extract_context_artifact_archive(archive, output)
 
     assert marker.read_text(encoding="utf-8") == "preserve"
-    assert not list(output.parent.glob(".extracted.extract-*"))
-    assert not list(output.parent.glob(".extracted.previous-*"))
+    assert not list(output.parent.glob(".extracted.normalize-*"))
 
 
 def test_extract_archive_preserves_output_changed_during_build(
@@ -580,7 +1434,7 @@ def test_extract_archive_rejects_output_symlink(tmp_path: Path) -> None:
     output = tmp_path / "output"
     output.symlink_to(victim, target_is_directory=True)
 
-    with pytest.raises(ValueError, match="symbolic link"):
+    with pytest.raises(ValueError, match="not a directory or is a link"):
         extract_context_artifact_archive(archive, output)
 
     assert output.is_symlink()
@@ -601,20 +1455,21 @@ def test_extract_archive_does_not_follow_swapped_stage_symlink(
 
     from codenib.artifacts import archive as archive_module
 
-    real_mkdtemp = archive_module.tempfile.mkdtemp
+    real_stage = archive_module.OwnedDirectoryStage
     swapped: Path | None = None
 
-    def swap_stage(*args, **kwargs):
-        nonlocal swapped
-        created = Path(real_mkdtemp(*args, **kwargs))
-        created.rename(stolen)
-        created.symlink_to(victim, target_is_directory=True)
-        swapped = created
-        return str(created)
+    class SwappedStage(real_stage):
+        def __init__(self, destination, **kwargs):
+            nonlocal swapped
+            super().__init__(destination, **kwargs)
+            if Path(destination).name == "output" and swapped is None:
+                self.path.rename(stolen)
+                self.path.symlink_to(victim, target_is_directory=True)
+                swapped = self.path
 
-    monkeypatch.setattr(archive_module.tempfile, "mkdtemp", swap_stage)
+    monkeypatch.setattr(archive_module, "OwnedDirectoryStage", SwappedStage)
 
-    with pytest.raises(ValueError, match="link"):
+    with pytest.raises(RuntimeError, match="owned stage root changed"):
         extract_context_artifact_archive(archive, tmp_path / "output")
 
     assert swapped is not None and swapped.is_symlink()
@@ -785,7 +1640,10 @@ def test_fetch_github_artifact_verifies_archive_digest_and_reuses_cache(
     assert second.downloaded is False
     assert second.record is None
     assert calls == {"list": 1, "download": 1}
-    with pytest.raises(ValueError, match="inventory exceeds 2 files"):
+    with pytest.raises(
+        ValueError,
+        match="inventory exceeds 2 files|contains more than 2 inventoried files",
+    ):
         fetch_github_context_artifact(
             "example/project",
             commit,
@@ -1046,3 +1904,94 @@ def test_mcp_server_starts_from_verified_artifact(tmp_path: Path) -> None:
         "views": ["bm25"],
     }
     assert manifest["runtime"]["loaded_views"] == ["bm25"]
+
+
+def test_mcp_server_query_only_v1_artifact_loads_bm25_without_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    _rewrite_artifact_source_fingerprint(artifact, f"sha256:{'a' * 64}")
+
+    with patch.object(server_module.mcp, "run") as run_server:
+        server_module.main(
+            [
+                "--artifact",
+                str(artifact),
+                "--repository",
+                "example/project",
+                "--log-level",
+                "ERROR",
+            ]
+        )
+
+    run_server.assert_called_once_with(transport="stdio")
+    context = server_module.get_context()
+    assert context.source_verified is False
+    assert context.bm25 is not None
+    assert context.bm25.source_mode == bm25_module.SOURCE_MODE_PERSISTED_ONLY
+    cwd_source = tmp_path / "sample.py"
+    cwd_source.write_text("API_KEY = 'QUERY_ONLY_CWD_SECRET'\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        bm25_module,
+        "_read_source_text",
+        lambda *_args: pytest.fail("query-only artifact must not read source paths"),
+    )
+
+    relative = context.bm25.search("value", return_code_content=True)
+    assert relative
+    assert all(result.content is None for result in relative)
+    assert "QUERY_ONLY_CWD_SECRET" not in repr(relative)
+    assert context.bm25.search_identifier_occurrences("value")
+
+    context.bm25.documents[0].metadata["file"] = str(cwd_source)
+    absolute = context.bm25.search("value", return_code_content=True)
+    assert absolute
+    assert all(result.content is None for result in absolute)
+    assert "QUERY_ONLY_CWD_SECRET" not in repr(absolute)
+    assert context.bm25.search_identifier_occurrences("value")
+    with pytest.raises(RuntimeError, match="source binding has not been verified"):
+        read_source_impl(context, "sample.py", 1, 1)
+
+
+def test_mcp_server_query_only_v1_vector_artifact_never_parses_native_bytes(
+    tmp_path: Path,
+) -> None:
+    _repo, artifact, _commit = _vector_artifact(tmp_path)
+    _rewrite_artifact_source_fingerprint(artifact, f"sha256:{'a' * 64}")
+
+    with (
+        patch.object(server_module.mcp, "run") as run_server,
+        patch(
+            "codenib.index.embedding.artifact_integrity."
+            "capture_authenticated_vector_view"
+        ) as capture_vector,
+        patch(
+            "codenib.native_index_authorization."
+            "_mint_trusted_local_admin_authorization"
+        ) as mint_authorization,
+        patch.object(
+            CodeVectorStore,
+            "_initialize_embedding_model",
+        ) as initialize_embedding,
+    ):
+        server_module.main(
+            [
+                "--artifact",
+                str(artifact),
+                "--repository",
+                "example/semantic-project",
+                "--log-level",
+                "ERROR",
+            ]
+        )
+
+    run_server.assert_called_once_with(transport="stdio")
+    capture_vector.assert_not_called()
+    mint_authorization.assert_not_called()
+    initialize_embedding.assert_not_called()
+    context = server_module.get_context()
+    assert context.source_verified is False
+    assert context.vector is None
+    assert "external authorization" in context.errors["vector"]

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -39,7 +39,8 @@ from codenib.compiler.index_builders import VectorIndexBuilder
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
-from codenib.source_fingerprint import fingerprint_repository
+from codenib.mcp.tools.source import read_source_impl
+from codenib.source_fingerprint import RepositoryChangedError, fingerprint_repository
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -55,20 +56,26 @@ def _bm25_artifact(
     tmp_path: Path,
     *,
     source_symlink: bool = False,
+    internal_source_symlink: bool = False,
 ) -> tuple[Path, Path, str]:
     repo = tmp_path / "repo"
     repo.mkdir()
     source = repo / "sample.py"
+    if source_symlink and internal_source_symlink:
+        raise ValueError("source symlink fixture modes are mutually exclusive")
     if source_symlink:
         outside = tmp_path / "outside.py"
         outside.write_text("SECRET = 'outside checkout'\n", encoding="utf-8")
         source.symlink_to(outside)
+    elif internal_source_symlink:
+        (repo / "real.py").write_text("VALUE = 1\n", encoding="utf-8")
+        source.symlink_to("real.py")
     else:
         source.write_text("VALUE = 1\n", encoding="utf-8")
     _git(repo, "init", "--quiet")
     _git(repo, "config", "user.name", "CodeNib Test")
     _git(repo, "config", "user.email", "codenib@example.invalid")
-    _git(repo, "add", "sample.py")
+    _git(repo, "add", ".")
     _git(repo, "commit", "--quiet", "-m", "fixture")
     commit = _git(repo, "rev-parse", "HEAD")
 
@@ -299,6 +306,34 @@ def test_verify_and_bind_artifact_before_loading_bm25(tmp_path: Path) -> None:
     assert "VALUE = 1" in (results[0].content or "")
 
 
+def test_stage_bind_query_and_mcp_accept_contained_source_symlink(
+    tmp_path: Path,
+) -> None:
+    repo, artifact, commit = _bm25_artifact(
+        tmp_path,
+        internal_source_symlink=True,
+    )
+    binding = bind_context_artifact(
+        artifact,
+        repo,
+        expected_repository="example/project",
+        expected_commit=commit,
+    )
+    context = ServerContext.load(
+        binding.manifest,
+        views=["bm25"],
+        artifact={"repository": "example/project"},
+    )
+    context.source_verified = True
+    context.source_error = None
+
+    assert context.bm25 is not None
+    results = context.bm25.search("value", return_code_content=True)
+    assert "VALUE = 1" in (results[0].content or "")
+    source = read_source_impl(context, "sample.py", 1, 1)
+    assert source["content"] == "VALUE = 1\n"
+
+
 def test_bind_and_query_portable_semantic_artifact_without_pickle(
     tmp_path: Path,
 ) -> None:
@@ -421,11 +456,12 @@ def test_verify_rejects_unsafe_bm25_source_contract(tmp_path: Path) -> None:
         verify_context_artifact(artifact)
 
 
-def test_bind_rejects_source_symlink_outside_checkout(tmp_path: Path) -> None:
-    repo, artifact, _commit = _bm25_artifact(tmp_path, source_symlink=True)
-
-    with pytest.raises(ValueError, match="inside the repository checkout"):
-        bind_context_artifact(artifact, repo)
+def test_stage_rejects_source_symlink_outside_checkout(tmp_path: Path) -> None:
+    with pytest.raises(
+        (ValueError, RepositoryChangedError),
+        match="stable contained source|resolves outside|could not be read consistently",
+    ):
+        _bm25_artifact(tmp_path, source_symlink=True)
 
 
 def test_bind_rejects_checkout_commit_drift(tmp_path: Path) -> None:

--- a/test/compiler/test_artifact_quality.py
+++ b/test/compiler/test_artifact_quality.py
@@ -11,7 +11,9 @@ from types import SimpleNamespace
 
 import faiss
 import numpy as np
+import pytest
 
+from codenib import compat_pickle
 from codenib.compiler.artifact_quality import (
     assess_vector_artifact,
     constrain_and_assess_graph_artifact,
@@ -19,6 +21,8 @@ from codenib.compiler.artifact_quality import (
 )
 from codenib.git_snapshot import GitSourceSurface
 from codenib.graph.code_graph import CodeGraph
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 
 
 def _git(repo, *args):
@@ -42,6 +46,28 @@ def _source_surface(tmp_path):
     _git(repo, "add", "src/main.py")
     _git(repo, "commit", "-m", "initial")
     return repo, GitSourceSurface.load(repo)
+
+
+def _assess_vector_as_trusted_local_admin(root, **kwargs):
+    """Test-only lexical admin boundary for locally constructed fixtures."""
+
+    expected_artifact = kwargs["expected_artifact"]
+    with capture_authenticated_vector_view(root) as view:
+        authorization = _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=expected_artifact,
+            evidence=(
+                "artifact-quality-test-owned-fixture",
+                "captured-vector-tree-subject",
+            ),
+        )
+        return assess_vector_artifact(
+            root,
+            authenticated_view=view,
+            native_index_authorization=authorization,
+            **kwargs,
+        )
 
 
 def test_graph_quality_removes_paths_outside_commit(tmp_path):
@@ -105,7 +131,10 @@ def test_graph_quality_reports_malformed_paths_before_constraining(tmp_path):
     assert "../generated.py" not in graph.name_to_vertex
 
 
-def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
+def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(
+    tmp_path,
+    monkeypatch,
+):
     _repo, surface = _source_surface(tmp_path)
     model = "test/model"
     suffix = "test__model"
@@ -137,7 +166,66 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
         encoding="utf-8",
     )
 
-    report = assess_vector_artifact(
+    def parser_must_not_run(*_args, **_kwargs):
+        raise AssertionError("native parser ran before external authorization")
+
+    with capture_authenticated_vector_view(root) as view:
+        with monkeypatch.context() as guard:
+            guard.setattr(compat_pickle, "load", parser_must_not_run)
+            guard.setattr(faiss, "read_index", parser_must_not_run)
+            with pytest.raises(ValueError, match="requires external authorization"):
+                assess_vector_artifact(
+                    root,
+                    embedding_model=model,
+                    build_levels=["l0"],
+                    surface=surface,
+                    expected_artifact=identity,
+                    required_l0_files=["src/main.py"],
+                    authenticated_view=view,
+                    native_index_authorization=None,
+                )
+
+    with capture_authenticated_vector_view(root) as view:
+        authorization = _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=identity,
+            evidence=(
+                "artifact-quality-primary-error-test",
+                "captured-vector-tree-subject",
+            ),
+        )
+
+        def fail_assessment(_paths):
+            raise ValueError("primary assessment failure")
+
+        def fail_final_verification():
+            raise RuntimeError("secondary final verification failure")
+
+        failing_surface = SimpleNamespace(
+            commit=surface.commit,
+            tree=surface.tree,
+            classify=fail_assessment,
+        )
+        with monkeypatch.context() as guard:
+            guard.setattr(
+                type(view),
+                "verify_final",
+                lambda _self: fail_final_verification(),
+            )
+            with pytest.raises(ValueError, match="primary assessment failure"):
+                assess_vector_artifact(
+                    root,
+                    embedding_model=model,
+                    build_levels=["l0"],
+                    surface=failing_surface,
+                    expected_artifact=identity,
+                    required_l0_files=["src/main.py"],
+                    authenticated_view=view,
+                    native_index_authorization=authorization,
+                )
+
+    report = _assess_vector_as_trusted_local_admin(
         root,
         embedding_model=model,
         build_levels=["l0"],
@@ -171,7 +259,7 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
     stale_level.mkdir()
     stale_index = stale_level / f"index_{suffix}.faiss"
     stale_index.write_bytes(b"stale")
-    unexpected = assess_vector_artifact(
+    unexpected = _assess_vector_as_trusted_local_admin(
         root,
         embedding_model=model,
         build_levels=["l0"],
@@ -186,7 +274,7 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
     documents[0].metadata = []
     with documents_path.open("wb") as handle:
         pickle.dump(documents, handle)
-    invalid = assess_vector_artifact(
+    invalid = _assess_vector_as_trusted_local_admin(
         root,
         embedding_model=model,
         build_levels=["l0"],
@@ -203,7 +291,7 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
         documents[0].metadata = metadata
         with documents_path.open("wb") as handle:
             pickle.dump(documents, handle)
-        invalid_path = assess_vector_artifact(
+        invalid_path = _assess_vector_as_trusted_local_admin(
             root,
             embedding_model=model,
             build_levels=["l0"],
@@ -225,7 +313,7 @@ def test_vector_quality_does_not_report_missing_level_as_empty(tmp_path):
         encoding="utf-8",
     )
 
-    report = assess_vector_artifact(
+    report = _assess_vector_as_trusted_local_admin(
         root,
         embedding_model=model,
         build_levels=["l0"],

--- a/test/compiler/test_cache_lock.py
+++ b/test/compiler/test_cache_lock.py
@@ -362,6 +362,19 @@ class _AbortLockBody(BaseException):
     pass
 
 
+def _assert_secondary_cleanup_diagnostic(
+    primary: BaseException,
+    cleanup: BaseException,
+) -> None:
+    notes = tuple(getattr(primary, "__notes__", ())) + tuple(
+        getattr(primary, "_codenib_cleanup_notes", ())
+    )
+    diagnostic = "\n".join(notes)
+    assert "compiler cache lock" in diagnostic
+    assert "cleanup also failed" in diagnostic
+    assert repr(cleanup) in diagnostic
+
+
 def test_base_exception_releases_lock_for_reacquisition(tmp_path: Path) -> None:
     cache = tmp_path / "cache"
 
@@ -369,6 +382,131 @@ def test_base_exception_releases_lock_for_reacquisition(tmp_path: Path) -> None:
         with compiler_cache_lock(cache):
             raise _AbortLockBody
 
+    with compiler_cache_lock(cache):
+        pass
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or not Path("/proc/self/fd").is_dir(),
+    reason="requires POSIX procfs descriptor accounting",
+)
+@pytest.mark.parametrize("failure_stage", ["entry", "body"])
+@pytest.mark.parametrize("close_phase", ["before", "after"])
+@pytest.mark.parametrize(
+    "primary_type",
+    [KeyboardInterrupt, SystemExit, GeneratorExit],
+)
+def test_posix_lock_cleanup_never_masks_first_base_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+    close_phase: str,
+    primary_type: type[BaseException],
+) -> None:
+    cache = tmp_path / "cache"
+    primary = primary_type(f"{failure_stage} primary")
+    cleanup = SystemExit(f"close {close_phase} cleanup")
+    real_validate = lock_module._validate_posix_lock_entry
+    real_close = lock_module.os.close
+    lock_descriptor: int | None = None
+    interrupted = False
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    def validate(descriptor, *args, **kwargs):
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+        if failure_stage == "entry":
+            raise primary
+        return real_validate(descriptor, *args, **kwargs)
+
+    def interrupt_lock_close(descriptor: int) -> None:
+        nonlocal interrupted
+        if descriptor == lock_descriptor and not interrupted:
+            interrupted = True
+            if close_phase == "after":
+                real_close(descriptor)
+            raise cleanup
+        real_close(descriptor)
+
+    monkeypatch.setattr(lock_module, "_validate_posix_lock_entry", validate)
+    monkeypatch.setattr(lock_module.os, "close", interrupt_lock_close)
+
+    with pytest.raises(primary_type) as caught:
+        with compiler_cache_lock(cache):
+            if failure_stage == "body":
+                raise primary
+            raise AssertionError("entry failure must prevent the lock body")
+
+    assert caught.value is primary
+    assert interrupted is True
+    _assert_secondary_cleanup_diagnostic(primary, cleanup)
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
+    assert lock_module._ACTIVE_POSIX_LOCK_DESCRIPTORS == set()
+
+    monkeypatch.setattr(lock_module.os, "close", real_close)
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_posix_lock_entry",
+        real_validate,
+    )
+    with compiler_cache_lock(cache):
+        pass
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or not Path("/proc/self/fd").is_dir(),
+    reason="requires POSIX procfs descriptor accounting",
+)
+@pytest.mark.parametrize("close_phase", ["before", "after"])
+def test_posix_lock_cleanup_is_primary_without_a_body_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    close_phase: str,
+) -> None:
+    cache = tmp_path / "cache"
+    cleanup = SystemExit(f"close {close_phase} cleanup")
+    real_validate = lock_module._validate_posix_lock_entry
+    real_close = lock_module.os.close
+    lock_descriptor: int | None = None
+    interrupted = False
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    def capture_descriptor(descriptor, *args, **kwargs):
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+        return real_validate(descriptor, *args, **kwargs)
+
+    def interrupt_lock_close(descriptor: int) -> None:
+        nonlocal interrupted
+        if descriptor == lock_descriptor and not interrupted:
+            interrupted = True
+            if close_phase == "after":
+                real_close(descriptor)
+            raise cleanup
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_posix_lock_entry",
+        capture_descriptor,
+    )
+    monkeypatch.setattr(lock_module.os, "close", interrupt_lock_close)
+
+    with pytest.raises(SystemExit) as caught:
+        with compiler_cache_lock(cache):
+            pass
+
+    assert caught.value is cleanup
+    assert interrupted is True
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
+    assert lock_module._ACTIVE_POSIX_LOCK_DESCRIPTORS == set()
+
+    monkeypatch.setattr(lock_module.os, "close", real_close)
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_posix_lock_entry",
+        real_validate,
+    )
     with compiler_cache_lock(cache):
         pass
 
@@ -1415,6 +1553,143 @@ def test_windows_lock_retries_contention_and_unlocks(
         lock_module._WINDOWS_LOCK_RETRY_SECONDS,
     ]
     assert lock_path.read_bytes() == b""
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="requires procfs descriptor accounting",
+)
+@pytest.mark.parametrize("failure_stage", ["entry", "body"])
+@pytest.mark.parametrize("close_phase", ["before", "after"])
+@pytest.mark.parametrize(
+    "primary_type",
+    [KeyboardInterrupt, SystemExit, GeneratorExit],
+)
+def test_windows_lock_cleanup_never_masks_first_base_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+    close_phase: str,
+    primary_type: type[BaseException],
+) -> None:
+    cache = tmp_path / "cache"
+    primary = primary_type(f"{failure_stage} primary")
+    cleanup = SystemExit(f"close {close_phase} cleanup")
+    real_validate = lock_module._validate_windows_lock_entry
+    real_close = lock_module.os.close
+    lock_descriptor: int | None = None
+    interrupted = False
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    def validate(descriptor, *args, **kwargs):
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+        if failure_stage == "entry":
+            raise primary
+        return real_validate(descriptor, *args, **kwargs)
+
+    def acquire(descriptor: int) -> None:
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+
+    def interrupt_lock_close(descriptor: int) -> None:
+        nonlocal interrupted
+        if descriptor == lock_descriptor and not interrupted:
+            interrupted = True
+            if close_phase == "after":
+                real_close(descriptor)
+            raise cleanup
+        real_close(descriptor)
+
+    monkeypatch.setattr(lock_module, "msvcrt", object())
+    monkeypatch.setattr(lock_module, "_validate_windows_lock_entry", validate)
+    monkeypatch.setattr(lock_module, "_acquire_windows_lock", acquire)
+    monkeypatch.setattr(lock_module, "_release_windows_lock", lambda _fd: None)
+    monkeypatch.setattr(lock_module.os, "close", interrupt_lock_close)
+
+    with pytest.raises(primary_type) as caught:
+        with lock_module._windows_compiler_cache_lock(cache):
+            if failure_stage == "body":
+                raise primary
+            raise AssertionError("entry failure must prevent the lock body")
+
+    assert caught.value is primary
+    assert interrupted is True
+    _assert_secondary_cleanup_diagnostic(primary, cleanup)
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
+
+    monkeypatch.setattr(lock_module.os, "close", real_close)
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_windows_lock_entry",
+        real_validate,
+    )
+    with lock_module._windows_compiler_cache_lock(cache):
+        pass
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="requires procfs descriptor accounting",
+)
+@pytest.mark.parametrize("close_phase", ["before", "after"])
+def test_windows_lock_cleanup_is_primary_without_a_body_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    close_phase: str,
+) -> None:
+    cache = tmp_path / "cache"
+    cleanup = SystemExit(f"close {close_phase} cleanup")
+    real_validate = lock_module._validate_windows_lock_entry
+    real_close = lock_module.os.close
+    lock_descriptor: int | None = None
+    interrupted = False
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    def capture_descriptor(descriptor, *args, **kwargs):
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+        return real_validate(descriptor, *args, **kwargs)
+
+    def acquire(descriptor: int) -> None:
+        nonlocal lock_descriptor
+        lock_descriptor = descriptor
+
+    def interrupt_lock_close(descriptor: int) -> None:
+        nonlocal interrupted
+        if descriptor == lock_descriptor and not interrupted:
+            interrupted = True
+            if close_phase == "after":
+                real_close(descriptor)
+            raise cleanup
+        real_close(descriptor)
+
+    monkeypatch.setattr(lock_module, "msvcrt", object())
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_windows_lock_entry",
+        capture_descriptor,
+    )
+    monkeypatch.setattr(lock_module, "_acquire_windows_lock", acquire)
+    monkeypatch.setattr(lock_module, "_release_windows_lock", lambda _fd: None)
+    monkeypatch.setattr(lock_module.os, "close", interrupt_lock_close)
+
+    with pytest.raises(SystemExit) as caught:
+        with lock_module._windows_compiler_cache_lock(cache):
+            pass
+
+    assert caught.value is cleanup
+    assert interrupted is True
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
+
+    monkeypatch.setattr(lock_module.os, "close", real_close)
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_windows_lock_entry",
+        real_validate,
+    )
+    with lock_module._windows_compiler_cache_lock(cache):
+        pass
 
 
 @pytest.mark.skipif(

--- a/test/compiler/test_checkout_identity.py
+++ b/test/compiler/test_checkout_identity.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from codenib.compiler.checkout_identity import validate_checkout_identity
 from codenib.compiler.manifest import RepoManifest
 from codenib.source_fingerprint import fingerprint_repository
@@ -43,3 +45,59 @@ def test_checkout_identity_excludes_only_internal_artifact_tree(tmp_path: Path) 
     (artifact_root / "runtime.json").write_text("{}\n", encoding="utf-8")
 
     validate_checkout_identity(repo, manifest, artifact_root=artifact_root)
+
+
+def test_checkout_identity_rejects_legacy_v1_fingerprint(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=f"sha256:{'a' * 64}",
+        languages=["python"],
+    )
+
+    with pytest.raises(ValueError, match="legacy or unsupported"):
+        validate_checkout_identity(repo, manifest, artifact_root=tmp_path)
+
+
+def test_checkout_identity_rejects_missing_source_fingerprint(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        commit="a" * 40,
+        source_fingerprint="",
+        languages=["python"],
+    )
+
+    with pytest.raises(ValueError, match="legacy or unsupported"):
+        validate_checkout_identity(repo, manifest, artifact_root=tmp_path)
+
+
+def test_checkout_identity_never_resolves_replaceable_source_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    )
+    resolve_calls = 0
+
+    def forbidden_resolve(*_args, **_kwargs):
+        nonlocal resolve_calls
+        resolve_calls += 1
+        raise AssertionError("checkout identity followed a replaceable path")
+
+    monkeypatch.setattr(Path, "resolve", forbidden_resolve)
+
+    validate_checkout_identity(repo, manifest, artifact_root=tmp_path / "artifact")
+    assert resolve_calls == 0

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import threading
 import time
@@ -18,6 +19,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+import codenib.compiler.index_compiler as index_compiler_module
 from codenib.compiler.index_builders import (
     BM25IndexBuilder,
     IndexBuilderRegistry,
@@ -1185,7 +1187,7 @@ class TestIndexCompiler:
             data = json.load(f)
         assert data["version"] == MANIFEST_VERSION
         assert "bm25" in data["indexes"]
-        assert data["repo"]["source_fingerprint"].startswith("sha256:")
+        assert data["repo"]["source_fingerprint"].startswith("sha256-v2:")
         assert data["indexes"]["bm25"]["source_fingerprint"] == (
             data["repo"]["source_fingerprint"]
         )
@@ -1565,7 +1567,7 @@ class TestUpdateRepo:
         assert calls == [("build", 1, None), ("build", 2, None)]
         assert manifest.indexes["rec"].config["builder_schema"] == 2
 
-    def test_uses_incremental_path_when_head_moved(self, tmp_path):
+    def test_clean_new_head_uses_authority_safe_full_rebuild(self, tmp_path):
         first = _git_repo(tmp_path)
         calls: list = []
         compiler = self._compiler(calls)
@@ -1574,9 +1576,72 @@ class TestUpdateRepo:
         assert first != second
 
         compiler.update_repo(str(tmp_path))
-        assert calls[-2] == ("incremental_update", first)
+        assert calls == [("build", None), ("build", None)]
 
-    def test_incremental_builder_receives_previous_manifest_config(self, tmp_path):
+    def test_path_status_a_b_a_cannot_authorize_incremental_reuse(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git_repo(repo)
+        calls: list = []
+        compiler = self._compiler(calls)
+        compiler.compile_repo(str(repo))
+        _commit(repo, "b.py")
+
+        clean_replacement = tmp_path / "clean-replacement"
+        shutil.copytree(repo, clean_replacement, symlinks=True)
+        (repo / "a.py").write_text("def dirty_a():\n    return 9\n")
+        parked = tmp_path / "parked-a"
+        status_calls = []
+
+        def observe_temporary_clean_replacement(*args, **kwargs):
+            status_calls.append((args, kwargs))
+            os.rename(repo, parked)
+            os.rename(clean_replacement, repo)
+            try:
+                return False
+            finally:
+                os.rename(repo, clean_replacement)
+                os.rename(parked, repo)
+
+        monkeypatch.setattr(
+            index_compiler_module,
+            "repository_source_is_dirty",
+            observe_temporary_clean_replacement,
+            raising=False,
+        )
+
+        compiler.update_repo(str(repo))
+
+        assert status_calls == []
+        assert calls == [("build", None), ("build", None)]
+
+    def test_v1_manifest_forces_full_rebuild_instead_of_incremental_update(
+        self,
+        tmp_path,
+    ):
+        _git_repo(tmp_path)
+        calls: list = []
+        compiler = self._compiler(calls)
+        manifest = compiler.compile_repo(str(tmp_path))
+        legacy = f"sha256:{'a' * 64}"
+        manifest.source_fingerprint = legacy
+        manifest.last_indexed_source_fingerprint = legacy
+        manifest.indexes["rec"].source_fingerprint = legacy
+        manifest.save(tmp_path / ".codenib_cache" / MANIFEST_FILENAME)
+        _commit(tmp_path, "b.py")
+        calls.clear()
+
+        rebuilt = compiler.update_repo(str(tmp_path))
+
+        assert calls == [("build", None)]
+        assert rebuilt.source_fingerprint.startswith("sha256-v2:")
+        assert rebuilt.indexes["rec"].source_fingerprint == (rebuilt.source_fingerprint)
+
+    def test_full_rebuild_does_not_receive_previous_manifest_config(self, tmp_path):
         _git_repo(tmp_path)
         observed = []
 
@@ -1609,15 +1674,15 @@ class TestUpdateRepo:
             registry,
             IndexCompilerConfig(index_types=["rec"], languages=["python"]),
         )
-        first_manifest = compiler.compile_repo(str(tmp_path))
+        compiler.compile_repo(str(tmp_path))
         _commit(tmp_path, "b.py")
 
         compiler.update_repo(str(tmp_path))
 
-        assert observed == [first_manifest.indexes["rec"].config]
+        assert observed == []
 
-    def test_incremental_graph_preserves_partial_language_coverage(self, tmp_path):
-        first = _git_repo(tmp_path)
+    def test_full_graph_rebuild_recomputes_partial_language_coverage(self, tmp_path):
+        _git_repo(tmp_path)
         calls = []
 
         class PartialGraphBuilder:
@@ -1670,7 +1735,7 @@ class TestUpdateRepo:
         manifest = compiler.update_repo(str(tmp_path))
         metadata = manifest.indexes["symbol_graph"].metadata
 
-        assert calls == [("build", None), ("incremental_update", first)]
+        assert calls == [("build", None), ("build", None)]
         assert metadata["available_languages"] == ["python"]
         assert metadata["failed_languages"] == {"cpp": "compile database unavailable"}
         assert metadata["partial"] is True
@@ -1716,7 +1781,7 @@ class TestUpdateRepo:
         def boom(scope, **kwargs):
             raise RuntimeError("builder exploded")
 
-        builder.incremental_update = boom
+        builder.build = boom
 
         manifest = compiler.update_repo(str(tmp_path))
         assert manifest.commit == second
@@ -1733,15 +1798,15 @@ class TestUpdateRepo:
         _commit(tmp_path, "b.py")
 
         builder = compiler._builders.get("rec")
-        healthy = builder.incremental_update
+        healthy = builder.build
 
         def boom(scope, **kwargs):
             raise RuntimeError("builder exploded")
 
-        builder.incremental_update = boom
+        builder.build = boom
         compiler.update_repo(str(tmp_path))
 
-        builder.incremental_update = healthy
+        builder.build = healthy
         calls.clear()
         compiler.update_repo(str(tmp_path))
         # Not a no-op: the failure left work to do.

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -279,6 +279,42 @@ class TestVectorIndexBuilder:
         assert result.metadata["update_mode"] == "full_rebuild"
         assert result.metadata["incremental_fallback_reason"] == "ValueError"
 
+    def test_missing_native_authority_rebuilds_before_model_initialization(
+        self,
+        tmp_path,
+    ):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        rebuilt = IndexStatus(
+            index_type="vector",
+            state=IndexState.FRESH,
+            path=str(tmp_path / "vector"),
+            metadata={},
+        )
+
+        with (
+            patch(
+                "codenib.index.embedding.vector_store.CodeVectorStore",
+                side_effect=AssertionError(
+                    "missing authority must not initialize an embedding model"
+                ),
+            ) as store_type,
+            patch.object(builder, "build", return_value=rebuilt) as mock_build,
+        ):
+            result = builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "vector"),
+                last_commit="a" * 40,
+            )
+
+        store_type.assert_not_called()
+        mock_build.assert_called_once()
+        assert result.metadata["update_mode"] == "full_rebuild"
+        assert result.metadata["incremental_fallback_reason"] == "ValueError"
+
     def test_missing_incremental_state_attempts_one_rebuild(self, tmp_path):
         builder = VectorIndexBuilder(
             embedding_model="test-model",
@@ -374,11 +410,18 @@ class TestVectorIndexBuilder:
         }
         vector_store = MagicMock(dimension=384)
         vector_store.load.side_effect = RuntimeError("stop after generation check")
+        authorization = object()
 
-        with patch(
-            "codenib.index.embedding.vector_store.CodeVectorStore",
-            return_value=vector_store,
-        ) as store_type:
+        with (
+            patch(
+                "codenib.native_index_authorization.require_native_index_authorization_preflight",
+                return_value=None,
+            ),
+            patch(
+                "codenib.index.embedding.vector_store.CodeVectorStore",
+                return_value=vector_store,
+            ) as store_type,
+        ):
             with pytest.raises(RuntimeError, match="generation check"):
                 builder._incremental_update_once(
                     scope="current_repo",
@@ -386,9 +429,14 @@ class TestVectorIndexBuilder:
                     output_dir=str(output_path),
                     last_commit="a" * 40,
                     previous_artifact_config=previous,
+                    native_index_authorization=authorization,
                 )
 
         assert store_type.call_args.kwargs["artifact_metadata"] == previous
+        vector_store.load.assert_called_once_with(
+            str(output_path),
+            native_index_authorization=authorization,
+        )
 
     @pytest.mark.parametrize("missing", ["chunk_json", "embedding_pair"])
     def test_pickle_only_incremental_state_forces_rebuild(self, tmp_path, missing):

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -20,6 +20,11 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 import codenib.compiler.index_compiler as index_compiler_module
+from codenib._atomic_directory import (
+    capture_directory_ownership,
+    directory_ownership_digest,
+    directory_ownership_root_identity,
+)
 from codenib.compiler.index_builders import (
     BM25IndexBuilder,
     IndexBuilderRegistry,
@@ -45,6 +50,10 @@ from codenib.index.embedding.artifact_integrity import VECTOR_VIEW_UPDATE_MARKER
 from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
 from codenib.index.incremental import IncrementalState
 from codenib.ls_router import GraphBuildResult
+from codenib.native_index_authorization import (
+    InvalidNativeIndexAuthorizationError,
+    _mint_trusted_local_admin_authorization,
+)
 from codenib.repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     default_exclude_patterns,
@@ -197,13 +206,42 @@ class TestBM25IndexBuilder:
 # ---------------------------------------------------------------------------
 
 
+def _write_mock_vector_generation(root: Path, model_suffix: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"config_{model_suffix}.json").write_text(
+        '{"level_artifacts": {}}',
+        encoding="utf-8",
+    )
+    level = root / "l2"
+    level.mkdir()
+    (level / f"config_{model_suffix}.json").write_text("{}", encoding="utf-8")
+    (level / f"index_{model_suffix}.faiss").write_bytes(b"new-vector")
+    (level / f"documents_{model_suffix}.pkl").write_bytes(b"new-documents")
+
+
+def _tree_file_bytes(root: Path) -> dict[str, bytes]:
+    if not root.exists():
+        return {}
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
 class TestVectorIndexBuilder:
     @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
     def test_build_returns_status_with_stats(self, mock_build_fn, tmp_path):
         mock_vs = MagicMock()
         mock_vs.l0_documents = ["d1", "d2"]
         mock_vs.l2_documents = ["d3", "d4", "d5"]
-        mock_build_fn.return_value = mock_vs
+
+        def build_vector(**kwargs):
+            build_path = Path(kwargs["index_path"])
+            _write_mock_vector_generation(build_path, "test-model")
+            return mock_vs
+
+        mock_build_fn.side_effect = build_vector
 
         builder = VectorIndexBuilder(
             languages=["python"],
@@ -238,7 +276,319 @@ class TestVectorIndexBuilder:
         mock_build_fn.assert_called_once()
         assert mock_build_fn.call_args.kwargs["force_rebuild"] is True
         assert mock_build_fn.call_args.kwargs["strict_chunking"] is True
+        assert mock_build_fn.call_args.kwargs["_atomic_publish"] is False
         assert not (output_path / VECTOR_VIEW_UPDATE_MARKER).exists()
+
+    def test_build_publishes_one_complete_generation_without_stale_state(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        output_path = tmp_path / "vector"
+        output_path.mkdir()
+        (output_path / "config_test-model.json").write_bytes(b"old-config")
+        (output_path / "incremental_state.json").write_bytes(b"old-state")
+        (output_path / "chunk_store.json").write_bytes(b"old-chunks")
+        (output_path / VECTOR_VIEW_UPDATE_MARKER).write_bytes(b"stale-marker")
+        (output_path / "stale-owned-file").write_bytes(b"stale")
+
+        document = SimpleNamespace(
+            page_content="def fresh():\n    return 1\n",
+            metadata={
+                "file": "fresh.py",
+                "start_line": 0,
+                "end_line": 1,
+                "chunk_type": "function",
+                "name": "fresh",
+                "node_id": "fresh.py::fresh",
+            },
+        )
+        vector_store = MagicMock(
+            dimension=384,
+            l0_documents=[],
+            l2_documents=[document],
+        )
+        vector_store.get_embeddings_by_content_hash.return_value = {
+            "fresh-hash": [0.1, 0.2]
+        }
+        calls = []
+
+        def build_vector(**kwargs):
+            calls.append(kwargs)
+            build_path = Path(kwargs["index_path"])
+            assert (build_path / VECTOR_VIEW_UPDATE_MARKER).is_file()
+            _write_mock_vector_generation(build_path, "test-model")
+            return vector_store
+
+        monkeypatch.setattr(
+            "codenib.index.embedding.builders.build_hierarchical_vector_store",
+            build_vector,
+        )
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+
+        status = builder.build(
+            scope="current_repo",
+            repo_path=str(tmp_path),
+            output_dir=str(output_path),
+        )
+
+        files = _tree_file_bytes(output_path)
+        assert set(files) == {
+            "chunk_store.json",
+            "chunk_store.pkl",
+            "config_test-model.json",
+            "embeddings_cache.json",
+            "embeddings_cache.npz",
+            "embeddings_cache.pkl",
+            "incremental_state.json",
+            "l2/config_test-model.json",
+            "l2/documents_test-model.pkl",
+            "l2/index_test-model.faiss",
+        }
+        assert files["config_test-model.json"] != b"old-config"
+        assert VECTOR_VIEW_UPDATE_MARKER not in files
+        state = IncrementalState.load(output_path)
+        assert state is not None
+        assert state.index_path == str(output_path.resolve())
+        assert status.path == str(output_path)
+        assert calls[0]["_atomic_publish"] is False
+
+    @pytest.mark.parametrize("replacement", ["directory", "symlink"])
+    def test_build_private_root_replacement_cannot_publish_or_write_outside(
+        self,
+        replacement,
+        monkeypatch,
+        tmp_path,
+    ):
+        output_path = tmp_path / "vector"
+        _write_mock_vector_generation(output_path, "test-model")
+        (output_path / "incremental_state.json").write_bytes(b"old-state")
+        before_files = _tree_file_bytes(output_path)
+        before_ownership = capture_directory_ownership(output_path)
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        victim = outside / "victim.bin"
+        victim.write_bytes(b"outside-original")
+        vector_store = MagicMock(
+            dimension=384,
+            l0_documents=[],
+            l2_documents=[],
+        )
+
+        def replace_build_root(**kwargs):
+            anchored_root = Path(kwargs["index_path"])
+            named_root = anchored_root.resolve(strict=True)
+            moved_root = named_root.with_name(f"{named_root.name}.moved")
+            named_root.rename(moved_root)
+            if replacement == "directory":
+                named_root.mkdir()
+                (named_root / "attacker-tree").write_bytes(b"attacker")
+            else:
+                named_root.symlink_to(outside, target_is_directory=True)
+            (anchored_root / "victim.bin").write_bytes(b"private-only")
+            _write_mock_vector_generation(anchored_root, "test-model")
+            return vector_store
+
+        monkeypatch.setattr(
+            "codenib.index.embedding.builders.build_hierarchical_vector_store",
+            replace_build_root,
+        )
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+
+        with pytest.raises(RuntimeError, match="private build root changed"):
+            builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_path),
+            )
+
+        assert _tree_file_bytes(output_path) == before_files
+        after_ownership = capture_directory_ownership(output_path)
+        assert directory_ownership_root_identity(after_ownership) == (
+            directory_ownership_root_identity(before_ownership)
+        )
+        assert directory_ownership_digest(after_ownership) == (
+            directory_ownership_digest(before_ownership)
+        )
+        assert victim.read_bytes() == b"outside-original"
+
+    @pytest.mark.parametrize(
+        "phase",
+        [
+            "marker_begin",
+            "vector_save",
+            "after_vector",
+            "seed",
+            "save",
+            "state_save",
+            "marker_finish",
+            "before_publish",
+            "after_publish_rename",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "exception_type",
+        [KeyboardInterrupt, SystemExit, GeneratorExit],
+    )
+    def test_incremental_rebuild_base_exception_restores_previous_generation(
+        self,
+        phase,
+        exception_type,
+        monkeypatch,
+        tmp_path,
+    ):
+        import codenib._atomic_directory as atomic_directory
+        from codenib._captured_directory import OwnedDirectoryStage
+        from codenib.index.incremental import (
+            EmbeddingsCache,
+            IncrementalChunkStore,
+        )
+        from codenib.index.incremental import IncrementalState as StateType
+
+        output_path = tmp_path / "vector"
+        _write_mock_vector_generation(output_path, "test-model")
+        (output_path / "chunk_store.json").write_bytes(b"old-chunks")
+        (output_path / "embeddings_cache.json").write_bytes(b"old-cache")
+        (output_path / "embeddings_cache.npz").write_bytes(b"old-vectors")
+        IncrementalState(
+            last_commit="a" * 40,
+            chunk_store_path="chunk_store.pkl",
+            embeddings_cache_path="embeddings_cache.pkl",
+            index_path=str(output_path.resolve()),
+            build_levels=["l0", "l2"],
+        ).save(output_path)
+
+        document = SimpleNamespace(
+            page_content="def replacement():\n    return 2\n",
+            metadata={
+                "file": "replacement.py",
+                "start_line": 0,
+                "end_line": 1,
+                "chunk_type": "function",
+                "name": "replacement",
+                "node_id": "replacement.py::replacement",
+            },
+        )
+        vector_store = MagicMock(
+            dimension=384,
+            l0_documents=[],
+            l2_documents=[document],
+        )
+        vector_store.get_embeddings_by_content_hash.return_value = {
+            "replacement-hash": [0.3, 0.4]
+        }
+
+        def interrupt(*_args, **_kwargs):
+            raise exception_type(f"interrupt during {phase}")
+
+        def build_vector(**kwargs):
+            _write_mock_vector_generation(Path(kwargs["index_path"]), "test-model")
+            if phase == "vector_save":
+                interrupt()
+            return vector_store
+
+        monkeypatch.setattr(
+            "codenib.index.embedding.builders.build_hierarchical_vector_store",
+            build_vector,
+        )
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        previous_artifact = builder.artifact_identity()
+        before_files = _tree_file_bytes(output_path)
+        before_ownership = capture_directory_ownership(output_path)
+        authorization = _mint_trusted_local_admin_authorization(
+            before_ownership,
+            view_type="vector",
+            semantic_contract=previous_artifact,
+            evidence=("verified-incremental-rollback-test",),
+        )
+
+        if phase == "marker_begin":
+            monkeypatch.setattr(
+                "codenib.index.embedding.artifact_integrity."
+                "begin_vector_view_update",
+                interrupt,
+            )
+        elif phase == "after_vector":
+            monkeypatch.setattr(builder, "_validate_vector_dimension", interrupt)
+        elif phase == "seed":
+            monkeypatch.setattr(
+                IncrementalChunkStore,
+                "from_chunks",
+                classmethod(interrupt),
+            )
+        elif phase == "save":
+            monkeypatch.setattr(EmbeddingsCache, "save", interrupt)
+        elif phase == "state_save":
+            monkeypatch.setattr(StateType, "save", interrupt)
+        elif phase == "marker_finish":
+            monkeypatch.setattr(
+                "codenib.index.embedding.artifact_integrity."
+                "finish_vector_view_update",
+                interrupt,
+            )
+        elif phase == "before_publish":
+            real_publish = OwnedDirectoryStage.publish
+
+            def interrupt_final_publish(stage, *args, **kwargs):
+                if stage.destination == output_path.absolute():
+                    return interrupt()
+                return real_publish(stage, *args, **kwargs)
+
+            monkeypatch.setattr(
+                OwnedDirectoryStage,
+                "publish",
+                interrupt_final_publish,
+            )
+        elif phase == "after_publish_rename":
+            real_rename = atomic_directory._rename_noreplace_at
+            interrupted = False
+
+            def interrupt_after_rename(source, destination, source_fd, dest_fd):
+                nonlocal interrupted
+                real_rename(source, destination, source_fd, dest_fd)
+                if (
+                    source.startswith(".vector.normalize-")
+                    and destination == "vector"
+                    and not interrupted
+                ):
+                    interrupted = True
+                    interrupt()
+
+            monkeypatch.setattr(
+                atomic_directory,
+                "_rename_noreplace_at",
+                interrupt_after_rename,
+            )
+
+        with pytest.raises(exception_type, match=phase):
+            builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_path),
+                last_commit="a" * 40,
+                previous_artifact_config=previous_artifact,
+                native_index_authorization=authorization,
+            )
+
+        assert _tree_file_bytes(output_path) == before_files
+        after_ownership = capture_directory_ownership(output_path)
+        assert directory_ownership_root_identity(after_ownership) == (
+            directory_ownership_root_identity(before_ownership)
+        )
+        assert directory_ownership_digest(after_ownership) == (
+            directory_ownership_digest(before_ownership)
+        )
+        assert not list(tmp_path.glob(".vector.generation-build-*"))
 
     def test_incremental_failure_falls_back_to_full_build(self, tmp_path):
         builder = VectorIndexBuilder(
@@ -279,6 +629,161 @@ class TestVectorIndexBuilder:
         assert result.metadata["update_mode"] == "full_rebuild"
         assert result.metadata["incremental_fallback_reason"] == "ValueError"
 
+    def test_explicit_invalid_native_authority_propagates(self, tmp_path):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+
+        with patch.object(builder, "build") as mock_build:
+            with pytest.raises(
+                InvalidNativeIndexAuthorizationError,
+                match="malformed",
+            ):
+                builder.incremental_update(
+                    scope="current_repo",
+                    repo_path=str(tmp_path),
+                    output_dir=str(tmp_path / "vector"),
+                    last_commit="a" * 40,
+                    native_index_authorization=object(),
+                )
+
+        mock_build.assert_not_called()
+
+    def test_invalid_native_authority_error_is_propagated_unchanged(self, tmp_path):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        authorization_error = InvalidNativeIndexAuthorizationError(
+            "authorization does not match captured bytes"
+        )
+
+        with (
+            patch.object(
+                builder,
+                "_incremental_update_once",
+                side_effect=authorization_error,
+            ),
+            patch.object(builder, "build") as mock_build,
+        ):
+            with pytest.raises(InvalidNativeIndexAuthorizationError) as raised:
+                builder.incremental_update(
+                    scope="current_repo",
+                    repo_path=str(tmp_path),
+                    output_dir=str(tmp_path / "vector"),
+                    last_commit="a" * 40,
+                    native_index_authorization=object(),
+                )
+
+        assert raised.value is authorization_error
+        mock_build.assert_not_called()
+
+    def test_valid_native_authority_is_passed_to_incremental_path(self, tmp_path):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        authorization_root = tmp_path / "authorized-vector"
+        authorization_root.mkdir()
+        (authorization_root / "index.faiss").write_bytes(b"native")
+        authorization = _mint_trusted_local_admin_authorization(
+            capture_directory_ownership(authorization_root),
+            view_type="vector",
+            semantic_contract=builder.artifact_identity(),
+            evidence=("verified-test-boundary",),
+        )
+        updated = IndexStatus(
+            index_type="vector",
+            state=IndexState.FRESH,
+            path=str(tmp_path / "vector"),
+            metadata={"update_mode": "incremental"},
+        )
+
+        with patch.object(
+            builder,
+            "_incremental_update_once",
+            return_value=updated,
+        ) as incremental:
+            result = builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "vector"),
+                last_commit="a" * 40,
+                native_index_authorization=authorization,
+            )
+
+        assert result is updated
+        assert incremental.call_args.kwargs["native_index_authorization"] is (
+            authorization
+        )
+
+    @pytest.mark.parametrize("mismatch", ["tree", "semantic"])
+    def test_exact_native_authority_rejects_before_model_initialization(
+        self,
+        tmp_path,
+        mismatch,
+    ):
+        output_path = tmp_path / "vector"
+        IncrementalState(
+            last_commit="a" * 40,
+            chunk_store_path="chunk_store.pkl",
+            embeddings_cache_path="embeddings_cache.pkl",
+            index_path=str(output_path.resolve()),
+            build_levels=["l0", "l2"],
+        ).save(output_path)
+        (output_path / "chunk_store.json").write_text("{}", encoding="utf-8")
+        (output_path / "embeddings_cache.json").write_text("[]", encoding="utf-8")
+        (output_path / "embeddings_cache.npz").write_bytes(b"placeholder")
+
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        expected_semantic = builder.artifact_identity()
+        authorization_root = output_path
+        authorization_semantic = expected_semantic
+        if mismatch == "tree":
+            authorization_root = tmp_path / "other-vector"
+            authorization_root.mkdir()
+            (authorization_root / "config_test-model.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+        else:
+            authorization_semantic = {"embedding_dimension": 1024}
+        authorization = _mint_trusted_local_admin_authorization(
+            capture_directory_ownership(authorization_root),
+            view_type="vector",
+            semantic_contract=authorization_semantic,
+            evidence=(f"wrong-{mismatch}-test",),
+        )
+
+        with (
+            patch(
+                "codenib.index.embedding.vector_store.CodeVectorStore",
+                side_effect=AssertionError(
+                    "exact authorization must fail before model initialization"
+                ),
+            ) as store_type,
+            patch.object(builder, "build") as full_build,
+        ):
+            with pytest.raises(
+                InvalidNativeIndexAuthorizationError,
+                match="does not match captured bytes",
+            ):
+                builder.incremental_update(
+                    scope="current_repo",
+                    repo_path=str(tmp_path),
+                    output_dir=str(output_path),
+                    last_commit="a" * 40,
+                    previous_artifact_config=expected_semantic,
+                    native_index_authorization=authorization,
+                )
+
+        store_type.assert_not_called()
+        full_build.assert_not_called()
+
     def test_missing_native_authority_rebuilds_before_model_initialization(
         self,
         tmp_path,
@@ -313,7 +818,9 @@ class TestVectorIndexBuilder:
         store_type.assert_not_called()
         mock_build.assert_called_once()
         assert result.metadata["update_mode"] == "full_rebuild"
-        assert result.metadata["incremental_fallback_reason"] == "ValueError"
+        assert result.metadata["incremental_fallback_reason"] == (
+            "MissingNativeIndexAuthorizationError"
+        )
 
     def test_missing_incremental_state_attempts_one_rebuild(self, tmp_path):
         builder = VectorIndexBuilder(
@@ -384,7 +891,10 @@ class TestVectorIndexBuilder:
         mock_build.assert_called_once()
         assert result.metadata["update_mode"] == "full_rebuild"
 
-    def test_incremental_load_uses_previous_manifest_generation(self, tmp_path):
+    def test_authorized_incremental_generation_rebuilds_before_model_init(
+        self,
+        tmp_path,
+    ):
         output_path = tmp_path / "vector"
         IncrementalState(
             last_commit="a" * 40,
@@ -408,35 +918,52 @@ class TestVectorIndexBuilder:
                 "sha256": "0" * 64,
             },
         }
-        vector_store = MagicMock(dimension=384)
-        vector_store.load.side_effect = RuntimeError("stop after generation check")
-        authorization = object()
+        authorization = _mint_trusted_local_admin_authorization(
+            capture_directory_ownership(output_path),
+            view_type="vector",
+            semantic_contract=previous,
+            evidence=("verified-previous-generation",),
+        )
+        rebuilt = IndexStatus(
+            index_type="vector",
+            state=IndexState.FRESH,
+            path=str(output_path),
+            metadata={},
+        )
+        before = _tree_file_bytes(output_path)
 
         with (
             patch(
-                "codenib.native_index_authorization.require_native_index_authorization_preflight",
-                return_value=None,
-            ),
-            patch(
                 "codenib.index.embedding.vector_store.CodeVectorStore",
-                return_value=vector_store,
+                side_effect=AssertionError(
+                    "disabled in-place update must not initialize a model"
+                ),
             ) as store_type,
+            patch.object(builder, "build", return_value=rebuilt) as full_build,
         ):
-            with pytest.raises(RuntimeError, match="generation check"):
-                builder._incremental_update_once(
-                    scope="current_repo",
-                    repo_path=str(tmp_path),
-                    output_dir=str(output_path),
-                    last_commit="a" * 40,
-                    previous_artifact_config=previous,
-                    native_index_authorization=authorization,
-                )
+            result = builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_path),
+                last_commit="a" * 40,
+                previous_artifact_config=previous,
+                native_index_authorization=authorization,
+            )
 
-        assert store_type.call_args.kwargs["artifact_metadata"] == previous
-        vector_store.load.assert_called_once_with(
-            str(output_path),
+        store_type.assert_not_called()
+        full_build.assert_called_once_with(
+            "current_repo",
+            repo_path=str(tmp_path),
+            output_dir=str(output_path),
             native_index_authorization=authorization,
         )
+        assert result is rebuilt
+        assert result.metadata["update_mode"] == "full_rebuild"
+        assert result.metadata["incremental_fallback_reason"] == (
+            "_AtomicIncrementalRebuildRequired"
+        )
+        assert _tree_file_bytes(output_path) == before
+        assert not (output_path / VECTOR_VIEW_UPDATE_MARKER).exists()
 
     @pytest.mark.parametrize("missing", ["chunk_json", "embedding_pair"])
     def test_pickle_only_incremental_state_forces_rebuild(self, tmp_path, missing):
@@ -561,12 +1088,21 @@ class TestVectorIndexBuilder:
                 repo_path="/fake/repo",
                 output_dir=str(output_path),
             )
-        assert (output_path / VECTOR_VIEW_UPDATE_MARKER).is_file()
+        assert not output_path.exists()
 
     @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
     def test_remote_runtime_secret_is_not_persisted(self, mock_build_fn, tmp_path):
         mock_vs = MagicMock(l0_documents=[], l2_documents=["doc"])
-        mock_build_fn.return_value = mock_vs
+
+        def build_vector(**kwargs):
+            build_path = Path(kwargs["index_path"])
+            _write_mock_vector_generation(
+                build_path,
+                "text-embedding-3-small",
+            )
+            return mock_vs
+
+        mock_build_fn.side_effect = build_vector
         output_path = tmp_path / "vector"
         output_path.mkdir()
         (output_path / "config_text-embedding-3-small.json").write_text(

--- a/test/compiler/test_manifest.py
+++ b/test/compiler/test_manifest.py
@@ -25,6 +25,11 @@ from codenib.compiler.resources import (
     IndexStatus,
     ResourceResolver,
 )
+from codenib.source_fingerprint import is_secure_source_fingerprint_v2
+
+_SOURCE_V2 = f"sha256-v2:{'a' * 64}"
+_OTHER_SOURCE_V2 = f"sha256-v2:{'b' * 64}"
+_LEGACY_SOURCE_V1 = f"sha256:{'c' * 64}"
 
 # ---------------------------------------------------------------------------
 # IndexEntry
@@ -287,7 +292,7 @@ class TestRepoManifest:
 
     def test_derive_capabilities_stale_source_excluded(self):
         m = RepoManifest(
-            source_fingerprint="sha256:current",
+            source_fingerprint=_SOURCE_V2,
             indexes={
                 "bm25": IndexEntry(
                     index_type="bm25",
@@ -295,7 +300,7 @@ class TestRepoManifest:
                     built_at="2024-01-15T10:30:00+00:00",
                     built_at_epoch=time.time(),
                     status="fresh",
-                    source_fingerprint="sha256:old",
+                    source_fingerprint=_OTHER_SOURCE_V2,
                 ),
             },
         )
@@ -304,8 +309,8 @@ class TestRepoManifest:
 
     def test_source_identity_roundtrip(self):
         m = RepoManifest(
-            source_fingerprint="sha256:current",
-            last_indexed_source_fingerprint="sha256:complete",
+            source_fingerprint=_SOURCE_V2,
+            last_indexed_source_fingerprint=_OTHER_SOURCE_V2,
             indexes={
                 "bm25": IndexEntry(
                     index_type="bm25",
@@ -313,16 +318,41 @@ class TestRepoManifest:
                     built_at="2024-01-15T10:30:00+00:00",
                     built_at_epoch=time.time(),
                     status="fresh",
-                    source_fingerprint="sha256:current",
+                    source_fingerprint=_SOURCE_V2,
                 )
             },
         )
 
         restored = RepoManifest.from_dict(m.to_dict())
 
-        assert restored.source_fingerprint == "sha256:current"
-        assert restored.last_indexed_source_fingerprint == "sha256:complete"
+        assert restored.source_fingerprint == _SOURCE_V2
+        assert restored.last_indexed_source_fingerprint == _OTHER_SOURCE_V2
         assert restored.index_is_current("bm25") is True
+
+    def test_v1_source_identity_loads_for_inert_query_compatibility(self):
+        restored = RepoManifest.from_dict(
+            RepoManifest(
+                source_fingerprint=_LEGACY_SOURCE_V1,
+                last_indexed_source_fingerprint=_LEGACY_SOURCE_V1,
+                indexes={
+                    "bm25": IndexEntry(
+                        index_type="bm25",
+                        path="/tmp/bm25",
+                        built_at="2024-01-15T10:30:00+00:00",
+                        built_at_epoch=time.time(),
+                        status="fresh",
+                        source_fingerprint=_LEGACY_SOURCE_V1,
+                    )
+                },
+            ).to_dict()
+        )
+
+        assert restored.source_fingerprint == _LEGACY_SOURCE_V1
+        assert restored.last_indexed_source_fingerprint == _LEGACY_SOURCE_V1
+        assert restored.index_is_current("bm25") is True
+        assert not is_secure_source_fingerprint_v2(restored.source_fingerprint)
+        restored.derive_capabilities()
+        assert restored.capabilities["sparse_search"] is True
 
     def test_empty_manifest(self):
         m = RepoManifest()

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -25,6 +25,8 @@ pin down:
 
 from __future__ import annotations
 
+from contextlib import nullcontext
+from types import SimpleNamespace
 from typing import List
 
 import pytest
@@ -40,7 +42,7 @@ from codenib.agent.skills.registry import SkillRegistry
 from codenib.compiler import resources as compiler_resources
 from codenib.compiler import skill_context
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
-from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.compiler.manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
 from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
 
 
@@ -459,6 +461,8 @@ def test_embedding_resource_limits_reach_builder_and_loader(
             "embedding_kwargs": {"max_seq_length": 8192},
             "trust_remote_code": False,
             "default_batch_size": 4,
+            "artifact_metadata": None,
+            "native_index_authorization": None,
         }
     ]
 
@@ -487,8 +491,125 @@ def test_bundled_embedding_policy_reaches_builder_and_loader(
             "embedding_kwargs": None,
             "trust_remote_code": True,
             "default_batch_size": None,
+            "artifact_metadata": None,
+            "native_index_authorization": None,
         }
     ]
+
+
+def test_existing_required_vector_without_authority_forces_rebuild(
+    registry,
+    mocked_build,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    vector = cache / "vector"
+    vector.mkdir(parents=True)
+    (vector / "existing").write_text("untrusted", encoding="utf-8")
+
+    skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["embedding_search"],
+        cache_dir=str(cache),
+        skill_registry=registry,
+    )
+
+    assert mocked_build["compile"] == [("vector",)]
+
+
+def test_compiler_owned_vector_mints_exact_manifest_contract(
+    registry,
+    mocked_build,
+    monkeypatch,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    vector = cache / "vector"
+    contract = {"embedding_fingerprint": "sha256:compiler-owned"}
+    entry = IndexEntry(
+        index_type="vector",
+        path=str(vector),
+        built_at="2026-08-11T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config=contract,
+    )
+    manifest = RepoManifest(indexes={"vector": entry})
+    ownership = object()
+    authorization = object()
+    minted = []
+
+    monkeypatch.setattr(
+        skill_context,
+        "_run_compiler",
+        lambda *_args, **_kwargs: manifest,
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.artifact_integrity.capture_authenticated_vector_view",
+        lambda path: nullcontext(SimpleNamespace(ownership=ownership, root=path)),
+    )
+
+    def mint(captured, **kwargs):
+        minted.append((captured, kwargs))
+        return authorization
+
+    monkeypatch.setattr(
+        "codenib.native_index_authorization._mint_trusted_local_admin_authorization",
+        mint,
+    )
+
+    skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["embedding_search"],
+        cache_dir=str(cache),
+        skill_registry=registry,
+    )
+
+    assert minted[0][0] is ownership
+    assert minted[0][1]["semantic_contract"] == contract
+    assert mocked_build["vector_kwargs"][0]["artifact_metadata"] == contract
+    assert (
+        mocked_build["vector_kwargs"][0]["native_index_authorization"] is authorization
+    )
+
+
+def test_existing_vector_token_uses_current_manifest_contract(
+    registry,
+    mocked_build,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    vector = cache / "vector"
+    vector.mkdir(parents=True)
+    (vector / "existing").write_text("captured", encoding="utf-8")
+    contract = {"embedding_fingerprint": "sha256:expected"}
+    RepoManifest(
+        indexes={
+            "vector": IndexEntry(
+                index_type="vector",
+                path=str(vector),
+                built_at="2026-08-11T00:00:00Z",
+                built_at_epoch=0.0,
+                status="fresh",
+                config=contract,
+            )
+        }
+    ).save(cache / MANIFEST_FILENAME)
+    authorization = object()
+
+    skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["embedding_search"],
+        cache_dir=str(cache),
+        skill_registry=registry,
+        native_index_authorization=authorization,
+    )
+
+    assert mocked_build["compile"] == []
+    assert mocked_build["vector_kwargs"][0]["artifact_metadata"] == contract
+    assert (
+        mocked_build["vector_kwargs"][0]["native_index_authorization"] is authorization
+    )
 
 
 def test_partial_cache_only_rebuilds_missing(registry, mocked_build, tmp_path):
@@ -513,6 +634,17 @@ def test_partial_cache_only_rebuilds_missing(registry, mocked_build, tmp_path):
 # optional index handling in build_skill_contexts — load-if-present only,
 # never build.
 # ---------------------------------------------------------------------------
+
+
+def _optional_vector_registry() -> SkillRegistry:
+    reg = SkillRegistry()
+    metadata = _make_meta("fallback_search", SkillType.RETRIEVAL)
+    metadata.index_requirements = [
+        compiler_resources.IndexRequirement(index_type="bm25"),
+        compiler_resources.IndexRequirement(index_type="vector", required=False),
+    ]
+    reg.register(metadata)
+    return reg
 
 
 def test_optional_index_loaded_when_already_present(
@@ -555,6 +687,29 @@ def test_optional_index_skipped_when_absent(mixed_registry, mocked_build, tmp_pa
     assert mocked_build["loaded"] == ["bm25"]
     assert "expand" not in contexts
     assert contexts["retrieve"].bm25 is not None
+
+
+def test_optional_vector_without_authority_preserves_bm25_fallback(
+    mocked_build,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    for index_type in ("bm25", "vector"):
+        directory = cache / index_type
+        directory.mkdir(parents=True)
+        (directory / "present").write_text("present", encoding="utf-8")
+
+    contexts = skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["fallback_search"],
+        cache_dir=str(cache),
+        skill_registry=_optional_vector_registry(),
+    )
+
+    assert mocked_build["compile"] == []
+    assert mocked_build["loaded"] == ["bm25"]
+    assert contexts["retrieve"].bm25 is not None
+    assert contexts["retrieve"].vector_store is None
 
 
 def test_build_skill_contexts_without_reset_is_idempotent(
@@ -816,6 +971,76 @@ def test_manifest_skips_optional_index_when_absent(mixed_registry, mocked_build)
     assert mocked_build["loaded"] == ["bm25"]
     assert "expand" not in contexts
     assert contexts["retrieve"].bm25 is not None
+
+
+def test_manifest_optional_vector_without_authority_preserves_bm25_fallback(
+    mocked_build,
+):
+    manifest = RepoManifest(
+        indexes={
+            "bm25": _fresh_entry("bm25", "/idx/bm25"),
+            "vector": _fresh_entry("vector", "/idx/vector"),
+        }
+    )
+
+    contexts = skill_context.load_contexts_from_manifest(
+        manifest,
+        skill_ids=["fallback_search"],
+        skill_registry=_optional_vector_registry(),
+    )
+
+    assert mocked_build["loaded"] == ["bm25"]
+    assert contexts["retrieve"].bm25 is not None
+    assert contexts["retrieve"].vector_store is None
+
+
+def test_manifest_required_vector_without_authority_fails_before_model_init(
+    registry,
+    monkeypatch,
+):
+    entry = _fresh_entry("vector", "/idx/vector")
+    entry.config = {
+        "builder_schema": 2,
+        "embedding_model": "vendor/model",
+        "embedding_provider": "huggingface",
+        "embedding_dimension": 4,
+        "dimension": 4,
+        "embedding_kwargs": {},
+    }
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.CodeVectorStore",
+        lambda **_kwargs: pytest.fail(
+            "missing authority must fail before embedding model initialization"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires external authorization"):
+        skill_context.load_contexts_from_manifest(
+            RepoManifest(indexes={"vector": entry}),
+            skill_ids=["embedding_search"],
+            skill_registry=registry,
+        )
+
+
+def test_skill_vector_rejects_invalid_authority_before_model_init(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.CodeVectorStore",
+        lambda **_kwargs: pytest.fail(
+            "invalid authority must fail before embedding model initialization"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires external authorization"):
+        skill_context._load_vector(
+            str(tmp_path / "vector"),
+            embedding_model="vendor/model",
+            embedding_provider="huggingface",
+            embedding_dimension=4,
+            native_index_authorization=object(),
+        )
 
 
 def test_manifest_missing_required_index_raises(mixed_registry, mocked_build):

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -44,6 +44,7 @@ from codenib.compiler import skill_context
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
 from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
+from codenib.native_index_authorization import InvalidNativeIndexAuthorizationError
 
 
 def _make_meta(
@@ -612,6 +613,61 @@ def test_existing_vector_token_uses_current_manifest_contract(
     )
 
 
+def test_existing_vector_resolver_receives_exact_current_manifest_entry(
+    registry,
+    mocked_build,
+    tmp_path,
+):
+    cache = tmp_path / "cache"
+    vector = cache / "vector"
+    vector.mkdir(parents=True)
+    (vector / "existing").write_text("captured", encoding="utf-8")
+    contract = {"embedding_fingerprint": "sha256:resolver-bound"}
+    expected_entry = IndexEntry(
+        index_type="vector",
+        path=str(vector),
+        built_at="2026-08-11T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config=contract,
+    )
+    RepoManifest(indexes={"vector": expected_entry}).save(cache / MANIFEST_FILENAME)
+    authorization = object()
+    resolved = []
+
+    contexts = skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["embedding_search"],
+        cache_dir=str(cache),
+        skill_registry=registry,
+        native_index_authorization_resolver=lambda entry: (
+            resolved.append(entry) or authorization
+        ),
+    )
+
+    assert contexts["retrieve"].vector_store is not None
+    assert mocked_build["compile"] == []
+    assert len(resolved) == 1
+    assert resolved[0].path == expected_entry.path
+    assert resolved[0].config == contract
+    assert mocked_build["vector_kwargs"][0]["artifact_metadata"] == contract
+    assert (
+        mocked_build["vector_kwargs"][0]["native_index_authorization"] is authorization
+    )
+
+
+def test_build_context_rejects_token_and_resolver_together(registry, tmp_path):
+    with pytest.raises(ValueError, match="either native_index_authorization"):
+        skill_context.build_skill_contexts(
+            repo_path=str(tmp_path),
+            skill_ids=["embedding_search"],
+            cache_dir=str(tmp_path / "cache"),
+            skill_registry=registry,
+            native_index_authorization=object(),
+            native_index_authorization_resolver=lambda _entry: object(),
+        )
+
+
 def test_partial_cache_only_rebuilds_missing(registry, mocked_build, tmp_path):
     """bm25 already built, vector missing → only vector is rebuilt."""
     cache = tmp_path / "cache"
@@ -1022,6 +1078,38 @@ def test_manifest_required_vector_without_authority_fails_before_model_init(
         )
 
 
+def test_manifest_vector_resolver_receives_exact_loaded_entry(
+    registry,
+    mocked_build,
+):
+    entry = _fresh_entry("vector", "/idx/vector")
+    entry.config = {
+        "builder_schema": 2,
+        "embedding_model": "vendor/model",
+        "embedding_provider": "huggingface",
+        "embedding_dimension": 4,
+        "dimension": 4,
+        "embedding_kwargs": {},
+    }
+    authorization = object()
+    resolved = []
+
+    contexts = skill_context.load_contexts_from_manifest(
+        RepoManifest(indexes={"vector": entry}),
+        skill_ids=["embedding_search"],
+        skill_registry=registry,
+        native_index_authorization_resolver=lambda candidate: (
+            resolved.append(candidate) or authorization
+        ),
+    )
+
+    assert contexts["retrieve"].vector_store is not None
+    assert resolved == [entry]
+    assert (
+        mocked_build["vector_kwargs"][0]["native_index_authorization"] is authorization
+    )
+
+
 def test_skill_vector_rejects_invalid_authority_before_model_init(
     monkeypatch,
     tmp_path,
@@ -1033,7 +1121,10 @@ def test_skill_vector_rejects_invalid_authority_before_model_init(
         ),
     )
 
-    with pytest.raises(ValueError, match="requires external authorization"):
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="malformed",
+    ):
         skill_context._load_vector(
             str(tmp_path / "vector"),
             embedding_model="vendor/model",

--- a/test/examples/test_swerank_retrieve_rerank.py
+++ b/test/examples/test_swerank_retrieve_rerank.py
@@ -130,7 +130,7 @@ def test_default_index_cache_fingerprints_dirty_checkout(recipe, monkeypatch, tm
         source_fingerprint,
         "fingerprint_repository",
         lambda repo: source_fingerprint.SourceFingerprint(
-            value=f"sha256:{'b' * 64}", file_count=3
+            value=f"sha256-v2:{'b' * 64}", file_count=3
         ),
     )
 
@@ -141,7 +141,7 @@ def test_default_index_cache_fingerprints_dirty_checkout(recipe, monkeypatch, tm
         state
         / "recipes"
         / "swerank-embed-small"
-        / f"source-{'b' * 64}"
+        / f"source-sha256-v2-{'b' * 64}"
         / recipe._cache_profile_key(["python"], args.max_lines_per_chunk)
     )
 

--- a/test/index/sparse_idx/test_bm25_safe_source.py
+++ b/test/index/sparse_idx/test_bm25_safe_source.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+import codenib._contained_source as contained_source_module
 from codenib.code_chunking.base import CodeChunk
 from codenib.index.sparse_idx import bm25_index as bm25_module
 from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
@@ -221,7 +222,7 @@ def test_source_on_a_different_windows_drive_is_rejected(tmp_path: Path) -> None
     )
 
 
-def test_final_source_symlink_is_rejected(tmp_path: Path) -> None:
+def test_absolute_final_source_symlink_is_rejected(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     target = repo / "real.py"
@@ -231,6 +232,124 @@ def test_final_source_symlink_is_rejected(tmp_path: Path) -> None:
     indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
 
     assert _content(indexer) is None
+
+
+def test_relative_final_source_symlink_inside_root_is_accepted(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "real.py").write_text("contained alias target\n", encoding="utf-8")
+    _symlink_or_skip(repo / "source.py", Path("real.py"))
+
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) == "contained alias target\n"
+
+
+def test_relative_intermediate_symlink_with_parent_inside_root_is_accepted(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    real = repo / "real" / "source.py"
+    real.parent.mkdir(parents=True)
+    real.write_text("inside_call()\n", encoding="utf-8")
+    links = repo / "links"
+    links.mkdir()
+    _symlink_or_skip(links / "pkg", Path("../real"), directory=True)
+    indexer = _indexer(repo, "links/pkg/source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) == "inside_call()\n"
+    occurrences = indexer.search_identifier_occurrences(
+        "inside_call",
+        wrap_with_ln=False,
+    )
+    assert [item.content for item in occurrences] == ["inside_call()\n"]
+
+
+@pytest.mark.parametrize("target", ["../outside.py", "missing.py"])
+def test_relative_final_source_symlink_outside_or_broken_is_rejected(
+    tmp_path: Path,
+    target: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside.py").write_text("outside secret\n", encoding="utf-8")
+    _symlink_or_skip(repo / "source.py", Path(target))
+
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+
+
+def test_source_symlink_loop_is_rejected(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _symlink_or_skip(repo / "source.py", Path("other.py"))
+    _symlink_or_skip(repo / "other.py", Path("source.py"))
+
+    assert _content(_indexer(repo, "source.py", node_type=NODE_TYPE_FILE)) is None
+
+
+def test_source_symlink_hop_limit_is_enforced(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "real.py").write_text("safe\n", encoding="utf-8")
+    for index in range(41):
+        target = f"link-{index + 1}.py" if index < 40 else "real.py"
+        _symlink_or_skip(repo / f"link-{index}.py", Path(target))
+
+    assert _content(_indexer(repo, "link-0.py", node_type=NODE_TYPE_FILE)) is None
+
+
+def test_source_symlink_reversible_swap_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "real.py").write_text("safe\n", encoding="utf-8")
+    outside = tmp_path / "outside.py"
+    outside.write_text("outside secret\n", encoding="utf-8")
+    link = repo / "source.py"
+    _symlink_or_skip(link, Path("real.py"))
+    real_verify = contained_source_module._BoundRepositoryFile.verify
+    calls = 0
+
+    def swap_then_restore(binding) -> None:
+        nonlocal calls
+        calls += 1
+        if calls != 2:
+            return real_verify(binding)
+        link.unlink()
+        link.symlink_to(Path("../outside.py"))
+        try:
+            return real_verify(binding)
+        finally:
+            link.unlink()
+            link.symlink_to(Path("real.py"))
+
+    monkeypatch.setattr(
+        contained_source_module._BoundRepositoryFile,
+        "verify",
+        swap_then_restore,
+    )
+
+    assert _content(_indexer(repo, "source.py", node_type=NODE_TYPE_FILE)) is None
+    assert calls == 2
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs")
+def test_contained_symlink_reads_do_not_leak_descriptors(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "real.py").write_text("safe\n", encoding="utf-8")
+    _symlink_or_skip(repo / "source.py", Path("real.py"))
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+    before = len(list(Path("/proc/self/fd").iterdir()))
+
+    for _ in range(20):
+        assert _content(indexer) == "safe\n"
+
+    assert len(list(Path("/proc/self/fd").iterdir())) == before
 
 
 def test_intermediate_source_symlink_is_rejected(tmp_path: Path) -> None:

--- a/test/index/sparse_idx/test_bm25_safe_source.py
+++ b/test/index/sparse_idx/test_bm25_safe_source.py
@@ -11,9 +11,14 @@ from pathlib import Path
 import pytest
 
 import codenib._contained_source as contained_source_module
+import codenib.source_fingerprint as source_fingerprint_module
 from codenib.code_chunking.base import CodeChunk
 from codenib.index.sparse_idx import bm25_index as bm25_module
 from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
+from codenib.source_fingerprint import (
+    RepositorySourceBinding,
+    capture_repository_source,
+)
 from codenib.types import NODE_TYPE_FILE
 
 
@@ -152,6 +157,81 @@ def test_regular_file_node_still_returns_the_entire_source(tmp_path: Path) -> No
     assert _content(indexer) == "first\nsecond\n"
 
 
+def test_bound_search_reads_each_source_file_once_per_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "pkg" / "source.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("shared_marker_one()\nshared_marker_two()\n", encoding="utf-8")
+    indexer = BM25CodeIndexer(
+        chunks=[
+            CodeChunk(
+                content="shared_marker first",
+                start_line=0,
+                end_line=0,
+                chunk_type="function",
+                name="shared_marker_one",
+                file="pkg/source.py",
+                node_id="pkg/source.py:shared_marker_one()",
+            ),
+            CodeChunk(
+                content="shared_marker second",
+                start_line=1,
+                end_line=1,
+                chunk_type="function",
+                name="shared_marker_two",
+                file="pkg/source.py",
+                node_id="pkg/source.py:shared_marker_two()",
+            ),
+        ],
+        project_root=str(repo),
+    )
+    binding = capture_repository_source(repo)
+    indexer.bind_repository_source(binding)
+
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    real_read = RepositorySourceBinding._read_record
+    scans = 0
+    reads = 0
+
+    def counted_scan(*args, **kwargs):
+        nonlocal scans
+        scans += 1
+        return real_scan(*args, **kwargs)
+
+    def counted_read(self, *args, **kwargs):
+        nonlocal reads
+        reads += 1
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        counted_scan,
+    )
+    monkeypatch.setattr(RepositorySourceBinding, "_read_record", counted_read)
+
+    try:
+        results = indexer.search(
+            "shared_marker",
+            top_k=2,
+            return_code_content=True,
+            wrap_with_ln=False,
+        )
+
+        assert len(results) == 2
+        assert {result.content for result in results} == {
+            "shared_marker_one()\n",
+            "shared_marker_two()\n",
+        }
+        assert reads == 1
+        assert scans == 2
+    finally:
+        binding.close()
+
+
 def test_absolute_source_beneath_root_is_accepted(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     source = repo / "pkg" / "source.py"
@@ -222,7 +302,7 @@ def test_source_on_a_different_windows_drive_is_rejected(tmp_path: Path) -> None
     )
 
 
-def test_absolute_final_source_symlink_is_rejected(tmp_path: Path) -> None:
+def test_absolute_contained_final_source_symlink_is_accepted(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     target = repo / "real.py"
@@ -231,7 +311,7 @@ def test_absolute_final_source_symlink_is_rejected(tmp_path: Path) -> None:
 
     indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
 
-    assert _content(indexer) is None
+    assert _content(indexer) == "contained alias target\n"
 
 
 def test_relative_final_source_symlink_inside_root_is_accepted(tmp_path: Path) -> None:

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -2,11 +2,41 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+import codenib._atomic_directory as atomic_directory
 from codenib.index.embedding import builders
+from codenib.index.embedding.artifact_integrity import VECTOR_VIEW_UPDATE_MARKER
+from codenib.native_index_authorization import (
+    InvalidNativeIndexAuthorizationError,
+    _mint_trusted_local_admin_authorization,
+)
+
+
+def _write_fake_vector_store(path, *, model_suffix, levels):
+    root = Path(path)
+    root.mkdir(parents=True, exist_ok=True)
+    for level in levels:
+        level_path = root / level
+        level_path.mkdir()
+        (level_path / f"config_{model_suffix}.json").write_text(
+            "{}",
+            encoding="utf-8",
+        )
+        (level_path / f"index_{model_suffix}.faiss").write_bytes(b"new-index")
+        (level_path / f"documents_{model_suffix}.pkl").write_bytes(b"new-docs")
+    (root / f"config_{model_suffix}.json").write_text("{}", encoding="utf-8")
+
+
+def _file_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
 
 
 def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path):
@@ -40,7 +70,11 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
             self.l2_documents.extend(chunks)
 
         def save(self, path):
-            pass
+            _write_fake_vector_store(
+                path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
 
     monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
     monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
@@ -58,6 +92,18 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
         path.write_bytes(b"stale")
     unrelated = stale_level / "index_other-model.faiss"
     unrelated.write_bytes(b"other")
+    generation_root = stale_level.parent
+    stale_state_files = [
+        generation_root / "chunk_store.json",
+        generation_root / "chunk_store.pkl",
+        generation_root / "embeddings_cache.json",
+        generation_root / "embeddings_cache.npz",
+        generation_root / "embeddings_cache.pkl",
+        generation_root / "incremental_state.json",
+        generation_root / VECTOR_VIEW_UPDATE_MARKER,
+    ]
+    for path in stale_state_files:
+        path.write_bytes(b"stale-generation-state")
 
     result = builders.build_hierarchical_vector_store(
         repo_path=str(tmp_path),
@@ -78,6 +124,7 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
     assert captured["strict_chunking"] is True
     assert result.l2_documents
     assert all(not path.exists() for path in stale_files)
+    assert all(not path.exists() for path in stale_state_files)
     assert unrelated.read_bytes() == b"other"
 
 
@@ -121,6 +168,11 @@ def test_cached_index_without_authority_is_rebuilt_from_source(
 
         def save(self, _path):
             calls["save"] += 1
+            _write_fake_vector_store(
+                _path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
 
     monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
     monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
@@ -183,7 +235,12 @@ def test_authorized_cache_is_loaded_without_rechunking(monkeypatch, tmp_path):
     index = tmp_path / "index"
     index.mkdir()
     (index / "config_test-model.json").write_text("{}", encoding="utf-8")
-    authorization = object()
+    authorization = _mint_trusted_local_admin_authorization(
+        atomic_directory.capture_directory_ownership(index),
+        view_type="vector",
+        semantic_contract={},
+        evidence=("verified-test-cache",),
+    )
     calls = []
 
     class FakeStore:
@@ -213,28 +270,84 @@ def test_authorized_cache_is_loaded_without_rechunking(monkeypatch, tmp_path):
     assert calls == [(str(index), authorization)]
 
 
-def test_invalid_cache_authority_propagates_without_rebuild(monkeypatch, tmp_path):
+def test_wrong_semantic_cache_authority_rejects_before_model_init(
+    monkeypatch,
+    tmp_path,
+):
     index = tmp_path / "index"
     index.mkdir()
     (index / "config_test-model.json").write_text("{}", encoding="utf-8")
 
-    class FakeStore:
-        def __init__(self, **_kwargs):
-            pass
-
-        def load(self, _path, *, native_index_authorization):
-            assert native_index_authorization is invalid_authorization
-            raise ValueError("authorization does not match captured bytes")
-
-    invalid_authorization = object()
-    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+    invalid_authorization = _mint_trusted_local_admin_authorization(
+        atomic_directory.capture_directory_ownership(index),
+        view_type="vector",
+        semantic_contract={"dimension": 3},
+        evidence=("wrong-semantic-test-cache",),
+    )
+    monkeypatch.setattr(
+        builders,
+        "CodeVectorStore",
+        lambda **_kwargs: pytest.fail(
+            "wrong-semantic authority must fail before model initialization"
+        ),
+    )
     monkeypatch.setattr(
         builders,
         "CodeChunker",
         lambda **_kwargs: pytest.fail("invalid authority must not trigger rebuild"),
     )
 
-    with pytest.raises(ValueError, match="does not match captured bytes"):
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="does not match captured bytes",
+    ):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(tmp_path),
+            index_path=str(index),
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            artifact_metadata={"dimension": 2},
+            native_index_authorization=invalid_authorization,
+        )
+
+
+def test_wrong_tree_cache_authority_rejects_before_model_init(
+    monkeypatch,
+    tmp_path,
+):
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "config_test-model.json").write_text("{}", encoding="utf-8")
+    other = tmp_path / "other-index"
+    other.mkdir()
+    (other / "config_test-model.json").write_text(
+        '{"different":true}',
+        encoding="utf-8",
+    )
+    invalid_authorization = _mint_trusted_local_admin_authorization(
+        atomic_directory.capture_directory_ownership(other),
+        view_type="vector",
+        semantic_contract={},
+        evidence=("wrong-tree-test-cache",),
+    )
+    monkeypatch.setattr(
+        builders,
+        "CodeVectorStore",
+        lambda **_kwargs: pytest.fail(
+            "wrong-tree authority must fail before model initialization"
+        ),
+    )
+    monkeypatch.setattr(
+        builders,
+        "CodeChunker",
+        lambda **_kwargs: pytest.fail("invalid authority must not trigger rebuild"),
+    )
+
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="does not match captured bytes",
+    ):
         builders.build_hierarchical_vector_store(
             repo_path=str(tmp_path),
             index_path=str(index),
@@ -243,3 +356,404 @@ def test_invalid_cache_authority_propagates_without_rebuild(monkeypatch, tmp_pat
             embedding_dimension=2,
             native_index_authorization=invalid_authorization,
         )
+
+
+def test_failed_staged_save_preserves_existing_cache(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": source.read_text()},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            return [chunk]
+
+    class FailingStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            getattr(self, f"{level}_documents").extend(chunks)
+
+        def save(self, path):
+            _write_fake_vector_store(
+                path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
+            raise RuntimeError("simulated staged save failure")
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FailingStore)
+
+    index = tmp_path / "index"
+    _write_fake_vector_store(
+        index,
+        model_suffix="test-model",
+        levels=("l0", "l2"),
+    )
+    before = _file_snapshot(index)
+
+    with pytest.raises(RuntimeError, match="staged save failure"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(repo),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert _file_snapshot(index) == before
+    assert not list(tmp_path.glob(".index.vector-build-*"))
+
+
+def test_bad_repository_preserves_existing_cache(monkeypatch, tmp_path):
+    class FailingChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            raise OSError("bad repository")
+
+    monkeypatch.setattr(builders, "CodeChunker", FailingChunker)
+    monkeypatch.setattr(
+        builders,
+        "CodeVectorStore",
+        lambda **_kwargs: pytest.fail("store must not be built after chunk failure"),
+    )
+
+    index = tmp_path / "index"
+    _write_fake_vector_store(
+        index,
+        model_suffix="test-model",
+        levels=("l0", "l2"),
+    )
+    before = _file_snapshot(index)
+
+    with pytest.raises(OSError, match="bad repository"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(tmp_path / "missing-repo"),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert _file_snapshot(index) == before
+
+
+def test_unrequested_symlink_level_rejects_rebuild_without_mutation(
+    monkeypatch,
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": source.read_text()},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            return [chunk]
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            getattr(self, f"{level}_documents").extend(chunks)
+
+        def save(self, path):
+            _write_fake_vector_store(
+                path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+
+    outside = tmp_path / "outside"
+    _write_fake_vector_store(
+        outside,
+        model_suffix="test-model",
+        levels=(),
+    )
+    outside_config = outside / "config_test-model.json"
+    outside_config.unlink()
+    (outside / "index_test-model.faiss").write_bytes(b"outside-index")
+    (outside / "documents_test-model.pkl").write_bytes(b"outside-docs")
+    before = _file_snapshot(outside)
+
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "l0").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises((ValueError, RuntimeError), match="link"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(repo),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert (index / "l0").is_symlink()
+    assert _file_snapshot(outside) == before
+
+
+def test_requested_symlink_level_rejects_publish_without_mutation(
+    monkeypatch,
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": source.read_text()},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            return [chunk]
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            getattr(self, f"{level}_documents").extend(chunks)
+
+        def save(self, path):
+            _write_fake_vector_store(
+                path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "index_test-model.faiss").write_bytes(b"outside-index")
+    before = _file_snapshot(outside)
+    index = tmp_path / "index"
+    index.mkdir()
+    old_config = index / "config_test-model.json"
+    old_config.write_bytes(b"old-config")
+    (index / "l2").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises((ValueError, RuntimeError), match="link"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(repo),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert old_config.read_bytes() == b"old-config"
+    assert (index / "l2").is_symlink()
+    assert _file_snapshot(outside) == before
+
+
+def test_interrupted_directory_switch_restores_old_cache(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": source.read_text()},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            return [chunk]
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            getattr(self, f"{level}_documents").extend(chunks)
+
+        def save(self, path):
+            _write_fake_vector_store(
+                path,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+
+    index = tmp_path / "index"
+    _write_fake_vector_store(
+        index,
+        model_suffix="test-model",
+        levels=("l0", "l2"),
+    )
+    (index / "incremental_state.json").write_bytes(b"old-incremental-state")
+    before = _file_snapshot(index)
+    real_rename = atomic_directory._rename_noreplace_at
+    injected = False
+
+    def interrupt_after_publish(source_name, destination_name, source_fd, dest_fd):
+        nonlocal injected
+        real_rename(source_name, destination_name, source_fd, dest_fd)
+        if (
+            source_name.startswith(".index.normalize-")
+            and destination_name == "index"
+            and not injected
+        ):
+            injected = True
+            raise KeyboardInterrupt("simulated completed publication interrupt")
+
+    monkeypatch.setattr(
+        atomic_directory,
+        "_rename_noreplace_at",
+        interrupt_after_publish,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="publication interrupt"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(repo),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert injected is True
+    assert _file_snapshot(index) == before
+
+
+@pytest.mark.parametrize("replacement", ["directory", "symlink"])
+def test_private_build_root_replacement_cannot_publish_or_write_outside(
+    monkeypatch,
+    tmp_path,
+    replacement,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {"file": "source.py", "content": source.read_text()},
+    )
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            del repo_path, strict
+            return [chunk]
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.bin"
+    victim.write_bytes(b"outside-original")
+
+    class ReplacingStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            getattr(self, f"{level}_documents").extend(chunks)
+
+        def save(self, path):
+            anchored_root = Path(path)
+            named_root = anchored_root.resolve(strict=True)
+            moved_root = named_root.with_name(f"{named_root.name}.moved")
+            named_root.rename(moved_root)
+            if replacement == "directory":
+                named_root.mkdir()
+                (named_root / "attacker-tree").write_bytes(b"attacker")
+            else:
+                named_root.symlink_to(outside, target_is_directory=True)
+
+            # A writer that continues using the supplied path remains anchored
+            # to the retained original inode, even after the public name is a
+            # directory or a symlink to the victim tree.
+            (anchored_root / "victim.bin").write_bytes(b"private-only")
+            _write_fake_vector_store(
+                anchored_root,
+                model_suffix="test-model",
+                levels=("l2",),
+            )
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", ReplacingStore)
+
+    index = tmp_path / "index"
+    _write_fake_vector_store(
+        index,
+        model_suffix="test-model",
+        levels=("l0", "l2"),
+    )
+    before = _file_snapshot(index)
+
+    with pytest.raises(RuntimeError, match="private build root changed"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(repo),
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            force_rebuild=True,
+        )
+
+    assert _file_snapshot(index) == before
+    assert victim.read_bytes() == b"outside-original"

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -4,6 +4,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from codenib.index.embedding import builders
 
 
@@ -77,3 +79,167 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
     assert result.l2_documents
     assert all(not path.exists() for path in stale_files)
     assert unrelated.read_bytes() == b"other"
+
+
+def test_cached_index_without_authority_is_rebuilt_from_source(
+    monkeypatch,
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {
+            "file": "source.py",
+            "content": source.read_text(encoding="utf-8"),
+        },
+    )
+    calls = {"chunk": 0, "load": 0, "save": 0}
+
+    class FakeChunker:
+        def __init__(self, **_kwargs):
+            pass
+
+        def chunk_repository(self, repo_path, *, strict=False):
+            assert repo_path == str(repo)
+            calls["chunk"] += 1
+            return [chunk]
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def load(self, *_args, **_kwargs):
+            calls["load"] += 1
+
+        def add_code_chunks(self, chunks, level):
+            assert level == "l2"
+            self.l2_documents.extend(chunks)
+
+        def save(self, _path):
+            calls["save"] += 1
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+
+    index = tmp_path / "index"
+    stale_l0 = index / "l0"
+    stale_l0.mkdir(parents=True)
+    (index / "config_test-model.json").write_text("{}", encoding="utf-8")
+    (stale_l0 / "index_test-model.faiss").write_bytes(b"stale")
+
+    result = builders.build_hierarchical_vector_store(
+        repo_path=str(repo),
+        index_path=str(index),
+        languages=["python"],
+        build_levels=["l2"],
+        embedding_model="test-model",
+        embedding_provider="huggingface",
+        embedding_dimension=2,
+    )
+
+    assert result.l2_documents
+    assert calls == {"chunk": 1, "load": 0, "save": 1}
+    assert not stale_l0.exists()
+
+
+def test_cached_index_without_authority_or_source_is_left_unchanged(tmp_path):
+    index = tmp_path / "index"
+    stale_l0 = index / "l0"
+    stale_l0.mkdir(parents=True)
+    config = index / "config_test-model.json"
+    stale = stale_l0 / "index_test-model.faiss"
+    config.write_bytes(b"config")
+    stale.write_bytes(b"stale")
+    before = {
+        path.relative_to(index).as_posix(): path.read_bytes()
+        for path in index.rglob("*")
+        if path.is_file()
+    }
+
+    with pytest.raises(ValueError, match="repo_path is required to rebuild"):
+        builders.build_hierarchical_vector_store(
+            repo_path="",
+            index_path=str(index),
+            languages=["python"],
+            build_levels=["l2"],
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+        )
+
+    after = {
+        path.relative_to(index).as_posix(): path.read_bytes()
+        for path in index.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+
+
+def test_authorized_cache_is_loaded_without_rechunking(monkeypatch, tmp_path):
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "config_test-model.json").write_text("{}", encoding="utf-8")
+    authorization = object()
+    calls = []
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            pass
+
+        def load(self, path, *, native_index_authorization):
+            calls.append((path, native_index_authorization))
+
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+    monkeypatch.setattr(
+        builders,
+        "CodeChunker",
+        lambda **_kwargs: pytest.fail("authorized cache must not be rechunked"),
+    )
+
+    result = builders.build_hierarchical_vector_store(
+        repo_path="",
+        index_path=str(index),
+        embedding_model="test-model",
+        embedding_provider="huggingface",
+        embedding_dimension=2,
+        native_index_authorization=authorization,
+    )
+
+    assert isinstance(result, FakeStore)
+    assert calls == [(str(index), authorization)]
+
+
+def test_invalid_cache_authority_propagates_without_rebuild(monkeypatch, tmp_path):
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "config_test-model.json").write_text("{}", encoding="utf-8")
+
+    class FakeStore:
+        def __init__(self, **_kwargs):
+            pass
+
+        def load(self, _path, *, native_index_authorization):
+            assert native_index_authorization is invalid_authorization
+            raise ValueError("authorization does not match captured bytes")
+
+    invalid_authorization = object()
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+    monkeypatch.setattr(
+        builders,
+        "CodeChunker",
+        lambda **_kwargs: pytest.fail("invalid authority must not trigger rebuild"),
+    )
+
+    with pytest.raises(ValueError, match="does not match captured bytes"):
+        builders.build_hierarchical_vector_store(
+            repo_path=str(tmp_path),
+            index_path=str(index),
+            embedding_model="test-model",
+            embedding_provider="huggingface",
+            embedding_dimension=2,
+            native_index_authorization=invalid_authorization,
+        )

--- a/test/index/test_vector_artifact_identity.py
+++ b/test/index/test_vector_artifact_identity.py
@@ -4,15 +4,19 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from codenib._atomic_directory import capture_directory_ownership
 from codenib.index.embedding.vector_store import (
     CodeVectorStore,
     _OpenAIEmbeddingWrapper,
+    _read_authenticated_faiss,
 )
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 
 
 class _Embedding:
@@ -24,6 +28,51 @@ class _Embedding:
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         return [[0.0] * self.dimension for _ in texts]
+
+
+def test_faiss_callback_caps_oversized_native_read_requests(monkeypatch) -> None:
+    payload_size = 8 * 1024 * 1024 + 17
+
+    class _Snapshot:
+        def __init__(self) -> None:
+            self.record = SimpleNamespace(size=payload_size)
+            self.offset = 0
+            self.requests: list[int] = []
+
+        def read(self, size: int) -> bytes:
+            self.requests.append(size)
+            remaining = payload_size - self.offset
+            consumed = min(size, remaining)
+            self.offset += consumed
+            return b"x" * consumed
+
+    snapshot = _Snapshot()
+    view = SimpleNamespace(
+        authenticated_snapshot=lambda _relative: nullcontext(
+            (snapshot, snapshot.record)
+        )
+    )
+    observed: list[int] = []
+    sentinel = object()
+
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.faiss.PyCallbackIOReader",
+        lambda callback: callback,
+    )
+
+    def read_index(callback):
+        while block := callback(1 << 60):
+            observed.append(len(block))
+        return sentinel
+
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.faiss.read_index",
+        read_index,
+    )
+
+    assert _read_authenticated_faiss(view, "l2/index.faiss") is sentinel
+    assert observed == [8 * 1024 * 1024, 17]
+    assert max(snapshot.requests) == 8 * 1024 * 1024
 
 
 def _store(
@@ -45,6 +94,51 @@ def _store(
     )
 
 
+def _authorization(path, store):
+    return _mint_trusted_local_admin_authorization(
+        capture_directory_ownership(path),
+        view_type="vector",
+        semantic_contract=store.artifact_metadata,
+        evidence=("vector-artifact-test-local-admin",),
+    )
+
+
+def test_load_denies_missing_authorization_before_tree_capture(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = _store(tmp_path, fingerprint="sha256:expected")
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.capture_authenticated_vector_view",
+        lambda _path: pytest.fail("denied native load must not capture the tree"),
+    )
+
+    with pytest.raises(ValueError, match="requires external authorization"):
+        store.load()
+
+
+def test_load_denies_foreign_pid_authorization_before_tree_capture(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import codenib.native_index_authorization as authorization_module
+
+    store = _store(tmp_path, fingerprint="sha256:expected")
+    authorization = _authorization(tmp_path, store)
+    monkeypatch.setattr(
+        authorization_module.os,
+        "getpid",
+        lambda: authorization.process_id + 1,
+    )
+    monkeypatch.setattr(
+        "codenib.index.embedding.vector_store.capture_authenticated_vector_view",
+        lambda _path: pytest.fail("foreign-PID load must not capture the tree"),
+    )
+
+    with pytest.raises(ValueError, match="another process"):
+        store.load(native_index_authorization=authorization)
+
+
 def test_load_rejects_manifest_and_saved_artifact_fingerprint_mismatch(
     tmp_path,
 ) -> None:
@@ -52,7 +146,7 @@ def test_load_rejects_manifest_and_saved_artifact_fingerprint_mismatch(
     reopened = _store(tmp_path, fingerprint="sha256:second")
 
     with pytest.raises(ValueError, match="does not match manifest"):
-        reopened.load()
+        reopened.load(native_index_authorization=_authorization(tmp_path, reopened))
 
 
 def test_load_rejects_provider_substitution(tmp_path) -> None:
@@ -64,7 +158,7 @@ def test_load_rejects_provider_substitution(tmp_path) -> None:
     )
 
     with pytest.raises(ValueError, match="provider mismatch"):
-        reopened.load()
+        reopened.load(native_index_authorization=_authorization(tmp_path, reopened))
 
 
 def test_load_rejects_embedding_revision_substitution(tmp_path) -> None:
@@ -76,7 +170,7 @@ def test_load_rejects_embedding_revision_substitution(tmp_path) -> None:
     )
 
     with pytest.raises(ValueError, match="embedding revision mismatch"):
-        reopened.load()
+        reopened.load(native_index_authorization=_authorization(tmp_path, reopened))
 
 
 @pytest.mark.parametrize("option", ["revision", "trust_remote_code"])
@@ -98,7 +192,7 @@ def test_load_requires_saved_identity_when_manifest_has_a_fingerprint(tmp_path) 
     reopened = _store(tmp_path, fingerprint="sha256:expected")
 
     with pytest.raises(ValueError, match="top-level configuration"):
-        reopened.load()
+        reopened.load(native_index_authorization=_authorization(tmp_path, reopened))
 
 
 def test_openai_wrapper_sends_vector_options_on_embedding_requests() -> None:

--- a/test/index/test_vector_artifact_identity.py
+++ b/test/index/test_vector_artifact_identity.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from codenib._atomic_directory import capture_directory_ownership
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.index.embedding.vector_store import (
     CodeVectorStore,
     _OpenAIEmbeddingWrapper,
@@ -95,12 +95,16 @@ def _store(
 
 
 def _authorization(path, store):
-    return _mint_trusted_local_admin_authorization(
-        capture_directory_ownership(path),
-        view_type="vector",
-        semantic_contract=store.artifact_metadata,
-        evidence=("vector-artifact-test-local-admin",),
-    )
+    with capture_authenticated_vector_view(path) as view:
+        return _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=store.artifact_metadata,
+            evidence=(
+                "vector-artifact-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
 
 
 def test_load_denies_missing_authorization_before_tree_capture(

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -23,10 +23,10 @@ import faiss
 import numpy as np
 import pytest
 
-from codenib._atomic_directory import capture_directory_ownership
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
     VECTOR_VIEW_UPDATE_MARKER,
+    capture_authenticated_vector_view,
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
@@ -70,12 +70,16 @@ def _make_store(**kwargs) -> CodeVectorStore:
 
 def _authorization(store: CodeVectorStore, path=None):
     root = Path(path) if path is not None else Path(store.store_path)
-    return _mint_trusted_local_admin_authorization(
-        capture_directory_ownership(root),
-        view_type="vector",
-        semantic_contract=store.artifact_metadata,
-        evidence=("vector-store-test-local-admin",),
-    )
+    with capture_authenticated_vector_view(root) as view:
+        return _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=store.artifact_metadata,
+            evidence=(
+                "vector-store-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
 
 
 def _load_trusted(store: CodeVectorStore, path=None) -> None:

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 import hashlib
 import json
 import pickle
+from pathlib import Path
 from unittest.mock import patch
 
 import faiss
 import numpy as np
 import pytest
 
+from codenib._atomic_directory import capture_directory_ownership
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
     VECTOR_VIEW_UPDATE_MARKER,
@@ -29,6 +31,7 @@ from codenib.index.embedding.artifact_integrity import (
     vector_level_artifact_records,
 )
 from codenib.index.embedding.vector_store import CodeVectorStore
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 
 _DIM = 16
 
@@ -63,6 +66,30 @@ def _make_store(**kwargs) -> CodeVectorStore:
         return_value=_FakeEmbedding(_DIM),
     ):
         return CodeVectorStore(dimension=_DIM, **kwargs)
+
+
+def _authorization(store: CodeVectorStore, path=None):
+    root = Path(path) if path is not None else Path(store.store_path)
+    return _mint_trusted_local_admin_authorization(
+        capture_directory_ownership(root),
+        view_type="vector",
+        semantic_contract=store.artifact_metadata,
+        evidence=("vector-store-test-local-admin",),
+    )
+
+
+def _load_trusted(store: CodeVectorStore, path=None) -> None:
+    store.load(
+        path,
+        native_index_authorization=_authorization(store, path),
+    )
+
+
+def _swap_trusted(store: CodeVectorStore, path) -> None:
+    store.swap_index(
+        str(path),
+        native_index_authorization=_authorization(store, path),
+    )
 
 
 def _chunks(n: int) -> list:
@@ -183,7 +210,7 @@ def test_ivf_save_load_roundtrip(tmp_path):
     store.save(path)
 
     loaded = _make_store(index_type="ivf", ivf_nlist=5, ivf_nprobe=5, store_path=path)
-    loaded.load(path)
+    _load_trusted(loaded, path)
     assert loaded.l2_index.ntotal == 5
     res = loaded.search(chunks[1]["content"], top_k=3)
     assert res and res[0].node_name == chunks[1]["name"]
@@ -204,7 +231,7 @@ def test_save_removes_persisted_level_after_last_document_is_deleted(tmp_path):
     assert config["l2_documents"] == 0
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
-    loaded.load()
+    _load_trusted(loaded)
     assert loaded.l2_index.ntotal == 0
     assert loaded.l2_documents == []
 
@@ -237,11 +264,11 @@ def test_failed_save_blocks_load_until_successful_retry(tmp_path):
     assert marker.is_file()
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="interrupted save marker"):
-        loaded.load()
+        _load_trusted(loaded)
 
     store.save(str(path))
     assert not marker.exists()
-    loaded.load()
+    _load_trusted(loaded)
     assert len(loaded.l2_documents) == 2
 
 
@@ -254,7 +281,7 @@ def test_load_rejects_incomplete_multi_artifact_update(tmp_path):
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="incomplete update marker"):
-        loaded.load()
+        _load_trusted(loaded)
 
 
 def test_load_prefers_portable_json_documents(tmp_path):
@@ -287,7 +314,7 @@ def test_load_prefers_portable_json_documents(tmp_path):
     _commit_portable_documents(path, "test__model")
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
-    loaded.load()
+    _load_trusted(loaded)
 
     assert [document.metadata["file"] for document in loaded.l2_documents] == [
         "m0.py",
@@ -311,7 +338,7 @@ def test_load_rejects_invalid_portable_json_documents(tmp_path):
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="invalid content or metadata"):
-        loaded.load()
+        _load_trusted(loaded)
 
 
 def test_load_rejects_faiss_document_count_mismatch(tmp_path):
@@ -337,7 +364,7 @@ def test_load_rejects_faiss_document_count_mismatch(tmp_path):
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="2 vectors for 1 documents"):
-        loaded.load()
+        _load_trusted(loaded)
 
 
 def test_load_rejects_top_level_document_count_mismatch(tmp_path):
@@ -353,7 +380,7 @@ def test_load_rejects_top_level_document_count_mismatch(tmp_path):
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="config expects 3 documents, loaded 2"):
-        loaded.load()
+        _load_trusted(loaded)
 
 
 def test_load_rejects_same_count_torn_document_write(tmp_path):
@@ -372,9 +399,12 @@ def test_load_rejects_same_count_torn_document_write(tmp_path):
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(
         ValueError,
-        match="committed documents vector artifact does not match",
+        match=(
+            "committed documents vector artifact does not match|"
+            "vector artifact does not match its fingerprint"
+        ),
     ):
-        loaded.load()
+        _load_trusted(loaded)
 
 
 def test_load_rejects_vector_config_from_another_manifest_generation(tmp_path):
@@ -395,8 +425,11 @@ def test_load_rejects_vector_config_from_another_manifest_generation(tmp_path):
         artifact_metadata={"persistence_config_fingerprint": expected},
     )
 
-    with pytest.raises(ValueError, match="manifest fingerprint"):
-        loaded.load()
+    with pytest.raises(
+        ValueError,
+        match="manifest fingerprint|vector artifact does not match its fingerprint",
+    ):
+        _load_trusted(loaded)
 
 
 def test_zero_top_level_count_does_not_resurrect_stale_level_files(tmp_path):
@@ -413,7 +446,7 @@ def test_zero_top_level_count_does_not_resurrect_stale_level_files(tmp_path):
     config_path.write_text(json.dumps(config), encoding="utf-8")
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
-    loaded.load()
+    _load_trusted(loaded)
 
     assert loaded.l2_index.ntotal == 0
     assert loaded.l2_documents == []
@@ -431,7 +464,7 @@ def test_failed_swap_preserves_the_serving_index(tmp_path):
     (replacement_path / "l2" / "documents_test__model.pkl").unlink()
 
     with pytest.raises(ValueError, match="vector artifact file"):
-        current.swap_index(str(replacement_path))
+        _swap_trusted(current, replacement_path)
 
     assert current.l2_index.ntotal == 2
     assert len(current.l2_documents) == 2
@@ -452,7 +485,7 @@ def test_successful_swap_replaces_all_levels(tmp_path):
     replacement.add_code_chunks([replacement_chunk], level="l2")
     replacement.save(str(replacement_path))
 
-    current.swap_index(str(replacement_path))
+    _swap_trusted(current, replacement_path)
 
     assert current.l0_index.ntotal == 0
     assert current.l0_documents == []
@@ -485,4 +518,4 @@ def test_load_rejects_faiss_dimension_mismatch(tmp_path):
         )
 
     with pytest.raises(ValueError, match="FAISS dimension mismatch"):
-        loaded.load()
+        _load_trusted(loaded)

--- a/test/mcp/test_mcp_e2e.py
+++ b/test/mcp/test_mcp_e2e.py
@@ -17,13 +17,35 @@ import pytest
 
 import codenib.mcp.server as server_module
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.mcp.context import ServerContext
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.paths import prebuilt_data_dir
 
 # Test data from codenib-base-dataset
 CODENIB_DATA = prebuilt_data_dir()
 TEST_REPO = "astropy__astropy-12907"
 TEST_REPO_PATH = CODENIB_DATA / TEST_REPO
+
+
+def _load_test_owned_vector(store, path):
+    """Authorize one explicitly selected local E2E fixture tree."""
+
+    semantic_contract = dict(store.artifact_metadata)
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "mcp-e2e-direct-local-fixture",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
 
 
 @pytest.mark.slow
@@ -156,7 +178,7 @@ class TestMCPServerE2E:
             index_metric="ip",
             store_path=str(TEST_REPO_PATH),
         )
-        vector_store.load()
+        _load_test_owned_vector(vector_store, TEST_REPO_PATH)
 
         query = "coordinate transformation"
         top_k = 5

--- a/test/mcp/test_search_semantic_integration.py
+++ b/test/mcp/test_search_semantic_integration.py
@@ -13,14 +13,35 @@ import asyncio
 import pytest
 
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
 from codenib.mcp.context import ServerContext
 from codenib.mcp.tools.search import search_semantic
+from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.paths import prebuilt_data_dir
 
 # Test data directory
 CODENIB_DATA = prebuilt_data_dir()
 TEST_REPO = "astropy__astropy-12907"
 TEST_REPO_PATH = CODENIB_DATA / TEST_REPO
+
+
+def _load_test_owned_vector(store, path, semantic_contract):
+    """Authorize the explicitly configured local slow-test fixture."""
+
+    with capture_authenticated_vector_view(path) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "semantic-integration-local-fixture",
+                "captured-vector-tree-subject",
+            ),
+        )
+        store.load(
+            str(path),
+            native_index_authorization=authorization,
+        )
 
 
 @pytest.mark.slow
@@ -36,6 +57,12 @@ class TestSearchSemanticIntegration:
         """Create ServerContext with real embedding index."""
         # Create manifest for test repo
         # Note: No actual manifest file exists, we construct it programmatically
+        vector_contract = {
+            "embedding_model": "jinaai/jina-code-embeddings-1.5b",
+            "embedding_provider": "huggingface",
+            "dimension": 1536,
+            "index_metric": "ip",
+        }
         manifest = RepoManifest(
             repo_path=str(TEST_REPO_PATH),
             commit="test",
@@ -46,12 +73,7 @@ class TestSearchSemanticIntegration:
                     built_at="2024-04-12T20:57:00Z",
                     built_at_epoch=1712957820.0,
                     status="fresh",
-                    config={
-                        "embedding_model": "jinaai/jina-code-embeddings-1.5b",
-                        "embedding_provider": "huggingface",
-                        "dimension": 1536,
-                        "index_metric": "ip",
-                    },
+                    config=vector_contract,
                 )
             },
         )
@@ -67,8 +89,13 @@ class TestSearchSemanticIntegration:
             dimension=1536,
             index_metric="ip",
             store_path=str(TEST_REPO_PATH),  # Parent directory
+            artifact_metadata=vector_contract,
         )
-        ctx.vector.load()
+        _load_test_owned_vector(
+            ctx.vector,
+            TEST_REPO_PATH,
+            vector_contract,
+        )
 
         return ctx
 

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +17,359 @@ from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprin
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.mcp.context import RUNTIME_VIEW_NAMES, ServerContext
 from codenib.provider_routes import resolve_inference_route
+from codenib.source_fingerprint import (
+    capture_repository_source,
+    fingerprint_repository,
+)
+
+
+class _PendingSourceOwner:
+    def __init__(self, source: object) -> None:
+        self.source = source
+        self.closed = False
+
+    @property
+    def pending_sources(self) -> tuple[object, ...]:
+        return () if self.closed else (self.source,)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_server_context_rejects_mismatched_source_authority(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "a.py").write_bytes(b"A\n")
+    (second / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(first)
+    identity = fingerprint_repository(second)
+    manifest = RepoManifest(
+        repo_path=str(second),
+        source_fingerprint=identity.value,
+        file_count=identity.file_count,
+    )
+
+    with pytest.raises(ValueError, match="does not match the manifest"):
+        ServerContext.load(manifest, views=[], source_binding=binding)
+
+    assert not binding.usable
+
+
+def test_server_context_load_failure_closes_transferred_source_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=binding.fingerprint,
+        file_count=binding.file_count,
+    )
+
+    def fail_load_views(self, _views):
+        raise RuntimeError("injected load failure")
+
+    monkeypatch.setattr(ServerContext, "load_views", fail_load_views)
+    with pytest.raises(RuntimeError, match="injected load failure"):
+        ServerContext.load(manifest, views=[], source_binding=binding)
+
+    assert not binding.usable
+
+
+def test_server_context_provider_failure_closes_transferred_source_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=binding.fingerprint,
+        file_count=binding.file_count,
+    )
+
+    def fail_provider_configuration(self, **_kwargs):
+        raise RuntimeError("injected provider configuration failure")
+
+    monkeypatch.setattr(
+        ServerContext,
+        "configure_lsp_provider",
+        fail_provider_configuration,
+    )
+    with pytest.raises(RuntimeError, match="provider configuration failure"):
+        ServerContext.load(manifest, views=[], source_binding=binding)
+
+    assert not binding.usable
+
+
+def test_init_server_provider_reconfiguration_failure_closes_new_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.mcp import server as server_module
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    identity = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=identity.value,
+        file_count=identity.file_count,
+        languages=["cpp"],
+    ).save(manifest_path)
+    captured = []
+    configure_calls = []
+
+    def capture(*args, **kwargs):
+        source = capture_repository_source(*args, **kwargs)
+        captured.append(source)
+        return source
+
+    def configure(
+        self,
+        *,
+        allow_native: bool,
+        native_disabled_reason: str = "native_provider_not_authorized",
+    ):
+        configure_calls.append((allow_native, native_disabled_reason))
+        self._lsp_allow_native = allow_native
+        self._lsp_native_disabled_reason = native_disabled_reason
+        if allow_native:
+            raise RuntimeError("injected native provider configuration failure")
+        self.lsp_provider = None
+        self.lsp_provider_selection = {"status": "unavailable"}
+        return dict(self.lsp_provider_selection)
+
+    monkeypatch.setattr(
+        "codenib.source_fingerprint.capture_repository_source",
+        capture,
+    )
+    monkeypatch.setattr(ServerContext, "configure_lsp_provider", configure)
+    previous_context = object()
+    monkeypatch.setattr(server_module, "_ctx", previous_context)
+
+    with pytest.raises(RuntimeError, match="native provider configuration failure"):
+        server_module.init_server(manifest_path)
+
+    assert configure_calls == [
+        (False, "local_source_not_verified"),
+        (False, "local_source_not_verified"),
+        (True, "local_source_not_verified"),
+    ]
+    assert len(captured) == 1
+    assert captured[0].closed
+    assert server_module._ctx is previous_context
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("context close interrupted"), id="keyboard"),
+        pytest.param(SystemExit("context close exited"), id="system-exit"),
+    ],
+)
+def test_server_context_mismatch_propagates_after_close_cancellation_and_old_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "a.py").write_bytes(b"A\n")
+    (second / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(first)
+    identity = fingerprint_repository(second)
+    manifest = RepoManifest(
+        repo_path=str(second),
+        source_fingerprint=identity.value,
+        file_count=identity.file_count,
+    )
+    old_source = object()
+    old_owner = _PendingSourceOwner(old_source)
+    method = ServerContext.load.__func__
+    source_type = type(binding)
+    real_close = source_type.close
+    close_calls = 0
+    injected_owner = False
+
+    def close_then_interrupt(source) -> None:
+        nonlocal close_calls
+        close_calls += 1
+        real_close(source)
+        raise interruption
+
+    def attach_old_owner(frame, event, arg):
+        nonlocal injected_owner
+        if (
+            not injected_owner
+            and frame.f_code is method.__code__
+            and event == "exception"
+            and isinstance(arg[1], ValueError)
+            and "does not match the manifest" in str(arg[1])
+        ):
+            injected_owner = True
+            arg[1].source_cleanup_owner = old_owner
+        return attach_old_owner
+
+    monkeypatch.setattr(source_type, "close", close_then_interrupt)
+    sys.settrace(attach_old_owner)
+    try:
+        with pytest.raises(type(interruption)) as caught:
+            ServerContext.load(manifest, views=[], source_binding=binding)
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected_owner
+    assert close_calls == 1
+    assert binding.closed
+    assert caught.value.source_cleanup_owner is old_owner
+
+    old_owner.close()
+    assert old_owner.closed
+
+
+def test_server_context_mismatch_merges_old_owner_with_persistent_close_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "a.py").write_bytes(b"A\n")
+    (second / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(first)
+    identity = fingerprint_repository(second)
+    manifest = RepoManifest(
+        repo_path=str(second),
+        source_fingerprint=identity.value,
+        file_count=identity.file_count,
+    )
+    old_source = object()
+    old_owner = _PendingSourceOwner(old_source)
+    method = ServerContext.load.__func__
+    source_type = type(binding)
+    real_close = source_type.close
+    primary_error: BaseException | None = None
+
+    def persistent_close(_source) -> None:
+        raise OSError("injected persistent context close EIO")
+
+    def attach_old_owner(frame, event, arg):
+        nonlocal primary_error
+        if (
+            primary_error is None
+            and frame.f_code is method.__code__
+            and event == "exception"
+            and isinstance(arg[1], ValueError)
+            and "does not match the manifest" in str(arg[1])
+        ):
+            primary_error = arg[1]
+            arg[1].source_cleanup_owner = old_owner
+        return attach_old_owner
+
+    monkeypatch.setattr(source_type, "close", persistent_close)
+    sys.settrace(attach_old_owner)
+    try:
+        with pytest.raises(ValueError, match="does not match the manifest") as caught:
+            ServerContext.load(manifest, views=[], source_binding=binding)
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is primary_error
+    retry_owner = caught.value.source_cleanup_owner
+    assert set(retry_owner.pending_sources) == {old_source, binding}
+    assert not binding.closed
+
+    monkeypatch.setattr(source_type, "close", real_close)
+    retry_owner.close()
+    assert retry_owner.closed
+    assert old_owner.closed
+    assert binding.closed
+
+
+def test_local_bm25_without_source_binding_is_persisted_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.index.sparse_idx.bm25_index as bm25_module
+
+    view = tmp_path / "bm25"
+    view.mkdir()
+    secret = tmp_path / "secret.py"
+    secret.write_text("API_KEY = 'LOCAL_BM25_SECRET'\n", encoding="utf-8")
+    (view / "documents.json").write_text(
+        json.dumps(
+            [
+                {
+                    "page_content": "safe persisted needle",
+                    "metadata": {
+                        "file": str(secret),
+                        "name": "needle",
+                        "node_id": "secret.py:needle",
+                        "type": "variable",
+                        "start_line": 0,
+                        "end_line": 0,
+                    },
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (view / "bm25_metadata.json").write_text(
+        json.dumps(
+            {
+                "project_root": str(tmp_path),
+                "max_k": 10,
+                "language": "english",
+            }
+        ),
+        encoding="utf-8",
+    )
+    legacy = "sha256:" + "a" * 64
+    manifest = RepoManifest(
+        repo_path=str(tmp_path),
+        source_fingerprint=legacy,
+        last_indexed_source_fingerprint=legacy,
+        indexes={
+            "bm25": IndexEntry(
+                index_type="bm25",
+                path=str(view),
+                built_at="2026-01-01T00:00:00+00:00",
+                built_at_epoch=1.0,
+                status="fresh",
+                source_fingerprint=legacy,
+                config={
+                    "artifact_file_fingerprints": bm25_artifact_file_fingerprints(view)
+                },
+            )
+        },
+    )
+    monkeypatch.setattr(
+        bm25_module,
+        "_read_source_text",
+        lambda *_args: pytest.fail("unbound BM25 must not read live source"),
+    )
+
+    context = ServerContext.load(manifest, views={"bm25"})
+
+    assert context.bm25 is not None
+    assert context.bm25.source_mode == bm25_module.SOURCE_MODE_PERSISTED_ONLY
+    results = context.bm25.search("needle", return_code_content=True)
+    assert results and results[0].content is None
+    assert "LOCAL_BM25_SECRET" not in repr(results)
 
 
 @pytest.fixture()
@@ -91,29 +445,44 @@ def test_load_selects_only_requested_views(
     assert calls == ["bm25"]
 
 
-def test_portable_context_never_attaches_project_local_native_provider(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_portable_artifact_context_never_loads_graph_or_other_native_views(
+    manifest_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    graph = object()
+    calls = _record_view_loads(monkeypatch)
 
-    def load_graph(self):
-        self.symbol_graph = graph
-
-    monkeypatch.setattr(ServerContext, "_load_symbol_graph", load_graph)
-    manifest = RepoManifest(repo_path=str(tmp_path), languages=["cpp"])
     with patch("codenib.ls_router.LSIndexer") as indexer:
         ctx = ServerContext.load(
-            manifest,
-            views={"symbol_graph"},
-            artifact={"verified": True},
+            manifest_dir / "repo_manifest.json",
+            artifact={"schema": "codenib.context-artifact.v1"},
         )
 
     indexer.assert_not_called()
-    assert ctx.lsp_provider.graph is graph
-    assert ctx.lsp_provider_selection["backend"] == "persisted-symbol-graph-v1"
+    assert calls == ["bm25", "vector"]
+    assert ctx.lsp_provider is None
+    assert ctx.lsp_provider_selection["backend"] == "unavailable"
     assert ctx.lsp_provider_selection["fallback_reason"] == (
         "portable_artifact_uses_persisted_graph"
     )
+    with pytest.raises(ValueError, match="cannot load native views"):
+        ctx.load_views({"symbol_graph"})
+
+
+def test_empty_portable_artifact_context_stays_native_view_inert(
+    manifest_dir: Path,
+) -> None:
+    ctx = ServerContext.load(
+        manifest_dir / "repo_manifest.json",
+        views=(),
+        artifact={},
+    )
+
+    assert ctx.artifact == {}
+    with pytest.raises(
+        ValueError,
+        match="portable artifact contexts cannot load native views: symbol_graph",
+    ):
+        ctx.load_views({"symbol_graph"})
 
 
 def test_load_views_adds_resources_idempotently(
@@ -137,11 +506,11 @@ def test_load_views_adds_resources_idempotently(
     assert ctx.loaded_views == frozenset({"bm25"})
 
 
-def test_load_views_rebinds_lsp_provider_after_lazy_graph_load(
+def test_load_views_rebinds_persisted_provider_after_lazy_graph_load(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     manifest = RepoManifest(repo_path=str(tmp_path), languages=["cpp"])
-    ctx = ServerContext.load(manifest, views=(), artifact={"verified": True})
+    ctx = ServerContext.load(manifest, views=())
     graph = object()
 
     def load_graph(self):
@@ -158,7 +527,7 @@ def test_load_views_rebinds_lsp_provider_after_lazy_graph_load(
         "backend": "persisted-symbol-graph-v1",
         "status": "ok",
         "index_snapshot": "symbol_graph:unknown:0:0",
-        "fallback_reason": "portable_artifact_uses_persisted_graph",
+        "fallback_reason": "local_source_not_verified",
         "capabilities": {
             "definition": True,
             "references": True,
@@ -305,11 +674,15 @@ def test_load_vector_accepts_compiler_manifest_identity(tmp_path: Path) -> None:
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 3}
+    authorization = object()
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
     ) as cls:
-        ctx = ServerContext.load(tmp_path / "repo_manifest.json")
+        ctx = ServerContext.load(
+            tmp_path / "repo_manifest.json",
+            native_index_authorization=authorization,
+        )
 
     cls.assert_called_once_with(
         embedding_model="test-model",
@@ -330,7 +703,9 @@ def test_load_vector_accepts_compiler_manifest_identity(tmp_path: Path) -> None:
         max_seq_length=8192,
         revision="model-commit",
     )
-    vector.load.assert_called_once_with()
+    vector.load.assert_called_once_with(
+        native_index_authorization=authorization,
+    )
     assert ctx.vector is vector
     assert "vector" not in ctx.errors
 
@@ -360,15 +735,23 @@ def test_validate_views_probes_vector_without_loading_embedding_model(
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 3}
+    authorization = object()
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
     ) as cls:
-        errors = ServerContext.validate_views(manifest, views={"vector"})
+        errors = ServerContext.validate_views(
+            manifest,
+            views={"vector"},
+            native_index_authorization=authorization,
+        )
 
     assert errors == {}
     assert cls.call_args.kwargs["embedding"].dimension == 384
+    vector.load.assert_called_once_with(
+        native_index_authorization=authorization,
+    )
 
 
 def test_load_vector_rebinds_openai_credential_without_persisting_it(
@@ -414,11 +797,15 @@ def test_load_vector_rebinds_openai_credential_without_persisting_it(
     vector = MagicMock()
     vector.embedding_model = route.model
     vector.get_stats.return_value = {"total_documents": 3}
+    authorization = object()
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
     ) as cls:
-        ctx = ServerContext.load(tmp_path / "repo_manifest.json")
+        ctx = ServerContext.load(
+            tmp_path / "repo_manifest.json",
+            native_index_authorization=authorization,
+        )
 
     kwargs = cls.call_args.kwargs
     assert kwargs["embedding_provider"] == "openai"
@@ -469,17 +856,24 @@ def test_validate_views_does_not_require_remote_embedding_credentials(
     vector = MagicMock()
     vector.embedding_model = route.model
     vector.get_stats.return_value = {"total_documents": 3}
+    authorization = object()
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
     ) as cls:
-        errors = ServerContext.validate_views(manifest, views={"vector"})
+        errors = ServerContext.validate_views(
+            manifest,
+            views={"vector"},
+            native_index_authorization=authorization,
+        )
 
     assert errors == {}
     assert "api_key" not in cls.call_args.kwargs
     assert cls.call_args.kwargs["embedding"].dimension == 1536
-    vector.load.assert_called_once_with()
+    vector.load.assert_called_once_with(
+        native_index_authorization=authorization,
+    )
     vector.close.assert_called_once_with()
 
 
@@ -506,12 +900,17 @@ def test_validate_views_rejects_empty_vector_artifact(tmp_path: Path) -> None:
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 0}
+    authorization = object()
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
     ):
-        errors = ServerContext.validate_views(manifest, views={"vector"})
+        errors = ServerContext.validate_views(
+            manifest,
+            views={"vector"},
+            native_index_authorization=authorization,
+        )
 
     assert errors == {"vector": "vector index contains no documents"}
     vector.close.assert_called_once_with()

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -15,7 +15,13 @@ import pytest
 
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import (
+    capture_authenticated_vector_view,
+)
 from codenib.mcp.context import RUNTIME_VIEW_NAMES, ServerContext
+from codenib.native_index_authorization import (
+    _mint_trusted_local_admin_authorization,
+)
 from codenib.provider_routes import resolve_inference_route
 from codenib.source_fingerprint import (
     capture_repository_source,
@@ -34,6 +40,47 @@ class _PendingSourceOwner:
 
     def close(self) -> None:
         self.closed = True
+
+
+def _authorize_test_vector(vector_dir: Path, semantic_contract):
+    with capture_authenticated_vector_view(vector_dir) as vector_view:
+        return _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "mcp-context-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+
+
+def _portable_vector_manifest(tmp_path: Path) -> tuple[RepoManifest, Path]:
+    vector_dir = tmp_path / "portable-vector"
+    vector_dir.mkdir()
+    config = {
+        "embedding_model": "test-model",
+        "embedding_provider": "huggingface",
+        "embedding_dimension": 4,
+        "dimension": 4,
+        "embedding_kwargs": {},
+    }
+    return (
+        RepoManifest(
+            repo_path=str(tmp_path),
+            indexes={
+                "vector": IndexEntry(
+                    index_type="vector",
+                    path=str(vector_dir),
+                    built_at="2026-08-11T00:00:00Z",
+                    built_at_epoch=0.0,
+                    status="fresh",
+                    config=config,
+                )
+            },
+        ),
+        vector_dir,
+    )
 
 
 def test_server_context_rejects_mismatched_source_authority(tmp_path: Path) -> None:
@@ -485,6 +532,92 @@ def test_empty_portable_artifact_context_stays_native_view_inert(
         ctx.load_views({"symbol_graph"})
 
 
+@pytest.mark.parametrize("origin", ["plain", "binding"])
+def test_portable_artifact_eager_load_rejects_exact_native_authority_before_parser(
+    tmp_path: Path,
+    origin: str,
+) -> None:
+    manifest, vector_dir = _portable_vector_manifest(tmp_path)
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
+    origin_kwargs = (
+        {"artifact": {"schema": "codenib.context-artifact.v1"}}
+        if origin == "plain"
+        else {"artifact_binding": MagicMock()}
+    )
+
+    with (
+        patch("codenib.mcp.context.require_authorized_vector_view") as exact_gate,
+        patch(
+            "codenib.index.embedding.vector_store.CodeVectorStore"
+        ) as vector_constructor,
+        patch("codenib.index.embedding.vector_store.faiss.read_index") as faiss_parser,
+        patch(
+            "codenib.index.embedding.vector_store.compat_pickle.load"
+        ) as pickle_parser,
+    ):
+        with pytest.raises(
+            ValueError,
+            match="portable artifact contexts cannot authorize native vector",
+        ):
+            ServerContext.load(
+                manifest,
+                views={"vector"},
+                native_index_authorization=authorization,
+                **origin_kwargs,
+            )
+
+    exact_gate.assert_not_called()
+    vector_constructor.assert_not_called()
+    faiss_parser.assert_not_called()
+    pickle_parser.assert_not_called()
+
+
+def test_plain_portable_artifact_lazy_load_stays_inert_with_exact_authority(
+    tmp_path: Path,
+) -> None:
+    manifest, vector_dir = _portable_vector_manifest(tmp_path)
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
+    context = ServerContext.load(
+        manifest,
+        views=(),
+        artifact={"schema": "codenib.context-artifact.v1"},
+    )
+
+    with (
+        patch("codenib.mcp.context.require_authorized_vector_view") as exact_gate,
+        patch(
+            "codenib.index.embedding.vector_store.CodeVectorStore"
+        ) as vector_constructor,
+        patch("codenib.index.embedding.vector_store.faiss.read_index") as faiss_parser,
+        patch(
+            "codenib.index.embedding.vector_store.compat_pickle.load"
+        ) as pickle_parser,
+    ):
+        with pytest.raises(
+            ValueError,
+            match="portable artifact contexts cannot authorize native parsing",
+        ):
+            context.load_views(
+                {"vector"},
+                native_index_authorization=authorization,
+            )
+
+        assert context._native_index_authorization is None
+        errors = context.load_views({"vector"})
+
+    assert "external authorization" in errors["vector"]
+    exact_gate.assert_not_called()
+    vector_constructor.assert_not_called()
+    faiss_parser.assert_not_called()
+    pickle_parser.assert_not_called()
+
+
 def test_load_views_adds_resources_idempotently(
     manifest_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -674,7 +807,10 @@ def test_load_vector_accepts_compiler_manifest_identity(tmp_path: Path) -> None:
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 3}
-    authorization = object()
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
@@ -735,7 +871,10 @@ def test_validate_views_probes_vector_without_loading_embedding_model(
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 3}
-    authorization = object()
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
@@ -797,7 +936,10 @@ def test_load_vector_rebinds_openai_credential_without_persisting_it(
     vector = MagicMock()
     vector.embedding_model = route.model
     vector.get_stats.return_value = {"total_documents": 3}
-    authorization = object()
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
         return_value=vector,
@@ -856,7 +998,10 @@ def test_validate_views_does_not_require_remote_embedding_credentials(
     vector = MagicMock()
     vector.embedding_model = route.model
     vector.get_stats.return_value = {"total_documents": 3}
-    authorization = object()
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",
@@ -900,7 +1045,10 @@ def test_validate_views_rejects_empty_vector_artifact(tmp_path: Path) -> None:
     vector = MagicMock()
     vector.embedding_model = "test-model"
     vector.get_stats.return_value = {"total_documents": 0}
-    authorization = object()
+    authorization = _authorize_test_vector(
+        vector_dir,
+        manifest.indexes["vector"].config,
+    )
 
     with patch(
         "codenib.index.embedding.vector_store.CodeVectorStore",

--- a/test/mcp_server/test_source_tool.py
+++ b/test/mcp_server/test_source_tool.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import errno
 import json
 import os
 import subprocess
@@ -12,11 +14,14 @@ from types import SimpleNamespace
 
 import pytest
 
+import codenib.artifacts.runtime as artifact_runtime_module
 import codenib.mcp.server as server_module
-from codenib.compiler.manifest import RepoManifest
+import codenib.source_fingerprint as source_fingerprint_module
+from codenib._contained_source import read_repository_file
+from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.mcp.tools._validation import MAX_SOURCE_CONTENT_CHARS
 from codenib.mcp.tools.source import read_source_impl
-from codenib.source_fingerprint import fingerprint_repository
+from codenib.source_fingerprint import RepositorySourceBinding, fingerprint_repository
 
 
 def _context(repo: Path, *, verified: bool = True):
@@ -26,12 +31,18 @@ def _context(repo: Path, *, verified: bool = True):
         source_fingerprint="sha256:" + "b" * 64,
         languages=["python"],
     )
-    return SimpleNamespace(
+    context = SimpleNamespace(
         manifest=manifest,
         artifact={"repository": "example/project"},
         source_verified=verified,
-        source_error=None if verified else "checkout drifted",
+        source_error=None if verified else "source content drifted",
     )
+    context.read_source_bytes = lambda relative, max_bytes: read_repository_file(
+        repo,
+        relative,
+        max_bytes=max_bytes,
+    )
+    return context
 
 
 def test_read_source_returns_bounded_verified_window(tmp_path: Path) -> None:
@@ -50,6 +61,9 @@ def test_read_source_returns_bounded_verified_window(tmp_path: Path) -> None:
         "commit": "a" * 40,
         "source_fingerprint": "sha256:" + "b" * 64,
         "verified": True,
+        "verification_scope": "content-bytes",
+        "commit_verified": False,
+        "checkout_state": "not-attested",
     }
 
 
@@ -68,7 +82,7 @@ def test_read_source_rejects_noncanonical_paths(
         read_source_impl(_context(tmp_path), file_path)
 
 
-def test_read_source_rejects_absolute_symlinks_and_nonregular_files(
+def test_read_source_accepts_absolute_contained_symlink_and_rejects_nonregular(
     tmp_path: Path,
 ) -> None:
     source = tmp_path / "source.py"
@@ -76,8 +90,9 @@ def test_read_source_rejects_absolute_symlinks_and_nonregular_files(
     (tmp_path / "link.py").symlink_to(source)
     (tmp_path / "folder").mkdir()
 
-    with pytest.raises(ValueError, match="readable regular"):
-        read_source_impl(_context(tmp_path), "link.py")
+    assert read_source_impl(_context(tmp_path), "link.py", 1, 1)["content"] == (
+        "value = 1\n"
+    )
     with pytest.raises(ValueError, match="readable regular"):
         read_source_impl(_context(tmp_path), "folder")
 
@@ -139,10 +154,10 @@ def test_read_source_rejects_invalid_windows(
         read_source_impl(_context(tmp_path), "source.py", start, end)
 
 
-def test_read_source_requires_verified_checkout(tmp_path: Path) -> None:
+def test_read_source_requires_content_authenticated_binding(tmp_path: Path) -> None:
     (tmp_path / "source.py").write_text("value = 1\n", encoding="utf-8")
 
-    with pytest.raises(RuntimeError, match="checkout drifted"):
+    with pytest.raises(RuntimeError, match="source content drifted"):
         read_source_impl(_context(tmp_path, verified=False), "source.py")
 
 
@@ -198,10 +213,387 @@ def test_init_server_disables_source_reads_after_checkout_drift(
 
     server_module.init_server(manifest_path)
     assert server_module.get_context().source_verified is True
+    initial_manifest = asyncio.run(server_module.get_manifest())
+    assert initial_manifest["runtime"]["source_read"] == {
+        "verified": True,
+        "error": None,
+        "verification_scope": "content-bytes",
+        "commit_verified": False,
+        "checkout_state": "not-attested",
+    }
 
     source.write_text("value = 2\n", encoding="utf-8")
+    runtime_manifest = asyncio.run(server_module.get_manifest())
+    assert runtime_manifest["runtime"]["source_read"]["verified"] is False
+    assert runtime_manifest["runtime"]["source_read"]["verification_scope"] is None
+    assert runtime_manifest["runtime"]["source_read"]["commit_verified"] is False
+    assert (
+        runtime_manifest["runtime"]["source_read"]["checkout_state"] == "not-attested"
+    )
+    assert server_module.get_context().source_verified is False
+    assert "inventory changed" in str(
+        runtime_manifest["runtime"]["source_read"]["error"]
+    )
+
     server_module.init_server(manifest_path)
 
     ctx = server_module.get_context()
     assert ctx.source_verified is False
     assert "do not match the indexed content" in str(ctx.source_error)
+
+
+def test_init_server_capture_return_cancellation_closes_preowned_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+    captured: list[RepositorySourceBinding] = []
+    real_capture = source_fingerprint_module.capture_repository_source
+    interruption = KeyboardInterrupt("injected after MCP source capture returned")
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        raise interruption
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        capture,
+    )
+    monkeypatch.setattr(server_module, "_ctx", None)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        server_module.init_server(manifest_path)
+
+    assert caught.value is interruption
+    assert len(captured) == 1
+    assert captured[0].closed
+    assert server_module._ctx is None
+
+
+def test_init_server_persistent_close_eio_preserves_primary_and_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source_path = repo / "source.py"
+    source_path.write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+    source_path.write_text("value = 2\n", encoding="utf-8")
+    captured: list[RepositorySourceBinding] = []
+    real_capture = source_fingerprint_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+
+    def capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        return source
+
+    def persistent_eio(source: RepositorySourceBinding) -> None:
+        if source in captured:
+            raise OSError(errno.EIO, "injected MCP source close EIO")
+        real_close(source)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        capture,
+    )
+    monkeypatch.setattr(RepositorySourceBinding, "close", persistent_eio)
+    monkeypatch.setattr(server_module, "_ctx", None)
+    with pytest.raises(ValueError, match="do not match the indexed content") as caught:
+        server_module.init_server(manifest_path)
+
+    assert len(captured) == 1
+    owner = caught.value.source_cleanup_owner
+    assert owner.pending_sources == (captured[0],)
+    assert not captured[0].closed
+    assert server_module._ctx is None
+
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    owner.close()
+    assert owner.closed
+    assert captured[0].closed
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(
+            KeyboardInterrupt("cleanup closed then interrupted"), id="keyboard"
+        ),
+        pytest.param(SystemExit("cleanup closed then exited"), id="system-exit"),
+    ],
+)
+def test_init_server_propagates_cleanup_cancellation_after_owner_is_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+    real_capture = source_fingerprint_module.capture_repository_source
+    real_owner_close = artifact_runtime_module.SourceBindingCleanupOwner.close
+    injected = False
+
+    def fail_capture(*args, **kwargs):
+        real_capture(*args, **kwargs)
+        raise ValueError("injected capture primary")
+
+    def close_then_interrupt(owner) -> None:
+        nonlocal injected
+        real_owner_close(owner)
+        if not injected:
+            injected = True
+            raise interruption
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        fail_capture,
+    )
+    monkeypatch.setattr(
+        artifact_runtime_module.SourceBindingCleanupOwner,
+        "close",
+        close_then_interrupt,
+    )
+    previous_context = SimpleNamespace(marker="previous")
+    monkeypatch.setattr(server_module, "_ctx", previous_context)
+
+    with pytest.raises(type(interruption)) as caught:
+        server_module.init_server(manifest_path)
+
+    assert caught.value is interruption
+    assert server_module._ctx is previous_context
+
+
+def test_init_server_primary_cancellation_wins_and_retains_eio_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+    real_capture = source_fingerprint_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+    captured: list[RepositorySourceBinding] = []
+    primary = KeyboardInterrupt("injected capture cancellation")
+
+    def interrupt_capture(*args, **kwargs):
+        source = real_capture(*args, **kwargs)
+        captured.append(source)
+        raise primary
+
+    def persistent_eio(source: RepositorySourceBinding) -> None:
+        if source in captured:
+            raise OSError(errno.EIO, "injected cleanup EIO")
+        real_close(source)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        interrupt_capture,
+    )
+    monkeypatch.setattr(RepositorySourceBinding, "close", persistent_eio)
+    previous_context = SimpleNamespace(marker="previous")
+    monkeypatch.setattr(server_module, "_ctx", previous_context)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        server_module.init_server(manifest_path)
+
+    assert caught.value is primary
+    owner = caught.value.source_cleanup_owner
+    assert owner.pending_sources == (captured[0],)
+    assert server_module._ctx is previous_context
+
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    owner.close()
+    assert owner.closed
+
+
+def test_init_server_does_not_downgrade_capture_error_with_nested_pending_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+
+    class PendingOwner:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    pending = PendingOwner()
+    primary = ValueError("capture failed with partial owner")
+    primary.source_cleanup_owner = pending  # type: ignore[attr-defined]
+
+    def fail_capture(*_args, **_kwargs):
+        raise primary
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        fail_capture,
+    )
+    previous_context = SimpleNamespace(marker="previous")
+    monkeypatch.setattr(server_module, "_ctx", previous_context)
+
+    with pytest.raises(ValueError) as caught:
+        server_module.init_server(manifest_path)
+
+    assert caught.value is primary
+    assert caught.value.source_cleanup_owner is pending
+    assert server_module._ctx is previous_context
+    pending.close()
+
+
+def test_init_server_attaches_nested_owner_to_actual_cleanup_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    fingerprint = fingerprint_repository(repo)
+    manifest_path = tmp_path / "repo_manifest.json"
+    RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint.value,
+        file_count=fingerprint.file_count,
+        languages=["python"],
+    ).save(manifest_path)
+
+    class PendingOwner:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    pending = PendingOwner()
+    primary = ValueError("capture failed with partial owner")
+    primary.source_cleanup_owner = pending  # type: ignore[attr-defined]
+    interruption = SystemExit("cleanup cancellation")
+    real_owner_close = artifact_runtime_module.SourceBindingCleanupOwner.close
+    injected = False
+
+    def fail_capture(*_args, **_kwargs):
+        raise primary
+
+    def interrupt_empty_owner(owner) -> None:
+        nonlocal injected
+        real_owner_close(owner)
+        if not injected:
+            injected = True
+            raise interruption
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        fail_capture,
+    )
+    monkeypatch.setattr(
+        artifact_runtime_module.SourceBindingCleanupOwner,
+        "close",
+        interrupt_empty_owner,
+    )
+    previous_context = SimpleNamespace(marker="previous")
+    monkeypatch.setattr(server_module, "_ctx", previous_context)
+
+    with pytest.raises(SystemExit) as caught:
+        server_module.init_server(manifest_path)
+
+    assert caught.value is interruption
+    assert caught.value.source_cleanup_owner is pending
+    assert server_module._ctx is previous_context
+    pending.close()
+
+
+def test_init_server_never_treats_explicit_legacy_identity_as_verified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_fingerprint = "sha256:" + "a" * 64
+    manifest = RepoManifest(
+        repo_path="/unavailable",
+        source_fingerprint=legacy_fingerprint,
+        indexes={
+            "vector": IndexEntry(
+                index_type="vector",
+                path="/must-not-be-read/vector",
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=0.0,
+                status="fresh",
+                source_fingerprint=legacy_fingerprint,
+            )
+        },
+    )
+    from codenib import native_index_authorization
+    from codenib.index.embedding import artifact_integrity
+
+    capture_calls: list[str] = []
+    mint_calls: list[str] = []
+    monkeypatch.setattr(
+        artifact_integrity,
+        "capture_authenticated_vector_view",
+        lambda _path: capture_calls.append("capture"),
+    )
+    monkeypatch.setattr(
+        native_index_authorization,
+        "_mint_trusted_local_admin_authorization",
+        lambda *_args, **_kwargs: mint_calls.append("mint"),
+    )
+    monkeypatch.setattr(server_module, "_ctx", None)
+
+    server_module.init_server(manifest)
+
+    ctx = server_module.get_context()
+    assert ctx.source_verified is False
+    assert "source binding has not been verified" in str(ctx.source_error)
+    assert ctx.vector is None
+    assert "external authorization" in ctx.errors["vector"]
+    assert capture_calls == []
+    assert mint_calls == []

--- a/test/mcp_server/test_source_tool.py
+++ b/test/mcp_server/test_source_tool.py
@@ -68,16 +68,46 @@ def test_read_source_rejects_noncanonical_paths(
         read_source_impl(_context(tmp_path), file_path)
 
 
-def test_read_source_rejects_symlinks_and_nonregular_files(tmp_path: Path) -> None:
+def test_read_source_rejects_absolute_symlinks_and_nonregular_files(
+    tmp_path: Path,
+) -> None:
     source = tmp_path / "source.py"
     source.write_text("value = 1\n", encoding="utf-8")
     (tmp_path / "link.py").symlink_to(source)
     (tmp_path / "folder").mkdir()
 
-    with pytest.raises(ValueError, match="symbolic link"):
+    with pytest.raises(ValueError, match="readable regular"):
         read_source_impl(_context(tmp_path), "link.py")
     with pytest.raises(ValueError, match="readable regular"):
         read_source_impl(_context(tmp_path), "folder")
+
+
+def test_read_source_accepts_relative_symlink_contained_in_repository(
+    tmp_path: Path,
+) -> None:
+    real = tmp_path / "real" / "source.py"
+    real.parent.mkdir()
+    real.write_text("contained = True\n", encoding="utf-8")
+    (tmp_path / "alias.py").symlink_to("real/source.py")
+
+    result = read_source_impl(_context(tmp_path), "alias.py", 1, 1)
+
+    assert result["content"] == "contained = True\n"
+
+
+def test_read_source_accepts_contained_intermediate_symlink_with_parent(
+    tmp_path: Path,
+) -> None:
+    real = tmp_path / "real" / "source.py"
+    real.parent.mkdir()
+    real.write_text("contained = True\n", encoding="utf-8")
+    links = tmp_path / "links"
+    links.mkdir()
+    (links / "package").symlink_to("../real", target_is_directory=True)
+
+    result = read_source_impl(_context(tmp_path), "links/package/source.py", 1, 1)
+
+    assert result["content"] == "contained = True\n"
 
 
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="POSIX FIFO required")

--- a/test/model/test_embedding_model_loading.py
+++ b/test/model/test_embedding_model_loading.py
@@ -73,6 +73,54 @@ def test_embedding_pipeline_rejects_huggingface_options_for_remote_provider(
         raise AssertionError("expected provider-specific options to be rejected")
 
 
+def test_embedding_pipeline_forwards_authority_to_cache_builder(
+    monkeypatch,
+    tmp_path,
+):
+    from codenib.model import embedding_retrieve_pipeline as module
+
+    calls = []
+    store = object()
+    authorization = object()
+    monkeypatch.setattr(
+        module,
+        "build_hierarchical_vector_store",
+        lambda **kwargs: calls.append(kwargs) or store,
+    )
+
+    pipeline = module.EmbeddingRetrievePipeline(
+        repo_path=str(tmp_path),
+        index_path=str(tmp_path / "index"),
+        native_index_authorization=authorization,
+    )
+
+    assert pipeline.vector_store is store
+    assert calls[0]["native_index_authorization"] is authorization
+
+
+def test_embedding_pipeline_hot_swap_forwards_exact_authority():
+    from codenib.model import embedding_retrieve_pipeline as module
+
+    calls = []
+    authorization = object()
+    pipeline = object.__new__(module.EmbeddingRetrievePipeline)
+    pipeline.vector_store = SimpleNamespace(
+        swap_index=lambda path, **kwargs: calls.append((path, kwargs))
+    )
+
+    pipeline.load_index(
+        "/idx/vector",
+        native_index_authorization=authorization,
+    )
+
+    assert calls == [
+        (
+            "/idx/vector",
+            {"native_index_authorization": authorization},
+        )
+    ]
+
+
 def test_retrieve_rerank_pipeline_preserves_embedding_model_policy():
     from codenib.model.retrieve_rerank_pipeline import RetrieveRerankPipeline
 

--- a/test/model/test_embedding_model_loading.py
+++ b/test/model/test_embedding_model_loading.py
@@ -180,14 +180,17 @@ def test_hybrid_pipeline_forwards_model_policy(monkeypatch, tmp_path):
     monkeypatch.setattr(module, "build_skill_contexts", fake_build_skill_contexts)
     monkeypatch.setattr(SkillLoader, "load_all", lambda *args, **kwargs: [])
     revision = "e" * 40
+    authorization = object()
 
     module.HybridRetrievePipeline(
         repo_path=str(tmp_path),
         embedding_model="vendor/custom-model",
         embedding_revision=revision,
         trust_remote_code=True,
+        native_index_authorization=authorization,
     )
 
     [kwargs] = calls
     assert kwargs["embedding_revision"] == revision
     assert kwargs["trust_remote_code"] is True
+    assert kwargs["native_index_authorization"] is authorization

--- a/test/model/test_retrieve_pipeline_indexer_routing.py
+++ b/test/model/test_retrieve_pipeline_indexer_routing.py
@@ -120,6 +120,7 @@ def test_graph_pipeline_routes_languages_to_graph_builder_and_rerank(
 
     repo_path = str(tmp_path / "repo")
     index_path = str(tmp_path / "index")
+    authorization = object()
     pipeline = pipeline_module.GraphRetrievePipeline(
         repo_path=repo_path,
         index_path=index_path,
@@ -130,6 +131,7 @@ def test_graph_pipeline_routes_languages_to_graph_builder_and_rerank(
         languages=["rust", "python"],
         graph_route="scip-candidate",
         project_name="repo__case",
+        native_index_authorization=authorization,
     )
 
     assert graph_calls == [
@@ -156,6 +158,7 @@ def test_graph_pipeline_routes_languages_to_graph_builder_and_rerank(
         "revision": "f" * 40,
         "trust_remote_code": True,
     }
+    assert vector_call["native_index_authorization"] is authorization
 
 
 def test_graph_retrieve_pipeline_name_is_sparse_seeded_alias():
@@ -264,12 +267,27 @@ def test_retrieve_rerank_authorized_cache_loads_without_rebuild(
     monkeypatch,
     tmp_path,
 ):
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
     from codenib.model import retrieve_rerank_pipeline as pipeline_module
+    from codenib.native_index_authorization import (
+        _mint_trusted_local_admin_authorization,
+    )
 
     index = tmp_path / "index"
     index.mkdir()
     (index / "config_model.json").write_text("{}", encoding="utf-8")
-    authorization = object()
+    with capture_authenticated_vector_view(index) as vector_view:
+        authorization = _mint_trusted_local_admin_authorization(
+            vector_view.ownership,
+            view_type="vector",
+            semantic_contract={},
+            evidence=(
+                "retrieve-cache-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
     loads = []
 
     class FakeVectorStore:

--- a/test/model/test_retrieve_pipeline_indexer_routing.py
+++ b/test/model/test_retrieve_pipeline_indexer_routing.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 
 def make_fake_graph_builder(calls):
     def fake_build_graph_for_languages(
@@ -209,3 +211,98 @@ def test_retrieve_rerank_cache_miss_reuses_loaded_embedding(monkeypatch, tmp_pat
     assert result is built_store
     assert len(builder_calls) == 1
     assert builder_calls[0]["embedding"] is embedding
+
+
+def test_retrieve_rerank_cache_without_authority_forces_source_rebuild(
+    monkeypatch,
+    tmp_path,
+):
+    from codenib.model import retrieve_rerank_pipeline as pipeline_module
+
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "config_model.json").write_text("{}", encoding="utf-8")
+    built_store = object()
+    builder_calls = []
+
+    class FakeVectorStore:
+        def __init__(self, **_kwargs):
+            self.embedding = object()
+
+        def load(self, *_args, **_kwargs):
+            raise AssertionError("unauthorized cache must not be loaded")
+
+    monkeypatch.setattr(pipeline_module, "CodeVectorStore", FakeVectorStore)
+    monkeypatch.setattr(
+        pipeline_module,
+        "build_hierarchical_vector_store",
+        lambda **kwargs: builder_calls.append(kwargs) or built_store,
+    )
+    pipeline = object.__new__(pipeline_module.RetrieveRerankPipeline)
+    pipeline.repo_path = str(tmp_path)
+    pipeline.index_path = index
+    pipeline.retrieval_level = "l2"
+    pipeline.languages = ["python"]
+    pipeline.max_lines_per_chunk = 300
+    pipeline.index_metric = "ip"
+    pipeline.profiler = None
+    pipeline._native_index_authorization = None
+
+    result = pipeline._initialize_vector_store(
+        embedding_model="model",
+        embedding_provider="huggingface",
+        embedding_dimension=4,
+        embedding_kwargs={},
+    )
+
+    assert result is built_store
+    assert builder_calls[0]["force_rebuild"] is True
+    assert builder_calls[0]["native_index_authorization"] is None
+
+
+def test_retrieve_rerank_authorized_cache_loads_without_rebuild(
+    monkeypatch,
+    tmp_path,
+):
+    from codenib.model import retrieve_rerank_pipeline as pipeline_module
+
+    index = tmp_path / "index"
+    index.mkdir()
+    (index / "config_model.json").write_text("{}", encoding="utf-8")
+    authorization = object()
+    loads = []
+
+    class FakeVectorStore:
+        def __init__(self, **_kwargs):
+            self.embedding = object()
+            self.l0_documents = [object()]
+            self.l2_documents = [object()]
+
+        def load(self, path, *, native_index_authorization):
+            loads.append((path, native_index_authorization))
+
+    monkeypatch.setattr(pipeline_module, "CodeVectorStore", FakeVectorStore)
+    monkeypatch.setattr(
+        pipeline_module,
+        "build_hierarchical_vector_store",
+        lambda **_kwargs: pytest.fail("authorized complete cache must be reused"),
+    )
+    pipeline = object.__new__(pipeline_module.RetrieveRerankPipeline)
+    pipeline.repo_path = str(tmp_path)
+    pipeline.index_path = index
+    pipeline.retrieval_level = "l2"
+    pipeline.languages = ["python"]
+    pipeline.max_lines_per_chunk = 300
+    pipeline.index_metric = "ip"
+    pipeline.profiler = None
+    pipeline._native_index_authorization = authorization
+
+    result = pipeline._initialize_vector_store(
+        embedding_model="model",
+        embedding_provider="huggingface",
+        embedding_dimension=4,
+        embedding_kwargs={},
+    )
+
+    assert isinstance(result, FakeVectorStore)
+    assert loads == [(str(index), authorization)]

--- a/test/sandbox/test_docker.py
+++ b/test/sandbox/test_docker.py
@@ -7,12 +7,15 @@ from __future__ import annotations
 import io
 import json
 import os
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
 from codenib.sandbox import (
     DockerSandboxProvider,
     ExecRequest,
@@ -25,10 +28,17 @@ from codenib.sandbox import (
     SandboxSpec,
     SandboxUnavailableError,
 )
-from codenib.sandbox.docker import _normalize_no_index_patch
+from codenib.sandbox.docker import _FINGERPRINT_SOURCE_SCRIPT, _normalize_no_index_patch
+from codenib.source_fingerprint import (
+    SOURCE_FINGERPRINT_VERSION,
+    RepositoryChangedError,
+    fingerprint_repository,
+)
 
 DIGEST = "sha256:" + "a" * 64
 IMAGE = f"registry.example/codenib-agent@{DIGEST}"
+SOURCE_FINGERPRINT = "sha256-v2:" + "e" * 64
+TEST_DOCKER_BINARY = str(Path(sys.executable).resolve(strict=True))
 
 
 class RecordingCLI:
@@ -72,7 +82,7 @@ class RecordingCLI:
             stdout = json.dumps(
                 {
                     "file_count": 2,
-                    "source_fingerprint": "sha256:" + "e" * 64,
+                    "source_fingerprint": SOURCE_FINGERPRINT,
                 }
             )
         else:
@@ -124,6 +134,115 @@ class HangingProcess(FinishedProcess):
             returncode=None,
             **kwargs,
         )
+
+
+def test_container_fingerprint_helper_matches_host_v2_framing(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    baseline = tmp_path / "baseline"
+    source.mkdir()
+    (source / "a").write_bytes(b"")
+    (source / "b").write_bytes(b"X\0F\0c\0Y")
+    (source / "package").mkdir()
+    (source / "package" / "module.py").write_bytes(b"VALUE = 1\n")
+    try:
+        (source / "relative-link").symlink_to("b")
+        (source / "absolute-link").symlink_to(source / "b")
+        (source / "relative-directory-link").symlink_to("package")
+        (source / "absolute-directory-link").symlink_to(source / "package")
+        (source / "relative-root-link").symlink_to(".", target_is_directory=True)
+        (source / "absolute-root-link").symlink_to(
+            source,
+            target_is_directory=True,
+        )
+        (source / "broken-link").symlink_to("missing")
+        (source / "loop-link").symlink_to("loop-link")
+        os.mkfifo(source / ".codenib-hidden-pipe")
+        (source / "fifo-link").symlink_to(".codenib-hidden-pipe")
+    except OSError as exc:  # pragma: no cover - platform capability
+        pytest.skip(f"source fingerprint parity needs symlink support: {exc}")
+
+    expected = fingerprint_repository(source)
+    baseline.mkdir()
+    for path in source.iterdir():
+        destination = baseline / path.name
+        if path.is_symlink():
+            destination.symlink_to(os.readlink(path))
+        elif path.name == ".codenib-hidden-pipe":
+            os.mkfifo(destination)
+        elif path.is_dir():
+            shutil.copytree(path, destination, symlinks=True)
+        else:
+            shutil.copy2(path, destination)
+    source_label = str(source)
+    source.rename(tmp_path / "source-unmounted")
+    script = _FINGERPRINT_SOURCE_SCRIPT.replace(
+        "pathlib.Path('/workspace')",
+        f"pathlib.Path({str(baseline)!r})",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            script,
+            "[]",
+            str(SOURCE_FINGERPRINT_VERSION),
+            str(REPOSITORY_FILTER_POLICY_VERSION),
+            source_label,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    observed = json.loads(completed.stdout)
+
+    assert observed == {
+        "file_count": expected.file_count,
+        "source_fingerprint": expected.value,
+    }
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_container_fingerprint_helper_rejects_outside_directory_symlink(
+    tmp_path: Path,
+    absolute: bool,
+) -> None:
+    baseline = tmp_path / "baseline"
+    outside = tmp_path / "outside"
+    baseline.mkdir()
+    outside.mkdir()
+    (baseline / "outside-link").symlink_to(
+        outside if absolute else "../outside",
+        target_is_directory=True,
+    )
+    with pytest.raises(RepositoryChangedError):
+        fingerprint_repository(baseline)
+
+    script = _FINGERPRINT_SOURCE_SCRIPT.replace(
+        "pathlib.Path('/workspace')",
+        f"pathlib.Path({str(baseline)!r})",
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            script,
+            "[]",
+            str(SOURCE_FINGERPRINT_VERSION),
+            str(REPOSITORY_FILTER_POLICY_VERSION),
+            str(baseline),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "outside the repository" in completed.stderr
 
 
 def _spec(tmp_path: Path, *, limits=None):
@@ -193,7 +312,7 @@ def _git_repo(tmp_path: Path) -> tuple[Path, str]:
 
 def test_create_replays_default_security_flags(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     session = _provider(tmp_path, cli).create(_spec(tmp_path))
@@ -244,7 +363,7 @@ def test_create_rejects_symlinked_source_path(tmp_path):
 
 def test_agent_command_is_after_image_and_uses_non_root_user(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     processes = []
@@ -276,7 +395,7 @@ def test_write_file_enables_interactive_stdin_and_isolates_helper(
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     processes = []
@@ -305,7 +424,7 @@ def test_write_file_enables_interactive_stdin_and_isolates_helper(
 
 def test_read_file_uses_isolated_python_and_read_only_mount(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     processes = []
@@ -333,7 +452,7 @@ def test_read_file_uses_isolated_python_and_read_only_mount(monkeypatch, tmp_pat
 
 def test_file_byte_limit_zero_fails_instead_of_using_default(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     session = _provider(tmp_path, RecordingCLI()).create(_spec(tmp_path))
 
@@ -345,7 +464,7 @@ def test_file_byte_limit_zero_fails_instead_of_using_default(monkeypatch, tmp_pa
 
 def test_host_secrets_are_not_forwarded(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     monkeypatch.setenv("GITHUB_TOKEN", "do-not-forward")
     monkeypatch.setenv("OPENAI_API_KEY", "do-not-forward")
@@ -372,7 +491,7 @@ def test_host_secrets_are_not_forwarded(monkeypatch, tmp_path):
         "PATH": "/usr/bin:/bin",
     }
     assert processes[0][0][:3] == [
-        "/usr/bin/docker",
+        TEST_DOCKER_BINARY,
         "--host",
         f"unix:///run/user/{os.getuid()}/docker.sock",
     ]
@@ -381,7 +500,7 @@ def test_host_secrets_are_not_forwarded(monkeypatch, tmp_path):
 
 def test_revision_snapshot_archives_git_objects_not_worktree(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     source, revision = _git_repo(tmp_path)
     spec = SandboxSpec(
@@ -406,7 +525,7 @@ def test_revision_snapshot_archives_git_objects_not_worktree(monkeypatch, tmp_pa
     assert "dst=/repository.git,readonly" in rendered
     assert f"type=bind,src={source},dst=/source" not in rendered
     assert revision in archive_call
-    assert session.metadata.source_fingerprint == "sha256:" + "e" * 64
+    assert session.metadata.source_fingerprint == SOURCE_FINGERPRINT
     created = json.loads(
         (session.audit_dir / "events.jsonl").read_text().splitlines()[0]
     )
@@ -418,7 +537,7 @@ def test_revision_snapshot_archives_git_objects_not_worktree(monkeypatch, tmp_pa
 
 def test_revision_snapshot_rejects_submodules(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     source, first_revision = _git_repo(tmp_path)
     subprocess.run(
@@ -467,7 +586,7 @@ def test_revision_snapshot_rejects_submodules(monkeypatch, tmp_path):
 
 def test_revision_snapshot_rejects_tracked_symlinks(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     source, _ = _git_repo(tmp_path)
     os.symlink("tracked.txt", source / "tracked-link")
@@ -507,7 +626,7 @@ def test_revision_snapshot_rejects_tracked_symlinks(monkeypatch, tmp_path):
 
 def test_revision_snapshot_rejects_archive_mutating_attributes(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     source, _ = _git_repo(tmp_path)
     (source / ".gitattributes").write_text(
@@ -549,7 +668,7 @@ def test_revision_snapshot_rejects_archive_mutating_attributes(monkeypatch, tmp_
 
 def test_revision_snapshot_requires_repository_top_level(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     source, revision = _git_repo(tmp_path)
     subdirectory = source / "nested"
@@ -568,7 +687,7 @@ def test_revision_snapshot_requires_repository_top_level(monkeypatch, tmp_path):
 
 def test_non_rootless_daemon_fails_before_volume_creation(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI(rootless=False)
 
@@ -582,7 +701,7 @@ def test_non_rootless_daemon_fails_before_volume_creation(monkeypatch, tmp_path)
 
 def test_image_declared_volume_fails_closed(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI(
         image_overrides={"Config": {"Env": [], "Volumes": {"/data": {}}}}
@@ -594,7 +713,7 @@ def test_image_declared_volume_fails_closed(monkeypatch, tmp_path):
 
 def test_timeout_kills_and_removes_container(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     process = None
@@ -625,7 +744,7 @@ def test_timeout_kills_and_removes_container(monkeypatch, tmp_path):
 
 def test_output_limit_is_hard_and_audited(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
 
@@ -646,7 +765,7 @@ def test_output_limit_is_hard_and_audited(monkeypatch, tmp_path):
 
 def test_model_preview_budget_is_shared_across_stdout_and_stderr(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
 
     def popen(argv, **kwargs):
@@ -671,7 +790,7 @@ def test_model_preview_budget_is_shared_across_stdout_and_stderr(monkeypatch, tm
 
 def test_diff_output_limit_fails_without_returning_partial_patch(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
 
     def popen(argv, **kwargs):
@@ -690,7 +809,7 @@ def test_diff_output_limit_fails_without_returning_partial_patch(monkeypatch, tm
 
 def test_timeout_cleanup_failure_poisons_session(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
 
     class FailingCleanupCLI(RecordingCLI):
@@ -727,7 +846,7 @@ def test_timeout_cleanup_failure_poisons_session(monkeypatch, tmp_path):
 
 def test_close_is_idempotent_and_removes_both_volumes(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     cli = RecordingCLI()
     session = _provider(tmp_path, cli).create(_spec(tmp_path))
@@ -745,7 +864,7 @@ def test_close_is_idempotent_and_removes_both_volumes(monkeypatch, tmp_path):
 
 def test_close_remains_closed_when_final_audit_write_fails(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     session = _provider(tmp_path, RecordingCLI()).create(_spec(tmp_path))
     original_record = session._record_audit
@@ -765,7 +884,7 @@ def test_close_remains_closed_when_final_audit_write_fails(monkeypatch, tmp_path
 @pytest.mark.parametrize("failed_phase", ["command_started", "command_finished"])
 def test_command_audit_failure_poisons_session(monkeypatch, tmp_path, failed_phase):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     session = _provider(tmp_path, RecordingCLI()).create(_spec(tmp_path))
     original_record = session._record_audit
@@ -787,7 +906,7 @@ def test_artifact_bundle_size_is_bounded_and_partial_file_removed(
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     provider = _provider(tmp_path, RecordingCLI())
     session = provider.create(_spec(tmp_path))
@@ -818,7 +937,7 @@ def test_artifact_bundle_size_is_bounded_and_partial_file_removed(
 
 def test_artifact_bundle_is_controller_private(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+        "codenib.sandbox.docker.shutil.which", lambda _: TEST_DOCKER_BINARY
     )
     provider = _provider(tmp_path, RecordingCLI())
     session = provider.create(_spec(tmp_path))

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -6,15 +6,52 @@ from __future__ import annotations
 
 import errno
 import hashlib
+import multiprocessing
 import os
-import threading
+import stat
 from pathlib import Path
+from queue import Empty
 
 import pytest
 
+import codenib._atomic_directory as atomic_module
+import codenib._owned_file_publication as owned_file_module
 import codenib.storage.cas as cas_module
 from codenib.storage.cas import LocalCAS
 from codenib.storage.models import StorageIntegrityError, StorageValidationError
+
+
+def _descriptor_count() -> int:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting requires procfs")
+    return len(os.listdir(descriptor_root))
+
+
+def _assert_bad_descriptor(descriptor: int) -> None:
+    with pytest.raises(OSError) as caught:
+        os.fstat(descriptor)
+    assert caught.value.errno == errno.EBADF
+
+
+def _exception_notes(error: BaseException) -> tuple[str, ...]:
+    return (
+        *tuple(getattr(error, "__notes__", ())),
+        *tuple(getattr(error, "_codenib_cleanup_notes", ())),
+    )
+
+
+def _put_bytes_in_process(
+    root: str,
+    payload: bytes,
+    ready: multiprocessing.Queue,
+    start: multiprocessing.Event,
+) -> None:
+    store = LocalCAS(Path(root), require_preprovisioned=True)
+    ready.put(os.getpid())
+    if not start.wait(timeout=30):
+        raise TimeoutError("CAS publication start was not released")
+    store.put_bytes(payload)
 
 
 def test_put_bytes_uses_canonical_key_and_deduplicates(tmp_path: Path) -> None:
@@ -32,6 +69,11 @@ def test_put_bytes_uses_canonical_key_and_deduplicates(tmp_path: Path) -> None:
     assert first.byte_size == len(payload)
     assert first.storage_key == f"sha256/{digest[:2]}/{digest[2:]}"
     assert stored.stat().st_ino == first_metadata.st_ino
+    assert stat.S_IMODE(stored.stat().st_mode) == 0o600
+    assert stored.stat().st_nlink == 1
+    orphans = list(stored.parent.glob(".codenib-file-*"))
+    assert len(orphans) == 1
+    assert orphans[0].read_bytes() == payload
     assert store.has(digest)
     assert store.verify(digest) == first
     assert store.read_bytes(digest) == payload
@@ -106,11 +148,11 @@ def test_existing_special_object_is_rejected(tmp_path: Path) -> None:
 
     with pytest.raises(StorageIntegrityError, match="not a regular file"):
         store.has(digest)
-    with pytest.raises(StorageIntegrityError, match="not a regular file"):
+    with pytest.raises(StorageIntegrityError, match="failed integrity"):
         store.put_bytes(payload)
 
 
-def test_failed_put_cleans_temporary_without_publishing(
+def test_failed_file_fsync_leaves_owned_stage_without_publishing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -119,16 +161,22 @@ def test_failed_put_cleans_temporary_without_publishing(
     digest = hashlib.sha256(payload).hexdigest()
     destination = store.root / "sha256" / digest[:2] / digest[2:]
 
-    def fail_link(*_args, **_kwargs):
-        raise OSError("injected publish failure")
+    real_fsync = owned_file_module.os.fsync
 
-    monkeypatch.setattr("codenib.storage.cas._link_at", fail_link)
+    def fail_file_fsync(descriptor: int) -> None:
+        if stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError(errno.EIO, "injected file fsync failure")
+        real_fsync(descriptor)
 
-    with pytest.raises(OSError, match="injected publish failure"):
+    monkeypatch.setattr(owned_file_module.os, "fsync", fail_file_fsync)
+
+    with pytest.raises(OSError, match="injected file fsync failure"):
         store.put_bytes(payload)
 
     assert not destination.exists()
-    assert list(destination.parent.glob("*.tmp")) == []
+    stages = list(destination.parent.glob(".codenib-file-*"))
+    assert len(stages) == 1
+    assert stages[0].read_bytes() == payload
 
 
 def test_materialize_atomically_replaces_regular_file(tmp_path: Path) -> None:
@@ -189,22 +237,51 @@ def test_put_file_rejects_source_changed_between_passes(
 ) -> None:
     store = LocalCAS(tmp_path / "objects")
     source = tmp_path / "source.bin"
-    source.write_bytes(b"first version")
-    real_create_temporary = cas_module._create_temporary_file
+    original = b"first version"
+    source.write_bytes(original)
+    original_digest = hashlib.sha256(original).hexdigest()
+    real_publish = LocalCAS._publish_object
 
-    def mutate_then_create(*args, **kwargs):
+    def mutate_then_publish(self, *args, **kwargs):
         source.write_bytes(b"second version with a different size")
-        return real_create_temporary(*args, **kwargs)
+        return real_publish(self, *args, **kwargs)
 
     monkeypatch.setattr(
-        "codenib.storage.cas._create_temporary_file",
-        mutate_then_create,
+        LocalCAS,
+        "_publish_object",
+        mutate_then_publish,
     )
 
     with pytest.raises(OSError, match="source changed"):
         store.put_file(source)
 
-    assert list((store.root / "sha256").rglob("*.tmp")) == []
+    destination = store.root / "sha256" / original_digest[:2] / original_digest[2:]
+    assert not destination.exists()
+    stages = list(destination.parent.glob(".codenib-file-*"))
+    assert len(stages) == 1
+
+
+def test_second_file_pass_checks_same_size_mutation_before_stop_iteration(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.bin"
+    original = b"same-size-original"
+    replacement = b"same-size-mutated!"
+    assert len(replacement) == len(original)
+    source.write_bytes(original)
+    digest, byte_size, signature = cas_module._hash_stable_file(source)
+    chunks = cas_module._stable_file_chunks(
+        source,
+        expected_signature=signature,
+        expected_digest=digest,
+        expected_size=byte_size,
+    )
+
+    assert next(chunks) == original
+    source.write_bytes(replacement)
+
+    with pytest.raises(OSError, match="source changed"):
+        next(chunks)
 
 
 @pytest.mark.parametrize("swapped_component", ["sha256", "shard"])
@@ -275,39 +352,200 @@ def test_relative_root_remains_stable_after_working_directory_change(
 
     monkeypatch.chdir(elsewhere)
 
-    assert store.root == (tmp_path / "relative-objects").resolve()
+    assert store.root == Path(os.path.abspath(tmp_path / "relative-objects"))
     assert store.read_bytes(info.digest) == b"stable root"
     assert store.put_bytes(b"another object").byte_size == len(b"another object")
 
 
-def test_new_root_fsyncs_each_created_parent_directory(
+def test_constructor_never_resolves_or_follows_a_lexical_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    existing = tmp_path / "existing"
-    existing.mkdir()
-    root = existing / "level-one" / "level-two" / "objects"
-    fsynced: list[Path] = []
+    root = tmp_path / "objects"
+    resolved = False
 
-    monkeypatch.setattr(
-        cas_module,
-        "_fsync_directory",
-        lambda path: fsynced.append(path),
-    )
-    monkeypatch.setattr(
-        cas_module,
-        "_fsync_directory_handle",
-        lambda _descriptor, _path: None,
-    )
+    def forbidden_resolve(*_args, **_kwargs):
+        nonlocal resolved
+        resolved = True
+        raise AssertionError("CAS root used Path.resolve")
 
+    monkeypatch.setattr(Path, "resolve", forbidden_resolve)
     store = LocalCAS(root)
 
     assert store.root == root
-    assert fsynced == [
-        existing,
-        existing / "level-one",
-        existing / "level-one" / "level-two",
-    ]
+    assert not resolved
+
+
+def test_constructor_rejects_symlinked_ancestor_without_foreign_mutation(
+    tmp_path: Path,
+) -> None:
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(foreign, target_is_directory=True)
+
+    for require_preprovisioned in (False, True):
+        with pytest.raises(StorageValidationError, match="not a real directory"):
+            LocalCAS(
+                alias / "objects",
+                require_preprovisioned=require_preprovisioned,
+            )
+
+    assert list(foreign.iterdir()) == []
+
+
+def test_provision_rejects_filesystem_anchor_before_mkdir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mkdir_calls: list[tuple[object, ...]] = []
+
+    def forbidden_mkdir(*args, **_kwargs) -> None:
+        mkdir_calls.append(args)
+        raise AssertionError("provision attempted mkdir before rejecting root")
+
+    monkeypatch.setattr(cas_module.os, "mkdir", forbidden_mkdir)
+
+    with pytest.raises(StorageValidationError, match="lexical parent"):
+        LocalCAS.provision(Path(os.path.sep))
+
+    assert mkdir_calls == []
+
+
+def test_provision_requires_preexisting_parent_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing_parent = tmp_path / "missing-parent"
+    root = missing_parent / "objects"
+    mkdir_calls: list[tuple[object, ...]] = []
+
+    def forbidden_mkdir(*args, **_kwargs) -> None:
+        mkdir_calls.append(args)
+        raise AssertionError("provision attempted to create a missing ancestor")
+
+    monkeypatch.setattr(cas_module.os, "mkdir", forbidden_mkdir)
+
+    with pytest.raises(StorageValidationError, match="parent must already exist"):
+        LocalCAS.provision(root)
+
+    assert mkdir_calls == []
+    assert not missing_parent.exists()
+
+
+def test_provision_rejects_symlinked_parent_without_foreign_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(foreign, target_is_directory=True)
+    mkdir_calls: list[tuple[object, ...]] = []
+
+    def forbidden_mkdir(*args, **_kwargs) -> None:
+        mkdir_calls.append(args)
+        raise AssertionError("provision followed a symlinked root parent")
+
+    monkeypatch.setattr(cas_module.os, "mkdir", forbidden_mkdir)
+
+    with pytest.raises(StorageValidationError, match="real directory"):
+        LocalCAS.provision(alias / "objects")
+
+    assert mkdir_calls == []
+    assert list(foreign.iterdir()) == []
+
+
+@pytest.mark.parametrize("entry", ["root", "sha256", "last-shard"])
+@pytest.mark.parametrize("phase", ["before", "after"])
+def test_provision_retry_unconditionally_replays_complete_fsync_chain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    entry: str,
+    phase: str,
+) -> None:
+    root = tmp_path / "objects"
+    sha256_root = root / "sha256"
+    real_fsync = cas_module.os.fsync
+    injected = False
+
+    def matches_target(descriptor: int) -> bool:
+        observed = os.fstat(descriptor)
+        if entry == "root":
+            target = root.parent
+        elif entry == "sha256":
+            target = root
+        else:
+            if not (sha256_root / "ff").is_dir():
+                return False
+            target = sha256_root
+        metadata = target.stat()
+        return (observed.st_dev, observed.st_ino) == (
+            metadata.st_dev,
+            metadata.st_ino,
+        )
+
+    def fail_target_fsync(descriptor: int) -> None:
+        nonlocal injected
+        if not injected and matches_target(descriptor):
+            injected = True
+            if phase == "after":
+                real_fsync(descriptor)
+            raise OSError(errno.EIO, f"injected {entry} {phase} fsync failure")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(cas_module.os, "fsync", fail_target_fsync)
+    with pytest.raises(OSError, match=f"injected {entry} {phase}"):
+        LocalCAS.provision(root)
+    assert injected
+
+    replayed_after_complete_layout = False
+
+    def record_retry_fsync(descriptor: int) -> None:
+        nonlocal replayed_after_complete_layout
+        real_fsync(descriptor)
+        if (
+            sha256_root.is_dir()
+            and len([path for path in sha256_root.iterdir() if path.is_dir()]) == 256
+            and matches_target(descriptor)
+        ):
+            replayed_after_complete_layout = True
+
+    monkeypatch.setattr(cas_module.os, "fsync", record_retry_fsync)
+    store = LocalCAS.provision(root)
+
+    assert replayed_after_complete_layout
+    assert store.put_bytes(b"durable retry").byte_size == len(b"durable retry")
+
+
+def test_provision_replays_durability_chain_in_child_to_parent_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "objects"
+    LocalCAS.provision(root)
+    targets = {
+        (metadata.st_dev, metadata.st_ino): label
+        for label, metadata in (
+            ("sha256", (root / "sha256").stat()),
+            ("root", root.stat()),
+            ("root-parent", root.parent.stat()),
+        )
+    }
+    events: list[str] = []
+    real_fsync = cas_module.os.fsync
+
+    def record_fsync(descriptor: int) -> None:
+        metadata = os.fstat(descriptor)
+        label = targets.get((metadata.st_dev, metadata.st_ino))
+        if label is not None:
+            events.append(label)
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(cas_module.os, "fsync", record_fsync)
+
+    LocalCAS.provision(root)
+
+    assert events == ["sha256", "root", "root-parent"]
 
 
 def test_constructor_rejects_symlink_and_special_root(tmp_path: Path) -> None:
@@ -318,138 +556,720 @@ def test_constructor_rejects_symlink_and_special_root(tmp_path: Path) -> None:
     file_root = tmp_path / "file-root"
     file_root.write_text("not a directory", encoding="utf-8")
 
-    with pytest.raises(StorageValidationError, match="not a real directory"):
-        LocalCAS(symlink_root)
-    with pytest.raises(StorageValidationError, match="not a real directory"):
-        LocalCAS(file_root)
+    for require_preprovisioned in (False, True):
+        with pytest.raises(StorageValidationError, match="not a real directory"):
+            LocalCAS(
+                symlink_root,
+                require_preprovisioned=require_preprovisioned,
+            )
+        with pytest.raises(StorageValidationError, match="not a real directory"):
+            LocalCAS(
+                file_root,
+                require_preprovisioned=require_preprovisioned,
+            )
+    assert list(real_root.iterdir()) == []
 
 
-def test_concurrent_same_digest_put_publishes_without_overwrite(
+def test_provision_builds_complete_strict_layout_and_put_never_mkdirs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    store = LocalCAS(tmp_path / "objects")
-    payload = b"concurrent immutable object"
+    root = tmp_path / "objects"
+    LocalCAS.provision(root)
+    sha256_root = root / "sha256"
+
+    assert {entry.name for entry in sha256_root.iterdir()} == {
+        f"{value:02x}" for value in range(256)
+    }
+    store = LocalCAS(root, require_preprovisioned=True)
+    assert store._strict_root_identity is not None
+    assert store._strict_sha256_identity is not None
+    assert len(store._strict_shard_identities) == 256
+
+    def forbidden_mkdir(*_args, **_kwargs) -> None:
+        raise AssertionError("strict CAS put attempted to create a directory")
+
+    monkeypatch.setattr(cas_module.os, "mkdir", forbidden_mkdir)
+    info = store.put_bytes(b"strict preprovisioned object")
+
+    assert store.read_bytes(info.digest) == b"strict preprovisioned object"
+
+
+def test_strict_put_rejects_preprovisioned_shard_generation_replacement(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = b"generation-bound object"
+    digest = hashlib.sha256(payload).hexdigest()
+    shard = root / "sha256" / digest[:2]
+    previous = root / "sha256" / f"{digest[:2]}-previous"
+    shard.rename(previous)
+    shard.mkdir()
+
+    with pytest.raises(StorageIntegrityError, match="generation changed"):
+        store.put_bytes(payload)
+
+    assert list(shard.iterdir()) == []
+    assert list(previous.iterdir()) == []
+
+
+@pytest.mark.parametrize("layer", ["root", "sha256", "shard"])
+@pytest.mark.parametrize("phase", ["before", "after"])
+@pytest.mark.parametrize("exception_type", [OSError, KeyboardInterrupt, SystemExit])
+def test_directory_owner_close_fault_cleans_all_and_preserves_primary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    layer: str,
+    phase: str,
+    exception_type: type[BaseException],
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = f"{layer}-{phase}-{exception_type.__name__}".encode()
+    digest = hashlib.sha256(payload).hexdigest()
+    paths = {
+        "root": root,
+        "sha256": root / "sha256",
+        "shard": root / "sha256" / digest[:2],
+    }
+    target_metadata = paths[layer].stat()
+    target_identity = (target_metadata.st_dev, target_metadata.st_ino)
+    captured: list[int] = []
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = cas_module.os.close
+    error = (
+        OSError(errno.EIO, f"{phase} {layer} close failure")
+        if exception_type is OSError
+        else exception_type(f"{phase} {layer} close interruption")
+    )
+    injected = False
+
+    def capture_target_open(
+        owner,
+        path,
+        flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        metadata = os.fstat(descriptor)
+        if not captured and (metadata.st_dev, metadata.st_ino) == target_identity:
+            captured.append(descriptor)
+        return descriptor
+
+    def fail_target_close(descriptor: int) -> None:
+        nonlocal injected
+        if captured and descriptor == captured[0] and not injected:
+            injected = True
+            if phase == "after":
+                real_close(descriptor)
+            raise error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        capture_target_open,
+    )
+    monkeypatch.setattr(cas_module.os, "close", fail_target_close)
+    before = _descriptor_count()
+
+    with pytest.raises(exception_type) as caught:
+        store.put_bytes(payload)
+
+    assert caught.value is error
+    assert injected
+    assert len(captured) == 1
+    _assert_bad_descriptor(captured[0])
+    assert _descriptor_count() <= before
+    destination = root / "sha256" / digest[:2] / digest[2:]
+    committed_inode = destination.stat().st_ino
+
+    monkeypatch.setattr(cas_module.os, "close", real_close)
+    assert store.put_bytes(payload).digest == digest
+    assert destination.stat().st_ino == committed_inode
+
+
+@pytest.mark.parametrize("layer", ["root", "sha256", "shard"])
+def test_directory_owner_retries_repeated_eio(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    layer: str,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = f"persistent-{layer}".encode()
+    digest = hashlib.sha256(payload).hexdigest()
+    paths = {
+        "root": root,
+        "sha256": root / "sha256",
+        "shard": root / "sha256" / digest[:2],
+    }
+    metadata = paths[layer].stat()
+    target_identity = (metadata.st_dev, metadata.st_ino)
+    captured: list[int] = []
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = cas_module.os.close
+    error = OSError(errno.EIO, f"repeated {layer} close failure")
+    failures_remaining = 5
+
+    def capture_target_open(
+        owner,
+        path,
+        flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        opened = os.fstat(descriptor)
+        if not captured and (opened.st_dev, opened.st_ino) == target_identity:
+            captured.append(descriptor)
+        return descriptor
+
+    def fail_repeatedly(descriptor: int) -> None:
+        nonlocal failures_remaining
+        if captured and descriptor == captured[0] and failures_remaining:
+            failures_remaining -= 1
+            raise error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        capture_target_open,
+    )
+    monkeypatch.setattr(cas_module.os, "close", fail_repeatedly)
+    before = _descriptor_count()
+
+    with pytest.raises(OSError) as caught:
+        store.put_bytes(payload)
+
+    assert caught.value is error
+    assert failures_remaining == 0
+    _assert_bad_descriptor(captured[0])
+    assert _descriptor_count() <= before
+
+
+def test_nested_directory_cleanup_keeps_first_error_and_attempts_every_layer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = b"nested cleanup first primary"
+    digest = hashlib.sha256(payload).hexdigest()
+    target_paths = [root / "sha256" / digest[:2], root / "sha256"]
+    target_identities = {
+        (path.stat().st_dev, path.stat().st_ino): index
+        for index, path in enumerate(target_paths)
+    }
+    descriptors: dict[int, int] = {}
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = cas_module.os.close
+    primary = KeyboardInterrupt("shard close interruption")
+    secondary = SystemExit("sha256 close interruption")
+    injected: set[int] = set()
+
+    def capture_target_open(
+        owner,
+        path,
+        flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        metadata = os.fstat(descriptor)
+        index = target_identities.get((metadata.st_dev, metadata.st_ino))
+        if index is not None and index not in descriptors:
+            descriptors[index] = descriptor
+        return descriptor
+
+    def fail_two_layers(descriptor: int) -> None:
+        for index, error in ((0, primary), (1, secondary)):
+            if descriptors.get(index) == descriptor and index not in injected:
+                injected.add(index)
+                raise error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        capture_target_open,
+    )
+    monkeypatch.setattr(cas_module.os, "close", fail_two_layers)
+    before = _descriptor_count()
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        store.put_bytes(payload)
+
+    assert caught.value is primary
+    assert injected == {0, 1}
+    assert any(
+        "sha256 close interruption" in note for note in _exception_notes(primary)
+    )
+    assert all(descriptor >= 0 for descriptor in descriptors.values())
+    for descriptor in descriptors.values():
+        _assert_bad_descriptor(descriptor)
+    assert _descriptor_count() <= before
+
+
+@pytest.mark.parametrize("layer", ["root", "sha256", "shard"])
+def test_directory_owner_does_not_close_observably_reused_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    layer: str,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = f"reuse-{layer}".encode()
+    digest = hashlib.sha256(payload).hexdigest()
+    paths = {
+        "root": root,
+        "sha256": root / "sha256",
+        "shard": root / "sha256" / digest[:2],
+    }
+    metadata = paths[layer].stat()
+    target_identity = (metadata.st_dev, metadata.st_ino)
+    foreign = tmp_path / f"foreign-{layer}.bin"
+    foreign.write_bytes(b"foreign")
+    foreign_source = os.open(foreign, os.O_RDONLY)
+    captured: list[int] = []
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = cas_module.os.close
+    interruption = KeyboardInterrupt(f"{layer} close reused fd")
+    reused = False
+
+    def capture_target_open(
+        owner,
+        path,
+        flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        opened = os.fstat(descriptor)
+        if not captured and (opened.st_dev, opened.st_ino) == target_identity:
+            captured.append(descriptor)
+        return descriptor
+
+    def close_then_reuse(descriptor: int) -> None:
+        nonlocal reused
+        real_close(descriptor)
+        if captured and descriptor == captured[0] and not reused:
+            os.dup2(foreign_source, descriptor)
+            reused = True
+            raise interruption
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        capture_target_open,
+    )
+    monkeypatch.setattr(cas_module.os, "close", close_then_reuse)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            store.put_bytes(payload)
+
+        assert caught.value is interruption
+        assert reused
+        assert os.pread(captured[0], len(b"foreign"), 0) == b"foreign"
+        assert store.put_bytes(payload).digest == digest
+        assert os.pread(captured[0], len(b"foreign"), 0) == b"foreign"
+    finally:
+        monkeypatch.setattr(cas_module.os, "close", real_close)
+        if captured:
+            real_close(captured[0])
+        real_close(foreign_source)
+
+
+def test_strict_constructor_rejects_incomplete_layout_without_mutation(
+    tmp_path: Path,
+) -> None:
+    missing_root = tmp_path / "missing"
+
+    with pytest.raises(StorageValidationError, match="does not exist"):
+        LocalCAS(missing_root, require_preprovisioned=True)
+    assert not missing_root.exists()
+
+    incomplete = tmp_path / "incomplete"
+    (incomplete / "sha256").mkdir(parents=True)
+    marker = incomplete / "sha256" / "keep"
+    marker.write_bytes(b"unchanged")
+    before = sorted(path.relative_to(incomplete) for path in incomplete.rglob("*"))
+
+    with pytest.raises(StorageValidationError, match="all 256 digest shards"):
+        LocalCAS(incomplete, require_preprovisioned=True)
+
+    after = sorted(path.relative_to(incomplete) for path in incomplete.rglob("*"))
+    assert after == before
+    assert marker.read_bytes() == b"unchanged"
+
+
+def test_capability_gate_fails_before_lazy_layout_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "objects"
+    monkeypatch.setattr(cas_module, "_SAFE_DIRECTORY_FDS", False)
+
+    with pytest.raises(RuntimeError, match="directory-fd support"):
+        LocalCAS(root)
+
+    assert not root.exists()
+
+
+def test_windows_gate_fails_before_constructor_or_provision_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(owned_file_module.sys, "platform", "win32")
+    lazy_root = tmp_path / "lazy"
+    provisioned_root = tmp_path / "provisioned"
+
+    with pytest.raises(RuntimeError, match="unsupported on Windows"):
+        LocalCAS(lazy_root)
+    with pytest.raises(RuntimeError, match="unsupported on Windows"):
+        LocalCAS.provision(provisioned_root)
+
+    assert not lazy_root.exists()
+    assert not provisioned_root.exists()
+
+
+def test_real_multiprocess_same_digest_publishes_one_canonical_inode(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "objects"
+    store = LocalCAS.provision(root)
+    payload = b"multiprocess immutable object"
+    digest = hashlib.sha256(payload).hexdigest()
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    start = context.Event()
+    processes = [
+        context.Process(
+            target=_put_bytes_in_process,
+            args=(str(root), payload, ready, start),
+        )
+        for _index in range(4)
+    ]
+    for process in processes:
+        process.start()
+    try:
+        for _process in processes:
+            try:
+                ready.get(timeout=30)
+            except Empty as exc:  # pragma: no cover - failure diagnostic
+                raise AssertionError("CAS worker did not reach the race") from exc
+    finally:
+        start.set()
+    for process in processes:
+        process.join(timeout=30)
+    try:
+        assert all(not process.is_alive() for process in processes)
+        assert [process.exitcode for process in processes] == [0, 0, 0, 0]
+    finally:
+        for process in processes:
+            if process.is_alive():  # pragma: no cover - failure cleanup
+                process.terminate()
+                process.join(timeout=10)
+        ready.close()
+        ready.join_thread()
+
+    destination = root / "sha256" / digest[:2] / digest[2:]
+    assert destination.read_bytes() == payload
+    assert destination.stat().st_nlink == 1
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o600
+    stages = list(destination.parent.glob(".codenib-file-*"))
+    assert len(stages) == len(processes) - 1
+    assert all(stage.read_bytes() == payload for stage in stages)
+    assert store.verify(digest).byte_size == len(payload)
+
+
+def test_destination_appearing_during_rename_is_never_overwritten(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"requested object"
+    competing = b"competing object"
     digest = hashlib.sha256(payload).hexdigest()
     destination = store.root / "sha256" / digest[:2] / digest[2:]
-    gate = threading.Barrier(2)
-    local = threading.local()
-    real_verify = LocalCAS._verify_existing_at
+    real_rename = atomic_module._rename_noreplace_at
+    raced = False
 
-    def synchronize_publish_check(self, *args, **kwargs):
-        result = real_verify(self, *args, **kwargs)
-        count = getattr(local, "count", 0) + 1
-        local.count = count
-        if count == 2 and result is None:
-            gate.wait(timeout=5)
-        return result
+    def publish_competitor_then_rename(
+        source: str,
+        target: str,
+        source_parent: int,
+        target_parent: int,
+    ) -> None:
+        nonlocal raced
+        if not raced:
+            raced = True
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            descriptor = os.open(target, flags, 0o600, dir_fd=target_parent)
+            try:
+                os.write(descriptor, competing)
+                os.fchmod(descriptor, 0o600)
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+        real_rename(source, target, source_parent, target_parent)
 
-    successful_inodes: list[int] = []
-    real_link = cas_module._link_at
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        publish_competitor_then_rename,
+    )
 
-    def record_link(*args, **kwargs):
-        real_link(*args, **kwargs)
-        successful_inodes.append(destination.stat().st_ino)
+    with pytest.raises(StorageIntegrityError) as caught:
+        store.put_bytes(payload)
 
-    monkeypatch.setattr(LocalCAS, "_verify_existing_at", synchronize_publish_check)
-    monkeypatch.setattr(cas_module, "_link_at", record_link)
-
-    errors: list[BaseException] = []
-
-    def put() -> None:
-        try:
-            store.put_bytes(payload)
-        except Exception as exc:  # pragma: no cover - asserted below
-            errors.append(exc)
-
-    threads = [threading.Thread(target=put) for _ in range(2)]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join(timeout=10)
-
-    assert all(not thread.is_alive() for thread in threads)
-    assert errors == []
-    assert len(successful_inodes) == 1
-    assert destination.stat().st_ino == successful_inodes[0]
-    assert store.read_bytes(digest) == payload
+    assert isinstance(caught.value.__cause__, owned_file_module.OwnedFileConflictError)
+    assert destination.read_bytes() == competing
+    assert len(list(destination.parent.glob(".codenib-file-*"))) == 1
 
 
-def test_deduplicated_put_flushes_concurrent_publish_before_return(
+@pytest.mark.parametrize("defect", ["mode", "link-count"])
+def test_existing_object_metadata_conflict_is_not_healed(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    defect: str,
 ) -> None:
-    store = LocalCAS(tmp_path / "objects")
-    payload = b"concurrent durability receipt"
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"canonical payload"
     digest = hashlib.sha256(payload).hexdigest()
-    shard = store.root / "sha256" / digest[:2]
-    linked = threading.Event()
-    release_first_writer = threading.Event()
-    dedupe_flushed = threading.Event()
-    real_link = cas_module._link_at
-    real_fsync = cas_module._fsync_directory_handle
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    destination.write_bytes(payload)
+    destination.chmod(0o600)
+    sibling = destination.parent / "extra-link"
+    if defect == "mode":
+        destination.chmod(0o644)
+    else:
+        os.link(destination, sibling)
+    before = destination.stat()
 
-    def link_then_pause(*args, **kwargs) -> None:
-        real_link(*args, **kwargs)
-        linked.set()
-        if not release_first_writer.wait(timeout=5):
-            raise TimeoutError("first CAS publisher was not released")
+    with pytest.raises(StorageIntegrityError) as caught:
+        store.put_bytes(payload)
 
-    def record_fsync(descriptor: int | None, path: Path) -> None:
-        if linked.is_set() and path == shard:
-            dedupe_flushed.set()
-        real_fsync(descriptor, path)
-
-    monkeypatch.setattr(cas_module, "_link_at", link_then_pause)
-    monkeypatch.setattr(cas_module, "_fsync_directory_handle", record_fsync)
-    errors: list[BaseException] = []
-
-    def put() -> None:
-        try:
-            store.put_bytes(payload)
-        except Exception as exc:  # pragma: no cover - asserted below
-            errors.append(exc)
-
-    first = threading.Thread(target=put)
-    first.start()
-    assert linked.wait(timeout=5)
-    second = threading.Thread(target=put)
-    second.start()
-    second.join(timeout=5)
-
-    try:
-        assert not second.is_alive()
-        assert dedupe_flushed.is_set()
-        assert errors == []
-    finally:
-        release_first_writer.set()
-        first.join(timeout=5)
-
-    assert not first.is_alive()
-    assert errors == []
-    assert store.read_bytes(digest) == payload
+    after = destination.stat()
+    assert isinstance(caught.value.__cause__, owned_file_module.OwnedFileConflictError)
+    assert after.st_ino == before.st_ino
+    assert after.st_nlink == before.st_nlink
+    assert stat.S_IMODE(after.st_mode) == stat.S_IMODE(before.st_mode)
+    assert destination.read_bytes() == payload
+    if defect == "link-count":
+        assert sibling.stat().st_ino == before.st_ino
 
 
-def test_put_falls_back_to_atomic_replace_without_hard_link_support(
+def test_rename_failure_before_commit_leaves_stage_and_fresh_retry_inode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    store = LocalCAS(tmp_path / "objects")
-    replacements: list[str] = []
-    real_replace = cas_module._replace_at
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"retry before rename"
+    digest = hashlib.sha256(payload).hexdigest()
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    real_rename = atomic_module._rename_noreplace_at
 
-    def unsupported_link(*_args, **_kwargs) -> None:
-        raise OSError(errno.EOPNOTSUPP, "hard links unavailable")
+    def fail_before_rename(*_args, **_kwargs) -> None:
+        raise OSError(errno.EIO, "injected before rename")
 
-    def record_replace(*args, **kwargs) -> None:
-        real_replace(*args, **kwargs)
-        replacements.append("replaced")
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", fail_before_rename)
+    with pytest.raises(OSError, match="injected before rename"):
+        store.put_bytes(payload)
 
-    monkeypatch.setattr(cas_module, "_link_at", unsupported_link)
-    monkeypatch.setattr(cas_module, "_replace_at", record_replace)
+    assert not destination.exists()
+    stages = list(destination.parent.glob(".codenib-file-*"))
+    assert len(stages) == 1
+    failed_inode = stages[0].stat().st_ino
 
-    info = store.put_bytes(b"fallback publication")
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", real_rename)
+    info = store.put_bytes(payload)
 
-    assert replacements == ["replaced"]
-    assert store.read_bytes(info.digest) == b"fallback publication"
-    assert list((store.root / "sha256").rglob("*.tmp")) == []
+    assert info.digest == digest
+    assert destination.read_bytes() == payload
+    assert destination.stat().st_ino != failed_inode
+    assert stages[0].exists()
+
+
+def test_rename_failure_after_commit_reuses_same_inode_on_fresh_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"retry after rename"
+    digest = hashlib.sha256(payload).hexdigest()
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    real_rename = atomic_module._rename_noreplace_at
+
+    def rename_then_fail(*args, **kwargs) -> None:
+        real_rename(*args, **kwargs)
+        raise OSError(errno.EIO, "injected after rename")
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", rename_then_fail)
+    with pytest.raises(OSError, match="injected after rename"):
+        store.put_bytes(payload)
+
+    committed_inode = destination.stat().st_ino
+    assert list(destination.parent.glob(".codenib-file-*")) == []
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", real_rename)
+    info = store.put_bytes(payload)
+
+    assert info.digest == digest
+    assert destination.stat().st_ino == committed_inode
+    assert len(list(destination.parent.glob(".codenib-file-*"))) == 1
+
+
+def test_parent_fsync_failure_returns_no_blob_and_retry_reuses_inode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"retry after parent fsync"
+    digest = hashlib.sha256(payload).hexdigest()
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    real_fsync = owned_file_module.os.fsync
+    failed = False
+
+    def fail_first_directory_fsync(descriptor: int) -> None:
+        nonlocal failed
+        if not failed and stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            failed = True
+            raise OSError(errno.EIO, "injected parent fsync failure")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(owned_file_module.os, "fsync", fail_first_directory_fsync)
+    with pytest.raises(OSError, match="injected parent fsync failure"):
+        store.put_bytes(payload)
+
+    assert failed
+    committed_inode = destination.stat().st_ino
+
+    monkeypatch.setattr(owned_file_module.os, "fsync", real_fsync)
+    info = store.put_bytes(payload)
+
+    assert info.digest == digest
+    assert destination.stat().st_ino == committed_inode
+    assert len(list(destination.parent.glob(".codenib-file-*"))) == 1
+
+
+def test_blob_info_is_created_only_after_durable_receipt_consumption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    events: list[str] = []
+    real_fsync = owned_file_module.os.fsync
+    real_rename = atomic_module._rename_noreplace_at
+    real_consume = owned_file_module.PublishedFileReceiptOwner.consume
+    real_receipt_close = owned_file_module.PublishedFileReceipt._close_from_owner
+    real_owner_close = owned_file_module.PublishedFileReceiptOwner.close
+    real_blob_info = LocalCAS._blob_info
+
+    def record_fsync(descriptor: int) -> None:
+        metadata = os.fstat(descriptor)
+        real_fsync(descriptor)
+        events.append(
+            "parent-fsync" if stat.S_ISDIR(metadata.st_mode) else "file-fsync"
+        )
+
+    def record_rename(*args, **kwargs) -> None:
+        real_rename(*args, **kwargs)
+        events.append("rename")
+
+    def record_consume(self, callback) -> None:
+        events.append("consume-enter")
+        real_consume(self, callback)
+        events.append("consume-return")
+
+    def record_receipt_close(self, authority) -> None:
+        events.append("receipt-close-enter")
+        real_receipt_close(self, authority)
+        events.append("receipt-close-return")
+
+    def record_owner_close(self) -> None:
+        events.append("owner-close-enter")
+        real_owner_close(self)
+        assert self.closed
+        events.append("owner-terminal")
+
+    def record_blob_info(digest: str, byte_size: int):
+        events.append("blob-info")
+        return real_blob_info(digest, byte_size)
+
+    monkeypatch.setattr(owned_file_module.os, "fsync", record_fsync)
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", record_rename)
+    monkeypatch.setattr(
+        owned_file_module.PublishedFileReceiptOwner,
+        "consume",
+        record_consume,
+    )
+    monkeypatch.setattr(
+        owned_file_module.PublishedFileReceipt,
+        "_close_from_owner",
+        record_receipt_close,
+    )
+    monkeypatch.setattr(
+        owned_file_module.PublishedFileReceiptOwner,
+        "close",
+        record_owner_close,
+    )
+    monkeypatch.setattr(LocalCAS, "_blob_info", staticmethod(record_blob_info))
+
+    store.put_bytes(b"ordered publication")
+
+    assert events == [
+        "file-fsync",
+        "rename",
+        "parent-fsync",
+        "consume-enter",
+        "consume-return",
+        "owner-close-enter",
+        "receipt-close-enter",
+        "receipt-close-return",
+        "owner-terminal",
+        "blob-info",
+    ]
+
+
+def test_unsupported_no_replace_never_uses_legacy_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"no fallback publication"
+    digest = hashlib.sha256(payload).hexdigest()
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    replaced = False
+
+    def unsupported_rename(*_args, **_kwargs) -> None:
+        raise RuntimeError("filesystem no-replace unsupported")
+
+    def forbidden_replace(*_args, **_kwargs) -> None:
+        nonlocal replaced
+        replaced = True
+        raise AssertionError("legacy replace fallback was used")
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", unsupported_rename)
+    monkeypatch.setattr(cas_module.os, "replace", forbidden_replace)
+
+    with pytest.raises(RuntimeError, match="no-replace unsupported"):
+        store.put_bytes(payload)
+
+    assert not replaced
+    assert not destination.exists()
+    assert len(list(destination.parent.glob(".codenib-file-*"))) == 1
+    for symbol in (
+        "_create_temporary_file",
+        "_link_at",
+        "_replace_at",
+        "_unlink_at",
+    ):
+        assert not hasattr(cas_module, symbol)

--- a/test/storage/test_models.py
+++ b/test/storage/test_models.py
@@ -18,8 +18,61 @@ from codenib.storage.models import (
     StorageValidationError,
     ViewGeneration,
     ViewProfile,
+    assert_no_secret_fields,
     canonical_json,
 )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "access_key",
+        "cookie",
+        "credential",
+        "refresh_token",
+        "secret",
+        "Refresh-Token",
+        "accessKey",
+        "headers",
+        "Proxy-Authorization",
+        "proxy_authorization_options",
+        "X-API-Key",
+        "x-api-key-secondary",
+        "X-Auth-Token",
+        "aws_secret_access_key",
+        "github_token",
+        "auth_token",
+        "my_client_secret",
+    ],
+)
+def test_shared_secret_classifier_rejects_normalized_field_names(field: str) -> None:
+    with pytest.raises(StorageValidationError, match="secret field"):
+        assert_no_secret_fields({"nested": [{field: "value"}]}, source="profile")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://user:password@example.test/api",
+        "//user:password@example.test/api",
+        "Bearer token-value",
+        "Basic dXNlcjpwYXNz",
+    ],
+)
+def test_shared_secret_classifier_rejects_credential_values(value: str) -> None:
+    with pytest.raises(StorageValidationError, match="credentials"):
+        assert_no_secret_fields({"endpoint": value}, source="profile")
+
+
+def test_shared_secret_classifier_does_not_reject_noncredential_token_words() -> None:
+    assert_no_secret_fields(
+        {
+            "authorization_url": "https://example.test/oauth/authorize",
+            "token_count": 10,
+            "tokenizer": "cl100k_base",
+        },
+        source="profile",
+    )
 
 
 def _object(suffix: str) -> ObjectRecord:

--- a/test/storage/test_models.py
+++ b/test/storage/test_models.py
@@ -64,6 +64,12 @@ def test_shared_secret_classifier_rejects_credential_values(value: str) -> None:
         assert_no_secret_fields({"endpoint": value}, source="profile")
 
 
+def test_shared_secret_classifier_rejects_userinfo_after_authority_whitespace() -> None:
+    value = "http://user pass@host/" + ("x" * 9_000)
+    with pytest.raises(StorageValidationError, match="credentials"):
+        assert_no_secret_fields({"endpoint": value}, source="profile")
+
+
 def test_shared_secret_classifier_does_not_reject_noncredential_token_words() -> None:
     assert_no_secret_fields(
         {

--- a/test/storage/test_view_bundle.py
+++ b/test/storage/test_view_bundle.py
@@ -43,6 +43,16 @@ def _source(root: Path) -> Path:
     return source
 
 
+def _moved_publication_root(destination: Path) -> Path:
+    matches = tuple(
+        path
+        for path in destination.parent.iterdir()
+        if path.name.startswith(f".{destination.name}.previous-")
+    )
+    assert len(matches) == 1
+    return matches[0]
+
+
 def _canonical_info(
     name: str,
     mode: int = 0o644,
@@ -164,6 +174,10 @@ def test_build_verify_and_materialize_round_trip(tmp_path: Path) -> None:
     ]
     assert [member.mode for member in built.members] == [0o644, 0o755]
     assert materialized.payload_dir == materialized.output_dir / "payload"
+    assert (
+        atomic_module.capture_directory_ownership(materialized.output_dir)
+        == materialized.ownership
+    )
     assert _tree(materialized.payload_dir) == {
         "documents.json": (b"[]\n", 0o644),
         "index/shard": (b"immutable shard", 0o755),
@@ -1517,13 +1531,16 @@ def test_materialization_rolls_back_late_payload_mode_change(
         validate = kwargs["validate_moved_destination"]
         calls = 0
 
-        def validate_then_mutate(moved: Path) -> None:
+        def validate_then_mutate(
+            moved: atomic_module.PublicationDirectoryReader,
+        ) -> None:
             nonlocal calls
             assert callable(validate)
             validate(moved)
             calls += 1
             if calls == 1:
-                (moved / "payload" / "documents.json").chmod(0o600)
+                moved_root = _moved_publication_root(destination)
+                (moved_root / "payload" / "documents.json").chmod(0o600)
 
         kwargs["validate_moved_destination"] = validate_then_mutate
         original_publish(stage, destination, **kwargs)
@@ -1534,7 +1551,7 @@ def test_materialization_rolls_back_late_payload_mode_change(
         publish_with_late_chmod,
     )
 
-    with pytest.raises(RuntimeError, match="safe cleanup validation"):
+    with pytest.raises(RuntimeError, match="moved destination changed"):
         materialize_view_bundle(archive, output)
 
     assert stat.S_IMODE((output / "payload" / "documents.json").stat().st_mode) == 0o600
@@ -1560,13 +1577,16 @@ def test_materialization_rolls_back_write_after_first_boundary_validation(
         validate = kwargs["validate_moved_destination"]
         calls = 0
 
-        def validate_then_write(moved: Path) -> None:
+        def validate_then_write(
+            moved: atomic_module.PublicationDirectoryReader,
+        ) -> None:
             nonlocal calls
             assert callable(validate)
             validate(moved)
             calls += 1
             if calls == 1:
-                (moved / "payload" / "index" / "late.txt").write_text(
+                moved_root = _moved_publication_root(destination)
+                (moved_root / "payload" / "index" / "late.txt").write_text(
                     "preserve",
                     encoding="utf-8",
                 )
@@ -1580,7 +1600,7 @@ def test_materialization_rolls_back_write_after_first_boundary_validation(
         publish_with_late_write,
     )
 
-    with pytest.raises(RuntimeError, match="safe cleanup validation"):
+    with pytest.raises(RuntimeError, match="moved destination changed"):
         materialize_view_bundle(archive, output)
 
     assert (output / "payload" / "index" / "late.txt").read_text(
@@ -1685,17 +1705,30 @@ def test_materialization_revalidates_published_stage_before_old_cleanup(
     (source / "documents.json").write_bytes(b"new")
     second_archive = tmp_path / "second.zip"
     build_view_bundle(source, second_archive, view_type="bm25")
-    real_replace = atomic_module.os.replace
+    real_rename = atomic_module._rename_noreplace_at
 
-    def mutate_after_stage_publish(source_path, destination_path):
-        result = real_replace(source_path, destination_path)
-        if Path(destination_path) == output and Path(source_path).name.startswith(
+    def mutate_after_stage_publish(
+        source_name: str,
+        destination_name: str,
+        source_descriptor: int,
+        destination_descriptor: int,
+    ) -> None:
+        real_rename(
+            source_name,
+            destination_name,
+            source_descriptor,
+            destination_descriptor,
+        )
+        if destination_name == output.name and source_name.startswith(
             ".runtime.materialize-"
         ):
             (output / "payload" / "documents.json").write_bytes(b"bad")
-        return result
 
-    monkeypatch.setattr(atomic_module.os, "replace", mutate_after_stage_publish)
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        mutate_after_stage_publish,
+    )
 
     with pytest.raises(RuntimeError, match="published directory identity"):
         materialize_view_bundle(second_archive, output)
@@ -1732,7 +1765,7 @@ def test_materialization_rejects_owned_payload_mount_without_deleting_it(
     output = tmp_path / "runtime"
     materialize_view_bundle(archive, output)
     mounted = output / "payload" / "index"
-    original_mount_check = bundle_module._path_is_mount_point
+    original_mount_check = atomic_module._path_is_mount_point
 
     def fake_mount_check(path: Path, **kwargs: object) -> bool:
         return Path(path) == mounted or original_mount_check(path, **kwargs)
@@ -1777,7 +1810,9 @@ def test_materialization_rolls_back_mount_detected_after_linearization(
         validate = kwargs["validate_moved_destination"]
         calls = 0
 
-        def validate_then_mount(moved: Path) -> None:
+        def validate_then_mount(
+            moved: atomic_module.PublicationDirectoryReader,
+        ) -> None:
             nonlocal calls, mounted
             assert callable(validate)
             validate(moved)
@@ -1788,14 +1823,14 @@ def test_materialization_rolls_back_mount_detected_after_linearization(
         kwargs["validate_moved_destination"] = validate_then_mount
         original_publish(stage, destination, **kwargs)
 
-    monkeypatch.setattr(bundle_module, "_path_is_mount_point", fake_mount_check)
+    monkeypatch.setattr(atomic_module, "_path_is_mount_point", fake_mount_check)
     monkeypatch.setattr(
         bundle_module,
         "publish_staged_directory",
         publish_with_late_mount,
     )
 
-    with pytest.raises(RuntimeError, match="safe cleanup validation"):
+    with pytest.raises(RuntimeError, match="moved destination changed"):
         materialize_view_bundle(archive, output)
 
     assert (output / "payload" / "index" / "shard").read_bytes() == b"immutable shard"

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -14,6 +14,7 @@ import pytest
 import codenib._atomic_directory as atomic_module
 from codenib._atomic_directory import (
     capture_directory_ownership,
+    directory_ownership_inventory,
     publish_staged_directory,
 )
 
@@ -369,6 +370,24 @@ def test_directory_ownership_is_independent_of_entry_order(tmp_path: Path) -> No
         second_token.entries,
         second_token.byte_count,
         second_token.metadata_bytes,
+    )
+
+
+def test_directory_ownership_inventory_comes_from_the_bounded_scan(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (root / "one.txt").write_text("one", encoding="utf-8")
+    (nested / "two.txt").write_text("two", encoding="utf-8")
+
+    ownership = capture_directory_ownership(root)
+
+    assert directory_ownership_inventory(ownership) == (
+        ("nested", "directory"),
+        ("nested/two.txt", "file"),
+        ("one.txt", "file"),
     )
 
 

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -4,38 +4,243 @@
 
 from __future__ import annotations
 
+import dis
+import errno
+import hashlib
+import inspect
 import os
 import stat
-from pathlib import Path
+import sys
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 
 import pytest
 
 import codenib._atomic_directory as atomic_module
+import codenib._windows_fs_authority as windows_authority_module
 from codenib._atomic_directory import (
+    DirectoryOrphan,
     capture_directory_ownership,
     directory_ownership_inventory,
+    publication_parent_identity,
     publish_staged_directory,
 )
 
 
-def test_publish_staged_directory_replaces_existing_tree(tmp_path: Path) -> None:
+def _write_tree(root: Path, name: str, value: str) -> None:
+    root.mkdir()
+    (root / name).write_text(value, encoding="utf-8")
+
+
+class _FakeWindowsApi:
+    """In-memory HANDLE/FILE_ID model; it intentionally has no path reads."""
+
+    def __init__(self) -> None:
+        self.nodes: dict[int, dict[str, object]] = {}
+        self.handles: dict[int, int] = {}
+        self.offsets: dict[int, int] = {}
+        self.next_file_id = 10
+        self.next_handle = 100
+        self.open_by_id_calls: list[tuple[int, int, int, bool]] = []
+        self.rename_calls: list[tuple[int, int, str]] = []
+        self.root_id = self.add_directory()
+
+    def add_directory(self, parent: int | None = None, name: str = "") -> int:
+        file_id = self.next_file_id
+        self.next_file_id += 1
+        self.nodes[file_id] = {
+            "directory": True,
+            "children": {},
+            "data": b"",
+            "version": 1,
+        }
+        if parent is not None:
+            children = self.nodes[parent]["children"]
+            assert isinstance(children, dict)
+            children[name] = file_id
+        return file_id
+
+    def add_file(self, parent: int, name: str, data: bytes) -> int:
+        file_id = self.next_file_id
+        self.next_file_id += 1
+        self.nodes[file_id] = {
+            "directory": False,
+            "children": {},
+            "data": data,
+            "version": 1,
+        }
+        children = self.nodes[parent]["children"]
+        assert isinstance(children, dict)
+        children[name] = file_id
+        return file_id
+
+    def _new_handle(self, file_id: int) -> int:
+        handle = self.next_handle
+        self.next_handle += 1
+        self.handles[handle] = file_id
+        self.offsets[handle] = 0
+        return handle
+
+    def create_directory_handle(self, _path: Path) -> int:
+        return self._new_handle(self.root_id)
+
+    def duplicate_handle(self, handle: int) -> int:
+        return self._new_handle(self.handles[handle])
+
+    def close(self, handle: int) -> None:
+        self.handles.pop(handle, None)
+        self.offsets.pop(handle, None)
+
+    def metadata(self, handle: int) -> object:
+        node = self.nodes[self.handles[handle]]
+        directory = bool(node["directory"])
+        data = node["data"]
+        assert isinstance(data, bytes)
+        version = int(node["version"])
+        attributes = atomic_module._WINDOWS_FILE_ATTRIBUTE_DIRECTORY if directory else 0
+        return atomic_module._WindowsHandleMetadata(
+            st_dev=7,
+            st_ino=self.handles[handle],
+            st_mode=atomic_module._windows_mode_from_attributes(attributes),
+            st_size=0 if directory else len(data),
+            st_mtime_ns=version,
+            st_ctime_ns=version,
+            st_nlink=int(node.get("nlink", 1)),
+            st_file_attributes=attributes,
+        )
+
+    def enumerate_directory(
+        self,
+        handle: int,
+    ) -> tuple[object, ...]:
+        node = self.nodes[self.handles[handle]]
+        children = node["children"]
+        assert isinstance(children, dict)
+        return tuple(
+            atomic_module._WindowsDirectoryEntry(
+                name=name,
+                file_id=file_id,
+                attributes=(
+                    atomic_module._WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+                    if self.nodes[file_id]["directory"]
+                    else 0
+                ),
+            )
+            for name, file_id in children.items()
+        )
+
+    def open_by_id(
+        self,
+        volume_hint: int,
+        file_id: int,
+        *,
+        desired_access: int,
+        is_directory: bool,
+    ) -> int:
+        assert self.nodes[file_id]["directory"] is is_directory
+        self.open_by_id_calls.append(
+            (volume_hint, file_id, desired_access, is_directory)
+        )
+        return self._new_handle(file_id)
+
+    def read(self, handle: int, size: int) -> bytes:
+        node = self.nodes[self.handles[handle]]
+        data = node["data"]
+        assert isinstance(data, bytes)
+        offset = self.offsets[handle]
+        block = data[offset : offset + size]
+        self.offsets[handle] += len(block)
+        return block
+
+    def rename_noreplace(
+        self,
+        source_handle: int,
+        parent_handle: int,
+        destination: str,
+    ) -> None:
+        parent = self.nodes[self.handles[parent_handle]]
+        children = parent["children"]
+        assert isinstance(children, dict)
+        if any(name.casefold() == destination.casefold() for name in children):
+            raise FileExistsError(destination)
+        source_id = self.handles[source_handle]
+        source_names = [
+            name for name, file_id in children.items() if file_id == source_id
+        ]
+        if len(source_names) != 1:
+            raise FileNotFoundError(source_id)
+        source_name = source_names[0]
+        children[destination] = children.pop(source_name)
+        parent["version"] = int(parent["version"]) + 1
+        self.rename_calls.append((source_handle, parent_handle, destination))
+
+
+def test_publish_staged_directory_replaces_existing_tree(
+    tmp_path: Path,
+) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     nested = destination / "nested"
     nested.mkdir()
     (nested / "one.txt").write_text("one", encoding="utf-8")
-    (nested / "two.txt").write_text("two", encoding="utf-8")
-    stage = tmp_path / ".published.tmp"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
 
-    publish_staged_directory(stage, destination)
+    orphan = publish_staged_directory(stage, destination)
 
+    assert isinstance(orphan, DirectoryOrphan)
+    assert orphan.verified_at_isolation
+    assert orphan.path.name.startswith(".published.previous-")
+    assert (orphan.path / "old.txt").read_text(encoding="utf-8") == "old"
     assert not stage.exists()
-    assert not (destination / "old.txt").exists()
     assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_first_publication_does_not_create_an_empty_orphan(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is None
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+def test_rename_noreplace_at_moves_without_overwriting(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.write_text("source", encoding="utf-8")
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        atomic_module._rename_noreplace_at("source", "moved", descriptor, descriptor)
+        assert not source.exists()
+        assert (tmp_path / "moved").read_text(encoding="utf-8") == "source"
+
+        source.write_text("new source", encoding="utf-8")
+        with pytest.raises(FileExistsError):
+            atomic_module._rename_noreplace_at(
+                "source", "moved", descriptor, descriptor
+            )
+    finally:
+        os.close(descriptor)
+
+    assert source.read_text(encoding="utf-8") == "new source"
+    assert (tmp_path / "moved").read_text(encoding="utf-8") == "source"
+
+
+@pytest.mark.parametrize("name", ["", ".", "..", "a/b", "a\\b", "a\x00b"])
+def test_rename_noreplace_at_rejects_non_child_names(
+    tmp_path: Path,
+    name: str,
+) -> None:
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(ValueError, match="one bounded file name"):
+            atomic_module._rename_noreplace_at(name, "target", descriptor, descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def test_publish_staged_directory_restores_previous_tree_on_failure(
@@ -43,25 +248,24 @@ def test_publish_staged_directory_restores_previous_tree_on_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / ".published.tmp"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_replace = os.replace
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
 
-    def fail_stage_publish(source, target):
-        if Path(source) == stage and Path(target) == destination:
+    def fail_final(src: str, dst: str, src_dir_fd: int, dst_dir_fd: int) -> None:
+        if src == stage.name and dst == destination.name:
             raise OSError("injected final rename failure")
-        return real_replace(source, target)
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
 
-    monkeypatch.setattr("codenib._atomic_directory.os.replace", fail_stage_publish)
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", fail_final)
 
     with pytest.raises(OSError, match="injected final rename failure"):
         publish_staged_directory(stage, destination)
 
     assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
 
 
 def test_publish_staged_directory_restores_missing_target_on_failure(
@@ -70,16 +274,15 @@ def test_publish_staged_directory_restores_missing_target_on_failure(
 ) -> None:
     destination = tmp_path / "published"
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_replace = os.replace
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
 
-    def fail_stage_publish(source, target):
-        if Path(source) == stage and Path(target) == destination:
+    def fail_final(src: str, dst: str, src_dir_fd: int, dst_dir_fd: int) -> None:
+        if src == stage.name and dst == destination.name:
             raise OSError("injected final rename failure")
-        return real_replace(source, target)
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
 
-    monkeypatch.setattr("codenib._atomic_directory.os.replace", fail_stage_publish)
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", fail_final)
 
     with pytest.raises(OSError, match="injected final rename failure"):
         publish_staged_directory(stage, destination)
@@ -94,11 +297,11 @@ def test_publish_staged_directory_rejects_invalid_relationships(
 ) -> None:
     stage = tmp_path / "stage"
     stage.mkdir()
-    destination_file = tmp_path / "published"
-    destination_file.write_text("keep", encoding="utf-8")
-
     with pytest.raises(ValueError, match="must differ"):
         publish_staged_directory(stage, stage)
+
+    destination_file = tmp_path / "published"
+    destination_file.write_text("keep", encoding="utf-8")
     with pytest.raises(ValueError, match="not a directory"):
         publish_staged_directory(stage, destination_file)
 
@@ -106,21 +309,17 @@ def test_publish_staged_directory_rejects_invalid_relationships(
 def test_publish_staged_directory_does_not_follow_destination_symlink(
     tmp_path: Path,
 ) -> None:
-    victim = tmp_path / "victim"
-    victim.mkdir()
-    (victim / "keep.txt").write_text("keep", encoding="utf-8")
-    destination = tmp_path / "published"
-    destination.symlink_to(victim, target_is_directory=True)
     stage = tmp_path / "stage"
     stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-
+    victim = tmp_path / "victim"
+    _write_tree(victim, "keep.txt", "keep")
+    destination = tmp_path / "published"
+    destination.symlink_to(victim, target_is_directory=True)
     with pytest.raises(ValueError, match="link"):
         publish_staged_directory(stage, destination)
 
     assert destination.is_symlink()
     assert (victim / "keep.txt").read_text(encoding="utf-8") == "keep"
-    assert not (victim / "new.txt").exists()
 
 
 def test_publish_staged_directory_detects_destination_swap_at_boundary(
@@ -128,31 +327,955 @@ def test_publish_staged_directory_detects_destination_swap_at_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stolen = tmp_path / "stolen"
-    victim = tmp_path / "victim"
-    victim.mkdir()
-    (victim / "keep.txt").write_text("keep", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-old"
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
 
-    def swap_then_allocate(*args, **kwargs):
-        destination.rename(stolen)
-        destination.symlink_to(victim, target_is_directory=True)
-        return real_mkdtemp(*args, **kwargs)
+    def replace_before_claim(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == destination.name and ".published.previous-" in dst and not injected:
+            injected = True
+            destination.rename(stolen)
+            _write_tree(destination, "foreign.txt", "preserve")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
 
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", swap_then_allocate)
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        replace_before_claim,
+    )
 
     with pytest.raises(RuntimeError, match="changed at the publication boundary"):
         publish_staged_directory(stage, destination)
 
-    assert destination.is_symlink()
-    assert (victim / "keep.txt").read_text(encoding="utf-8") == "keep"
-    assert not (victim / "new.txt").exists()
+    assert (destination / "foreign.txt").read_text(encoding="utf-8") == "preserve"
     assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_raced_destination_before_final_rename_is_never_overwritten(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def insert_foreign(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            _write_tree(destination, "foreign.txt", "preserve")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", insert_foreign)
+
+    with pytest.raises(RuntimeError, match="previous output remains isolated"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    previous = list(tmp_path.glob(".published.previous-*"))
+    assert len(previous) == 1
+    assert (previous[0] / "old.txt").read_text(encoding="utf-8") == "old"
+
+
+def test_publish_staged_directory_rejects_real_stage_swap_before_destination_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-stage"
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def replace_stage(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            stage.rename(stolen)
+            _write_tree(stage, "foreign.txt", "preserve")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", replace_stage)
+
+    with pytest.raises(RuntimeError, match="suspect output was quarantined"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stolen / "new.txt").read_text(encoding="utf-8") == "new"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "foreign.txt").read_text(encoding="utf-8") == ("preserve")
+
+
+def test_expected_stage_ownership_requires_the_complete_token(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    expected = capture_directory_ownership(stage)
+    (stage / "new.txt").write_text("NEW", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="changed before publication"):
+        publish_staged_directory(
+            stage,
+            destination,
+            expected_stage_root_ownership=expected,
+        )
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "NEW"
+
+
+def test_publish_uses_borrowed_parent_descriptor_without_closing_it(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    expected_parent = publication_parent_identity(descriptor)
+    try:
+        orphan = publish_staged_directory(
+            stage,
+            destination,
+            parent_descriptor=descriptor,
+            expected_parent_identity=expected_parent,
+        )
+        assert publication_parent_identity(descriptor) == expected_parent
+    finally:
+        os.close(descriptor)
+
+    assert orphan is not None
+    assert orphan.parent_identity == expected_parent
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_public_publish_wrapper_does_not_request_strict_commit_fsync(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    def forbidden_fsync(_descriptor: int) -> None:
+        raise AssertionError("compatibility publication must not use strict fsync")
+
+    monkeypatch.setattr(atomic_module.os, "fsync", forbidden_fsync)
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is not None
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_authority_publish_helper_rejects_noncallable_commit_before_mutation(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        with pytest.raises(TypeError, match="commit callback must be callable"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                commit_callback=object(),  # type: ignore[arg-type]
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict commit durability currently requires Linux directory fsync",
+)
+def test_authority_publish_helper_borrows_authority_and_commits_exact_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    expected_previous = capture_directory_ownership(destination)
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    expected_stage = capture_directory_ownership(stage)
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    events: list[str] = []
+    observed: list[tuple[object, object, DirectoryOrphan | None]] = []
+    real_verify = authority._verify_callback
+    real_fsync = atomic_module.os.fsync
+
+    def verify_parent_binding() -> None:
+        real_verify()
+        events.append("verified")
+
+    def fsync_parent(descriptor: int) -> None:
+        assert descriptor == authority.resource
+        real_fsync(descriptor)
+        events.append("synced")
+
+    def commit(
+        sealed: object,
+        published: object,
+        previous: DirectoryOrphan | None,
+    ) -> None:
+        assert events == ["verified", "synced"]
+        events.append("committed")
+        observed.append((sealed, published, previous))
+
+    authority._verify_callback = verify_parent_binding
+    monkeypatch.setattr(atomic_module.os, "fsync", fsync_parent)
+    try:
+        orphan = atomic_module._publish_staged_directory_with_authority(
+            authority,
+            stage,
+            destination,
+            expected_stage_root_ownership=expected_stage,
+            commit_callback=commit,
+        )
+        assert not authority._closed
+        authority.verify_path_binding()
+    finally:
+        authority.close()
+
+    assert authority._closed
+    assert events == ["verified", "synced", "committed", "verified"]
+    assert len(observed) == 1
+    assert observed[0][0] == expected_stage
+    published = observed[0][1]
+    assert isinstance(published, type(expected_stage))
+    assert (
+        replace(
+            published,
+            root_version_identity=expected_stage.root_version_identity,
+        )
+        == expected_stage
+    )
+    assert observed[0][2] is orphan
+    assert orphan is not None
+    assert orphan.ownership_digest == expected_previous.digest
+    assert (orphan.path / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert published == capture_directory_ownership(destination)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict commit durability currently requires Linux directory fsync",
+)
+def test_authority_publish_helper_does_not_commit_before_validation_finishes(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    commits: list[object] = []
+
+    def fail_validation(_reader: object) -> None:
+        raise RuntimeError("injected pre-commit validation failure")
+
+    try:
+        with pytest.raises(RuntimeError, match="suspect output was quarantined"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                validate_published_destination=fail_validation,
+                commit_callback=lambda sealed, _published, _previous: commits.append(
+                    sealed
+                ),
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert commits == []
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict commit durability currently requires Linux directory fsync",
+)
+def test_authority_publish_helper_rechecks_exact_tree_after_orphan_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    commits: list[object] = []
+    real_orphan_metadata = atomic_module._orphan_metadata
+
+    def mutate_after_orphan_receipt(*args: object, **kwargs: object) -> DirectoryOrphan:
+        orphan = real_orphan_metadata(*args, **kwargs)
+        (destination / "late.txt").write_text("late", encoding="utf-8")
+        return orphan
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_orphan_metadata",
+        mutate_after_orphan_receipt,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="published staged directory changed"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                commit_callback=lambda sealed, _published, _previous: commits.append(
+                    sealed
+                ),
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert commits == []
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (destination / "late.txt").read_text(encoding="utf-8") == "late"
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict commit durability currently requires Linux directory fsync",
+)
+def test_authority_publish_helper_fsync_failure_prevents_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    commits: list[object] = []
+    error = OSError(errno.EIO, "injected parent fsync failure")
+
+    def fail_parent_fsync(descriptor: int) -> None:
+        assert descriptor == authority.resource
+        raise error
+
+    monkeypatch.setattr(atomic_module.os, "fsync", fail_parent_fsync)
+    try:
+        with pytest.raises(OSError) as caught:
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                commit_callback=lambda sealed, _published, _previous: commits.append(
+                    sealed
+                ),
+            )
+        assert caught.value is error
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert commits == []
+    assert not stage.exists()
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    previous = list(tmp_path.glob(".published.previous-*"))
+    assert len(previous) == 1
+    assert (previous[0] / "old.txt").read_text(encoding="utf-8") == "old"
+
+
+@pytest.mark.parametrize("backend_tag", ["windows-file-id", "darwin-renameatx-np"])
+def test_authority_publish_helper_rejects_unsupported_durable_commit(
+    tmp_path: Path,
+    backend_tag: str,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    authority.backend_tag = backend_tag
+    commits: list[object] = []
+    try:
+        with pytest.raises(RuntimeError, match="supported Linux"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                commit_callback=lambda sealed, _published, _previous: commits.append(
+                    sealed
+                ),
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert commits == []
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+@pytest.mark.parametrize("error_type", [KeyboardInterrupt, SystemExit])
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict commit durability currently requires Linux directory fsync",
+)
+def test_authority_publish_helper_never_rolls_back_commit_interruptions(
+    tmp_path: Path,
+    error_type: type[BaseException],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    expected_stage = capture_directory_ownership(stage)
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    observed: list[tuple[object, object, DirectoryOrphan | None]] = []
+    synced = False
+    real_fsync = atomic_module.os.fsync
+
+    def fsync_parent(descriptor: int) -> None:
+        nonlocal synced
+        assert descriptor == authority.resource
+        real_fsync(descriptor)
+        synced = True
+
+    def interrupt_commit(
+        sealed: object,
+        published: object,
+        previous: DirectoryOrphan | None,
+    ) -> None:
+        assert synced
+        observed.append((sealed, published, previous))
+        raise error_type("injected commit interruption")
+
+    monkeypatch.setattr(atomic_module.os, "fsync", fsync_parent)
+    try:
+        with pytest.raises(error_type, match="injected commit interruption"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+                commit_callback=interrupt_commit,
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert len(observed) == 1
+    assert observed[0][0] == expected_stage
+    published = observed[0][1]
+    assert isinstance(published, type(expected_stage))
+    assert (
+        replace(
+            published,
+            root_version_identity=expected_stage.root_version_identity,
+        )
+        == expected_stage
+    )
+    previous = observed[0][2]
+    assert previous is not None
+    assert (previous.path / "old.txt").read_text(encoding="utf-8") == "old"
+    assert not stage.exists()
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_authority_publish_helper_rejects_paths_outside_authority_parent(
+    tmp_path: Path,
+) -> None:
+    foreign_parent = tmp_path / "foreign"
+    foreign_parent.mkdir()
+    destination = foreign_parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = foreign_parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        with pytest.raises(ValueError, match="match the authority parent"):
+            atomic_module._publish_staged_directory_with_authority(
+                authority,
+                stage,
+                destination,
+            )
+        assert not authority._closed
+    finally:
+        authority.close()
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_rejects_wrong_parent_authority_before_mutation(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(RuntimeError, match="does not match authority"):
+            publish_staged_directory(
+                stage,
+                destination,
+                parent_descriptor=descriptor,
+                expected_parent_identity=(0,),
+            )
+    finally:
+        os.close(descriptor)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publication_paths_never_call_path_resolve(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    def forbidden_resolve(*_args: object, **_kwargs: object) -> Path:
+        raise AssertionError("publication authority must not resolve lexical paths")
+
+    monkeypatch.setattr(Path, "resolve", forbidden_resolve)
+
+    publish_staged_directory(stage, destination)
+
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publication_rejects_preexisting_parent_symlink(
+    tmp_path: Path,
+) -> None:
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    destination = foreign / "published"
+    _write_tree(destination, "valuable.txt", "preserve")
+    stage = foreign / "stage"
+    _write_tree(stage, "new.txt", "new")
+    alias = tmp_path / "alias"
+    alias.symlink_to(foreign, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="real directory"):
+        publish_staged_directory(alias / "stage", alias / "published")
+
+    assert (destination / "valuable.txt").read_text(encoding="utf-8") == "preserve"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publication_rejects_reversible_intermediate_parent_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trusted = tmp_path / "trusted"
+    intermediate = trusted / "intermediate"
+    parent = intermediate / "parent"
+    parent.mkdir(parents=True)
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    foreign = tmp_path / "foreign-intermediate"
+    foreign_parent = foreign / "parent"
+    foreign_parent.mkdir(parents=True)
+    _write_tree(foreign_parent / "published", "valuable.txt", "preserve")
+    saved = tmp_path / "saved-intermediate"
+    real_open = atomic_module.os.open
+    swapped = False
+
+    def reversible_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if path == "intermediate" and dir_fd is not None and not swapped:
+            swapped = True
+            intermediate.rename(saved)
+            foreign.rename(intermediate)
+            try:
+                return real_open(path, flags, mode, dir_fd=dir_fd)
+            finally:
+                intermediate.rename(foreign)
+                saved.rename(intermediate)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(atomic_module.os, "open", reversible_open)
+
+    with pytest.raises(RuntimeError, match="changed while it was opened"):
+        publish_staged_directory(stage, destination)
+
+    assert swapped
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (foreign_parent / "published" / "valuable.txt").read_text(
+        encoding="utf-8"
+    ) == "preserve"
+
+
+def test_parent_path_replacement_cannot_redirect_pinned_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = tmp_path / "active-parent"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    moved_parent = tmp_path / "moved-parent"
+    descriptor = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+    expected_parent = publication_parent_identity(descriptor)
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def replace_parent(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            parent.rename(moved_parent)
+            parent.mkdir()
+            foreign = parent / destination.name
+            _write_tree(foreign, "foreign.txt", "preserve")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", replace_parent)
+    try:
+        with pytest.raises(RuntimeError, match="parent path changed"):
+            publish_staged_directory(
+                stage,
+                destination,
+                parent_descriptor=descriptor,
+                expected_parent_identity=expected_parent,
+            )
+    finally:
+        os.close(descriptor)
+
+    assert (parent / "published" / "foreign.txt").read_text(
+        encoding="utf-8"
+    ) == "preserve"
+    assert (moved_parent / "published" / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_discard_owned_directory_isolates_instead_of_deleting(tmp_path: Path) -> None:
+    root = tmp_path / "owned"
+    _write_tree(root, "payload.txt", "payload")
+    ownership = capture_directory_ownership(root)
+
+    orphan = atomic_module.discard_owned_directory(root, ownership)
+
+    assert isinstance(orphan, DirectoryOrphan)
+    assert orphan.verified_at_isolation
+    assert not root.exists()
+    assert (orphan.path / "payload.txt").read_text(encoding="utf-8") == "payload"
+
+
+def test_discard_restores_foreign_replacement_claimed_at_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "owned"
+    _write_tree(root, "payload.txt", "payload")
+    ownership = capture_directory_ownership(root)
+    stolen = tmp_path / "stolen-owned"
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def replace_before_claim(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == root.name and ".owned.discarded-" in dst and not injected:
+            injected = True
+            root.rename(stolen)
+            _write_tree(root, "foreign.txt", "preserve")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        replace_before_claim,
+    )
+
+    orphan = atomic_module.discard_owned_directory(root, ownership)
+
+    assert orphan is None
+    assert (root / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+    assert (stolen / "payload.txt").read_text(encoding="utf-8") == "payload"
+
+
+def test_publish_and_discard_never_recursively_unlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("online cleanup must not delete entries")
+
+    monkeypatch.setattr(atomic_module.os, "unlink", forbidden)
+    monkeypatch.setattr(atomic_module.os, "rmdir", forbidden)
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    previous = publish_staged_directory(stage, destination)
+    assert previous is not None
+    published = capture_directory_ownership(destination)
+    discarded = atomic_module.discard_owned_directory(destination, published)
+
+    assert discarded is not None
+    assert (previous.path / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (discarded.path / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_restores_old_tree_when_rename_completes_then_interrupts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def interrupt_after_claim(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+        if src == destination.name and ".published.previous-" in dst and not injected:
+            injected = True
+            raise KeyboardInterrupt("post-claim interruption")
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", interrupt_after_claim)
+
+    with pytest.raises(KeyboardInterrupt, match="post-claim interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_final_rename_that_completes_before_interrupt_is_rolled_back(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def interrupt_after_publish(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            raise KeyboardInterrupt("post-publish interruption")
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        interrupt_after_publish,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="post-publish interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_published_callback_cannot_bypass_exact_tree_token(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    def mutate(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        assert reader.read_bytes("new.txt", max_bytes=16) == b"new"
+        (destination / "late.txt").write_text("late", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="suspect output was quarantined"):
+        publish_staged_directory(
+            stage,
+            destination,
+            validate_published_destination=mutate,
+        )
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
+
+
+def test_publish_staged_directory_never_restores_swapped_callback_backup(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-old"
+    calls = 0
+
+    def swap_on_second_validation(reader: object) -> None:
+        nonlocal calls
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        assert reader.read_bytes("old.txt", max_bytes=16) == b"old"
+        calls += 1
+        if calls == 2:
+            backup = next(tmp_path.glob(".published.previous-*"))
+            backup.rename(stolen)
+            _write_tree(backup, "foreign.txt", "preserve")
+            raise RuntimeError("injected previous validation failure")
+
+    with pytest.raises(
+        RuntimeError,
+        match="previous output identity lost",
+    ):
+        publish_staged_directory(
+            stage,
+            destination,
+            validate_moved_destination=swap_on_second_validation,
+        )
+
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    previous = list(tmp_path.glob(".published.previous-*"))
+    assert len(previous) == 1
+    assert (previous[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_publication_fails_closed_on_unsupported_platform(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    monkeypatch.setattr(atomic_module.sys, "platform", "freebsd14")
+
+    with pytest.raises(RuntimeError, match="unsupported on this host"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_orphan_name_collision_budget_fails_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    monkeypatch.setattr(atomic_module.secrets, "token_hex", lambda _size: "a" * 32)
+    collision = tmp_path / f".published.previous-{'a' * 32}"
+    collision.write_text("foreign", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="claim directory under a bounded orphan"):
+        publish_staged_directory(stage, destination)
+
+    assert collision.read_text(encoding="utf-8") == "foreign"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
 
 
@@ -161,25 +1284,22 @@ def test_publish_staged_directory_preserves_late_destination_entry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    _write_tree(stage, "new.txt", "new")
+    real_claim = atomic_module._claim_child_as_orphan
+    injected = False
 
-    def mutate_then_allocate(*args, **kwargs):
-        (destination / "late.txt").write_text("late", encoding="utf-8")
-        return real_mkdtemp(*args, **kwargs)
+    def mutate_then_claim(*args: object, **kwargs: object) -> Path:
+        nonlocal injected
+        if not injected:
+            injected = True
+            (destination / "late.txt").write_text("late", encoding="utf-8")
+        return real_claim(*args, **kwargs)
 
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_identity",
-        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
-    )
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+    monkeypatch.setattr(atomic_module, "_claim_child_as_orphan", mutate_then_claim)
 
-    with pytest.raises(RuntimeError, match="changed at the publication boundary"):
+    with pytest.raises(RuntimeError, match="changed during directory publication"):
         publish_staged_directory(stage, destination)
 
     assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
@@ -196,26 +1316,24 @@ def test_publish_staged_directory_preserves_nested_late_destination_entry(
     nested.mkdir(parents=True)
     (nested / "old.txt").write_text("old", encoding="utf-8")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    _write_tree(stage, "new.txt", "new")
+    real_claim = atomic_module._claim_child_as_orphan
+    injected = False
 
-    def mutate_then_allocate(*args, **kwargs):
-        (nested / "late.txt").write_text("late", encoding="utf-8")
-        return real_mkdtemp(*args, **kwargs)
+    def mutate_then_claim(*args: object, **kwargs: object) -> Path:
+        nonlocal injected
+        if not injected:
+            injected = True
+            (nested / "late.txt").write_text("late", encoding="utf-8")
+        return real_claim(*args, **kwargs)
 
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_identity",
-        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
-    )
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+    monkeypatch.setattr(atomic_module, "_claim_child_as_orphan", mutate_then_claim)
 
-    with pytest.raises(RuntimeError, match="changed at the publication boundary"):
+    with pytest.raises(RuntimeError, match="changed during directory publication"):
         publish_staged_directory(stage, destination)
 
     assert (destination / "nested" / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (destination / "nested" / "late.txt").read_text(encoding="utf-8") == ("late")
+    assert (destination / "nested" / "late.txt").read_text(encoding="utf-8") == "late"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
 
 
@@ -224,26 +1342,24 @@ def test_publish_staged_directory_rejects_nested_stage_mutation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     stage = tmp_path / "stage"
     nested = stage / "nested"
     nested.mkdir(parents=True)
     (nested / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    real_claim = atomic_module._claim_child_as_orphan
+    injected = False
 
-    def mutate_then_allocate(*args, **kwargs):
-        (nested / "late.txt").write_text("late", encoding="utf-8")
-        return real_mkdtemp(*args, **kwargs)
+    def mutate_then_claim(*args: object, **kwargs: object) -> Path:
+        nonlocal injected
+        if not injected:
+            injected = True
+            (nested / "late.txt").write_text("late", encoding="utf-8")
+        return real_claim(*args, **kwargs)
 
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_identity",
-        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
-    )
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+    monkeypatch.setattr(atomic_module, "_claim_child_as_orphan", mutate_then_claim)
 
-    with pytest.raises(RuntimeError, match="before destination publication"):
+    with pytest.raises(RuntimeError, match="staged directory changed"):
         publish_staged_directory(stage, destination)
 
     assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
@@ -256,26 +1372,23 @@ def test_publish_staged_directory_rejects_same_size_destination_rewrite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
+    _write_tree(destination, "old.txt", "old")
     previous = destination / "old.txt"
-    previous.write_text("old", encoding="utf-8")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    _write_tree(stage, "new.txt", "new")
+    real_claim = atomic_module._claim_child_as_orphan
+    injected = False
 
-    def mutate_then_allocate(*args, **kwargs):
-        previous.write_text("NEW", encoding="utf-8")
-        return real_mkdtemp(*args, **kwargs)
+    def rewrite_then_claim(*args: object, **kwargs: object) -> Path:
+        nonlocal injected
+        if not injected:
+            injected = True
+            previous.write_text("NEW", encoding="utf-8")
+        return real_claim(*args, **kwargs)
 
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_identity",
-        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
-    )
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+    monkeypatch.setattr(atomic_module, "_claim_child_as_orphan", rewrite_then_claim)
 
-    with pytest.raises(RuntimeError, match="changed at the publication boundary"):
+    with pytest.raises(RuntimeError, match="changed during directory publication"):
         publish_staged_directory(stage, destination)
 
     assert previous.read_text(encoding="utf-8") == "NEW"
@@ -288,32 +1401,457 @@ def test_publish_staged_directory_preserves_raced_missing_target_content(
 ) -> None:
     destination = tmp_path / "published"
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
 
-    def mutate_then_allocate(*args, **kwargs):
-        (destination / "late.txt").write_text("late", encoding="utf-8")
-        return real_mkdtemp(*args, **kwargs)
+    def race_missing_target(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            _write_tree(destination, "late.txt", "late")
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
 
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_identity",
-        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
-    )
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", race_missing_target)
 
-    with pytest.raises(RuntimeError, match="raced content remains"):
+    with pytest.raises(FileExistsError):
         publish_staged_directory(
             stage,
             destination,
             expected_destination_identity=None,
-            validate_moved_destination=lambda _path: None,
-            validate_published_destination=lambda _path: None,
         )
 
     assert (destination / "late.txt").read_text(encoding="utf-8") == "late"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_restores_old_tree_on_scan_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_require = atomic_module._require_tree_ownership_at
+
+    def interrupt_moved_tree(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        expected: object,
+        label: str,
+        allow_root_rename: bool = False,
+    ) -> None:
+        if label == "moved destination":
+            raise KeyboardInterrupt("injected ownership interruption")
+        real_require(
+            authority,
+            name,
+            path=path,
+            expected=expected,
+            label=label,
+            allow_root_rename=allow_root_rename,
+        )
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_require_tree_ownership_at",
+        interrupt_moved_tree,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="ownership interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+def test_publish_restores_old_tree_when_moved_lstat_is_interrupted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_directory_or_missing = atomic_module._directory_or_missing_at
+
+    def interrupt_moved_lstat(
+        parent_descriptor: int,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> os.stat_result | None:
+        if label == "moved destination":
+            raise KeyboardInterrupt("injected moved lstat interruption")
+        return real_directory_or_missing(
+            parent_descriptor,
+            name,
+            path=path,
+            label=label,
+        )
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_directory_or_missing_at",
+        interrupt_moved_lstat,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="moved lstat interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_restores_old_tree_when_final_stage_lstat_is_interrupted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_require = atomic_module._require_tree_ownership_at
+    stage_checks = 0
+
+    def interrupt_final_stage_check(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        expected: object,
+        label: str,
+        allow_root_rename: bool = False,
+    ) -> None:
+        nonlocal stage_checks
+        if label == "staged directory":
+            stage_checks += 1
+            if stage_checks == 2:
+                raise KeyboardInterrupt("injected final stage interruption")
+        real_require(
+            authority,
+            name,
+            path=path,
+            expected=expected,
+            label=label,
+            allow_root_rename=allow_root_rename,
+        )
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_require_tree_ownership_at",
+        interrupt_final_stage_check,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="final stage interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert stage_checks == 2
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_first_publication_fails_closed_without_safe_ownership_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    monkeypatch.setattr(atomic_module, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
+
+    with pytest.raises(RuntimeError, match="no-follow directory-fd support"):
+        publish_staged_directory(stage, destination)
+
+    assert stage.is_dir()
+    assert not destination.exists()
+
+
+def test_existing_publication_fails_closed_without_safe_ownership_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    monkeypatch.setattr(atomic_module, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
+
+    with pytest.raises(RuntimeError, match="no-follow directory-fd support"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_quarantines_failed_published_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def mutate_after_publish(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            (destination / "late.txt").write_text("late", encoding="utf-8")
+
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", mutate_after_publish)
+
+    with pytest.raises(RuntimeError, match="suspect output was quarantined"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
+
+
+def test_published_boundary_quarantines_new_before_lost_backup_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-old"
+    real_rename = atomic_module._rename_noreplace_at
+    injected = False
+
+    def lose_backup_after_publish(
+        src: str,
+        dst: str,
+        src_dir_fd: int,
+        dst_dir_fd: int,
+    ) -> None:
+        nonlocal injected
+        real_rename(src, dst, src_dir_fd, dst_dir_fd)
+        if src == stage.name and dst == destination.name and not injected:
+            injected = True
+            backup = next(tmp_path.glob(".published.previous-*"))
+            backup.rename(stolen)
+            _write_tree(backup, "foreign.txt", "preserve")
+            (destination / "late.txt").write_text("late", encoding="utf-8")
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_rename_noreplace_at",
+        lose_backup_after_publish,
+    )
+
+    with pytest.raises(RuntimeError, match="previous output remains isolated"):
+        publish_staged_directory(stage, destination)
+
+    assert not destination.exists()
+    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    backups = list(tmp_path.glob(".published.previous-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
+
+
+def test_published_callback_quarantines_new_before_lost_backup_check(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-old"
+
+    def lose_backup_during_validation(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        assert reader.read_bytes("new.txt", max_bytes=16) == b"new"
+        backup = next(tmp_path.glob(".published.previous-*"))
+        backup.rename(stolen)
+        _write_tree(backup, "foreign.txt", "preserve")
+        raise RuntimeError("injected published validation failure")
+
+    with pytest.raises(RuntimeError, match="previous output remains isolated"):
+        publish_staged_directory(
+            stage,
+            destination,
+            validate_published_destination=lose_backup_during_validation,
+        )
+
+    assert not destination.exists()
+    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    backups = list(tmp_path.glob(".published.previous-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_fails_closed_without_safe_cleanup_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("orphan-only publication must not delete")
+
+    monkeypatch.setattr(atomic_module.os, "unlink", forbidden)
+    monkeypatch.setattr(atomic_module.os, "rmdir", forbidden)
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is not None
+    assert (orphan.path / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_removes_empty_sentinel_without_cleanup_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("first publication must not create/delete a sentinel")
+
+    monkeypatch.setattr(atomic_module.os, "unlink", forbidden)
+    monkeypatch.setattr(atomic_module.os, "rmdir", forbidden)
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is None
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+def test_expected_stage_root_preserves_substituted_cleanup_path(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    expected = capture_directory_ownership(stage)
+    stolen = tmp_path / "stolen-stage"
+    stage.rename(stolen)
+    _write_tree(stage, "foreign.txt", "preserve")
+
+    with pytest.raises(RuntimeError, match="root changed before publication"):
+        publish_staged_directory(
+            stage,
+            destination,
+            expected_stage_root_ownership=expected,
+        )
+    atomic_module.discard_owned_directory(stage, expected)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stolen / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (stage / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_publish_staged_directory_does_not_reacquire_swapped_backup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    stolen = tmp_path / "stolen-old"
+    real_require = atomic_module._require_tree_ownership_at
+    injected = False
+
+    def swap_before_previous_check(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        expected: object,
+        label: str,
+        allow_root_rename: bool = False,
+    ) -> None:
+        nonlocal injected
+        if label == "previous destination" and not injected:
+            injected = True
+            path.rename(stolen)
+            _write_tree(path, "foreign.txt", "preserve")
+        real_require(
+            authority,
+            name,
+            path=path,
+            expected=expected,
+            label=label,
+            allow_root_rename=allow_root_rename,
+        )
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_require_tree_ownership_at",
+        swap_before_previous_check,
+    )
+
+    with pytest.raises(RuntimeError, match="previous output identity lost"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    backups = list(tmp_path.glob(".published.previous-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_publish_staged_directory_does_not_rollback_after_cleanup_starts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "one.txt", "one")
+    (destination / "two.txt").write_text("two", encoding="utf-8")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    unlink_calls = 0
+
+    def count_forbidden(*_args: object, **_kwargs: object) -> None:
+        nonlocal unlink_calls
+        unlink_calls += 1
+        raise AssertionError("destructive cleanup is unreachable")
+
+    monkeypatch.setattr(atomic_module.os, "unlink", count_forbidden)
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert unlink_calls == 0
+    assert orphan is not None
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (orphan.path / "one.txt").read_text(encoding="utf-8") == "one"
+    assert (orphan.path / "two.txt").read_text(encoding="utf-8") == "two"
 
 
 @pytest.mark.parametrize(
@@ -333,8 +1871,9 @@ def test_publish_staged_directory_bounds_builtin_ownership_scan(
     files: dict[str, str],
     error: str,
 ) -> None:
-    destination = tmp_path / "published"
-    stage = tmp_path / "stage"
+    short_names = constant == "_MAX_OWNERSHIP_COMPONENT_BYTES"
+    destination = tmp_path / ("d" if short_names else "published")
+    stage = tmp_path / ("s" if short_names else "stage")
     stage.mkdir()
     for name, content in files.items():
         (stage / name).write_text(content, encoding="utf-8")
@@ -344,8 +1883,6 @@ def test_publish_staged_directory_bounds_builtin_ownership_scan(
         publish_staged_directory(stage, destination)
 
     assert not destination.exists()
-    for name, content in files.items():
-        assert (stage / name).read_text(encoding="utf-8") == content
 
 
 def test_directory_ownership_is_independent_of_entry_order(tmp_path: Path) -> None:
@@ -487,16 +2024,13 @@ def test_expected_destination_ownership_rejects_identical_root_swap(
     tmp_path: Path,
 ) -> None:
     destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     expected = capture_directory_ownership(destination)
     stolen = tmp_path / "stolen"
     destination.rename(stolen)
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
+    _write_tree(destination, "old.txt", "old")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
+    _write_tree(stage, "new.txt", "new")
 
     with pytest.raises(RuntimeError, match="changed before directory publication"):
         publish_staged_directory(
@@ -507,358 +2041,6 @@ def test_expected_destination_ownership_rejects_identical_root_swap(
 
     assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
     assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-
-
-def test_expected_stage_root_preserves_substituted_cleanup_path(
-    tmp_path: Path,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    expected = capture_directory_ownership(stage)
-    stolen = tmp_path / "stolen-stage"
-    stage.rename(stolen)
-    stage.mkdir()
-    (stage / "foreign.txt").write_text("preserve", encoding="utf-8")
-
-    with pytest.raises(RuntimeError, match="root changed before publication"):
-        publish_staged_directory(
-            stage,
-            destination,
-            expected_stage_root_ownership=expected,
-        )
-    atomic_module.discard_owned_directory(stage, expected)
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert stolen.is_dir()
-    assert (stage / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-
-
-def test_publish_staged_directory_restores_old_tree_on_scan_interrupt(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_require = atomic_module._require_tree_ownership
-
-    def interrupt_moved_tree(path, expected, *, label):
-        if label == "moved destination":
-            raise KeyboardInterrupt("injected ownership interruption")
-        return real_require(path, expected, label=label)
-
-    monkeypatch.setattr(
-        atomic_module,
-        "_require_tree_ownership",
-        interrupt_moved_tree,
-    )
-
-    with pytest.raises(KeyboardInterrupt, match="ownership interruption"):
-        publish_staged_directory(stage, destination)
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.previous-*"))
-
-
-def test_publish_restores_old_tree_when_moved_lstat_is_interrupted(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_directory_or_missing = atomic_module._directory_or_missing
-
-    def interrupt_moved_lstat(path: Path, *, label: str):
-        if label == "moved destination":
-            raise KeyboardInterrupt("injected moved lstat interruption")
-        return real_directory_or_missing(path, label=label)
-
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_or_missing",
-        interrupt_moved_lstat,
-    )
-
-    with pytest.raises(KeyboardInterrupt, match="moved lstat interruption"):
-        publish_staged_directory(stage, destination)
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.previous-*"))
-
-
-def test_publish_restores_old_tree_when_rename_completes_then_interrupts(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_replace = atomic_module.os.replace
-
-    def interrupt_after_old_rename(source, target):
-        result = real_replace(source, target)
-        if Path(source) == destination and Path(target).name.startswith(
-            ".published.previous-"
-        ):
-            raise KeyboardInterrupt("injected post-rename interruption")
-        return result
-
-    monkeypatch.setattr(atomic_module.os, "replace", interrupt_after_old_rename)
-
-    with pytest.raises(KeyboardInterrupt, match="post-rename interruption"):
-        publish_staged_directory(stage, destination)
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.previous-*"))
-
-
-def test_publish_restores_old_tree_when_final_stage_lstat_is_interrupted(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_directory_or_missing = atomic_module._directory_or_missing
-    staged_calls = 0
-
-    def interrupt_final_stage_lstat(path: Path, *, label: str):
-        nonlocal staged_calls
-        if label == "staged directory":
-            staged_calls += 1
-            if staged_calls == 3:
-                raise KeyboardInterrupt("injected final stage lstat interruption")
-        return real_directory_or_missing(path, label=label)
-
-    monkeypatch.setattr(
-        atomic_module,
-        "_directory_or_missing",
-        interrupt_final_stage_lstat,
-    )
-
-    with pytest.raises(KeyboardInterrupt, match="final stage lstat interruption"):
-        publish_staged_directory(stage, destination)
-
-    assert staged_calls == 3
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.previous-*"))
-
-
-def test_first_publication_works_without_safe_ownership_fds(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    monkeypatch.setattr(atomic_module, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
-
-    publish_staged_directory(
-        stage,
-        destination,
-        expected_destination_ownership=None,
-        validate_staged_directory=lambda _path: None,
-        validate_published_destination=lambda _path: None,
-    )
-
-    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
-
-
-def test_existing_publication_fails_closed_without_safe_ownership_fds(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    monkeypatch.setattr(atomic_module, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
-
-    with pytest.raises(RuntimeError, match="non-empty trees"):
-        publish_staged_directory(
-            stage,
-            destination,
-            validate_staged_directory=lambda _path: None,
-            validate_published_destination=lambda _path: None,
-        )
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-
-
-def test_publish_staged_directory_quarantines_failed_published_identity(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_replace = os.replace
-
-    def mutate_after_publish(source, target):
-        result = real_replace(source, target)
-        if Path(source) == stage and Path(target) == destination:
-            (destination / "late.txt").write_text("late", encoding="utf-8")
-        return result
-
-    monkeypatch.setattr(atomic_module.os, "replace", mutate_after_publish)
-
-    with pytest.raises(RuntimeError, match="quarantined"):
-        publish_staged_directory(stage, destination)
-
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
-    assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert not stage.exists()
-
-
-def test_published_callback_cannot_bypass_exact_tree_token(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_replace = os.replace
-
-    def add_empty_directory_after_publish(source, target):
-        result = real_replace(source, target)
-        if Path(source) == stage and Path(target) == destination:
-            (destination / "late-empty").mkdir()
-        return result
-
-    monkeypatch.setattr(atomic_module.os, "replace", add_empty_directory_after_publish)
-
-    with pytest.raises(RuntimeError, match="quarantined"):
-        publish_staged_directory(
-            stage,
-            destination,
-            validate_staged_directory=lambda _path: None,
-            validate_published_destination=lambda _path: None,
-        )
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "late-empty").is_dir()
-
-
-def test_published_boundary_quarantines_new_before_lost_backup_check(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    stolen = tmp_path / "stolen-old"
-    real_replace = os.replace
-
-    def lose_backup_after_publish(source, target):
-        result = real_replace(source, target)
-        if Path(source) == stage and Path(target) == destination:
-            backup = next(tmp_path.glob(".published.previous-*"))
-            backup.rename(stolen)
-            backup.mkdir()
-            (backup / "foreign.txt").write_text("preserve", encoding="utf-8")
-            (destination / "late.txt").write_text("late", encoding="utf-8")
-        return result
-
-    monkeypatch.setattr(atomic_module.os, "replace", lose_backup_after_publish)
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "suspect output was quarantined at .*previous output identity lost; "
-            "active destination is absent"
-        ),
-    ):
-        publish_staged_directory(stage, destination)
-
-    assert not destination.exists()
-    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
-    backups = list(tmp_path.glob(".published.previous-*"))
-    assert len(backups) == 1
-    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
-    assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
-
-
-def test_published_callback_quarantines_new_before_lost_backup_check(
-    tmp_path: Path,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    stolen = tmp_path / "stolen-old"
-
-    def lose_backup_during_published_validation(_path: Path) -> None:
-        backup = next(tmp_path.glob(".published.previous-*"))
-        backup.rename(stolen)
-        backup.mkdir()
-        (backup / "foreign.txt").write_text("preserve", encoding="utf-8")
-        raise RuntimeError("injected published-token validation failure")
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "suspect output was quarantined at .*previous output identity lost; "
-            "active destination is absent"
-        ),
-    ):
-        publish_staged_directory(
-            stage,
-            destination,
-            validate_published_destination=lose_backup_during_published_validation,
-        )
-
-    assert not destination.exists()
-    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
-    backups = list(tmp_path.glob(".published.previous-*"))
-    assert len(backups) == 1
-    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
 
 
 def test_publish_staged_directory_rejects_mounted_tree_before_publication(
@@ -870,219 +2052,19 @@ def test_publish_staged_directory_rejects_mounted_tree_before_publication(
     mounted.mkdir(parents=True)
     (mounted / "external.txt").write_text("preserve", encoding="utf-8")
     stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    original_mount_check = atomic_module._path_is_mount_point
+    _write_tree(stage, "new.txt", "new")
+    real_mount_check = atomic_module._path_is_mount_point
 
-    def fake_mount_check(
-        path: Path,
-        **kwargs: object,
-    ) -> bool:
-        return Path(path).name == "mounted" or original_mount_check(path, **kwargs)
+    def fake_mount_check(path: Path, **kwargs: object) -> bool:
+        return Path(path).name == "mounted" or real_mount_check(path, **kwargs)
 
     monkeypatch.setattr(atomic_module, "_path_is_mount_point", fake_mount_check)
 
     with pytest.raises(RuntimeError, match="ownership scan refuses mounted"):
         publish_staged_directory(stage, destination)
 
-    assert (destination / "mounted" / "external.txt").read_text(
-        encoding="utf-8"
-    ) == "preserve"
+    assert (mounted / "external.txt").read_text(encoding="utf-8") == "preserve"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.quarantine-*"))
-
-
-def test_publish_staged_directory_fails_closed_without_safe_cleanup_fds(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "foreign.txt").write_text("preserve", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    monkeypatch.setattr(atomic_module, "_SAFE_REMOVAL_DIRECTORY_FDS", False)
-
-    with pytest.raises(RuntimeError, match="safe cleanup validation"):
-        publish_staged_directory(stage, destination)
-
-    assert (destination / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
-
-
-def test_publish_staged_directory_removes_empty_sentinel_without_cleanup_fds(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    monkeypatch.setattr(atomic_module, "_SAFE_REMOVAL_DIRECTORY_FDS", False)
-
-    publish_staged_directory(stage, destination)
-
-    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
-    assert not list(tmp_path.glob(".published.previous-*"))
-
-
-def test_publish_staged_directory_rejects_real_stage_swap_before_destination_rename(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    expected_stage_identity = atomic_module._directory_identity(stage.lstat())
-    stolen = tmp_path / "stolen-stage"
-    real_mkdtemp = atomic_module.tempfile.mkdtemp
-
-    def swap_stage_then_allocate(*args, **kwargs):
-        allocated = real_mkdtemp(*args, **kwargs)
-        stage.rename(stolen)
-        stage.mkdir()
-        (stage / "foreign.txt").write_text("preserve", encoding="utf-8")
-        return allocated
-
-    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", swap_stage_then_allocate)
-
-    with pytest.raises(RuntimeError, match="before destination publication"):
-        publish_staged_directory(
-            stage,
-            destination,
-            expected_stage_identity=expected_stage_identity,
-        )
-
-    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
-    assert (stolen / "new.txt").read_text(encoding="utf-8") == "new"
-    assert (stage / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-
-
-def test_publish_staged_directory_does_not_reacquire_swapped_backup(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    stolen = tmp_path / "stolen-old"
-    original_remove = atomic_module._remove_owned_directory
-
-    def swap_backup_then_remove(
-        path: Path,
-        expected_identity: tuple[int, ...],
-        **kwargs: object,
-    ) -> None:
-        path.rename(stolen)
-        path.mkdir()
-        (path / "foreign.txt").write_text("preserve", encoding="utf-8")
-        original_remove(path, expected_identity, **kwargs)
-
-    monkeypatch.setattr(
-        atomic_module,
-        "_remove_owned_directory",
-        swap_backup_then_remove,
-    )
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "publication committed; cleanup incomplete; previous output identity lost"
-        ),
-    ):
-        publish_staged_directory(stage, destination)
-
-    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
-    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
-    backups = list(tmp_path.glob(".published.previous-*"))
-    assert len(backups) == 1
-    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-    assert not list(tmp_path.glob(".published.quarantine-*"))
-
-
-def test_publish_staged_directory_never_restores_swapped_callback_backup(
-    tmp_path: Path,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "old.txt").write_text("old", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    stolen = tmp_path / "stolen-old"
-    callback_calls = 0
-
-    def swap_backup_on_second_validation(path: Path) -> None:
-        nonlocal callback_calls
-        callback_calls += 1
-        if callback_calls == 2:
-            path.rename(stolen)
-            path.mkdir()
-            (path / "foreign.txt").write_text("preserve", encoding="utf-8")
-            raise RuntimeError("injected second validation failure")
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "publication committed; cleanup incomplete; previous output identity lost"
-        ),
-    ):
-        publish_staged_directory(
-            stage,
-            destination,
-            validate_moved_destination=swap_backup_on_second_validation,
-        )
-
-    assert callback_calls == 2
-    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
-    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
-    backups = list(tmp_path.glob(".published.previous-*"))
-    assert len(backups) == 1
-    assert (backups[0] / "foreign.txt").read_text(encoding="utf-8") == "preserve"
-    assert not list(tmp_path.glob(".published.quarantine-*"))
-
-
-def test_publish_staged_directory_does_not_rollback_after_cleanup_starts(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    destination = tmp_path / "published"
-    destination.mkdir()
-    (destination / "one.txt").write_text("one", encoding="utf-8")
-    (destination / "two.txt").write_text("two", encoding="utf-8")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-    (stage / "new.txt").write_text("new", encoding="utf-8")
-    real_unlink = atomic_module.os.unlink
-    unlink_calls = 0
-
-    def fail_second_unlink(path, *args, **kwargs):
-        nonlocal unlink_calls
-        unlink_calls += 1
-        if unlink_calls == 2:
-            raise OSError("injected second unlink failure")
-        return real_unlink(path, *args, **kwargs)
-
-    monkeypatch.setattr(atomic_module.os, "unlink", fail_second_unlink)
-
-    with pytest.raises(RuntimeError, match="publication committed; cleanup incomplete"):
-        publish_staged_directory(stage, destination)
-
-    assert unlink_calls == 2
-    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
-    backups = list(tmp_path.glob(".published.previous-*"))
-    assert len(backups) == 1
-    assert len(list(backups[0].iterdir())) == 1
-    assert not list(tmp_path.glob(".published.quarantine-*"))
 
 
 def test_quarantine_replace_failure_preserves_original_exception(
@@ -1092,16 +2074,20 @@ def test_quarantine_replace_failure_preserves_original_exception(
     destination = tmp_path / "published"
     destination.mkdir()
 
-    def fail_replace(_source, _target):
+    def fail_rename(
+        _src: str,
+        _dst: str,
+        _src_dir_fd: int,
+        _dst_dir_fd: int,
+    ) -> None:
         raise OSError("injected quarantine rename failure")
 
-    monkeypatch.setattr(atomic_module.os, "replace", fail_replace)
+    monkeypatch.setattr(atomic_module, "_rename_noreplace_at", fail_rename)
 
     with pytest.raises(OSError, match="injected quarantine rename failure"):
         atomic_module._quarantine_destination(destination)
 
     assert destination.is_dir()
-    assert not list(tmp_path.glob(".published.quarantine-*"))
 
 
 def test_directory_check_rejects_windows_reparse_directory(
@@ -1116,3 +2102,2379 @@ def test_directory_check_rejects_windows_reparse_directory(
 
     with pytest.raises(ValueError, match="link"):
         atomic_module._directory_or_missing(tmp_path / "junction", label="target")
+
+
+def test_darwin_rename_uses_exclusive_renameatx_np(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[int, bytes, int, bytes, int]] = []
+
+    class FakeRename:
+        argtypes: object = None
+        restype: object = None
+
+        def __call__(
+            self,
+            source_fd: int,
+            source: bytes,
+            destination_fd: int,
+            destination: bytes,
+            flags: int,
+        ) -> int:
+            calls.append((source_fd, source, destination_fd, destination, flags))
+            return 0
+
+    fake_rename = FakeRename()
+    fake_libc = SimpleNamespace(renameatx_np=fake_rename)
+    monkeypatch.setattr(atomic_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        atomic_module.ctypes,
+        "CDLL",
+        lambda *_args, **_kwargs: fake_libc,
+    )
+
+    atomic_module._rename_noreplace_at("source", "target", 11, 12)
+
+    assert calls == [(11, b"source", 12, b"target", 0x4)]
+
+
+def test_darwin_exclusive_rename_preserves_existing_destination_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ExistingRename:
+        argtypes: object = None
+        restype: object = None
+
+        def __call__(self, *_args: object) -> int:
+            atomic_module.ctypes.set_errno(errno.EEXIST)
+            return -1
+
+    monkeypatch.setattr(atomic_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        atomic_module.ctypes,
+        "CDLL",
+        lambda *_args, **_kwargs: SimpleNamespace(renameatx_np=ExistingRename()),
+    )
+
+    with pytest.raises(FileExistsError):
+        atomic_module._rename_noreplace_at("source", "target", 11, 12)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires real macOS syscalls")
+def test_darwin_real_exclusive_rename_does_not_replace(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "source.txt").write_text("source", encoding="utf-8")
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    (destination / "destination.txt").write_text("destination", encoding="utf-8")
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        with pytest.raises(FileExistsError):
+            atomic_module._rename_noreplace_at(
+                source.name,
+                destination.name,
+                descriptor,
+                descriptor,
+            )
+    finally:
+        os.close(descriptor)
+
+    assert (source / "source.txt").read_text(encoding="utf-8") == "source"
+    assert (destination / "destination.txt").read_text(
+        encoding="utf-8"
+    ) == "destination"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires real macOS syscalls")
+def test_darwin_real_publication_reader_and_orphan_locator(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    observed: list[bytes] = []
+
+    def validate(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        observed.append(reader.read_bytes("new.txt", max_bytes=16))
+
+    orphan = publish_staged_directory(
+        stage,
+        destination,
+        validate_staged_directory=validate,
+        validate_published_destination=validate,
+    )
+
+    assert orphan is not None
+    assert observed == [b"new", b"new"]
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("old.txt", max_bytes=16))
+        == b"old"
+    )
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires real macOS syscalls")
+def test_darwin_real_authority_closes_fds_after_reader_failure(
+    tmp_path: Path,
+) -> None:
+    stage = tmp_path / "stage"
+    _write_tree(stage, "payload.txt", "payload")
+    before = len(os.listdir("/dev/fd"))
+
+    for _attempt in range(16):
+        authority = atomic_module._open_publication_authority(
+            tmp_path,
+            parent_resource=None,
+            expected_parent_identity=None,
+        )
+        try:
+            ownership = authority.capture_child(
+                stage.name,
+                path=stage,
+                label="stage",
+            )
+
+            def fail(reader: object) -> None:
+                assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+                reader.read_bytes("missing.txt", max_bytes=16)
+
+            with pytest.raises(ValueError, match="absent from captured ownership"):
+                authority.read_child(
+                    stage.name,
+                    path=stage,
+                    label="stage",
+                    expected_ownership=ownership,
+                    callback=fail,
+                )
+        finally:
+            authority.close()
+
+    assert len(os.listdir("/dev/fd")) <= before
+
+
+def test_publication_authority_has_no_proc_path_dependency() -> None:
+    atomic_source = inspect.getsource(atomic_module)
+    windows_source = inspect.getsource(windows_authority_module)
+    assert "/proc/self/fd" not in atomic_source
+    assert "/proc/self/fd" not in windows_source
+    assert "renameatx_np" in atomic_source
+    assert "SetFileInformationByHandle" in windows_source
+
+
+def test_windows_handle_primitives_are_owned_by_neutral_module() -> None:
+    atomic_source = inspect.getsource(atomic_module)
+    windows_source = inspect.getsource(windows_authority_module)
+    assert atomic_module._WindowsKernelApi is windows_authority_module.WindowsKernelApi
+    assert (
+        atomic_module._WindowsHandleMetadata
+        is windows_authority_module.WindowsHandleMetadata
+    )
+    assert (
+        atomic_module._WindowsDirectoryEntry
+        is windows_authority_module.WindowsDirectoryEntry
+    )
+    assert "class _WindowsKernelApi" not in atomic_source
+    assert "OpenFileById" not in atomic_source
+    assert "SetFileInformationByHandle" not in atomic_source
+    assert "OpenFileById" in windows_source
+    assert "SetFileInformationByHandle" in windows_source
+    assert "_atomic_directory" not in windows_source
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux fd accounting",
+)
+def test_linux_authority_closes_fds_after_preopen_authentication_failure(
+    tmp_path: Path,
+) -> None:
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    nested = stage / "nested"
+    _write_tree(nested, "payload.txt", "payload")
+    before = len(os.listdir("/proc/self/fd"))
+    authority = atomic_module._open_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            stage.name,
+            path=stage,
+            label="stage",
+        )
+        original = nested / "payload.txt"
+        held = nested / ".payload.txt.held"
+        original.rename(held)
+        original.write_bytes(b"foreign")
+
+        def read_replaced_file(reader: object) -> None:
+            assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+            reader.read_bytes("nested/payload.txt", max_bytes=16)
+
+        with pytest.raises(RuntimeError, match="differs from captured ownership"):
+            authority.read_child(
+                stage.name,
+                path=stage,
+                label="stage",
+                expected_ownership=ownership,
+                callback=read_replaced_file,
+            )
+    finally:
+        authority.close()
+
+    assert len(os.listdir("/proc/self/fd")) <= before
+
+
+def test_windows_ownership_and_authenticated_reader_traverse_file_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    nested = api.add_directory(api.root_id, "nested")
+    nested_file = api.add_file(nested, "one.txt", b"one")
+    root_file = api.add_file(api.root_id, "two.txt", b"two")
+    root_handle = api.create_directory_handle(Path("C:/authority"))
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            root_handle,
+            Path("C:/authority"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+        reader = atomic_module.PublicationDirectoryReader(
+            Path("C:/authority"),
+            ownership.root_identity,
+            lambda required_root_file, allow_empty_root, entry_policy: (
+                atomic_module._capture_windows_directory_handle(
+                    api,
+                    root_handle,
+                    Path("C:/authority"),
+                    required_root_file=required_root_file,
+                    allow_empty_root=allow_empty_root,
+                    entry_policy=entry_policy,
+                )
+            ),
+            lambda relative, max_bytes, expected: (
+                atomic_module._open_windows_authenticated_file(
+                    api,
+                    root_handle,
+                    Path("C:/authority"),
+                    relative,
+                    max_bytes=max_bytes,
+                    expected=expected,
+                )
+            ),
+            ownership,
+        )
+        try:
+            snapshot = reader.authenticated_snapshot(
+                "nested/one.txt",
+                max_bytes=16,
+            )
+        finally:
+            reader._deactivate()
+    finally:
+        api.close(root_handle)
+
+    assert ownership.inventory == (
+        ("nested", "directory"),
+        ("nested/one.txt", "file"),
+        ("two.txt", "file"),
+    )
+    assert snapshot.read_bytes() == b"one"
+    assert snapshot.record.sha256 == hashlib.sha256(b"one").hexdigest()
+    opened_ids = {
+        file_id for _volume, file_id, _access, _directory in api.open_by_id_calls
+    }
+    assert {nested, nested_file, root_file} <= opened_ids
+
+
+def test_windows_ownership_rejects_zero_directory_entry_file_id() -> None:
+    api = _FakeWindowsApi()
+    api.add_file(api.root_id, "payload.txt", b"payload")
+    root_handle = api.create_directory_handle(Path("C:/authority"))
+    enumerate_directory = api.enumerate_directory
+
+    def enumerate_with_zero_id(handle: int) -> tuple[object, ...]:
+        return tuple(
+            atomic_module._WindowsDirectoryEntry(
+                name=entry.name,
+                file_id=0,
+                attributes=entry.attributes,
+            )
+            for entry in enumerate_directory(handle)
+        )
+
+    api.enumerate_directory = enumerate_with_zero_id  # type: ignore[method-assign]
+    try:
+        with pytest.raises(RuntimeError, match="reliable FILE_ID"):
+            atomic_module._capture_windows_directory_handle(
+                api,
+                root_handle,
+                Path("C:/authority"),
+                required_root_file=None,
+                allow_empty_root=False,
+                entry_policy=None,
+            )
+    finally:
+        api.close(root_handle)
+
+
+def test_windows_authority_closes_handles_after_reader_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    stage = api.add_directory(api.root_id, "stage")
+    api.add_file(stage, "payload.txt", b"payload")
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+
+    authority = atomic_module._open_windows_publication_authority(
+        Path("C:/authority"),
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            "stage",
+            path=Path("C:/authority/stage"),
+            label="stage",
+        )
+
+        def fail(reader: object) -> None:
+            assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+            reader.read_bytes("missing.txt", max_bytes=16)
+
+        with pytest.raises(ValueError, match="absent from captured ownership"):
+            authority.read_child(
+                "stage",
+                path=Path("C:/authority/stage"),
+                label="stage",
+                expected_ownership=ownership,
+                callback=fail,
+            )
+        wrong_root = replace(
+            ownership,
+            root_identity=(
+                ownership.root_identity[0],
+                ownership.root_identity[1] + 1,
+                *ownership.root_identity[2:],
+            ),
+        )
+        with pytest.raises(RuntimeError, match="differs from captured ownership"):
+            authority.read_child(
+                "stage",
+                path=Path("C:/authority/stage"),
+                label="stage",
+                expected_ownership=wrong_root,
+                callback=lambda _reader: None,
+            )
+    finally:
+        authority.close()
+
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_handle_rename_does_not_replace(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    _write_tree(source, "source.txt", "source")
+    destination = tmp_path / "destination"
+    _write_tree(destination, "destination.txt", "destination")
+    authority = atomic_module._open_windows_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        with pytest.raises(FileExistsError):
+            authority.rename_noreplace(source.name, destination.name)
+    finally:
+        authority.close()
+
+    assert (source / "source.txt").read_text(encoding="utf-8") == "source"
+    assert (destination / "destination.txt").read_text(
+        encoding="utf-8"
+    ) == "destination"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_publication_blocks_root_rename_and_reopens_orphan(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+    held = tmp_path / "held"
+    observed: list[bytes] = []
+
+    def validate_stage(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        with pytest.raises(OSError):
+            stage.rename(held)
+        observed.append(reader.read_bytes("new.txt", max_bytes=16))
+
+    orphan = publish_staged_directory(
+        stage,
+        destination,
+        validate_staged_directory=validate_stage,
+        validate_published_destination=lambda reader: observed.append(
+            reader.read_bytes("new.txt", max_bytes=16)
+        ),
+    )
+
+    assert orphan is not None
+    assert observed == [b"new", b"new"]
+    assert (
+        orphan.reopen(lambda reader: reader.read_bytes("old.txt", max_bytes=16))
+        == b"old"
+    )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_mode_contract_is_readonly_and_execute_neutral(
+    tmp_path: Path,
+) -> None:
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    writable = stage / "writable.bin"
+    writable.write_bytes(b"writable")
+    readonly = stage / "readonly.bin"
+    readonly.write_bytes(b"readonly")
+    readonly.chmod(stat.S_IREAD)
+    executable = stage / "tool.exe"
+    executable.write_bytes(b"tool")
+    executable.chmod(0o755)
+    try:
+        ownership = capture_directory_ownership(stage)
+        modes = {
+            record.path: record.mode
+            for record in atomic_module.directory_ownership_file_records(ownership)
+        }
+        assert modes == {
+            "readonly.bin": 0o444,
+            "tool.exe": 0o666,
+            "writable.bin": 0o666,
+        }
+
+        def require_posix_modes(
+            path: str,
+            kind: str,
+            mode: int,
+            _size: int,
+        ) -> None:
+            if kind == "file" and mode not in {0o644, 0o755}:
+                raise ValueError(f"unrepresentable portable mode: {path}")
+
+        with pytest.raises(ValueError, match="unrepresentable portable mode"):
+            capture_directory_ownership(stage, entry_policy=require_posix_modes)
+    finally:
+        readonly.chmod(stat.S_IWRITE)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_publishable_stage_rejects_hard_link(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "payload.txt", "payload")
+    alias = tmp_path / "payload-alias.txt"
+    os.link(stage / "payload.txt", alias)
+
+    with pytest.raises(RuntimeError, match="external hard link"):
+        publish_staged_directory(stage, destination)
+
+    assert alias.read_text(encoding="utf-8") == "payload"
+    assert (stage / "payload.txt").read_text(encoding="utf-8") == "payload"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_authority_closes_handles_after_reader_failure(
+    tmp_path: Path,
+) -> None:
+    import ctypes.wintypes as wintypes
+
+    kernel32 = atomic_module.ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.GetProcessHandleCount.argtypes = (
+        wintypes.HANDLE,
+        atomic_module.ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.GetProcessHandleCount.restype = wintypes.BOOL
+
+    def handle_count() -> int:
+        count = wintypes.DWORD()
+        if not kernel32.GetProcessHandleCount(
+            kernel32.GetCurrentProcess(),
+            atomic_module.ctypes.byref(count),
+        ):
+            raise atomic_module.ctypes.WinError(atomic_module.ctypes.get_last_error())
+        return int(count.value)
+
+    stage = tmp_path / "stage"
+    _write_tree(stage, "payload.txt", "payload")
+    before = handle_count()
+    for _attempt in range(16):
+        authority = atomic_module._open_windows_publication_authority(
+            tmp_path,
+            parent_resource=None,
+            expected_parent_identity=None,
+        )
+        try:
+            ownership = authority.capture_child(
+                stage.name,
+                path=stage,
+                label="stage",
+            )
+
+            def fail(reader: object) -> None:
+                assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+                reader.read_bytes("missing.txt", max_bytes=16)
+
+            with pytest.raises(ValueError, match="absent from captured ownership"):
+                authority.read_child(
+                    stage.name,
+                    path=stage,
+                    label="stage",
+                    expected_ownership=ownership,
+                    callback=fail,
+                )
+        finally:
+            authority.close()
+
+    assert handle_count() <= before
+
+
+def test_windows_authority_renames_source_handle_without_replace_or_share_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    stage = api.add_directory(api.root_id, "stage")
+    api.add_file(stage, "payload.txt", b"payload")
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+
+    authority = atomic_module._open_windows_publication_authority(
+        Path("C:/authority"),
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            "stage",
+            path=Path("C:/authority/stage"),
+            label="stage",
+        )
+        authority.rename_noreplace("stage", "published")
+    finally:
+        authority.close()
+
+    assert ownership.inventory == (("payload.txt", "file"),)
+    assert api.rename_calls
+    source_opens = [
+        call
+        for call in api.open_by_id_calls
+        if call[1] == stage and call[2] & atomic_module._WINDOWS_DELETE
+    ]
+    assert source_opens
+    implementation = inspect.getsource(atomic_module._WindowsKernelApi)
+    assert "ReplaceIfExists = False" in implementation
+    assert "FILE_SHARE_DELETE" not in implementation
+
+
+def test_windows_stage_gate_rejects_external_file_id_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    stage = api.add_directory(api.root_id, "stage")
+    payload = api.add_file(stage, "payload.txt", b"payload")
+    api.nodes[payload]["nlink"] = 2
+    root_handle = api._new_handle(stage)
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            root_handle,
+            Path("C:/authority/stage"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+    finally:
+        api.close(root_handle)
+
+    with pytest.raises(RuntimeError, match="external hard link"):
+        atomic_module.require_publishable_directory_ownership(ownership)
+    assert api.nodes[payload]["data"] == b"payload"
+
+
+def test_windows_modes_follow_readonly_attributes_without_posix_fabrication() -> None:
+    writable_file = atomic_module._windows_mode_from_attributes(0)
+    readonly_file = atomic_module._windows_mode_from_attributes(
+        atomic_module._WINDOWS_FILE_ATTRIBUTE_READONLY
+    )
+    writable_directory = atomic_module._windows_mode_from_attributes(
+        atomic_module._WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+    )
+    readonly_directory = atomic_module._windows_mode_from_attributes(
+        atomic_module._WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+        | atomic_module._WINDOWS_FILE_ATTRIBUTE_READONLY
+    )
+
+    assert stat.S_IMODE(writable_file) == 0o666
+    assert stat.S_IMODE(readonly_file) == 0o444
+    assert stat.S_IMODE(writable_directory) == 0o777
+    assert stat.S_IMODE(readonly_directory) == 0o555
+
+
+@pytest.mark.parametrize(
+    ("name", "error"),
+    [
+        ("payload:stream", "canonical Windows"),
+        ("CON", "canonical Windows"),
+        ("trailing.", "canonical Windows"),
+        ("trailing ", "canonical Windows"),
+    ],
+)
+def test_windows_authority_rejects_aliased_child_names(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    error: str,
+) -> None:
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    with pytest.raises(ValueError, match=error):
+        atomic_module._simple_child_name(name, label="child")
+
+
+def test_publishable_stage_rejects_external_posix_hard_link(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = tmp_path / "stage"
+    _write_tree(stage, "payload.txt", "payload")
+    alias = tmp_path / "payload-alias.txt"
+    os.link(stage / "payload.txt", alias)
+
+    with pytest.raises(RuntimeError, match="external hard link"):
+        publish_staged_directory(stage, destination)
+
+    assert alias.read_text(encoding="utf-8") == "payload"
+    assert (stage / "payload.txt").read_text(encoding="utf-8") == "payload"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+
+
+def test_legacy_destination_hard_link_can_be_observed_and_isolated(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    _write_tree(destination, "old.txt", "old")
+    alias = tmp_path / "old-alias.txt"
+    os.link(destination / "old.txt", alias)
+    stage = tmp_path / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is not None
+    assert alias.read_text(encoding="utf-8") == "old"
+    assert (orphan.path / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_directory_orphan_reopens_through_parent_authority(tmp_path: Path) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+
+    orphan = publish_staged_directory(stage, destination)
+
+    assert orphan is not None
+    rebound = orphan.rebind()
+    assert rebound.digest == orphan.ownership_digest
+    saved_reader: list[object] = []
+
+    def read_old(reader: object) -> bytes:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        saved_reader.append(reader)
+        return reader.read_bytes("old.txt", max_bytes=16)
+
+    assert orphan.reopen(read_old) == b"old"
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_reader[0].capture_ownership()
+
+
+def test_publication_reader_streams_and_authenticates_on_context_exit(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    payload = (b"0123456789abcdef" * 131_072) + b"tail"
+    stage.mkdir()
+    (stage / "documents.json").write_bytes(payload)
+    records: list[object] = []
+    prefixes: list[bytes] = []
+
+    def validate(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        with reader.open_authenticated_file(
+            "documents.json",
+            max_bytes=4 << 20,
+        ) as authenticated:
+            prefixes.append(authenticated.read(17))
+            # Stop early deliberately. Context exit must drain and authenticate
+            # the same handle without retaining the complete payload.
+        records.append(authenticated.record)
+
+    orphan = publish_staged_directory(
+        stage,
+        destination,
+        validate_staged_directory=validate,
+        validate_published_destination=validate,
+    )
+
+    assert orphan is None
+    assert prefixes == [payload[:17], payload[:17]]
+    assert all(
+        record.sha256 == hashlib.sha256(payload).hexdigest() for record in records
+    )
+
+
+def test_directory_orphan_rebind_rejects_replaced_parent(tmp_path: Path) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    orphan = publish_staged_directory(stage, destination)
+    assert orphan is not None
+    moved_parent = tmp_path / "moved-authority"
+    parent.rename(moved_parent)
+    parent.mkdir()
+
+    with pytest.raises(RuntimeError, match="does not match authority"):
+        orphan.rebind()
+
+    assert (moved_parent / orphan.path.name / "old.txt").read_text(
+        encoding="utf-8"
+    ) == "old"
+
+
+@pytest.mark.parametrize("window", ["stage", "moved", "published"])
+def test_reader_callbacks_survive_reversible_parent_swap(
+    tmp_path: Path,
+    window: str,
+) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    moved_parent = tmp_path / f"moved-parent-{window}"
+    foreign_parent = tmp_path / f"foreign-parent-{window}"
+    injected = False
+    observed: list[bytes] = []
+
+    def validate(reader: object) -> None:
+        nonlocal injected
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        expected_name = "old.txt" if window == "moved" else "new.txt"
+        if not injected:
+            injected = True
+            if window == "stage":
+                active_name = stage.name
+            elif window == "moved":
+                active_name = next(parent.glob(".published.previous-*")).name
+            else:
+                active_name = destination.name
+            parent.rename(moved_parent)
+            parent.mkdir()
+            _write_tree(parent / active_name, "foreign.txt", "foreign")
+            observed.append(reader.read_bytes(expected_name, max_bytes=16))
+            parent.rename(foreign_parent)
+            moved_parent.rename(parent)
+        else:
+            observed.append(reader.read_bytes(expected_name, max_bytes=16))
+
+    callbacks = {
+        "stage": {"validate_staged_directory": validate},
+        "moved": {"validate_moved_destination": validate},
+        "published": {"validate_published_destination": validate},
+    }
+    orphan = publish_staged_directory(
+        stage,
+        destination,
+        **callbacks[window],
+    )
+
+    assert orphan is not None
+    assert observed and set(observed) == ({b"old"} if window == "moved" else {b"new"})
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    foreign_children = list(foreign_parent.iterdir())
+    assert len(foreign_children) == 1
+    assert (foreign_children[0] / "foreign.txt").read_text(
+        encoding="utf-8"
+    ) == "foreign"
+
+
+@pytest.mark.parametrize("window", ["stage", "moved", "published"])
+def test_reader_callbacks_survive_reversible_root_swap(
+    tmp_path: Path,
+    window: str,
+) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    held = parent / f"held-{window}"
+    foreign = parent / f"foreign-{window}"
+    injected = False
+    observed: list[bytes] = []
+
+    def validate(reader: object) -> None:
+        nonlocal injected
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        expected_name = "old.txt" if window == "moved" else "new.txt"
+        if not injected:
+            injected = True
+            if window == "stage":
+                active = stage
+            elif window == "moved":
+                active = next(parent.glob(".published.previous-*"))
+            else:
+                active = destination
+            active.rename(held)
+            _write_tree(active, "foreign.txt", "foreign")
+            observed.append(reader.read_bytes(expected_name, max_bytes=16))
+            active.rename(foreign)
+            held.rename(active)
+        else:
+            observed.append(reader.read_bytes(expected_name, max_bytes=16))
+
+    callbacks = {
+        "stage": {"validate_staged_directory": validate},
+        "moved": {"validate_moved_destination": validate},
+        "published": {"validate_published_destination": validate},
+    }
+    if window == "stage":
+        with pytest.raises(RuntimeError, match="staged directory changed"):
+            publish_staged_directory(stage, destination, **callbacks[window])
+        assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    else:
+        orphan = publish_staged_directory(
+            stage,
+            destination,
+            **callbacks[window],
+        )
+        assert orphan is not None
+        assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+    assert observed and set(observed) == ({b"old"} if window == "moved" else {b"new"})
+    assert (foreign / "foreign.txt").read_text(encoding="utf-8") == "foreign"
+
+
+@pytest.mark.parametrize("window", ["stage", "moved", "published"])
+def test_reader_rejects_suppressed_file_swap_authentication_failure(
+    tmp_path: Path,
+    window: str,
+) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    evil_store = tmp_path / f"evil-{window}.txt"
+    injected = False
+    suppressed: list[bool] = []
+
+    def validate(reader: object) -> None:
+        nonlocal injected
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        if injected:
+            return
+        injected = True
+        expected_name = "old.txt" if window == "moved" else "new.txt"
+        if window == "stage":
+            active = stage
+        elif window == "moved":
+            active = next(parent.glob(".published.previous-*"))
+        else:
+            active = destination
+        expected_file = active / expected_name
+        held_original = active / f".{expected_name}.held"
+        expected_file.rename(held_original)
+        expected_file.write_bytes(b"foreign bytes")
+        try:
+            try:
+                reader.read_bytes(expected_name, max_bytes=64)
+            except RuntimeError:
+                suppressed.append(True)
+        finally:
+            expected_file.rename(evil_store)
+            held_original.rename(expected_file)
+
+    callbacks = {
+        "stage": {"validate_staged_directory": validate},
+        "moved": {"validate_moved_destination": validate},
+        "published": {"validate_published_destination": validate},
+    }
+    with pytest.raises(RuntimeError) as raised:
+        publish_staged_directory(stage, destination, **callbacks[window])
+
+    messages: list[str] = []
+    pending: list[BaseException | None] = [raised.value]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        messages.append(str(current))
+        pending.extend([current.__cause__, current.__context__])
+    assert any("suppressed authentication failure" in message for message in messages)
+    assert suppressed == [True]
+    assert evil_store.read_bytes() == b"foreign bytes"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    if window in {"stage", "moved"}:
+        assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    else:
+        quarantines = list(parent.glob(".published.quarantine-*"))
+        assert len(quarantines) == 1
+        assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publication_reader_builds_expected_lookup_maps_once(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    for index in range(1_000):
+        (stage / f"file-{index:04d}.txt").touch()
+    observations: list[tuple[int, int]] = []
+
+    def validate(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        records = reader.file_records()
+        assert reader.file_records() is records
+        record_map_id = id(reader._records_by_path)
+        entry_map_id = id(reader._entries_by_path)
+        for record in records:
+            expected = reader._expected_file(PurePosixPath(record.path))
+            assert expected.record is record
+        observations.append((record_map_id, entry_map_id))
+        assert id(reader._records_by_path) == record_map_id
+        assert id(reader._entries_by_path) == entry_map_id
+
+    orphan = publish_staged_directory(
+        stage,
+        destination,
+        validate_staged_directory=validate,
+    )
+
+    assert orphan is None
+    assert len(observations) == 1
+    assert len(list(destination.iterdir())) == 1_000
+
+
+def test_reopen_authenticated_directory_freshly_matches_before_and_after(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    parent_descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        parent_identity = publication_parent_identity(parent_descriptor)
+    finally:
+        os.close(parent_descriptor)
+    capture_calls = 0
+    capture_descriptor = atomic_module._capture_posix_directory_descriptor
+
+    def count_capture(*args: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        return capture_descriptor(*args, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_capture_posix_directory_descriptor",
+        count_capture,
+    )
+    saved_readers: list[object] = []
+
+    def consume(reader: object) -> tuple[bytes, tuple[tuple[str, str], ...]]:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        saved_readers.append(reader)
+        return reader.read_bytes("payload.txt", max_bytes=16), reader.inventory()
+
+    result = atomic_module.reopen_authenticated_directory(
+        directory,
+        ownership,
+        consume,
+        expected_parent_identity=parent_identity,
+    )
+
+    assert result == (b"payload", (("payload.txt", "file"),))
+    assert capture_calls == 2
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
+def test_reopen_authenticated_directory_rejects_reversible_root_swap(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    held = tmp_path / "held"
+    foreign = tmp_path / "foreign"
+    observed: list[bytes] = []
+
+    def consume(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        directory.rename(held)
+        _write_tree(directory, "payload.txt", "foreign")
+        try:
+            observed.append(reader.read_bytes("payload.txt", max_bytes=16))
+        finally:
+            directory.rename(foreign)
+            held.rename(directory)
+
+    with pytest.raises(RuntimeError, match="changed while it was consumed"):
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            consume,
+        )
+
+    assert observed == [b"payload"]
+    assert (directory / "payload.txt").read_text(encoding="utf-8") == "payload"
+    assert (foreign / "payload.txt").read_text(encoding="utf-8") == "foreign"
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux fd accounting",
+)
+def test_reopen_authenticated_directory_rejects_suppressed_error_without_fd_leak(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    evil = tmp_path / "evil.txt"
+    before = len(os.listdir("/proc/self/fd"))
+    suppressed: list[bool] = []
+
+    def consume(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        payload = directory / "payload.txt"
+        held = directory / ".payload.txt.held"
+        payload.rename(held)
+        payload.write_bytes(b"foreign")
+        try:
+            try:
+                reader.read_bytes("payload.txt", max_bytes=16)
+            except RuntimeError:
+                suppressed.append(True)
+        finally:
+            payload.rename(evil)
+            held.rename(payload)
+
+    with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            consume,
+        )
+
+    assert suppressed == [True]
+    assert evil.read_bytes() == b"foreign"
+    assert (directory / "payload.txt").read_bytes() == b"payload"
+    assert len(os.listdir("/proc/self/fd")) <= before
+
+
+def test_reopen_authenticated_directory_fake_windows_survives_root_swap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    directory_id = api.add_directory(api.root_id, "existing")
+    api.add_file(directory_id, "payload.txt", b"payload")
+    foreign_id = api.add_directory()
+    api.add_file(foreign_id, "payload.txt", b"foreign")
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_require_publication_api", lambda: None)
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    path = Path("C:/authority/existing")
+    authority = atomic_module._open_windows_publication_authority(
+        path.parent,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            path.name,
+            path=path,
+            label="existing",
+        )
+    finally:
+        authority.close()
+    assert api.handles == {}
+
+    def consume(reader: object) -> bytes:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        root_children = api.nodes[api.root_id]["children"]
+        assert isinstance(root_children, dict)
+        root_children["held"] = root_children.pop("existing")
+        root_children["existing"] = foreign_id
+        try:
+            return reader.read_bytes("payload.txt", max_bytes=16)
+        finally:
+            root_children["foreign"] = root_children.pop("existing")
+            root_children["existing"] = root_children.pop("held")
+
+    assert (
+        atomic_module.reopen_authenticated_directory(path, ownership, consume)
+        == b"payload"
+    )
+    assert api.handles == {}
+    root_children = api.nodes[api.root_id]["children"]
+    assert isinstance(root_children, dict)
+    assert root_children["existing"] == directory_id
+    assert root_children["foreign"] == foreign_id
+
+
+def test_reopen_authenticated_directory_fake_windows_rejects_suppressed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    directory_id = api.add_directory(api.root_id, "existing")
+    original_id = api.add_file(directory_id, "payload.txt", b"payload")
+    foreign_id = api.add_file(directory_id, "foreign.txt", b"foreign")
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_require_publication_api", lambda: None)
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    path = Path("C:/authority/existing")
+    authority = atomic_module._open_windows_publication_authority(
+        path.parent,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            path.name,
+            path=path,
+            label="existing",
+        )
+    finally:
+        authority.close()
+    suppressed: list[bool] = []
+
+    def consume(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        children = api.nodes[directory_id]["children"]
+        assert isinstance(children, dict)
+        children["held.txt"] = children.pop("payload.txt")
+        children["payload.txt"] = children.pop("foreign.txt")
+        try:
+            try:
+                reader.read_bytes("payload.txt", max_bytes=16)
+            except RuntimeError:
+                suppressed.append(True)
+        finally:
+            children["foreign.txt"] = children.pop("payload.txt")
+            children["payload.txt"] = children.pop("held.txt")
+
+    with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+        atomic_module.reopen_authenticated_directory(path, ownership, consume)
+
+    assert suppressed == [True]
+    assert api.handles == {}
+    children = api.nodes[directory_id]["children"]
+    assert isinstance(children, dict)
+    assert children["payload.txt"] == original_id
+    assert children["foreign.txt"] == foreign_id
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_reopen_authenticated_directory_gates_swaps_and_handles(
+    tmp_path: Path,
+) -> None:
+    import ctypes.wintypes as wintypes
+
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    kernel32 = atomic_module.ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.GetProcessHandleCount.argtypes = (
+        wintypes.HANDLE,
+        atomic_module.ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.GetProcessHandleCount.restype = wintypes.BOOL
+
+    def handle_count() -> int:
+        count = wintypes.DWORD()
+        if not kernel32.GetProcessHandleCount(
+            kernel32.GetCurrentProcess(),
+            atomic_module.ctypes.byref(count),
+        ):
+            raise atomic_module.ctypes.WinError(atomic_module.ctypes.get_last_error())
+        return int(count.value)
+
+    held_root = tmp_path / "held-root"
+
+    def consume_original(reader: object) -> bytes:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        with pytest.raises(OSError):
+            directory.rename(held_root)
+        return reader.read_bytes("payload.txt", max_bytes=16)
+
+    assert (
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            consume_original,
+        )
+        == b"payload"
+    )
+
+    before = handle_count()
+    evil = tmp_path / "evil.txt"
+
+    def suppress_file_swap(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        payload = directory / "payload.txt"
+        held = directory / ".payload.txt.held"
+        payload.rename(held)
+        payload.write_bytes(b"foreign")
+        try:
+            try:
+                reader.read_bytes("payload.txt", max_bytes=16)
+            except RuntimeError:
+                pass
+        finally:
+            payload.rename(evil)
+            held.rename(payload)
+
+    with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            suppress_file_swap,
+        )
+
+    assert evil.read_bytes() == b"foreign"
+    assert (directory / "payload.txt").read_bytes() == b"payload"
+    assert handle_count() <= before
+
+
+def test_capture_directory_ownership_if_exists_captures_existing_tree(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+
+    ownership = atomic_module.capture_directory_ownership_if_exists(directory)
+
+    assert ownership is not None
+    assert ownership == capture_directory_ownership(directory)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux fd accounting",
+)
+def test_capture_directory_ownership_if_exists_does_not_bless_missing_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "appeared"
+    before = len(os.listdir("/proc/self/fd"))
+    child_metadata = atomic_module._PublicationAuthority.child_metadata
+    injected = False
+
+    def inject_after_missing(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> object | None:
+        nonlocal injected
+        observed = child_metadata(
+            authority,
+            name,
+            path=path,
+            label=label,
+        )
+        if observed is None and path == directory and not injected:
+            injected = True
+            _write_tree(directory, "foreign.txt", "foreign")
+        return observed
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "child_metadata",
+        inject_after_missing,
+    )
+
+    ownership = atomic_module.capture_directory_ownership_if_exists(directory)
+
+    assert ownership is None
+    assert injected
+    assert (directory / "foreign.txt").read_text(encoding="utf-8") == "foreign"
+    assert len(os.listdir("/proc/self/fd")) <= before
+    source = inspect.getsource(atomic_module.capture_directory_ownership_if_exists)
+    assert ".exists(" not in source
+    assert "except RuntimeError" not in source
+
+
+def test_capture_directory_ownership_if_exists_rejects_existing_root_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "original.txt", "original")
+    held = tmp_path / "held"
+    child_metadata = atomic_module._PublicationAuthority.child_metadata
+    observations = 0
+
+    def replace_after_first_observation(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> object | None:
+        nonlocal observations
+        observed = child_metadata(
+            authority,
+            name,
+            path=path,
+            label=label,
+        )
+        if path == directory and observed is not None:
+            observations += 1
+            if observations == 1:
+                directory.rename(held)
+                _write_tree(directory, "foreign.txt", "foreign")
+        return observed
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "child_metadata",
+        replace_after_first_observation,
+    )
+
+    with pytest.raises(RuntimeError, match="changed while it was captured"):
+        atomic_module.capture_directory_ownership_if_exists(directory)
+
+    assert (held / "original.txt").read_text(encoding="utf-8") == "original"
+    assert (directory / "foreign.txt").read_text(encoding="utf-8") == "foreign"
+
+
+@pytest.mark.parametrize("kind", ["file", "symlink"])
+def test_capture_directory_ownership_if_exists_rejects_unsafe_child_kind(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    child = tmp_path / "unsafe"
+    if kind == "file":
+        child.write_text("file", encoding="utf-8")
+    else:
+        child.symlink_to(tmp_path / "missing-target", target_is_directory=True)
+
+    with pytest.raises(ValueError, match="not a directory or is a link"):
+        atomic_module.capture_directory_ownership_if_exists(child)
+
+
+def test_capture_directory_ownership_if_exists_fake_windows_missing_race_closes_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    path = Path("C:/authority/appeared")
+    child_metadata = atomic_module._PublicationAuthority.child_metadata
+    injected = False
+
+    def inject_after_missing(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> object | None:
+        nonlocal injected
+        observed = child_metadata(
+            authority,
+            name,
+            path=path,
+            label=label,
+        )
+        if observed is None and not injected:
+            injected = True
+            foreign = api.add_directory(api.root_id, name)
+            api.add_file(foreign, "foreign.txt", b"foreign")
+        return observed
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "child_metadata",
+        inject_after_missing,
+    )
+
+    ownership = atomic_module.capture_directory_ownership_if_exists(path)
+
+    assert ownership is None
+    assert injected
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_capture_if_exists_missing_race_closes_handles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ctypes.wintypes as wintypes
+
+    directory = tmp_path / "appeared"
+    kernel32 = atomic_module.ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.GetProcessHandleCount.argtypes = (
+        wintypes.HANDLE,
+        atomic_module.ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.GetProcessHandleCount.restype = wintypes.BOOL
+
+    def handle_count() -> int:
+        count = wintypes.DWORD()
+        if not kernel32.GetProcessHandleCount(
+            kernel32.GetCurrentProcess(),
+            atomic_module.ctypes.byref(count),
+        ):
+            raise atomic_module.ctypes.WinError(atomic_module.ctypes.get_last_error())
+        return int(count.value)
+
+    atomic_module._windows_kernel_api()
+    before = handle_count()
+    child_metadata = atomic_module._PublicationAuthority.child_metadata
+    injected = False
+
+    def inject_after_missing(
+        authority: object,
+        name: str,
+        *,
+        path: Path,
+        label: str,
+    ) -> object | None:
+        nonlocal injected
+        observed = child_metadata(
+            authority,
+            name,
+            path=path,
+            label=label,
+        )
+        if observed is None and not injected:
+            injected = True
+            _write_tree(directory, "foreign.txt", "foreign")
+        return observed
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "child_metadata",
+        inject_after_missing,
+    )
+
+    ownership = atomic_module.capture_directory_ownership_if_exists(directory)
+
+    assert ownership is None
+    assert injected
+    assert (directory / "foreign.txt").read_text(encoding="utf-8") == "foreign"
+    assert handle_count() <= before
+
+
+def _call_with_interrupt_after_store(
+    function: object,
+    local_name: str,
+    callback: object,
+    *,
+    predicate: object | None = None,
+    error: BaseException,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    assert predicate is None or callable(predicate)
+    code = function.__code__
+    instructions = tuple(dis.get_instructions(function))
+    offsets_after_store = {
+        instructions[index + 1].offset
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_FAST" and instruction.argval == local_name
+    }
+    previous_trace = sys.gettrace()
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            event == "opcode"
+            and frame.f_code is code
+            and frame.f_lasti in offsets_after_store
+            and int(frame.f_locals.get(local_name, -1)) >= 0
+            and (predicate is None or predicate(frame.f_locals))
+        ):
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+
+
+def _posix_authority_resources(
+    authority: object,
+) -> atomic_module._PosixResourceOwner:
+    closure = authority._close_callback.__closure__ or ()
+    matches = [
+        cell.cell_contents
+        for cell in closure
+        if isinstance(cell.cell_contents, atomic_module._PosixResourceOwner)
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _assert_descriptor_closed(descriptor: int) -> None:
+    with pytest.raises(OSError) as caught:
+        os.fstat(descriptor)
+    assert caught.value.errno == errno.EBADF
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_owner_recovers_interrupt_after_open_result_store(tmp_path: Path) -> None:
+    owner = atomic_module._PosixResourceOwner()
+    error = KeyboardInterrupt("after os.open result store")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _call_with_interrupt_after_store(
+            atomic_module._PosixResourceOwner.open,
+            "descriptor",
+            lambda: owner.open(
+                tmp_path,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            ),
+            error=error,
+        )
+
+    assert caught.value is error
+    assert owner.closed
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_owner_closes_same_directory_after_permission_change(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "mutable-mode"
+    directory.mkdir()
+    directory.chmod(0o755)
+    owner = atomic_module._PosixResourceOwner()
+    descriptor = owner.open(
+        directory,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    before = os.fstat(descriptor)
+    try:
+        directory.chmod(0o700)
+        after = os.fstat(descriptor)
+        assert atomic_module._ownership_binding_identity(before) != (
+            atomic_module._ownership_binding_identity(after)
+        )
+        assert atomic_module._resource_owner_identity(before) == (
+            atomic_module._resource_owner_identity(after)
+        )
+
+        owner.close_all()
+
+        assert owner.closed
+        _assert_descriptor_closed(descriptor)
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError as exc:
+            if exc.errno != errno.EBADF:
+                raise
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_owner_retries_persistent_eio_after_permission_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "mutable-mode-eio"
+    directory.mkdir()
+    directory.chmod(0o755)
+    owner = atomic_module._PosixResourceOwner()
+    descriptor = owner.open(
+        directory,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    directory.chmod(0o700)
+    real_close = atomic_module.os.close
+    error = OSError(errno.EIO, "persistent close failure after chmod")
+
+    def fail_owned_descriptor(candidate: int) -> None:
+        if candidate == descriptor:
+            raise error
+        real_close(candidate)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", fail_owned_descriptor)
+        for _attempt in range(2):
+            with pytest.raises(OSError) as caught:
+                owner.close_all()
+            assert caught.value is error
+            assert not owner.closed
+            os.fstat(descriptor)
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        owner.close_all()
+
+    assert owner.closed
+    _assert_descriptor_closed(descriptor)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_factory_recovers_interrupt_in_child_open_registration(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "registration-child"
+    parent.mkdir()
+    error = SystemExit("after child descriptor store")
+
+    with pytest.raises(SystemExit) as caught:
+        _call_with_interrupt_after_store(
+            atomic_module._PosixResourceOwner.open,
+            "descriptor",
+            lambda: atomic_module._open_posix_publication_authority(
+                parent,
+                parent_resource=None,
+                expected_parent_identity=None,
+            ),
+            predicate=lambda local: local["path"] == parent.name,
+            error=error,
+        )
+
+    assert caught.value is error
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_owner_recovers_interrupt_after_dup_result_store(tmp_path: Path) -> None:
+    descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    owner = atomic_module._PosixResourceOwner()
+    error = KeyboardInterrupt("after os.dup result store")
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            _call_with_interrupt_after_store(
+                atomic_module._PosixResourceOwner.duplicate,
+                "duplicate",
+                lambda: owner.duplicate(descriptor),
+                error=error,
+            )
+        assert caught.value is error
+        assert owner.closed
+        os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_authority_handoff_closes_on_interrupt_before_caller_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "owned"
+    _write_tree(directory, "payload.txt", "payload")
+    real_open = atomic_module._open_posix_publication_authority
+    opened: list[object] = []
+    error = KeyboardInterrupt("after authority factory return")
+
+    def open_then_interrupt(*args: object, **kwargs: object) -> object:
+        authority = real_open(*args, **kwargs)
+        opened.append(authority)
+        raise error
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_open_posix_publication_authority",
+        open_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        capture_directory_ownership(directory)
+
+    assert caught.value is error
+    assert len(opened) == 1
+    authority = opened[0]
+    assert authority._closed
+    assert _posix_authority_resources(authority).closed
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_authority_close_before_close_interrupt_is_retryable_and_cleans_all(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    target = descriptors[-1]
+    real_close = atomic_module.os.close
+    error = KeyboardInterrupt("before real close")
+    injected = False
+
+    def interrupt_before_close(descriptor: int) -> None:
+        nonlocal injected
+        if descriptor == target and not injected:
+            injected = True
+            raise error
+        real_close(descriptor)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", interrupt_before_close)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is error
+        assert injected
+        assert not authority._closed
+        os.fstat(target)
+        for descriptor in descriptors[:-1]:
+            _assert_descriptor_closed(descriptor)
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        authority.close()
+
+    assert authority._closed
+    _assert_descriptor_closed(target)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_authority_close_after_close_system_exit_closes_everything(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    target = descriptors[-1]
+    real_close = atomic_module.os.close
+    error = SystemExit("after real close")
+    injected = False
+
+    def interrupt_after_close(descriptor: int) -> None:
+        nonlocal injected
+        real_close(descriptor)
+        if descriptor == target and not injected:
+            injected = True
+            raise error
+
+    monkeypatch.setattr(atomic_module.os, "close", interrupt_after_close)
+    with pytest.raises(SystemExit) as caught:
+        authority.close()
+
+    assert caught.value is error
+    assert injected
+    assert authority._closed
+    assert resources.closed
+    for descriptor in descriptors:
+        _assert_descriptor_closed(descriptor)
+    authority.close()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_authority_persistent_eio_retains_only_failed_owner_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    target = descriptors[-1]
+    real_close = atomic_module.os.close
+    error = OSError(errno.EIO, "persistent close failure")
+
+    def fail_target(descriptor: int) -> None:
+        if descriptor == target:
+            raise error
+        real_close(descriptor)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", fail_target)
+        for _attempt in range(2):
+            with pytest.raises(OSError) as caught:
+                authority.close()
+            assert caught.value is error
+            assert not authority._closed
+            os.fstat(target)
+        for descriptor in descriptors[:-1]:
+            _assert_descriptor_closed(descriptor)
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        authority.close()
+
+    assert authority._closed
+    _assert_descriptor_closed(target)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_authority_close_preserves_first_error_and_attempts_all(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    first_target, second_target = descriptors[-1], descriptors[-2]
+    real_close = atomic_module.os.close
+    first_error = KeyboardInterrupt("first close failure")
+    second_error = SystemExit("second close failure")
+
+    def fail_two(descriptor: int) -> None:
+        if descriptor == first_target:
+            raise first_error
+        if descriptor == second_target:
+            raise second_error
+        real_close(descriptor)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", fail_two)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is first_error
+        assert not authority._closed
+        notes = (
+            *getattr(first_error, "__notes__", ()),
+            *getattr(first_error, "_codenib_cleanup_notes", ()),
+        )
+        assert any("second close failure" in note for note in notes)
+        os.fstat(first_target)
+        os.fstat(second_target)
+        for descriptor in descriptors[:-2]:
+            _assert_descriptor_closed(descriptor)
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        authority.close()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_authority_owner_preserves_operation_error_over_close_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority_owner = atomic_module._PublicationAuthorityOwner()
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+        authority_owner=authority_owner,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    target = descriptors[-1]
+    real_close = atomic_module.os.close
+    primary_error = SystemExit("original operation interruption")
+    close_error = OSError(errno.EIO, "cleanup failure")
+
+    def fail_target(descriptor: int) -> None:
+        if descriptor == target:
+            raise close_error
+        real_close(descriptor)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", fail_target)
+        with pytest.raises(SystemExit) as caught:
+            with authority_owner:
+                raise primary_error
+        assert caught.value is primary_error
+        notes = (
+            *getattr(primary_error, "__notes__", ()),
+            *getattr(primary_error, "_codenib_cleanup_notes", ()),
+        )
+        assert any("cleanup failure" in note for note in notes)
+        assert not authority._closed
+        os.fstat(target)
+        for descriptor in descriptors[:-1]:
+            _assert_descriptor_closed(descriptor)
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        authority_owner.close()
+
+
+def test_publication_authority_close_preserves_close_error_over_state_probe() -> None:
+    close_error = KeyboardInterrupt("primary authority close interruption")
+    probe_error = SystemExit("secondary close-state interruption")
+
+    def fail_close(_resource: int) -> None:
+        raise close_error
+
+    def fail_probe() -> bool:
+        raise probe_error
+
+    authority = atomic_module._PublicationAuthority(
+        display_parent=Path("/authority"),
+        identity=(1, 2),
+        backend_tag="test",
+        resource=7,
+        close_callback=fail_close,
+        metadata_callback=lambda _name, _path, _label: None,
+        reader_callback=lambda *_args: None,
+        rename_callback=lambda _source, _destination: None,
+        verify_callback=lambda: None,
+        close_complete_callback=fail_probe,
+    )
+    authority_owner = atomic_module._PublicationAuthorityOwner()
+    authority_owner.install(authority)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        authority_owner.close()
+
+    assert caught.value is close_error
+    notes = (
+        *getattr(close_error, "__notes__", ()),
+        *getattr(close_error, "_codenib_cleanup_notes", ()),
+    )
+    assert any("secondary close-state interruption" in note for note in notes)
+    assert not authority._close_state
+    assert authority_owner.authority is authority
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_posix_close_reconciliation_does_not_close_observable_reused_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    resources = _posix_authority_resources(authority)
+    descriptors = tuple(record.descriptor for record in resources._records)
+    target = descriptors[-1]
+    foreign_path = tmp_path / "foreign-directory"
+    foreign_path.mkdir()
+    foreign_source = os.open(
+        foreign_path,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    foreign_identity = atomic_module._resource_owner_identity(os.fstat(foreign_source))
+    real_close = atomic_module.os.close
+    error = KeyboardInterrupt("after close and observable fd reuse")
+    replacement_installed = False
+
+    def close_then_reuse(descriptor: int) -> None:
+        nonlocal replacement_installed
+        real_close(descriptor)
+        if descriptor == target and not replacement_installed:
+            os.dup2(foreign_source, target)
+            replacement_installed = True
+            raise error
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", close_then_reuse)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is error
+        assert replacement_installed
+        assert authority._closed
+        assert resources.closed
+        assert atomic_module._resource_owner_identity(os.fstat(target)) == (
+            foreign_identity
+        )
+        authority.close()
+        assert atomic_module._resource_owner_identity(os.fstat(target)) == (
+            foreign_identity
+        )
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        real_close(target)
+        real_close(foreign_source)
+
+
+def _open_fake_windows_authority(
+    api: _FakeWindowsApi,
+    monkeypatch: pytest.MonkeyPatch,
+) -> object:
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    return atomic_module._open_windows_publication_authority(
+        Path("C:/authority"),
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+
+
+def test_windows_owner_closes_same_file_after_content_change() -> None:
+    api = _FakeWindowsApi()
+    file_id = api.add_file(api.root_id, "mutable.txt", b"one")
+    handle = api._new_handle(file_id)
+    owner = atomic_module._WindowsResourceOwner(api)
+    owned_handle = owner.acquire(lambda: handle)
+    before = api.metadata(owned_handle)
+
+    node = api.nodes[file_id]
+    node["data"] = b"changed content"
+    node["version"] = int(node["version"]) + 1
+    after = api.metadata(owned_handle)
+    assert atomic_module._ownership_binding_identity(before) != (
+        atomic_module._ownership_binding_identity(after)
+    )
+    assert atomic_module._resource_owner_identity(before) == (
+        atomic_module._resource_owner_identity(after)
+    )
+
+    owner.close_all()
+
+    assert owner.closed
+    assert owned_handle not in api.handles
+
+
+def test_windows_authority_close_before_close_interrupt_is_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    real_close = api.close
+    error = KeyboardInterrupt("before CloseHandle")
+    target: int | None = None
+
+    def interrupt_before_close(handle: int) -> None:
+        nonlocal target
+        if target is None:
+            target = handle
+            raise error
+        real_close(handle)
+
+    try:
+        monkeypatch.setattr(api, "close", interrupt_before_close)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is error
+        assert not authority._closed
+        assert target is not None
+        assert set(api.handles) == {target}
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        authority.close()
+
+    assert authority._closed
+    assert api.handles == {}
+
+
+def test_windows_authority_close_after_close_system_exit_closes_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    real_close = api.close
+    error = SystemExit("after CloseHandle")
+    injected = False
+
+    def interrupt_after_close(handle: int) -> None:
+        nonlocal injected
+        real_close(handle)
+        if not injected:
+            injected = True
+            raise error
+
+    monkeypatch.setattr(api, "close", interrupt_after_close)
+    with pytest.raises(SystemExit) as caught:
+        authority.close()
+
+    assert caught.value is error
+    assert injected
+    assert authority._closed
+    assert api.handles == {}
+    authority.close()
+
+
+def test_windows_authority_persistent_eio_retains_failed_handle_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    real_close = api.close
+    target = max(api.handles)
+    error = OSError(errno.EIO, "persistent CloseHandle failure")
+
+    def fail_target(handle: int) -> None:
+        if handle == target:
+            raise error
+        real_close(handle)
+
+    try:
+        monkeypatch.setattr(api, "close", fail_target)
+        for _attempt in range(2):
+            with pytest.raises(OSError) as caught:
+                authority.close()
+            assert caught.value is error
+            assert not authority._closed
+            assert set(api.handles) == {target}
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        authority.close()
+
+    assert authority._closed
+    assert api.handles == {}
+
+
+def test_windows_authority_close_preserves_first_error_and_attempts_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    first_target, second_target = sorted(api.handles, reverse=True)
+    real_close = api.close
+    first_error = KeyboardInterrupt("first CloseHandle failure")
+    second_error = SystemExit("second CloseHandle failure")
+
+    def fail_two(handle: int) -> None:
+        if handle == first_target:
+            raise first_error
+        if handle == second_target:
+            raise second_error
+        real_close(handle)
+
+    try:
+        monkeypatch.setattr(api, "close", fail_two)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is first_error
+        assert not authority._closed
+        notes = (
+            *getattr(first_error, "__notes__", ()),
+            *getattr(first_error, "_codenib_cleanup_notes", ()),
+        )
+        assert any("second CloseHandle failure" in note for note in notes)
+        assert set(api.handles) == {first_target, second_target}
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        authority.close()
+
+    assert api.handles == {}
+
+
+def test_windows_close_reconciliation_does_not_close_observable_reused_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    foreign_id = api.add_directory()
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    target = max(api.handles)
+    real_close = api.close
+    error = KeyboardInterrupt("after close and observable HANDLE reuse")
+    replacement_installed = False
+
+    def close_then_reuse(handle: int) -> None:
+        nonlocal replacement_installed
+        real_close(handle)
+        if handle == target and not replacement_installed:
+            api.handles[target] = foreign_id
+            api.offsets[target] = 0
+            replacement_installed = True
+            raise error
+
+    try:
+        monkeypatch.setattr(api, "close", close_then_reuse)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            authority.close()
+        assert caught.value is error
+        assert replacement_installed
+        assert authority._closed
+        assert api.handles == {target: foreign_id}
+        authority.close()
+        assert api.handles == {target: foreign_id}
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        real_close(target)
+
+
+@pytest.mark.parametrize("use_duplicate", [False, True])
+def test_windows_factory_recovers_interrupt_after_registered_handle_return(
+    monkeypatch: pytest.MonkeyPatch,
+    use_duplicate: bool,
+) -> None:
+    api = _FakeWindowsApi()
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    external = api.create_directory_handle(Path("C:/external")) if use_duplicate else 0
+    real_acquire = atomic_module._WindowsResourceOwner.acquire
+    error = KeyboardInterrupt("after registered HANDLE return")
+    injected = False
+
+    def acquire_then_interrupt(self: object, callback: object) -> int:
+        nonlocal injected
+        handle = real_acquire(self, callback)
+        if not injected:
+            injected = True
+            raise error
+        return handle
+
+    monkeypatch.setattr(
+        atomic_module._WindowsResourceOwner,
+        "acquire",
+        acquire_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        atomic_module._open_windows_publication_authority(
+            Path("C:/authority"),
+            parent_resource=external or None,
+            expected_parent_identity=None,
+        )
+
+    assert caught.value is error
+    assert injected
+    assert set(api.handles) == ({external} if external else set())
+    if external:
+        api.close(external)
+
+
+def test_windows_owner_recovers_interrupt_after_handle_result_store() -> None:
+    api = _FakeWindowsApi()
+    owner = atomic_module._WindowsResourceOwner(api)
+    error = KeyboardInterrupt("after raw HANDLE result store")
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _call_with_interrupt_after_store(
+            atomic_module._WindowsResourceOwner.acquire,
+            "handle",
+            lambda: owner.acquire(
+                lambda: api.create_directory_handle(Path("C:/authority"))
+            ),
+            error=error,
+        )
+
+    assert caught.value is error
+    assert owner.closed
+    assert api.handles == {}
+
+
+def test_windows_child_open_return_interrupt_remains_authority_owned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    api.add_directory(api.root_id, "child")
+    authority = _open_fake_windows_authority(api, monkeypatch)
+    baseline_handles = set(api.handles)
+    real_acquire = atomic_module._WindowsResourceOwner.acquire
+    error = SystemExit("after child HANDLE owner return")
+    injected = False
+
+    def acquire_then_interrupt(self: object, callback: object) -> int:
+        nonlocal injected
+        handle = real_acquire(self, callback)
+        if not injected:
+            injected = True
+            raise error
+        return handle
+
+    monkeypatch.setattr(
+        atomic_module._WindowsResourceOwner,
+        "acquire",
+        acquire_then_interrupt,
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        authority.child_metadata(
+            "child",
+            path=Path("C:/authority/child"),
+            label="child",
+        )
+
+    assert caught.value is error
+    assert injected
+    assert set(api.handles) > baseline_handles
+    authority.close()
+    assert api.handles == {}
+
+
+def test_resource_owner_documents_native_p2_boundary() -> None:
+    posix_source = inspect.getsource(atomic_module._PosixResourceOwner)
+    windows_source = inspect.getsource(atomic_module._WindowsResourceOwner)
+    reconciliation_source = inspect.getsource(
+        atomic_module._PosixResourceOwner._close_record
+    )
+
+    assert "raw" in posix_source and "native owning object" in posix_source
+    assert "raw HANDLE" in windows_source and "native owning object" in windows_source
+    assert "exact dup2 ABA" in reconciliation_source

--- a/test/test_bounded_json.py
+++ b/test/test_bounded_json.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import json
+import math
+
+import pytest
+
+from codenib._bounded_json import canonical_json_array_chunks, iter_bounded_json_array
+
+
+class _ChunkReader:
+    def __init__(self, payload: bytes, chunk_size: int) -> None:
+        self.payload = payload
+        self.chunk_size = chunk_size
+        self.offset = 0
+
+    def read(self, _size: int = -1) -> bytes:
+        block = self.payload[self.offset : self.offset + self.chunk_size]
+        self.offset += len(block)
+        return block
+
+
+def test_bounded_array_handles_every_chunk_boundary() -> None:
+    values = [
+        123,
+        {"content": 'é\\"😀', "values": [True, None, -0.0, 1e-10]},
+        "tail",
+    ]
+    payload = json.dumps(values, ensure_ascii=False, separators=(",", ":")).encode()
+
+    for chunk_size in range(1, len(payload) + 1):
+        assert (
+            list(
+                iter_bounded_json_array(
+                    _ChunkReader(payload, chunk_size),
+                    label="documents",
+                )
+            )
+            == values
+        )
+
+
+def test_bounded_array_does_not_accept_a_number_prefix_at_a_chunk_end() -> None:
+    assert list(
+        iter_bounded_json_array(
+            _ChunkReader(b"[123,4]", 3),
+            label="documents",
+        )
+    ) == [123, 4]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b'[{"a":1,"\\u0061":2}]',
+        b"[NaN]",
+        b"[Infinity]",
+        b"[1e9999]",
+        b"[" + b"1" * 1_025 + b"]",
+    ],
+)
+def test_bounded_array_rejects_ambiguous_or_unbounded_numbers(payload: bytes) -> None:
+    with pytest.raises(ValueError):
+        list(iter_bounded_json_array(io.BytesIO(payload), label="documents"))
+
+
+def test_bounded_array_enforces_complexity_before_decode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._bounded_json as bounded_json
+
+    decode_called = False
+
+    class _ForbiddenDecoder:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def raw_decode(self, _value: str, _offset: int):
+            nonlocal decode_called
+            decode_called = True
+            raise AssertionError("lexical budget must reject before DOM allocation")
+
+    monkeypatch.setattr(bounded_json.json, "JSONDecoder", _ForbiddenDecoder)
+    with pytest.raises(ValueError, match="token limit"):
+        list(
+            bounded_json.iter_bounded_json_array(
+                io.BytesIO(b"[[" + b",".join(b"0" for _ in range(20)) + b"]]"),
+                label="documents",
+                max_lexical_tokens=10,
+            )
+        )
+    assert decode_called is False
+
+
+def test_canonical_array_chunks_match_the_existing_json_contract() -> None:
+    values = [
+        {},
+        {"z": [1, {"é": "line\n😀"}], "a": -0.0},
+        [True, False, None, math.nextafter(1.0, 2.0)],
+        "\ud800",
+    ]
+    observed = b"".join(canonical_json_array_chunks(iter(values)))
+    expected = (
+        json.dumps(
+            values,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("ascii")
+
+    assert observed == expected

--- a/test/test_bounded_json.py
+++ b/test/test_bounded_json.py
@@ -7,6 +7,11 @@ from __future__ import annotations
 import io
 import json
 import math
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
 
 import pytest
 
@@ -54,6 +59,26 @@ def test_bounded_array_does_not_accept_a_number_prefix_at_a_chunk_end() -> None:
     ) == [123, 4]
 
 
+@pytest.mark.parametrize("block", [bytearray(b"[]"), "[]", None])
+def test_bounded_array_rejects_non_bytes_reader_blocks(block: object) -> None:
+    class InvalidReader:
+        def read(self, _size: int = -1) -> object:
+            return block
+
+    with pytest.raises(ValueError, match="invalid or oversized block"):
+        list(iter_bounded_json_array(InvalidReader(), label="documents"))
+
+
+def test_bounded_array_rejects_oversized_reader_blocks() -> None:
+    class OversizedReader:
+        def read(self, size: int = -1) -> bytes:
+            assert size > 0
+            return b" " * (size + 1)
+
+    with pytest.raises(ValueError, match="invalid or oversized block"):
+        list(iter_bounded_json_array(OversizedReader(), label="documents"))
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -97,6 +122,121 @@ def test_bounded_array_enforces_complexity_before_decode(
     assert decode_called is False
 
 
+@pytest.mark.parametrize(
+    ("payload", "limits", "message"),
+    [
+        (b"[[0,1,2]]", {"max_nodes_per_element": 3}, "node limit"),
+        (b"[[[[0]]]]", {"max_depth": 2}, "depth limit"),
+    ],
+)
+def test_node_and_depth_budgets_reject_before_dom_allocation(
+    payload: bytes,
+    limits: dict[str, int],
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._bounded_json as bounded_json
+
+    decode_called = False
+
+    class _ForbiddenDecoder:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def raw_decode(self, _value: str, _offset: int):
+            nonlocal decode_called
+            decode_called = True
+            raise AssertionError("structural budget must reject before decoding")
+
+    monkeypatch.setattr(bounded_json.json, "JSONDecoder", _ForbiddenDecoder)
+    with pytest.raises(ValueError, match=message):
+        list(
+            bounded_json.iter_bounded_json_array(
+                io.BytesIO(payload),
+                label="documents",
+                **limits,
+            )
+        )
+    assert decode_called is False
+
+
+def test_depth_budget_uses_the_same_one_based_levels_before_and_after_decode() -> None:
+    assert list(
+        iter_bounded_json_array(
+            io.BytesIO(b"[[[0]]]"),
+            label="documents",
+            max_depth=3,
+        )
+    ) == [[[0]]]
+
+
+def test_item_budget_rejects_the_next_element_before_decoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._bounded_json as bounded_json
+
+    real_decoder = json.JSONDecoder
+    decode_calls = 0
+
+    class _TrackingDecoder:
+        def __init__(self, **kwargs) -> None:
+            self._decoder = real_decoder(**kwargs)
+
+        def raw_decode(self, value: str, offset: int):
+            nonlocal decode_calls
+            decode_calls += 1
+            return self._decoder.raw_decode(value, offset)
+
+    monkeypatch.setattr(bounded_json.json, "JSONDecoder", _TrackingDecoder)
+    with pytest.raises(ValueError, match="1-item limit"):
+        list(
+            bounded_json.iter_bounded_json_array(
+                io.BytesIO(b"[0,1]"),
+                label="documents",
+                max_items=1,
+            )
+        )
+    assert decode_calls == 1
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"\xef\xbb\xbf[]",
+        b"[0,]",
+        b"[0,,1]",
+        b"[{]",
+        b"[[)]",
+        b'["\\x"]',
+        b'["\x01"]',
+        b"[0] trailing",
+    ],
+)
+def test_bounded_array_rejects_malformed_framing(payload: bytes) -> None:
+    with pytest.raises(ValueError):
+        list(iter_bounded_json_array(io.BytesIO(payload), label="documents"))
+
+
+def test_escape_dense_string_scanning_scales_linearly() -> None:
+    def elapsed(pairs: int) -> float:
+        payload = b'["' + (b"\\\\" * pairs) + b'"]'
+        started = time.perf_counter()
+        assert list(
+            iter_bounded_json_array(
+                io.BytesIO(payload),
+                label="escape-dense documents",
+                max_element_bytes=len(payload),
+            )
+        ) == ["\\" * pairs]
+        return time.perf_counter() - started
+
+    # Use the best of two runs to reduce scheduler noise. The larger input is
+    # four times the size; the old repeated-find loop grew quadratically.
+    small = min(elapsed(100_000) for _ in range(2))
+    large = min(elapsed(400_000) for _ in range(2))
+    assert large < max(0.25, small * 8)
+
+
 def test_canonical_array_chunks_match_the_existing_json_contract() -> None:
     values = [
         {},
@@ -118,3 +258,104 @@ def test_canonical_array_chunks_match_the_existing_json_contract() -> None:
     ).encode("ascii")
 
     assert observed == expected
+
+
+def _pipeline_rss(path: Path) -> dict[str, int]:
+    script = textwrap.dedent("""
+        import hashlib
+        import json
+        import os
+        import sys
+
+        from codenib._bounded_json import (
+            canonical_json_array_chunks,
+            iter_bounded_json_array,
+        )
+
+        def vm_hwm_kib():
+            with open("/proc/self/status", encoding="ascii") as handle:
+                for line in handle:
+                    if line.startswith("VmHWM:"):
+                        return int(line.split()[1])
+            raise RuntimeError("VmHWM is unavailable")
+
+        before = vm_hwm_kib()
+        count = 0
+        largest_chunk = 0
+        digest = hashlib.sha256()
+
+        def values():
+            global count
+            with open(sys.argv[1], "rb") as source:
+                for value in iter_bounded_json_array(
+                    source,
+                    label="documents",
+                ):
+                    count += 1
+                    yield value
+
+        for chunk in canonical_json_array_chunks(values()):
+            largest_chunk = max(largest_chunk, len(chunk))
+            digest.update(chunk)
+        print(
+            json.dumps(
+                {
+                    "before_kib": before,
+                    "after_kib": vm_hwm_kib(),
+                    "count": count,
+                    "largest_chunk": largest_chunk,
+                    "input_bytes": os.path.getsize(sys.argv[1]),
+                }
+            )
+        )
+        """)
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="the isolated RSS evidence reads Linux VmHWM",
+)
+def test_streaming_pipeline_peak_rss_is_bounded_by_one_element(
+    tmp_path: Path,
+) -> None:
+    many = tmp_path / "many.json"
+    item = b'{"metadata":{},"page_content":"' + (b"x" * 8_160) + b'"}'
+    target_bytes = 32 * 1024 * 1024
+    with many.open("wb") as handle:
+        handle.write(b"[")
+        size = 1
+        count = 0
+        while size + len(item) + 2 < target_bytes:
+            if count:
+                handle.write(b",")
+                size += 1
+            handle.write(item)
+            size += len(item)
+            count += 1
+        handle.write(b"]")
+
+    many_stats = _pipeline_rss(many)
+    assert many_stats["count"] == count
+    assert many_stats["after_kib"] - many_stats["before_kib"] < 64 * 1024
+    assert many_stats["largest_chunk"] <= 1024 * 1024
+
+    near_limit = tmp_path / "near-limit.json"
+    with near_limit.open("wb") as handle:
+        handle.write(b'["')
+        block = b"x" * (1024 * 1024)
+        for _ in range(60):
+            handle.write(block)
+        handle.write(b'"]')
+
+    element_stats = _pipeline_rss(near_limit)
+    assert element_stats["count"] == 1
+    assert element_stats["after_kib"] - element_stats["before_kib"] < 256 * 1024
+    assert element_stats["largest_chunk"] <= 1024 * 1024

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -13,7 +13,7 @@ from codenib._atomic_directory import (
     capture_directory_ownership,
     directory_ownership_file_records,
 )
-from codenib._captured_directory import CapturedDirectoryReader
+from codenib._captured_directory import CapturedDirectoryReader, OwnedDirectoryStage
 
 
 def test_tree_ownership_exposes_canonical_file_records(tmp_path: Path) -> None:
@@ -78,3 +78,33 @@ def test_captured_reader_rejects_identical_nested_a_b_a_replacement(
         reader.close()
 
     assert (replacement / "payload").read_bytes() == b"same bytes"
+
+
+def test_owned_stage_publishes_its_final_full_tree(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    stage = OwnedDirectoryStage(destination)
+    stage.write_file("nested/payload", [b"owned bytes"])
+
+    stage.publish(expected_destination_ownership=None)
+
+    assert (destination / "nested" / "payload").read_bytes() == b"owned bytes"
+
+
+def test_owned_stage_rejects_root_replacement_before_publish(tmp_path: Path) -> None:
+    destination = tmp_path / "published"
+    stage = OwnedDirectoryStage(destination)
+    stage.write_file("payload", [b"owned bytes"])
+    stolen = tmp_path / "stolen-stage"
+    stage.path.rename(stolen)
+    stage.path.mkdir()
+    (stage.path / "foreign").write_bytes(b"foreign")
+
+    try:
+        with pytest.raises(RuntimeError, match="owned stage root changed"):
+            stage.publish(expected_destination_ownership=None)
+    finally:
+        stage.discard()
+
+    assert not destination.exists()
+    assert (stolen / "payload").read_bytes() == b"owned bytes"
+    assert (stage.path / "foreign").read_bytes() == b"foreign"

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -34,6 +34,7 @@ from codenib._captured_directory import (
     WorkspaceDirectory,
     WorkspaceFile,
     WorkspacePlan,
+    require_owned_workspace_publication_support,
 )
 
 
@@ -513,6 +514,111 @@ def test_workspace_plan_is_canonical_and_bound_to_its_subject() -> None:
     )
 
 
+def test_workspace_plan_rejects_atomic_scanner_overflow_before_provisioning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden_provisioning(*_args, **_kwargs) -> None:
+        raise AssertionError("oversized workspace plan reached provisioning")
+
+    monkeypatch.setattr(
+        captured_directory,
+        "_open_publication_authority",
+        forbidden_provisioning,
+    )
+
+    with pytest.raises(ValueError, match="too many entries"):
+        WorkspacePlan(
+            subject_digest="c" * 64,
+            directories=(WorkspaceDirectory("entry"),) * 100_001,
+        )
+
+
+def test_owned_workspace_publication_support_gate_is_side_effect_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capability_checks: list[str] = []
+
+    def forbid_provisioning(*_args, **_kwargs) -> None:
+        raise AssertionError("support check attempted workspace provisioning")
+
+    monkeypatch.setattr(captured_directory.sys, "platform", "linux")
+    monkeypatch.setattr(captured_directory, "_SAFE_OWNERSHIP_DIRECTORY_FDS", True)
+    monkeypatch.setattr(
+        captured_directory,
+        "_require_rename_noreplace_platform",
+        lambda: capability_checks.append("rename-noreplace"),
+    )
+    monkeypatch.setattr(
+        captured_directory,
+        "_open_publication_authority",
+        forbid_provisioning,
+    )
+
+    assert require_owned_workspace_publication_support() is None
+    assert capability_checks == ["rename-noreplace"]
+    assert "require_owned_workspace_publication_support" in captured_directory.__all__
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32", "freebsd14"])
+def test_owned_workspace_publication_support_rejects_non_linux_before_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+) -> None:
+    def forbidden_probe() -> None:
+        raise AssertionError("unsupported platform reached rename capability probe")
+
+    monkeypatch.setattr(captured_directory.sys, "platform", platform)
+    monkeypatch.setattr(
+        captured_directory,
+        "_require_rename_noreplace_platform",
+        forbidden_probe,
+    )
+
+    with pytest.raises(UnsupportedWorkspaceCreation, match="Linux"):
+        require_owned_workspace_publication_support()
+
+
+def test_owned_workspace_publication_support_requires_anchored_directory_fds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden_probe() -> None:
+        raise AssertionError("unsafe directory-fd host reached rename capability probe")
+
+    monkeypatch.setattr(captured_directory.sys, "platform", "linux")
+    monkeypatch.setattr(captured_directory, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
+    monkeypatch.setattr(
+        captured_directory,
+        "_require_rename_noreplace_platform",
+        forbidden_probe,
+    )
+
+    with pytest.raises(UnsupportedWorkspaceCreation, match="directory-fd"):
+        require_owned_workspace_publication_support()
+
+
+def test_owned_workspace_publication_support_wraps_missing_rename_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unsupported_rename() -> None:
+        raise RuntimeError("renameat2 is missing")
+
+    monkeypatch.setattr(captured_directory.sys, "platform", "linux")
+    monkeypatch.setattr(captured_directory, "_SAFE_OWNERSHIP_DIRECTORY_FDS", True)
+    monkeypatch.setattr(
+        captured_directory,
+        "_require_rename_noreplace_platform",
+        unsupported_rename,
+    )
+
+    with pytest.raises(
+        UnsupportedWorkspaceCreation,
+        match="no-replace rename",
+    ) as raised:
+        require_owned_workspace_publication_support()
+
+    assert isinstance(raised.value.__cause__, RuntimeError)
+
+
 @pytest.mark.parametrize(
     ("directories", "files", "message"),
     [
@@ -573,11 +679,14 @@ def test_preopened_workspace_writes_only_planned_files_without_mkdir(
             plan=plan,
             expected_destination=None,
         )
-        workspace.write_file("root.bin", [b"root"])
-        workspace.write_file("nested/payload.bin", [b"payload"])
+        root_record = workspace.write_file("root.bin", [b"root"])
+        nested_record = workspace.write_file(
+            "nested/payload.bin",
+            [b"payload"],
+        )
         ownership = workspace.seal()
 
-        assert directory_ownership_file_records(ownership) == (
+        expected_records = (
             atomic_directory.TreeFileRecord(
                 path="nested/payload.bin",
                 mode=0o644,
@@ -595,6 +704,8 @@ def test_preopened_workspace_writes_only_planned_files_without_mkdir(
                 ),
             ),
         )
+        assert (nested_record, root_record) == expected_records
+        assert directory_ownership_file_records(ownership) == expected_records
         assert os.lseek(parent_fd, 0, os.SEEK_CUR) == 37
         assert os.lseek(root_fd, 0, os.SEEK_CUR) == 37
         assert (stage / "nested" / "payload.bin").read_bytes() == b"payload"
@@ -1287,6 +1398,114 @@ def test_owned_workspace_publish_installs_fresh_durable_receipt(
         receipt_owner.close()
         assert receipt_owner.closed
         assert receipt.closed
+
+
+def test_owned_workspace_publish_runs_staged_and_published_validators(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="3" * 64,
+        files=(WorkspaceFile("payload", max_bytes=9),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        record = workspace.write_file("payload", [b"validated"])
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        observed: list[tuple[str, tuple[atomic_directory.TreeFileRecord, ...]]] = []
+
+        def validate_staged(
+            reader: atomic_directory.PublicationDirectoryReader,
+        ) -> None:
+            assert stage.is_dir()
+            assert not destination.exists()
+            assert reader.read_bytes("payload", max_bytes=9) == b"validated"
+            observed.append(("staged", reader.file_records()))
+
+        def validate_published(
+            reader: atomic_directory.PublicationDirectoryReader,
+        ) -> None:
+            assert not stage.exists()
+            assert destination.is_dir()
+            assert reader.read_bytes("payload", max_bytes=9) == b"validated"
+            observed.append(("published", reader.file_records()))
+
+        workspace.publish_into(
+            receipt_owner,
+            validate_staged_directory=validate_staged,
+            validate_published_destination=validate_published,
+        )
+
+        assert observed == [
+            ("staged", (record,)),
+            ("published", (record,)),
+        ]
+        assert receipt_owner.active
+        receipt_owner.close()
+
+
+@pytest.mark.parametrize(
+    ("validator_name", "message"),
+    [
+        ("validate_staged_directory", "staged workspace validator"),
+        ("validate_published_destination", "published workspace validator"),
+    ],
+)
+def test_owned_workspace_rejects_noncallable_validator_before_transfer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    validator_name: str,
+    message: str,
+) -> None:
+    plan = WorkspacePlan(subject_digest="3" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        def forbidden_publish(*_args, **_kwargs) -> None:
+            raise AssertionError("noncallable validator reached atomic publication")
+
+        monkeypatch.setattr(
+            captured_directory,
+            "_publish_staged_directory_with_authority",
+            forbidden_publish,
+        )
+
+        with pytest.raises(TypeError, match=message):
+            workspace.publish_into(
+                receipt_owner,
+                **{validator_name: object()},
+            )
+
+        assert workspace.state == "sealed"
+        assert workspace._publication_transfer is None
+        assert workspace._resources_transferred is False
+        assert receipt_owner.state == "empty"
+        assert stage.is_dir()
+        assert not destination.exists()
+        workspace.close()
+        receipt_owner.close()
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import codenib._atomic_directory as atomic_directory
+from codenib._atomic_directory import (
+    capture_directory_ownership,
+    directory_ownership_file_records,
+)
+from codenib._captured_directory import CapturedDirectoryReader
+
+
+def test_tree_ownership_exposes_canonical_file_records(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (root / "b.txt").write_bytes(b"b")
+    (nested / "a.txt").write_bytes(b"alpha")
+
+    records = directory_ownership_file_records(capture_directory_ownership(root))
+
+    assert [(record.path, record.size) for record in records] == [
+        ("b.txt", 1),
+        ("nested/a.txt", 5),
+    ]
+    assert all(len(record.sha256) == 64 for record in records)
+
+
+def test_entry_policy_rejects_before_file_bytes_are_hashed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "documents.json").write_bytes(b"x" * 32)
+
+    def reject_large(_path: str, kind: str, _mode: int, size: int) -> None:
+        if kind == "file" and size > 16:
+            raise ValueError("prehash size policy")
+
+    def forbidden_read(_descriptor: int, _size: int) -> bytes:
+        raise AssertionError("oversized file must be rejected before hashing")
+
+    monkeypatch.setattr(atomic_directory.os, "read", forbidden_read)
+    with pytest.raises(ValueError, match="prehash size policy"):
+        capture_directory_ownership(root, entry_policy=reject_large)
+
+
+def test_captured_reader_rejects_identical_nested_a_b_a_replacement(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    source = nested / "payload"
+    source.write_bytes(b"same bytes")
+    ownership = capture_directory_ownership(root)
+    reader = CapturedDirectoryReader(root, ownership)
+    saved = tmp_path / "saved-nested"
+
+    nested.rename(saved)
+    nested.mkdir()
+    (nested / "payload").write_bytes(b"same bytes")
+    replacement = tmp_path / "replacement-nested"
+    nested.rename(replacement)
+    saved.rename(nested)
+
+    try:
+        with pytest.raises(ValueError, match="captured path is not a real directory"):
+            reader.read_bytes("nested/payload", max_bytes=64)
+    finally:
+        reader.close()
+
+    assert (replacement / "payload").read_bytes() == b"same bytes"

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -533,6 +533,21 @@ def test_workspace_plan_rejects_atomic_scanner_overflow_before_provisioning(
         )
 
 
+def test_workspace_plan_rejects_metadata_budget_before_provisioning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(captured_directory, "_MAX_OWNERSHIP_METADATA_BYTES", 100)
+
+    with pytest.raises(ValueError, match="path metadata exceeds"):
+        WorkspacePlan(
+            subject_digest="c" * 64,
+            directories=(
+                WorkspaceDirectory("a" * 48),
+                WorkspaceDirectory("b" * 48),
+            ),
+        )
+
+
 def test_owned_workspace_publication_support_gate_is_side_effect_free(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1156,6 +1171,40 @@ def test_preopened_workspace_record_install_interruption_terminally_fails(
         workspace._written_files = InterruptingRecords()
 
         with pytest.raises(KeyboardInterrupt, match="record install interruption"):
+            workspace.write_file("payload", [b"safe"])
+
+        assert workspace.state == "closed"
+        assert (stage / "payload").read_bytes() == b"safe"
+        with pytest.raises(RuntimeError, match="cannot seal while closed"):
+            workspace.seal()
+
+
+def test_preopened_workspace_record_construction_interruption_terminally_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="a" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+
+        def interrupt_record(*_args, **_kwargs):
+            raise KeyboardInterrupt("record construction interruption")
+
+        monkeypatch.setattr(captured_directory, "TreeFileRecord", interrupt_record)
+        with pytest.raises(KeyboardInterrupt, match="record construction interruption"):
             workspace.write_file("payload", [b"safe"])
 
         assert workspace.state == "closed"

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -4,16 +4,146 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import dis
+import errno
+import os
+import signal
+import stat
+import sys
+import threading
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+from typing import Callable, Iterator
 
 import pytest
 
 import codenib._atomic_directory as atomic_directory
+import codenib._captured_directory as captured_directory
 from codenib._atomic_directory import (
     capture_directory_ownership,
     directory_ownership_file_records,
 )
-from codenib._captured_directory import CapturedDirectoryReader, OwnedDirectoryStage
+from codenib._captured_directory import (
+    AuthenticatedSnapshotReader,
+    CapturedDirectoryReader,
+    OwnedDirectoryStage,
+    OwnedWorkspaceAuthority,
+    PublishedWorkspaceReceipt,
+    PublishedWorkspaceReceiptOwner,
+    UnsupportedWorkspaceCreation,
+    WorkspaceDirectory,
+    WorkspaceFile,
+    WorkspacePlan,
+)
+
+
+@contextmanager
+def _preopened_workspace(
+    tmp_path: Path,
+    plan: WorkspacePlan,
+) -> Iterator[tuple[Path, Path, int, int, dict[str, int]]]:
+    parent = tmp_path / "workspace-parent"
+    parent.mkdir(mode=0o700)
+    destination = parent / "destination"
+    stage = parent / "trusted-stage"
+    stage.mkdir(mode=plan.root_mode)
+    for item in plan.directories:
+        (stage / item.path.as_posix()).mkdir(mode=item.mode)
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_descriptor = os.open(parent, flags)
+    root_descriptor = os.open(stage, flags)
+    directories = {
+        item.path.as_posix(): os.open(stage / item.path.as_posix(), flags)
+        for item in plan.directories
+    }
+    try:
+        yield (
+            destination,
+            stage,
+            parent_descriptor,
+            root_descriptor,
+            directories,
+        )
+    finally:
+        for descriptor in directories.values():
+            os.close(descriptor)
+        os.close(root_descriptor)
+        os.close(parent_descriptor)
+
+
+def _interrupt_before_store(
+    callback: Callable[[], object],
+    *,
+    local_name: str,
+    error: BaseException,
+) -> None:
+    target_code = callback.__code__
+    instructions = {
+        instruction.offset: instruction
+        for instruction in dis.get_instructions(target_code)
+    }
+    previous_trace = sys.gettrace()
+
+    def trace(frame, event, _arg):
+        if event == "call" and frame.f_code is target_code:
+            frame.f_trace_opcodes = True
+            return trace
+        if event == "opcode" and frame.f_code is target_code:
+            instruction = instructions.get(frame.f_lasti)
+            if (
+                instruction is not None
+                and instruction.opname == "STORE_FAST"
+                and instruction.argval == local_name
+            ):
+                sys.settrace(None)
+                raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+
+
+def _interrupt_after_store_attr(
+    callback: Callable[[], object],
+    *,
+    target_code: object,
+    attribute: str,
+    error: BaseException,
+) -> None:
+    instructions = {
+        instruction.offset: instruction
+        for instruction in dis.get_instructions(target_code)
+    }
+    previous_trace = sys.gettrace()
+    armed = False
+
+    def trace(frame, event, _arg):
+        nonlocal armed
+        if event == "call" and frame.f_code is target_code:
+            frame.f_trace_opcodes = True
+            return trace
+        if event == "opcode" and frame.f_code is target_code:
+            if armed:
+                sys.settrace(None)
+                raise error
+            instruction = instructions.get(frame.f_lasti)
+            if (
+                instruction is not None
+                and instruction.opname == "STORE_ATTR"
+                and instruction.argval == attribute
+            ):
+                armed = True
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
 
 
 def test_tree_ownership_exposes_canonical_file_records(tmp_path: Path) -> None:
@@ -80,31 +210,1774 @@ def test_captured_reader_rejects_identical_nested_a_b_a_replacement(
     assert (replacement / "payload").read_bytes() == b"same bytes"
 
 
-def test_owned_stage_publishes_its_final_full_tree(tmp_path: Path) -> None:
-    destination = tmp_path / "published"
-    stage = OwnedDirectoryStage(destination)
-    stage.write_file("nested/payload", [b"owned bytes"])
-
-    stage.publish(expected_destination_ownership=None)
-
-    assert (destination / "nested" / "payload").read_bytes() == b"owned bytes"
-
-
-def test_owned_stage_rejects_root_replacement_before_publish(tmp_path: Path) -> None:
-    destination = tmp_path / "published"
-    stage = OwnedDirectoryStage(destination)
-    stage.write_file("payload", [b"owned bytes"])
-    stolen = tmp_path / "stolen-stage"
-    stage.path.rename(stolen)
-    stage.path.mkdir()
-    (stage.path / "foreign").write_bytes(b"foreign")
+def test_authenticated_descriptor_exposes_only_a_sealed_good_snapshot(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / "payload"
+    source.write_bytes(b"GOOD")
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+    observed = b""
 
     try:
-        with pytest.raises(RuntimeError, match="owned stage root changed"):
-            stage.publish(expected_destination_ownership=None)
+        with pytest.raises(ValueError, match="changed after authentication"):
+            with reader.authenticated_descriptor("payload", max_bytes=4) as (
+                descriptor,
+                record,
+            ):
+                assert record.size == 4
+                source.write_bytes(b"EVIL")
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                observed = os.read(descriptor, 4)
+                with pytest.raises(OSError):
+                    os.write(descriptor, b"FAIL")
     finally:
-        stage.discard()
+        reader.close()
 
-    assert not destination.exists()
-    assert (stolen / "payload").read_bytes() == b"owned bytes"
-    assert (stage.path / "foreign").read_bytes() == b"foreign"
+    assert observed == b"GOOD"
+
+
+def test_authenticated_snapshot_has_bounded_immutable_bytes_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._captured_directory as captured_directory
+
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_bytes(b"first\nsecond")
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+
+    def unavailable() -> int:
+        raise captured_directory._SnapshotUnavailable("unsupported host")
+
+    monkeypatch.setattr(captured_directory, "_create_sealable_memfd", unavailable)
+    try:
+        with reader.authenticated_snapshot("payload") as (snapshot, record):
+            assert record.size == 12
+            assert snapshot.readline() == b"first\n"
+            assert snapshot.read() == b"second"
+            with pytest.raises(RuntimeError, match="no sealed descriptor"):
+                _ = snapshot.descriptor
+    finally:
+        reader.close()
+
+
+def test_authenticated_snapshot_reader_caps_oversized_requests(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    payload = b"x" * (8 * 1024 * 1024 + 17)
+    (root / "payload").write_bytes(payload)
+    reader = CapturedDirectoryReader(root, capture_directory_ownership(root))
+
+    try:
+        with reader.authenticated_snapshot("payload") as (snapshot, _record):
+            source = AuthenticatedSnapshotReader(snapshot)
+            first = source.read(1 << 60)
+            second = source.read(1 << 60)
+            assert len(first) == 8 * 1024 * 1024
+            assert first + second == payload
+            assert source.read(1 << 60) == b""
+        with reader.authenticated_snapshot("payload") as (snapshot, _record):
+            source = AuthenticatedSnapshotReader(snapshot)
+            assert len(source.readline(1 << 60)) == 8 * 1024 * 1024
+    finally:
+        reader.close()
+
+
+def test_owned_stage_noreplace_never_overwrites_raced_foreign_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stage = OwnedDirectoryStage(tmp_path / "destination")
+    valuable = tmp_path / "valuable"
+    valuable.write_bytes(b"foreign")
+    real_rename = captured_directory._rename_noreplace_at
+
+    def race_rename(source, destination, src_dir_fd, dst_dir_fd) -> None:
+        valuable.rename(stage.path / destination)
+        real_rename(
+            source,
+            destination,
+            src_dir_fd,
+            dst_dir_fd,
+        )
+
+    monkeypatch.setattr(captured_directory, "_rename_noreplace_at", race_rename)
+    try:
+        with pytest.raises(ValueError, match="already exists"):
+            stage.write_file("payload", [b"new"])
+        assert (stage.path / "payload").read_bytes() == b"foreign"
+    finally:
+        stage.close()
+
+
+def test_owned_stage_does_not_reacquire_foreign_nested_directory(
+    tmp_path: Path,
+) -> None:
+    stage = OwnedDirectoryStage(tmp_path / "destination")
+    foreign = stage.path / "nested"
+    foreign.mkdir()
+    try:
+        with pytest.raises(ValueError, match="was not created here"):
+            stage.write_file("nested/payload", [b"new"])
+        assert not (foreign / "payload").exists()
+    finally:
+        stage.close()
+
+
+def test_owned_stage_rejects_preexisting_ancestor_symlink(tmp_path: Path) -> None:
+    foreign = tmp_path / "foreign"
+    parent = foreign / "parent"
+    parent.mkdir(parents=True)
+    valuable = parent / "valuable.txt"
+    valuable.write_text("preserve", encoding="utf-8")
+    trusted = tmp_path / "trusted"
+    trusted.mkdir()
+    (trusted / "alias").symlink_to(foreign, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="real directory"):
+        OwnedDirectoryStage(trusted / "alias" / "parent" / "published")
+
+    assert valuable.read_text(encoding="utf-8") == "preserve"
+    assert not list(parent.glob(".*.normalize-*"))
+
+
+def test_owned_stage_prepare_creates_nested_parent_and_publishes(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "new" / "nested" / "published"
+    stage = OwnedDirectoryStage.prepare(
+        destination,
+        required_destination_file="marker.txt",
+        allow_empty_destination=True,
+    )
+    stage.write_file("marker.txt", [b"owned"])
+
+    stage.publish()
+
+    assert (destination / "marker.txt").read_bytes() == b"owned"
+
+
+def test_owned_stage_prepare_rejects_parent_replacement_before_write(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "parent" / "published"
+    stage = OwnedDirectoryStage.prepare(destination)
+    saved = tmp_path / "saved-parent"
+    destination.parent.rename(saved)
+    destination.parent.mkdir()
+    valuable = destination.parent / "valuable.txt"
+    valuable.write_text("preserve", encoding="utf-8")
+    try:
+        with pytest.raises(RuntimeError, match="parent path changed"):
+            stage.write_file("marker.txt", [b"owned"])
+        assert valuable.read_text(encoding="utf-8") == "preserve"
+        assert not (destination.parent / "marker.txt").exists()
+    finally:
+        stage.close()
+
+
+def test_owned_stage_prepare_keeps_pinned_parent_across_reversible_swap(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "parent" / "published"
+    stage = OwnedDirectoryStage.prepare(destination)
+    saved = tmp_path / "saved-parent"
+    destination.parent.rename(saved)
+    destination.parent.mkdir()
+    valuable = destination.parent / "valuable.txt"
+    valuable.write_text("preserve", encoding="utf-8")
+    foreign = tmp_path / "foreign-parent"
+    destination.parent.rename(foreign)
+    saved.rename(destination.parent)
+    try:
+        stage.write_file("marker.txt", [b"owned"])
+        stage.publish()
+        assert (destination / "marker.txt").read_bytes() == b"owned"
+        assert (foreign / "valuable.txt").read_text(encoding="utf-8") == "preserve"
+    finally:
+        stage.close()
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs")
+def test_owned_stage_closes_parent_fd_when_iterator_creation_fails(
+    tmp_path: Path,
+) -> None:
+    class RaisingIterable:
+        def __iter__(self):
+            raise RuntimeError("iterator creation failed")
+
+    stage = OwnedDirectoryStage(tmp_path / "destination")
+    baseline = len(list(Path("/proc/self/fd").iterdir()))
+    try:
+        with pytest.raises(RuntimeError, match="iterator creation failed"):
+            stage.write_file("payload", RaisingIterable())
+        assert len(list(Path("/proc/self/fd").iterdir())) == baseline
+    finally:
+        stage.close()
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs")
+def test_owned_stage_closes_all_fds_when_iterator_close_fails(tmp_path: Path) -> None:
+    class RaisingCloseIterator:
+        yielded = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            if self.yielded:
+                raise StopIteration
+            self.yielded = True
+            return b"new"
+
+        def close(self) -> None:
+            raise RuntimeError("iterator close failed")
+
+    stage = OwnedDirectoryStage(tmp_path / "destination")
+    baseline = len(list(Path("/proc/self/fd").iterdir()))
+    try:
+        with pytest.raises(RuntimeError, match="iterator close failed"):
+            stage.write_file("payload", RaisingCloseIterator())
+        assert len(list(Path("/proc/self/fd").iterdir())) == baseline
+        assert (stage.path / "payload").read_bytes() == b"new"
+    finally:
+        stage.close()
+
+
+def test_owned_stage_rejects_root_swap_between_capture_and_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_open = captured_directory.os.open
+    swapped: dict[str, str] = {}
+
+    def race_open(path, flags, mode=0o777, *, dir_fd=None):
+        if (
+            not swapped
+            and dir_fd is not None
+            and isinstance(path, str)
+            and ".normalize-" in path
+            and flags & os.O_DIRECTORY
+        ):
+            stolen = f"{path}.stolen"
+            os.rename(path, stolen, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+            os.mkdir(path, mode=0o700, dir_fd=dir_fd)
+            swapped.update(active=path, stolen=stolen)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(captured_directory.os, "open", race_open)
+    with pytest.raises(RuntimeError, match="root changed"):
+        OwnedDirectoryStage(tmp_path / "destination")
+
+    assert swapped
+    assert (tmp_path / swapped["active"]).is_dir()
+    assert (tmp_path / swapped["stolen"]).is_dir()
+
+
+def test_workspace_plan_is_canonical_and_bound_to_its_subject() -> None:
+    first = WorkspacePlan(
+        subject_digest="a" * 64,
+        directories=(
+            WorkspaceDirectory("nested/deeper"),
+            WorkspaceDirectory("nested"),
+        ),
+        files=(
+            WorkspaceFile("root.bin", max_bytes=8),
+            WorkspaceFile("nested/deeper/payload.bin", mode=0o644, max_bytes=16),
+        ),
+    )
+    second = WorkspacePlan(
+        subject_digest="a" * 64,
+        directories=(
+            WorkspaceDirectory("nested"),
+            WorkspaceDirectory("nested/deeper"),
+        ),
+        files=tuple(reversed(first.files)),
+    )
+
+    assert first == second
+    assert first.digest == second.digest
+    assert len(first.digest) == 64
+    assert (
+        WorkspacePlan(
+            subject_digest="b" * 64,
+            directories=first.directories,
+            files=first.files,
+        ).digest
+        != first.digest
+    )
+
+
+@pytest.mark.parametrize(
+    ("directories", "files", "message"),
+    [
+        ((), (WorkspaceFile("nested/payload", max_bytes=1),), "ancestor"),
+        (
+            (WorkspaceDirectory("A"), WorkspaceDirectory("a")),
+            (),
+            "portable path collision",
+        ),
+        (
+            (WorkspaceDirectory("entry"),),
+            (WorkspaceFile("entry", max_bytes=1),),
+            "both file and directory",
+        ),
+    ],
+)
+def test_workspace_plan_rejects_ambiguous_skeletons(
+    directories: tuple[WorkspaceDirectory, ...],
+    files: tuple[WorkspaceFile, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        WorkspacePlan(
+            subject_digest="c" * 64,
+            directories=directories,
+            files=files,
+        )
+
+
+def test_preopened_workspace_writes_only_planned_files_without_mkdir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="d" * 64,
+        directories=(WorkspaceDirectory("nested"),),
+        files=(
+            WorkspaceFile("root.bin", max_bytes=4),
+            WorkspaceFile("nested/payload.bin", mode=0o644, max_bytes=8),
+        ),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        os.lseek(parent_fd, 37, os.SEEK_SET)
+        os.lseek(root_fd, 37, os.SEEK_SET)
+        workspace = OwnedWorkspaceAuthority()
+
+        def forbidden_mkdir(*_args, **_kwargs) -> None:
+            raise AssertionError("strict workspace runtime must not create directories")
+
+        monkeypatch.setattr(captured_directory.os, "mkdir", forbidden_mkdir)
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("root.bin", [b"root"])
+        workspace.write_file("nested/payload.bin", [b"payload"])
+        ownership = workspace.seal()
+
+        assert directory_ownership_file_records(ownership) == (
+            atomic_directory.TreeFileRecord(
+                path="nested/payload.bin",
+                mode=0o644,
+                size=7,
+                sha256=(
+                    "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5"
+                ),
+            ),
+            atomic_directory.TreeFileRecord(
+                path="root.bin",
+                mode=0o600,
+                size=4,
+                sha256=(
+                    "4813494d137e1631bba301d5acab6e7bb7aa74ce1185d456565ef51d737677b2"
+                ),
+            ),
+        )
+        assert os.lseek(parent_fd, 0, os.SEEK_CUR) == 37
+        assert os.lseek(root_fd, 0, os.SEEK_CUR) == 37
+        assert (stage / "nested" / "payload.bin").read_bytes() == b"payload"
+        workspace.close()
+        os.fstat(parent_fd)
+        os.fstat(root_fd)
+
+
+def test_preopened_workspace_rejects_root_name_replacement(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="e" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        saved = stage.with_name("saved-stage")
+        stage.rename(saved)
+        stage.mkdir(mode=0o700)
+        workspace = OwnedWorkspaceAuthority()
+
+        with pytest.raises(RuntimeError, match="root handle"):
+            workspace.adopt(
+                destination=destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_fd,
+                root_descriptor=root_fd,
+                directory_descriptors=directories,
+                plan=plan,
+                expected_destination=None,
+            )
+
+        assert not (stage / "payload").exists()
+        os.fstat(root_fd)
+
+
+def test_preopened_workspace_rejects_nested_handle_replacement(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="f" * 64,
+        directories=(WorkspaceDirectory("nested"),),
+        files=(WorkspaceFile("nested/payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        nested = stage / "nested"
+        saved = tmp_path / "saved-nested"
+        nested.rename(saved)
+        nested.mkdir(mode=0o700)
+        workspace = OwnedWorkspaceAuthority()
+
+        with pytest.raises(RuntimeError, match="directory handle differs"):
+            workspace.adopt(
+                destination=destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_fd,
+                root_descriptor=root_fd,
+                directory_descriptors=directories,
+                plan=plan,
+                expected_destination=None,
+            )
+
+        assert not (nested / "payload").exists()
+
+
+def test_preopened_workspace_rejects_any_unplanned_skeleton_file(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="1" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        (stage / "foreign").write_bytes(b"preserve")
+        workspace = OwnedWorkspaceAuthority()
+
+        with pytest.raises(ValueError, match="contain no files"):
+            workspace.adopt(
+                destination=destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_fd,
+                root_descriptor=root_fd,
+                directory_descriptors=directories,
+                plan=plan,
+                expected_destination=None,
+            )
+
+        assert (stage / "foreign").read_bytes() == b"preserve"
+
+
+def test_preopened_workspace_rejects_existing_destination_when_missing_expected(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="2" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        destination.mkdir(mode=0o700)
+        workspace = OwnedWorkspaceAuthority()
+
+        with pytest.raises(RuntimeError, match="expected missing"):
+            workspace.adopt(
+                destination=destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_fd,
+                root_descriptor=root_fd,
+                directory_descriptors=directories,
+                plan=plan,
+                expected_destination=None,
+            )
+
+
+def test_preopened_workspace_noreplace_refuses_foreign_planned_leaf(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="3" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        (stage / "payload").write_bytes(b"evil")
+
+        with pytest.raises(RuntimeError, match="unplanned file"):
+            workspace.write_file("payload", [b"good"])
+
+        assert (stage / "payload").read_bytes() == b"evil"
+
+
+def test_strict_workspace_create_fails_before_filesystem_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden_mkdir(*_args, **_kwargs) -> None:
+        raise AssertionError("strict create must fail before mutation")
+
+    monkeypatch.setattr(captured_directory.os, "mkdir", forbidden_mkdir)
+    with pytest.raises(UnsupportedWorkspaceCreation, match="pre-opened skeleton"):
+        OwnedWorkspaceAuthority.create()
+
+
+def test_preopened_workspace_seal_rejects_external_hardlink(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="4" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"safe"])
+        os.link(stage / "payload", tmp_path / "external-alias")
+
+        with pytest.raises(RuntimeError, match="file changed"):
+            workspace.seal()
+
+
+def test_preopened_workspace_seal_is_idempotently_recoverable(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="5" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"safe"])
+
+        ownership = workspace.seal()
+
+        assert workspace.seal() is ownership
+        workspace.close()
+
+
+def test_preopened_workspace_seal_return_interruption_keeps_token_recoverable(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="8" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"safe"])
+
+        def seal_and_store() -> object:
+            ownership = workspace.seal()
+            return ownership
+
+        with pytest.raises(KeyboardInterrupt, match="seal return"):
+            _interrupt_before_store(
+                seal_and_store,
+                local_name="ownership",
+                error=KeyboardInterrupt("seal return"),
+            )
+
+        ownership = workspace.seal()
+        assert directory_ownership_file_records(ownership)[0].path == "payload"
+        workspace.close()
+
+
+def test_preopened_workspace_rejects_producer_reentrant_close(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="6" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+
+        def chunks() -> Iterator[bytes]:
+            with pytest.raises(RuntimeError, match="close is reentrant"):
+                workspace.close()
+            yield b"safe"
+
+        workspace.write_file("payload", chunks())
+        workspace.seal()
+        assert (stage / "payload").read_bytes() == b"safe"
+        workspace.close()
+
+
+def test_preopened_workspace_retains_file_owner_after_persistent_close_eio(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="7" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        real_close = os.close
+        retained: set[int] = set()
+
+        def persistent_file_eio(descriptor: int) -> None:
+            metadata = os.fstat(descriptor)
+            if stat.S_ISREG(metadata.st_mode):
+                retained.add(descriptor)
+                raise OSError(errno.EIO, "persistent file close failure")
+            real_close(descriptor)
+
+        monkeypatch.setattr(captured_directory.os, "close", persistent_file_eio)
+        with pytest.raises(OSError, match="persistent file close failure"):
+            workspace.write_file("payload", [b"safe"])
+
+        assert retained
+        descriptor = next(iter(retained))
+        os.fstat(descriptor)
+        assert workspace.state == "failed"
+
+        monkeypatch.setattr(captured_directory.os, "close", real_close)
+        workspace.close()
+        with pytest.raises(OSError):
+            os.fstat(descriptor)
+
+
+def test_preopened_workspace_close_reconciliation_preserves_first_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="9" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        real_close = os.close
+        armed = [False]
+
+        def persistent_file_eio(descriptor: int) -> None:
+            if stat.S_ISREG(os.fstat(descriptor).st_mode):
+                armed[0] = True
+                raise OSError(errno.EIO, "first file close failure")
+            real_close(descriptor)
+
+        owner_type = type(workspace._resources)
+        real_closed = owner_type.closed
+
+        def interrupted_reconciliation(owner) -> bool:
+            if armed[0] and owner is workspace._resources:
+                raise SystemExit("secondary close-state interruption")
+            return real_closed.fget(owner)
+
+        monkeypatch.setattr(captured_directory.os, "close", persistent_file_eio)
+        monkeypatch.setattr(
+            owner_type,
+            "closed",
+            property(interrupted_reconciliation),
+        )
+        with pytest.raises(OSError, match="first file close failure") as caught:
+            workspace.write_file("payload", [b"safe"])
+
+        assert not isinstance(caught.value, SystemExit)
+        assert workspace.state == "failed"
+
+        monkeypatch.setattr(owner_type, "closed", real_closed)
+        monkeypatch.setattr(captured_directory.os, "close", real_close)
+        workspace.close()
+
+
+def test_preopened_workspace_iterator_close_lookup_preserves_primary_and_fds(
+    tmp_path: Path,
+) -> None:
+    class RaisingCloseLookup:
+        yielded = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            if not self.yielded:
+                self.yielded = True
+                return b"x"
+            raise RuntimeError("producer primary")
+
+        @property
+        def close(self):
+            raise SystemExit("close lookup cancellation")
+
+    plan = WorkspacePlan(
+        subject_digest="0" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        with pytest.raises(RuntimeError, match="producer primary") as caught:
+            workspace.write_file("payload", RaisingCloseLookup())
+
+        assert any(
+            "close lookup cancellation" in note
+            for note in tuple(getattr(caught.value, "__notes__", ()))
+            + tuple(getattr(caught.value, "_codenib_cleanup_notes", ()))
+        )
+        assert all(record.owner.descriptor < 0 for record in workspace._file_owners)
+        assert workspace.state == "closed"
+        assert (stage / "payload").read_bytes() == b"x"
+
+
+def test_preopened_workspace_record_install_interruption_terminally_fails(
+    tmp_path: Path,
+) -> None:
+    class InterruptingRecords(dict):
+        def __setitem__(self, key, value) -> None:
+            super().__setitem__(key, value)
+            raise KeyboardInterrupt("record install interruption")
+
+    plan = WorkspacePlan(
+        subject_digest="a" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace._written_files = InterruptingRecords()
+
+        with pytest.raises(KeyboardInterrupt, match="record install interruption"):
+            workspace.write_file("payload", [b"safe"])
+
+        assert workspace.state == "closed"
+        assert (stage / "payload").read_bytes() == b"safe"
+        with pytest.raises(RuntimeError, match="cannot seal while closed"):
+            workspace.seal()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_owned_workspace_child_closes_inherited_resources_without_parent_effect(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="f" * 64,
+        directories=(WorkspaceDirectory("nested"),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        authority = workspace._parent_owner.authority
+        assert authority is not None
+        workspace_descriptors = {
+            authority._resource,
+            *(record.descriptor for record in workspace._resources._records),
+        }
+        workspace_descriptors.discard(-1)
+
+        lock_acquired = threading.Event()
+        release_lock = threading.Event()
+
+        def hold_lifecycle_lock() -> None:
+            def wait_for_release() -> None:
+                lock_acquired.set()
+                assert release_lock.wait(timeout=5)
+
+            workspace._lock.run(wait_for_release)
+
+        holder = threading.Thread(target=hold_lifecycle_lock)
+        holder.start()
+        assert lock_acquired.wait(timeout=5)
+        child = os.fork()
+        if child == 0:  # pragma: no branch - assertions report through exit code
+            signal.signal(signal.SIGALRM, lambda *_args: os._exit(90))
+            signal.alarm(3)
+            real_close = os.close
+            target_descriptor = workspace._root_descriptor
+            target_barrier = threading.Barrier(2)
+            target_close_calls: list[int] = []
+            close_errors: list[BaseException] = []
+
+            def counted_close(descriptor: int) -> None:
+                if descriptor == target_descriptor:
+                    try:
+                        target_barrier.wait(timeout=0.25)
+                    except threading.BrokenBarrierError:
+                        pass
+                    target_close_calls.append(descriptor)
+                real_close(descriptor)
+
+            captured_directory.os.close = counted_close
+
+            def close_in_child() -> None:
+                try:
+                    workspace.close()
+                except RuntimeError as exc:
+                    if "PID boundary" not in str(exc):
+                        close_errors.append(exc)
+                except BaseException as exc:  # noqa: B036 - child reports failure
+                    close_errors.append(exc)
+                else:
+                    close_errors.append(AssertionError("PID boundary was accepted"))
+
+            closers = [threading.Thread(target=close_in_child) for _ in range(2)]
+            for closer in closers:
+                closer.start()
+            for closer in closers:
+                closer.join(timeout=2)
+            if any(closer.is_alive() for closer in closers):
+                os._exit(91)
+            if close_errors:
+                os._exit(92)
+            if target_close_calls != [target_descriptor]:
+                os._exit(95)
+            try:
+                for descriptor in workspace_descriptors:
+                    try:
+                        os.fstat(descriptor)
+                    except OSError as exc:
+                        if exc.errno != errno.EBADF:
+                            os._exit(93)
+                    else:
+                        os._exit(94)
+            except BaseException:  # noqa: B036 - child reports exact failure
+                os._exit(96)
+            os._exit(0)
+
+        release_lock.set()
+        holder.join(timeout=5)
+        assert not holder.is_alive()
+        _pid, status = os.waitpid(child, 0)
+        assert os.WIFEXITED(status)
+        assert os.WEXITSTATUS(status) == 0
+        for descriptor in workspace_descriptors:
+            os.fstat(descriptor)
+        workspace.close()
+
+
+def test_owned_workspace_adopt_skeleton_validation_is_linear(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    count = 64
+    plan = WorkspacePlan(
+        subject_digest="1" * 64,
+        directories=tuple(
+            WorkspaceDirectory(f"directory-{index:03d}") for index in range(count)
+        ),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        calls = 0
+        real_as_posix = PurePosixPath.as_posix
+
+        def counted_as_posix(path: PurePosixPath) -> str:
+            nonlocal calls
+            calls += 1
+            return real_as_posix(path)
+
+        monkeypatch.setattr(PurePosixPath, "as_posix", counted_as_posix)
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+
+        assert count <= calls < count * 20
+        workspace.close()
+
+
+def test_owned_workspace_seal_flushes_directories_bottom_up(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="2" * 64,
+        directories=(
+            WorkspaceDirectory("nested"),
+            WorkspaceDirectory("nested/deeper"),
+        ),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        descriptor_paths = {
+            descriptor: path
+            for path, descriptor in workspace._directory_descriptors.items()
+        }
+        observed: list[str] = []
+        real_fsync = captured_directory.os.fsync
+
+        def record_fsync(descriptor: int) -> None:
+            path = descriptor_paths.get(descriptor)
+            if path is not None:
+                observed.append(path)
+            real_fsync(descriptor)
+
+        monkeypatch.setattr(captured_directory.os, "fsync", record_fsync)
+
+        workspace.seal()
+
+        assert observed == ["nested/deeper", "nested", ""]
+        workspace.close()
+
+
+def test_owned_workspace_publish_installs_fresh_durable_receipt(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="3" * 64,
+        files=(WorkspaceFile("payload", max_bytes=8),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"durable"])
+        sealed = workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        workspace.publish_into(receipt_owner)
+
+        receipt = receipt_owner.receipt
+        assert isinstance(receipt, PublishedWorkspaceReceipt)
+        assert receipt.durable is True
+        assert receipt.plan_digest == plan.digest
+        assert receipt.sealed_ownership == sealed
+        assert receipt.ownership == capture_directory_ownership(destination)
+        assert receipt.ownership != sealed
+        assert not stage.exists()
+        assert (destination / "payload").read_bytes() == b"durable"
+        assert receipt_owner.consume(
+            lambda borrowed, reader: (
+                borrowed.plan_digest,
+                reader.read_bytes("payload", max_bytes=8),
+            )
+        ) == (plan.digest, b"durable")
+        with pytest.raises(RuntimeError, match="ReceiptOwner"):
+            workspace.close()
+        receipt_owner.close()
+        assert receipt_owner.closed
+        assert receipt.closed
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_published_workspace_child_closes_transfer_without_parent_effect(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(subject_digest="3" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+        authority = workspace._parent_owner.authority
+        assert authority is not None
+        internal_descriptors = {
+            authority.resource,
+            *(record.descriptor for record in workspace._resources._records),
+        }
+        internal_descriptors.discard(-1)
+
+        child = os.fork()
+        if child == 0:  # pragma: no branch - exact child result via exit
+            signal.signal(signal.SIGALRM, lambda *_signal_args: os._exit(70))
+            signal.alarm(3)
+            failures: list[BaseException] = []
+            target_descriptor = workspace._root_descriptor
+            target_barrier = threading.Barrier(2)
+            target_close_calls: list[int] = []
+            real_close = os.close
+
+            def counted_close(descriptor: int) -> None:
+                if descriptor == target_descriptor:
+                    try:
+                        target_barrier.wait(timeout=0.25)
+                    except threading.BrokenBarrierError:
+                        pass
+                    target_close_calls.append(descriptor)
+                real_close(descriptor)
+
+            captured_directory.os.close = counted_close
+
+            def close_in_child() -> None:
+                try:
+                    receipt_owner.close()
+                except RuntimeError as exc:
+                    if "PID boundary" not in str(exc):
+                        failures.append(exc)
+                except BaseException as exc:  # noqa: B036 - child report
+                    failures.append(exc)
+                else:
+                    failures.append(AssertionError("PID boundary was accepted"))
+
+            closers = [threading.Thread(target=close_in_child) for _ in range(2)]
+            for closer in closers:
+                closer.start()
+            for closer in closers:
+                closer.join(timeout=2)
+            if any(closer.is_alive() for closer in closers):
+                os._exit(71)
+            if failures:
+                os._exit(72)
+            if target_close_calls != [target_descriptor]:
+                os._exit(75)
+            for descriptor in internal_descriptors:
+                try:
+                    os.fstat(descriptor)
+                except OSError as exc:
+                    if exc.errno != errno.EBADF:
+                        os._exit(73)
+                else:
+                    os._exit(74)
+            os._exit(0)
+
+        _pid, status = os.waitpid(child, 0)
+        assert os.WIFEXITED(status)
+        assert os.WEXITSTATUS(status) == 0
+        for descriptor in internal_descriptors:
+            os.fstat(descriptor)
+        assert receipt_owner.active
+        receipt_owner.close()
+
+
+def test_owned_workspace_publish_reserves_transfer_before_atomic_helper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="4" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        real_publish = captured_directory._publish_staged_directory_with_authority
+        observed: list[tuple[str, bool]] = []
+
+        def inspect_reservation(*args, **kwargs):
+            observed.append((receipt_owner.state, workspace._resources_transferred))
+            return real_publish(*args, **kwargs)
+
+        monkeypatch.setattr(
+            captured_directory,
+            "_publish_staged_directory_with_authority",
+            inspect_reservation,
+        )
+
+        workspace.publish_into(receipt_owner)
+
+        assert observed == [("reserved", True)]
+        receipt_owner.close()
+
+
+def test_owned_workspace_install_after_store_interruption_keeps_active_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="5" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"safe"])
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        real_install = PublishedWorkspaceReceiptOwner._install
+
+        def install_then_interrupt(self, reservation, receipt) -> None:
+            real_install(self, reservation, receipt)
+            raise KeyboardInterrupt("receipt install return interruption")
+
+        monkeypatch.setattr(
+            PublishedWorkspaceReceiptOwner,
+            "_install",
+            install_then_interrupt,
+        )
+
+        with pytest.raises(KeyboardInterrupt, match="install return"):
+            workspace.publish_into(receipt_owner)
+
+        assert receipt_owner.active
+        assert workspace.state == "published"
+        assert (
+            receipt_owner.consume(
+                lambda _receipt, reader: reader.read_bytes("payload", max_bytes=4)
+            )
+            == b"safe"
+        )
+        receipt_owner.close()
+
+
+def test_owned_workspace_parent_fsync_failure_installs_no_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="6" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        authority = workspace._parent_owner.authority
+        assert authority is not None
+        target = authority.resource
+        real_fsync = captured_directory.os.fsync
+
+        def fail_parent_fsync(descriptor: int) -> None:
+            if descriptor == target:
+                raise OSError(errno.EIO, "parent fsync failed")
+            real_fsync(descriptor)
+
+        monkeypatch.setattr(captured_directory.os, "fsync", fail_parent_fsync)
+
+        with pytest.raises(OSError, match="parent fsync failed"):
+            workspace.publish_into(receipt_owner)
+
+        assert receipt_owner.state == "cleanup"
+        assert workspace.state == "failed"
+        assert destination.is_dir()
+        assert not stage.exists()
+        with pytest.raises(RuntimeError, match="expected active"):
+            _ = receipt_owner.receipt
+        receipt_owner.close()
+        assert receipt_owner.closed
+
+
+def test_owned_workspace_receipt_rejects_suppressed_authentication_failure(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="7" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.write_file("payload", [b"safe"])
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+
+        def suppress_failure(
+            _receipt: PublishedWorkspaceReceipt,
+            reader: atomic_directory.PublicationDirectoryReader,
+        ) -> None:
+            with pytest.raises(ValueError, match="absent"):
+                reader.read_bytes("missing", max_bytes=1)
+
+        with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+            receipt_owner.consume(suppress_failure)
+        assert receipt_owner.active
+        receipt_owner.close()
+
+
+def test_owned_workspace_receipt_rejects_post_publish_root_change(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(subject_digest="8" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+        destination.chmod(0o500)
+
+        with pytest.raises(RuntimeError, match="root handle changed"):
+            receipt_owner.consume(lambda _receipt, _reader: None)
+        receipt_owner.close()
+
+
+def test_owned_workspace_receipt_close_persistent_eio_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="9" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+        target = workspace._root_descriptor
+        real_close = captured_directory.os.close
+        injected = False
+
+        def fail_once(descriptor: int) -> None:
+            nonlocal injected
+            if descriptor == target and not injected:
+                injected = True
+                raise OSError(errno.EIO, "persistent workspace close")
+            real_close(descriptor)
+
+        monkeypatch.setattr(captured_directory.os, "close", fail_once)
+
+        with pytest.raises(OSError, match="persistent workspace close"):
+            receipt_owner.close()
+        assert receipt_owner.state == "close-failed"
+        os.fstat(target)
+        receipt_owner.close()
+        assert receipt_owner.closed
+
+
+def test_owned_workspace_existing_destination_receipt_retains_exact_orphan(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="a" * 64,
+        files=(WorkspaceFile("new", max_bytes=3),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        destination.mkdir(mode=0o700)
+        (destination / "old").write_bytes(b"old")
+        expected_destination = capture_directory_ownership(destination)
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=expected_destination,
+        )
+        workspace.write_file("new", [b"new"])
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        workspace.publish_into(receipt_owner)
+
+        orphan = receipt_owner.receipt.orphan
+        assert orphan is not None
+        assert (
+            orphan.reopen(lambda reader: reader.read_bytes("old", max_bytes=3))
+            == b"old"
+        )
+        assert (
+            receipt_owner.consume(
+                lambda _receipt, reader: reader.read_bytes("new", max_bytes=3)
+            )
+            == b"new"
+        )
+        receipt_owner.close()
+
+
+def test_owned_workspace_receipt_constructor_interruption_keeps_cleanup_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="b" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        def interrupt_constructor(self, **kwargs) -> None:
+            self._transfer = kwargs["transfer"]
+            raise SystemExit("workspace receipt constructor interruption")
+
+        monkeypatch.setattr(
+            PublishedWorkspaceReceipt,
+            "__init__",
+            interrupt_constructor,
+        )
+
+        with pytest.raises(SystemExit, match="constructor interruption"):
+            workspace.publish_into(receipt_owner)
+
+        assert destination.is_dir()
+        assert receipt_owner.state == "cleanup"
+        with pytest.raises(RuntimeError, match="ReceiptOwner"):
+            workspace.close()
+        receipt_owner.close()
+        assert receipt_owner.closed
+
+
+def test_owned_workspace_reservation_after_store_interruption_is_cleanup_owned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="c" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        real_reserve = PublishedWorkspaceReceiptOwner._reserve
+
+        def reserve_then_interrupt(self, reservation) -> None:
+            real_reserve(self, reservation)
+            raise KeyboardInterrupt("reservation return interruption")
+
+        monkeypatch.setattr(
+            PublishedWorkspaceReceiptOwner,
+            "_reserve",
+            reserve_then_interrupt,
+        )
+
+        with pytest.raises(KeyboardInterrupt, match="reservation return"):
+            workspace.publish_into(receipt_owner)
+
+        assert stage.is_dir()
+        assert not destination.exists()
+        assert receipt_owner.state == "cleanup"
+        receipt_owner.close()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_owned_workspace_child_closes_reserved_publication_resources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="c" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        def fork_while_reserved(*_args, **_kwargs) -> None:
+            authority = workspace._parent_owner.authority
+            assert authority is not None
+            internal_descriptors = {
+                authority.resource,
+                *(record.descriptor for record in workspace._resources._records),
+            }
+            internal_descriptors.discard(-1)
+            child = os.fork()
+            if child == 0:  # pragma: no branch - exact child result via exit
+                signal.signal(signal.SIGALRM, lambda *_signal_args: os._exit(80))
+                signal.alarm(3)
+                try:
+                    receipt_owner.close()
+                except RuntimeError as exc:
+                    if "PID boundary" not in str(exc):
+                        os._exit(81)
+                except BaseException:  # noqa: B036 - child reports by status
+                    os._exit(82)
+                else:
+                    os._exit(83)
+                for descriptor in internal_descriptors:
+                    try:
+                        os.fstat(descriptor)
+                    except OSError as exc:
+                        if exc.errno != errno.EBADF:
+                            os._exit(84)
+                    else:
+                        os._exit(85)
+                os._exit(0)
+            _pid, status = os.waitpid(child, 0)
+            assert os.WIFEXITED(status)
+            assert os.WEXITSTATUS(status) == 0
+            for descriptor in internal_descriptors:
+                os.fstat(descriptor)
+            raise RuntimeError("stop after reserved child cleanup")
+
+        monkeypatch.setattr(
+            captured_directory,
+            "_publish_staged_directory_with_authority",
+            fork_while_reserved,
+        )
+
+        with pytest.raises(RuntimeError, match="reserved child cleanup"):
+            workspace.publish_into(receipt_owner)
+
+        assert receipt_owner.state == "cleanup"
+        receipt_owner.close()
+
+
+def test_owned_workspace_first_transfer_store_interruption_is_reconciled(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(subject_digest="e" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        with pytest.raises(SystemExit, match="first transfer store"):
+            _interrupt_after_store_attr(
+                lambda: workspace.publish_into(receipt_owner),
+                target_code=OwnedWorkspaceAuthority._publish_into_locked.__code__,
+                attribute="_publication_transfer",
+                error=SystemExit("first transfer store interruption"),
+            )
+
+        assert workspace.state == "closed"
+        assert receipt_owner.state == "empty"
+        assert stage.is_dir()
+        assert not destination.exists()
+        receipt_owner.close()
+
+
+def test_owned_workspace_post_install_failure_does_not_deadlock_owner_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(subject_digest="f" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        installed = threading.Event()
+        observer_entered_workspace = threading.Event()
+        observed_states: list[str] = []
+        failures: list[BaseException] = []
+        real_install = PublishedWorkspaceReceiptOwner._install
+        real_closed = OwnedWorkspaceAuthority._publication_transfer_closed
+
+        def install_then_interrupt(self, reservation, receipt) -> None:
+            real_install(self, reservation, receipt)
+            installed.set()
+            assert observer_entered_workspace.wait(timeout=5)
+            raise KeyboardInterrupt("post-install publication interruption")
+
+        def observe_workspace_close(self, transfer) -> bool:
+            observer_entered_workspace.set()
+            return real_closed(self, transfer)
+
+        monkeypatch.setattr(
+            PublishedWorkspaceReceiptOwner,
+            "_install",
+            install_then_interrupt,
+        )
+        monkeypatch.setattr(
+            OwnedWorkspaceAuthority,
+            "_publication_transfer_closed",
+            observe_workspace_close,
+        )
+
+        def observe_owner() -> None:
+            try:
+                assert installed.wait(timeout=5)
+                observed_states.append(receipt_owner.state)
+            except BaseException as exc:  # noqa: B036 - report worker failure
+                failures.append(exc)
+
+        observer = threading.Thread(target=observe_owner, daemon=True)
+        publisher_errors: list[BaseException] = []
+
+        def publish() -> None:
+            try:
+                workspace.publish_into(receipt_owner)
+            except BaseException as exc:  # noqa: B036 - report worker failure
+                publisher_errors.append(exc)
+
+        publisher = threading.Thread(target=publish, daemon=True)
+        observer.start()
+        publisher.start()
+        publisher.join(timeout=5)
+        observer.join(timeout=5)
+
+        assert not publisher.is_alive()
+        assert not observer.is_alive()
+        assert not failures
+        assert len(publisher_errors) == 1
+        assert isinstance(publisher_errors[0], KeyboardInterrupt)
+        assert "post-install publication" in str(publisher_errors[0])
+        assert observed_states == ["active"]
+        assert receipt_owner.active
+        receipt_owner.close()
+
+
+def test_owned_workspace_consume_and_close_are_linear(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(subject_digest="d" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        workspace.publish_into(receipt_owner)
+        consuming = threading.Event()
+        release_consumer = threading.Event()
+        consumer_done = threading.Event()
+        close_done = threading.Event()
+        failures: list[BaseException] = []
+
+        def consume() -> None:
+            try:
+
+                def hold_reader(_receipt, _reader) -> None:
+                    consuming.set()
+                    assert release_consumer.wait(timeout=5)
+
+                receipt_owner.consume(hold_reader)
+                consumer_done.set()
+            except BaseException as exc:  # noqa: B036 - report from worker
+                failures.append(exc)
+
+        def close() -> None:
+            try:
+                receipt_owner.close()
+                close_done.set()
+            except BaseException as exc:  # noqa: B036 - report from worker
+                failures.append(exc)
+
+        consumer = threading.Thread(target=consume)
+        closer = threading.Thread(target=close)
+        consumer.start()
+        assert consuming.wait(timeout=5)
+        closer.start()
+        assert not close_done.wait(timeout=0.1)
+        release_consumer.set()
+        consumer.join(timeout=5)
+        closer.join(timeout=5)
+
+        assert not failures
+        assert consumer_done.is_set()
+        assert close_done.is_set()
+        assert receipt_owner.closed

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import errno
 import json
+import sys
 from pathlib import Path
 from subprocess import CompletedProcess
 from types import SimpleNamespace
@@ -1170,6 +1171,78 @@ def test_prepare_local_wiki_keeps_embedding_secret_process_local(
 
     assert "embedding-secret" not in local.config_path.read_text()
     assert local.runtime_env["CODENIB_EMBEDDING_API_KEY"] == "embedding-secret"
+
+
+def test_wiki_audit_injects_local_native_authority_resolver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = {}
+    config = SimpleNamespace(
+        model="model",
+        model_api_base=None,
+        model_api_key=None,
+        embedding_api_key=None,
+        wiki_generation_model="model",
+        wiki_generation_api_base=None,
+        wiki_generation_api_key=None,
+        wiki_generation_options={},
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo="owner/sample", base_commit="abc123")
+    )
+
+    def resolver(_repo_entry, _manifest, _vector_entry):
+        return object()
+
+    class Registry:
+        def __init__(self, supplied_config, **kwargs):
+            captured["config"] = supplied_config
+            captured.update(kwargs)
+
+        def load_all(self):
+            captured["loaded"] = True
+
+        def get(self, repo_id):
+            assert repo_id == "sample"
+            return bundle
+
+    monkeypatch.setattr("codenib.web.config.load_config", lambda _path: config)
+    monkeypatch.setattr(
+        "codenib.web.native_authority.authorize_local_manifest_vector",
+        resolver,
+    )
+    monkeypatch.setattr("codenib.web.repo_registry.RepoRegistry", Registry)
+    monkeypatch.setitem(
+        sys.modules,
+        "codenib.llm.litellm_chat",
+        SimpleNamespace(LiteLLMChat=lambda **_kwargs: object()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "codenib.wiki.agent_wiki",
+        SimpleNamespace(AgentWiki=lambda *_args, **_kwargs: object()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "codenib.wiki.quality",
+        SimpleNamespace(audit_wiki=lambda _builder: {"passed": True}),
+    )
+    local = SimpleNamespace(
+        config_path=tmp_path / "config.yaml",
+        runtime_env={},
+        repo_id="sample",
+        data_dir=tmp_path,
+    )
+
+    report = cli._audit_local_wiki(local)
+
+    assert report["passed"] is True
+    assert captured == {
+        "config": config,
+        "native_index_authorization_resolver": resolver,
+        "loaded": True,
+    }
 
 
 def test_wiki_audit_exits_without_starting_frontend(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -12,7 +13,9 @@ from types import SimpleNamespace
 import pytest
 import yaml
 
+import codenib.web.local as local_module
 from codenib import cli
+from codenib.source_fingerprint import RepositorySourceBinding
 from codenib.web import launcher
 from codenib.web.local import prepare_local_wiki
 
@@ -34,6 +37,18 @@ def test_parser_exposes_release_commands() -> None:
 
     publish = parser.parse_args(["publish", "."])
     assert publish.preset == "auto"
+
+
+def test_mcp_artifact_repo_is_explicit() -> None:
+    parser = cli.build_parser()
+
+    query_only = parser.parse_args(["mcp", "--artifact", "/tmp/context"])
+    bound = parser.parse_args(
+        ["mcp", "--artifact", "/tmp/context", "--repo", "/tmp/repo"]
+    )
+
+    assert query_only.repo is None
+    assert bound.repo == "/tmp/repo"
 
 
 @pytest.mark.parametrize(
@@ -850,6 +865,12 @@ def test_mcp_command_reports_required_extra(
     assert "codenib[mcp]" in capsys.readouterr().err
 
 
+def _test_source_fingerprint(repo: Path, cache: Path) -> str:
+    from codenib.source_fingerprint import fingerprint_repository
+
+    return fingerprint_repository(repo, exclude_roots=(cache,)).value
+
+
 def test_prepare_local_wiki_writes_single_repo_registry(
     tmp_path: Path,
 ) -> None:
@@ -857,9 +878,11 @@ def test_prepare_local_wiki_writes_single_repo_registry(
 
     manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
     manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
     manifest = RepoManifest(
         repo_path=str(tmp_path),
         commit="abc123",
+        source_fingerprint=source,
         languages=["python"],
         indexes={
             "bm25": IndexEntry(
@@ -868,6 +891,8 @@ def test_prepare_local_wiki_writes_single_repo_registry(
                 built_at="2026-07-25T00:00:00+00:00",
                 built_at_epoch=0.0,
                 status="fresh",
+                commit="abc123",
+                source_fingerprint=source,
             )
         },
     )
@@ -884,7 +909,7 @@ def test_prepare_local_wiki_writes_single_repo_registry(
     assert local.repo_id == tmp_path.name.lower()
 
 
-def test_prepare_local_wiki_rejects_mismatched_checkout(
+def test_prepare_local_wiki_capture_return_cancellation_closes_source(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -892,25 +917,107 @@ def test_prepare_local_wiki_rejects_mismatched_checkout(
 
     manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
     manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
+    RepoManifest(
+        repo_path=str(tmp_path),
+        source_fingerprint=source,
+        languages=["python"],
+    ).save(str(manifest_path))
+    captured: list[RepositorySourceBinding] = []
+    real_capture = local_module.capture_repository_source
+    interruption = SystemExit("injected after local wiki capture returned")
+
+    def capture(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        captured.append(binding)
+        raise interruption
+
+    monkeypatch.setattr(local_module, "capture_repository_source", capture)
+    with pytest.raises(SystemExit) as caught:
+        prepare_local_wiki(tmp_path, manifest_path, frontend_port=3000)
+
+    assert caught.value is interruption
+    assert len(captured) == 1
+    assert captured[0].closed
+
+
+def test_prepare_local_wiki_persistent_close_preserves_primary_and_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.compiler.manifest import RepoManifest
+
+    source_path = tmp_path / "module.py"
+    source_path.write_text("VALUE = 1\n")
+    manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
+    manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
+    RepoManifest(
+        repo_path=str(tmp_path),
+        source_fingerprint=source,
+        languages=["python"],
+    ).save(str(manifest_path))
+    source_path.write_text("VALUE = 2\n")
+    captured: list[RepositorySourceBinding] = []
+    real_capture = local_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+
+    def capture(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        captured.append(binding)
+        return binding
+
+    def persistent_eio(binding: RepositorySourceBinding) -> None:
+        if binding in captured:
+            raise OSError(errno.EIO, "injected local wiki source close EIO")
+        real_close(binding)
+
+    monkeypatch.setattr(local_module, "capture_repository_source", capture)
+    monkeypatch.setattr(RepositorySourceBinding, "close", persistent_eio)
+    with pytest.raises(ValueError, match="does not match the manifest") as caught:
+        prepare_local_wiki(tmp_path, manifest_path, frontend_port=3000)
+
+    assert len(captured) == 1
+    owner = caught.value.source_cleanup_owner
+    assert owner.pending_sources == (captured[0],)
+    assert not captured[0].closed
+
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    owner.close()
+    assert owner.closed
+    assert captured[0].closed
+
+
+def test_prepare_local_wiki_treats_manifest_commit_as_indexed_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.compiler.manifest import RepoManifest
+
+    manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
+    manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
     RepoManifest(
         repo_path=str(tmp_path),
         commit="a" * 40,
+        source_fingerprint=source,
         languages=["python"],
     ).save(str(manifest_path))
     monkeypatch.setattr(
         "codenib.compiler.checkout_identity.checkout_commit",
-        lambda _repo_path: "b" * 40,
+        lambda _repo_path: pytest.fail(
+            "local content authentication must not claim a Git HEAD attestation"
+        ),
     )
 
-    with pytest.raises(
-        ValueError,
-        match="repository checkout does not match the indexed snapshot",
-    ):
-        prepare_local_wiki(
-            tmp_path,
-            manifest_path,
-            frontend_port=3000,
-        )
+    local = prepare_local_wiki(
+        tmp_path,
+        manifest_path,
+        frontend_port=3000,
+    )
+
+    registry = json.loads((local.data_dir / "qa_registry.json").read_text())
+    assert registry[0]["base_commit"] == "a" * 40
 
 
 def test_prepare_local_wiki_rejects_changed_source_at_same_commit(
@@ -936,7 +1043,7 @@ def test_prepare_local_wiki_rejects_changed_source_at_same_commit(
 
     with pytest.raises(
         ValueError,
-        match="repository source files do not match the indexed content",
+        match="repository source content does not match the manifest",
     ):
         prepare_local_wiki(
             tmp_path,
@@ -953,9 +1060,11 @@ def test_prepare_local_wiki_uses_github_origin_identity(
 
     manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
     manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
     RepoManifest(
         repo_path=str(tmp_path),
         commit="abc123",
+        source_fingerprint=source,
         languages=["python"],
     ).save(str(manifest_path))
     monkeypatch.setattr(
@@ -982,9 +1091,11 @@ def test_prepare_generated_wiki_keeps_secret_out_of_config(
 
     manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
     manifest_path.parent.mkdir()
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
     RepoManifest(
         repo_path=str(tmp_path),
         commit="abc123",
+        source_fingerprint=source,
         languages=["python"],
         indexes={
             "bm25": IndexEntry(
@@ -993,6 +1104,8 @@ def test_prepare_generated_wiki_keeps_secret_out_of_config(
                 built_at="2026-07-25T00:00:00+00:00",
                 built_at_epoch=0.0,
                 status="fresh",
+                commit="abc123",
+                source_fingerprint=source,
             )
         },
     ).save(str(manifest_path))
@@ -1040,7 +1153,12 @@ def test_prepare_local_wiki_keeps_embedding_secret_process_local(
 
     manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
     manifest_path.parent.mkdir()
-    RepoManifest(repo_path=str(tmp_path), languages=["python"]).save(str(manifest_path))
+    source = _test_source_fingerprint(tmp_path, manifest_path.parent)
+    RepoManifest(
+        repo_path=str(tmp_path),
+        source_fingerprint=source,
+        languages=["python"],
+    ).save(str(manifest_path))
     monkeypatch.setenv("EMBEDDING_KEY", "embedding-secret")
 
     local = prepare_local_wiki(

--- a/test/test_native_index_authorization.py
+++ b/test/test_native_index_authorization.py
@@ -12,9 +12,13 @@ import pytest
 from codenib._atomic_directory import capture_directory_ownership
 from codenib.native_index_authorization import (
     NATIVE_INDEX_SUBJECT_SCHEMA,
+    InvalidNativeIndexAuthorizationError,
+    MissingNativeIndexAuthorizationError,
+    NativeIndexAuthorizationError,
     _mint_trusted_local_admin_authorization,
     native_index_subject,
     require_native_index_authorization,
+    require_native_index_authorization_preflight,
 )
 
 
@@ -60,7 +64,10 @@ def test_native_index_authorization_is_process_local_and_exact(tmp_path: Path) -
 
     payload.write_bytes(b"changed")
     changed = capture_directory_ownership(root)
-    with pytest.raises(ValueError, match="does not match captured bytes"):
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="does not match captured bytes",
+    ):
         require_native_index_authorization(
             authorization,
             changed,
@@ -95,7 +102,7 @@ def test_native_index_authorization_is_immutable_and_pid_bound(
         "getpid",
         lambda: authorization.process_id + 1,
     )
-    with pytest.raises(ValueError, match="another process"):
+    with pytest.raises(InvalidNativeIndexAuthorizationError, match="another process"):
         require_native_index_authorization(
             authorization,
             ownership,
@@ -125,10 +132,59 @@ def test_native_index_authorization_defaults_to_deny(tmp_path: Path) -> None:
     (root / "index.faiss").write_bytes(b"native")
     ownership = capture_directory_ownership(root)
 
-    with pytest.raises(ValueError, match="requires external authorization"):
+    with pytest.raises(
+        MissingNativeIndexAuthorizationError,
+        match="requires external authorization",
+    ):
         require_native_index_authorization(
             None,
             ownership,
             view_type="vector",
             semantic_contract={"dimension": 3},
+        )
+
+
+def test_native_index_authorization_errors_remain_value_errors() -> None:
+    assert issubclass(NativeIndexAuthorizationError, ValueError)
+    assert issubclass(MissingNativeIndexAuthorizationError, ValueError)
+    assert issubclass(InvalidNativeIndexAuthorizationError, ValueError)
+
+    import codenib.native_index_authorization as authorization_module
+
+    assert {
+        "NativeIndexAuthorizationError",
+        "MissingNativeIndexAuthorizationError",
+        "InvalidNativeIndexAuthorizationError",
+    } <= set(authorization_module.__all__)
+
+
+def test_explicit_malformed_authorization_is_not_missing() -> None:
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="malformed",
+    ):
+        require_native_index_authorization_preflight(object(), view_type="vector")
+
+
+def test_wrong_semantic_authorization_is_invalid(tmp_path: Path) -> None:
+    root = tmp_path / "vector"
+    root.mkdir()
+    (root / "index.faiss").write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+    authorization = _mint_trusted_local_admin_authorization(
+        ownership,
+        view_type="vector",
+        semantic_contract={"dimension": 3},
+        evidence=("verified-local-boundary",),
+    )
+
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="does not match captured bytes",
+    ):
+        require_native_index_authorization(
+            authorization,
+            ownership,
+            view_type="vector",
+            semantic_contract={"dimension": 4},
         )

--- a/test/test_native_index_authorization.py
+++ b/test/test_native_index_authorization.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+import pytest
+
+from codenib._atomic_directory import capture_directory_ownership
+from codenib.native_index_authorization import (
+    NATIVE_INDEX_SUBJECT_SCHEMA,
+    mint_trusted_local_authorization,
+    native_index_subject,
+    require_native_index_authorization,
+)
+
+
+def test_native_index_subject_commits_tree_files_and_semantics(tmp_path: Path) -> None:
+    root = tmp_path / "vector"
+    root.mkdir()
+    (root / "index.faiss").write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+
+    subject = native_index_subject(
+        ownership,
+        view_type="vector",
+        semantic_contract={"dimension": 3, "index_metric": "ip"},
+    )
+
+    assert NATIVE_INDEX_SUBJECT_SCHEMA.encode("ascii") in subject.canonical_bytes()
+    assert subject.files[0][0] == "index.faiss"
+    assert len(subject.digest) == 64
+
+
+def test_native_index_authorization_is_process_local_and_exact(tmp_path: Path) -> None:
+    root = tmp_path / "vector"
+    root.mkdir()
+    payload = root / "index.faiss"
+    payload.write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+    semantic = {"dimension": 3, "index_metric": "ip"}
+    authorization = mint_trusted_local_authorization(
+        ownership,
+        view_type="vector",
+        semantic_contract=semantic,
+        evidence=("compiler-lock-and-checkout",),
+    )
+
+    require_native_index_authorization(
+        authorization,
+        ownership,
+        view_type="vector",
+        semantic_contract=semantic,
+    )
+    with pytest.raises(TypeError, match="process-local"):
+        pickle.dumps(authorization)
+
+    payload.write_bytes(b"changed")
+    changed = capture_directory_ownership(root)
+    with pytest.raises(ValueError, match="does not match captured bytes"):
+        require_native_index_authorization(
+            authorization,
+            changed,
+            view_type="vector",
+            semantic_contract=semantic,
+        )
+
+
+def test_native_index_authorization_defaults_to_deny(tmp_path: Path) -> None:
+    root = tmp_path / "vector"
+    root.mkdir()
+    (root / "index.faiss").write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+
+    with pytest.raises(ValueError, match="requires external authorization"):
+        require_native_index_authorization(
+            None,
+            ownership,
+            view_type="vector",
+            semantic_contract={"dimension": 3},
+        )

--- a/test/test_native_index_authorization.py
+++ b/test/test_native_index_authorization.py
@@ -12,7 +12,7 @@ import pytest
 from codenib._atomic_directory import capture_directory_ownership
 from codenib.native_index_authorization import (
     NATIVE_INDEX_SUBJECT_SCHEMA,
-    mint_trusted_local_authorization,
+    _mint_trusted_local_admin_authorization,
     native_index_subject,
     require_native_index_authorization,
 )
@@ -42,7 +42,7 @@ def test_native_index_authorization_is_process_local_and_exact(tmp_path: Path) -
     payload.write_bytes(b"native")
     ownership = capture_directory_ownership(root)
     semantic = {"dimension": 3, "index_metric": "ip"}
-    authorization = mint_trusted_local_authorization(
+    authorization = _mint_trusted_local_admin_authorization(
         ownership,
         view_type="vector",
         semantic_contract=semantic,
@@ -66,6 +66,56 @@ def test_native_index_authorization_is_process_local_and_exact(tmp_path: Path) -
             changed,
             view_type="vector",
             semantic_contract=semantic,
+        )
+
+
+def test_native_index_authorization_is_immutable_and_pid_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.native_index_authorization as authorization_module
+
+    root = tmp_path / "vector"
+    root.mkdir()
+    (root / "index.faiss").write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+    semantic = {"dimension": 3}
+    authorization = _mint_trusted_local_admin_authorization(
+        ownership,
+        view_type="vector",
+        semantic_contract=semantic,
+        evidence=("verified-local-boundary",),
+    )
+
+    with pytest.raises(AttributeError, match="immutable"):
+        authorization.subject_digest = "0" * 64
+
+    monkeypatch.setattr(
+        authorization_module.os,
+        "getpid",
+        lambda: authorization.process_id + 1,
+    )
+    with pytest.raises(ValueError, match="another process"):
+        require_native_index_authorization(
+            authorization,
+            ownership,
+            view_type="vector",
+            semantic_contract=semantic,
+        )
+
+
+def test_trusted_local_issuer_requires_auditable_evidence(tmp_path: Path) -> None:
+    root = tmp_path / "vector"
+    root.mkdir()
+    (root / "index.faiss").write_bytes(b"native")
+    ownership = capture_directory_ownership(root)
+
+    with pytest.raises(ValueError, match="evidence"):
+        _mint_trusted_local_admin_authorization(
+            ownership,
+            view_type="vector",
+            semantic_contract={"dimension": 3},
+            evidence=(),
         )
 
 

--- a/test/test_owned_file_publication.py
+++ b/test/test_owned_file_publication.py
@@ -1,0 +1,2660 @@
+# SPDX-FileCopyrightText: 2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import dis
+import errno
+import hashlib
+import multiprocessing
+import os
+import stat
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+import codenib._atomic_directory as atomic_module
+import codenib._owned_file_publication as publication_module
+from codenib._owned_file_publication import (
+    OwnedFileConflictError,
+    OwnedFilePublicationAuthority,
+    PublishedFileReceiptOwner,
+    publish_owned_file,
+    require_owned_file_publication_support,
+)
+
+
+def _descriptor_count() -> int:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting requires procfs")
+    return len(os.listdir(descriptor_root))
+
+
+def _assert_bad_descriptor(descriptor: int) -> None:
+    with pytest.raises(OSError) as caught:
+        os.fstat(descriptor)
+    assert caught.value.errno == errno.EBADF
+
+
+def _exception_notes(error: BaseException) -> tuple[str, ...]:
+    return (
+        *tuple(getattr(error, "__notes__", ())),
+        *tuple(getattr(error, "_codenib_cleanup_notes", ())),
+    )
+
+
+def _set_nonzero_directory_offset(descriptor: int) -> int:
+    offset = os.lseek(descriptor, 37, os.SEEK_SET)
+    assert offset != 0
+    return offset
+
+
+def _call_with_interrupt_before_store(
+    function: object,
+    local_name: str,
+    callback: object,
+    *,
+    error: BaseException,
+) -> None:
+    """Raise while a call result is on-stack before its first STORE_FAST."""
+
+    assert callable(function)
+    assert callable(callback)
+    code = function.__code__
+    store_offsets = {
+        instruction.offset
+        for instruction in dis.get_instructions(function)
+        if instruction.opname == "STORE_FAST" and instruction.argval == local_name
+    }
+    assert store_offsets
+    previous_trace = sys.gettrace()
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            event == "opcode"
+            and frame.f_code is code
+            and frame.f_lasti in store_offsets
+        ):
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+
+
+def _store_publish_result(
+    publication: OwnedFilePublicationAuthority,
+    receipt_owner: PublishedFileReceiptOwner,
+) -> None:
+    result = publication.publish_into(receipt_owner)
+    assert result is None
+
+
+def _store_helper_result(
+    destination: Path,
+    receipt_owner: PublishedFileReceiptOwner,
+) -> None:
+    result = publish_owned_file(
+        destination,
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    assert result is None
+
+
+def _publish_in_process(destination: str, payload: bytes) -> None:
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publish_owned_file(
+            Path(destination),
+            [payload],
+            max_bytes=len(payload),
+            receipt_owner=receipt_owner,
+        )
+        receipt = receipt_owner.receipt
+        assert receipt.read_bytes(max_bytes=len(payload)) == payload
+
+
+def test_publish_returns_handle_bound_receipt(tmp_path: Path) -> None:
+    destination = tmp_path / "object"
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        assert (
+            publish_owned_file(
+                destination,
+                [b"abc", b"def"],
+                max_bytes=6,
+                mode=0o640,
+                receipt_owner=receipt_owner,
+            )
+            is None
+        )
+        receipt = receipt_owner.receipt
+        assert not receipt.reused
+        assert receipt.orphan is None
+        assert receipt.record.size == 6
+        assert receipt.record.sha256 == hashlib.sha256(b"abcdef").hexdigest()
+        assert receipt.record.mode == 0o640
+        assert receipt.read_bytes(max_bytes=6) == b"abcdef"
+        with pytest.raises(RuntimeError, match="ReceiptOwner"):
+            receipt.close()
+        assert receipt_owner.active
+        assert destination.read_bytes() == b"abcdef"
+        assert stat.S_IMODE(destination.stat().st_mode) == 0o640
+    assert receipt_owner.closed
+
+
+def test_identical_existing_file_is_authenticated_and_reused(tmp_path: Path) -> None:
+    destination = tmp_path / "object"
+    destination.write_bytes(b"same")
+    destination.chmod(0o640)
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publish_owned_file(
+            destination,
+            b"same",
+            max_bytes=4,
+            mode=0o640,
+            receipt_owner=receipt_owner,
+        )
+        receipt = receipt_owner.receipt
+        orphan = receipt.orphan
+        assert receipt.reused
+        assert receipt.record.mode == 0o640
+        assert receipt.read_bytes(max_bytes=4) == b"same"
+        assert orphan is not None
+        assert orphan.path.exists()
+        assert orphan.path.read_bytes() == b"same"
+
+
+def test_borrowed_parent_resource_is_never_closed(tmp_path: Path) -> None:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    expected_identity = atomic_module.publication_parent_identity(parent_resource)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    try:
+        with PublishedFileReceiptOwner() as receipt_owner:
+            publish_owned_file(
+                tmp_path / "object",
+                b"same-parent",
+                max_bytes=len(b"same-parent"),
+                parent_resource=parent_resource,
+                receipt_owner=receipt_owner,
+            )
+            receipt = receipt_owner.receipt
+            assert receipt.parent_identity == expected_identity
+            assert receipt.read_bytes(max_bytes=len(b"same-parent")) == b"same-parent"
+
+        assert atomic_module.publication_parent_identity(parent_resource) == (
+            expected_identity
+        )
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+    finally:
+        os.close(parent_resource)
+
+
+def test_borrowed_parent_mismatch_fails_before_stage_or_destination(
+    tmp_path: Path,
+) -> None:
+    destination_parent = tmp_path / "destination-parent"
+    borrowed_parent = tmp_path / "borrowed-parent"
+    destination_parent.mkdir()
+    borrowed_parent.mkdir()
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(borrowed_parent, flags)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    try:
+        with pytest.raises(RuntimeError, match="parent path changed"):
+            OwnedFilePublicationAuthority(
+                destination_parent / "object",
+                max_bytes=1,
+                parent_resource=parent_resource,
+            )
+
+        assert list(destination_parent.iterdir()) == []
+        assert list(borrowed_parent.iterdir()) == []
+        os.fstat(parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+    finally:
+        os.close(parent_resource)
+
+
+def test_borrowed_parent_conflict_does_not_change_caller_offset(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "object"
+    destination.write_bytes(b"old")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    try:
+        with pytest.raises(OwnedFileConflictError):
+            publish_owned_file(
+                destination,
+                b"new",
+                max_bytes=3,
+                parent_resource=parent_resource,
+                consume=lambda _receipt: None,
+            )
+
+        os.fstat(parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+        assert destination.read_bytes() == b"old"
+    finally:
+        os.close(parent_resource)
+
+
+def test_borrowed_parent_bridge_rejects_fd_replacement_before_openat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    original_alias = os.dup(parent_resource)
+    foreign_resource = os.open(foreign, flags)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    real_open = atomic_module._PosixResourceOwner.open
+    replaced = False
+
+    def replace_then_open(
+        owner,
+        path,
+        open_flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        nonlocal replaced
+        if path == "." and dir_fd == parent_resource and not replaced:
+            os.dup2(foreign_resource, parent_resource)
+            replaced = True
+        return real_open(
+            owner,
+            path,
+            open_flags,
+            mode,
+            dir_fd=dir_fd,
+        )
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        replace_then_open,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="changed while opened"):
+            OwnedFilePublicationAuthority(
+                tmp_path / "object",
+                max_bytes=1,
+                parent_resource=parent_resource,
+            )
+
+        assert replaced
+        assert atomic_module.publication_parent_identity(parent_resource) == (
+            atomic_module.publication_parent_identity(foreign_resource)
+        )
+        assert not (tmp_path / "object").exists()
+        assert not list(tmp_path.glob(".codenib-file-*"))
+    finally:
+        os.dup2(original_alias, parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+        os.close(foreign_resource)
+        os.close(original_alias)
+        os.close(parent_resource)
+
+
+@pytest.mark.parametrize("phase", ["before", "after"])
+@pytest.mark.parametrize("exception_type", [OSError, KeyboardInterrupt, SystemExit])
+def test_borrowed_parent_bridge_close_failure_preserves_caller_ofd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+    exception_type: type[BaseException],
+) -> None:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    before = _descriptor_count()
+    bridge_descriptors: list[int] = []
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = publication_module.os.close
+    error = (
+        OSError(errno.EIO, f"{phase} bridge close failure")
+        if exception_type is OSError
+        else exception_type(f"{phase} bridge close interruption")
+    )
+    injected = False
+
+    def record_bridge_open(
+        owner,
+        path,
+        open_flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(
+            owner,
+            path,
+            open_flags,
+            mode,
+            dir_fd=dir_fd,
+        )
+        if path == "." and dir_fd == parent_resource:
+            bridge_descriptors.append(descriptor)
+        return descriptor
+
+    def fail_bridge_close(descriptor: int) -> None:
+        nonlocal injected
+        if bridge_descriptors and descriptor == bridge_descriptors[0] and not injected:
+            injected = True
+            if phase == "after":
+                real_close(descriptor)
+            raise error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        record_bridge_open,
+    )
+    monkeypatch.setattr(publication_module.os, "close", fail_bridge_close)
+    try:
+        with pytest.raises(exception_type) as caught:
+            OwnedFilePublicationAuthority(
+                tmp_path / "object",
+                max_bytes=1,
+                parent_resource=parent_resource,
+            )
+
+        assert caught.value is error
+        assert injected
+        assert len(bridge_descriptors) == 1
+        _assert_bad_descriptor(bridge_descriptors[0])
+        os.fstat(parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+        assert _descriptor_count() <= before
+        assert not (tmp_path / "object").exists()
+        assert not list(tmp_path.glob(".codenib-file-*"))
+    finally:
+        os.close(parent_resource)
+
+
+def test_borrowed_parent_bridge_retries_repeated_eio_without_touching_caller(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    before = _descriptor_count()
+    bridge_descriptors: list[int] = []
+    real_open = atomic_module._PosixResourceOwner.open
+    real_close = publication_module.os.close
+    error = OSError(errno.EIO, "repeated bridge close failure")
+    failures_remaining = 4
+
+    def record_bridge_open(
+        owner,
+        path,
+        open_flags,
+        mode=0o777,
+        *,
+        dir_fd=None,
+    ):
+        descriptor = real_open(
+            owner,
+            path,
+            open_flags,
+            mode,
+            dir_fd=dir_fd,
+        )
+        if path == "." and dir_fd == parent_resource:
+            bridge_descriptors.append(descriptor)
+        return descriptor
+
+    def fail_repeatedly(descriptor: int) -> None:
+        nonlocal failures_remaining
+        if (
+            bridge_descriptors
+            and descriptor == bridge_descriptors[0]
+            and failures_remaining
+        ):
+            failures_remaining -= 1
+            raise error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        record_bridge_open,
+    )
+    monkeypatch.setattr(publication_module.os, "close", fail_repeatedly)
+    try:
+        with pytest.raises(OSError) as caught:
+            OwnedFilePublicationAuthority(
+                tmp_path / "object",
+                max_bytes=1,
+                parent_resource=parent_resource,
+            )
+
+        assert caught.value is error
+        assert failures_remaining == 0
+        _assert_bad_descriptor(bridge_descriptors[0])
+        os.fstat(parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+        assert _descriptor_count() <= before
+    finally:
+        os.close(parent_resource)
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_publish_into_caller_store_cancellation_keeps_owner_and_leaks_no_fd(
+    tmp_path: Path,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    interruption = exception_type("injected before caller receipt-result store")
+
+    try:
+        with pytest.raises(exception_type) as caught:
+            _call_with_interrupt_before_store(
+                _store_publish_result,
+                "result",
+                lambda: _store_publish_result(publication, receipt_owner),
+                error=interruption,
+            )
+        assert caught.value is interruption
+        assert publication.state == "published"
+        assert receipt_owner.active
+        assert receipt_owner.receipt.read_bytes(max_bytes=1) == b"x"
+    finally:
+        receipt_owner.close()
+        publication.close()
+
+    assert receipt_owner.closed
+    assert _descriptor_count() <= before
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_helper_caller_store_cancellation_keeps_owner_and_leaks_no_fd(
+    tmp_path: Path,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    destination = tmp_path / "object"
+    receipt_owner = PublishedFileReceiptOwner()
+    interruption = exception_type("injected before caller helper-result store")
+
+    try:
+        with pytest.raises(exception_type) as caught:
+            _call_with_interrupt_before_store(
+                _store_helper_result,
+                "result",
+                lambda: _store_helper_result(destination, receipt_owner),
+                error=interruption,
+            )
+        assert caught.value is interruption
+        assert receipt_owner.active
+        assert receipt_owner.receipt.read_bytes(max_bytes=1) == b"x"
+    finally:
+        receipt_owner.close()
+
+    assert receipt_owner.closed
+    assert _descriptor_count() <= before
+
+
+def test_publication_requires_precreated_owner_before_any_rename(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=1)
+    publication.write([b"x"])
+    try:
+        with pytest.raises(TypeError, match="receipt_owner"):
+            publication.publish()
+        assert publication.state == "written"
+        assert not destination.exists()
+    finally:
+        publication.close()
+
+    with pytest.raises(TypeError, match="exactly one"):
+        publish_owned_file(tmp_path / "other", [b"x"], max_bytes=1)
+    assert not (tmp_path / "other").exists()
+
+
+def test_helper_consumer_gets_borrowed_receipt_and_closes_it_on_return(
+    tmp_path: Path,
+) -> None:
+    observed: list[publication_module.PublishedFileReceipt] = []
+
+    def consume(receipt: publication_module.PublishedFileReceipt) -> None:
+        observed.append(receipt)
+        assert receipt.read_bytes(max_bytes=1) == b"x"
+
+    assert (
+        publish_owned_file(
+            tmp_path / "object",
+            [b"x"],
+            max_bytes=1,
+            consume=consume,
+        )
+        is None
+    )
+    assert len(observed) == 1
+    assert observed[0].closed
+
+
+def test_helper_consumer_primary_wins_persistent_close_and_leaks_no_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = _descriptor_count()
+    primary = KeyboardInterrupt("consumer cancellation")
+    cleanup = OSError(errno.EIO, "persistent helper receipt close failure")
+    captured: list[publication_module.PublishedFileReceipt] = []
+    captured_descriptors: list[int] = []
+    real_close = publication_module.os.close
+
+    def fail_receipt_close(candidate: int) -> None:
+        if captured_descriptors and candidate == captured_descriptors[0]:
+            raise cleanup
+        real_close(candidate)
+
+    def consume(receipt: publication_module.PublishedFileReceipt) -> None:
+        captured.append(receipt)
+        captured_descriptors.append(receipt._descriptor)
+        raise primary
+
+    monkeypatch.setattr(publication_module.os, "close", fail_receipt_close)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        publish_owned_file(
+            tmp_path / "object",
+            [b"x"],
+            max_bytes=1,
+            consume=consume,
+        )
+
+    assert caught.value is primary
+    assert len(captured) == 1
+    assert captured[0].closed
+    assert any(
+        "descriptor cleanup also failed" in note
+        and "persistent helper receipt close failure" in note
+        for note in _exception_notes(primary)
+    )
+    assert _descriptor_count() <= before
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_existing_open_cancellation_invalidates_owner_without_fd_leak(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    destination = tmp_path / "object"
+    destination.write_bytes(b"same")
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=4)
+    publication.write([b"same"])
+    interruption = exception_type("injected after existing descriptor ownership")
+    real_open = publication_module._DescriptorOwner.open
+
+    def open_then_interrupt(owner, path, flags, mode=0o777, *, dir_fd=None):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        if path == destination.name:
+            raise interruption
+        return descriptor
+
+    monkeypatch.setattr(
+        publication_module._DescriptorOwner,
+        "open",
+        open_then_interrupt,
+    )
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(exception_type) as caught:
+                publication.publish_into(receipt_owner)
+            assert caught.value is interruption
+        finally:
+            publication.close()
+
+    assert destination.read_bytes() == b"same"
+    assert _descriptor_count() <= before
+
+
+def test_receipt_constructor_cancellation_invalidates_every_fd_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = _descriptor_count()
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    interruption = SystemExit("injected after receipt construction")
+    real_receipt_type = publication_module.PublishedFileReceipt
+    captured_receipts = []
+    captured_descriptors: list[int] = []
+
+    class InterruptingReceipt(real_receipt_type):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            captured_receipts.append(self)
+            captured_descriptors.append(self._descriptor)
+            raise interruption
+
+    monkeypatch.setattr(
+        publication_module,
+        "PublishedFileReceipt",
+        InterruptingReceipt,
+    )
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(SystemExit) as caught:
+                publication.publish_into(receipt_owner)
+            assert caught.value is interruption
+        finally:
+            publication.close()
+
+    assert len(captured_receipts) == 1
+    assert captured_receipts[0].closed
+    stale_descriptor = captured_descriptors[0]
+    _assert_bad_descriptor(stale_descriptor)
+
+    foreign = tmp_path / "foreign"
+    foreign.write_bytes(b"foreign")
+    opened = os.open(foreign, os.O_RDONLY)
+    replacement = stale_descriptor
+    if opened != replacement:
+        os.dup2(opened, replacement)
+        os.close(opened)
+    try:
+        with pytest.raises(RuntimeError, match="ReceiptOwner"):
+            captured_receipts[0].close()
+        assert os.pread(replacement, 7, 0) == b"foreign"
+    finally:
+        os.close(replacement)
+    assert _descriptor_count() <= before
+
+
+@pytest.mark.parametrize("existing_mode", [0o600, 0o666])
+def test_existing_mode_mismatch_or_unsafe_mode_is_a_conflict(
+    tmp_path: Path,
+    existing_mode: int,
+) -> None:
+    destination = tmp_path / "object"
+    destination.write_bytes(b"same")
+    destination.chmod(existing_mode)
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        with pytest.raises(OwnedFileConflictError):
+            publish_owned_file(
+                destination,
+                b"same",
+                max_bytes=4,
+                mode=0o640,
+                receipt_owner=receipt_owner,
+            )
+
+    assert stat.S_IMODE(destination.stat().st_mode) == existing_mode
+
+
+def test_different_existing_file_is_a_non_destructive_conflict(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "object"
+    destination.write_bytes(b"old")
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        with pytest.raises(OwnedFileConflictError) as caught:
+            publish_owned_file(
+                destination,
+                [b"new"],
+                max_bytes=3,
+                receipt_owner=receipt_owner,
+            )
+
+    assert destination.read_bytes() == b"old"
+    assert caught.value.observed is not None
+    assert caught.value.orphan.path.read_bytes() == b"new"
+
+
+@pytest.mark.parametrize("kind", ["fifo", "symlink", "directory"])
+def test_existing_non_regular_destination_is_a_conflict(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    destination = tmp_path / "object"
+    if kind == "fifo":
+        os.mkfifo(destination)
+    elif kind == "symlink":
+        destination.symlink_to("missing-target")
+    else:
+        destination.mkdir()
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        with pytest.raises(OwnedFileConflictError) as caught:
+            publish_owned_file(
+                destination,
+                [b"new"],
+                max_bytes=3,
+                receipt_owner=receipt_owner,
+            )
+
+    assert destination.lstat()
+    assert caught.value.observed is None
+    assert caught.value.orphan.path.read_bytes() == b"new"
+
+
+def test_destination_appearing_at_rename_is_never_replaced(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=3)
+    publication.write([b"new"])
+    assert publication._authority is not None
+    original = publication._authority._rename_callback
+
+    def race(source: str, final: str) -> None:
+        assert publication._authority is not None
+        descriptor = os.open(
+            final,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o644,
+            dir_fd=publication._authority.resource,
+        )
+        try:
+            os.write(descriptor, b"old")
+        finally:
+            os.close(descriptor)
+        original(source, final)
+
+    publication._authority._rename_callback = race
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(OwnedFileConflictError):
+                publication.publish_into(receipt_owner)
+        finally:
+            publication.close()
+
+    assert destination.read_bytes() == b"old"
+
+
+def test_stage_create_uses_exclusive_nofollow_cloexec_and_exact_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_flags: list[int] = []
+    real_open = publication_module.os.open
+
+    def record_open(path, flags, mode=0o777, *, dir_fd=None):
+        if isinstance(path, str) and path.startswith(".codenib-file-"):
+            observed_flags.append(flags)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(publication_module.os, "open", record_open)
+    publication = OwnedFilePublicationAuthority(
+        tmp_path / "object",
+        max_bytes=1,
+        mode=0o640,
+    )
+    try:
+        metadata = os.fstat(publication._descriptor)
+        assert stat.S_ISREG(metadata.st_mode)
+        assert metadata.st_nlink == 1
+        assert stat.S_IMODE(metadata.st_mode) == 0o640
+        assert observed_flags
+        assert observed_flags[0] & os.O_CREAT
+        assert observed_flags[0] & os.O_EXCL
+        assert observed_flags[0] & os.O_NOFOLLOW
+        assert observed_flags[0] & os.O_CLOEXEC
+    finally:
+        publication.close()
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_constructor_cancellation_after_authority_acquire_closes_all_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    interruption = exception_type("injected after authority acquisition")
+    real_acquire = publication_module._PublicationAuthorityOwner.acquire
+
+    def acquire_then_interrupt(owner, path: Path) -> None:
+        real_acquire(owner, path)
+        raise interruption
+
+    monkeypatch.setattr(
+        publication_module._PublicationAuthorityOwner,
+        "acquire",
+        acquire_then_interrupt,
+    )
+
+    with pytest.raises(exception_type) as caught:
+        OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+
+    assert caught.value is interruption
+    assert _descriptor_count() <= before
+    assert not list(tmp_path.glob(".codenib-file-*"))
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_borrowed_parent_authority_cancellation_closes_only_owned_duplicates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    parent_resource = os.open(tmp_path, flags)
+    before = _descriptor_count()
+    expected_offset = _set_nonzero_directory_offset(parent_resource)
+    interruption = exception_type("injected after borrowed authority acquisition")
+    real_acquire = publication_module._PublicationAuthorityOwner.acquire
+
+    def acquire_then_interrupt(
+        owner,
+        path: Path,
+        *,
+        parent_resource: int | None = None,
+    ) -> None:
+        real_acquire(owner, path, parent_resource=parent_resource)
+        raise interruption
+
+    monkeypatch.setattr(
+        publication_module._PublicationAuthorityOwner,
+        "acquire",
+        acquire_then_interrupt,
+    )
+    try:
+        with pytest.raises(exception_type) as caught:
+            OwnedFilePublicationAuthority(
+                tmp_path / "object",
+                max_bytes=1,
+                parent_resource=parent_resource,
+            )
+
+        assert caught.value is interruption
+        os.fstat(parent_resource)
+        assert os.lseek(parent_resource, 0, os.SEEK_CUR) == expected_offset
+        assert _descriptor_count() <= before
+        assert not list(tmp_path.glob(".codenib-file-*"))
+    finally:
+        os.close(parent_resource)
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_authority_factory_return_cancellation_uses_preinstalled_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    interruption = exception_type("injected before authority factory handoff")
+    real_open = atomic_module._open_publication_authority
+    installed_owners: list[publication_module._PublicationAuthorityOwner] = []
+
+    def open_then_interrupt(*args, **kwargs):
+        owner = kwargs.get("authority_owner")
+        assert isinstance(owner, publication_module._PublicationAuthorityOwner)
+        authority = real_open(*args, **kwargs)
+        assert owner.authority is authority
+        installed_owners.append(owner)
+        raise interruption
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_open_publication_authority",
+        open_then_interrupt,
+    )
+
+    with pytest.raises(exception_type) as caught:
+        OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+
+    assert caught.value is interruption
+    assert installed_owners
+    assert installed_owners[0].authority is None
+    assert _descriptor_count() <= before
+    assert not list(tmp_path.glob(".codenib-file-*"))
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_constructor_cancellation_after_stage_open_closes_all_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    before = _descriptor_count()
+    interruption = exception_type("injected after stage descriptor ownership")
+    real_open = publication_module._DescriptorOwner.open
+
+    def open_then_interrupt(owner, path, flags, mode=0o777, *, dir_fd=None):
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        if isinstance(path, str) and path.startswith(".codenib-file-"):
+            raise interruption
+        return descriptor
+
+    monkeypatch.setattr(
+        publication_module._DescriptorOwner,
+        "open",
+        open_then_interrupt,
+    )
+
+    with pytest.raises(exception_type) as caught:
+        OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+
+    assert caught.value is interruption
+    assert _descriptor_count() <= before
+    stages = list(tmp_path.glob(".codenib-file-*"))
+    assert len(stages) == 1
+    assert stages[0].read_bytes() == b""
+
+
+def test_stage_with_a_second_link_is_rejected(tmp_path: Path) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+
+    class LinkingProducer:
+        def __iter__(self):
+            yield b"x"
+            assert publication._authority is not None
+            os.link(
+                publication._stage_name,
+                "foreign-link",
+                src_dir_fd=publication._authority.resource,
+                dst_dir_fd=publication._authority.resource,
+                follow_symlinks=False,
+            )
+
+    try:
+        with pytest.raises(RuntimeError, match="identity changed"):
+            publication.write(LinkingProducer())
+    finally:
+        publication.close()
+
+    assert not (tmp_path / "object").exists()
+    assert (tmp_path / "foreign-link").read_bytes() == b"x"
+
+
+def test_same_size_stage_mutation_is_caught_by_pre_publish_rehash(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=3)
+    publication.write([b"abc"])
+    os.pwrite(publication._descriptor, b"x", 0)
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(RuntimeError, match="producer digest"):
+                publication.publish_into(receipt_owner)
+        finally:
+            publication.close()
+
+    assert not (tmp_path / "object").exists()
+
+
+def test_same_size_mutation_after_rename_is_caught_before_receipt(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=3)
+    publication.write([b"abc"])
+    assert publication._authority is not None
+    original = publication._authority._rename_callback
+
+    def rename_then_mutate(source: str, final: str) -> None:
+        original(source, final)
+        os.pwrite(publication._descriptor, b"x", 0)
+
+    publication._authority._rename_callback = rename_then_mutate
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(RuntimeError, match="producer digest"):
+                publication.publish_into(receipt_owner)
+        finally:
+            publication.close()
+
+    assert destination.read_bytes() == b"xbc"
+
+
+def test_first_receipt_is_duplicated_from_held_stage_not_reopened_by_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+
+    def forbidden_reopen(*_args, **_kwargs):
+        raise AssertionError("first publication reopened the final path")
+
+    monkeypatch.setattr(
+        OwnedFilePublicationAuthority,
+        "_open_regular",
+        forbidden_reopen,
+    )
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publication.publish_into(receipt_owner)
+        receipt = receipt_owner.receipt
+        assert receipt.read_bytes(max_bytes=1) == b"x"
+    try:
+        assert receipt_owner.closed
+    finally:
+        publication.close()
+
+
+@pytest.mark.parametrize("swap", ["parent", "ancestor"])
+def test_parent_path_aba_fails_before_publication(
+    tmp_path: Path,
+    swap: str,
+) -> None:
+    ancestor = tmp_path / "ancestor"
+    parent = ancestor / "parent"
+    parent.mkdir(parents=True)
+    publication = OwnedFilePublicationAuthority(parent / "object", max_bytes=1)
+    publication.write([b"x"])
+
+    if swap == "parent":
+        moved = ancestor / "moved-parent"
+        parent.rename(moved)
+        parent.mkdir()
+        replacement_parent = parent
+    else:
+        moved = tmp_path / "moved-ancestor"
+        ancestor.rename(moved)
+        ancestor.mkdir()
+        replacement_parent = ancestor / "parent"
+        replacement_parent.mkdir()
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(RuntimeError, match="parent path changed"):
+                publication.publish_into(receipt_owner)
+        finally:
+            publication.close()
+
+    assert not (replacement_parent / "object").exists()
+
+
+def test_producer_error_closes_iterator_and_preserves_owned_orphan(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=2)
+
+    class BrokenProducer:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.closed = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            self.calls += 1
+            if self.calls == 1:
+                return b"x"
+            raise LookupError("producer failed")
+
+        def close(self) -> None:
+            self.closed = True
+
+    producer = BrokenProducer()
+    try:
+        with pytest.raises(LookupError, match="producer failed"):
+            publication.write(producer)
+        assert producer.closed
+        assert publication.state == "failed"
+        assert publication.orphan is not None
+        assert publication.orphan.path.read_bytes() == b"x"
+    finally:
+        publication.close()
+
+
+def test_iterator_close_error_prevents_publication(tmp_path: Path) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+
+    def fail_close() -> None:
+        raise OSError(errno.EIO, "close failed")
+
+    class CloseableIterator:
+        def __init__(self) -> None:
+            self.done = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            if self.done:
+                raise StopIteration
+            self.done = True
+            return b"x"
+
+        close = staticmethod(fail_close)
+
+    try:
+        with pytest.raises(OSError, match="close failed"):
+            publication.write(CloseableIterator())
+        assert publication.state == "failed"
+        assert publication.orphan is not None
+        assert publication.orphan.path.read_bytes() == b"x"
+    finally:
+        publication.close()
+
+
+def test_iterator_primary_cancellation_wins_and_close_cancellation_is_noted(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    primary = KeyboardInterrupt("producer interrupted")
+    secondary = SystemExit("iterator close cancelled")
+
+    class DoublyInterruptedIterator:
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            raise primary
+
+        def close(self) -> None:
+            raise secondary
+
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            publication.write(DoublyInterruptedIterator())
+        assert caught.value is primary
+        assert any(
+            "publication iterator cleanup also failed" in note
+            and "iterator close cancelled" in note
+            for note in _exception_notes(primary)
+        )
+        assert publication.state == "failed"
+    finally:
+        publication.close()
+
+
+def test_file_fsync_error_leaves_only_an_owned_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    stage_descriptor = publication._descriptor
+    real_fsync = publication_module.os.fsync
+
+    def fail_file_fsync(descriptor: int) -> None:
+        if descriptor == stage_descriptor:
+            raise OSError(errno.EIO, "file fsync failed")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(publication_module.os, "fsync", fail_file_fsync)
+    try:
+        with pytest.raises(OSError, match="file fsync failed"):
+            publication.write([b"x"])
+        assert publication.orphan is not None
+        assert not (tmp_path / "object").exists()
+    finally:
+        publication.close()
+
+
+def test_parent_fsync_error_returns_no_receipt_after_committed_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    assert publication._authority is not None
+    parent_descriptor = publication._authority.resource
+    real_fsync = publication_module.os.fsync
+
+    def fail_parent_fsync(descriptor: int) -> None:
+        if descriptor == parent_descriptor:
+            raise OSError(errno.EIO, "parent fsync failed")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(publication_module.os, "fsync", fail_parent_fsync)
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(OSError, match="parent fsync failed"):
+                publication.publish_into(receipt_owner)
+            assert publication.state == "failed"
+        finally:
+            publication.close()
+
+    assert (tmp_path / "object").read_bytes() == b"x"
+
+
+def test_rename_error_before_mutation_preserves_stage(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    assert publication._authority is not None
+
+    def fail_rename(_source: str, _destination: str) -> None:
+        raise OSError(errno.EIO, "rename failed")
+
+    publication._authority._rename_callback = fail_rename
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(OSError, match="rename failed"):
+                publication.publish_into(receipt_owner)
+            assert publication.orphan is not None
+            assert publication.orphan.path.read_bytes() == b"x"
+        finally:
+            publication.close()
+
+
+def test_rename_error_after_mutation_returns_no_receipt_and_retry_reuses(
+    tmp_path: Path,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    assert publication._authority is not None
+    original = publication._authority._rename_callback
+
+    def rename_then_fail(source: str, destination: str) -> None:
+        original(source, destination)
+        raise OSError(errno.EIO, "injected after rename")
+
+    publication._authority._rename_callback = rename_then_fail
+    with PublishedFileReceiptOwner() as failed_owner:
+        try:
+            with pytest.raises(OSError, match="injected after rename"):
+                publication.publish_into(failed_owner)
+            assert publication.orphan is None
+        finally:
+            publication.close()
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publish_owned_file(
+            tmp_path / "object",
+            [b"x"],
+            max_bytes=1,
+            receipt_owner=receipt_owner,
+        )
+        receipt = receipt_owner.receipt
+        assert receipt.reused
+        assert receipt.read_bytes(max_bytes=1) == b"x"
+
+
+def test_rename_reconciliation_cancellation_is_secondary_and_conservative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    assert publication._authority is not None
+    primary = KeyboardInterrupt("rename interrupted")
+    secondary = SystemExit("rename reconciliation cancelled")
+    orphan = publication.orphan
+    assert orphan is not None
+    stage_path = orphan.path
+
+    def interrupt_rename(_source: str, _destination: str) -> None:
+        raise primary
+
+    def interrupt_reconciliation() -> bool:
+        raise secondary
+
+    publication._authority._rename_callback = interrupt_rename
+    monkeypatch.setattr(
+        OwnedFilePublicationAuthority,
+        "_rename_committed",
+        lambda _publication: interrupt_reconciliation(),
+    )
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(KeyboardInterrupt) as caught:
+                publication.publish_into(receipt_owner)
+            assert caught.value is primary
+            assert any(
+                "rename outcome reconciliation also failed" in note
+                and "rename reconciliation cancelled" in note
+                for note in _exception_notes(primary)
+            )
+            # A cancelled reconciliation cannot safely advertise either
+            # namespace name as an owned orphan, even though this injected
+            # pre-rename case leaves the diagnostic path visible.
+            assert publication.orphan is None
+            assert stage_path.read_bytes() == b"x"
+        finally:
+            publication.close()
+
+
+def test_stage_close_error_prevents_a_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    stage_descriptor = publication._descriptor
+    real_close = publication_module.os.close
+
+    def fail_stage_close(descriptor: int) -> None:
+        if descriptor == stage_descriptor:
+            raise OSError(errno.EIO, "stage close failed")
+        real_close(descriptor)
+
+    monkeypatch.setattr(publication_module.os, "close", fail_stage_close)
+    with PublishedFileReceiptOwner() as receipt_owner:
+        try:
+            with pytest.raises(OSError, match="stage close failed"):
+                publication.publish_into(receipt_owner)
+            with pytest.raises(OSError) as caught:
+                os.fstat(stage_descriptor)
+            assert caught.value.errno == errno.EBADF
+        finally:
+            monkeypatch.setattr(publication_module.os, "close", real_close)
+            publication.close()
+
+
+@pytest.mark.parametrize(
+    ("phase", "interruption"),
+    [
+        pytest.param(
+            "before",
+            OSError(errno.EIO, "before close failure"),
+            id="oserror-before",
+        ),
+        pytest.param(
+            "after",
+            OSError(errno.EIO, "after close failure"),
+            id="oserror-after",
+        ),
+        pytest.param(
+            "before",
+            KeyboardInterrupt("before close interrupt"),
+            id="keyboardinterrupt-before",
+        ),
+        pytest.param(
+            "after",
+            SystemExit("after close cancellation"),
+            id="systemexit-after",
+        ),
+    ],
+)
+def test_receipt_owner_close_reconciles_before_and_after_real_close_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+    interruption: BaseException,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    receipt = receipt_owner.receipt
+    descriptor = receipt._descriptor
+    real_close = publication_module.os.close
+
+    def injected_close(candidate: int) -> None:
+        if candidate != descriptor:
+            real_close(candidate)
+            return
+        if phase == "after":
+            real_close(candidate)
+        raise interruption
+
+    monkeypatch.setattr(publication_module.os, "close", injected_close)
+    with pytest.raises(type(interruption)) as caught:
+        receipt_owner.close()
+
+    assert caught.value is interruption
+    if phase == "before":
+        assert receipt_owner.active
+        assert not receipt.closed
+        assert os.fstat(descriptor)
+        monkeypatch.setattr(publication_module.os, "close", real_close)
+        receipt_owner.close()
+    else:
+        assert receipt_owner.closed
+    assert receipt.closed
+    _assert_bad_descriptor(descriptor)
+
+
+def test_receipt_owner_close_interrupted_while_arming_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    receipt = receipt_owner.receipt
+    descriptor = receipt._descriptor
+    interruption = SystemExit("injected during close ownership arming")
+    real_arm = publication_module._arm_descriptor_for_close
+    injected = False
+
+    def interrupt_first_arm(candidate: int, **kwargs) -> int:
+        nonlocal injected
+        if candidate == descriptor and not injected:
+            injected = True
+            raise interruption
+        return real_arm(candidate, **kwargs)
+
+    monkeypatch.setattr(
+        publication_module,
+        "_arm_descriptor_for_close",
+        interrupt_first_arm,
+    )
+    with pytest.raises(SystemExit) as caught:
+        receipt_owner.close()
+
+    assert caught.value is interruption
+    assert injected
+    assert receipt_owner.active
+    assert not receipt.closed
+    monkeypatch.setattr(
+        publication_module,
+        "_arm_descriptor_for_close",
+        real_arm,
+    )
+    receipt_owner.close()
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+@pytest.mark.parametrize("replacement_kind", ["different-inode", "same-inode-new-ofd"])
+def test_receipt_close_preserves_observable_fd_reuse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement_kind: str,
+) -> None:
+    destination = tmp_path / "object"
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        destination,
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    receipt = receipt_owner.receipt
+    descriptor = receipt._descriptor
+    replacement_path = destination
+    if replacement_kind == "different-inode":
+        replacement_path = tmp_path / "foreign"
+        replacement_path.write_bytes(b"foreign")
+    expected = replacement_path.read_bytes()
+    real_close = publication_module.os.close
+    real_open = publication_module.os.open
+    interruption = SystemExit("injected after close and observable fd reuse")
+
+    def close_then_reuse(candidate: int) -> None:
+        if candidate != descriptor:
+            real_close(candidate)
+            return
+        real_close(candidate)
+        opened = real_open(replacement_path, os.O_RDONLY)
+        if opened != candidate:
+            os.dup2(opened, candidate)
+            real_close(opened)
+        raise interruption
+
+    monkeypatch.setattr(publication_module.os, "close", close_then_reuse)
+    try:
+        with pytest.raises(SystemExit) as caught:
+            receipt_owner.close()
+        assert caught.value is interruption
+        assert receipt_owner.closed
+        assert receipt.closed
+        assert os.pread(descriptor, len(expected), 0) == expected
+
+        # The invalidated owner must not touch the replacement on a retry.
+        receipt_owner.close()
+        assert os.pread(descriptor, len(expected), 0) == expected
+    finally:
+        real_close(descriptor)
+
+
+def test_exact_same_ofd_aba_is_retained_but_foreign_reuse_is_not_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    receipt = receipt_owner.receipt
+    descriptor = receipt._descriptor
+    alias = os.dup(descriptor)
+    real_close = publication_module.os.close
+    interruption = KeyboardInterrupt("injected exact same-OFD dup2 ABA")
+
+    def close_then_restore_exact_alias(candidate: int) -> None:
+        if candidate != descriptor:
+            real_close(candidate)
+            return
+        real_close(candidate)
+        os.dup2(alias, candidate)
+        raise interruption
+
+    monkeypatch.setattr(
+        publication_module.os,
+        "close",
+        close_then_restore_exact_alias,
+    )
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            receipt_owner.close()
+        assert caught.value is interruption
+        assert receipt_owner.active
+        assert not receipt.closed
+
+        # Identity plus the shared offset cookie cannot distinguish this ABA,
+        # so the retryable owner conservatively retains it.  A later observable
+        # reuse is rejected before another close syscall touches that number.
+        assert os.fstat(descriptor)
+        assert os.fstat(alias)
+
+        monkeypatch.setattr(publication_module.os, "close", real_close)
+        foreign = tmp_path / "foreign-after-aba"
+        foreign.write_bytes(b"foreign")
+        opened = os.open(foreign, os.O_RDONLY)
+        if opened != descriptor:
+            os.dup2(opened, descriptor)
+            real_close(opened)
+        with pytest.raises(RuntimeError, match="changed before close retry"):
+            receipt_owner.close()
+        assert receipt_owner.closed
+        assert os.pread(descriptor, 7, 0) == b"foreign"
+        real_close(descriptor)
+    finally:
+        real_close(alias)
+
+
+def test_receipt_owner_persistent_close_eio_retains_owner_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    real_close = publication_module.os.close
+    error = OSError(errno.EIO, "persistent receipt close failure")
+    close_calls = 0
+
+    def fail_receipt_close(candidate: int) -> None:
+        nonlocal close_calls
+        if candidate == descriptor:
+            close_calls += 1
+            raise error
+        real_close(candidate)
+
+    try:
+        monkeypatch.setattr(publication_module.os, "close", fail_receipt_close)
+        for _attempt in range(2):
+            with pytest.raises(OSError) as caught:
+                receipt_owner.close()
+            assert caught.value is error
+            assert receipt_owner.active
+            assert os.fstat(descriptor)
+    finally:
+        monkeypatch.setattr(publication_module.os, "close", real_close)
+        receipt_owner.close()
+
+    assert close_calls == 2
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+def test_receipt_owner_close_after_error_preserves_primary_and_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    real_close = publication_module.os.close
+    primary = KeyboardInterrupt("primary cancellation")
+    cleanup = OSError(errno.EIO, "persistent receipt cleanup failure")
+
+    def fail_receipt_close(candidate: int) -> None:
+        if candidate == descriptor:
+            raise cleanup
+        real_close(candidate)
+
+    try:
+        monkeypatch.setattr(publication_module.os, "close", fail_receipt_close)
+        with pytest.raises(KeyboardInterrupt) as caught:
+            try:
+                raise primary
+            except BaseException as body_error:
+                receipt_owner.close_after_error(body_error)
+                raise
+        assert caught.value is primary
+        assert any(
+            "published receipt owner cleanup also failed" in note
+            and "persistent receipt cleanup failure" in note
+            for note in _exception_notes(primary)
+        )
+        assert receipt_owner.active
+        assert os.fstat(descriptor)
+    finally:
+        monkeypatch.setattr(publication_module.os, "close", real_close)
+        receipt_owner.close()
+
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+def test_publish_error_after_install_preserves_primary_and_installed_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    primary = SystemExit("injected after receipt owner install")
+    cleanup = OSError(errno.EIO, "installed receipt close failure")
+    installed_descriptor = -1
+    real_install = PublishedFileReceiptOwner._install
+    real_close = publication_module.os.close
+
+    def install_then_interrupt(owner, reservation, receipt) -> None:
+        nonlocal installed_descriptor
+        real_install(owner, reservation, receipt)
+        installed_descriptor = receipt._descriptor
+        raise primary
+
+    def fail_installed_close(candidate: int) -> None:
+        if candidate == installed_descriptor:
+            raise cleanup
+        real_close(candidate)
+
+    monkeypatch.setattr(PublishedFileReceiptOwner, "_install", install_then_interrupt)
+    monkeypatch.setattr(publication_module.os, "close", fail_installed_close)
+    try:
+        with pytest.raises(SystemExit) as caught:
+            publication.publish_into(receipt_owner)
+        assert caught.value is primary
+        assert installed_descriptor >= 0
+        assert receipt_owner.active
+        assert os.fstat(installed_descriptor)
+        assert any(
+            "published receipt owner cleanup also failed" in note
+            and "installed receipt close failure" in note
+            for note in _exception_notes(primary)
+        )
+    finally:
+        monkeypatch.setattr(publication_module.os, "close", real_close)
+        receipt_owner.close()
+        publication.close()
+
+    assert destination.read_bytes() == b"x"
+    assert receipt_owner.closed
+    _assert_bad_descriptor(installed_descriptor)
+
+
+def test_receipt_install_reentry_is_rejected_without_double_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    real_install = PublishedFileReceiptOwner._install
+    reentry_errors: list[BaseException] = []
+
+    def install_with_reentry(owner, reservation, receipt) -> None:
+        try:
+            publication.publish_into(owner)
+        except RuntimeError as error:
+            reentry_errors.append(error)
+        real_install(owner, reservation, receipt)
+
+    monkeypatch.setattr(PublishedFileReceiptOwner, "_install", install_with_reentry)
+    try:
+        publication.publish_into(receipt_owner)
+        assert len(reentry_errors) == 1
+        assert isinstance(reentry_errors[0], RuntimeError)
+        assert "publishing, expected written" in str(reentry_errors[0])
+        assert receipt_owner.receipt.read_bytes(max_bytes=1) == b"x"
+    finally:
+        receipt_owner.close()
+        publication.close()
+
+    assert receipt_owner.closed
+
+
+def test_owner_lifecycle_lock_recovers_acquire_success_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    real_acquire = publication_module._CancellationSafeRLock._acquire
+    interruption = KeyboardInterrupt("after lifecycle lock acquire")
+    injected = False
+
+    def acquire_then_interrupt(lock) -> None:
+        nonlocal injected
+        real_acquire(lock)
+        if lock is receipt_owner._lock and not injected:
+            injected = True
+            raise interruption
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_acquire",
+        acquire_then_interrupt,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _ = receipt_owner.state
+    assert caught.value is interruption
+    assert injected
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_acquire",
+        real_acquire,
+    )
+    observed: list[str] = []
+    observer = threading.Thread(target=lambda: observed.append(receipt_owner.state))
+    observer.start()
+    observer.join(timeout=2)
+    assert not observer.is_alive()
+    assert observed == ["empty"]
+
+
+def test_owner_lifecycle_lock_release_cancellation_keeps_closed_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    real_release = publication_module._CancellationSafeRLock._release
+    interruption = SystemExit("after lifecycle lock release")
+    injected = False
+
+    def release_then_interrupt(lock) -> None:
+        nonlocal injected
+        real_release(lock)
+        if lock is receipt_owner._lock and not injected:
+            injected = True
+            raise interruption
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_release",
+        release_then_interrupt,
+    )
+    with pytest.raises(SystemExit) as caught:
+        receipt_owner.close()
+    assert caught.value is interruption
+    assert injected
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_release",
+        real_release,
+    )
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+    receipt_owner.close()
+
+
+def test_owner_lifecycle_release_failure_is_secondary_to_callback_primary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    real_release = publication_module._CancellationSafeRLock._release
+    primary = KeyboardInterrupt("lifecycle callback primary")
+    secondary = SystemExit("before lifecycle lock release")
+    injected = False
+
+    def release_interrupt_once(lock) -> None:
+        nonlocal injected
+        if lock is receipt_owner._lock and not injected:
+            injected = True
+            raise secondary
+        real_release(lock)
+
+    def fail_callback() -> None:
+        raise primary
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_release",
+        release_interrupt_once,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        receipt_owner._lock.run(fail_callback)
+    assert caught.value is primary
+    assert injected
+    assert any(
+        "receipt lifecycle lock release was interrupted" in note
+        and "before lifecycle lock release" in note
+        for note in _exception_notes(primary)
+    )
+
+    monkeypatch.setattr(
+        publication_module._CancellationSafeRLock,
+        "_release",
+        real_release,
+    )
+    observed: list[str] = []
+    observer = threading.Thread(target=lambda: observed.append(receipt_owner.state))
+    observer.start()
+    observer.join(timeout=2)
+    assert not observer.is_alive()
+    assert observed == ["empty"]
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_consume_return_cleanup_cancellation_does_not_strand_reentrancy_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    callback_returned = False
+    injected = False
+    interruption = exception_type("after consume callback return")
+    real_normalize = PublishedFileReceiptOwner._normalize_closed_locked
+
+    def normalize_after_callback(owner) -> None:
+        nonlocal injected
+        if owner is receipt_owner and callback_returned and not injected:
+            injected = True
+            raise interruption
+        real_normalize(owner)
+
+    def consume(receipt: publication_module.PublishedFileReceipt) -> None:
+        nonlocal callback_returned
+        assert receipt.read_bytes(max_bytes=1) == b"x"
+        callback_returned = True
+
+    monkeypatch.setattr(
+        PublishedFileReceiptOwner,
+        "_normalize_closed_locked",
+        normalize_after_callback,
+    )
+    with pytest.raises(exception_type) as caught:
+        receipt_owner.consume(consume)
+    assert caught.value is interruption
+    assert callback_returned
+    assert injected
+
+    monkeypatch.setattr(
+        PublishedFileReceiptOwner,
+        "_normalize_closed_locked",
+        real_normalize,
+    )
+    receipt_owner.close()
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+@pytest.mark.parametrize("exception_type", [KeyboardInterrupt, SystemExit])
+def test_persistent_close_error_wins_state_cleanup_cancellation_and_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    receipt = receipt_owner.receipt
+    descriptor = receipt._descriptor
+    real_close = publication_module.os.close
+    real_closed = publication_module.PublishedFileReceipt.closed.fget
+    assert real_closed is not None
+    close_error = OSError(errno.EIO, "persistent close before real syscall")
+    interruption = exception_type("receipt close-state observation cancelled")
+    close_attempted = False
+    injected = False
+
+    def fail_close(candidate: int) -> None:
+        nonlocal close_attempted
+        if candidate == descriptor:
+            close_attempted = True
+            raise close_error
+        real_close(candidate)
+
+    def interrupt_closed(candidate) -> bool:
+        nonlocal injected
+        if candidate is receipt and close_attempted and not injected:
+            injected = True
+            raise interruption
+        return real_closed(candidate)
+
+    monkeypatch.setattr(publication_module.os, "close", fail_close)
+    monkeypatch.setattr(
+        publication_module.PublishedFileReceipt,
+        "closed",
+        property(interrupt_closed),
+    )
+    with pytest.raises(OSError) as caught:
+        receipt_owner.close()
+
+    assert caught.value is close_error
+    assert close_attempted
+    assert injected
+    assert any(
+        "receipt owner close-state cleanup also failed" in note
+        and "close-state observation cancelled" in note
+        for note in _exception_notes(close_error)
+    )
+    assert receipt_owner.active
+    assert os.fstat(descriptor)
+
+    monkeypatch.setattr(publication_module.os, "close", real_close)
+    monkeypatch.setattr(
+        publication_module.PublishedFileReceipt,
+        "closed",
+        property(real_closed),
+    )
+    receipt_owner.close()
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+@pytest.mark.parametrize("phase", ["before", "after"])
+def test_after_real_close_state_transition_cancellation_converges_by_observation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    interruption = SystemExit(f"{phase} receipt close-state transition")
+    real_settle = PublishedFileReceiptOwner._settle_receipt_locked
+    injected = False
+
+    def settle_then_interrupt(owner, receipt):
+        nonlocal injected
+        if owner is receipt_owner and not injected:
+            injected = True
+            if phase == "after":
+                real_settle(owner, receipt)
+            raise interruption
+        return real_settle(owner, receipt)
+
+    monkeypatch.setattr(
+        PublishedFileReceiptOwner,
+        "_settle_receipt_locked",
+        settle_then_interrupt,
+    )
+    with pytest.raises(SystemExit) as caught:
+        receipt_owner.close()
+
+    assert caught.value is interruption
+    assert injected
+    _assert_bad_descriptor(descriptor)
+    assert receipt_owner.closed
+    receipt_owner.close()
+
+
+@pytest.mark.parametrize(
+    ("phase", "exception_type"),
+    [
+        pytest.param("before", KeyboardInterrupt, id="before-keyboardinterrupt"),
+        pytest.param("after", SystemExit, id="after-systemexit"),
+    ],
+)
+def test_publication_primary_wins_cancel_reservation_transition_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+    exception_type: type[BaseException],
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    primary = LookupError("publication authentication primary")
+    interruption = exception_type(f"{phase} terminal reservation slot store")
+    real_bind = OwnedFilePublicationAuthority._bind_stage
+    real_cancel = PublishedFileReceiptOwner._cancel_reservation_locked
+    injected = False
+
+    def fail_publish_bind(candidate, record) -> None:
+        if candidate is publication:
+            raise primary
+        real_bind(candidate, record)
+
+    def cancel_then_interrupt(owner, reservation) -> bool:
+        nonlocal injected
+        if owner is receipt_owner and not injected:
+            injected = True
+            if phase == "after":
+                real_cancel(owner, reservation)
+            raise interruption
+        return real_cancel(owner, reservation)
+
+    monkeypatch.setattr(OwnedFilePublicationAuthority, "_bind_stage", fail_publish_bind)
+    monkeypatch.setattr(
+        PublishedFileReceiptOwner,
+        "_cancel_reservation_locked",
+        cancel_then_interrupt,
+    )
+    try:
+        with pytest.raises(LookupError) as caught:
+            publication.publish_into(receipt_owner)
+        assert caught.value is primary
+        assert injected
+        assert any(
+            "receipt reservation cleanup also failed" in note
+            and "terminal reservation slot store" in note
+            for note in _exception_notes(primary)
+        )
+        assert receipt_owner.closed
+        receipt_owner.close()
+        assert not destination.exists()
+    finally:
+        publication.close()
+
+
+def test_helper_consumer_primary_wins_terminal_close_cancellation_and_no_fd_leak(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = _descriptor_count()
+    primary = KeyboardInterrupt("helper consumer primary")
+    interruption = SystemExit("before terminal descriptor close")
+    captured: list[publication_module.PublishedFileReceipt] = []
+    descriptors: list[int] = []
+    real_close = publication_module.os.close
+    injected = False
+    close_calls = 0
+
+    def interrupt_first_close(candidate: int) -> None:
+        nonlocal close_calls, injected
+        if descriptors and candidate == descriptors[0]:
+            close_calls += 1
+            if not injected:
+                injected = True
+                raise interruption
+        real_close(candidate)
+
+    def consume(receipt: publication_module.PublishedFileReceipt) -> None:
+        captured.append(receipt)
+        descriptors.append(receipt._descriptor)
+        raise primary
+
+    monkeypatch.setattr(publication_module.os, "close", interrupt_first_close)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        publish_owned_file(
+            tmp_path / "object",
+            [b"x"],
+            max_bytes=1,
+            consume=consume,
+        )
+
+    assert caught.value is primary
+    assert injected
+    assert close_calls == 2
+    assert len(captured) == 1
+    assert captured[0].closed
+    _assert_bad_descriptor(descriptors[0])
+    assert any(
+        "descriptor terminal cleanup was interrupted" in note
+        and "before terminal descriptor close" in note
+        for note in _exception_notes(primary)
+    )
+    assert _descriptor_count() <= before
+
+
+def test_concurrent_owner_close_calls_are_linear_after_one_close_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    real_close = publication_module.os.close
+    interruption = OSError(errno.EIO, "first concurrent close failure")
+    start = threading.Barrier(3)
+    outcomes: list[BaseException | None] = []
+    close_calls = 0
+
+    def fail_first_close(candidate: int) -> None:
+        nonlocal close_calls
+        if candidate == descriptor:
+            close_calls += 1
+            if close_calls == 1:
+                raise interruption
+        real_close(candidate)
+
+    def close() -> None:
+        start.wait()
+        try:
+            receipt_owner.close()
+        except BaseException as error:  # noqa: B036 - report thread outcome
+            outcomes.append(error)
+        else:
+            outcomes.append(None)
+
+    monkeypatch.setattr(publication_module.os, "close", fail_first_close)
+    workers = [threading.Thread(target=close) for _index in range(2)]
+    for worker in workers:
+        worker.start()
+    start.wait()
+    for worker in workers:
+        worker.join(timeout=3)
+        assert not worker.is_alive()
+
+    assert len(outcomes) == 2
+    assert sum(error is interruption for error in outcomes) == 1
+    assert sum(error is None for error in outcomes) == 1
+    assert close_calls == 2
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+def test_one_owner_concurrent_reservations_allow_exactly_one_publication(
+    tmp_path: Path,
+) -> None:
+    before = _descriptor_count()
+    receipt_owner = PublishedFileReceiptOwner()
+    publications = [
+        OwnedFilePublicationAuthority(tmp_path / f"object-{index}", max_bytes=1)
+        for index in range(2)
+    ]
+    for index, publication in enumerate(publications):
+        publication.write([bytes([ord("a") + index])])
+    start = threading.Barrier(3)
+    outcomes: list[tuple[int, str, BaseException | None]] = []
+
+    def publish(index: int) -> None:
+        publication = publications[index]
+        start.wait()
+        try:
+            publication.publish_into(receipt_owner)
+        except RuntimeError as error:
+            outcomes.append((index, "error", error))
+        else:
+            outcomes.append((index, "published", None))
+        finally:
+            publication.close()
+
+    workers = [threading.Thread(target=publish, args=(index,)) for index in range(2)]
+    for worker in workers:
+        worker.start()
+    start.wait()
+    for worker in workers:
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+
+    published = [entry for entry in outcomes if entry[1] == "published"]
+    rejected = [entry for entry in outcomes if entry[1] == "error"]
+    assert len(published) == 1
+    assert len(rejected) == 1
+    assert isinstance(rejected[0][2], RuntimeError)
+    assert receipt_owner.active
+    winning_index = published[0][0]
+    assert receipt_owner.receipt.path == tmp_path / f"object-{winning_index}"
+    assert sum((tmp_path / f"object-{index}").exists() for index in range(2)) == 1
+
+    receipt_owner.close()
+    assert receipt_owner.closed
+    assert _descriptor_count() <= before
+
+
+def test_owner_close_cannot_cancel_a_reserved_publication_before_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "object"
+    publication = OwnedFilePublicationAuthority(destination, max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    reserved = threading.Event()
+    continue_publication = threading.Event()
+    errors: list[Exception] = []
+    real_reserve = PublishedFileReceiptOwner._reserve
+
+    def reserve_then_wait(owner, reservation) -> None:
+        real_reserve(owner, reservation)
+        if owner is receipt_owner:
+            reserved.set()
+            assert continue_publication.wait(timeout=2)
+
+    def publish() -> None:
+        try:
+            publication.publish_into(receipt_owner)
+        except Exception as error:
+            errors.append(error)
+
+    monkeypatch.setattr(PublishedFileReceiptOwner, "_reserve", reserve_then_wait)
+    worker = threading.Thread(target=publish)
+    worker.start()
+    assert reserved.wait(timeout=2)
+    assert receipt_owner.state == "reserved"
+    assert not destination.exists()
+    with pytest.raises(RuntimeError, match="publication is in progress"):
+        receipt_owner.close()
+    assert receipt_owner.state == "reserved"
+    assert not destination.exists()
+
+    continue_publication.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    try:
+        assert errors == []
+        assert receipt_owner.active
+        assert destination.read_bytes() == b"x"
+    finally:
+        receipt_owner.close()
+        publication.close()
+
+
+def test_owner_consume_and_close_are_linear_across_threads(tmp_path: Path) -> None:
+    receipt_owner = PublishedFileReceiptOwner()
+    publish_owned_file(
+        tmp_path / "object",
+        [b"x"],
+        max_bytes=1,
+        receipt_owner=receipt_owner,
+    )
+    descriptor = receipt_owner.receipt._descriptor
+    consume_started = threading.Event()
+    allow_consume_return = threading.Event()
+    close_started = threading.Event()
+    close_finished = threading.Event()
+    consumed: list[bytes] = []
+    errors: list[BaseException] = []
+
+    def consume(receipt: publication_module.PublishedFileReceipt) -> None:
+        try:
+            consume_started.set()
+            consumed.append(receipt.read_bytes(max_bytes=1))
+            assert allow_consume_return.wait(timeout=2)
+            consumed.append(receipt.read_bytes(max_bytes=1))
+        except Exception as error:
+            errors.append(error)
+
+    def close() -> None:
+        try:
+            close_started.set()
+            receipt_owner.close()
+        except Exception as error:
+            errors.append(error)
+        finally:
+            close_finished.set()
+
+    consumer = threading.Thread(target=lambda: receipt_owner.consume(consume))
+    consumer.start()
+    assert consume_started.wait(timeout=2)
+    closer = threading.Thread(target=close)
+    closer.start()
+    assert close_started.wait(timeout=2)
+    assert not close_finished.wait(timeout=0.05)
+    allow_consume_return.set()
+    consumer.join(timeout=2)
+    closer.join(timeout=2)
+
+    assert not consumer.is_alive()
+    assert not closer.is_alive()
+    assert errors == []
+    assert consumed == [b"x", b"x"]
+    assert receipt_owner.closed
+    _assert_bad_descriptor(descriptor)
+
+
+@pytest.mark.parametrize(
+    ("phase", "exception_type"),
+    [
+        pytest.param("before", KeyboardInterrupt, id="keyboardinterrupt-before"),
+        pytest.param("after", SystemExit, id="systemexit-after"),
+    ],
+)
+def test_parent_authority_close_defers_interrupt_and_closes_all_resources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+    exception_type: type[BaseException],
+) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    assert publication._authority is not None
+    parent_descriptor = publication._authority.resource
+    real_close = publication_module.os.close
+    interruption = exception_type(f"{phase} parent close interrupt")
+
+    def interrupt_parent_close(descriptor: int) -> None:
+        if descriptor != parent_descriptor:
+            real_close(descriptor)
+            return
+        if phase == "after":
+            real_close(descriptor)
+        raise interruption
+
+    monkeypatch.setattr(publication_module.os, "close", interrupt_parent_close)
+    with PublishedFileReceiptOwner() as receipt_owner:
+        with pytest.raises(exception_type) as caught:
+            publication.publish_into(receipt_owner)
+
+        assert caught.value is interruption
+        _assert_bad_descriptor(parent_descriptor)
+        publication.close()
+
+
+def test_body_error_wins_while_close_visits_stage_and_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = _descriptor_count()
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    stage_descriptor = publication._descriptor
+    assert publication._authority is not None
+    parent_descriptor = publication._authority.resource
+    real_close = publication_module.os.close
+    stage_interruption = KeyboardInterrupt("stage cleanup interrupted")
+    parent_cancellation = SystemExit("parent cleanup cancelled")
+    stage_injected = False
+    parent_injected = False
+
+    def interrupt_two_closes(descriptor: int) -> None:
+        nonlocal stage_injected, parent_injected
+        if descriptor == stage_descriptor and not stage_injected:
+            stage_injected = True
+            raise stage_interruption
+        if descriptor == parent_descriptor and not parent_injected:
+            parent_injected = True
+            real_close(descriptor)
+            raise parent_cancellation
+        real_close(descriptor)
+
+    monkeypatch.setattr(publication_module.os, "close", interrupt_two_closes)
+
+    class BrokenProducer:
+        def __iter__(self):
+            raise LookupError("primary producer failure")
+
+    with pytest.raises(LookupError, match="primary producer failure") as caught:
+        with publication:
+            publication.write(BrokenProducer())
+
+    assert stage_injected
+    assert parent_injected
+    assert publication.state == "closed"
+    _assert_bad_descriptor(stage_descriptor)
+    _assert_bad_descriptor(parent_descriptor)
+    assert any(
+        "publication cleanup also failed" in note
+        and "stage cleanup interrupted" in note
+        for note in _exception_notes(caught.value)
+    )
+    assert _descriptor_count() <= before
+
+
+def test_linear_state_and_pid_binding(tmp_path: Path, monkeypatch) -> None:
+    publication = OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    publication.write([b"x"])
+    receipt_owner = PublishedFileReceiptOwner()
+    with pytest.raises(RuntimeError, match="expected staged"):
+        publication.write([b"x"])
+
+    owner_pid = os.getpid()
+    monkeypatch.setattr(publication_module.os, "getpid", lambda: owner_pid + 1)
+    with pytest.raises(RuntimeError, match="PID boundary"):
+        publication.publish_into(receipt_owner)
+    with pytest.raises(RuntimeError, match="PID boundary"):
+        publication.close()
+    with pytest.raises(RuntimeError, match="PID boundary"):
+        _ = receipt_owner.state
+    with pytest.raises(RuntimeError, match="PID boundary"):
+        receipt_owner.close()
+
+    monkeypatch.setattr(publication_module.os, "getpid", lambda: owner_pid)
+    assert receipt_owner.closed
+
+
+def test_missing_parent_and_noncanonical_leaf_do_not_create_paths(
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing"
+    with pytest.raises(FileNotFoundError):
+        OwnedFilePublicationAuthority(missing / "object", max_bytes=1)
+    assert not missing.exists()
+
+    with pytest.raises(ValueError, match="safe final component"):
+        OwnedFilePublicationAuthority(tmp_path / "..", max_bytes=1)
+
+
+def test_publication_uses_no_destructive_or_resolving_path_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("destructive or resolving path call")
+
+    for name in ("resolve", "mkdir", "unlink", "rmdir"):
+        monkeypatch.setattr(Path, name, forbidden)
+    for name in ("unlink", "remove", "rmdir"):
+        monkeypatch.setattr(publication_module.os, name, forbidden)
+
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publish_owned_file(
+            tmp_path / "object",
+            [b"x"],
+            max_bytes=1,
+            receipt_owner=receipt_owner,
+        )
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux process gate")
+def test_concurrent_processes_publish_identical_bytes(tmp_path: Path) -> None:
+    destination = tmp_path / "object"
+    payload = b"shared bytes"
+    context = multiprocessing.get_context("fork")
+    processes = [
+        context.Process(
+            target=_publish_in_process,
+            args=(os.fspath(destination), payload),
+        )
+        for _index in range(4)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=20)
+        assert process.exitcode == 0
+
+    assert destination.read_bytes() == payload
+    assert len(list(tmp_path.glob(".codenib-file-*"))) == 3
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs")
+def test_failure_and_receipt_close_do_not_leak_descriptors(tmp_path: Path) -> None:
+    before = len(list(Path("/proc/self/fd").iterdir()))
+    destination = tmp_path / "object"
+    destination.write_bytes(b"old")
+    for index in range(12):
+        with PublishedFileReceiptOwner() as failed_owner:
+            with pytest.raises(OwnedFileConflictError):
+                publish_owned_file(
+                    destination,
+                    [f"new-{index}".encode()],
+                    max_bytes=16,
+                    receipt_owner=failed_owner,
+                )
+    with PublishedFileReceiptOwner() as receipt_owner:
+        publish_owned_file(
+            destination,
+            [b"old"],
+            max_bytes=3,
+            receipt_owner=receipt_owner,
+        )
+    after = len(list(Path("/proc/self/fd").iterdir()))
+    assert after <= before + 1
+
+
+def test_darwin_rename_dispatch_uses_existing_renameatx_np(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[object, ...]] = []
+
+    class Rename:
+        argtypes = None
+        restype = None
+
+        def __call__(self, *args):
+            calls.append(args)
+            return 0
+
+    class Libc:
+        renameatx_np = Rename()
+
+    monkeypatch.setattr(atomic_module.sys, "platform", "darwin")
+    monkeypatch.setattr(atomic_module.ctypes, "CDLL", lambda *_args, **_kwargs: Libc())
+
+    atomic_module._rename_noreplace_at("stage", "final", 10, 11)
+
+    assert calls == [(10, b"stage", 11, b"final", atomic_module._RENAME_EXCL)]
+
+
+def test_windows_fails_before_opening_or_mutating_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    opened = False
+
+    def forbidden_open(*_args, **_kwargs):
+        nonlocal opened
+        opened = True
+        raise AssertionError("Windows publication authority was opened")
+
+    monkeypatch.setattr(publication_module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        publication_module._atomic,
+        "_open_publication_authority",
+        forbidden_open,
+    )
+
+    with pytest.raises(RuntimeError, match="unsupported on Windows"):
+        OwnedFilePublicationAuthority(tmp_path / "object", max_bytes=1)
+    assert not opened
+    assert not (tmp_path / "object").exists()
+
+
+@pytest.mark.parametrize(
+    ("platform", "message"),
+    (("win32", "unsupported on Windows"), ("freebsd", "unsupported on this host")),
+)
+def test_support_gate_fails_before_opening_or_mutating_any_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+    message: str,
+) -> None:
+    touched = False
+
+    def forbidden(*_args, **_kwargs):
+        nonlocal touched
+        touched = True
+        raise AssertionError("support gate touched filesystem publication state")
+
+    monkeypatch.setattr(publication_module.sys, "platform", platform)
+    monkeypatch.setattr(
+        publication_module._atomic,
+        "_require_rename_noreplace_platform",
+        forbidden,
+    )
+    monkeypatch.setattr(
+        publication_module._atomic,
+        "_open_publication_authority",
+        forbidden,
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        require_owned_file_publication_support()
+
+    assert not touched
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_support_gate_covers_atomic_directory_fd_prerequisites(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend_checked = False
+
+    def forbidden_backend_check() -> None:
+        nonlocal backend_checked
+        backend_checked = True
+        raise AssertionError("rename backend was checked after a failed fd gate")
+
+    monkeypatch.setattr(
+        publication_module._atomic,
+        "_SAFE_OWNERSHIP_DIRECTORY_FDS",
+        False,
+    )
+    monkeypatch.setattr(
+        publication_module._atomic,
+        "_require_rename_noreplace_platform",
+        forbidden_backend_check,
+    )
+
+    with pytest.raises(RuntimeError, match="anchored directory-fd support"):
+        require_owned_file_publication_support()
+
+    assert not backend_checked
+    assert list(tmp_path.iterdir()) == []

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -4,16 +4,33 @@
 
 from __future__ import annotations
 
+import hashlib
+import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
 import codenib._contained_source as contained_source_module
+from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
 from codenib.source_fingerprint import (
+    SOURCE_FINGERPRINT_VERSION,
     RepositoryChangedError,
     fingerprint_repository,
     repository_source_is_dirty,
 )
+
+
+def _legacy_link_only_digest(path: bytes, target: bytes) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        (
+            f"codenib-source-fingerprint:{SOURCE_FINGERPRINT_VERSION}:"
+            f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
+        ).encode("ascii")
+    )
+    digest.update(b"L\0" + path + b"\0" + target + b"\0")
+    return f"sha256:{digest.hexdigest()}"
 
 
 def test_fingerprint_changes_with_source_content_and_path(tmp_path):
@@ -74,6 +91,41 @@ def test_fingerprint_includes_symlink_target_and_content(tmp_path):
     (repo / "other.py").write_text("VALUE = 3\n")
     link.symlink_to("other.py")
     assert fingerprint_repository(repo).value != changed_content.value
+
+
+@pytest.mark.parametrize("terminal", ["missing", "fifo", "loop"])
+def test_fingerprint_preserves_v1_link_only_terminal_digest(
+    tmp_path: Path,
+    terminal: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    link = repo / "link.py"
+    if terminal == "missing":
+        target = "missing.py"
+    elif terminal == "fifo":
+        target = ".codenib-hidden-pipe"
+        os.mkfifo(repo / target)
+    else:
+        target = "link.py"
+    link.symlink_to(target)
+
+    observed = fingerprint_repository(repo)
+
+    assert observed.file_count == 1
+    assert observed.value == _legacy_link_only_digest(b"link.py", os.fsencode(target))
+
+
+def test_fingerprint_accepts_absolute_contained_symlink(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "target.py"
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+    (repo / "link.py").symlink_to(target)
+
+    observed = fingerprint_repository(repo)
+
+    assert observed.file_count == 2
 
 
 def test_fingerprint_rejects_source_symlink_outside_repository(tmp_path) -> None:

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -6,7 +6,11 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
+import codenib._contained_source as contained_source_module
 from codenib.source_fingerprint import (
+    RepositoryChangedError,
     fingerprint_repository,
     repository_source_is_dirty,
 )
@@ -56,10 +60,10 @@ def test_fingerprint_ignores_git_worktree_pointer_file(tmp_path):
 def test_fingerprint_includes_symlink_target_and_content(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
-    target = tmp_path / "target.py"
+    target = repo / "target.py"
     target.write_text("VALUE = 1\n")
     link = repo / "current.py"
-    link.symlink_to(target)
+    link.symlink_to("target.py")
     initial = fingerprint_repository(repo)
 
     target.write_text("VALUE = 2\n")
@@ -67,8 +71,55 @@ def test_fingerprint_includes_symlink_target_and_content(tmp_path):
     assert changed_content.value != initial.value
 
     link.unlink()
-    link.symlink_to(tmp_path / "other.py")
+    (repo / "other.py").write_text("VALUE = 3\n")
+    link.symlink_to("other.py")
     assert fingerprint_repository(repo).value != changed_content.value
+
+
+def test_fingerprint_rejects_source_symlink_outside_repository(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside.py").write_text("SECRET = 1\n")
+    (repo / "current.py").symlink_to("../outside.py")
+
+    with pytest.raises(RepositoryChangedError, match="could not be read consistently"):
+        fingerprint_repository(repo)
+
+
+def test_fingerprint_rejects_reversible_source_symlink_swap(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "target.py").write_text("VALUE = 1\n")
+    (tmp_path / "outside.py").write_text("SECRET = 1\n")
+    link = repo / "current.py"
+    link.symlink_to("target.py")
+    real_verify = contained_source_module._BoundRepositoryFile.verify
+    calls = 0
+
+    def swap_then_restore(binding) -> None:
+        nonlocal calls
+        calls += 1
+        if calls != 2:
+            return real_verify(binding)
+        link.unlink()
+        link.symlink_to("../outside.py")
+        try:
+            return real_verify(binding)
+        finally:
+            link.unlink()
+            link.symlink_to("target.py")
+
+    monkeypatch.setattr(
+        contained_source_module._BoundRepositoryFile,
+        "verify",
+        swap_then_restore,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="could not be read consistently"):
+        fingerprint_repository(repo)
 
 
 def test_dirty_check_ignores_generated_dirs_but_detects_source_changes(tmp_path):

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -4,33 +4,1095 @@
 
 from __future__ import annotations
 
+import dis
+import errno
 import hashlib
+import inspect
 import os
 import subprocess
+import sys
+import threading
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import codenib._contained_source as contained_source_module
+import codenib._windows_fs_authority as windows_fs_module
+import codenib.source_fingerprint as source_fingerprint_module
+from codenib.artifacts.runtime import SourceBindingCleanupOwner
 from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
 from codenib.source_fingerprint import (
     SOURCE_FINGERPRINT_VERSION,
     RepositoryChangedError,
+    RepositorySourceBinding,
+    capture_repository_source,
     fingerprint_repository,
+    fingerprint_repository_v1_for_diagnostics,
+    is_legacy_source_fingerprint_v1,
+    is_secure_source_fingerprint_v2,
     repository_source_is_dirty,
+    source_fingerprint_version,
 )
+
+
+class _InterruptAfterPopList(list[int]):
+    def __init__(self, values: list[int], interruption: BaseException) -> None:
+        super().__init__(values)
+        self._interruption = interruption
+        self._armed = True
+
+    def pop(self, *args):
+        value = super().pop(*args)
+        if self._armed:
+            self._armed = False
+            raise self._interruption
+        return value
+
+
+class _AcquireThenInterruptRLock:
+    def __init__(self) -> None:
+        self.runtime = threading.RLock()
+        self.acquire_calls = 0
+        self.acquire_interrupted = False
+        self.probe_interrupted = False
+        self.acquire_failure = KeyboardInterrupt("injected completed acquire")
+
+    def acquire(self, *args, **kwargs):
+        self.acquire_calls += 1
+        acquired = self.runtime.acquire(*args, **kwargs)
+        if not self.acquire_interrupted:
+            self.acquire_interrupted = True
+            raise self.acquire_failure
+        return acquired
+
+    def release(self) -> None:
+        self.runtime.release()
+
+    def _is_owned(self) -> bool:
+        if self.acquire_interrupted and not self.probe_interrupted:
+            self.probe_interrupted = True
+            raise SystemExit("injected acquisition recovery cancellation")
+        return self.runtime._is_owned()
+
+
+class _ReleaseThenInterruptRLock:
+    def __init__(self) -> None:
+        self.runtime = threading.RLock()
+        self.release_calls = 0
+        self.release_interrupted = False
+        self.probe_interrupted = False
+        self.release_failure = KeyboardInterrupt("injected completed release")
+
+    def acquire(self, *args, **kwargs):
+        return self.runtime.acquire(*args, **kwargs)
+
+    def release(self) -> None:
+        self.release_calls += 1
+        self.runtime.release()
+        if not self.release_interrupted:
+            self.release_interrupted = True
+            raise self.release_failure
+
+    def _is_owned(self) -> bool:
+        if self.release_interrupted and not self.probe_interrupted:
+            self.probe_interrupted = True
+            raise SystemExit("injected release recovery cancellation")
+        return self.runtime._is_owned()
+
+
+def test_source_lock_double_acquire_cancellation_does_not_add_native_recursion() -> (
+    None
+):
+    lock = source_fingerprint_module._SourceLifecycleRLock()
+    runtime = _AcquireThenInterruptRLock()
+    lock._lock = runtime
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with source_fingerprint_module._SourceLockLease(lock) as failure:
+            assert failure is runtime.acquire_failure
+            raise failure
+
+    assert caught.value is runtime.acquire_failure
+    assert runtime.acquire_calls == 1
+    assert lock.depth() == 0
+    acquired_elsewhere = []
+
+    def acquire_elsewhere() -> None:
+        acquired = runtime.runtime.acquire(timeout=1)
+        acquired_elsewhere.append(acquired)
+        if acquired:
+            runtime.runtime.release()
+
+    thread = threading.Thread(target=acquire_elsewhere)
+    thread.start()
+    thread.join(timeout=2)
+    assert acquired_elsewhere == [True]
+
+
+def test_source_lock_double_release_cancellation_does_not_retry_native_release() -> (
+    None
+):
+    lock = source_fingerprint_module._SourceLifecycleRLock()
+    runtime = _ReleaseThenInterruptRLock()
+    lock._lock = runtime
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with source_fingerprint_module._SourceLockLease(lock):
+            pass
+
+    assert caught.value is runtime.release_failure
+    assert runtime.release_calls == 1
+    assert lock.depth() == 0
+    assert runtime.runtime.acquire(timeout=1)
+    runtime.runtime.release()
+
+
+def test_source_lock_persistent_probe_failure_is_bounded() -> None:
+    class BrokenProbeRLock:
+        def acquire(self, *args, **kwargs):
+            raise AssertionError("native acquire must wait for a successful probe")
+
+        def release(self) -> None:
+            raise AssertionError("unacquired lock must not be released")
+
+        def _is_owned(self) -> bool:
+            raise RuntimeError("persistent ownership probe failure")
+
+    lock = source_fingerprint_module._SourceLifecycleRLock()
+    lock._lock = BrokenProbeRLock()
+
+    with pytest.raises(RuntimeError, match="persistent ownership probe failure"):
+        source_fingerprint_module._SourceLockLease(lock).__enter__()
+
+
+def test_repository_source_binding_reads_exact_captured_records(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+    hidden = repo / ".hidden"
+    hidden.mkdir()
+    (hidden / "target.py").write_bytes(b"TARGET = 2\n")
+    (repo / "link.py").symlink_to(".hidden/target.py")
+    expected = fingerprint_repository(repo)
+
+    with capture_repository_source(repo) as binding:
+        assert binding.fingerprint == expected.value
+        assert binding.file_count == expected.file_count
+        assert {record.path for record in binding.file_records} == {
+            ".hidden/target.py",
+            "a.py",
+            "link.py",
+        }
+        assert binding.read_bytes("a.py", max_bytes=1024) == b"VALUE = 1\n"
+        assert binding.read_bytes("link.py", max_bytes=1024) == b"TARGET = 2\n"
+
+
+def test_repository_source_binding_poisoned_by_touched_or_unrelated_change(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "a.py"
+    other = repo / "b.py"
+    source.write_bytes(b"VALUE = 1\n")
+    other.write_bytes(b"OTHER = 1\n")
+    binding = capture_repository_source(repo)
+    other.write_bytes(b"OTHER = 999\n")
+
+    with pytest.raises(RepositoryChangedError):
+        binding.read_bytes("a.py", max_bytes=1024)
+
+    other.write_bytes(b"OTHER = 1\n")
+    with pytest.raises(RepositoryChangedError, match="poisoned"):
+        binding.read_bytes("a.py", max_bytes=1024)
+    binding.close()
+
+
+def test_repository_source_binding_rejects_legal_replacement_root(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+    binding = capture_repository_source(repo)
+    pinned = tmp_path / "pinned"
+    repo.rename(pinned)
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+
+    with pytest.raises(RepositoryChangedError):
+        binding.verify_snapshot()
+    assert not binding.usable
+    binding.close()
+
+
+def test_source_authority_rejects_preexisting_ancestor_symlink(
+    tmp_path: Path,
+) -> None:
+    foreign = tmp_path / "foreign"
+    repo = foreign / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+    trusted = tmp_path / "trusted"
+    trusted.mkdir()
+    (trusted / "alias").symlink_to(foreign, target_is_directory=True)
+
+    with pytest.raises(RepositoryChangedError):
+        fingerprint_repository(trusted / "alias" / "repo")
+
+
+def test_repository_source_binding_rejects_replaced_ancestor(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "parent"
+    repo = parent / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+    binding = capture_repository_source(repo)
+    saved = tmp_path / "saved-parent"
+    parent.rename(saved)
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"VALUE = 1\n")
+
+    with pytest.raises(RepositoryChangedError):
+        binding.verify_snapshot()
+    binding.close()
+
+
+def test_repository_source_read_session_scans_whole_tree_twice(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    (repo / "b.py").write_bytes(b"B\n")
+    binding = capture_repository_source(repo)
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    scans = 0
+
+    def counted_scan(*args, **kwargs):
+        nonlocal scans
+        scans += 1
+        return real_scan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        counted_scan,
+    )
+    with binding.read_session():
+        assert binding.read_bytes("a.py", max_bytes=16) == b"A\n"
+        assert binding.read_bytes("b.py", max_bytes=16) == b"B\n"
+
+    assert scans == 2
+    binding.close()
+
+
+def test_repository_source_read_session_trace_interrupt_releases_lock(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    wrapped = RepositorySourceBinding.read_session.__wrapped__
+    lines, first_line = inspect.getsourcelines(wrapped)
+    target_line = first_line + next(
+        index
+        for index, line in enumerate(lines)
+        if "if self._session_depth == 0:" in line
+    )
+    interrupted = False
+
+    def interrupt_after_acquire(frame, event, _arg):
+        nonlocal interrupted
+        if (
+            not interrupted
+            and frame.f_code is wrapped.__code__
+            and event == "line"
+            and frame.f_lineno == target_line
+        ):
+            interrupted = True
+            raise KeyboardInterrupt("injected after lock acquisition")
+        return interrupt_after_acquire
+
+    sys.settrace(interrupt_after_acquire)
+    try:
+        with pytest.raises(KeyboardInterrupt, match="after lock acquisition"):
+            with binding.read_session():
+                pytest.fail("interruption must happen before the session body")
+    finally:
+        sys.settrace(None)
+
+    completed = threading.Event()
+
+    def close_from_another_thread() -> None:
+        binding.close()
+        completed.set()
+
+    thread = threading.Thread(target=close_from_another_thread)
+    thread.start()
+    thread.join(timeout=2)
+    assert completed.is_set(), "interrupted acquisition stranded the source lock"
+    assert binding.closed
+
+
+def test_repository_source_read_session_exit_interrupt_poison_closes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    scans = 0
+    interruption = KeyboardInterrupt("injected exit inventory interruption")
+
+    def interrupt_exit(*args, **kwargs):
+        nonlocal scans
+        scans += 1
+        if scans == 2:
+            raise interruption
+        return real_scan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        interrupt_exit,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with binding.read_session():
+            assert binding.read_bytes("a.py", max_bytes=16) == b"A\n"
+
+    assert caught.value is interruption
+    assert binding.closed
+    assert not binding.usable
+
+
+def test_repository_source_read_session_preserves_body_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    real_scan = source_fingerprint_module._scan_pinned_repository
+    scans = 0
+    primary = KeyboardInterrupt("primary session cancellation")
+
+    def interrupt_exit(*args, **kwargs):
+        nonlocal scans
+        scans += 1
+        if scans == 2:
+            raise SystemExit("secondary exit cancellation")
+        return real_scan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        interrupt_exit,
+    )
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with binding.read_session():
+            raise primary
+
+    assert caught.value is primary
+    assert binding.closed
+
+
+@pytest.mark.parametrize(
+    ("timing", "interruption"),
+    [
+        pytest.param(
+            "before",
+            KeyboardInterrupt("injected before descriptor close"),
+            id="before-close",
+        ),
+        pytest.param(
+            "after",
+            SystemExit("injected after descriptor close"),
+            id="after-close",
+        ),
+    ],
+)
+def test_repository_source_close_finishes_descriptor_chain_before_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    timing: str,
+    interruption: BaseException,
+) -> None:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting needs /proc/self/fd")
+    repo = tmp_path / "one" / "two" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"A\n")
+    before = len(tuple(descriptor_root.iterdir()))
+    binding = capture_repository_source(repo)
+    authority = binding._posix_authority
+    assert authority is not None
+    targets = set(authority._resources)
+    real_close = os.close
+    calls = 0
+    injected = False
+    seen: set[int] = set()
+
+    def interrupt_one_close(descriptor: int) -> None:
+        nonlocal calls, injected
+        if descriptor in targets:
+            seen.add(descriptor)
+            calls += 1
+            if calls == 2 and not injected:
+                injected = True
+                if timing == "before":
+                    raise interruption
+                real_close(descriptor)
+                raise interruption
+        real_close(descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "close", interrupt_one_close)
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert injected
+    assert binding.closed
+    assert targets <= seen
+    after = len(tuple(descriptor_root.iterdir()))
+    assert after <= before + 1
+
+
+def test_repository_source_close_commits_interrupted_owner_pop(
+    tmp_path: Path,
+) -> None:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting needs /proc/self/fd")
+    repo = tmp_path / "parent" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"A\n")
+    before = len(tuple(descriptor_root.iterdir()))
+    binding = capture_repository_source(repo)
+    authority = binding._posix_authority
+    assert authority is not None
+    interruption = KeyboardInterrupt("injected after descriptor owner pop")
+    authority._resources = _InterruptAfterPopList(
+        authority._resources,
+        interruption,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert binding.closed
+    assert len(tuple(descriptor_root.iterdir())) <= before + 1
+
+
+def test_repository_source_close_persistent_eio_keeps_owner_and_closes_rest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "one" / "two" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    authority = binding._posix_authority
+    assert authority is not None
+    targets = tuple(authority._resources)
+    failed = targets[-1]
+    real_close = os.close
+
+    def fail_one_descriptor(descriptor: int) -> None:
+        if descriptor == failed:
+            raise OSError(errno.EIO, "injected persistent close EIO")
+        real_close(descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "close", fail_one_descriptor)
+    with pytest.raises(OSError, match="persistent close EIO"):
+        binding.close()
+
+    assert not binding.closed
+    assert not binding.usable
+    assert authority._resources == [failed]
+    for descriptor in targets[:-1]:
+        with pytest.raises(OSError) as caught:
+            os.fstat(descriptor)
+        assert caught.value.errno == errno.EBADF
+
+    monkeypatch.setattr(source_fingerprint_module.os, "close", real_close)
+    binding.close()
+    assert binding.closed
+
+
+def test_repository_source_close_preflight_eio_keeps_owner_and_closes_rest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "one" / "two" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"A\n")
+    binding = capture_repository_source(repo)
+    authority = binding._posix_authority
+    assert authority is not None
+    targets = tuple(authority._resources)
+    failed = targets[-1]
+    real_fstat = os.fstat
+
+    def fail_one_descriptor(descriptor: int):
+        if descriptor == failed:
+            raise OSError(errno.EIO, "injected persistent fstat EIO")
+        return real_fstat(descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "fstat", fail_one_descriptor)
+    with pytest.raises(OSError, match="persistent fstat EIO"):
+        binding.close()
+
+    assert not binding.closed
+    assert not binding.usable
+    assert authority._resources == [failed]
+    for descriptor in targets[:-1]:
+        with pytest.raises(OSError) as caught:
+            real_fstat(descriptor)
+        assert caught.value.errno == errno.EBADF
+
+    monkeypatch.setattr(source_fingerprint_module.os, "fstat", real_fstat)
+    binding.close()
+    assert binding.closed
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("root open interrupted"), id="keyboard"),
+        pytest.param(SystemExit("root open exited"), id="system-exit"),
+    ],
+)
+def test_repository_root_open_failure_closes_owned_descriptors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():
+        pytest.skip("descriptor accounting needs /proc/self/fd")
+    repo = tmp_path / "parent" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "a.py").write_bytes(b"A\n")
+    before = len(tuple(descriptor_root.iterdir()))
+    real_fstat = os.fstat
+    calls = 0
+
+    def interrupt_after_child_open(descriptor: int):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise interruption
+        return real_fstat(descriptor)
+
+    monkeypatch.setattr(
+        source_fingerprint_module.os,
+        "fstat",
+        interrupt_after_child_open,
+    )
+    with pytest.raises(type(interruption)) as caught:
+        fingerprint_repository(repo)
+
+    assert caught.value is interruption
+    after = len(tuple(descriptor_root.iterdir()))
+    assert after <= before + 1
+
+
+def test_capture_root_construction_eio_keeps_preinstalled_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "parent" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "source.py").write_bytes(b"VALUE = 1\n")
+    owner = SourceBindingCleanupOwner()
+    interruption = KeyboardInterrupt("injected POSIX root construction failure")
+    real_open = os.open
+    real_fstat = os.fstat
+    real_close = os.close
+    opened: list[int] = []
+    fstat_calls = 0
+
+    def record_open(*args, **kwargs):
+        descriptor = real_open(*args, **kwargs)
+        opened.append(descriptor)
+        return descriptor
+
+    def interrupt_metadata(descriptor: int):
+        nonlocal fstat_calls
+        fstat_calls += 1
+        if fstat_calls == 2:
+            raise interruption
+        return real_fstat(descriptor)
+
+    failed = -1
+
+    def persistent_close(descriptor: int) -> None:
+        nonlocal failed
+        if descriptor in opened and failed < 0:
+            failed = descriptor
+        if descriptor == failed:
+            raise OSError(errno.EIO, "injected POSIX construction close EIO")
+        real_close(descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "open", record_open)
+    monkeypatch.setattr(source_fingerprint_module.os, "fstat", interrupt_metadata)
+    monkeypatch.setattr(source_fingerprint_module.os, "close", persistent_close)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        capture_repository_source(repo, _source_owner=owner.retain)
+
+    assert caught.value is interruption
+    assert not owner.closed
+    assert owner.pending_sources
+    assert failed >= 0
+    assert real_fstat(failed)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "fstat", real_fstat)
+    monkeypatch.setattr(source_fingerprint_module.os, "close", real_close)
+    owner.close()
+    assert owner.closed
+
+
+def test_capture_scan_eio_keeps_primary_and_explicit_partial_fd_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "source.py").write_bytes(b"VALUE = 1\n")
+    interruption = SystemExit("injected POSIX scan failure")
+    real_close = os.close
+    scan_descriptor = -1
+
+    def interrupt_scan(descriptor: int):
+        nonlocal scan_descriptor
+        scan_descriptor = descriptor
+        raise interruption
+
+    def persistent_close(descriptor: int) -> None:
+        if descriptor == scan_descriptor:
+            raise OSError(errno.EIO, "injected POSIX scan close EIO")
+        real_close(descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "scandir", interrupt_scan)
+    monkeypatch.setattr(
+        source_fingerprint_module.os,
+        "supports_fd",
+        {*os.supports_fd, interrupt_scan},
+    )
+    monkeypatch.setattr(source_fingerprint_module.os, "close", persistent_close)
+
+    with pytest.raises(SystemExit) as caught:
+        capture_repository_source(tmp_path)
+
+    assert caught.value is interruption
+    cleanup_owner = caught.value.source_cleanup_owner
+    assert not cleanup_owner.closed
+    assert scan_descriptor in cleanup_owner.descriptors
+    assert os.fstat(scan_descriptor)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "close", real_close)
+    cleanup_owner.close()
+    assert cleanup_owner.closed
+
+
+def test_posix_resolution_construction_eio_keeps_primary_and_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_bytes(b"VALUE = 1\n")
+    authority = source_fingerprint_module._open_pinned_repository_root(repo)
+    expected = contained_source_module._version_identity(source.lstat())
+    interruption = KeyboardInterrupt("injected POSIX resolution failure")
+    real_open = os.open
+    real_fstat = os.fstat
+    real_close = os.close
+    failed = -1
+
+    def record_open(path, flags, *args, **kwargs):
+        nonlocal failed
+        descriptor = real_open(path, flags, *args, **kwargs)
+        if path == "source.py":
+            failed = descriptor
+        return descriptor
+
+    def interrupt_source_metadata(descriptor: int):
+        if descriptor == failed:
+            raise interruption
+        return real_fstat(descriptor)
+
+    def persistent_close(descriptor: int) -> None:
+        if descriptor == failed:
+            raise OSError(errno.EIO, "injected POSIX resolution close EIO")
+        real_close(descriptor)
+
+    monkeypatch.setattr(contained_source_module.os, "open", record_open)
+    monkeypatch.setattr(contained_source_module.os, "fstat", interrupt_source_metadata)
+    monkeypatch.setattr(contained_source_module.os, "close", persistent_close)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        with contained_source_module._resolved_repository_file_at(
+            repo,
+            authority.descriptor,
+            "source.py",
+            expected_root_identity=authority.root_identity,
+            expected_final_identity=expected,
+        ):
+            pytest.fail("resolution construction must not yield")
+
+    assert caught.value is interruption
+    cleanup_owner = caught.value.source_cleanup_owner
+    assert not cleanup_owner.closed
+    assert failed >= 0
+    assert real_fstat(failed)
+
+    monkeypatch.setattr(contained_source_module.os, "fstat", real_fstat)
+    monkeypatch.setattr(contained_source_module.os, "close", real_close)
+    cleanup_owner.close()
+    authority.close()
+    assert cleanup_owner.closed
 
 
 def _legacy_link_only_digest(path: bytes, target: bytes) -> str:
     digest = hashlib.sha256()
     digest.update(
         (
-            f"codenib-source-fingerprint:{SOURCE_FINGERPRINT_VERSION}:"
-            f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
+            "codenib-source-fingerprint:1:" f"{REPOSITORY_FILTER_POLICY_VERSION}\0"
         ).encode("ascii")
     )
     digest.update(b"L\0" + path + b"\0" + target + b"\0")
     return f"sha256:{digest.hexdigest()}"
+
+
+class _FakeWindowsSourceApi:
+    """HANDLE-only Windows source model with exact 128-bit identities."""
+
+    def __init__(self) -> None:
+        self.nodes: dict[bytes, dict[str, object]] = {}
+        self.handles: dict[int, bytes] = {}
+        self.offsets: dict[int, int] = {}
+        self.next_id = 1
+        self.next_handle = 100
+        self.open_relative_hook = None
+        self.create_root_hook = None
+        self.query_reparse_hook = None
+        self.created_paths: list[str] = []
+        self.volume_id = self.add_directory()
+        self.root_id = self.add_directory(self.volume_id, "repo")
+
+    def _file_id(self) -> bytes:
+        value = self.next_id.to_bytes(16, "little")
+        self.next_id += 1
+        return value
+
+    def add_directory(
+        self,
+        parent: bytes | None = None,
+        name: str = "",
+    ) -> bytes:
+        file_id = self._file_id()
+        self.nodes[file_id] = {
+            "kind": "directory",
+            "children": {},
+            "data": b"",
+            "version": 1,
+            "file_id": file_id,
+            "reparse": None,
+        }
+        if parent is not None:
+            self._children(parent)[name] = file_id
+        return file_id
+
+    def add_file(self, parent: bytes, name: str, data: bytes) -> bytes:
+        file_id = self._file_id()
+        self.nodes[file_id] = {
+            "kind": "file",
+            "children": {},
+            "data": data,
+            "version": 1,
+            "file_id": file_id,
+            "reparse": None,
+        }
+        self._children(parent)[name] = file_id
+        return file_id
+
+    def add_symlink(
+        self,
+        parent: bytes,
+        name: str,
+        target: str,
+        *,
+        directory: bool = False,
+        absolute: bool = False,
+        substitute: str | None = None,
+    ) -> bytes:
+        file_id = self._file_id()
+        point = windows_fs_module.WindowsReparsePoint(
+            tag=windows_fs_module.IO_REPARSE_TAG_SYMLINK,
+            substitute_name=substitute or target,
+            print_name=target,
+            flags=0 if absolute else windows_fs_module.SYMLINK_FLAG_RELATIVE,
+        )
+        self.nodes[file_id] = {
+            "kind": "directory-link" if directory else "link",
+            "children": {},
+            "data": b"",
+            "version": 1,
+            "file_id": file_id,
+            "reparse": point,
+        }
+        self._children(parent)[name] = file_id
+        return file_id
+
+    def add_unknown_reparse(self, parent: bytes, name: str) -> bytes:
+        file_id = self._file_id()
+        self.nodes[file_id] = {
+            "kind": "link",
+            "children": {},
+            "data": b"",
+            "version": 1,
+            "file_id": file_id,
+            "reparse": windows_fs_module.WindowsReparsePoint(
+                tag=windows_fs_module.IO_REPARSE_TAG_MOUNT_POINT,
+                substitute_name=None,
+                print_name=None,
+            ),
+        }
+        self._children(parent)[name] = file_id
+        return file_id
+
+    def _children(self, file_id: bytes) -> dict[str, bytes]:
+        children = self.nodes[file_id]["children"]
+        assert isinstance(children, dict)
+        return children
+
+    def _new_handle(self, file_id: bytes) -> int:
+        handle = self.next_handle
+        self.next_handle += 1
+        self.handles[handle] = file_id
+        self.offsets[handle] = 0
+        return handle
+
+    def create_directory_handle(self, _path: Path) -> int:
+        self.created_paths.append(str(_path))
+        file_id = self.volume_id
+        if self.create_root_hook is not None:
+            file_id = self.create_root_hook(file_id)
+        return self._new_handle(file_id)
+
+    def duplicate_handle(self, handle: int) -> int:
+        return self._new_handle(self.handles[handle])
+
+    def close(self, handle: int) -> None:
+        self.handles.pop(handle, None)
+        self.offsets.pop(handle, None)
+
+    def metadata(self, handle: int) -> windows_fs_module.WindowsHandleMetadata:
+        file_id = self.handles[handle]
+        node = self.nodes[file_id]
+        kind = str(node["kind"])
+        directory = kind in {"directory", "directory-link"}
+        reparse = node["reparse"]
+        attributes = windows_fs_module.FILE_ATTRIBUTE_DIRECTORY if directory else 0
+        reparse_tag = 0
+        if isinstance(reparse, windows_fs_module.WindowsReparsePoint):
+            attributes |= windows_fs_module.FILE_ATTRIBUTE_REPARSE_POINT
+            reparse_tag = reparse.tag
+        data = node["data"]
+        assert isinstance(data, bytes)
+        version = int(node["version"])
+        return windows_fs_module.WindowsHandleMetadata(
+            st_dev=7,
+            st_ino=int.from_bytes(file_id[:8], "little"),
+            st_mode=windows_fs_module.windows_mode_from_attributes(attributes),
+            st_size=len(data),
+            st_mtime_ns=version,
+            st_ctime_ns=version,
+            st_nlink=1,
+            st_file_attributes=attributes,
+            file_id_128=file_id,
+            reparse_tag=reparse_tag,
+            delete_pending=False,
+        )
+
+    def iter_directory(self, handle: int):
+        parent_id = self.handles[handle]
+        for name, file_id in list(self._children(parent_id).items()):
+            child_handle = self._new_handle(file_id)
+            try:
+                metadata = self.metadata(child_handle)
+            finally:
+                self.close(child_handle)
+            yield windows_fs_module.WindowsDirectoryEntry(
+                name=name,
+                file_id=int.from_bytes(file_id[:8], "little"),
+                attributes=metadata.st_file_attributes,
+                file_id_128=file_id,
+                reparse_tag=metadata.reparse_tag,
+            )
+
+    def enumerate_directory(
+        self,
+        handle: int,
+    ) -> tuple[windows_fs_module.WindowsDirectoryEntry, ...]:
+        return tuple(self.iter_directory(handle))
+
+    def open_relative(
+        self,
+        parent_handle: int,
+        name: str,
+        *,
+        desired_access: int,
+        is_directory: bool,
+        allow_reparse: bool,
+    ) -> int:
+        del desired_access
+        parent_id = self.handles[parent_handle]
+        file_id = self._children(parent_id)[name]
+        if self.open_relative_hook is not None:
+            file_id = self.open_relative_hook(parent_id, name, file_id)
+        node = self.nodes[file_id]
+        directory = str(node["kind"]) in {"directory", "directory-link"}
+        assert directory is is_directory
+        if node["reparse"] is not None and not allow_reparse:
+            raise ValueError("fake no-follow open rejected a reparse point")
+        assert allow_reparse is (node["reparse"] is not None)
+        return self._new_handle(file_id)
+
+    def query_reparse_point(
+        self,
+        handle: int,
+    ) -> windows_fs_module.WindowsReparsePoint:
+        point = self.nodes[self.handles[handle]]["reparse"]
+        assert isinstance(point, windows_fs_module.WindowsReparsePoint)
+        if self.query_reparse_hook is not None:
+            return self.query_reparse_hook(point)
+        return point
+
+    def read(self, handle: int, size: int) -> bytes:
+        node = self.nodes[self.handles[handle]]
+        data = node["data"]
+        assert isinstance(data, bytes)
+        offset = self.offsets[handle]
+        block = data[offset : offset + size]
+        self.offsets[handle] += len(block)
+        return block
+
+
+def _open_fake_windows_resolution(
+    api: _FakeWindowsSourceApi,
+    relative: str,
+):
+    selected, authority, root_identity = (
+        contained_source_module._open_windows_pinned_repository_root(
+            Path(r"C:\repo"),
+            api=api,
+        )
+    )
+    scan = source_fingerprint_module._scan_pinned_windows_repository(
+        selected,
+        authority.handle,
+        excluded=(),
+        collect_entries=True,
+    )
+    record = next(entry for entry in scan.entries if entry.relative == relative)
+    binding = contained_source_module._open_windows_resolution_at(
+        Path(r"C:\repo"),
+        authority,
+        tuple(relative.split("/")),
+        expected_root_identity=root_identity,
+        expected_final_identity=source_fingerprint_module._entry_version_identity(
+            record.metadata
+        ),
+        allow_stable_unresolved=True,
+        api=selected,
+    )
+    return authority, binding
+
+
+def _fake_windows_resolution_handoff_case(
+    case: str,
+) -> tuple[
+    _FakeWindowsSourceApi,
+    object,
+    tuple[object, ...],
+    tuple[object, ...],
+]:
+    api = _FakeWindowsSourceApi()
+    if case == "regular":
+        api.add_file(api.root_id, "current.py", b"VALUE = 1\n")
+    elif case == "link-loop":
+        api.add_symlink(api.root_id, "current.py", "current.py")
+    elif case == "directory":
+        api.add_symlink(api.root_id, "current.py", ".", directory=True)
+    elif case == "missing":
+        api.add_symlink(api.root_id, "current.py", "missing.py")
+    else:  # pragma: no cover - test parameter invariant
+        raise AssertionError(case)
+    selected, authority, root_identity = (
+        contained_source_module._open_windows_pinned_repository_root(
+            Path(r"C:\repo"),
+            api=api,
+        )
+    )
+    scan = source_fingerprint_module._scan_pinned_windows_repository(
+        selected,
+        authority.handle,
+        excluded=(),
+        collect_entries=True,
+    )
+    record = scan.entries[0]
+    if case == "missing":
+        del api._children(api.root_id)["current.py"]
+    return (
+        api,
+        authority,
+        root_identity,
+        source_fingerprint_module._entry_version_identity(record.metadata),
+    )
+
+
+def _opcode_offset(
+    function,
+    *,
+    source_text: str,
+    opname: str,
+    argval: object | None = None,
+    occurrence: str = "last",
+) -> int:
+    lines, first_line = inspect.getsourcelines(function)
+    matching_lines = [
+        first_line + index for index, line in enumerate(lines) if source_text in line
+    ]
+    assert matching_lines
+    target_line = matching_lines[-1] if occurrence == "last" else matching_lines[0]
+    current_line = None
+    matches: list[int] = []
+    for instruction in dis.get_instructions(function):
+        if instruction.starts_line is not None:
+            current_line = instruction.starts_line
+        if (
+            current_line == target_line
+            and instruction.opname == opname
+            and (argval is None or instruction.argval == argval)
+        ):
+            matches.append(instruction.offset)
+    assert matches
+    return matches[-1] if occurrence == "last" else matches[0]
 
 
 def test_fingerprint_changes_with_source_content_and_path(tmp_path):
@@ -46,6 +1108,1422 @@ def test_fingerprint_changes_with_source_content_and_path(tmp_path):
     source.rename(tmp_path / "renamed.py")
     changed_path = fingerprint_repository(tmp_path)
     assert changed_path.value != changed_content.value
+
+
+def test_v2_fingerprint_is_canonical_and_deterministic(tmp_path: Path) -> None:
+    (tmp_path / "module.py").write_bytes(b"VALUE = 1\n")
+
+    first = fingerprint_repository(tmp_path)
+    second = fingerprint_repository(tmp_path)
+
+    assert SOURCE_FINGERPRINT_VERSION == 2
+    assert first == second
+    assert first.value.startswith("sha256-v2:")
+    assert is_secure_source_fingerprint_v2(first.value)
+    assert source_fingerprint_version(first.value) == 2
+
+
+def test_windows_fake_regular_tree_matches_posix_v1_and_v2(
+    tmp_path: Path,
+) -> None:
+    package = tmp_path / "package"
+    package.mkdir()
+    (tmp_path / "module.py").write_bytes(b"VALUE = 1\n")
+    (package / "nested.py").write_bytes(b"NESTED = 1\n")
+    expected_v1 = fingerprint_repository_v1_for_diagnostics(tmp_path)
+    expected_v2 = fingerprint_repository(tmp_path)
+
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "module.py", b"VALUE = 1\n")
+    fake_package = api.add_directory(api.root_id, "package")
+    api.add_file(fake_package, "nested.py", b"NESTED = 1\n")
+
+    observed_v1 = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=1,
+        api=api,
+    )
+    observed_v2 = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+    )
+
+    assert observed_v1 == expected_v1
+    assert observed_v2 == expected_v2
+    assert api.handles == {}
+    assert set(api.created_paths) == {"C:\\"}
+
+
+def test_windows_reparse_parser_is_bounded_and_exact() -> None:
+    substitute = r"target.py".encode("utf-16-le")
+    printable = r"target.py".encode("utf-16-le")
+    path_buffer = substitute + printable
+    data_length = 12 + len(path_buffer)
+    payload = b"".join(
+        (
+            windows_fs_module.IO_REPARSE_TAG_SYMLINK.to_bytes(4, "little"),
+            data_length.to_bytes(2, "little"),
+            b"\0\0",
+            (0).to_bytes(2, "little"),
+            len(substitute).to_bytes(2, "little"),
+            len(substitute).to_bytes(2, "little"),
+            len(printable).to_bytes(2, "little"),
+            windows_fs_module.SYMLINK_FLAG_RELATIVE.to_bytes(4, "little"),
+            path_buffer,
+        )
+    )
+
+    assert windows_fs_module.parse_windows_reparse_data(payload) == (
+        windows_fs_module.WindowsReparsePoint(
+            tag=windows_fs_module.IO_REPARSE_TAG_SYMLINK,
+            substitute_name="target.py",
+            print_name="target.py",
+            flags=windows_fs_module.SYMLINK_FLAG_RELATIVE,
+        )
+    )
+    with pytest.raises(RuntimeError, match="out of bounds"):
+        windows_fs_module.parse_windows_reparse_data(
+            payload[:10] + (0xFFFE).to_bytes(2, "little") + payload[12:]
+        )
+
+
+def test_windows_fake_public_contained_read_and_hash_close_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "target.py", b"VALUE = 1\n")
+    api.add_symlink(api.root_id, "current.py", "target.py")
+    monkeypatch.setattr(contained_source_module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        contained_source_module,
+        "_windows_kernel_api",
+        lambda: api,
+    )
+    monkeypatch.setattr(
+        contained_source_module,
+        "_shared_windows_require_source_api",
+        lambda _api: None,
+    )
+
+    contained_source_module.validate_repository_file(
+        r"C:\repo",
+        "current.py",
+    )
+    assert (
+        contained_source_module.read_repository_file(
+            r"C:\repo",
+            "current.py",
+            max_bytes=64,
+        )
+        == b"VALUE = 1\n"
+    )
+    digest = hashlib.sha256()
+    contained_source_module.update_repository_file_hash(
+        r"C:\repo",
+        "current.py",
+        digest,
+    )
+
+    assert digest.hexdigest() == hashlib.sha256(b"VALUE = 1\n").hexdigest()
+    assert api.handles == {}
+
+
+def test_windows_fake_relative_symlink_matches_posix_v1_and_v2(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "target.py").write_bytes(b"VALUE = 1\n")
+    try:
+        (tmp_path / "current.py").symlink_to("target.py")
+    except OSError as exc:  # pragma: no cover - platform capability
+        pytest.skip(f"symlink parity fixture is unavailable: {exc}")
+    expected_v1 = fingerprint_repository_v1_for_diagnostics(tmp_path)
+    expected_v2 = fingerprint_repository(tmp_path)
+
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "target.py", b"VALUE = 1\n")
+    api.add_symlink(api.root_id, "current.py", "target.py")
+
+    assert (
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=1,
+            api=api,
+        )
+        == expected_v1
+    )
+    assert (
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+        == expected_v2
+    )
+    assert api.handles == {}
+
+
+def test_windows_fake_excludes_contained_directory_and_root_links() -> None:
+    api = _FakeWindowsSourceApi()
+    package = api.add_directory(api.root_id, "package")
+    api.add_file(package, "module.py", b"VALUE = 1\n")
+    baseline_v1 = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=1,
+        api=api,
+    )
+    baseline_v2 = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+    )
+    api.add_symlink(
+        api.root_id,
+        "package-link",
+        "package",
+        directory=True,
+    )
+    api.add_symlink(api.root_id, "root-link", ".", directory=True)
+
+    assert (
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=1,
+            api=api,
+        )
+        == baseline_v1
+    )
+    assert (
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+        == baseline_v2
+    )
+    assert api.handles == {}
+
+
+def test_windows_fake_accepts_absolute_contained_symlink() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "target.py", b"VALUE = 1\n")
+    api.add_symlink(
+        api.root_id,
+        "current.py",
+        r"C:\repo\target.py",
+        absolute=True,
+        substitute=r"\??\C:\repo\target.py",
+    )
+
+    observed = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+    )
+
+    assert observed.file_count == 2
+    assert observed.value.startswith("sha256-v2:")
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    "target,absolute,substitute",
+    [
+        (r"..\outside.py", False, None),
+        (r"C:\outside.py", True, r"\??\C:\outside.py"),
+    ],
+)
+def test_windows_fake_rejects_outside_symlink_without_handle_leak(
+    target: str,
+    absolute: bool,
+    substitute: str | None,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(
+        api.root_id,
+        "current.py",
+        target,
+        absolute=absolute,
+        substitute=substitute,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_broken_link_preserves_v1_link_only_semantics() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(api.root_id, "link.py", "missing.py")
+
+    legacy = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=1,
+        api=api,
+    )
+    current = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+    )
+
+    assert legacy.value == _legacy_link_only_digest(b"link.py", b"missing.py")
+    assert legacy.file_count == current.file_count == 1
+    assert current.value != legacy.value
+    assert api.handles == {}
+
+
+def test_windows_fake_rejects_junction_or_unknown_reparse() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_unknown_reparse(api.root_id, "unsafe")
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_rejects_zero_128_bit_entry_identity() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    iter_directory = api.iter_directory
+
+    def zero_identity(handle: int):
+        for entry in iter_directory(handle):
+            yield windows_fs_module.WindowsDirectoryEntry(
+                name=entry.name,
+                file_id=0,
+                attributes=entry.attributes,
+                file_id_128=b"\0" * 16,
+                reparse_tag=entry.reparse_tag,
+            )
+
+    api.iter_directory = zero_identity  # type: ignore[method-assign]
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_rejects_root_a_to_b_to_a_rebind() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 'owned'\n")
+    foreign = api.add_directory()
+    api.add_file(foreign, "source.py", b"VALUE = 'foreign'\n")
+    injected = False
+
+    def reversible_swap(parent: bytes, name: str, original: bytes) -> bytes:
+        nonlocal injected
+        if parent == api.volume_id and name == "repo" and not injected:
+            injected = True
+            return foreign
+        return original
+
+    api.open_relative_hook = reversible_swap
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert injected
+    assert api.handles == {}
+
+
+def test_windows_fake_authority_rejects_late_root_a_to_b_to_a_rebind() -> None:
+    api = _FakeWindowsSourceApi()
+    foreign = api.add_directory()
+    authority = windows_fs_module.open_lexical_directory_authority(
+        r"C:\repo",
+        api=api,
+    )
+    iter_directory = api.iter_directory
+    injected = False
+
+    def reversible_rebind(handle: int):
+        nonlocal injected
+        if api.handles[handle] == api.volume_id and not injected:
+            injected = True
+            yield windows_fs_module.WindowsDirectoryEntry(
+                name="repo",
+                file_id=int.from_bytes(foreign[:8], "little"),
+                attributes=windows_fs_module.FILE_ATTRIBUTE_DIRECTORY,
+                file_id_128=foreign,
+            )
+            return
+        yield from iter_directory(handle)
+
+    api.iter_directory = reversible_rebind  # type: ignore[method-assign]
+    try:
+        with pytest.raises(RuntimeError, match="binding changed"):
+            authority.verify()
+    finally:
+        authority.close()
+
+    assert injected
+    assert api.handles == {}
+
+
+def test_windows_fake_rejects_walker_to_open_foreign_replacement() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 'owned'\n")
+    foreign = api.add_file(api.root_id, ".foreign", b"VALUE = 'foreign'\n")
+    injected = False
+
+    def substitute_open(parent: bytes, name: str, original: bytes) -> bytes:
+        nonlocal injected
+        if parent == api.root_id and name == "source.py" and not injected:
+            injected = True
+            return foreign
+        return original
+
+    api.open_relative_hook = substitute_open
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert injected
+    assert api.handles == {}
+
+
+def test_windows_fake_lexical_root_rejects_intermediate_reparse() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(
+        api.volume_id,
+        "alias",
+        "repo",
+        directory=True,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\alias\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_baseexception_during_reparse_query_closes_handles() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(api.root_id, "current.py", "missing.py")
+
+    def interrupt(_point):
+        raise KeyboardInterrupt("injected reparse interruption")
+
+    api.query_reparse_hook = interrupt
+
+    with pytest.raises(KeyboardInterrupt, match="injected"):
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert api.handles == {}
+
+
+def test_windows_fake_scan_eio_keeps_primary_and_partial_handle_owner() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(api.root_id, "current.py", "missing.py")
+    interruption = SystemExit("injected Windows scan failure")
+    real_query = api.query_reparse_point
+    real_close = api.close
+    failed = 0
+
+    def interrupt_query(handle: int):
+        nonlocal failed
+        failed = handle
+        raise interruption
+
+    def persistent_close(handle: int) -> None:
+        if handle == failed:
+            raise OSError(errno.EIO, "injected Windows scan close EIO")
+        real_close(handle)
+
+    api.query_reparse_point = interrupt_query  # type: ignore[method-assign]
+    api.close = persistent_close  # type: ignore[method-assign]
+
+    with pytest.raises(SystemExit) as caught:
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+        )
+
+    assert caught.value is interruption
+    cleanup_owner = caught.value.source_cleanup_owner
+    assert not cleanup_owner.closed
+    assert failed in api.handles
+
+    api.query_reparse_point = real_query  # type: ignore[method-assign]
+    api.close = real_close  # type: ignore[method-assign]
+    cleanup_owner.close()
+    assert cleanup_owner.closed
+    assert api.handles == {}
+
+
+def test_windows_resolution_construction_eio_keeps_primary_and_retry_owner() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_symlink(api.root_id, "current.py", "missing.py")
+    selected, authority, root_identity = (
+        contained_source_module._open_windows_pinned_repository_root(
+            Path(r"C:\repo"),
+            api=api,
+        )
+    )
+    scan = source_fingerprint_module._scan_pinned_windows_repository(
+        selected,
+        authority.handle,
+        excluded=(),
+        collect_entries=True,
+    )
+    record = scan.entries[0]
+    real_query = api.query_reparse_point
+    real_close = api.close
+    interruption = SystemExit("injected Windows resolution failure")
+    failed = 0
+
+    def interrupt_query(handle: int):
+        nonlocal failed
+        failed = handle
+        raise interruption
+
+    def persistent_close(handle: int) -> None:
+        if handle == failed:
+            raise OSError(errno.EIO, "injected Windows resolution close EIO")
+        real_close(handle)
+
+    api.query_reparse_point = interrupt_query  # type: ignore[method-assign]
+    api.close = persistent_close  # type: ignore[method-assign]
+
+    with pytest.raises(SystemExit) as caught:
+        contained_source_module._open_windows_resolution_at(
+            Path(r"C:\repo"),
+            authority,
+            ("current.py",),
+            expected_root_identity=root_identity,
+            expected_final_identity=(
+                source_fingerprint_module._entry_version_identity(record.metadata)
+            ),
+            allow_stable_unresolved=True,
+            api=selected,
+        )
+
+    assert caught.value is interruption
+    cleanup_owner = caught.value.source_cleanup_owner
+    assert not cleanup_owner.closed
+    assert failed in api.handles
+
+    api.query_reparse_point = real_query  # type: ignore[method-assign]
+    api.close = real_close  # type: ignore[method-assign]
+    cleanup_owner.close()
+    authority.close()
+    assert cleanup_owner.closed
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    ("timing", "interruption"),
+    [
+        pytest.param(
+            "before",
+            KeyboardInterrupt("injected before resolution HANDLE close"),
+            id="before-close",
+        ),
+        pytest.param(
+            "after",
+            SystemExit("injected after resolution HANDLE close"),
+            id="after-close",
+        ),
+    ],
+)
+def test_windows_fake_resolution_close_finishes_chain_before_cancellation(
+    timing: str,
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    authority, binding = _open_fake_windows_resolution(api, "source.py")
+    targets = set(binding.handles)
+    real_close = api.close
+    injected = False
+    seen: set[int] = set()
+
+    def interrupt_one_close(handle: int) -> None:
+        nonlocal injected
+        if handle in targets:
+            seen.add(handle)
+            if not injected:
+                injected = True
+                if timing == "before":
+                    raise interruption
+                real_close(handle)
+                raise interruption
+        real_close(handle)
+
+    api.close = interrupt_one_close  # type: ignore[method-assign]
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert injected
+    assert binding.closed
+    assert binding.handles == []
+    assert targets <= seen
+    assert targets.isdisjoint(api.handles)
+
+    api.close = real_close  # type: ignore[method-assign]
+    authority.close()
+    assert api.handles == {}
+
+
+def test_windows_fake_resolution_close_persistent_eio_retains_retry_owner() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    authority, binding = _open_fake_windows_resolution(api, "source.py")
+    targets = tuple(binding.handles)
+    failed = targets[-1]
+    real_close = api.close
+
+    def persistent_eio(handle: int) -> None:
+        if handle == failed:
+            raise OSError(errno.EIO, "injected resolution HANDLE EIO")
+        real_close(handle)
+
+    api.close = persistent_eio  # type: ignore[method-assign]
+    with pytest.raises(OSError, match="resolution HANDLE EIO"):
+        binding.close()
+
+    assert not binding.closed
+    assert binding.handles == [failed]
+    assert set(api.handles) == {failed, *authority.handles}
+    with pytest.raises(ValueError, match="closed"):
+        binding.verify()
+
+    api.close = real_close  # type: ignore[method-assign]
+    binding.close()
+    assert binding.closed
+    authority.close()
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize("case", ["regular", "link-loop", "directory", "missing"])
+@pytest.mark.parametrize("timing", ["before-store", "after-store"])
+def test_windows_resolution_binding_slot_store_cancellation_closes_every_branch(
+    case: str,
+    timing: str,
+) -> None:
+    api, authority, root_identity, expected_identity = (
+        _fake_windows_resolution_handoff_case(case)
+    )
+    interruption = KeyboardInterrupt(f"injected {case} {timing}")
+
+    class InterruptingSlot(contained_source_module._SourceCleanupSlot):
+        def own(self, resource: object) -> None:
+            is_binding = isinstance(
+                resource,
+                contained_source_module._WindowsResolutionBinding,
+            )
+            if is_binding and timing == "before-store":
+                raise interruption
+            super().own(resource)
+            if is_binding and timing == "after-store":
+                raise interruption
+
+    slot = InterruptingSlot()
+    with pytest.raises(KeyboardInterrupt) as caught:
+        contained_source_module._open_windows_resolution_at(
+            Path(r"C:\repo"),
+            authority,
+            ("current.py",),
+            expected_root_identity=root_identity,
+            expected_final_identity=expected_identity,
+            allow_stable_unresolved=True,
+            api=api,
+            cleanup_slot=slot,
+        )
+
+    assert caught.value is interruption
+    assert slot.closed
+    assert set(api.handles) == set(authority.handles)
+    authority.close()
+    assert api.handles == {}
+
+
+def test_windows_resolution_return_cancellation_closes_slot_owner() -> None:
+    api, authority, root_identity, expected_identity = (
+        _fake_windows_resolution_handoff_case("regular")
+    )
+    method = contained_source_module._open_windows_resolution_at
+    target_offset = _opcode_offset(
+        method,
+        source_text="return binding",
+        opname="LOAD_FAST",
+        argval="binding",
+    )
+    interruption = SystemExit("injected resolution RETURN_VALUE cancellation")
+    injected = False
+    slot = contained_source_module._SourceCleanupSlot()
+
+    def interrupt_return(frame, event, _arg):
+        nonlocal injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "opcode"
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            raise interruption
+        frame.f_trace_opcodes = True
+        return interrupt_return
+
+    sys.settrace(interrupt_return)
+    try:
+        with pytest.raises(SystemExit) as caught:
+            method(
+                Path(r"C:\repo"),
+                authority,
+                ("current.py",),
+                expected_root_identity=root_identity,
+                expected_final_identity=expected_identity,
+                allow_stable_unresolved=True,
+                api=api,
+                cleanup_slot=slot,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected
+    assert slot.closed
+    assert set(api.handles) == set(authority.handles)
+    authority.close()
+    assert api.handles == {}
+
+
+def test_windows_resolution_return_eio_retains_owner_without_double_close() -> None:
+    api, authority, root_identity, expected_identity = (
+        _fake_windows_resolution_handoff_case("regular")
+    )
+    method = contained_source_module._open_windows_resolution_at
+    target_offset = _opcode_offset(
+        method,
+        source_text="return binding",
+        opname="LOAD_FAST",
+        argval="binding",
+    )
+    interruption = KeyboardInterrupt("injected resolution return cancellation")
+    real_close = api.close
+    failed = 0
+    close_calls: dict[int, int] = {}
+    injected = False
+    armed = False
+    slot = contained_source_module._SourceCleanupSlot()
+
+    def persistent_close(handle: int) -> None:
+        nonlocal failed
+        if not armed:
+            real_close(handle)
+            return
+        close_calls[handle] = close_calls.get(handle, 0) + 1
+        if handle not in authority.handles and not failed:
+            failed = handle
+        if handle == failed:
+            raise OSError(errno.EIO, "injected resolution return close EIO")
+        real_close(handle)
+
+    def interrupt_return(frame, event, _arg):
+        nonlocal armed, injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "opcode"
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            armed = True
+            raise interruption
+        frame.f_trace_opcodes = True
+        return interrupt_return
+
+    api.close = persistent_close  # type: ignore[method-assign]
+    sys.settrace(interrupt_return)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            method(
+                Path(r"C:\repo"),
+                authority,
+                ("current.py",),
+                expected_root_identity=root_identity,
+                expected_final_identity=expected_identity,
+                allow_stable_unresolved=True,
+                api=api,
+                cleanup_slot=slot,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert caught.value.source_cleanup_owner is slot
+    assert failed in api.handles
+    closed_once = {
+        handle
+        for handle, calls in close_calls.items()
+        if handle != failed and calls == 1
+    }
+    assert closed_once
+
+    api.close = real_close  # type: ignore[method-assign]
+    slot.close()
+    assert slot.closed
+    assert set(api.handles) == set(authority.handles)
+    assert all(close_calls[handle] == 1 for handle in closed_once)
+    authority.close()
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("after final resolution close"), id="keyboard"),
+        pytest.param(SystemExit("after final resolution close"), id="system-exit"),
+    ],
+)
+def test_windows_resolution_close_retry_publishes_closed_after_empty_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    authority, binding = _open_fake_windows_resolution(api, "source.py")
+    real_close_handles = contained_source_module._close_windows_handles
+    injected = False
+
+    def close_then_interrupt(*args, **kwargs):
+        nonlocal injected
+        failure = real_close_handles(*args, **kwargs)
+        if not injected:
+            injected = True
+            raise interruption
+        return failure
+
+    monkeypatch.setattr(
+        contained_source_module,
+        "_close_windows_handles",
+        close_then_interrupt,
+    )
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert binding.handles == []
+    assert not binding.closed
+
+    binding.close()
+    assert binding.closed
+    authority.close()
+    assert api.handles == {}
+
+
+def test_windows_fake_resolution_close_uses_stable_handle_cookie() -> None:
+    api = _FakeWindowsSourceApi()
+    file_id = api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    authority, binding = _open_fake_windows_resolution(api, "source.py")
+    api.nodes[file_id]["version"] = 2
+
+    binding.close()
+
+    assert binding.closed
+    authority.close()
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    ("timing", "interruption"),
+    [
+        pytest.param(
+            "before",
+            KeyboardInterrupt("injected before HANDLE close"),
+            id="before-close",
+        ),
+        pytest.param(
+            "after",
+            SystemExit("injected after HANDLE close"),
+            id="after-close",
+        ),
+    ],
+)
+def test_windows_fake_binding_close_finishes_handle_chain_before_cancellation(
+    timing: str,
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    targets = set(api.handles)
+    real_close = api.close
+    calls = 0
+    injected = False
+    seen: set[int] = set()
+
+    def interrupt_one_close(handle: int) -> None:
+        nonlocal calls, injected
+        if handle in targets:
+            seen.add(handle)
+            calls += 1
+            if calls == 2 and not injected:
+                injected = True
+                if timing == "before":
+                    raise interruption
+                real_close(handle)
+                raise interruption
+        real_close(handle)
+
+    api.close = interrupt_one_close  # type: ignore[method-assign]
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert injected
+    assert binding.closed
+    assert targets <= seen
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_close_commits_interrupted_owner_pop() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    interruption = SystemExit("injected after HANDLE owner pop")
+    authority.handles = _InterruptAfterPopList(
+        authority.handles,
+        interruption,
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert binding.closed
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize("timing", ["before-root-store", "after-root-store", "return"])
+def test_windows_repository_binding_handoff_cancellation_closes_slot_owner(
+    timing: str,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    method = source_fingerprint_module._fingerprint_windows_repository
+    store_offset = _opcode_offset(
+        method,
+        source_text="root_authority = None",
+        opname="STORE_FAST",
+        argval="root_authority",
+    )
+    instructions = list(dis.get_instructions(method))
+    store_index = next(
+        index
+        for index, instruction in enumerate(instructions)
+        if instruction.offset == store_offset
+    )
+    offsets = {
+        "before-root-store": store_offset,
+        "after-root-store": instructions[store_index + 1].offset,
+        "return": _opcode_offset(
+            method,
+            source_text="return binding",
+            opname="LOAD_FAST",
+            argval="binding",
+        ),
+    }
+    target_offset = offsets[timing]
+    interruption = SystemExit(f"injected repository {timing} cancellation")
+    injected = False
+    owner = SourceBindingCleanupOwner()
+
+    def interrupt_handoff(frame, event, _arg):
+        nonlocal injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "opcode"
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            raise interruption
+        frame.f_trace_opcodes = True
+        return interrupt_handoff
+
+    sys.settrace(interrupt_handoff)
+    try:
+        with pytest.raises(SystemExit) as caught:
+            method(
+                r"C:\repo",
+                exclude_roots=(),
+                version=SOURCE_FINGERPRINT_VERSION,
+                api=api,
+                retain_binding=True,
+                source_owner=owner.retain,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    assert injected
+    assert owner.pending_sources == ()
+    owner.close()
+    assert owner.closed
+    assert api.handles == {}
+
+
+def test_windows_repository_return_eio_attaches_retry_owner_without_double_close() -> (
+    None
+):
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    method = source_fingerprint_module._fingerprint_windows_repository
+    target_offset = _opcode_offset(
+        method,
+        source_text="return binding",
+        opname="LOAD_FAST",
+        argval="binding",
+    )
+    interruption = KeyboardInterrupt("injected repository return cancellation")
+    owner = SourceBindingCleanupOwner()
+    real_close = api.close
+    failed = 0
+    close_calls: dict[int, int] = {}
+    injected = False
+    armed = False
+
+    def persistent_close(handle: int) -> None:
+        nonlocal failed
+        if not armed:
+            real_close(handle)
+            return
+        close_calls[handle] = close_calls.get(handle, 0) + 1
+        if not failed:
+            failed = handle
+        if handle == failed:
+            raise OSError(errno.EIO, "injected repository return close EIO")
+        real_close(handle)
+
+    def interrupt_return(frame, event, _arg):
+        nonlocal armed, injected
+        if (
+            not injected
+            and frame.f_code is method.__code__
+            and event == "opcode"
+            and frame.f_lasti == target_offset
+        ):
+            injected = True
+            armed = True
+            raise interruption
+        frame.f_trace_opcodes = True
+        return interrupt_return
+
+    api.close = persistent_close  # type: ignore[method-assign]
+    sys.settrace(interrupt_return)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            method(
+                r"C:\repo",
+                exclude_roots=(),
+                version=SOURCE_FINGERPRINT_VERSION,
+                api=api,
+                retain_binding=True,
+                source_owner=owner.retain,
+            )
+    finally:
+        sys.settrace(None)
+
+    assert caught.value is interruption
+    retry_owner = caught.value.source_cleanup_owner
+    assert not retry_owner.closed
+    assert failed in api.handles
+    closed_once = {
+        handle
+        for handle, calls in close_calls.items()
+        if handle != failed and calls == 1
+    }
+    assert closed_once
+
+    api.close = real_close  # type: ignore[method-assign]
+    owner.close()
+    assert owner.closed
+    assert api.handles == {}
+    assert all(close_calls[handle] == 1 for handle in closed_once)
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("after final authority close"), id="keyboard"),
+        pytest.param(SystemExit("after final authority close"), id="system-exit"),
+    ],
+)
+def test_windows_binding_close_retry_converges_after_empty_authority_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    real_close_handles = windows_fs_module._close_windows_handles
+    injected = False
+
+    def close_then_interrupt(*args, **kwargs):
+        nonlocal injected
+        failure = real_close_handles(*args, **kwargs)
+        if not injected:
+            injected = True
+            raise interruption
+        return failure
+
+    monkeypatch.setattr(
+        windows_fs_module,
+        "_close_windows_handles",
+        close_then_interrupt,
+    )
+    with pytest.raises(type(interruption)) as caught:
+        binding.close()
+
+    assert caught.value is interruption
+    assert authority.handles == []
+    assert not authority.closed
+    assert not binding.closed
+
+    binding.close()
+    assert authority.closed
+    assert binding.closed
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_close_persistent_eio_keeps_owner_and_closes_rest() -> (
+    None
+):
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    targets = tuple(authority.handles)
+    failed = targets[-1]
+    real_close = api.close
+
+    def fail_one_handle(handle: int) -> None:
+        if handle == failed:
+            raise OSError(errno.EIO, "injected persistent HANDLE EIO")
+        real_close(handle)
+
+    api.close = fail_one_handle  # type: ignore[method-assign]
+    with pytest.raises(OSError, match="persistent HANDLE EIO"):
+        binding.close()
+
+    assert not binding.closed
+    assert not binding.usable
+    assert authority.handles == [failed]
+    assert set(api.handles) == {failed}
+
+    api.close = real_close  # type: ignore[method-assign]
+    binding.close()
+    assert binding.closed
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_close_preflight_eio_keeps_owner_and_closes_rest() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    targets = tuple(authority.handles)
+    failed = targets[-1]
+    real_metadata = api.metadata
+
+    def fail_one_handle(handle: int):
+        if handle == failed:
+            raise OSError(errno.EIO, "injected persistent HANDLE metadata EIO")
+        return real_metadata(handle)
+
+    api.metadata = fail_one_handle  # type: ignore[method-assign]
+    with pytest.raises(OSError, match="persistent HANDLE metadata EIO"):
+        binding.close()
+
+    assert not binding.closed
+    assert not binding.usable
+    assert authority.handles == [failed]
+    assert set(api.handles) == {failed}
+
+    api.metadata = real_metadata  # type: ignore[method-assign]
+    binding.close()
+    assert binding.closed
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_close_uses_stable_handle_identity() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    api.nodes[api.root_id]["version"] = 2
+
+    binding.close()
+
+    assert binding.closed
+    assert api.handles == {}
+
+
+def test_windows_fake_binding_close_does_not_close_reused_handle() -> None:
+    api = _FakeWindowsSourceApi()
+    api.add_file(api.root_id, "source.py", b"VALUE = 1\n")
+    binding = source_fingerprint_module._fingerprint_windows_repository(
+        r"C:\repo",
+        exclude_roots=(),
+        version=SOURCE_FINGERPRINT_VERSION,
+        api=api,
+        retain_binding=True,
+    )
+    assert isinstance(binding, RepositorySourceBinding)
+    authority = binding._windows_authority
+    assert authority is not None
+    reused = authority.handles[-1]
+    replacement_id = api.add_directory()
+    api.close(reused)
+    api.handles[reused] = replacement_id
+    api.offsets[reused] = 0
+
+    with pytest.raises(RuntimeError, match="ownership changed"):
+        binding.close()
+
+    assert binding.closed
+    assert api.handles == {reused: replacement_id}
+    api.close(reused)
+
+
+def test_windows_kernel_close_checks_closehandle_result() -> None:
+    class CloseFailureApi(windows_fs_module.WindowsKernelApi):
+        def _raise_last_error(self, context: str) -> None:
+            raise OSError(errno.EIO, context)
+
+    api = object.__new__(CloseFailureApi)
+    api.kernel32 = SimpleNamespace(CloseHandle=lambda _handle: 0)
+    api.invalid_handle = -1
+
+    with pytest.raises(OSError, match="could not close"):
+        api.close(41)
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("Windows root interrupted"), id="keyboard"),
+        pytest.param(SystemExit("Windows root exited"), id="system-exit"),
+    ],
+)
+def test_windows_fake_root_open_failure_closes_owned_handles(
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    real_metadata = api.metadata
+    calls = 0
+
+    def interrupt_after_child_open(handle: int):
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise interruption
+        return real_metadata(handle)
+
+    api.metadata = interrupt_after_child_open  # type: ignore[method-assign]
+    with pytest.raises(type(interruption)) as caught:
+        windows_fs_module.open_lexical_directory_authority(
+            r"C:\repo",
+            api=api,
+        )
+
+    assert caught.value is interruption
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        pytest.param(KeyboardInterrupt("after direct authority close"), id="keyboard"),
+        pytest.param(SystemExit("after direct authority close"), id="system-exit"),
+    ],
+)
+def test_windows_authority_close_retry_converges_after_last_handle_removed(
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    api = _FakeWindowsSourceApi()
+    authority = windows_fs_module.open_lexical_directory_authority(
+        r"C:\repo",
+        api=api,
+    )
+    real_close_handles = windows_fs_module._close_windows_handles
+    injected = False
+
+    def close_then_interrupt(*args, **kwargs):
+        nonlocal injected
+        failure = real_close_handles(*args, **kwargs)
+        if not injected:
+            injected = True
+            raise interruption
+        return failure
+
+    monkeypatch.setattr(
+        windows_fs_module,
+        "_close_windows_handles",
+        close_then_interrupt,
+    )
+    with pytest.raises(type(interruption)) as caught:
+        authority.close()
+
+    assert caught.value is interruption
+    assert authority.handles == []
+    assert not authority.closed
+
+    authority.close()
+    assert authority.closed
+    assert api.handles == {}
+
+
+def test_windows_root_construction_eio_keeps_preinstalled_retry_owner() -> None:
+    api = _FakeWindowsSourceApi()
+    owner = SourceBindingCleanupOwner()
+    real_metadata = api.metadata
+    real_close = api.close
+    interruption = KeyboardInterrupt("injected Windows root construction failure")
+    metadata_calls = 0
+    failed = 0
+
+    def interrupt_metadata(handle: int):
+        nonlocal metadata_calls
+        metadata_calls += 1
+        if metadata_calls == 3:
+            raise interruption
+        return real_metadata(handle)
+
+    def persistent_close(handle: int) -> None:
+        nonlocal failed
+        if not failed:
+            failed = handle
+        if handle == failed:
+            raise OSError(errno.EIO, "injected Windows construction close EIO")
+        real_close(handle)
+
+    api.metadata = interrupt_metadata  # type: ignore[method-assign]
+    api.close = persistent_close  # type: ignore[method-assign]
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        source_fingerprint_module._fingerprint_windows_repository(
+            r"C:\repo",
+            exclude_roots=(),
+            version=SOURCE_FINGERPRINT_VERSION,
+            api=api,
+            retain_binding=True,
+            source_owner=owner.retain,
+        )
+
+    assert caught.value is interruption
+    assert not owner.closed
+    assert failed in api.handles
+
+    api.metadata = real_metadata  # type: ignore[method-assign]
+    api.close = real_close  # type: ignore[method-assign]
+    owner.close()
+    assert owner.closed
+    assert api.handles == {}
 
 
 def test_fingerprint_ignores_generated_and_explicit_artifact_roots(tmp_path):
@@ -110,10 +2588,283 @@ def test_fingerprint_preserves_v1_link_only_terminal_digest(
         target = "link.py"
     link.symlink_to(target)
 
-    observed = fingerprint_repository(repo)
+    observed = fingerprint_repository_v1_for_diagnostics(repo)
+    current = fingerprint_repository(repo)
 
     assert observed.file_count == 1
     assert observed.value == _legacy_link_only_digest(b"link.py", os.fsencode(target))
+    assert is_legacy_source_fingerprint_v1(observed.value)
+    assert source_fingerprint_version(observed.value) == 1
+    assert current.value != observed.value
+
+
+def test_v2_framing_separates_a_v1_structural_collision(tmp_path: Path) -> None:
+    state_a = tmp_path / "state-a"
+    state_b = tmp_path / "state-b"
+    state_a.mkdir()
+    state_b.mkdir()
+    (state_a / "a").write_bytes(b"")
+    (state_a / "b").write_bytes(b"X\0F\0c\0Y")
+    (state_b / "a").write_bytes(b"\0F\0b\0X")
+    (state_b / "c").write_bytes(b"Y")
+
+    legacy_a = fingerprint_repository_v1_for_diagnostics(state_a)
+    legacy_b = fingerprint_repository_v1_for_diagnostics(state_b)
+    current_a = fingerprint_repository(state_a)
+    current_b = fingerprint_repository(state_b)
+
+    assert legacy_a.file_count == legacy_b.file_count == 2
+    assert legacy_a.value == legacy_b.value
+    assert current_a.file_count == current_b.file_count == 2
+    assert current_a.value != current_b.value
+
+
+def test_fingerprint_rejects_reversible_root_swap_after_enumeration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    replacement = tmp_path / "replacement"
+    parked = tmp_path / "parked"
+    repo.mkdir()
+    replacement.mkdir()
+    (repo / "source.py").write_text("VALUE = 'owned'\n", encoding="utf-8")
+    (replacement / "source.py").write_text("VALUE = 'foreign'\n", encoding="utf-8")
+    real_resolve = source_fingerprint_module._resolved_repository_file_at
+    swapped = False
+
+    @contextmanager
+    def swap_root(root, descriptor, relative, **kwargs):
+        nonlocal swapped
+        if swapped:
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+            return
+        swapped = True
+        repo.rename(parked)
+        replacement.rename(repo)
+        try:
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+        finally:
+            repo.rename(replacement)
+            parked.rename(repo)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_repository_file_at",
+        swap_root,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        fingerprint_repository(repo)
+    assert (repo / "source.py").read_text(encoding="utf-8") == "VALUE = 'owned'\n"
+    assert (replacement / "source.py").read_text(encoding="utf-8") == (
+        "VALUE = 'foreign'\n"
+    )
+
+
+def test_fingerprint_never_resolves_replaceable_root_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    replacement = tmp_path / "replacement"
+    parked = tmp_path / "parked"
+    repo.mkdir()
+    replacement.mkdir()
+    (repo / "source.py").write_text("VALUE = 'owned'\n", encoding="utf-8")
+    (replacement / "source.py").write_text("VALUE = 'foreign'\n", encoding="utf-8")
+    expected = fingerprint_repository(repo)
+    real_resolve = Path.resolve
+    resolve_calls = 0
+
+    def redirect_during_resolve(path, *args, **kwargs):
+        nonlocal resolve_calls
+        resolve_calls += 1
+        repo.rename(parked)
+        replacement.rename(repo)
+        try:
+            return real_resolve(replacement, *args, **kwargs)
+        finally:
+            repo.rename(replacement)
+            parked.rename(repo)
+
+    monkeypatch.setattr(Path, "resolve", redirect_during_resolve)
+
+    assert fingerprint_repository(repo) == expected
+    assert resolve_calls == 0
+
+
+def test_fingerprint_rejects_symlink_repository_root(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    alias = tmp_path / "alias"
+    repo.mkdir()
+    (repo / "source.py").write_text("VALUE = 1\n", encoding="utf-8")
+    try:
+        alias.symlink_to(repo, target_is_directory=True)
+    except OSError as exc:  # pragma: no cover - platform capability
+        pytest.skip(f"source fingerprint root test needs symlink support: {exc}")
+
+    with pytest.raises(RepositoryChangedError, match="repository changed"):
+        fingerprint_repository(alias)
+
+
+def test_scan_charges_wide_directory_before_sorting_all_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = 0
+
+    class WideDirectory:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            nonlocal observed
+            observed += 1
+            if observed > 4:  # pragma: no cover - proves eager scan regression
+                raise AssertionError("scanner consumed entries beyond its budget")
+            return SimpleNamespace(name=f"source-{observed}.py")
+
+    descriptor = os.open(tmp_path, source_fingerprint_module._directory_flags())
+    try:
+        monkeypatch.setattr(source_fingerprint_module, "_MAX_SOURCE_ENTRIES", 3)
+        monkeypatch.setattr(
+            source_fingerprint_module.os,
+            "scandir",
+            lambda _descriptor: WideDirectory(),
+        )
+
+        with pytest.raises(ValueError, match="entry limit"):
+            source_fingerprint_module._scan_pinned_repository(
+                descriptor,
+                excluded=(),
+                collect_entries=True,
+            )
+    finally:
+        os.close(descriptor)
+
+    assert observed == 4
+
+
+def test_fingerprint_scan_failure_closes_pinned_root_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    descriptor_root = Path("/proc/self/fd")
+    if not descriptor_root.is_dir():  # pragma: no cover - non-Linux host
+        pytest.skip("descriptor accounting needs /proc/self/fd")
+    (tmp_path / "source.py").write_text("VALUE = 1\n", encoding="utf-8")
+    before = len(tuple(descriptor_root.iterdir()))
+
+    def fail_scan(*_args, **_kwargs):
+        raise ValueError("injected scan failure")
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_repository",
+        fail_scan,
+    )
+    for _ in range(32):
+        with pytest.raises(RepositoryChangedError, match="repository changed"):
+            fingerprint_repository(tmp_path)
+
+    after = len(tuple(descriptor_root.iterdir()))
+    assert after <= before + 1
+
+
+def test_fingerprint_rejects_reversible_intermediate_swap_after_enumeration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    package = repo / "package"
+    replacement = tmp_path / "replacement"
+    parked = tmp_path / "parked"
+    package.mkdir(parents=True)
+    replacement.mkdir()
+    (package / "source.py").write_text("VALUE = 'owned'\n", encoding="utf-8")
+    (replacement / "source.py").write_text("VALUE = 'foreign'\n", encoding="utf-8")
+    real_resolve = source_fingerprint_module._resolved_repository_file_at
+    swapped = False
+
+    @contextmanager
+    def swap_intermediate(root, descriptor, relative, **kwargs):
+        nonlocal swapped
+        if swapped or relative != "package/source.py":
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+            return
+        swapped = True
+        package.rename(parked)
+        replacement.rename(package)
+        try:
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+        finally:
+            package.rename(replacement)
+            parked.rename(package)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_repository_file_at",
+        swap_intermediate,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        fingerprint_repository(repo)
+    assert (package / "source.py").read_text(encoding="utf-8") == ("VALUE = 'owned'\n")
+    assert (replacement / "source.py").read_text(encoding="utf-8") == (
+        "VALUE = 'foreign'\n"
+    )
+
+
+def test_fingerprint_rejects_file_swap_in_walker_to_open_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.py"
+    foreign = tmp_path / ".foreign"
+    parked = tmp_path / ".parked"
+    source.write_text("VALUE = 'owned'\n", encoding="utf-8")
+    foreign.write_text("VALUE = 'foreign'\n", encoding="utf-8")
+    real_resolve = source_fingerprint_module._resolved_repository_file_at
+    swapped = False
+
+    @contextmanager
+    def swap_file(root, descriptor, relative, **kwargs):
+        nonlocal swapped
+        if swapped or relative != "source.py":
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+            return
+        swapped = True
+        source.rename(parked)
+        foreign.rename(source)
+        try:
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+        finally:
+            source.rename(foreign)
+            parked.rename(source)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_repository_file_at",
+        swap_file,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        fingerprint_repository(tmp_path)
+    assert source.read_text(encoding="utf-8") == "VALUE = 'owned'\n"
+    assert foreign.read_text(encoding="utf-8") == "VALUE = 'foreign'\n"
 
 
 def test_fingerprint_accepts_absolute_contained_symlink(tmp_path: Path) -> None:
@@ -128,13 +2879,147 @@ def test_fingerprint_accepts_absolute_contained_symlink(tmp_path: Path) -> None:
     assert observed.file_count == 2
 
 
-def test_fingerprint_rejects_source_symlink_outside_repository(tmp_path) -> None:
+def test_fingerprint_excludes_contained_directory_symlink_in_v1_and_v2(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    package = repo / "package"
+    package.mkdir(parents=True)
+    (package / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
+    link = repo / "package-link"
+    link.symlink_to("package", target_is_directory=True)
+
+    current_with_link = fingerprint_repository(repo)
+    legacy_with_link = fingerprint_repository_v1_for_diagnostics(repo)
+    link.unlink()
+
+    assert fingerprint_repository(repo) == current_with_link
+    assert fingerprint_repository_v1_for_diagnostics(repo) == legacy_with_link
+    assert current_with_link.file_count == legacy_with_link.file_count == 1
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_fingerprint_excludes_repository_root_directory_symlink_in_v1_and_v2(
+    tmp_path: Path,
+    absolute: bool,
+) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
-    (tmp_path / "outside.py").write_text("SECRET = 1\n")
-    (repo / "current.py").symlink_to("../outside.py")
+    (repo / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
+    link = repo / "root-link"
+    link.symlink_to(repo if absolute else ".", target_is_directory=True)
+
+    current_with_link = fingerprint_repository(repo)
+    legacy_with_link = fingerprint_repository_v1_for_diagnostics(repo)
+    link.unlink()
+
+    assert fingerprint_repository(repo) == current_with_link
+    assert fingerprint_repository_v1_for_diagnostics(repo) == legacy_with_link
+    assert current_with_link.file_count == legacy_with_link.file_count == 1
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_fingerprint_rejects_source_symlink_outside_repository(
+    tmp_path: Path,
+    absolute: bool,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("SECRET = 1\n")
+    (repo / "current.py").symlink_to(outside if absolute else "../outside.py")
 
     with pytest.raises(RepositoryChangedError, match="could not be read consistently"):
+        fingerprint_repository(repo)
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_fingerprint_rejects_directory_symlink_outside_repository(
+    tmp_path: Path,
+    absolute: bool,
+) -> None:
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    repo.mkdir()
+    outside.mkdir()
+    (repo / "outside-link").symlink_to(
+        outside if absolute else "../outside",
+        target_is_directory=True,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="could not be read consistently"):
+        fingerprint_repository(repo)
+
+
+def test_inventory_scan_never_follows_source_symlinks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("SECRET = 1\n", encoding="utf-8")
+    (repo / "current.py").symlink_to(outside)
+    descriptor = os.open(repo, source_fingerprint_module._directory_flags())
+    real_stat = os.stat
+
+    def reject_follow(path, *args, **kwargs):
+        if kwargs.get("dir_fd") is not None and kwargs.get("follow_symlinks", True):
+            raise AssertionError("inventory scan followed a source symlink")
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(source_fingerprint_module.os, "stat", reject_follow)
+    try:
+        scan = source_fingerprint_module._scan_pinned_repository(
+            descriptor,
+            excluded=(),
+            collect_entries=True,
+        )
+    finally:
+        os.close(descriptor)
+
+    assert [entry.relative for entry in scan.entries] == ["current.py"]
+
+
+def test_fingerprint_rejects_link_to_directory_swap_before_classification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    directory = repo / "package"
+    repo.mkdir()
+    directory.mkdir()
+    (directory / "module.py").write_text("VALUE = 2\n", encoding="utf-8")
+    (repo / "target.py").write_text("VALUE = 1\n", encoding="utf-8")
+    link = repo / "current.py"
+    link.symlink_to("target.py")
+    real_resolve = source_fingerprint_module._resolved_repository_file_at
+    swapped = False
+
+    @contextmanager
+    def swap_to_directory(root, descriptor, relative, **kwargs):
+        nonlocal swapped
+        if swapped or relative != "current.py":
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+            return
+        swapped = True
+        link.unlink()
+        link.symlink_to("package", target_is_directory=True)
+        try:
+            with real_resolve(root, descriptor, relative, **kwargs) as binding:
+                yield binding
+        finally:
+            link.unlink()
+            link.symlink_to("target.py")
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_resolved_repository_file_at",
+        swap_to_directory,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
         fingerprint_repository(repo)
 
 
@@ -201,3 +3086,172 @@ def test_dirty_check_ignores_generated_dirs_but_detects_source_changes(tmp_path)
 
     source.write_text("VALUE = 2\n")
     assert repository_source_is_dirty(tmp_path) is True
+
+
+def test_dirty_check_never_resolves_replaceable_root_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    observed_command: list[str] = []
+
+    def reject_resolve(*_args, **_kwargs):
+        raise AssertionError("dirty check must keep the lexical repository root")
+
+    def clean_status(command, **_kwargs):
+        observed_command.extend(command)
+        return subprocess.CompletedProcess(command, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(Path, "resolve", reject_resolve)
+    monkeypatch.setattr(source_fingerprint_module.subprocess, "run", clean_status)
+
+    assert repository_source_is_dirty(repo) is False
+    assert observed_command[0:3] == ["git", "-C", str(repo)]
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_source_authority_abi_layout_node(tmp_path: Path) -> None:
+    import ctypes
+
+    api = windows_fs_module.windows_kernel_api()
+    assert ctypes.sizeof(api.FILE_ID_128) == 16
+    assert ctypes.sizeof(api.FILE_ID_INFO) == 24
+    assert api.FILE_ID_EXTD_DIR_INFO.FileId.offset == 72
+    assert api.FILE_ID_EXTD_DIR_INFO.FileName.offset == 88
+
+    handle = api.create_directory_handle(tmp_path)
+    reopened = 0
+    try:
+        metadata = api.metadata(handle)
+        assert windows_fs_module.windows_file_id_is_reliable(metadata.file_id_128)
+        reopened = api.open_by_extended_id(
+            handle,
+            metadata.file_id_128,
+            desired_access=(
+                windows_fs_module.FILE_LIST_DIRECTORY
+                | windows_fs_module.FILE_READ_ATTRIBUTES
+                | windows_fs_module.SYNCHRONIZE
+            ),
+            is_directory=True,
+        )
+        assert api.metadata(reopened).file_identity == metadata.file_identity
+    finally:
+        if reopened:
+            api.close(reopened)
+        api.close(handle)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_source_v2_regular_and_contained_symlink_node(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "target.py"
+    target.write_bytes(b"VALUE = 1\n")
+    try:
+        (repo / "relative.py").symlink_to("target.py")
+        (repo / "absolute.py").symlink_to(target)
+    except OSError as exc:  # pragma: no cover - Windows policy dependent
+        pytest.skip(f"Windows symlink creation is unavailable: {exc}")
+
+    first = fingerprint_repository(repo)
+    second = fingerprint_repository(repo)
+    legacy = fingerprint_repository_v1_for_diagnostics(repo)
+
+    assert first == second
+    assert first.file_count == legacy.file_count == 3
+    assert first.value.startswith("sha256-v2:")
+    assert legacy.value.startswith("sha256:")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_source_v2_rejects_outside_symlink_node(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_bytes(b"SECRET = 1\n")
+    try:
+        (repo / "current.py").symlink_to(outside)
+    except OSError as exc:  # pragma: no cover - Windows policy dependent
+        pytest.skip(f"Windows symlink creation is unavailable: {exc}")
+
+    with pytest.raises(RepositoryChangedError, match="read consistently"):
+        fingerprint_repository(repo)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_source_root_handle_blocks_reversible_swap_node(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_bytes(b"VALUE = 1\n")
+    parked = tmp_path / "parked"
+    scan = source_fingerprint_module._scan_pinned_windows_repository
+    attempted = False
+
+    def attempt_swap(*args, **kwargs):
+        nonlocal attempted
+        if not attempted:
+            attempted = True
+            with pytest.raises(OSError):
+                repo.rename(parked)
+        return scan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "_scan_pinned_windows_repository",
+        attempt_swap,
+    )
+
+    assert fingerprint_repository(repo).file_count == 1
+    assert attempted
+    assert repo.is_dir()
+    assert not parked.exists()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
+def test_windows_real_source_failure_closes_all_handles_node(
+    tmp_path: Path,
+) -> None:
+    import ctypes
+    import ctypes.wintypes as wintypes
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_bytes(b"SECRET = 1\n")
+    try:
+        (repo / "current.py").symlink_to(outside)
+    except OSError as exc:  # pragma: no cover - Windows policy dependent
+        pytest.skip(f"Windows symlink creation is unavailable: {exc}")
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetCurrentProcess.argtypes = ()
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.GetProcessHandleCount.argtypes = (
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.GetProcessHandleCount.restype = wintypes.BOOL
+
+    def handle_count() -> int:
+        count = wintypes.DWORD()
+        if not kernel32.GetProcessHandleCount(
+            kernel32.GetCurrentProcess(),
+            ctypes.byref(count),
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+        return int(count.value)
+
+    before = handle_count()
+    for _ in range(32):
+        with pytest.raises(RepositoryChangedError):
+            fingerprint_repository(repo)
+    after = handle_count()
+
+    assert after <= before + 2

--- a/test/test_vector_pre_model_authorization.py
+++ b/test/test_vector_pre_model_authorization.py
@@ -1,0 +1,375 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import (
+    capture_authenticated_vector_view,
+    require_authorized_vector_view,
+)
+from codenib.native_index_authorization import (
+    InvalidNativeIndexAuthorizationError,
+    MissingNativeIndexAuthorizationError,
+    _mint_trusted_local_admin_authorization,
+)
+
+_VECTOR_CONTRACT = {
+    "builder_schema": 2,
+    "embedding_model": "vendor/model",
+    "embedding_provider": "huggingface",
+    "embedding_dimension": 4,
+    "dimension": 4,
+    "embedding_kwargs": {},
+}
+
+
+def _mint_vector_authorization(root: Path, semantic_contract):
+    root.mkdir(parents=True, exist_ok=True)
+    with capture_authenticated_vector_view(root) as view:
+        return _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=semantic_contract,
+            evidence=(
+                "pre-model-gate-test-local-admin",
+                "captured-vector-tree-subject",
+            ),
+        )
+
+
+def _authorization_case(
+    case: str,
+    *,
+    target: Path,
+    semantic_contract,
+    tmp_path: Path,
+):
+    if case == "missing":
+        return None
+    if case == "malformed":
+        return object()
+    if case == "wrong-tree":
+        wrong_root = tmp_path / f"wrong-tree-{target.name}"
+        return _mint_vector_authorization(wrong_root, semantic_contract)
+    if case == "wrong-semantic":
+        return _mint_vector_authorization(
+            target,
+            {"different": "semantic-contract"},
+        )
+    raise AssertionError(f"unsupported authorization case: {case}")
+
+
+def test_authorized_vector_gate_preserves_primary_base_exception_on_cleanup(
+    monkeypatch,
+) -> None:
+    from codenib.index.embedding import artifact_integrity
+
+    events = []
+    primary_error = KeyboardInterrupt("primary")
+
+    class FailingView:
+        ownership = object()
+
+        def verify_final(self):
+            events.append("verify")
+
+        def close(self):
+            events.append("close")
+            raise SystemExit("cleanup")
+
+    monkeypatch.setattr(
+        artifact_integrity,
+        "require_native_index_authorization_preflight",
+        lambda *_args, **_kwargs: events.append("preflight"),
+    )
+    monkeypatch.setattr(
+        artifact_integrity,
+        "capture_authenticated_vector_view",
+        lambda _root: events.append("capture") or FailingView(),
+    )
+
+    def fail_exact(*_args, **_kwargs):
+        events.append("exact")
+        raise primary_error
+
+    monkeypatch.setattr(
+        artifact_integrity,
+        "require_native_index_authorization",
+        fail_exact,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        require_authorized_vector_view("/vector", object(), {})
+
+    assert caught.value is primary_error
+    assert events == ["preflight", "capture", "exact", "close"]
+    cleanup_notes = getattr(primary_error, "__notes__", ()) or getattr(
+        primary_error,
+        "_codenib_cleanup_notes",
+        (),
+    )
+    assert any("cleanup" in note for note in cleanup_notes)
+
+
+@pytest.mark.parametrize(
+    ("case", "error_type"),
+    [
+        ("missing", MissingNativeIndexAuthorizationError),
+        ("malformed", InvalidNativeIndexAuthorizationError),
+        ("wrong-tree", InvalidNativeIndexAuthorizationError),
+        ("wrong-semantic", InvalidNativeIndexAuthorizationError),
+    ],
+)
+def test_skill_vector_rejects_unbound_authority_before_store_constructor(
+    monkeypatch,
+    tmp_path,
+    case,
+    error_type,
+) -> None:
+    from codenib.compiler import skill_context
+    from codenib.index.embedding import vector_store as vector_store_module
+
+    target = tmp_path / "skill-vector"
+    target.mkdir()
+    authorization = _authorization_case(
+        case,
+        target=target,
+        semantic_contract=_VECTOR_CONTRACT,
+        tmp_path=tmp_path,
+    )
+    constructors = []
+
+    monkeypatch.setattr(
+        vector_store_module,
+        "CodeVectorStore",
+        lambda **kwargs: constructors.append(kwargs),
+    )
+
+    with pytest.raises(error_type):
+        skill_context._load_vector(
+            str(target),
+            embedding_model="vendor/model",
+            embedding_provider="huggingface",
+            embedding_dimension=4,
+            artifact_metadata=dict(_VECTOR_CONTRACT),
+            native_index_authorization=authorization,
+        )
+
+    assert constructors == []
+
+
+def test_skill_vector_valid_authority_continues_to_store_load(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from codenib.compiler import skill_context
+    from codenib.index.embedding import vector_store as vector_store_module
+
+    target = tmp_path / "skill-vector"
+    authorization = _mint_vector_authorization(target, _VECTOR_CONTRACT)
+    constructors = []
+    loads = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs):
+            constructors.append(kwargs)
+
+        def load(self, path, *, native_index_authorization):
+            loads.append((path, native_index_authorization))
+
+    monkeypatch.setattr(vector_store_module, "CodeVectorStore", FakeVectorStore)
+
+    result = skill_context._load_vector(
+        str(target),
+        embedding_model="vendor/model",
+        embedding_provider="huggingface",
+        embedding_dimension=4,
+        artifact_metadata=dict(_VECTOR_CONTRACT),
+        native_index_authorization=authorization,
+    )
+
+    assert isinstance(result, FakeVectorStore)
+    assert len(constructors) == 1
+    assert loads == [(str(target), authorization)]
+
+
+def _server_context(target: Path, authorization):
+    from codenib.mcp.context import ServerContext
+
+    entry = IndexEntry(
+        index_type="vector",
+        path=str(target),
+        built_at="2026-08-11T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config=dict(_VECTOR_CONTRACT),
+    )
+    return ServerContext(
+        manifest=RepoManifest(indexes={"vector": entry}),
+        _native_index_authorization=authorization,
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["missing", "malformed", "wrong-tree", "wrong-semantic"],
+)
+def test_mcp_vector_rejects_unbound_authority_before_store_constructor(
+    monkeypatch,
+    tmp_path,
+    case,
+) -> None:
+    from codenib.index.embedding import vector_store as vector_store_module
+
+    target = tmp_path / "mcp-vector"
+    target.mkdir()
+    authorization = _authorization_case(
+        case,
+        target=target,
+        semantic_contract=_VECTOR_CONTRACT,
+        tmp_path=tmp_path,
+    )
+    constructors = []
+    monkeypatch.setattr(
+        vector_store_module,
+        "CodeVectorStore",
+        lambda **kwargs: constructors.append(kwargs),
+    )
+    context = _server_context(target, authorization)
+
+    context._load_vector(probe=True)
+
+    assert constructors == []
+    assert context.vector is None
+    assert "vector" in context.errors
+
+
+def test_mcp_vector_valid_authority_continues_to_store_load(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from codenib.index.embedding import vector_store as vector_store_module
+
+    target = tmp_path / "mcp-vector"
+    authorization = _mint_vector_authorization(target, _VECTOR_CONTRACT)
+    constructors = []
+    loads = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs):
+            constructors.append(kwargs)
+            self.embedding_model = kwargs["embedding_model"]
+
+        def load(self, *, native_index_authorization):
+            loads.append(native_index_authorization)
+
+        def get_stats(self):
+            return {"total_documents": 1}
+
+    monkeypatch.setattr(vector_store_module, "CodeVectorStore", FakeVectorStore)
+    context = _server_context(target, authorization)
+
+    context._load_vector(probe=True)
+
+    assert isinstance(context.vector, FakeVectorStore)
+    assert len(constructors) == 1
+    assert loads == [authorization]
+    assert "vector" not in context.errors
+
+
+def _retrieve_pipeline(pipeline_module, tmp_path, authorization):
+    pipeline = object.__new__(pipeline_module.RetrieveRerankPipeline)
+    pipeline.repo_path = str(tmp_path)
+    pipeline.index_path = tmp_path / "retrieve-vector"
+    pipeline.retrieval_level = "l2"
+    pipeline.languages = ["python"]
+    pipeline.max_lines_per_chunk = 300
+    pipeline.index_metric = "ip"
+    pipeline.profiler = None
+    pipeline._native_index_authorization = authorization
+    return pipeline
+
+
+@pytest.mark.parametrize("case", ["malformed", "wrong-tree", "wrong-semantic"])
+def test_retrieve_cache_rejects_unbound_authority_before_store_constructor(
+    monkeypatch,
+    tmp_path,
+    case,
+) -> None:
+    from codenib.model import retrieve_rerank_pipeline as pipeline_module
+
+    target = tmp_path / "retrieve-vector"
+    target.mkdir()
+    (target / "config_model.json").write_text("{}", encoding="utf-8")
+    authorization = _authorization_case(
+        case,
+        target=target,
+        semantic_contract={},
+        tmp_path=tmp_path,
+    )
+    constructors = []
+    monkeypatch.setattr(
+        pipeline_module,
+        "CodeVectorStore",
+        lambda **kwargs: constructors.append(kwargs),
+    )
+    pipeline = _retrieve_pipeline(pipeline_module, tmp_path, authorization)
+
+    with pytest.raises(InvalidNativeIndexAuthorizationError):
+        pipeline._initialize_vector_store(
+            embedding_model="model",
+            embedding_provider="huggingface",
+            embedding_dimension=4,
+            embedding_kwargs={},
+        )
+
+    assert constructors == []
+
+
+def test_retrieve_cache_valid_authority_continues_to_store_load(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from codenib.model import retrieve_rerank_pipeline as pipeline_module
+
+    target = tmp_path / "retrieve-vector"
+    target.mkdir()
+    (target / "config_model.json").write_text("{}", encoding="utf-8")
+    authorization = _mint_vector_authorization(target, {})
+    constructors = []
+    loads = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs):
+            constructors.append(kwargs)
+            self.embedding = object()
+            self.l0_documents = [object()]
+            self.l2_documents = [object()]
+
+        def load(self, path, *, native_index_authorization):
+            loads.append((path, native_index_authorization))
+
+    monkeypatch.setattr(pipeline_module, "CodeVectorStore", FakeVectorStore)
+    monkeypatch.setattr(
+        pipeline_module,
+        "build_hierarchical_vector_store",
+        lambda **_kwargs: pytest.fail("authorized cache must be reused"),
+    )
+    pipeline = _retrieve_pipeline(pipeline_module, tmp_path, authorization)
+
+    result = pipeline._initialize_vector_store(
+        embedding_model="model",
+        embedding_provider="huggingface",
+        embedding_dimension=4,
+        embedding_kwargs={},
+    )
+
+    assert isinstance(result, FakeVectorStore)
+    assert len(constructors) == 1
+    assert loads == [(str(target), authorization)]

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -14,6 +14,53 @@ from fastapi.testclient import TestClient
 import codenib.web.app as web_app
 
 
+def test_lifespan_injects_local_native_authority_resolver(monkeypatch):
+    captured = {}
+    config = SimpleNamespace(
+        registry_path="/tmp/qa_registry.json",
+        data_dir="/tmp/data",
+        wiki_generation_model="model",
+        wiki_agent=False,
+        wiki_generation_api_base=None,
+        wiki_generation_api_key=None,
+        wiki_generation_options={},
+    )
+    resolver = object()
+
+    class Registry:
+        def __init__(self, supplied_config, **kwargs):
+            captured["config"] = supplied_config
+            captured.update(kwargs)
+
+        def load_all(self):
+            captured["loaded"] = True
+
+        def list_infos(self):
+            return []
+
+    monkeypatch.setattr(web_app, "load_config", lambda: config)
+    monkeypatch.setattr(web_app, "RepoRegistry", Registry)
+    monkeypatch.setattr(web_app, "authorize_local_manifest_vector", resolver)
+    monkeypatch.setattr(
+        web_app,
+        "_wiki_narrator",
+        lambda _config: SimpleNamespace(model="model", enabled=False, cache_dir=None),
+    )
+    application = SimpleNamespace(state=SimpleNamespace())
+
+    async def run_lifespan():
+        async with web_app.lifespan(application):
+            assert application.state.registry is not None
+
+    asyncio.run(run_lifespan())
+
+    assert captured == {
+        "config": config,
+        "native_index_authorization_resolver": resolver,
+        "loaded": True,
+    }
+
+
 def test_oversized_chat_request_is_rejected_before_runtime_lookup(monkeypatch):
     def unexpected_registry_lookup():
         raise AssertionError("invalid chat payload reached the repository runtime")

--- a/test/web/test_native_authority.py
+++ b/test/web/test_native_authority.py
@@ -1,0 +1,420 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Web runtime's trusted local native-index boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from codenib.compiler import cache_lock as cache_lock_module
+from codenib.compiler.cache_lock import (
+    COMPILER_CACHE_LOCK_FILENAME,
+    compiler_cache_lock,
+)
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import capture_authenticated_vector_view
+from codenib.native_index_authorization import (
+    InvalidNativeIndexAuthorizationError,
+    require_native_index_authorization,
+)
+from codenib.source_fingerprint import (
+    RepositoryChangedError,
+    RepositorySourceBinding,
+    fingerprint_repository,
+)
+from codenib.web import native_authority as native_authority_module
+from codenib.web.config import RepoEntry
+from codenib.web.native_authority import authorize_local_manifest_vector
+
+
+def _local_vector_manifest(tmp_path):
+    source_file = tmp_path / "sample.py"
+    source_file.write_text("def sample():\n    return 1\n")
+    cache = tmp_path / ".codenib_cache"
+    vector = cache / "vector"
+    vector.mkdir(parents=True)
+    (vector / "config.json").write_text(json.dumps({"dimension": 3}))
+    source = fingerprint_repository(tmp_path, exclude_roots=(cache,)).value
+    config = {
+        "embedding_model": "vendor/model",
+        "embedding_provider": "huggingface",
+        "embedding_dimension": 3,
+        "index_metric": "ip",
+    }
+    vector_entry = IndexEntry(
+        index_type="vector",
+        path=str(vector),
+        built_at="2026-08-11T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config=config,
+        commit="abc123",
+        source_fingerprint=source,
+    )
+    manifest = RepoManifest(
+        repo_path=str(tmp_path),
+        commit="abc123",
+        source_fingerprint=source,
+        file_count=1,
+        languages=["python"],
+        indexes={"vector": vector_entry},
+    )
+    manifest_path = cache / "repo_manifest.json"
+    manifest.save(manifest_path)
+    repo_entry = RepoEntry(
+        instance_id="sample",
+        repo="owner/sample",
+        base_commit="abc123",
+        language="python",
+        repo_dir=str(tmp_path),
+        manifest_path=str(manifest_path),
+    )
+    return repo_entry, manifest, vector_entry, source_file
+
+
+def test_local_resolver_binds_exact_tree_and_unmodified_manifest_config(tmp_path):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+
+    authorization = authorize_local_manifest_vector(
+        repo_entry,
+        manifest,
+        vector_entry,
+    )
+
+    with capture_authenticated_vector_view(vector_entry.path) as view:
+        require_native_index_authorization(
+            authorization,
+            view.ownership,
+            view_type="vector",
+            semantic_contract=vector_entry.config,
+        )
+        with pytest.raises(
+            InvalidNativeIndexAuthorizationError,
+            match="does not match captured bytes",
+        ):
+            require_native_index_authorization(
+                authorization,
+                view.ownership,
+                view_type="vector",
+                semantic_contract={**vector_entry.config, "embedding_dimension": 4},
+            )
+
+
+def test_local_resolver_rejects_source_drift_before_vector_capture(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, source_file = _local_vector_manifest(tmp_path)
+    source_file.write_text("def changed():\n    return 2\n")
+    monkeypatch.setattr(
+        "codenib.web.native_authority.capture_authenticated_vector_view",
+        lambda _path: pytest.fail("source drift must fail before vector capture"),
+    )
+
+    with pytest.raises(ValueError, match="source content does not match"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+
+def test_local_resolver_rejects_manifest_drift_before_source_capture(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    observed = RepoManifest.load(repo_entry.manifest_path)
+    observed.indexes["vector"].config["embedding_dimension"] = 4
+    observed.save(repo_entry.manifest_path)
+    monkeypatch.setattr(
+        "codenib.web.native_authority.capture_repository_source",
+        lambda *_args, **_kwargs: pytest.fail(
+            "manifest drift must fail before source capture"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="manifest changed"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+
+def test_local_resolver_rejects_symlinked_compiler_lock_before_source_capture(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    cache = Path(repo_entry.manifest_path).parent
+    victim = cache / "lock-victim"
+    victim.write_bytes(b"victim must remain unchanged")
+    lock_path = cache / COMPILER_CACHE_LOCK_FILENAME
+    try:
+        lock_path.symlink_to(victim)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symbolic links are unavailable: {exc}")
+    monkeypatch.setattr(
+        native_authority_module,
+        "capture_repository_source",
+        lambda *_args, **_kwargs: pytest.fail(
+            "an unsafe compiler lock must fail before source capture"
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="compiler cache lock"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    assert victim.read_bytes() == b"victim must remain unchanged"
+    assert lock_path.is_symlink()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="exercises POSIX lock identity")
+def test_local_resolver_rejects_compiler_lock_entry_swap_before_source_capture(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    cache = Path(repo_entry.manifest_path).parent
+    lock_path = cache / COMPILER_CACHE_LOCK_FILENAME
+    lock_path.write_bytes(b"original")
+    replacement = cache / "replacement-lock"
+    replacement.write_bytes(b"replacement")
+    stolen = cache / "stolen-lock"
+    real_validate = cache_lock_module._validate_posix_lock_entry
+    calls = 0
+
+    def swap_after_first_validation(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        identity = real_validate(*args, **kwargs)
+        if calls == 1:
+            os.replace(lock_path, stolen)
+            os.replace(replacement, lock_path)
+        return identity
+
+    monkeypatch.setattr(
+        cache_lock_module,
+        "_validate_posix_lock_entry",
+        swap_after_first_validation,
+    )
+    monkeypatch.setattr(
+        native_authority_module,
+        "capture_repository_source",
+        lambda *_args, **_kwargs: pytest.fail(
+            "a swapped compiler lock must fail before source capture"
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="compiler cache lock changed"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    assert calls == 2
+    assert stolen.read_bytes() == b"original"
+    assert lock_path.read_bytes() == b"replacement"
+
+
+def test_local_resolver_rejects_source_drift_after_authorization(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, source_file = _local_vector_manifest(tmp_path)
+    real_mint = native_authority_module._mint_trusted_local_admin_authorization
+
+    def mint_then_change_source(*args, **kwargs):
+        authorization = real_mint(*args, **kwargs)
+        source_file.write_text("def changed_during_authorization():\n    return 2\n")
+        return authorization
+
+    monkeypatch.setattr(
+        native_authority_module,
+        "_mint_trusted_local_admin_authorization",
+        mint_then_change_source,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="source inventory changed"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+
+def test_local_resolver_rejects_vector_tree_drift_after_authorization(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    vector_config = Path(vector_entry.path) / "config.json"
+    real_mint = native_authority_module._mint_trusted_local_admin_authorization
+
+    def mint_then_change_tree(*args, **kwargs):
+        authorization = real_mint(*args, **kwargs)
+        vector_config.write_text(json.dumps({"dimension": 4}))
+        return authorization
+
+    monkeypatch.setattr(
+        native_authority_module,
+        "_mint_trusted_local_admin_authorization",
+        mint_then_change_tree,
+    )
+
+    with pytest.raises(ValueError, match="vector view changed"):
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+
+def test_local_resolver_propagates_source_cleanup_failure_with_retry_owner(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    cleanup_failure = OSError("source cleanup failed")
+    captured = []
+    real_capture = native_authority_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+
+    def capture(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        captured.append(binding)
+        return binding
+
+    def fail_cleanup(binding):
+        if binding in captured:
+            raise cleanup_failure
+        real_close(binding)
+
+    monkeypatch.setattr(native_authority_module, "capture_repository_source", capture)
+    monkeypatch.setattr(RepositorySourceBinding, "close", fail_cleanup)
+
+    with pytest.raises(OSError, match="source cleanup failed") as caught:
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    assert caught.value is cleanup_failure
+    retry_owner = caught.value.source_cleanup_owner
+    assert retry_owner.pending_sources == tuple(captured)
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    retry_owner.close()
+    assert retry_owner.closed
+
+
+def test_local_resolver_rejects_incomplete_source_cleanup(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    captured = []
+    real_capture = native_authority_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+
+    def capture(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        captured.append(binding)
+        return binding
+
+    def leave_open(binding):
+        if binding not in captured:
+            real_close(binding)
+
+    monkeypatch.setattr(native_authority_module, "capture_repository_source", capture)
+    monkeypatch.setattr(RepositorySourceBinding, "close", leave_open)
+
+    with pytest.raises(RuntimeError, match="source cleanup did not finish") as caught:
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    retry_owner = caught.value.source_cleanup_owner
+    assert retry_owner.pending_sources == tuple(captured)
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    retry_owner.close()
+    assert retry_owner.closed
+
+
+def test_local_resolver_preserves_first_base_exception_when_cleanup_also_fails(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    cache = Path(repo_entry.manifest_path).parent
+    primary = KeyboardInterrupt("authorization interrupted")
+    cleanup_failure = OSError("source cleanup also failed")
+    captured = []
+    real_capture = native_authority_module.capture_repository_source
+    real_close = RepositorySourceBinding.close
+
+    def capture(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        captured.append(binding)
+        return binding
+
+    def interrupt_vector_capture(_path):
+        raise primary
+
+    def fail_cleanup(binding):
+        if binding in captured:
+            raise cleanup_failure
+        real_close(binding)
+
+    monkeypatch.setattr(native_authority_module, "capture_repository_source", capture)
+    monkeypatch.setattr(
+        native_authority_module,
+        "capture_authenticated_vector_view",
+        interrupt_vector_capture,
+    )
+    monkeypatch.setattr(RepositorySourceBinding, "close", fail_cleanup)
+
+    with pytest.raises(KeyboardInterrupt, match="authorization interrupted") as caught:
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    assert caught.value is primary
+    assert caught.value.__cause__ is cleanup_failure
+    retry_owner = caught.value.source_cleanup_owner
+    assert retry_owner.pending_sources == tuple(captured)
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    retry_owner.close()
+    assert retry_owner.closed
+    with compiler_cache_lock(cache):
+        pass
+
+
+@pytest.mark.skipif(os.name != "posix", reason="exercises the reported POSIX probe")
+def test_local_resolver_preserves_body_interrupt_when_lock_close_fails_afterward(
+    tmp_path,
+    monkeypatch,
+):
+    repo_entry, manifest, vector_entry, _source_file = _local_vector_manifest(tmp_path)
+    cache = Path(repo_entry.manifest_path).parent
+    primary = KeyboardInterrupt("resolver body interrupted")
+    cleanup = SystemExit("lock cleanup interrupted after close")
+    real_close = cache_lock_module._close_posix_lock_file
+
+    def interrupt_source_capture(*_args, **_kwargs):
+        raise primary
+
+    def close_then_interrupt(descriptor_owner, *, locked):
+        real_close(descriptor_owner, locked=locked)
+        raise cleanup
+
+    monkeypatch.setattr(
+        native_authority_module,
+        "capture_repository_source",
+        interrupt_source_capture,
+    )
+    monkeypatch.setattr(
+        cache_lock_module,
+        "_close_posix_lock_file",
+        close_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        authorize_local_manifest_vector(repo_entry, manifest, vector_entry)
+
+    assert caught.value is primary
+    notes = tuple(getattr(primary, "__notes__", ())) + tuple(
+        getattr(primary, "_codenib_cleanup_notes", ())
+    )
+    diagnostic = "\n".join(notes)
+    assert "compiler cache lock cleanup also failed" in diagnostic
+    assert repr(cleanup) in diagnostic
+    assert cache_lock_module._ACTIVE_POSIX_LOCK_DESCRIPTORS == set()
+
+    monkeypatch.setattr(
+        cache_lock_module,
+        "_close_posix_lock_file",
+        real_close,
+    )
+    with compiler_cache_lock(cache):
+        pass

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -11,6 +11,11 @@ import pytest
 from codenib.agent.skills.registry import SkillRegistry
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.native_index_authorization import (
+    InvalidNativeIndexAuthorizationError,
+    MissingNativeIndexAuthorizationError,
+    _mint_trusted_local_admin_authorization,
+)
 from codenib.web.config import (
     QAConfig,
     RepoEntry,
@@ -30,13 +35,14 @@ from codenib.web.repo_registry import (
 def native_authorization(monkeypatch):
     token = object()
 
-    def preflight(authorization, *, view_type):
+    def require_view(root, authorization, semantic_contract):
+        assert root
         assert authorization is token
-        assert view_type == "vector"
+        assert isinstance(semantic_contract, dict)
 
     monkeypatch.setattr(
-        "codenib.native_index_authorization.require_native_index_authorization_preflight",
-        preflight,
+        "codenib.index.embedding.artifact_integrity.require_authorized_vector_view",
+        require_view,
     )
     return token
 
@@ -245,10 +251,17 @@ def test_repo_views_respect_configured_index_mode(
         indexes={"vector": vector_entry},
         index_is_current=lambda index_type: index_type == "vector",
     )
-    bundle = SimpleNamespace(manifest=manifest)
+    repo_entry = SimpleNamespace(instance_id="repo")
+    bundle = SimpleNamespace(entry=repo_entry, manifest=manifest)
+    resolved = []
+
+    def resolve(entry, resolved_manifest, resolved_vector):
+        resolved.append((entry, resolved_manifest, resolved_vector))
+        return native_authorization
+
     registry = RepoRegistry(
         QAConfig(mode=mode),
-        native_index_authorization_resolver=lambda _entry: native_authorization,
+        native_index_authorization_resolver=resolve,
     )
     loaded = []
     monkeypatch.setattr(
@@ -261,10 +274,13 @@ def test_repo_views_respect_configured_index_mode(
 
     assert loaded == [vector_entry] * expected_vector_loads
     assert bundle.vector_store == ("vector-store" if expected_vector_loads else None)
+    assert resolved == (
+        [(repo_entry, manifest, vector_entry)] if expected_vector_loads else []
+    )
 
 
-@pytest.mark.parametrize("resolver_kind", ["missing", "raises", "invalid"])
-def test_repo_views_keep_bm25_when_vector_authority_is_unusable(
+@pytest.mark.parametrize("resolver_kind", ["missing", "declines"])
+def test_repo_views_keep_bm25_only_for_explicit_optional_authority_policy(
     monkeypatch,
     resolver_kind,
 ):
@@ -288,15 +304,10 @@ def test_repo_views_keep_bm25_when_vector_authority_is_unusable(
     )
     if resolver_kind == "missing":
         resolver = None
-    elif resolver_kind == "raises":
-
-        def resolver(_entry):
-            raise ValueError("denied")
-
     else:
 
-        def resolver(_entry):
-            return object()
+        def resolver(_repo_entry, _manifest, _vector_entry):
+            return None
 
     bm25_entry = SimpleNamespace(path="/idx/bm25", config={})
     vector_entry = SimpleNamespace(path="/idx/vector", config={})
@@ -304,15 +315,139 @@ def test_repo_views_keep_bm25_when_vector_authority_is_unusable(
         indexes={"bm25": bm25_entry, "vector": vector_entry},
         index_is_current=lambda _index_type: True,
     )
-    bundle = SimpleNamespace(manifest=manifest)
+    bundle = SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
     registry = RepoRegistry(
         QAConfig(mode="hybrid"),
         native_index_authorization_resolver=resolver,
+        allow_missing_native_index_authorization=True,
     )
 
     registry._load_repo_views(bundle)
 
     assert bundle.bm25.path == "/idx/bm25"
+    assert bundle.vector_store is None
+
+
+@pytest.mark.parametrize("resolver_kind", ["missing", "declines"])
+def test_repo_views_fail_closed_when_required_authority_is_missing(
+    monkeypatch,
+    resolver_kind,
+):
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "missing authority must fail before vector model initialization"
+        ),
+    )
+    if resolver_kind == "missing":
+        resolver = None
+    else:
+
+        def decline(_repo, _manifest, _entry):
+            return None
+
+        resolver = decline
+
+    vector_entry = SimpleNamespace(path="/idx/vector", config={})
+    manifest = SimpleNamespace(
+        indexes={"vector": vector_entry},
+        index_is_current=lambda _index_type: True,
+    )
+    bundle = SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
+    if resolver is None:
+        with pytest.raises(
+            MissingNativeIndexAuthorizationError,
+            match="requires an external",
+        ):
+            RepoRegistry(QAConfig(mode="hybrid"))
+        return
+
+    registry = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=resolver,
+    )
+    with pytest.raises(MissingNativeIndexAuthorizationError, match="returned no"):
+        registry._load_repo_views(bundle)
+
+
+def test_repo_views_propagate_resolver_rejection_before_model_initialization(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "resolver rejection must fail before vector model initialization"
+        ),
+    )
+
+    def reject(_repo, _manifest, _entry):
+        raise ValueError("operator denied vector authority")
+
+    vector_entry = SimpleNamespace(path="/idx/vector", config={})
+    manifest = SimpleNamespace(
+        indexes={"vector": vector_entry},
+        index_is_current=lambda _index_type: True,
+    )
+    registry = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=reject,
+        allow_missing_native_index_authorization=True,
+    )
+
+    with pytest.raises(ValueError, match="operator denied"):
+        registry._load_repo_views(
+            SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
+        )
+
+
+def test_repo_views_propagate_vector_integrity_failures(
+    native_authorization, monkeypatch
+):
+    vector_entry = SimpleNamespace(path="/idx/vector", config={})
+    manifest = SimpleNamespace(
+        indexes={"vector": vector_entry},
+        index_is_current=lambda _index_type: True,
+    )
+    registry = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=(
+            lambda _repo, _manifest, _entry: native_authorization
+        ),
+        allow_missing_native_index_authorization=True,
+    )
+    monkeypatch.setattr(
+        registry,
+        "_load_vector_store",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ValueError("authenticated vector bytes changed")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="vector bytes changed"):
+        registry._load_repo_views(
+            SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
+        )
+
+
+def test_hybrid_requires_a_current_vector_unless_explicitly_optional(monkeypatch):
+    manifest = SimpleNamespace(
+        indexes={},
+        index_is_current=lambda _index_type: False,
+    )
+    bundle = SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
+    required = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=(lambda _repo, _manifest, _entry: object()),
+    )
+
+    with pytest.raises(ValueError, match="requires a current vector"):
+        required._load_repo_views(bundle)
+
+    optional = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        allow_missing_native_index_authorization=True,
+    )
+    optional._load_repo_views(bundle)
     assert bundle.vector_store is None
 
 
@@ -325,10 +460,57 @@ def test_vector_authority_is_preflighted_before_model_initialization(monkeypatch
     )
     registry = RepoRegistry(QAConfig())
 
-    with pytest.raises(ValueError, match="requires external authorization"):
+    with pytest.raises(ValueError, match="malformed"):
         registry._load_vector_store(
             SimpleNamespace(path="/idx/vector", config={}),
             native_index_authorization=object(),
+        )
+
+
+@pytest.mark.parametrize("mismatch", ["tree", "semantic"])
+def test_exact_vector_authority_is_checked_before_model_initialization(
+    tmp_path,
+    monkeypatch,
+    mismatch,
+):
+    from codenib.index.embedding.artifact_integrity import (
+        capture_authenticated_vector_view,
+    )
+
+    authorized_root = tmp_path / "authorized"
+    loaded_root = tmp_path / "loaded"
+    authorized_root.mkdir()
+    loaded_root.mkdir()
+    (authorized_root / "config.json").write_text('{"tree":"authorized"}')
+    (loaded_root / "config.json").write_text('{"tree":"loaded"}')
+    manifest_config = {"embedding_model": "vendor/model"}
+    token_config = (
+        {"embedding_model": "different/model"}
+        if mismatch == "semantic"
+        else manifest_config
+    )
+    with capture_authenticated_vector_view(authorized_root) as view:
+        authorization = _mint_trusted_local_admin_authorization(
+            view.ownership,
+            view_type="vector",
+            semantic_contract=token_config,
+            evidence=("test-local-admin",),
+        )
+    target = authorized_root if mismatch == "semantic" else loaded_root
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "wrong-tree or wrong-semantic authority must fail before model init"
+        ),
+    )
+
+    with pytest.raises(
+        InvalidNativeIndexAuthorizationError,
+        match="does not match captured bytes",
+    ):
+        RepoRegistry(QAConfig())._load_vector_store(
+            SimpleNamespace(path=str(target), config=manifest_config),
+            native_index_authorization=authorization,
         )
 
 
@@ -608,6 +790,7 @@ def test_vector_store_supports_legacy_prebuilt_route_fallback(
     assert created[0].kwargs["embedding_provider"] == "huggingface"
     assert created[0].kwargs["embedding_model"] == "nomic-ai/CodeRankEmbed"
     assert created[0].kwargs["dimension"] == 768
+    assert created[0].kwargs["artifact_metadata"] == entry.config
 
 
 def test_vector_store_fills_legacy_dimension_with_persisted_provider(

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -26,6 +26,21 @@ from codenib.web.repo_registry import (
 )
 
 
+@pytest.fixture
+def native_authorization(monkeypatch):
+    token = object()
+
+    def preflight(authorization, *, view_type):
+        assert authorization is token
+        assert view_type == "vector"
+
+    monkeypatch.setattr(
+        "codenib.native_index_authorization.require_native_index_authorization_preflight",
+        preflight,
+    )
+    return token
+
+
 def test_fresh_registry_is_isolated_from_singleton():
     singleton = SkillRegistry()
     reg_a = _fresh_registry()
@@ -221,6 +236,7 @@ def test_config_index_types_for_mode():
 )
 def test_repo_views_respect_configured_index_mode(
     monkeypatch,
+    native_authorization,
     mode,
     expected_vector_loads,
 ):
@@ -230,18 +246,90 @@ def test_repo_views_respect_configured_index_mode(
         index_is_current=lambda index_type: index_type == "vector",
     )
     bundle = SimpleNamespace(manifest=manifest)
-    registry = RepoRegistry(QAConfig(mode=mode))
+    registry = RepoRegistry(
+        QAConfig(mode=mode),
+        native_index_authorization_resolver=lambda _entry: native_authorization,
+    )
     loaded = []
     monkeypatch.setattr(
         registry,
         "_load_vector_store",
-        lambda entry: loaded.append(entry) or "vector-store",
+        lambda entry, **_kwargs: loaded.append(entry) or "vector-store",
     )
 
     registry._load_repo_views(bundle)
 
     assert loaded == [vector_entry] * expected_vector_loads
     assert bundle.vector_store == ("vector-store" if expected_vector_loads else None)
+
+
+@pytest.mark.parametrize("resolver_kind", ["missing", "raises", "invalid"])
+def test_repo_views_keep_bm25_when_vector_authority_is_unusable(
+    monkeypatch,
+    resolver_kind,
+):
+    class FakeBM25:
+        def load_index(self, path):
+            self.path = path
+
+    monkeypatch.setattr(
+        "codenib.index.sparse_idx.bm25_index.BM25CodeIndexer",
+        FakeBM25,
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.require_bm25_manifest_artifact",
+        lambda _entry: None,
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "unusable authority must fail before vector model initialization"
+        ),
+    )
+    if resolver_kind == "missing":
+        resolver = None
+    elif resolver_kind == "raises":
+
+        def resolver(_entry):
+            raise ValueError("denied")
+
+    else:
+
+        def resolver(_entry):
+            return object()
+
+    bm25_entry = SimpleNamespace(path="/idx/bm25", config={})
+    vector_entry = SimpleNamespace(path="/idx/vector", config={})
+    manifest = SimpleNamespace(
+        indexes={"bm25": bm25_entry, "vector": vector_entry},
+        index_is_current=lambda _index_type: True,
+    )
+    bundle = SimpleNamespace(manifest=manifest)
+    registry = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=resolver,
+    )
+
+    registry._load_repo_views(bundle)
+
+    assert bundle.bm25.path == "/idx/bm25"
+    assert bundle.vector_store is None
+
+
+def test_vector_authority_is_preflighted_before_model_initialization(monkeypatch):
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "invalid authority must fail before vector model initialization"
+        ),
+    )
+    registry = RepoRegistry(QAConfig())
+
+    with pytest.raises(ValueError, match="requires external authorization"):
+        registry._load_vector_store(
+            SimpleNamespace(path="/idx/vector", config={}),
+            native_index_authorization=object(),
+        )
 
 
 def test_config_paths(tmp_path):
@@ -378,7 +466,10 @@ def test_rejects_unknown_embedding_provider(tmp_path):
         load_config(str(cfg_file))
 
 
-def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
+def test_vector_store_uses_provider_config_and_reuses_client(
+    monkeypatch,
+    native_authorization,
+):
     created = []
 
     class FakeVectorStore:
@@ -388,8 +479,9 @@ def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
             self.loaded = None
             created.append(self)
 
-        def load(self, path):
+        def load(self, path, **kwargs):
             self.loaded = path
+            assert kwargs["native_index_authorization"] is native_authorization
 
     monkeypatch.setattr(
         "codenib.web.repo_registry._vector_store_type",
@@ -413,8 +505,14 @@ def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
         },
     )
 
-    first = registry._load_vector_store(entry)
-    second = registry._load_vector_store(entry)
+    first = registry._load_vector_store(
+        entry,
+        native_index_authorization=native_authorization,
+    )
+    second = registry._load_vector_store(
+        entry,
+        native_index_authorization=native_authorization,
+    )
 
     assert first.loaded == "/tmp/vector"
     assert first.kwargs["embedding_provider"] == "openai"
@@ -424,7 +522,10 @@ def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
     assert second.kwargs["embedding"] is first.embedding
 
 
-def test_vector_store_restores_manifest_embedding_identity(monkeypatch):
+def test_vector_store_restores_manifest_embedding_identity(
+    monkeypatch,
+    native_authorization,
+):
     created = []
 
     class FakeVectorStore:
@@ -433,7 +534,7 @@ def test_vector_store_restores_manifest_embedding_identity(monkeypatch):
             self.embedding = kwargs.get("embedding") or object()
             created.append(self)
 
-        def load(self, _path):
+        def load(self, _path, **_kwargs):
             pass
 
     monkeypatch.setattr(
@@ -455,7 +556,10 @@ def test_vector_store_restores_manifest_embedding_identity(monkeypatch):
         },
     )
 
-    registry._load_vector_store(entry)
+    registry._load_vector_store(
+        entry,
+        native_index_authorization=native_authorization,
+    )
 
     assert created[0].kwargs["embedding_model"] == "nomic-ai/CodeRankEmbed"
     assert created[0].kwargs["dimension"] == 768
@@ -464,7 +568,10 @@ def test_vector_store_restores_manifest_embedding_identity(monkeypatch):
     assert created[0].kwargs["revision"] == "immutable-model-revision"
 
 
-def test_vector_store_supports_legacy_prebuilt_route_fallback(monkeypatch):
+def test_vector_store_supports_legacy_prebuilt_route_fallback(
+    monkeypatch,
+    native_authorization,
+):
     created = []
 
     class FakeVectorStore:
@@ -473,7 +580,7 @@ def test_vector_store_supports_legacy_prebuilt_route_fallback(monkeypatch):
             self.embedding = object()
             created.append(self)
 
-        def load(self, _path):
+        def load(self, _path, **_kwargs):
             pass
 
     monkeypatch.setattr(
@@ -493,14 +600,20 @@ def test_vector_store_supports_legacy_prebuilt_route_fallback(monkeypatch):
         },
     )
 
-    registry._load_vector_store(entry)
+    registry._load_vector_store(
+        entry,
+        native_index_authorization=native_authorization,
+    )
 
     assert created[0].kwargs["embedding_provider"] == "huggingface"
     assert created[0].kwargs["embedding_model"] == "nomic-ai/CodeRankEmbed"
     assert created[0].kwargs["dimension"] == 768
 
 
-def test_vector_store_fills_legacy_dimension_with_persisted_provider(monkeypatch):
+def test_vector_store_fills_legacy_dimension_with_persisted_provider(
+    monkeypatch,
+    native_authorization,
+):
     created = []
 
     class FakeVectorStore:
@@ -509,7 +622,7 @@ def test_vector_store_fills_legacy_dimension_with_persisted_provider(monkeypatch
             self.embedding = object()
             created.append(self)
 
-        def load(self, _path):
+        def load(self, _path, **_kwargs):
             pass
 
     monkeypatch.setattr(
@@ -530,12 +643,18 @@ def test_vector_store_fills_legacy_dimension_with_persisted_provider(monkeypatch
         },
     )
 
-    registry._load_vector_store(entry)
+    registry._load_vector_store(
+        entry,
+        native_index_authorization=native_authorization,
+    )
 
     assert created[0].kwargs["dimension"] == 768
 
 
-def test_vector_store_rejects_invalid_persisted_legacy_dimension(monkeypatch):
+def test_vector_store_rejects_invalid_persisted_legacy_dimension(
+    monkeypatch,
+    native_authorization,
+):
     monkeypatch.setattr(
         "codenib.web.repo_registry._vector_store_type",
         lambda: pytest.fail("invalid route must fail before loading the store"),
@@ -555,10 +674,16 @@ def test_vector_store_rejects_invalid_persisted_legacy_dimension(monkeypatch):
     )
 
     with pytest.raises(ValueError, match="dimension must be a positive integer"):
-        registry._load_vector_store(entry)
+        registry._load_vector_store(
+            entry,
+            native_index_authorization=native_authorization,
+        )
 
 
-def test_vector_store_cache_separates_model_revisions(monkeypatch):
+def test_vector_store_cache_separates_model_revisions(
+    monkeypatch,
+    native_authorization,
+):
     created = []
 
     class FakeVectorStore:
@@ -567,7 +692,7 @@ def test_vector_store_cache_separates_model_revisions(monkeypatch):
             self.embedding = kwargs.get("embedding") or object()
             created.append(self)
 
-        def load(self, _path):
+        def load(self, _path, **_kwargs):
             pass
 
     monkeypatch.setattr(
@@ -587,8 +712,14 @@ def test_vector_store_cache_separates_model_revisions(monkeypatch):
             },
         )
 
-    first = registry._load_vector_store(entry("revision-a"))
-    second = registry._load_vector_store(entry("revision-b"))
+    first = registry._load_vector_store(
+        entry("revision-a"),
+        native_index_authorization=native_authorization,
+    )
+    second = registry._load_vector_store(
+        entry("revision-b"),
+        native_index_authorization=native_authorization,
+    )
 
     assert first.embedding is not second.embedding
     assert second.kwargs["embedding"] is None
@@ -596,6 +727,7 @@ def test_vector_store_cache_separates_model_revisions(monkeypatch):
 
 def test_remote_embedding_override_cannot_replace_artifact_route(
     monkeypatch,
+    native_authorization,
 ):
     created = []
 
@@ -605,7 +737,7 @@ def test_remote_embedding_override_cannot_replace_artifact_route(
             self.embedding = object()
             created.append(self)
 
-        def load(self, _path):
+        def load(self, _path, **_kwargs):
             pass
 
     monkeypatch.setattr(
@@ -633,7 +765,10 @@ def test_remote_embedding_override_cannot_replace_artifact_route(
     )
 
     with pytest.raises(ValueError, match="endpoint does not match"):
-        registry._load_vector_store(entry)
+        registry._load_vector_store(
+            entry,
+            native_index_authorization=native_authorization,
+        )
 
     assert created == []
 


### PR DESCRIPTION
## Summary

Add the bounded parsing and strict workspace validation foundations required by the next portable publication layer.

This is a stacked PR based on #588. It intentionally excludes the later static export, BM25, and context publication migrations so those authority-sensitive changes remain independently reviewable.

## Changes

- enforce item, byte, lexical-token, node, and depth limits while framing streamed JSON array elements, before allocating decoded objects
- reject invalid or oversized reader blocks and credential-shaped URL authorities containing whitespace before userinfo
- add an explicit strict workspace publication capability preflight
- return authenticated file records from workspace writes and bind staged and published validators to callback-scoped publication readers
- add adversarial coverage for oversized readers, pre-decode complexity limits, strict workspace support, validator failures, cancellation cleanup, and credential userinfo variants

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/test_bounded_json.py test/test_captured_directory.py test/test_native_index_authorization.py test/test_source_fingerprint.py test/storage/test_models.py test/storage/test_view_bundle.py --tb=short` (312 passed, 5 skipped)
- Black, isort with the Black profile, flake8, and `git diff --check` on the changed surface

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Dependency: #588 is published and green but intentionally not merged yet.
