### PR TITLE
fix(storage): verify publication callbacks after errors

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -475,15 +475,39 @@ def _annotate_secondary_error(
     label: str,
     secondary_error: BaseException,
 ) -> None:
-    message = f"{label}: {secondary_error!r}"
-    if hasattr(primary_error, "add_note"):
-        primary_error.add_note(message)
+    """Best-effort diagnostics that can never replace the primary error."""
+
+    try:
+        message = f"{label}: {secondary_error!r}"
+        add_note = getattr(BaseException, "add_note", None)
+        if add_note is not None:
+            # Bypass a hostile BaseException subclass override.  Diagnostics
+            # must not execute code supplied by the exception being preserved.
+            add_note(primary_error, message)
+            return
+
+        try:
+            notes = BaseException.__getattribute__(
+                primary_error,
+                "_codenib_cleanup_notes",
+            )
+        except AttributeError:
+            notes = ()
+        if not isinstance(notes, tuple):
+            notes = ()
+        BaseException.__setattr__(
+            primary_error,
+            "_codenib_cleanup_notes",
+            (*notes, message),
+        )
+        if BaseException.__getattribute__(primary_error, "__cause__") is None:
+            BaseException.__setattr__(
+                primary_error,
+                "__cause__",
+                secondary_error,
+            )
+    except BaseException:  # noqa: B036 - diagnostics are strictly non-primary
         return
-    notes = list(getattr(primary_error, "_codenib_cleanup_notes", ()))
-    notes.append(message)
-    primary_error._codenib_cleanup_notes = tuple(notes)  # type: ignore[attr-defined]
-    if primary_error.__cause__ is None:
-        primary_error.__cause__ = secondary_error
 
 
 def _retain_first_error(
@@ -495,6 +519,44 @@ def _retain_first_error(
         return secondary_error
     _annotate_secondary_error(primary_error, label, secondary_error)
     return primary_error
+
+
+@dataclass(slots=True)
+class _OrderedActionState:
+    actions: tuple[tuple[str, Callable[[], None]], ...]
+    iteration_failure_label: str
+    primary_error: BaseException | None
+    next_index: int = 0
+
+    def retain(self, label: str, error: BaseException) -> None:
+        if self.primary_error is None:
+            self.primary_error = error
+            return
+        _annotate_secondary_error(self.primary_error, label, error)
+
+
+def _run_ordered_actions(state: _OrderedActionState) -> None:
+    """Run claimed actions in order and resume after a loop-edge interruption.
+
+    The outer exception region includes the normal loop back-edge and the
+    back-edge after an action failure is retained.  A transition interruption
+    therefore becomes another first-primary candidate instead of escaping and
+    skipping all remaining actions.  Claiming before invocation keeps cleanup
+    actions at-most-once when a close succeeds before raising.
+    """
+
+    try:
+        for index in range(state.next_index, len(state.actions)):
+            label, action = state.actions[index]
+            state.next_index = index + 1
+            try:
+                action()
+            except BaseException as action_error:  # noqa: B036 - keep first
+                state.retain(label, action_error)
+    except BaseException as iteration_error:  # noqa: B036 - resume remaining
+        state.retain(state.iteration_failure_label, iteration_error)
+        if state.next_index < len(state.actions):
+            _run_ordered_actions(state)
 
 
 @contextmanager
@@ -526,26 +588,24 @@ def _run_context_with_cleanup_actions(
         primary_error = context_error
         if primary_error is None and locally_unwinding:
             primary_error = active_error
+        failures = _OrderedActionState(
+            actions=(),
+            iteration_failure_label=(
+                "publication authenticated cleanup iteration also failed"
+            ),
+            primary_error=primary_error,
+        )
         try:
-            actions = cleanup_actions()
+            failures.actions = cleanup_actions()
         except BaseException as action_error:  # noqa: B036 - keep first primary
-            primary_error = _retain_first_error(
-                primary_error,
+            failures.retain(
                 "publication authenticated cleanup planning also failed",
                 action_error,
             )
         else:
-            for label, cleanup in actions:
-                try:
-                    cleanup()
-                except BaseException as cleanup_error:  # noqa: B036 - keep first
-                    primary_error = _retain_first_error(
-                        primary_error,
-                        label,
-                        cleanup_error,
-                    )
-        if not locally_unwinding and primary_error is not None:
-            raise primary_error
+            _run_ordered_actions(failures)
+        if not locally_unwinding and failures.primary_error is not None:
+            raise failures.primary_error
 
 
 def _run_callback_with_post_validations(
@@ -591,20 +651,16 @@ def _run_callback_with_post_validations(
         primary_error = callback_error
         if primary_error is None and locally_unwinding:
             primary_error = active_error
-        for label, validation in post_validations:
-            try:
-                validation()
-            except BaseException as validation_error:  # noqa: B036 - keep first
-                if primary_error is None:
-                    primary_error = validation_error
-                else:
-                    _annotate_secondary_error(
-                        primary_error,
-                        label,
-                        validation_error,
-                    )
-        if not locally_unwinding and primary_error is not None:
-            raise primary_error
+        failures = _OrderedActionState(
+            actions=post_validations,
+            iteration_failure_label=(
+                "publication callback post-validation iteration also failed"
+            ),
+            primary_error=primary_error,
+        )
+        _run_ordered_actions(failures)
+        if not locally_unwinding and failures.primary_error is not None:
+            raise failures.primary_error
 
 
 def _run_publication_reader_callback(

--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -497,6 +497,87 @@ def _retain_first_error(
     return primary_error
 
 
+def _run_callback_with_post_validations(
+    callback: Callable[[], _T],
+    post_validations: tuple[tuple[str, Callable[[], None]], ...],
+) -> _T:
+    """Run one callback and ordered postconditions without losing first-primary.
+
+    Postconditions live in ``finally`` around the callback result store, so
+    cancellation after a callback has returned cannot turn an unchecked result
+    into success.  Every postcondition is attempted in order.  A callback
+    failure remains primary and receives each postcondition failure as a direct
+    note; without an earlier failure, the first postcondition failure is
+    primary and later failures become its notes.
+    """
+
+    if not callable(callback) or not isinstance(post_validations, tuple):
+        raise TypeError("callback validation requires callable inputs")
+    for label, validation in post_validations:
+        if not isinstance(label, str) or not label or not callable(validation):
+            raise TypeError("callback post-validations must be labeled callables")
+    # ``sys.exc_info()`` is inherited from an active ``except`` in a caller.
+    # Snapshot that ambient exception so it is never mistaken for a failure
+    # raised by this callback or its result/return cancellation window.
+    ambient_error = sys.exc_info()[1]
+    callback_error: BaseException | None = None
+    try:
+        result = callback()
+        return result
+    except BaseException as error:  # noqa: B036 - preserve exact local primary
+        callback_error = error
+        raise
+    finally:
+        # The explicit callback state normally identifies the locally active
+        # exception.  The active-vs-ambient comparison also covers a new
+        # BaseException injected in the result/return seam before the handler
+        # can store it.  Let locally active failures keep unwinding via the
+        # original bare raise so their traceback is unchanged.
+        active_error = sys.exc_info()[1]
+        locally_unwinding = callback_error is not None or (
+            active_error is not None and active_error is not ambient_error
+        )
+        primary_error = callback_error
+        if primary_error is None and locally_unwinding:
+            primary_error = active_error
+        for label, validation in post_validations:
+            try:
+                validation()
+            except BaseException as validation_error:  # noqa: B036 - keep first
+                if primary_error is None:
+                    primary_error = validation_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        label,
+                        validation_error,
+                    )
+        if not locally_unwinding and primary_error is not None:
+            raise primary_error
+
+
+def _run_publication_reader_callback(
+    reader: PublicationDirectoryReader,
+    callback: Callable[[PublicationDirectoryReader], _T],
+    validate_child_binding: Callable[[], None],
+) -> _T:
+    """Run a reader callback and always recheck validity plus child binding."""
+
+    return _run_callback_with_post_validations(
+        lambda: callback(reader),
+        (
+            (
+                "publication reader validity validation also failed",
+                reader._require_valid,
+            ),
+            (
+                "publication reader child namespace validation also failed",
+                validate_child_binding,
+            ),
+        ),
+    )
+
+
 @dataclass(slots=True)
 class _PosixDescriptorRecord:
     descriptor: int
@@ -1224,25 +1305,55 @@ class DirectoryOrphan:
                 raise RuntimeError("directory orphan platform authority changed")
 
             def use_verified(reader: _PublicationTreeReader) -> _T:
-                before = reader.capture_ownership()
-                _require_matching_ownership(
-                    before,
-                    self.locator.ownership,
-                    label="directory orphan",
-                    allow_root_rename=True,
-                )
-                result = callback(reader)
-                after = reader.capture_ownership()
-                if after != before:
-                    raise RuntimeError("directory orphan changed while reopened")
-                return result
+                before: _TreeOwnership | None = None
 
-            return authority.read_child(
-                self.locator.child_name,
-                path=self.path,
-                label="directory orphan",
-                expected_ownership=self.locator.ownership,
-                callback=use_verified,
+                def consume() -> _T:
+                    nonlocal before
+                    before = reader.capture_ownership()
+                    _require_matching_ownership(
+                        before,
+                        self.locator.ownership,
+                        label="directory orphan",
+                        allow_root_rename=True,
+                    )
+                    return callback(reader)
+
+                def validate_after_ownership() -> None:
+                    after = reader.capture_ownership()
+                    _require_matching_ownership(
+                        after,
+                        self.locator.ownership,
+                        label="directory orphan",
+                        allow_root_rename=True,
+                    )
+                    if before is not None and after != before:
+                        raise RuntimeError("directory orphan changed while reopened")
+
+                return _run_callback_with_post_validations(
+                    consume,
+                    (
+                        (
+                            "directory orphan post-callback ownership validation "
+                            "also failed",
+                            validate_after_ownership,
+                        ),
+                    ),
+                )
+
+            return _run_callback_with_post_validations(
+                lambda: authority.read_child(
+                    self.locator.child_name,
+                    path=self.path,
+                    label="directory orphan",
+                    expected_ownership=self.locator.ownership,
+                    callback=use_verified,
+                ),
+                (
+                    (
+                        "directory orphan authority path validation also failed",
+                        authority.verify_path_binding,
+                    ),
+                ),
             )
 
     def rebind(self) -> _TreeOwnership:
@@ -1432,16 +1543,21 @@ def _open_posix_publication_authority(
                     ),
                     expected_ownership,
                 )
-                result = callback(reader)
-                reader._require_valid()
-                after = os.stat(
-                    name,
-                    dir_fd=owned_descriptor,
-                    follow_symlinks=False,
+
+                def validate_child_binding() -> None:
+                    after = os.stat(
+                        name,
+                        dir_fd=owned_descriptor,
+                        follow_symlinks=False,
+                    )
+                    if _directory_inode_identity(after) != root_identity:
+                        raise RuntimeError(f"{label} namespace binding changed")
+
+                return _run_publication_reader_callback(
+                    reader,
+                    callback,
+                    validate_child_binding,
                 )
-                if _directory_inode_identity(after) != root_identity:
-                    raise RuntimeError(f"{label} namespace binding changed")
-                return result
             except BaseException as exc:
                 primary_error = exc
                 raise
@@ -2491,12 +2607,17 @@ def _open_windows_publication_authority(
                     ),
                     expected_ownership,
                 )
-                result = callback(reader)
-                reader._require_valid()
-                rebound = _windows_find_child(api, owned_parent_handle, name)
-                if rebound is None or rebound.file_id != metadata.st_ino:
-                    raise RuntimeError(f"{label} namespace binding changed")
-                return result
+
+                def validate_child_binding() -> None:
+                    rebound = _windows_find_child(api, owned_parent_handle, name)
+                    if rebound is None or rebound.file_id != metadata.st_ino:
+                        raise RuntimeError(f"{label} namespace binding changed")
+
+                return _run_publication_reader_callback(
+                    reader,
+                    callback,
+                    validate_child_binding,
+                )
             except BaseException as exc:
                 primary_error = exc
                 raise
@@ -3414,6 +3535,43 @@ def _require_tree_ownership(
     )
 
 
+def _run_authenticated_directory_callback(
+    reader: PublicationDirectoryReader,
+    expected_ownership: _TreeOwnership,
+    callback: Callable[[PublicationDirectoryReader], _T],
+) -> _T:
+    """Run one authenticated callback inside an exact ownership sandwich."""
+
+    def consume() -> _T:
+        before = reader.capture_ownership()
+        if before != expected_ownership:
+            raise RuntimeError(
+                "authenticated directory differs from expected ownership"
+            )
+        return callback(reader)
+
+    def validate_after_ownership() -> None:
+        after = reader.capture_ownership()
+        if after != expected_ownership:
+            raise RuntimeError("authenticated directory changed while it was consumed")
+
+    return _run_callback_with_post_validations(
+        consume,
+        (
+            (
+                "authenticated directory post-callback reader validity "
+                "validation also failed",
+                reader._require_valid,
+            ),
+            (
+                "authenticated directory post-callback ownership validation "
+                "also failed",
+                validate_after_ownership,
+            ),
+        ),
+    )
+
+
 def reopen_authenticated_directory(
     path: Path,
     expected_ownership: _TreeOwnership,
@@ -3444,32 +3602,25 @@ def reopen_authenticated_directory(
             authority_owner=authority_owner,
         )
 
-        def consume(reader: PublicationDirectoryReader) -> _T:
-            before = reader.capture_ownership()
-            if before != expected_ownership:
-                raise RuntimeError(
-                    "authenticated directory differs from expected ownership"
-                )
-            result = callback(reader)
-            # A validator may deliberately catch a stream/snapshot failure.
-            # Reject before another namespace observation can hide that failure.
-            reader._require_valid()
-            after = reader.capture_ownership()
-            if after != expected_ownership:
-                raise RuntimeError(
-                    "authenticated directory changed while it was consumed"
-                )
-            return result
-
-        result = authority.read_child(
-            lexical.name,
-            path=lexical,
-            label="authenticated directory",
-            expected_ownership=expected_ownership,
-            callback=consume,
+        return _run_callback_with_post_validations(
+            lambda: authority.read_child(
+                lexical.name,
+                path=lexical,
+                label="authenticated directory",
+                expected_ownership=expected_ownership,
+                callback=lambda reader: _run_authenticated_directory_callback(
+                    reader,
+                    expected_ownership,
+                    callback,
+                ),
+            ),
+            (
+                (
+                    "authenticated directory authority path validation also failed",
+                    authority.verify_path_binding,
+                ),
+            ),
         )
-        authority.verify_path_binding()
-        return result
 
 
 def discard_owned_directory(

--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -497,6 +497,57 @@ def _retain_first_error(
     return primary_error
 
 
+@contextmanager
+def _run_context_with_cleanup_actions(
+    cleanup_actions: Callable[
+        [],
+        tuple[tuple[str, Callable[[], None]], ...],
+    ],
+) -> Iterator[None]:
+    """Run every cleanup action without replacing a context-body primary."""
+
+    if not callable(cleanup_actions):
+        raise TypeError("context cleanup actions must be callable")
+    # An outer ``except`` leaves an ambient value in ``sys.exc_info()``. Track
+    # it separately so cleanup-only failure still propagates from a successful
+    # context body entered while that unrelated exception is being handled.
+    ambient_error = sys.exc_info()[1]
+    context_error: BaseException | None = None
+    try:
+        yield
+    except BaseException as error:  # noqa: B036 - preserve exact local primary
+        context_error = error
+        raise
+    finally:
+        active_error = sys.exc_info()[1]
+        locally_unwinding = context_error is not None or (
+            active_error is not None and active_error is not ambient_error
+        )
+        primary_error = context_error
+        if primary_error is None and locally_unwinding:
+            primary_error = active_error
+        try:
+            actions = cleanup_actions()
+        except BaseException as action_error:  # noqa: B036 - keep first primary
+            primary_error = _retain_first_error(
+                primary_error,
+                "publication authenticated cleanup planning also failed",
+                action_error,
+            )
+        else:
+            for label, cleanup in actions:
+                try:
+                    cleanup()
+                except BaseException as cleanup_error:  # noqa: B036 - keep first
+                    primary_error = _retain_first_error(
+                        primary_error,
+                        label,
+                        cleanup_error,
+                    )
+        if not locally_unwinding and primary_error is not None:
+            raise primary_error
+
+
 def _run_callback_with_post_validations(
     callback: Callable[[], _T],
     post_validations: tuple[tuple[str, Callable[[], None]], ...],
@@ -2173,7 +2224,33 @@ def _open_windows_authenticated_file(
     authenticated: PublicationAuthenticatedFile | None = None
     expected_directories = dict(expected.directory_identities)
     traversed: list[str] = []
-    try:
+
+    def cleanup_actions() -> tuple[tuple[str, Callable[[], None]], ...]:
+        actions: list[tuple[str, Callable[[], None]]] = []
+        if authenticated is not None:
+            actions.append(
+                (
+                    "publication authenticated file finalization also failed",
+                    lambda: authenticated._finalize(),
+                )
+            )
+        if file_handle:
+            actions.append(
+                (
+                    "publication authenticated file HANDLE cleanup also failed",
+                    lambda: api.close(file_handle),
+                )
+            )
+        actions.extend(
+            (
+                "publication authenticated directory HANDLE cleanup also failed",
+                lambda handle=handle: api.close(handle),
+            )
+            for handle in reversed(opened_directories)
+        )
+        return tuple(actions)
+
+    with _run_context_with_cleanup_actions(cleanup_actions):
         for part in relative.parts[:-1]:
             traversed.append(part)
             relative_directory = "/".join(traversed)
@@ -2263,15 +2340,6 @@ def _open_windows_authenticated_file(
             verify_callback=verify,
         )
         yield authenticated
-    finally:
-        try:
-            if authenticated is not None:
-                authenticated._finalize()
-        finally:
-            if file_handle:
-                api.close(file_handle)
-            for handle in reversed(opened_directories):
-                api.close(handle)
 
 
 def _scan_windows_owned_directory(
@@ -2844,7 +2912,33 @@ def _open_posix_authenticated_file(
     authenticated: PublicationAuthenticatedFile | None = None
     expected_directories = dict(expected.directory_identities)
     traversed: list[str] = []
-    try:
+
+    def cleanup_actions() -> tuple[tuple[str, Callable[[], None]], ...]:
+        actions: list[tuple[str, Callable[[], None]]] = []
+        if authenticated is not None:
+            actions.append(
+                (
+                    "publication authenticated file finalization also failed",
+                    lambda: authenticated._finalize(),
+                )
+            )
+        if file_descriptor >= 0:
+            actions.append(
+                (
+                    "publication authenticated file descriptor cleanup also failed",
+                    lambda: os.close(file_descriptor),
+                )
+            )
+        actions.extend(
+            (
+                "publication authenticated directory descriptor cleanup also failed",
+                lambda descriptor=descriptor: os.close(descriptor),
+            )
+            for descriptor in reversed(descriptors)
+        )
+        return tuple(actions)
+
+    with _run_context_with_cleanup_actions(cleanup_actions):
         for part in relative.parts[:-1]:
             traversed.append(part)
             relative_directory = "/".join(traversed)
@@ -2939,15 +3033,6 @@ def _open_posix_authenticated_file(
             verify_callback=verify,
         )
         yield authenticated
-    finally:
-        try:
-            if authenticated is not None:
-                authenticated._finalize()
-        finally:
-            if file_descriptor >= 0:
-                os.close(file_descriptor)
-            for descriptor in reversed(descriptors):
-                os.close(descriptor)
 
 
 def _ownership_hash_field(hasher, value: bytes) -> None:

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -297,6 +297,16 @@ publish after it escapes. The gate records the exact callback result or
 callback failure. No production provider or BM25/context producer is wired to
 that strict contract yet, so M1 remains in progress.
 
+Callback-scoped directory results are likewise provisional until ordered
+reader-validity, exact-ownership, child-namespace, and parent-authority
+postconditions have been processed after callback success, failure, or
+cancellation. Authenticated-file exit continues through finalization and every
+remaining descriptor or HANDLE cleanup action when an action or loop transition
+fails. The first local callback, postflight, or cleanup failure stays primary;
+later failures are diagnostic only. This closes the Python-owned callback-result
+and action-loop back-edge seams without completing M1 producer wiring or the
+documented native-owner work for raw resource-return P2 gaps.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -2853,6 +2853,286 @@ def test_directory_orphan_callback_primary_survives_post_content_drift(
         saved_reader[0].capture_ownership()
 
 
+def _posix_cleanup_test_reader(
+    root: Path,
+) -> tuple[atomic_module.PublicationDirectoryReader, int]:
+    ownership = capture_directory_ownership(root)
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    root_descriptor = os.open(root, flags)
+    reader = atomic_module.PublicationDirectoryReader(
+        root,
+        ownership.root_identity,
+        lambda _required, _allow_empty, _policy: ownership,
+        lambda relative, max_bytes, expected: (
+            atomic_module._open_posix_authenticated_file(
+                root_descriptor,
+                root,
+                relative,
+                max_bytes=max_bytes,
+                expected=expected,
+            )
+        ),
+        ownership,
+    )
+    return reader, root_descriptor
+
+
+def _windows_cleanup_test_reader() -> tuple[
+    _FakeWindowsApi,
+    atomic_module.PublicationDirectoryReader,
+    int,
+]:
+    api = _FakeWindowsApi()
+    nested = api.add_directory(api.root_id, "nested")
+    api.add_file(nested, "payload.txt", b"payload")
+    root_path = Path("C:/authority")
+    root_handle = api.create_directory_handle(root_path)
+    ownership = atomic_module._capture_windows_directory_handle(
+        api,
+        root_handle,
+        root_path,
+        required_root_file=None,
+        allow_empty_root=False,
+        entry_policy=None,
+    )
+    reader = atomic_module.PublicationDirectoryReader(
+        root_path,
+        ownership.root_identity,
+        lambda _required, _allow_empty, _policy: ownership,
+        lambda relative, max_bytes, expected: (
+            atomic_module._open_windows_authenticated_file(
+                api,
+                root_handle,
+                root_path,
+                relative,
+                max_bytes=max_bytes,
+                expected=expected,
+            )
+        ),
+        ownership,
+    )
+    return api, reader, root_handle
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX directory descriptors",
+)
+@pytest.mark.parametrize("primary_type", [KeyboardInterrupt, SystemExit, GeneratorExit])
+def test_posix_authenticated_file_body_primary_survives_cleanup_faults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    primary_type: type[BaseException],
+) -> None:
+    root = tmp_path / "publication"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload.txt").write_bytes(b"payload")
+    reader, root_descriptor = _posix_cleanup_test_reader(root)
+    real_close = os.close
+    primary = primary_type("body-primary")
+    close_errors: list[OSError] = []
+
+    def fail_finalize(_authenticated: object) -> None:
+        raise RuntimeError("finalize-secondary")
+
+    def close_then_fail(descriptor: int) -> None:
+        real_close(descriptor)
+        error = OSError(f"close-secondary-{len(close_errors)}")
+        close_errors.append(error)
+        raise error
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(
+                atomic_module.PublicationAuthenticatedFile,
+                "_finalize",
+                fail_finalize,
+            )
+            faults.setattr(atomic_module.os, "close", close_then_fail)
+            with pytest.raises(primary_type, match="body-primary") as caught:
+                with reader.open_authenticated_file(
+                    "nested/payload.txt",
+                    max_bytes=16,
+                ):
+                    raise primary
+
+        assert caught.value is primary
+        notes = _exception_notes(primary)
+        assert any(
+            "file finalization also failed" in note and "finalize-secondary" in note
+            for note in notes
+        )
+        assert any("file descriptor cleanup also failed" in note for note in notes)
+        assert any("directory descriptor cleanup also failed" in note for note in notes)
+        assert len(close_errors) == 3
+        assert reader._authentication_failed is True
+        with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+            reader._require_valid()
+    finally:
+        reader._deactivate()
+        real_close(root_descriptor)
+
+
+@pytest.mark.parametrize("primary_type", [KeyboardInterrupt, SystemExit, GeneratorExit])
+def test_windows_authenticated_file_body_primary_survives_cleanup_faults(
+    monkeypatch: pytest.MonkeyPatch,
+    primary_type: type[BaseException],
+) -> None:
+    api, reader, root_handle = _windows_cleanup_test_reader()
+    real_close = api.close
+    primary = primary_type("body-primary")
+    close_errors: list[OSError] = []
+
+    def fail_finalize(_authenticated: object) -> None:
+        raise RuntimeError("finalize-secondary")
+
+    def close_then_fail(handle: int) -> None:
+        real_close(handle)
+        error = OSError(f"close-secondary-{len(close_errors)}")
+        close_errors.append(error)
+        raise error
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(
+                atomic_module.PublicationAuthenticatedFile,
+                "_finalize",
+                fail_finalize,
+            )
+            faults.setattr(api, "close", close_then_fail)
+            with pytest.raises(primary_type, match="body-primary") as caught:
+                with reader.open_authenticated_file(
+                    "nested/payload.txt",
+                    max_bytes=16,
+                ):
+                    raise primary
+
+        assert caught.value is primary
+        notes = _exception_notes(primary)
+        assert any(
+            "file finalization also failed" in note and "finalize-secondary" in note
+            for note in notes
+        )
+        assert any("file HANDLE cleanup also failed" in note for note in notes)
+        assert any("directory HANDLE cleanup also failed" in note for note in notes)
+        assert len(close_errors) == 2
+        assert reader._authentication_failed is True
+        with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+            reader._require_valid()
+    finally:
+        reader._deactivate()
+        real_close(root_handle)
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX directory descriptors",
+)
+@pytest.mark.parametrize("failure_phase", ["finalize", "close"])
+def test_posix_authenticated_file_cleanup_primary_is_exact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_phase: str,
+) -> None:
+    root = tmp_path / "publication"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload.txt").write_bytes(b"payload")
+    reader, root_descriptor = _posix_cleanup_test_reader(root)
+    real_close = os.close
+    cleanup_primary = SystemExit(f"{failure_phase}-primary")
+    close_calls = 0
+
+    def fail_finalize(_authenticated: object) -> None:
+        raise cleanup_primary
+
+    def close_with_first_fault(descriptor: int) -> None:
+        nonlocal close_calls
+        real_close(descriptor)
+        close_calls += 1
+        if close_calls == 1:
+            raise cleanup_primary
+
+    try:
+        with monkeypatch.context() as faults:
+            if failure_phase == "finalize":
+                faults.setattr(
+                    atomic_module.PublicationAuthenticatedFile,
+                    "_finalize",
+                    fail_finalize,
+                )
+            else:
+                faults.setattr(atomic_module.os, "close", close_with_first_fault)
+            with pytest.raises(SystemExit, match=f"{failure_phase}-primary") as caught:
+                with reader.open_authenticated_file(
+                    "nested/payload.txt",
+                    max_bytes=16,
+                ):
+                    pass
+
+        assert caught.value is cleanup_primary
+        if failure_phase == "close":
+            assert close_calls == 3
+        assert reader._authentication_failed is True
+        with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+            reader._require_valid()
+    finally:
+        reader._deactivate()
+        real_close(root_descriptor)
+
+
+@pytest.mark.parametrize("failure_phase", ["finalize", "close"])
+def test_windows_authenticated_file_cleanup_primary_is_exact(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_phase: str,
+) -> None:
+    api, reader, root_handle = _windows_cleanup_test_reader()
+    real_close = api.close
+    cleanup_primary = SystemExit(f"{failure_phase}-primary")
+    close_calls = 0
+
+    def fail_finalize(_authenticated: object) -> None:
+        raise cleanup_primary
+
+    def close_with_first_fault(handle: int) -> None:
+        nonlocal close_calls
+        real_close(handle)
+        close_calls += 1
+        if close_calls == 1:
+            raise cleanup_primary
+
+    try:
+        with monkeypatch.context() as faults:
+            if failure_phase == "finalize":
+                faults.setattr(
+                    atomic_module.PublicationAuthenticatedFile,
+                    "_finalize",
+                    fail_finalize,
+                )
+            else:
+                faults.setattr(api, "close", close_with_first_fault)
+            with pytest.raises(SystemExit, match=f"{failure_phase}-primary") as caught:
+                with reader.open_authenticated_file(
+                    "nested/payload.txt",
+                    max_bytes=16,
+                ):
+                    pass
+
+        assert caught.value is cleanup_primary
+        if failure_phase == "close":
+            assert close_calls == 2
+        assert reader._authentication_failed is True
+        with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+            reader._require_valid()
+    finally:
+        reader._deactivate()
+        real_close(root_handle)
+    assert api.handles == {}
+
+
 def test_publication_reader_streams_and_authenticates_on_context_exit(
     tmp_path: Path,
 ) -> None:

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -33,6 +33,13 @@ def _write_tree(root: Path, name: str, value: str) -> None:
     (root / name).write_text(value, encoding="utf-8")
 
 
+def _exception_notes(error: BaseException) -> tuple[str, ...]:
+    return (
+        *tuple(getattr(error, "__notes__", ())),
+        *tuple(getattr(error, "_codenib_cleanup_notes", ())),
+    )
+
+
 class _FakeWindowsApi:
     """In-memory HANDLE/FILE_ID model; it intentionally has no path reads."""
 
@@ -2813,6 +2820,39 @@ def test_directory_orphan_reopens_through_parent_authority(tmp_path: Path) -> No
         saved_reader[0].capture_ownership()
 
 
+def test_directory_orphan_callback_primary_survives_post_content_drift(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    orphan = publish_staged_directory(stage, destination)
+    assert orphan is not None
+    primary = ValueError("callback failed")
+    saved_reader: list[atomic_module.PublicationDirectoryReader] = []
+
+    def mutate_then_fail(reader: atomic_module.PublicationDirectoryReader) -> None:
+        saved_reader.append(reader)
+        (orphan.path / "old.txt").write_text("mutated", encoding="utf-8")
+        raise primary
+
+    with pytest.raises(ValueError) as caught:
+        orphan.reopen(mutate_then_fail)
+
+    assert caught.value is primary
+    notes = _exception_notes(primary)
+    assert any(
+        "directory orphan post-callback ownership validation also failed" in note
+        and ("changed" in note or "differs" in note)
+        for note in notes
+    )
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_reader[0].capture_ownership()
+
+
 def test_publication_reader_streams_and_authenticates_on_context_exit(
     tmp_path: Path,
 ) -> None:
@@ -3166,6 +3206,392 @@ def test_reopen_authenticated_directory_rejects_reversible_root_swap(
     assert (foreign / "payload.txt").read_text(encoding="utf-8") == "foreign"
 
 
+@pytest.mark.parametrize(
+    "primary",
+    [
+        pytest.param(ValueError("callback failed"), id="value-error"),
+        pytest.param(KeyboardInterrupt("callback interrupted"), id="keyboard"),
+        pytest.param(SystemExit("callback exited"), id="system-exit"),
+    ],
+)
+def test_reopen_callback_primary_survives_post_content_drift_detection(
+    tmp_path: Path,
+    primary: BaseException,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    saved_readers: list[object] = []
+
+    def mutate_then_fail(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        saved_readers.append(reader)
+        (directory / "payload.txt").write_text("mutated", encoding="utf-8")
+        raise primary
+
+    with pytest.raises(type(primary)) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            mutate_then_fail,
+        )
+
+    assert caught.value is primary
+    traceback_names: list[str] = []
+    traceback = caught.value.__traceback__
+    while traceback is not None:
+        traceback_names.append(traceback.tb_frame.f_code.co_name)
+        traceback = traceback.tb_next
+    assert "mutate_then_fail" in traceback_names
+    assert any(
+        "post-callback ownership validation also failed" in note
+        and ("changed" in note or "differs" in note)
+        for note in _exception_notes(primary)
+    )
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
+def test_reopen_active_outer_exception_raises_exact_postflight_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    outer_error = ValueError("ambient outer failure")
+    post_error = OSError(errno.EIO, "injected tree post-capture failure")
+    real_capture = atomic_module.PublicationDirectoryReader.capture_ownership
+    capture_calls = 0
+    saved_readers: list[atomic_module.PublicationDirectoryReader] = []
+
+    def fail_post_capture(reader: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        if capture_calls == 2:
+            raise post_error
+        return real_capture(reader, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_module.PublicationDirectoryReader,
+        "capture_ownership",
+        fail_post_capture,
+    )
+
+    def mutate_then_return(reader: atomic_module.PublicationDirectoryReader) -> int:
+        saved_readers.append(reader)
+        (directory / "payload.txt").write_text("mutated", encoding="utf-8")
+        return 7
+
+    try:
+        raise outer_error
+    except ValueError as active_outer:
+        assert active_outer is outer_error
+        with pytest.raises(OSError) as caught:
+            atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                mutate_then_return,
+            )
+
+    assert caught.value is post_error
+    assert capture_calls == 2
+    assert _exception_notes(outer_error) == ()
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
+def test_reopen_active_outer_exception_all_green_returns_result(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    outer_error = ValueError("ambient outer failure")
+    saved_readers: list[atomic_module.PublicationDirectoryReader] = []
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> int:
+        saved_readers.append(reader)
+        return 7
+
+    try:
+        raise outer_error
+    except ValueError as active_outer:
+        assert active_outer is outer_error
+        result = atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            consume,
+        )
+
+    assert result == 7
+    assert _exception_notes(outer_error) == ()
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
+def test_reopen_callback_primary_inside_active_outer_exception_is_local(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    outer_error = ValueError("ambient outer failure")
+    callback_error = OSError(errno.EIO, "local callback failure")
+    saved_readers: list[atomic_module.PublicationDirectoryReader] = []
+
+    def mutate_then_fail(reader: atomic_module.PublicationDirectoryReader) -> None:
+        saved_readers.append(reader)
+        (directory / "payload.txt").write_text("mutated", encoding="utf-8")
+        raise callback_error
+
+    try:
+        raise outer_error
+    except ValueError as active_outer:
+        assert active_outer is outer_error
+        with pytest.raises(OSError) as caught:
+            atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                mutate_then_fail,
+            )
+
+    assert caught.value is callback_error
+    traceback_names: list[str] = []
+    traceback = callback_error.__traceback__
+    while traceback is not None:
+        traceback_names.append(traceback.tb_frame.f_code.co_name)
+        traceback = traceback.tb_next
+    assert "mutate_then_fail" in traceback_names
+    assert any(
+        "post-callback ownership validation also failed" in note
+        and ("changed" in note or "differs" in note)
+        for note in _exception_notes(callback_error)
+    )
+    assert _exception_notes(outer_error) == ()
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
+def test_reopen_callback_primary_survives_child_namespace_drift_detection(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    held = tmp_path / "held"
+    primary = ValueError("callback failed after namespace drift")
+
+    def replace_root_then_fail(_reader: object) -> None:
+        directory.rename(held)
+        _write_tree(directory, "payload.txt", "foreign")
+        raise primary
+
+    with pytest.raises(ValueError) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            replace_root_then_fail,
+        )
+
+    assert caught.value is primary
+    assert any(
+        "child namespace validation also failed" in note
+        and "namespace binding changed" in note
+        for note in _exception_notes(primary)
+    )
+
+
+def test_reopen_callback_primary_survives_authority_path_binding_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    primary = ValueError("callback failed before authority verification")
+    path_error = OSError(errno.EIO, "injected authority path verification failure")
+    verification_calls = 0
+
+    def fail_path_binding(_authority: object) -> None:
+        nonlocal verification_calls
+        verification_calls += 1
+        raise path_error
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "verify_path_binding",
+        fail_path_binding,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            lambda _reader: (_ for _ in ()).throw(primary),
+        )
+
+    assert caught.value is primary
+    assert verification_calls == 1
+    assert any(
+        "authority path validation also failed" in note
+        and "injected authority path verification failure" in note
+        for note in _exception_notes(primary)
+    )
+
+
+def test_reopen_callback_primary_survives_post_capture_eio(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    primary = ValueError("callback failed before post capture")
+    post_error = OSError(errno.EIO, "injected authenticated post-capture failure")
+    real_capture = atomic_module.PublicationDirectoryReader.capture_ownership
+    capture_calls = 0
+
+    def fail_post_capture(reader: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        if capture_calls == 2:
+            raise post_error
+        return real_capture(reader, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_module.PublicationDirectoryReader,
+        "capture_ownership",
+        fail_post_capture,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            lambda _reader: (_ for _ in ()).throw(primary),
+        )
+
+    assert caught.value is primary
+    assert capture_calls == 2
+    assert any(
+        "post-callback ownership validation also failed" in note
+        and "authenticated post-capture failure" in note
+        for note in _exception_notes(primary)
+    )
+
+
+@pytest.mark.parametrize("callback_fails", [True, False], ids=["callback", "return"])
+def test_reopen_postflight_faults_are_best_effort_and_ordered(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    callback_fails: bool,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    held = tmp_path / "held"
+    callback_error = ValueError("callback failed after replacing the child")
+    tree_error = OSError(errno.EIO, "injected tree post-capture failure")
+    validity_error = RuntimeError("injected reader validity failure")
+    parent_error = RuntimeError("injected parent binding failure")
+    cleanup_error = RuntimeError("injected authority cleanup failure")
+    real_capture = atomic_module.PublicationDirectoryReader.capture_ownership
+    real_close = atomic_module._PublicationAuthority.close
+    capture_calls = 0
+    validity_calls = 0
+    saved_readers: list[atomic_module.PublicationDirectoryReader] = []
+
+    def fail_tree_post_capture(reader: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        if capture_calls == 2:
+            raise tree_error
+        return real_capture(reader, **kwargs)
+
+    def fail_reader_validity(_reader: object) -> None:
+        nonlocal validity_calls
+        validity_calls += 1
+        if validity_calls == 2:
+            raise validity_error
+
+    def fail_parent_binding(_authority: object) -> None:
+        raise parent_error
+
+    def close_then_fail(authority: object) -> None:
+        real_close(authority)
+        raise cleanup_error
+
+    monkeypatch.setattr(
+        atomic_module.PublicationDirectoryReader,
+        "capture_ownership",
+        fail_tree_post_capture,
+    )
+    monkeypatch.setattr(
+        atomic_module.PublicationDirectoryReader,
+        "_require_valid",
+        fail_reader_validity,
+    )
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "verify_path_binding",
+        fail_parent_binding,
+    )
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "close",
+        close_then_fail,
+    )
+
+    def replace_child_then_finish(
+        reader: atomic_module.PublicationDirectoryReader,
+    ) -> int:
+        saved_readers.append(reader)
+        directory.rename(held)
+        _write_tree(directory, "payload.txt", "foreign")
+        if callback_fails:
+            raise callback_error
+        return 7
+
+    with pytest.raises(BaseException) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            replace_child_then_finish,
+        )
+
+    expected_primary = callback_error if callback_fails else tree_error
+    assert caught.value is expected_primary
+    assert capture_calls == 2
+    assert validity_calls == 2
+    notes = _exception_notes(expected_primary)
+    expected_note_fragments = (
+        *(
+            ("post-callback ownership validation also failed",)
+            if callback_fails
+            else ()
+        ),
+        "publication reader validity validation also failed",
+        "publication reader child namespace validation also failed",
+        "authenticated directory authority path validation also failed",
+        "publication authority owner cleanup also failed",
+    )
+    note_positions = [
+        next(index for index, note in enumerate(notes) if fragment in note)
+        for fragment in expected_note_fragments
+    ]
+    assert note_positions == sorted(note_positions)
+    if callback_fails:
+        traceback_names: list[str] = []
+        traceback = caught.value.__traceback__
+        while traceback is not None:
+            traceback_names.append(traceback.tb_frame.f_code.co_name)
+            traceback = traceback.tb_next
+        assert "replace_child_then_finish" in traceback_names
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="requires Linux fd accounting",
@@ -3308,6 +3734,61 @@ def test_reopen_authenticated_directory_fake_windows_rejects_suppressed_error(
     assert isinstance(children, dict)
     assert children["payload.txt"] == original_id
     assert children["foreign.txt"] == foreign_id
+
+
+def test_reopen_authenticated_directory_fake_windows_checks_child_after_primary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    directory_id = api.add_directory(api.root_id, "existing")
+    api.add_file(directory_id, "payload.txt", b"payload")
+    foreign_id = api.add_directory()
+    api.add_file(foreign_id, "payload.txt", b"foreign")
+    monkeypatch.setattr(atomic_module.sys, "platform", "win32")
+    monkeypatch.setattr(atomic_module, "_windows_require_publication_api", lambda: None)
+    monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    path = Path("C:/authority/existing")
+    authority = atomic_module._open_windows_publication_authority(
+        path.parent,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            path.name,
+            path=path,
+            label="existing",
+        )
+    finally:
+        authority.close()
+    assert api.handles == {}
+    primary = KeyboardInterrupt("callback interrupted after child replacement")
+    saved_readers: list[object] = []
+
+    def replace_child_then_fail(reader: object) -> None:
+        saved_readers.append(reader)
+        children = api.nodes[api.root_id]["children"]
+        assert isinstance(children, dict)
+        children["held"] = children.pop("existing")
+        children["existing"] = foreign_id
+        raise primary
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        atomic_module.reopen_authenticated_directory(
+            path,
+            ownership,
+            replace_child_then_fail,
+        )
+
+    assert caught.value is primary
+    assert any(
+        "child namespace validation also failed" in note
+        and "namespace binding changed" in note
+        for note in _exception_notes(primary)
+    )
+    assert api.handles == {}
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
@@ -3668,6 +4149,51 @@ def _assert_descriptor_closed(descriptor: int) -> None:
     with pytest.raises(OSError) as caught:
         os.fstat(descriptor)
     assert caught.value.errno == errno.EBADF
+
+
+def test_reopen_interrupt_after_callback_result_store_runs_post_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    real_capture = atomic_module.PublicationDirectoryReader.capture_ownership
+    capture_calls = 0
+    saved_readers: list[object] = []
+    interruption = KeyboardInterrupt("after callback result store")
+
+    def count_capture(reader: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        return real_capture(reader, **kwargs)
+
+    def consume(reader: object) -> int:
+        saved_readers.append(reader)
+        return 7
+
+    monkeypatch.setattr(
+        atomic_module.PublicationDirectoryReader,
+        "capture_ownership",
+        count_capture,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _call_with_interrupt_after_store(
+            atomic_module._run_callback_with_post_validations,
+            "result",
+            lambda: atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                consume,
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert capture_calls == 2
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
 
 
 @pytest.mark.skipif(

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -4383,24 +4383,48 @@ def _call_with_interrupt_after_store(
     assert predicate is None or callable(predicate)
     code = function.__code__
     instructions = tuple(dis.get_instructions(function))
-    offsets_after_store = {
-        instructions[index + 1].offset
+    result_store_indexes = {
+        index
         for index, instruction in enumerate(instructions[:-1])
-        if instruction.opname == "STORE_FAST" and instruction.argval == local_name
+        if instruction.opname == "STORE_FAST"
+        and instruction.argval == local_name
+        and index > 0
+        and instructions[index - 1].opname.startswith("CALL")
     }
+    opcode_offsets_after_store = {
+        instructions[index + 1].offset for index in result_store_indexes
+    }
+    result_store_offsets = {
+        instructions[index].offset for index in result_store_indexes
+    }
+    line_offsets_after_store = {
+        instruction.offset
+        for instruction in instructions
+        if instruction.starts_line is not None
+        and any(
+            instruction.offset > store_offset for store_offset in result_store_offsets
+        )
+    }
+    assert result_store_indexes
     previous_trace = sys.gettrace()
+    injected = False
 
     def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
         if event == "call" and frame.f_code is code:
             frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
             return trace
         if (
-            event == "opcode"
-            and frame.f_code is code
-            and frame.f_lasti in offsets_after_store
+            frame.f_code is code
+            and (
+                (event == "opcode" and frame.f_lasti in opcode_offsets_after_store)
+                or (event == "line" and frame.f_lasti in line_offsets_after_store)
+            )
             and int(frame.f_locals.get(local_name, -1)) >= 0
             and (predicate is None or predicate(frame.f_locals))
         ):
+            injected = True
             sys.settrace(None)
             raise error
         return trace
@@ -4410,6 +4434,67 @@ def _call_with_interrupt_after_store(
         callback()
     finally:
         sys.settrace(previous_trace)
+        assert injected, f"failed to inject after {local_name} result store"
+
+
+def _call_with_interrupt_at_back_edge(
+    function: object,
+    callback: object,
+    *,
+    predicate: object,
+    error: BaseException,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    assert callable(predicate)
+    code = function.__code__
+    instructions = tuple(dis.get_instructions(function))
+    back_edges = tuple(
+        instruction
+        for instruction in instructions
+        if "JUMP" in instruction.opname
+        and isinstance(instruction.argval, int)
+        and instruction.argval < instruction.offset
+    )
+    assert back_edges
+    # The ordered runner may also have a handler-local back-edge.  Select the
+    # outer action-loop edge (the earliest destination) so a 3.12 line event
+    # cannot inject at handler fallthrough before the real normal back-edge.
+    loop_destination = min(instruction.argval for instruction in back_edges)
+    opcode_offsets = {
+        instruction.offset
+        for instruction in back_edges
+        if instruction.argval == loop_destination
+    }
+    line_offsets = {loop_destination}
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
+            return trace
+        if (
+            frame.f_code is code
+            and (
+                (event == "opcode" and frame.f_lasti in opcode_offsets)
+                or (event == "line" and frame.f_lasti in line_offsets)
+            )
+            and predicate(frame.f_locals)
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, "failed to inject at an ordered-action back-edge"
 
 
 def _posix_authority_resources(
@@ -4429,6 +4514,316 @@ def _assert_descriptor_closed(descriptor: int) -> None:
     with pytest.raises(OSError) as caught:
         os.fstat(descriptor)
     assert caught.value.errno == errno.EBADF
+
+
+@pytest.mark.parametrize("callback_fails", [True, False], ids=["primary", "return"])
+def test_ordered_post_validations_resume_after_back_edge_cancellation(
+    callback_fails: bool,
+) -> None:
+    callback_error = ValueError("callback primary")
+    interruption = KeyboardInterrupt("post-validation back-edge")
+    final_error = OSError(errno.EIO, "final validation failure")
+    calls: list[str] = []
+
+    def callback() -> int:
+        if callback_fails:
+            raise callback_error
+        return 7
+
+    def first_validation() -> None:
+        calls.append("first")
+
+    def final_validation() -> None:
+        calls.append("final")
+        raise final_error
+
+    def invoke() -> None:
+        atomic_module._run_callback_with_post_validations(
+            callback,
+            (
+                ("first post-validation also failed", first_validation),
+                ("final post-validation also failed", final_validation),
+            ),
+        )
+
+    with pytest.raises(BaseException) as caught:
+        _call_with_interrupt_at_back_edge(
+            atomic_module._run_ordered_actions,
+            invoke,
+            predicate=lambda local: (
+                local["state"].next_index == 1 and calls == ["first"]
+            ),
+            error=interruption,
+        )
+
+    expected_primary = callback_error if callback_fails else interruption
+    assert caught.value is expected_primary
+    assert calls == ["first", "final"]
+    notes = _exception_notes(expected_primary)
+    expected_fragments = (
+        *(
+            ("publication callback post-validation iteration also failed",)
+            if callback_fails
+            else ()
+        ),
+        "final post-validation also failed",
+    )
+    positions = [
+        next(index for index, note in enumerate(notes) if fragment in note)
+        for fragment in expected_fragments
+    ]
+    assert positions == sorted(positions)
+
+
+def test_ordered_post_validations_protect_back_edge_after_action_error() -> None:
+    callback_error = ValueError("callback primary")
+    first_error = OSError(errno.EIO, "first validation failure")
+    interruption = SystemExit("validation error-handler back-edge")
+    calls: list[str] = []
+
+    def first_validation() -> None:
+        calls.append("first")
+        raise first_error
+
+    def final_validation() -> None:
+        calls.append("final")
+
+    def invoke() -> None:
+        atomic_module._run_callback_with_post_validations(
+            lambda: (_ for _ in ()).throw(callback_error),
+            (
+                ("first post-validation also failed", first_validation),
+                ("final post-validation also failed", final_validation),
+            ),
+        )
+
+    with pytest.raises(ValueError) as caught:
+        _call_with_interrupt_at_back_edge(
+            atomic_module._run_ordered_actions,
+            invoke,
+            predicate=lambda local: (
+                local["state"].next_index == 1 and calls == ["first"]
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is callback_error
+    assert calls == ["first", "final"]
+    notes = _exception_notes(callback_error)
+    first_position = next(
+        index
+        for index, note in enumerate(notes)
+        if "first post-validation also failed" in note
+    )
+    interruption_position = next(
+        index
+        for index, note in enumerate(notes)
+        if "post-validation iteration also failed" in note
+    )
+    assert first_position < interruption_position
+
+
+@pytest.mark.parametrize("body_fails", [True, False], ids=["primary", "return"])
+def test_ordered_cleanup_resumes_after_back_edge_cancellation(
+    body_fails: bool,
+) -> None:
+    body_error = ValueError("context body primary")
+    interruption = KeyboardInterrupt("cleanup back-edge")
+    final_error = OSError(errno.EIO, "final cleanup failure")
+    calls: list[str] = []
+
+    def first_cleanup() -> None:
+        calls.append("first")
+
+    def final_cleanup() -> None:
+        calls.append("final")
+        raise final_error
+
+    def invoke() -> None:
+        with atomic_module._run_context_with_cleanup_actions(
+            lambda: (
+                ("first cleanup also failed", first_cleanup),
+                ("final cleanup also failed", final_cleanup),
+            )
+        ):
+            if body_fails:
+                raise body_error
+
+    with pytest.raises(BaseException) as caught:
+        _call_with_interrupt_at_back_edge(
+            atomic_module._run_ordered_actions,
+            invoke,
+            predicate=lambda local: (
+                local["state"].next_index == 1 and calls == ["first"]
+            ),
+            error=interruption,
+        )
+
+    expected_primary = body_error if body_fails else interruption
+    assert caught.value is expected_primary
+    assert calls == ["first", "final"]
+    notes = _exception_notes(expected_primary)
+    expected_fragments = (
+        *(
+            ("publication authenticated cleanup iteration also failed",)
+            if body_fails
+            else ()
+        ),
+        "final cleanup also failed",
+    )
+    positions = [
+        next(index for index, note in enumerate(notes) if fragment in note)
+        for fragment in expected_fragments
+    ]
+    assert positions == sorted(positions)
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX descriptors",
+)
+def test_cleanup_back_edge_cancellation_closes_remaining_posix_descriptors() -> None:
+    first_read, first_write = os.pipe()
+    final_read, final_write = os.pipe()
+    all_descriptors = (first_read, first_write, final_read, final_write)
+    body_error = ValueError("context body primary")
+    interruption = KeyboardInterrupt("descriptor cleanup back-edge")
+    calls: list[str] = []
+
+    def close_first() -> None:
+        os.close(first_read)
+        calls.append("first")
+
+    def close_final() -> None:
+        os.close(final_read)
+        calls.append("final")
+
+    def invoke() -> None:
+        with atomic_module._run_context_with_cleanup_actions(
+            lambda: (
+                ("first descriptor cleanup also failed", close_first),
+                ("final descriptor cleanup also failed", close_final),
+            )
+        ):
+            raise body_error
+
+    try:
+        with pytest.raises(ValueError) as caught:
+            _call_with_interrupt_at_back_edge(
+                atomic_module._run_ordered_actions,
+                invoke,
+                predicate=lambda local: (
+                    local["state"].next_index == 1 and calls == ["first"]
+                ),
+                error=interruption,
+            )
+
+        assert caught.value is body_error
+        assert calls == ["first", "final"]
+        _assert_descriptor_closed(first_read)
+        _assert_descriptor_closed(final_read)
+    finally:
+        for descriptor in all_descriptors:
+            try:
+                os.close(descriptor)
+            except OSError as error:
+                if error.errno != errno.EBADF:
+                    raise
+
+
+def test_cleanup_back_edge_cancellation_closes_remaining_windows_handles() -> None:
+    api = _FakeWindowsApi()
+    first_handle = api.create_directory_handle(Path("C:/authority"))
+    final_handle = api.duplicate_handle(first_handle)
+    body_error = ValueError("context body primary")
+    interruption = KeyboardInterrupt("HANDLE cleanup back-edge")
+    calls: list[str] = []
+
+    def close_first() -> None:
+        api.close(first_handle)
+        calls.append("first")
+
+    def close_final() -> None:
+        api.close(final_handle)
+        calls.append("final")
+
+    def invoke() -> None:
+        with atomic_module._run_context_with_cleanup_actions(
+            lambda: (
+                ("first HANDLE cleanup also failed", close_first),
+                ("final HANDLE cleanup also failed", close_final),
+            )
+        ):
+            raise body_error
+
+    try:
+        with pytest.raises(ValueError) as caught:
+            _call_with_interrupt_at_back_edge(
+                atomic_module._run_ordered_actions,
+                invoke,
+                predicate=lambda local: (
+                    local["state"].next_index == 1 and calls == ["first"]
+                ),
+                error=interruption,
+            )
+
+        assert caught.value is body_error
+        assert calls == ["first", "final"]
+        assert api.handles == {}
+    finally:
+        for handle in tuple(api.handles):
+            api.close(handle)
+
+
+@pytest.mark.parametrize("surface", ["post-validation", "cleanup"])
+def test_hostile_add_note_cannot_replace_primary_or_skip_actions(
+    surface: str,
+) -> None:
+    class HostilePrimary(BaseException):
+        def __init__(self) -> None:
+            super().__init__("hostile primary")
+            self.override_calls = 0
+
+        def add_note(self, _note: str) -> None:
+            self.override_calls += 1
+            raise RuntimeError("hostile add_note override")
+
+    primary = HostilePrimary()
+    secondary = OSError(errno.EIO, "secondary action failure")
+    calls: list[str] = []
+
+    def first_action() -> None:
+        calls.append("first")
+        raise secondary
+
+    def final_action() -> None:
+        calls.append("final")
+
+    def invoke() -> None:
+        actions = (
+            ("first ordered action also failed", first_action),
+            ("final ordered action also failed", final_action),
+        )
+        if surface == "post-validation":
+            atomic_module._run_callback_with_post_validations(
+                lambda: (_ for _ in ()).throw(primary),
+                actions,
+            )
+        else:
+            with atomic_module._run_context_with_cleanup_actions(lambda: actions):
+                raise primary
+
+    with pytest.raises(HostilePrimary) as caught:
+        invoke()
+
+    assert caught.value is primary
+    assert primary.override_calls == 0
+    assert calls == ["first", "final"]
+    assert any(
+        "first ordered action also failed" in note
+        and "secondary action failure" in note
+        for note in _exception_notes(primary)
+    )
 
 
 def test_reopen_interrupt_after_callback_result_store_runs_post_capture(


### PR DESCRIPTION
## Summary\n\nMake directory publication callbacks and authenticated-file cleanup preserve the exact first failure while still running every required postcondition and cleanup action.\n\nThis is a focused stacked PR based on #591 and is a prerequisite for the strict BM25/context producer migration.\n\n## Changes\n\n- add one ordered callback/post-validation runner that always attempts every postcondition\n- preserve the exact first callback or cancellation BaseException and attach later validation failures as diagnostics\n- reject callback results when reader validity, child namespace, ownership, or retained authority checks fail after callback execution\n- apply the same first-primary semantics to authenticated-directory reopen and directory-orphan callbacks\n- run POSIX and Windows authenticated-file finalize/file-close/directory-close actions without replacing the body primary\n- keep the first cleanup error primary when there is no body failure, while still attempting later cleanup actions\n- add fault matrices for callback errors, ambient exceptions, cancellation windows, suppressed reader failures, ownership drift, finalize failures, and multiple close failures\n\n## Type of Change\n\n- [x] Bug fix\n- [ ] New feature\n- [ ] Breaking change\n- [ ] Documentation update\n- [ ] Refactoring\n- [ ] Performance improvement\n- [x] Tests\n\n## Testing\n\n- [x] Tests pass locally\n- [x] Added new tests for the changes\n- Focused changed surface: 418 passed, 10 skipped\n- Authenticated-file POSIX/Windows failure matrix: 10 passed\n- Black, isort with the Black profile, flake8, py_compile, and git diff --check passed\n\n## Checklist\n\n- [x] My code follows the project style guidelines\n- [x] I have performed a self-review of my code\n- [x] I have commented my code, particularly in hard-to-understand areas\n- [x] My changes generate no new warnings\n- [ ] Any dependent changes have been merged and published\n\nDependency: #591 is published, green, and Ready for Review, but intentionally not merged yet.