### PR TITLE
perf(chunking): retain gated native Python chunking experiment

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -437,6 +437,7 @@ jobs:
           cmake -S core -B build/core \
             -DCMAKE_BUILD_TYPE=Release \
             -DCODENIB_BUILD_PYBIND=ON \
+            -DCODENIB_BUILD_TREE_SITTER_POC=OFF \
             -DPython_EXECUTABLE="$(which python)"
           cmake --build build/core -j "$(nproc)"
 

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ FACT_BUFFER_PROFILE_LANGUAGE ?=
 FACT_BUFFER_PROFILE_PROJECT_ROOT ?=
 FACT_BUFFER_PROFILE_OUTPUT ?=
 FACT_BUFFER_PROFILE_EXTRA_ARGS ?=
+PYTHON_CHUNK_POC_BUILD_DIR ?= build/core-chunk-poc
+PYTHON_CHUNK_PROFILE_REPO ?=
+PYTHON_CHUNK_PROFILE_OUTPUT ?=
+PYTHON_CHUNK_PROFILE_EXTRA_ARGS ?=
 CLANGD_WORKLOAD_GATE_INDEX_DIR ?=
 CLANGD_WORKLOAD_GATE_PROJECT_ROOT ?=
 CLANGD_WORKLOAD_GATE_OUTPUT ?= $(CODENIB_RESULTS_DIR)/clangd-workload-gate.json
@@ -204,6 +208,7 @@ endef
 .PHONY: go-tool scip-go-tool rust-tool scip-python-tool scip-typescript-tool scip-clang-tool
 .PHONY: node-workspace-tools zoekt-tool python-lsp-tool ty-tool typescript-lsp-tool gopls-tool clangd-tool
 .PHONY: core-system-deps-ubuntu core-python-deps core-build core-test fact-buffer-profile fact-query-profile clangd-fact-query-profile clangd-workload-gate clangd-fact-generation-profile
+.PHONY: core-chunk-poc-build core-chunk-poc-test core-chunk-poc-profile
 .PHONY: scip-cold-start-tools scip-cold-start-tools-all scip-cold-start-env scip-cold-start-system-deps-ubuntu
 .PHONY: scip-candidates scip-candidates-all scip-candidate-env scip-candidate-system-deps-ubuntu
 .PHONY: scip-jvm-compat-system-deps-ubuntu
@@ -419,7 +424,7 @@ core-python-deps:
 	python -m pip install "pybind11==$(PYBIND11_VERSION)"
 
 core-build: core-python-deps
-	cmake -S core -B build/core
+	cmake -S core -B build/core -DCODENIB_BUILD_TREE_SITTER_POC=OFF
 	cmake --build build/core
 
 core-test: core-build
@@ -429,6 +434,7 @@ core-test: core-build
 	./build/core/content_digest_test
 	./build/core/fact_query_index_test
 	PYTHONPATH="build/core:$$PYTHONPATH" python -c 'import sys; import codenib_core as core; required = ("decode_clangd_fact_query_index", "clangd_fact_query_contract", "clangd_fact_query_snapshot"); missing = [name for name in required if not hasattr(core, name)]; missing and sys.exit(f"codenib_core missing required bindings: {missing}")'
+	PYTHONPATH="build/core:$$PYTHONPATH" python -c 'import sys; import codenib_core as core; forbidden = ("extract_python_chunk_spans", "python_chunk_poc_contract"); present = [name for name in forbidden if hasattr(core, name)]; present and sys.exit(f"default codenib_core unexpectedly exposes experimental APIs: {present}")'
 	PYTHONPATH="build/core:$$PYTHONPATH" python -m pytest -q \
 		test/scip/test_scip_core.py \
 		test/scip/test_scip_core_registry.py \
@@ -499,6 +505,33 @@ clangd-fact-generation-profile: core-build
 		--build-context-digest "$(CLANGD_FACT_GENERATION_PROFILE_BUILD_CONTEXT_DIGEST)" \
 		$(if $(CLANGD_FACT_GENERATION_PROFILE_OUTPUT),--output-json "$(CLANGD_FACT_GENERATION_PROFILE_OUTPUT)",) \
 		$(CLANGD_FACT_GENERATION_PROFILE_EXTRA_ARGS)
+
+core-chunk-poc-build: core-python-deps
+	CODENIB_PYTHON_CHUNK_POC_BUILD_DIR="$(abspath $(PYTHON_CHUNK_POC_BUILD_DIR))" \
+		python -c 'import os, sys; from pathlib import Path; poc = Path(os.environ["CODENIB_PYTHON_CHUNK_POC_BUILD_DIR"]).resolve(); maintained = Path("build/core").resolve(); poc == maintained and sys.exit("PYTHON_CHUNK_POC_BUILD_DIR must not resolve to build/core")'
+	cmake -S core -B "$(PYTHON_CHUNK_POC_BUILD_DIR)" \
+		-DCODENIB_BUILD_TREE_SITTER_POC=ON \
+		-DCODENIB_BUILD_PYBIND=ON
+	cmake --build "$(PYTHON_CHUNK_POC_BUILD_DIR)" --target codenib_core_py
+
+core-chunk-poc-test: core-chunk-poc-build
+	CODENIB_PYTHON_CHUNK_POC_BUILD_DIR="$(abspath $(PYTHON_CHUNK_POC_BUILD_DIR))" \
+		PYTHONPATH="$(PYTHON_CHUNK_POC_BUILD_DIR):$$PYTHONPATH" \
+		python -c 'import sys; import codenib_core as core; required = ("extract_python_chunk_spans", "python_chunk_poc_contract"); missing = [name for name in required if not hasattr(core, name)]; missing and sys.exit(f"POC codenib_core missing required bindings: {missing}")'
+	CODENIB_PYTHON_CHUNK_POC_BUILD_DIR="$(abspath $(PYTHON_CHUNK_POC_BUILD_DIR))" \
+		PYTHONPATH="$(PYTHON_CHUNK_POC_BUILD_DIR):$$PYTHONPATH" \
+		python -m pytest -q \
+			test/chunker/test_python_native_chunk_poc.py \
+			test/scripts/test_profile_python_native_chunker.py
+
+core-chunk-poc-profile: core-chunk-poc-build
+	@test -n "$(PYTHON_CHUNK_PROFILE_REPO)" || { echo "Set PYTHON_CHUNK_PROFILE_REPO=/path/to/repo" >&2; exit 1; }
+	CODENIB_PYTHON_CHUNK_POC_BUILD_DIR="$(abspath $(PYTHON_CHUNK_POC_BUILD_DIR))" \
+		PYTHONPATH="$(PYTHON_CHUNK_POC_BUILD_DIR):$$PYTHONPATH" \
+		python scripts/profiling/profile_python_native_chunker.py \
+			--repo "$(PYTHON_CHUNK_PROFILE_REPO)" \
+			$(if $(PYTHON_CHUNK_PROFILE_OUTPUT),--output-json "$(PYTHON_CHUNK_PROFILE_OUTPUT)",) \
+			$(PYTHON_CHUNK_PROFILE_EXTRA_ARGS)
 
 scip-cold-start-tools: scip-java-tool gradle-tool sbt-tool scip-dotnet-tool scip-ruby-tool scip-php-info
 	@$(MAKE) --no-print-directory scip-cold-start-env

--- a/codenib/code_chunking/README.md
+++ b/codenib/code_chunking/README.md
@@ -190,6 +190,42 @@ chunker = create_chunker("rust", chunk_depth=0, skeleton_mode=True)
 chunker = create_chunker("cpp", chunk_depth=2, l2_level_exclusive=False)
 ```
 
+## Experimental Native Python Span Extraction
+
+[#558](https://github.com/sysevol-ai/CodeNib/issues/558) retains an optional
+C++ proof of concept for Python parsing and L1/L2 definition-span traversal.
+Python decodes its compact 20-byte rows and name arena, then performs the
+normal line splitting, node-ID generation, and final `CodeChunk` assembly.
+The POC supports non-skeleton Python depths 1 and 2.
+
+Both build and runtime selection are off by default. The POC builds separately
+under `build/core-chunk-poc`, and `auto` falls back to the established Python
+chunker per file. `required` fails closed for parity and benchmark runs.
+
+The final gate passed exact `CodeChunk` parity for decorators, async
+definitions, Unicode and PEP 695 syntax, L1/L2 selection, optional containers,
+headers, error recovery, and line splitting. Balanced clean-checkout profiles
+on CodeNib and HTTPie both missed the requirement for at least 20% end-to-end
+acceleration; the candidate was slower in both final reports. Exact subject
+revisions and medians are retained in the
+[multi-language roadmap](../../docs/scip_multilanguage_roadmap.md).
+
+```bash
+make core-chunk-poc-test
+make core-chunk-poc-profile \
+  PYTHON_CHUNK_PROFILE_REPO=/path/to/python/repository
+
+# Explicit experiment with compatible per-file fallback
+export CODENIB_NATIVE_PYTHON_CHUNKER=auto
+
+# Parity/profile mode: surface unsupported cases and native failures
+export CODENIB_NATIVE_PYTHON_CHUNKER=required
+```
+
+This target remains local/manual only and is not part of required CI. The next
+candidate should test incremental parse-tree reuse or repository-level batching
+instead of another per-file language-boundary crossing.
+
 ## File Extension Mapping
 
 Used by `gt_locate.py` to select the correct chunker:

--- a/codenib/code_chunking/base.py
+++ b/codenib/code_chunking/base.py
@@ -120,6 +120,13 @@ class BaseCodeChunker(ABC):
                 parser.language = language
             return parser
 
+    @staticmethod
+    def _read_source(file_path: str) -> str:
+        """Read source text through the shared chunker decoding contract."""
+
+        with open(file_path, "r", encoding="utf-8", errors="replace") as source:
+            return source.read()
+
     def chunk_file(
         self,
         file_path: str,
@@ -144,9 +151,9 @@ class BaseCodeChunker(ABC):
 
         # logger.debug(f"Chunking file: {file_path}")
 
-        # Read the file
-        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
-            code_content = f.read()
+        # Read the file through one helper so experimental and established
+        # parser routes measure and decode the exact same source boundary.
+        code_content = self._read_source(file_path)
 
         # Parse the code
         code_bytes = code_content.encode("utf-8")

--- a/codenib/code_chunking/python_chunker.py
+++ b/codenib/code_chunking/python_chunker.py
@@ -8,9 +8,137 @@
 Python-specific code chunker implementation.
 """
 
-from typing import List, Optional, Tuple
+import os
+import time
+from collections import namedtuple
+from struct import Struct
+from typing import Any, List, Optional, Tuple
 
 from .base import BaseCodeChunker
+
+_NATIVE_CHUNK_ENV = "CODENIB_NATIVE_PYTHON_CHUNKER"
+_NATIVE_CHUNK_OFF = frozenset({"", "0", "false", "no", "off", "disabled"})
+_NATIVE_CHUNK_AUTO = frozenset({"1", "true", "yes", "on", "auto"})
+_NATIVE_CHUNK_REQUIRED = frozenset({"required", "strict"})
+_NATIVE_CHUNK_ABI_VERSION = 1
+_NATIVE_CHUNK_ROW = Struct("<IIB3xII")
+_NATIVE_CHUNK_GRAMMAR = "tree-sitter-python@v0.25.0"
+_NATIVE_CHUNK_RUNTIME = "tree-sitter@v0.25.2"
+_NATIVE_CHUNK_SEMANTIC_PROFILE = "python-definition-spans-v1"
+_NATIVE_CHUNK_KINDS = {1: "function", 2: "class", 3: "method"}
+_NativeNodeSpan = namedtuple("_NativeNodeSpan", ["start_point", "end_point"])
+
+
+def _native_chunk_mode() -> str:
+    value = os.environ.get(_NATIVE_CHUNK_ENV, "off").strip().lower()
+    if value in _NATIVE_CHUNK_OFF:
+        return "off"
+    if value in _NATIVE_CHUNK_AUTO:
+        return "auto"
+    if value in _NATIVE_CHUNK_REQUIRED:
+        return "required"
+    raise ValueError(
+        f"{_NATIVE_CHUNK_ENV} must be auto, required, or 0/off; got {value!r}"
+    )
+
+
+def _load_native_core():
+    try:
+        import codenib_core
+    except ImportError:
+        return None
+    return codenib_core
+
+
+def _validate_native_contract(core: Any) -> dict[str, Any]:
+    contract_function = getattr(core, "python_chunk_poc_contract", None)
+    if not callable(contract_function):
+        raise RuntimeError("compiled core does not expose Python chunk POC contract")
+    contract = contract_function()
+    if not isinstance(contract, dict):
+        raise TypeError("native Python chunk contract must be a dict")
+
+    expected = {
+        "abi_version": _NATIVE_CHUNK_ABI_VERSION,
+        "row_size": _NATIVE_CHUNK_ROW.size,
+        "grammar": _NATIVE_CHUNK_GRAMMAR,
+        "runtime": _NATIVE_CHUNK_RUNTIME,
+        "semantic_profile": _NATIVE_CHUNK_SEMANTIC_PROFILE,
+    }
+    for name, value in expected.items():
+        compiled = contract.get(name)
+        if type(compiled) is not type(value) or compiled != value:
+            raise RuntimeError(
+                f"native Python chunk {name} mismatch: "
+                f"compiled={compiled!r}, python={value!r}"
+            )
+    return contract
+
+
+def _decode_native_chunk_payload(
+    payload: Any, *, source_line_count: int
+) -> tuple[List[Tuple], dict[str, float]]:
+    if not isinstance(payload, dict):
+        raise TypeError("native Python chunk payload must be a dict")
+    abi_version = payload.get("abi_version")
+    if type(abi_version) is not int or abi_version != _NATIVE_CHUNK_ABI_VERSION:
+        raise ValueError("native Python chunk payload ABI mismatch")
+    if type(source_line_count) is not int or source_line_count < 1:
+        raise ValueError("native Python chunk source_line_count must be positive")
+
+    rows = payload.get("rows")
+    arena = payload.get("arena")
+    row_count = payload.get("row_count")
+    if not isinstance(rows, bytes) or not isinstance(arena, bytes):
+        raise TypeError("native Python chunk rows and arena must be bytes")
+    if type(row_count) is not int or row_count < 0:
+        raise ValueError("native Python chunk row_count must be a non-negative integer")
+    if len(rows) != row_count * _NATIVE_CHUNK_ROW.size:
+        raise ValueError("native Python chunk row table has an invalid size")
+
+    definitions: List[Tuple] = []
+    previous_start_line: Optional[int] = None
+    for offset in range(0, len(rows), _NATIVE_CHUNK_ROW.size):
+        (
+            start_line,
+            end_line,
+            kind_id,
+            name_offset,
+            name_length,
+        ) = _NATIVE_CHUNK_ROW.unpack_from(rows, offset)
+        if start_line > end_line:
+            raise ValueError("native Python chunk span is reversed")
+        if end_line >= source_line_count:
+            raise ValueError("native Python chunk span exceeds source line bounds")
+        if previous_start_line is not None and start_line < previous_start_line:
+            raise ValueError("native Python chunk spans are not sorted")
+        previous_start_line = start_line
+
+        kind = _NATIVE_CHUNK_KINDS.get(kind_id)
+        if kind is None:
+            raise ValueError(f"native Python chunk kind is invalid: {kind_id}")
+        name_end = name_offset + name_length
+        if name_offset > len(arena) or name_end > len(arena):
+            raise ValueError("native Python chunk name exceeds arena bounds")
+        try:
+            name = arena[name_offset:name_end].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("native Python chunk name is not valid UTF-8") from exc
+        if not name:
+            raise ValueError("native Python chunk name must not be empty")
+        node = _NativeNodeSpan((start_line, 0), (end_line, 0))
+        definitions.append((node, name, kind))
+
+    timing_fields = {
+        "native_parse": payload.get("parse_ns"),
+        "native_extract_encode": payload.get("extract_ns"),
+    }
+    timings: dict[str, float] = {}
+    for name, value in timing_fields.items():
+        if type(value) is not int or value < 0:
+            raise ValueError(f"native Python chunk timing {name} is invalid")
+        timings[name] = value / 1_000_000_000
+    return definitions, timings
 
 
 class PythonCodeChunker(BaseCodeChunker):
@@ -38,6 +166,106 @@ class PythonCodeChunker(BaseCodeChunker):
             l2_level_exclusive=l2_level_exclusive,
             **kwargs,
         )
+        self.native_chunk_backend = "python"
+        self.native_chunk_fallback_error: Optional[str] = None
+        self.native_chunk_timings: dict[str, float] = {}
+        self._native_contract_validated = False
+        self._native_fallback_warned = False
+
+    def chunk_file(
+        self,
+        file_path: str,
+        relative_path: Optional[str] = None,
+        skeleton_mode: Optional[bool] = None,
+    ):
+        """Use the opt-in native span extractor with per-file fallback."""
+
+        self.native_chunk_backend = "python"
+        self.native_chunk_fallback_error = None
+        self.native_chunk_timings = {}
+        mode = _native_chunk_mode()
+        if mode == "off":
+            return super().chunk_file(file_path, relative_path, skeleton_mode)
+
+        use_skeleton = self.skeleton_mode if skeleton_mode is None else skeleton_mode
+        if self.chunk_depth not in {1, 2} or use_skeleton:
+            message = (
+                "native Python chunk extraction supports non-skeleton "
+                "chunk_depth 1 or 2"
+            )
+            if mode == "required":
+                raise RuntimeError(message)
+            self.native_chunk_backend = "python-unsupported"
+            return super().chunk_file(file_path, relative_path, skeleton_mode)
+
+        if not os.path.exists(file_path):
+            return super().chunk_file(file_path, relative_path, skeleton_mode)
+
+        try:
+            core = _load_native_core()
+            if core is None or not callable(
+                getattr(core, "extract_python_chunk_spans", None)
+            ):
+                raise RuntimeError(
+                    "compiled core does not include the native Python chunk POC"
+                )
+            if not self._native_contract_validated:
+                _validate_native_contract(core)
+                self._native_contract_validated = True
+
+            total_started = time.perf_counter()
+            read_started = time.perf_counter()
+            code_content = self._read_source(file_path)
+            file_read = time.perf_counter() - read_started
+            binding_started = time.perf_counter()
+            payload = core.extract_python_chunk_spans(
+                code_content,
+                chunk_depth=self.chunk_depth,
+                l2_level_exclusive=self.l2_level_exclusive,
+            )
+            binding = time.perf_counter() - binding_started
+            lines = code_content.split("\n")
+            decode_started = time.perf_counter()
+            definitions, timings = _decode_native_chunk_payload(
+                payload, source_line_count=len(lines)
+            )
+            buffer_decode = time.perf_counter() - decode_started
+
+            path_for_node_id = relative_path if relative_path else file_path
+            materialize_started = time.perf_counter()
+            chunks = self._generate_chunks(
+                lines=lines,
+                definitions=definitions,
+                file_path=file_path,
+                path_for_node_id=path_for_node_id,
+                code_content=code_content,
+                skeleton_mode=False,
+            )
+            materialize = time.perf_counter() - materialize_started
+            self.native_chunk_backend = "native-tree-sitter-poc"
+            self.native_chunk_timings = {
+                "file_read": file_read,
+                "binding": binding,
+                "buffer_decode": buffer_decode,
+                "chunk_materialize": materialize,
+                "total": time.perf_counter() - total_started,
+                **timings,
+            }
+            return chunks
+        except Exception as exc:
+            if mode == "required":
+                raise
+            self.native_chunk_fallback_error = f"{type(exc).__name__}: {exc}"
+            self.native_chunk_backend = "python-fallback"
+            if not self._native_fallback_warned:
+                from ..log_utils import get_logger
+
+                get_logger(__name__).warning(
+                    "Native Python chunk extraction failed; falling back per file: %s",
+                    self.native_chunk_fallback_error,
+                )
+                self._native_fallback_warned = True
+            return super().chunk_file(file_path, relative_path, skeleton_mode)
 
     def _find_top_level_definitions(
         self, root_node, include_l2_in_file_skeleton: bool = False

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -10,6 +10,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 option(CODENIB_ENABLE_DEBUG "Enable debug-friendly flags for codenib targets" OFF)
 option(CODENIB_ENABLE_O3 "Enable -O3 optimization for codenib targets" ON)
 option(CODENIB_BUILD_PYBIND "Build pybind11 Python extension module" ON)
+option(
+    CODENIB_BUILD_TREE_SITTER_POC
+    "Build the experimental native Python tree-sitter chunk extractor"
+    OFF
+)
 
 # -------------------------------------------------------------------------
 # Vendored c-igraph
@@ -42,6 +47,50 @@ FetchContent_Declare(
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(igraph)
+
+if(CODENIB_BUILD_TREE_SITTER_POC)
+    # Keep the proof of concept opt-in until its repository-level benchmark
+    # clears the acceleration gate. Both dependencies are immutable commits.
+    FetchContent_Declare(
+        tree_sitter_runtime
+        GIT_REPOSITORY https://github.com/tree-sitter/tree-sitter.git
+        GIT_TAG        6e0618704ad758ba2ea5822faa80bcd36fbeba3d # v0.25.2
+        GIT_SHALLOW    TRUE
+    )
+    FetchContent_Declare(
+        tree_sitter_python_grammar
+        GIT_REPOSITORY https://github.com/tree-sitter/tree-sitter-python.git
+        GIT_TAG        293fdc02038ee2bf0e2e206711b69c90ac0d413f # v0.25.0
+        GIT_SHALLOW    TRUE
+    )
+    if(POLICY CMP0169)
+        cmake_policy(PUSH)
+        cmake_policy(SET CMP0169 OLD)
+    endif()
+    FetchContent_GetProperties(tree_sitter_runtime)
+    if(NOT tree_sitter_runtime_POPULATED)
+        FetchContent_Populate(tree_sitter_runtime)
+    endif()
+    FetchContent_GetProperties(tree_sitter_python_grammar)
+    if(NOT tree_sitter_python_grammar_POPULATED)
+        FetchContent_Populate(tree_sitter_python_grammar)
+    endif()
+    if(POLICY CMP0169)
+        cmake_policy(POP)
+    endif()
+
+    add_library(codenib_tree_sitter_python STATIC
+        ${tree_sitter_runtime_SOURCE_DIR}/lib/src/lib.c
+        ${tree_sitter_python_grammar_SOURCE_DIR}/src/parser.c
+        ${tree_sitter_python_grammar_SOURCE_DIR}/src/scanner.c
+    )
+    target_include_directories(codenib_tree_sitter_python
+        PUBLIC ${tree_sitter_runtime_SOURCE_DIR}/lib/include
+        PRIVATE
+            ${tree_sitter_runtime_SOURCE_DIR}/lib/src
+            ${tree_sitter_python_grammar_SOURCE_DIR}/src
+    )
+endif()
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(RE2 REQUIRED re2)
@@ -79,6 +128,12 @@ target_link_libraries(codenib_core
         ${RE2_LIBRARIES}
         ZLIB::ZLIB
 )
+
+if(CODENIB_BUILD_TREE_SITTER_POC)
+    target_sources(codenib_core PRIVATE python_chunk_poc.cpp)
+    target_compile_definitions(codenib_core PUBLIC CODENIB_TREE_SITTER_POC=1)
+    target_link_libraries(codenib_core PUBLIC codenib_tree_sitter_python)
+endif()
 
 add_executable(scip_decode_test
     tests/scip_decode_test.cpp
@@ -118,6 +173,9 @@ target_link_libraries(scip_decode_repo PRIVATE codenib_core)
 
 if(CODENIB_ENABLE_O3)
     target_compile_options(codenib_core PRIVATE -O3)
+    if(TARGET codenib_tree_sitter_python)
+        target_compile_options(codenib_tree_sitter_python PRIVATE -O3)
+    endif()
     if(TARGET scip_decode_test)
         target_compile_options(scip_decode_test PRIVATE -O3)
     endif()

--- a/core/README.md
+++ b/core/README.md
@@ -22,6 +22,8 @@ core decoder continue to use the serial Python path.
 - `content_digest.{h,cpp}` — dependency-free streaming SHA-256 for native
   content receipts.
 - `graph_layers.{h,cpp}` — shared normalized edge-layer classification.
+- `python_chunk_poc.{h,cpp}` — opt-in Python tree-sitter definition-span
+  experiment.
 - `scip_decode_base.{h,cpp}` — common loading, document scheduling, merge, and
   post-processing behavior.
 - `scip_decode_common.{h,cpp}` — language-neutral SCIP parsing and subgraph
@@ -190,6 +192,34 @@ position-first, and route-first sessions, exact public-result parity, and zero
 native graph materializations in every workload. Mixed sessions retain the 20%
 non-regression budget. Concurrent native routes must also remain deterministic
 and graph-free. This result makes no claim about clangd index generation time.
+
+## Native Python Chunk Span POC
+
+[#558](https://github.com/sysevol-ai/CodeNib/issues/558) retains a native
+Python definition-span extractor as a reproducible experiment, not as a
+production acceleration claim. Its build switch and runtime switch both
+default to `off`. The experiment builds in the isolated
+`build/core-chunk-poc` directory; the normal `build/core` output remains the
+maintained extension without the POC bindings.
+
+The final gate passed exact `CodeChunk` parity across the maintained semantic
+matrix. Balanced clean-checkout profiles on CodeNib and HTTPie both missed the
+requirement for at least 20% end-to-end acceleration and reported a slower
+candidate. Exact receipts and medians live in the durable multi-language
+roadmap rather than being treated as a promoted user-facing claim. The POC
+therefore remains local/manual only and is not part of `make core-test` or
+required CI. Reproduce its parity and profile gates explicitly with:
+
+```bash
+make core-chunk-poc-test
+make core-chunk-poc-profile \
+  PYTHON_CHUNK_PROFILE_REPO=/path/to/python/repository
+```
+
+`CODENIB_NATIVE_PYTHON_CHUNKER=auto` enables per-file compatible fallback;
+`required` fails closed for parity and profiling. Future work should test
+incremental parse-tree reuse or repository-level batching instead of another
+per-file language-boundary crossing.
 
 ## Use Through Python
 

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -27,6 +27,9 @@
 #include "fact_query_index.h"
 #include "graph_layers.h"
 #include "scip_decode.h"
+#ifdef CODENIB_TREE_SITTER_POC
+#include "python_chunk_poc.h"
+#endif
 
 #include <chrono>
 #include <cstdint>
@@ -513,6 +516,36 @@ py::dict clangd_fact_query_snapshot(const std::string &idx_directory,
   return result;
 }
 
+#ifdef CODENIB_TREE_SITTER_POC
+py::dict extract_python_chunk_spans(const std::string &source, int chunk_depth,
+                                    bool l2_level_exclusive) {
+  codenib::core::PythonChunkBuffer buffer;
+  {
+    py::gil_scoped_release release;
+    buffer = codenib::core::extract_python_chunk_buffer(source, chunk_depth,
+                                                        l2_level_exclusive);
+  }
+  py::dict result;
+  result["abi_version"] = codenib::core::PYTHON_CHUNK_BUFFER_ABI_VERSION;
+  result["row_count"] = buffer.row_count;
+  result["rows"] = bytes_from_vector(buffer.rows);
+  result["arena"] = bytes_from_vector(buffer.arena);
+  result["parse_ns"] = buffer.parse_ns;
+  result["extract_ns"] = buffer.extract_ns;
+  return result;
+}
+
+py::dict python_chunk_poc_contract() {
+  py::dict result;
+  result["abi_version"] = codenib::core::PYTHON_CHUNK_BUFFER_ABI_VERSION;
+  result["row_size"] = codenib::core::PYTHON_CHUNK_BUFFER_ROW_SIZE;
+  result["grammar"] = codenib::core::PYTHON_CHUNK_GRAMMAR;
+  result["runtime"] = codenib::core::PYTHON_CHUNK_RUNTIME;
+  result["semantic_profile"] = codenib::core::PYTHON_CHUNK_SEMANTIC_PROFILE;
+  return result;
+}
+#endif
+
 codenib::core::LayerBuckets
 classify_edge_layers_py(const std::vector<std::string> &edge_types) {
   py::gil_scoped_release release;
@@ -765,6 +798,21 @@ capability.
         py::arg("position_encoding") =
             codenib::core::CLANGD_DEFAULT_POSITION_ENCODING,
         R"pbdoc(Return the current content-bound clangd index receipt.)pbdoc");
+
+#ifdef CODENIB_TREE_SITTER_POC
+  m.def("extract_python_chunk_spans", &extract_python_chunk_spans,
+        py::arg("source"), py::arg("chunk_depth") = 2,
+        py::arg("l2_level_exclusive") = true,
+        R"pbdoc(
+Parse Python source and return compact L1/L2 definition span buffers.
+
+This is an opt-in proof of concept. Content assembly and CodeChunk creation
+remain in Python so the current public schema and splitting semantics are
+preserved exactly.
+)pbdoc");
+  m.def("python_chunk_poc_contract", &python_chunk_poc_contract,
+        R"pbdoc(Return the experimental Python chunk buffer contract.)pbdoc");
+#endif
 
   m.def("canonical_scip_decoder_languages",
         &codenib::core::canonical_scip_decoder_languages,

--- a/core/python_chunk_poc.cpp
+++ b/core/python_chunk_poc.cpp
@@ -1,0 +1,236 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "python_chunk_poc.h"
+
+#include <tree_sitter/api.h>
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+extern "C" const TSLanguage *tree_sitter_python(void);
+
+namespace codenib::core {
+namespace {
+
+enum class ChunkKind : std::uint8_t {
+  Function = 1,
+  Class = 2,
+  Method = 3,
+};
+
+struct ChunkSpan {
+  std::uint32_t start_line;
+  std::uint32_t end_line;
+  ChunkKind kind;
+  std::string name;
+};
+
+using ParserPtr = std::unique_ptr<TSParser, decltype(&ts_parser_delete)>;
+using TreePtr = std::unique_ptr<TSTree, decltype(&ts_tree_delete)>;
+
+struct PythonParserState {
+  PythonParserState() : parser(ts_parser_new(), &ts_parser_delete) {
+    if (!parser)
+      throw std::runtime_error("failed to allocate tree-sitter parser");
+    if (!ts_parser_set_language(parser.get(), tree_sitter_python()))
+      throw std::runtime_error(
+          "bundled Python grammar is incompatible with tree-sitter runtime");
+  }
+
+  ParserPtr parser;
+};
+
+TSParser *thread_python_parser() {
+  thread_local PythonParserState state;
+  return state.parser.get();
+}
+
+bool node_has_type(TSNode node, std::string_view expected) {
+  const char *type = ts_node_type(node);
+  return type != nullptr && expected == type;
+}
+
+bool is_function(TSNode node) {
+  return node_has_type(node, "function_definition") ||
+         node_has_type(node, "async_function_definition");
+}
+
+std::optional<TSNode> direct_child_with_type(TSNode node,
+                                             std::string_view expected) {
+  const auto count = ts_node_child_count(node);
+  for (std::uint32_t index = 0; index < count; ++index) {
+    TSNode child = ts_node_child(node, index);
+    if (node_has_type(child, expected))
+      return child;
+  }
+  return std::nullopt;
+}
+
+std::optional<TSNode> decorated_definition(TSNode node) {
+  const auto count = ts_node_child_count(node);
+  for (std::uint32_t index = 0; index < count; ++index) {
+    TSNode child = ts_node_child(node, index);
+    if (is_function(child) || node_has_type(child, "class_definition"))
+      return child;
+  }
+  return std::nullopt;
+}
+
+std::optional<std::string> definition_name(TSNode node,
+                                           std::string_view source) {
+  const auto identifier = direct_child_with_type(node, "identifier");
+  if (!identifier.has_value())
+    return std::nullopt;
+  const auto start = ts_node_start_byte(*identifier);
+  const auto end = ts_node_end_byte(*identifier);
+  if (start > end || end > source.size())
+    throw std::runtime_error("tree-sitter returned an invalid name byte range");
+  return std::string(source.substr(start, end - start));
+}
+
+void append_span(std::vector<ChunkSpan> &spans, TSNode node, ChunkKind kind,
+                 std::string name) {
+  const auto start = ts_node_start_point(node).row;
+  const auto end = ts_node_end_point(node).row;
+  spans.push_back(ChunkSpan{start, end, kind, std::move(name)});
+}
+
+void append_class_methods(std::vector<ChunkSpan> &spans, TSNode class_node,
+                          std::string_view class_name,
+                          std::string_view source) {
+  const auto block = direct_child_with_type(class_node, "block");
+  if (!block.has_value())
+    return;
+  const auto count = ts_node_child_count(*block);
+  for (std::uint32_t index = 0; index < count; ++index) {
+    TSNode statement = ts_node_child(*block, index);
+    TSNode method_node = statement;
+    if (node_has_type(statement, "decorated_definition")) {
+      const auto actual = decorated_definition(statement);
+      if (!actual.has_value() || !is_function(*actual))
+        continue;
+      method_node = *actual;
+    } else if (!is_function(statement)) {
+      continue;
+    }
+    const auto method_name = definition_name(method_node, source);
+    if (!method_name.has_value())
+      continue;
+    std::string full_name(class_name);
+    full_name.push_back('.');
+    full_name.append(*method_name);
+    append_span(spans, statement, ChunkKind::Method, std::move(full_name));
+  }
+}
+
+void append_u32(std::vector<std::uint8_t> &output, std::uint32_t value) {
+  for (unsigned shift = 0; shift < 32; shift += 8)
+    output.push_back(static_cast<std::uint8_t>((value >> shift) & 0xffU));
+}
+
+std::uint64_t elapsed_ns(std::chrono::steady_clock::time_point start,
+                         std::chrono::steady_clock::time_point end) {
+  return static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+          .count());
+}
+
+} // namespace
+
+PythonChunkBuffer extract_python_chunk_buffer(std::string_view source,
+                                              int chunk_depth,
+                                              bool l2_level_exclusive) {
+  if (chunk_depth != 1 && chunk_depth != 2)
+    throw std::invalid_argument(
+        "native Python chunk extraction supports chunk_depth 1 or 2");
+  if (source.size() > std::numeric_limits<std::uint32_t>::max())
+    throw std::overflow_error("Python source exceeds tree-sitter's u32 limit");
+
+  using clock = std::chrono::steady_clock;
+  const auto parse_started = clock::now();
+  TSParser *parser = thread_python_parser();
+  TreePtr tree(
+      ts_parser_parse_string(parser, nullptr, source.data(),
+                             static_cast<std::uint32_t>(source.size())),
+      &ts_tree_delete);
+  if (!tree)
+    throw std::runtime_error("tree-sitter failed to parse Python source");
+  const auto parse_finished = clock::now();
+
+  std::vector<ChunkSpan> spans;
+  TSNode root = ts_tree_root_node(tree.get());
+  const auto count = ts_node_child_count(root);
+  const bool include_classes = chunk_depth < 2 || !l2_level_exclusive;
+  const bool include_methods = chunk_depth >= 2;
+  for (std::uint32_t index = 0; index < count; ++index) {
+    TSNode child = ts_node_child(root, index);
+    TSNode definition = child;
+    if (node_has_type(child, "decorated_definition")) {
+      const auto actual = decorated_definition(child);
+      if (!actual.has_value())
+        continue;
+      definition = *actual;
+    }
+
+    if (is_function(definition)) {
+      const auto name = definition_name(definition, source);
+      if (name.has_value())
+        append_span(spans, child, ChunkKind::Function, *name);
+      continue;
+    }
+    if (!node_has_type(definition, "class_definition"))
+      continue;
+    const auto name = definition_name(definition, source);
+    if (!name.has_value())
+      continue;
+    if (include_classes)
+      append_span(spans, child, ChunkKind::Class, *name);
+    if (include_methods)
+      append_class_methods(spans, definition, *name, source);
+  }
+  std::stable_sort(spans.begin(), spans.end(),
+                   [](const ChunkSpan &left, const ChunkSpan &right) {
+                     return left.start_line < right.start_line;
+                   });
+
+  PythonChunkBuffer result;
+  if (spans.size() > std::numeric_limits<std::uint32_t>::max())
+    throw std::overflow_error("native Python chunk rows exceed u32 count");
+  if (spans.size() > result.rows.max_size() / PYTHON_CHUNK_BUFFER_ROW_SIZE)
+    throw std::overflow_error("native Python chunk row table exceeds size_t");
+  result.row_count = static_cast<std::uint32_t>(spans.size());
+  result.rows.reserve(spans.size() * PYTHON_CHUNK_BUFFER_ROW_SIZE);
+  for (const auto &span : spans) {
+    if (span.name.size() > std::numeric_limits<std::uint32_t>::max() ||
+        result.arena.size() >
+            std::numeric_limits<std::uint32_t>::max() - span.name.size())
+      throw std::overflow_error("native Python chunk name arena exceeds u32");
+    const auto offset = static_cast<std::uint32_t>(result.arena.size());
+    const auto length = static_cast<std::uint32_t>(span.name.size());
+    append_u32(result.rows, span.start_line);
+    append_u32(result.rows, span.end_line);
+    result.rows.push_back(static_cast<std::uint8_t>(span.kind));
+    result.rows.insert(result.rows.end(), 3, 0);
+    append_u32(result.rows, offset);
+    append_u32(result.rows, length);
+    result.arena.insert(result.arena.end(), span.name.begin(), span.name.end());
+  }
+  const auto extract_finished = clock::now();
+  result.parse_ns = elapsed_ns(parse_started, parse_finished);
+  result.extract_ns = elapsed_ns(parse_finished, extract_finished);
+  return result;
+}
+
+} // namespace codenib::core

--- a/core/python_chunk_poc.h
+++ b/core/python_chunk_poc.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace codenib::core {
+
+inline constexpr std::uint16_t PYTHON_CHUNK_BUFFER_ABI_VERSION = 1;
+inline constexpr std::size_t PYTHON_CHUNK_BUFFER_ROW_SIZE = 20;
+inline constexpr char PYTHON_CHUNK_GRAMMAR[] = "tree-sitter-python@v0.25.0";
+inline constexpr char PYTHON_CHUNK_RUNTIME[] = "tree-sitter@v0.25.2";
+inline constexpr char PYTHON_CHUNK_SEMANTIC_PROFILE[] =
+    "python-definition-spans-v1";
+
+struct PythonChunkBuffer {
+  std::vector<std::uint8_t> rows;
+  std::vector<std::uint8_t> arena;
+  std::uint64_t parse_ns{0};
+  std::uint64_t extract_ns{0};
+  std::uint32_t row_count{0};
+};
+
+// Extract the same L1/L2 Python definition spans used by PythonCodeChunker.
+// The caller still owns content prefixing, line splitting, and CodeChunk
+// construction; only parsing and AST traversal cross into the native core.
+PythonChunkBuffer extract_python_chunk_buffer(std::string_view source,
+                                              int chunk_depth,
+                                              bool l2_level_exclusive);
+
+} // namespace codenib::core

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -342,6 +342,39 @@ insertion. In `auto` mode a deterministic rejection is recorded in
 `query_fallback_error` and the established graph decoder is used. `required`
 fails closed, while `off` never invokes the native reader.
 
+## Native Python Chunk Span POC
+
+The [#558](https://github.com/sysevol-ai/CodeNib/issues/558) proof of concept
+moves Python parsing and definition-span traversal behind an optional native
+buffer while leaving final `CodeChunk` assembly in Python. It supports
+non-skeleton Python L1/L2 chunking. The build option
+`CODENIB_BUILD_TREE_SITTER_POC` and runtime option
+`CODENIB_NATIVE_PYTHON_CHUNKER` both default to `off`.
+
+The POC uses the independent `build/core-chunk-poc` directory so enabling it
+cannot change the cached configuration or exported API of the maintained
+`build/core` extension. `auto` falls back per file, while `required` fails
+closed on unsupported configurations, contract mismatches, or native errors.
+
+The final gate passed exact `CodeChunk` parity across decorators, async
+definitions, Unicode and PEP 695 syntax, L1/L2 selection, optional containers,
+headers, error recovery, and line splitting. Balanced clean-checkout profiles
+on CodeNib and HTTPie both missed the requirement for at least 20% end-to-end
+acceleration and reported a slower candidate. Exact revisions, configurations,
+and medians are retained in the multi-language roadmap. The POC is therefore a
+local/manual experiment and is intentionally excluded from `make core-test`
+and required CI. Run its isolated gates explicitly:
+
+```bash
+make core-chunk-poc-test
+make core-chunk-poc-profile \
+  PYTHON_CHUNK_PROFILE_REPO=/path/to/python/repository
+```
+
+Python tree-sitter already performs parsing in native code, so the next
+experiment should amortize work through incremental parse-tree reuse or
+repository-level batching rather than repeat the same per-file boundary.
+
 ## Verify
 
 ```bash
@@ -371,6 +404,8 @@ skip report.
   by native content receipts.
 - `graph_layers.{h,cpp}` classifies normalized edge types into reusable graph
   layers.
+- `python_chunk_poc.{h,cpp}` implements the opt-in native Python
+  definition-span experiment.
 - `scip_decode_base.{h,cpp}` and `scip_decode_common.{h,cpp}` provide shared
   decoder mechanics.
 - `scip_decode_<language>.{h,cpp}` owns language-specific symbol and metadata
@@ -390,5 +425,11 @@ bottleneck. A new decoder must:
 4. update the C++ registry and Python language registry together;
 5. pass serial/core node, attribute, and edge-multiset parity checks.
 
-Performance measurements and promotion decisions belong in versioned benchmark
-artifacts or internal engineering records, not in this user-facing reference.
+Compact transport and native chunk experiments require exact semantic parity,
+but parity alone does not justify promotion. Keep them opt-in until an
+alternating-arm repository profile demonstrates at least 20% end-to-end
+acceleration.
+
+Detailed performance measurements and promotion decisions belong in versioned
+benchmark artifacts or the durable acceleration roadmap, not in general
+user-facing claims.

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -582,6 +582,9 @@ containment `ref=8 cand=8 missing=0 extra=0`, and references `ref=1 cand=0`.
 - [x] Keep a manifest-driven large-repository profiling harness for active
   SCIP languages whose C++ acceleration status is still serial-only or needs
   revalidation.
+- [x] Retain the [#558](https://github.com/sysevol-ai/CodeNib/issues/558)
+  native Python chunk-span POC in an isolated, default-off local/manual tier
+  after exact parity passed but the 20% end-to-end promotion gate failed.
 
 Exit condition: acceleration claims are backed by parity tests and profile
 numbers, and `core/` remains maintainable.
@@ -1011,6 +1014,36 @@ The same `make core-test` command is the documented local reproduction; slow,
 billed, and external clangd-generation benchmarks remain outside this
 deterministic job.
 
+Native Python chunk-span POC status
+([#558](https://github.com/sysevol-ai/CodeNib/issues/558)): the experiment
+builds separately under `build/core-chunk-poc`; both its build switch and
+`CODENIB_NATIVE_PYTHON_CHUNKER` runtime selection default to `off`. `auto`
+falls back per file and `required` fails closed. The maintained `build/core`
+extension, `make core-test`, and required CI do not enable the POC.
+
+The final gate passed exact `CodeChunk` parity for decorators, async
+definitions, Unicode and PEP 695 syntax, nested and conditional definitions,
+L1/L2 selection, optional containers, headers, error recovery, and line
+splitting. The balanced harness collects before and disables cyclic GC for
+each arm, keeps candidate-only validation outside the stopwatch, retains every
+raw sample and AB/BA order, rejects a Git identity change during measurement,
+and promotes only at an exact 20% improvement.
+Both recorded runs used `chunk_depth=2`, `l2_level_exclusive=true`,
+`include_header_epilogue=false`, no line cap, and excluded test files.
+
+The 2026-08-11 clean-checkout reports were both negative:
+
+| Subject | Scope | Rounds / warmups | Existing median | Native POC median | Change | Decision |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| CodeNib `a33bb13118e3a04f8d3d76eabcfb2602f785477a` | 520 files / 6,630,346 bytes / 5,620 chunks | 6 / 1 | 0.6430s | 0.8088s | 25.8% slower | keep experimental |
+| HTTPie `2105caa49bae87c5809c274e407619a0de2639d1` | 89 files / 338,976 bytes / 498 chunks | 20 / 4 | 0.03588s | 0.04294s | 19.7% slower | keep experimental |
+
+Both reports had `git_dirty=false`, exact parity, and `promoted=false`. The
+candidate missed the requirement for at least 20% acceleration and was slower
+on both subjects. Per-file native boundary work is therefore not the next
+promotion path; follow-up experiments should measure incremental parse-tree
+reuse or repository-level batching.
+
 ### Phase 6: Multi-Graph Python Surface
 
 Mixed-language repositories need a Python-side graph aggregation path before a
@@ -1125,6 +1158,9 @@ make graph-route-alignment \
   GRAPH_ALIGNMENT_CANDIDATE_ROUTE=lsp \
   GRAPH_ALIGNMENT_OUTPUT_DIR=${CODENIB_TEMP_DIR}/csharp-active-route-alignment \
   GRAPH_ALIGNMENT_EXTRA_ARGS=--candidate-include-references
+make core-chunk-poc-test
+make core-chunk-poc-profile \
+  PYTHON_CHUNK_PROFILE_REPO=/path/to/python/repository
 python -m mkdocs build --strict
 ```
 

--- a/scripts/profiling/profile_python_native_chunker.py
+++ b/scripts/profiling/profile_python_native_chunker.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark the opt-in native Python tree-sitter chunk extractor.
+
+Both arms run the production PythonCodeChunker content assembly. The only
+variable is whether parsing and definition-span traversal happen through the
+existing Python tree-sitter bindings or the compact C++ proof of concept.
+Measured arm order is balanced AB/BA and every iteration checks exact
+CodeChunk parity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import math
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_POC_BUILD_ENV = "CODENIB_PYTHON_CHUNK_POC_BUILD_DIR"
+_configured_build = os.environ.get(_POC_BUILD_ENV)
+_POC_BUILD = Path(
+    _configured_build if _configured_build else _PROJECT_ROOT / "build/core-chunk-poc"
+).expanduser()
+if not _POC_BUILD.is_absolute():
+    _POC_BUILD = (_PROJECT_ROOT / _POC_BUILD).resolve()
+else:
+    _POC_BUILD = _POC_BUILD.resolve()
+
+# Keep the summarizer local: importing another profile script would prepend
+# build/core and could silently benchmark the wrong extension. The POC build
+# path itself is added lazily by _require_native_core so importing this module
+# as a unit-test helper does not affect unrelated codenib_core imports.
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from codenib.code_chunker import CodeChunker, RepoChunkingConfig
+from codenib.code_chunking.python_chunker import (
+    PythonCodeChunker,
+    _validate_native_contract,
+)
+
+DEFAULT_THRESHOLD = 0.20
+DEFAULT_ITERATIONS = 6
+DEFAULT_WARMUPS = 1
+REPORT_SCHEMA_VERSION = 1
+
+
+def summarize_samples(values: Sequence[float]) -> dict[str, float | int]:
+    """Return stable distribution fields for a non-empty timing sample."""
+
+    if not values:
+        raise ValueError("at least one timing sample is required")
+    ordered = sorted(float(value) for value in values)
+    if any(not math.isfinite(value) or value < 0 for value in ordered):
+        raise ValueError("timing samples must be finite and non-negative")
+    p95_index = max(0, min(len(ordered) - 1, int(0.95 * len(ordered) - 1e-12)))
+    return {
+        "samples": len(ordered),
+        "min_seconds": ordered[0],
+        "median_seconds": statistics.median(ordered),
+        "p95_seconds": ordered[p95_index],
+        "max_seconds": ordered[-1],
+    }
+
+
+def promotion_decision(
+    *,
+    legacy_seconds: float,
+    candidate_seconds: float,
+    threshold: float = DEFAULT_THRESHOLD,
+    parity: bool = True,
+) -> dict[str, Any]:
+    """Apply the exact repository chunk-pass promotion gate."""
+
+    for name, value in (
+        ("legacy_seconds", legacy_seconds),
+        ("candidate_seconds", candidate_seconds),
+    ):
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(f"{name} must be finite and positive")
+    if not math.isfinite(threshold) or not 0 < threshold < 1:
+        raise ValueError("threshold must be finite and between 0 and 1")
+    if type(parity) is not bool:
+        raise ValueError("parity must be a bool")
+
+    improvement = (legacy_seconds - candidate_seconds) / legacy_seconds
+    promotion_cutoff = legacy_seconds * (1.0 - threshold)
+    promoted = parity and candidate_seconds <= promotion_cutoff
+    if promoted:
+        reason = "semantic parity and end-to-end threshold passed"
+    elif not parity:
+        reason = "semantic parity failed"
+    elif candidate_seconds > legacy_seconds:
+        reason = "candidate is slower than the established chunker"
+    else:
+        reason = "end-to-end improvement is below threshold"
+    return {
+        "gate": "repository_chunk_pass_end_to_end",
+        "threshold": threshold,
+        "parity": parity,
+        "legacy_seconds": legacy_seconds,
+        "candidate_seconds": candidate_seconds,
+        "promotion_cutoff_seconds": promotion_cutoff,
+        "improvement_fraction": improvement,
+        "promoted": promoted,
+        "recommendation": (
+            "promote-native-python-chunker" if promoted else "keep-experimental"
+        ),
+        "reason": reason,
+    }
+
+
+def _chunk_summary(chunk: Any) -> dict[str, Any]:
+    return {
+        "file": chunk.file,
+        "start_line": chunk.start_line,
+        "end_line": chunk.end_line,
+        "chunk_type": chunk.chunk_type,
+        "name": chunk.name,
+        "node_id": chunk.node_id,
+        "content_sha256": hashlib.sha256(chunk.content.encode("utf-8")).hexdigest(),
+    }
+
+
+def _assert_chunk_parity(reference: Sequence[Any], candidate: Sequence[Any]) -> None:
+    if len(reference) != len(candidate):
+        raise AssertionError(
+            f"chunk count differs: {len(reference)} != {len(candidate)}"
+        )
+    for index, (left, right) in enumerate(zip(reference, candidate, strict=True)):
+        if left != right:
+            raise AssertionError(
+                f"chunk {index} differs: {_chunk_summary(left)!r} != "
+                f"{_chunk_summary(right)!r}"
+            )
+
+
+def _run_arm(
+    *,
+    chunker: PythonCodeChunker,
+    files: Sequence[Path],
+    repo_root: Path,
+    mode: str,
+) -> tuple[list[Any], float, dict[str, float]]:
+    """Measure chunk calls while keeping validation/bookkeeping out of time."""
+
+    if mode not in {"off", "required"}:
+        raise ValueError("benchmark arm mode must be off or required")
+    previous_mode = os.environ.get("CODENIB_NATIVE_PYTHON_CHUNKER")
+    gc_was_enabled = gc.isenabled()
+    gc.collect()
+    gc.disable()
+    os.environ["CODENIB_NATIVE_PYTHON_CHUNKER"] = mode
+
+    stage_totals: dict[str, float] = {}
+    chunks: list[Any] = []
+    elapsed = 0.0
+    try:
+        for path in files:
+            relative = path.relative_to(repo_root).as_posix()
+            started = time.perf_counter()
+            file_chunks = chunker.chunk_file(str(path), relative_path=relative)
+            chunks.extend(file_chunks)
+            elapsed += time.perf_counter() - started
+
+            # These checks and the stage aggregation are deliberately after
+            # the per-file stopwatch. They must not tax only the candidate.
+            expected_backend = (
+                "native-tree-sitter-poc" if mode == "required" else "python"
+            )
+            if chunker.native_chunk_backend != expected_backend:
+                raise RuntimeError(
+                    f"{mode} chunk arm selected {chunker.native_chunk_backend!r} "
+                    f"for {relative}; expected {expected_backend!r}"
+                )
+            if mode == "required":
+                for name, value in chunker.native_chunk_timings.items():
+                    if not math.isfinite(value) or value < 0:
+                        raise RuntimeError(
+                            f"native chunk stage {name!r} is invalid: {value!r}"
+                        )
+                    stage_totals[name] = stage_totals.get(name, 0.0) + value
+    finally:
+        if previous_mode is None:
+            os.environ.pop("CODENIB_NATIVE_PYTHON_CHUNKER", None)
+        else:
+            os.environ["CODENIB_NATIVE_PYTHON_CHUNKER"] = previous_mode
+        if gc_was_enabled:
+            gc.enable()
+        else:
+            gc.disable()
+    return chunks, elapsed, stage_totals
+
+
+def _arm_order(iteration: int) -> tuple[str, str]:
+    """Return one half of a balanced AB/BA measurement sequence."""
+
+    return ("off", "required") if iteration % 2 == 0 else ("required", "off")
+
+
+def _discover_python_files(repo_root: Path, *, include_tests: bool) -> list[Path]:
+    config = RepoChunkingConfig(
+        languages=["python"],
+        filter_tests=not include_tests,
+    )
+    driver = CodeChunker(language="python", repo_config=config, chunk_depth=2)
+    return [
+        path
+        for path, language in driver._discover_files(repo_root, ["python"])
+        if language == "python"
+    ]
+
+
+def _git_subject_identity(repo_root: Path) -> dict[str, str | bool | None]:
+    """Return a non-mutating best-effort commit and dirty-state receipt."""
+
+    git_environment = os.environ.copy()
+    git_environment["GIT_OPTIONAL_LOCKS"] = "0"
+
+    def run(*arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(repo_root), *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=git_environment,
+        )
+
+    try:
+        revision = run("rev-parse", "--verify", "HEAD")
+        if revision.returncode != 0 or not revision.stdout.strip():
+            return {"git_commit": None, "git_dirty": None}
+        status = run("status", "--porcelain=v1", "--untracked-files=normal")
+    except (OSError, subprocess.TimeoutExpired):
+        return {"git_commit": None, "git_dirty": None}
+    return {
+        "git_commit": revision.stdout.strip(),
+        "git_dirty": None if status.returncode != 0 else bool(status.stdout),
+    }
+
+
+def _require_stable_subject_identity(
+    before: dict[str, str | bool | None],
+    after: dict[str, str | bool | None],
+) -> dict[str, str | bool | None]:
+    """Reject benchmark receipts if the subject changed during measurement."""
+
+    if before != after:
+        raise RuntimeError(
+            "repository Git identity changed during the benchmark: "
+            f"before={before!r}, after={after!r}"
+        )
+    return after
+
+
+def _require_native_core() -> tuple[Any, dict[str, Any], Path]:
+    poc_build = str(_POC_BUILD)
+    while poc_build in sys.path:
+        sys.path.remove(poc_build)
+    sys.path.insert(0, poc_build)
+    try:
+        import codenib_core
+    except ImportError as exc:
+        raise RuntimeError(
+            "native Python chunk POC is not built; run make core-chunk-poc-build"
+        ) from exc
+
+    origin_text = getattr(codenib_core, "__file__", None)
+    if not origin_text:
+        raise RuntimeError("native Python chunk POC module has no filesystem origin")
+    origin = Path(origin_text).resolve()
+    if not origin.is_relative_to(_POC_BUILD):
+        raise RuntimeError(
+            f"codenib_core resolved outside {_POC_BUILD}: {origin}; set "
+            f"{_POC_BUILD_ENV} to the independent POC build directory"
+        )
+    if not callable(getattr(codenib_core, "extract_python_chunk_spans", None)):
+        raise RuntimeError(
+            "native Python chunk POC is not built; configure core with "
+            "-DCODENIB_BUILD_TREE_SITTER_POC=ON"
+        )
+    return codenib_core, _validate_native_contract(codenib_core), origin
+
+
+def profile_repository(
+    *,
+    repo_root: Path,
+    iterations: int = DEFAULT_ITERATIONS,
+    warmups: int = DEFAULT_WARMUPS,
+    threshold: float = DEFAULT_THRESHOLD,
+    chunk_depth: int = 2,
+    l2_level_exclusive: bool = True,
+    include_header_epilogue: bool = False,
+    max_lines_per_chunk: int | None = None,
+    include_tests: bool = False,
+) -> dict[str, Any]:
+    """Profile a filtered repository chunk pass and return a JSON-ready report."""
+
+    if type(iterations) is not int or iterations < 2 or iterations % 2:
+        raise ValueError("iterations must be a positive even integer of at least 2")
+    if type(warmups) is not int or warmups < 0:
+        raise ValueError("warmups must be a non-negative integer")
+    if not math.isfinite(threshold) or not 0 < threshold < 1:
+        raise ValueError("threshold must be finite and between 0 and 1")
+    if chunk_depth not in {1, 2}:
+        raise ValueError("native POC profiling supports chunk_depth 1 or 2")
+    repo_root = repo_root.resolve()
+    if not repo_root.is_dir():
+        raise NotADirectoryError(repo_root)
+
+    subject_identity_before = _git_subject_identity(repo_root)
+    _, contract, native_module = _require_native_core()
+    files = _discover_python_files(repo_root, include_tests=include_tests)
+    if not files:
+        raise ValueError(f"no Python source files found under {repo_root}")
+
+    kwargs = {
+        "chunk_depth": chunk_depth,
+        "l2_level_exclusive": l2_level_exclusive,
+        "include_header_epilogue": include_header_epilogue,
+        "max_lines_per_chunk": max_lines_per_chunk,
+    }
+    legacy_chunker = PythonCodeChunker(**kwargs)
+    candidate_chunker = PythonCodeChunker(**kwargs)
+    chunkers = {"off": legacy_chunker, "required": candidate_chunker}
+
+    for warmup in range(warmups):
+        results = {
+            mode: _run_arm(
+                chunker=chunkers[mode],
+                files=files,
+                repo_root=repo_root,
+                mode=mode,
+            )
+            for mode in _arm_order(warmup)
+        }
+        _assert_chunk_parity(results["off"][0], results["required"][0])
+
+    legacy_samples: list[float] = []
+    candidate_samples: list[float] = []
+    stage_samples: dict[str, list[float]] = {}
+    measured_rounds: list[dict[str, Any]] = []
+    parity = True
+    parity_error = None
+    chunk_count = 0
+    expected_stage_names: set[str] | None = None
+    for iteration in range(iterations):
+        modes = _arm_order(iteration)
+        results = {
+            mode: _run_arm(
+                chunker=chunkers[mode],
+                files=files,
+                repo_root=repo_root,
+                mode=mode,
+            )
+            for mode in modes
+        }
+        reference, legacy_elapsed, _ = results["off"]
+        candidate, candidate_elapsed, stages = results["required"]
+        try:
+            _assert_chunk_parity(reference, candidate)
+        except AssertionError as exc:
+            if parity_error is None:
+                parity_error = str(exc)
+            parity = False
+        chunk_count = len(reference)
+        legacy_samples.append(legacy_elapsed)
+        candidate_samples.append(candidate_elapsed)
+
+        stage_names = set(stages)
+        if expected_stage_names is None:
+            expected_stage_names = stage_names
+        elif stage_names != expected_stage_names:
+            raise RuntimeError(
+                "native stage names changed across benchmark iterations: "
+                f"{sorted(expected_stage_names)} != {sorted(stage_names)}"
+            )
+        for name, value in stages.items():
+            stage_samples.setdefault(name, []).append(value)
+        measured_rounds.append(
+            {
+                "iteration": iteration + 1,
+                "arm_order": [
+                    "legacy" if mode == "off" else "candidate" for mode in modes
+                ],
+                "legacy_seconds": legacy_elapsed,
+                "candidate_seconds": candidate_elapsed,
+            }
+        )
+
+    legacy_summary = summarize_samples(legacy_samples)
+    candidate_summary = summarize_samples(candidate_samples)
+    decision = promotion_decision(
+        legacy_seconds=float(legacy_summary["median_seconds"]),
+        candidate_seconds=float(candidate_summary["median_seconds"]),
+        threshold=threshold,
+        parity=parity,
+    )
+    subject_identity = _require_stable_subject_identity(
+        subject_identity_before,
+        _git_subject_identity(repo_root),
+    )
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "benchmark": "native_python_tree_sitter_chunk_poc",
+        "subject": {
+            "repo_root": str(repo_root),
+            **subject_identity,
+            "file_count": len(files),
+            "source_bytes": sum(path.stat().st_size for path in files),
+            "chunk_count": chunk_count,
+        },
+        "configuration": {
+            "iterations": iterations,
+            "warmups": warmups,
+            "threshold": threshold,
+            "arm_order_policy": "balanced-ab-ba",
+            "chunk_depth": chunk_depth,
+            "l2_level_exclusive": l2_level_exclusive,
+            "include_header_epilogue": include_header_epilogue,
+            "max_lines_per_chunk": max_lines_per_chunk,
+            "include_tests": include_tests,
+            "native_build_dir": str(_POC_BUILD),
+            "native_module": str(native_module),
+            "native_contract": contract,
+        },
+        "measurements": measured_rounds,
+        "parity": {"passed": parity, "error": parity_error},
+        "legacy": {
+            "total": legacy_summary,
+            "samples_seconds": legacy_samples,
+        },
+        "candidate": {
+            "total": candidate_summary,
+            "samples_seconds": candidate_samples,
+            "native_stages": {
+                name: {
+                    **summarize_samples(values),
+                    "samples_seconds": values,
+                }
+                for name, values in stage_samples.items()
+            },
+        },
+        "decision": decision,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    parser.add_argument("--chunk-depth", type=int, choices=(1, 2), default=2)
+    parser.add_argument("--include-l1-containers", action="store_true")
+    parser.add_argument("--include-header-epilogue", action="store_true")
+    parser.add_argument("--max-lines-per-chunk", type=int)
+    parser.add_argument("--include-tests", action="store_true")
+    parser.add_argument("--output-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = profile_repository(
+        repo_root=args.repo,
+        iterations=args.iterations,
+        warmups=args.warmups,
+        threshold=args.threshold,
+        chunk_depth=args.chunk_depth,
+        l2_level_exclusive=not args.include_l1_containers,
+        include_header_epilogue=args.include_header_epilogue,
+        max_lines_per_chunk=args.max_lines_per_chunk,
+        include_tests=args.include_tests,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered, encoding="utf-8")
+    sys.stdout.write(rendered)
+    return 0 if report["parity"]["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/chunker/test_python_native_chunk_poc.py
+++ b/test/chunker/test_python_native_chunk_poc.py
@@ -1,0 +1,526 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parity, validation, and fallback tests for the Python chunk POC."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from codenib.code_chunking import python_chunker
+from codenib.code_chunking.base import BaseCodeChunker
+from codenib.code_chunking.python_chunker import PythonCodeChunker
+
+EXPECTED_CONTRACT = {
+    "abi_version": 1,
+    "row_size": 20,
+    "grammar": "tree-sitter-python@v0.25.0",
+    "runtime": "tree-sitter@v0.25.2",
+    "semantic_profile": "python-definition-spans-v1",
+}
+
+PARITY_SOURCES = [
+    pytest.param(
+        """\
+# tête
+@trace(α=1)
+async def café(value: str):
+    return value
+
+@registered
+class 服务:
+    @classmethod
+    async def 创建(cls):
+        return cls()
+""",
+        id="decorators-async-unicode",
+    ),
+    pytest.param(
+        """\
+def identity[T](value: T) -> T:
+    return value
+
+class Box[T]:
+    def get(self) -> T:
+        ...
+""",
+        id="pep695-generics",
+    ),
+    pytest.param(
+        """\
+def outer():
+    def inner():
+        return 1
+    return inner()
+
+class Visible:
+    class Nested:
+        def hidden(self):
+            return 2
+
+    def direct(self):
+        return 3
+""",
+        id="nested-definitions",
+    ),
+    pytest.param(
+        """\
+if ENABLED:
+    def conditional():
+        return 1
+
+class Service:
+    if ENABLED:
+        def conditional_method(self):
+            return 2
+
+    def direct(self):
+        return 3
+""",
+        id="conditional-definitions",
+    ),
+    pytest.param(
+        """\
+def valid():
+    return 1
+
+def broken(:
+    missing
+
+class Recovered:
+    def method(self):
+        return 2
+""",
+        id="error-recovery",
+    ),
+    pytest.param(
+        """\
+@first
+@second(
+    1,
+)
+def multiline(
+    value,
+):
+    return value
+""",
+        id="multiline-decorators",
+    ),
+    pytest.param(
+        """\
+# module header
+import os
+
+def body():
+    return os.name
+
+# module epilogue
+RESULT = body()
+""",
+        id="header-epilogue",
+    ),
+    pytest.param(
+        "def compact(): return 1\nclass Empty: pass\n",
+        id="single-line-suites",
+    ),
+    pytest.param("", id="empty-source"),
+    pytest.param(
+        """\
+@decorated
+class Factory:
+    @classmethod
+    async def build(cls):
+        return cls()
+
+    def run(self):
+        return None
+""",
+        id="decorated-class-methods",
+    ),
+]
+
+PARITY_CONFIGURATIONS = [
+    pytest.param(
+        {
+            "chunk_depth": 1,
+            "l2_level_exclusive": True,
+            "include_header_epilogue": False,
+            "max_lines_per_chunk": None,
+        },
+        id="l1",
+    ),
+    pytest.param(
+        {
+            "chunk_depth": 2,
+            "l2_level_exclusive": True,
+            "include_header_epilogue": False,
+            "max_lines_per_chunk": None,
+        },
+        id="l2-exclusive",
+    ),
+    pytest.param(
+        {
+            "chunk_depth": 2,
+            "l2_level_exclusive": False,
+            "include_header_epilogue": True,
+            "max_lines_per_chunk": 3,
+        },
+        id="l2-containers-headers-split",
+    ),
+]
+
+
+def _native_available() -> bool:
+    core = python_chunker._load_native_core()
+    return core is not None and hasattr(core, "extract_python_chunk_spans")
+
+
+def _payload(*, rows=b"", arena=b"", row_count=0, **overrides):
+    payload = {
+        "abi_version": 1,
+        "row_count": row_count,
+        "rows": rows,
+        "arena": arena,
+        "parse_ns": 2_000_000,
+        "extract_ns": 1_000_000,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_validate_native_contract_requires_exact_profile():
+    class Core:
+        @staticmethod
+        def python_chunk_poc_contract():
+            return dict(EXPECTED_CONTRACT)
+
+    assert python_chunker._validate_native_contract(Core()) == EXPECTED_CONTRACT
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("abi_version", True),
+        ("abi_version", 2),
+        ("row_size", True),
+        ("row_size", 24),
+        ("grammar", "tree-sitter-python@v0.24.0"),
+        ("runtime", "tree-sitter@v0.24.0"),
+        ("semantic_profile", "python-definition-spans-v2"),
+        ("semantic_profile", None),
+    ],
+)
+def test_validate_native_contract_rejects_mismatch(field, value):
+    contract = dict(EXPECTED_CONTRACT)
+    contract[field] = value
+
+    class Core:
+        @staticmethod
+        def python_chunk_poc_contract():
+            return contract
+
+    with pytest.raises(RuntimeError, match=field):
+        python_chunker._validate_native_contract(Core())
+
+
+def test_decode_native_chunk_payload_reads_compact_rows():
+    rows = b"".join(
+        [
+            python_chunker._NATIVE_CHUNK_ROW.pack(1, 3, 1, 0, 3),
+            python_chunker._NATIVE_CHUNK_ROW.pack(5, 8, 3, 3, 9),
+        ]
+    )
+    definitions, timings = python_chunker._decode_native_chunk_payload(
+        _payload(rows=rows, arena=b"topThing.run", row_count=2),
+        source_line_count=10,
+    )
+
+    assert [
+        (node.start_point[0], node.end_point[0], name, kind)
+        for node, name, kind in definitions
+    ] == [
+        (1, 3, "top", "function"),
+        (5, 8, "Thing.run", "method"),
+    ]
+    assert timings == {
+        "native_parse": 0.002,
+        "native_extract_encode": 0.001,
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        _payload(abi_version=True),
+        _payload(abi_version=2),
+        _payload(row_count=True),
+        _payload(row_count=1),
+        _payload(
+            rows=python_chunker._NATIVE_CHUNK_ROW.pack(4, 3, 1, 0, 1),
+            arena=b"x",
+            row_count=1,
+        ),
+        _payload(
+            rows=python_chunker._NATIVE_CHUNK_ROW.pack(9, 10, 1, 0, 1),
+            arena=b"x",
+            row_count=1,
+        ),
+        _payload(
+            rows=b"".join(
+                [
+                    python_chunker._NATIVE_CHUNK_ROW.pack(5, 6, 1, 0, 1),
+                    python_chunker._NATIVE_CHUNK_ROW.pack(1, 2, 1, 1, 1),
+                ]
+            ),
+            arena=b"xy",
+            row_count=2,
+        ),
+        _payload(
+            rows=python_chunker._NATIVE_CHUNK_ROW.pack(1, 2, 9, 0, 1),
+            arena=b"x",
+            row_count=1,
+        ),
+        _payload(
+            rows=python_chunker._NATIVE_CHUNK_ROW.pack(1, 2, 1, 1, 2),
+            arena=b"x",
+            row_count=1,
+        ),
+        _payload(
+            rows=python_chunker._NATIVE_CHUNK_ROW.pack(1, 2, 1, 0, 1),
+            arena=b"\xff",
+            row_count=1,
+        ),
+        _payload(parse_ns=True),
+        _payload(extract_ns=-1),
+        _payload(parse_ns=None),
+    ],
+)
+def test_decode_native_chunk_payload_rejects_invalid_envelopes(payload):
+    with pytest.raises((TypeError, ValueError)):
+        python_chunker._decode_native_chunk_payload(payload, source_line_count=10)
+
+
+@pytest.mark.parametrize("source_line_count", [True, 0, -1])
+def test_decode_native_chunk_payload_rejects_invalid_source_line_count(
+    source_line_count,
+):
+    with pytest.raises(ValueError, match="source_line_count"):
+        python_chunker._decode_native_chunk_payload(
+            _payload(), source_line_count=source_line_count
+        )
+
+
+def test_native_python_chunk_mode_defaults_off_without_loading_core(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "sample.py"
+    source.write_text("def established():\n    return 1\n", encoding="utf-8")
+    monkeypatch.delenv("CODENIB_NATIVE_PYTHON_CHUNKER", raising=False)
+    monkeypatch.setattr(
+        python_chunker,
+        "_load_native_core",
+        lambda: pytest.fail("default-off route loaded the native module"),
+    )
+
+    chunker = PythonCodeChunker(chunk_depth=1)
+    chunks = chunker.chunk_file(str(source), relative_path="sample.py")
+
+    assert [chunk.name for chunk in chunks] == ["established"]
+    assert chunker.native_chunk_backend == "python"
+    assert chunker.native_chunk_timings == {}
+
+
+def test_native_python_chunk_auto_mode_falls_back_per_file(tmp_path, monkeypatch):
+    source = tmp_path / "sample.py"
+    source.write_text("def established():\n    return 1\n", encoding="utf-8")
+    chunker = PythonCodeChunker(chunk_depth=1)
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "off")
+    reference = chunker.chunk_file(str(source), relative_path="sample.py")
+
+    class BrokenCore:
+        @staticmethod
+        def python_chunk_poc_contract():
+            return dict(EXPECTED_CONTRACT)
+
+        @staticmethod
+        def extract_python_chunk_spans(*args, **kwargs):
+            raise RuntimeError("synthetic native failure")
+
+    monkeypatch.setattr(python_chunker, "_load_native_core", lambda: BrokenCore())
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "auto")
+
+    assert chunker.chunk_file(str(source), relative_path="sample.py") == reference
+    assert chunker.native_chunk_backend == "python-fallback"
+    assert "synthetic native failure" in chunker.native_chunk_fallback_error
+
+
+def test_native_python_chunk_auto_mode_falls_back_on_contract_mismatch(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "sample.py"
+    source.write_text("def established():\n    return 1\n", encoding="utf-8")
+    chunker = PythonCodeChunker(chunk_depth=1)
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "off")
+    reference = chunker.chunk_file(str(source), relative_path="sample.py")
+
+    class WrongCore:
+        @staticmethod
+        def python_chunk_poc_contract():
+            return {**EXPECTED_CONTRACT, "semantic_profile": "unexpected"}
+
+        @staticmethod
+        def extract_python_chunk_spans(*args, **kwargs):
+            pytest.fail("mismatched contract reached native extraction")
+
+    monkeypatch.setattr(python_chunker, "_load_native_core", lambda: WrongCore())
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "auto")
+
+    assert chunker.chunk_file(str(source), relative_path="sample.py") == reference
+    assert chunker.native_chunk_backend == "python-fallback"
+    assert "semantic_profile" in chunker.native_chunk_fallback_error
+
+
+def test_native_python_chunk_required_mode_fails_closed_without_api(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "sample.py"
+    source.write_text("def established():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setattr(python_chunker, "_load_native_core", object)
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "required")
+
+    with pytest.raises(RuntimeError, match="does not include"):
+        PythonCodeChunker(chunk_depth=1).chunk_file(str(source))
+
+
+def test_native_python_chunk_required_mode_fails_closed_on_malformed_payload(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "sample.py"
+    source.write_text("def established():\n    return 1\n", encoding="utf-8")
+
+    class MalformedCore:
+        @staticmethod
+        def python_chunk_poc_contract():
+            return dict(EXPECTED_CONTRACT)
+
+        @staticmethod
+        def extract_python_chunk_spans(*args, **kwargs):
+            rows = python_chunker._NATIVE_CHUNK_ROW.pack(0, 100, 1, 0, 11)
+            return _payload(rows=rows, arena=b"established", row_count=1)
+
+    monkeypatch.setattr(python_chunker, "_load_native_core", lambda: MalformedCore())
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "required")
+
+    with pytest.raises(ValueError, match="source line bounds"):
+        PythonCodeChunker(chunk_depth=1).chunk_file(str(source))
+
+
+def test_native_python_chunk_required_mode_rejects_unsupported_skeleton(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "sample.py"
+    source.write_text("def established():\n    return 1\n", encoding="utf-8")
+    chunker = PythonCodeChunker(chunk_depth=2, skeleton_mode=True)
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "required")
+
+    with pytest.raises(RuntimeError, match="non-skeleton"):
+        chunker.chunk_file(str(source))
+
+
+def test_native_python_chunk_mode_rejects_unknown_value(monkeypatch):
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "sometimes")
+
+    with pytest.raises(ValueError, match="must be auto"):
+        python_chunker._native_chunk_mode()
+
+
+@pytest.mark.skipif(not _native_available(), reason="native chunk POC not built")
+@pytest.mark.parametrize("configuration", PARITY_CONFIGURATIONS)
+@pytest.mark.parametrize("source_text", PARITY_SOURCES)
+def test_native_python_chunks_match_existing_chunker(
+    tmp_path, monkeypatch, configuration, source_text
+):
+    source = tmp_path / "sample.py"
+    source.write_text(source_text, encoding="utf-8")
+    chunker = PythonCodeChunker(**configuration)
+
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "off")
+    reference = chunker.chunk_file(str(source), relative_path="pkg/sample.py")
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "required")
+    candidate = chunker.chunk_file(str(source), relative_path="pkg/sample.py")
+
+    assert candidate == reference
+    assert chunker.native_chunk_backend == "native-tree-sitter-poc"
+    assert chunker.native_chunk_fallback_error is None
+    assert chunker.native_chunk_timings["native_parse"] >= 0
+
+
+@pytest.mark.skipif(not _native_available(), reason="native chunk POC not built")
+def test_native_and_legacy_routes_share_source_reader(tmp_path, monkeypatch):
+    source = tmp_path / "sample.py"
+    source.write_text("def shared():\n    return 1\n", encoding="utf-8")
+    calls = []
+    original = BaseCodeChunker._read_source
+
+    def tracked_reader(file_path):
+        calls.append(file_path)
+        return original(file_path)
+
+    monkeypatch.setattr(BaseCodeChunker, "_read_source", staticmethod(tracked_reader))
+    chunker = PythonCodeChunker(chunk_depth=1)
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "off")
+    reference = chunker.chunk_file(str(source), relative_path="sample.py")
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "required")
+    candidate = chunker.chunk_file(str(source), relative_path="sample.py")
+
+    assert candidate == reference
+    assert calls == [str(source), str(source)]
+
+
+@pytest.mark.skipif(not _native_available(), reason="native chunk POC not built")
+@pytest.mark.parametrize("chunk_depth", [0, 3, -1])
+def test_native_binding_rejects_unsupported_chunk_depth(chunk_depth):
+    core = python_chunker._load_native_core()
+
+    with pytest.raises(ValueError, match="chunk_depth"):
+        core.extract_python_chunk_spans(
+            "def sample():\n    return 1\n",
+            chunk_depth=chunk_depth,
+            l2_level_exclusive=True,
+        )
+
+
+@pytest.mark.skipif(not _native_available(), reason="native chunk POC not built")
+def test_native_binding_is_deterministic_across_threads():
+    core = python_chunker._load_native_core()
+    source = """\
+@trace
+async def café(value):
+    return value
+
+class Service:
+    def run(self):
+        return café(1)
+"""
+
+    def extract_semantics(_):
+        payload = core.extract_python_chunk_spans(
+            source, chunk_depth=2, l2_level_exclusive=False
+        )
+        return (
+            payload["abi_version"],
+            payload["row_count"],
+            payload["rows"],
+            payload["arena"],
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(extract_semantics, range(32)))
+
+    assert results
+    assert all(result == results[0] for result in results)
+    assert python_chunker._validate_native_contract(core) == EXPECTED_CONTRACT

--- a/test/scripts/test_profile_python_native_chunker.py
+++ b/test/scripts/test_profile_python_native_chunker.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the native Python chunk benchmark and promotion gate."""
+
+from __future__ import annotations
+
+import math
+import os
+
+import pytest
+
+from codenib.code_chunking.base import CodeChunk
+from codenib.code_chunking.python_chunker import _load_native_core
+from scripts.profiling import profile_python_native_chunker as profile
+
+
+def _native_available() -> bool:
+    core = _load_native_core()
+    return core is not None and hasattr(core, "extract_python_chunk_spans")
+
+
+def test_promotion_decision_accepts_exact_threshold_with_parity():
+    decision = profile.promotion_decision(
+        legacy_seconds=1.0,
+        candidate_seconds=0.8,
+        threshold=0.20,
+    )
+
+    assert decision["improvement_fraction"] == pytest.approx(0.20)
+    assert decision["promotion_cutoff_seconds"] == 0.8
+    assert decision["promoted"] is True
+    assert decision["recommendation"] == "promote-native-python-chunker"
+
+
+def test_promotion_decision_rejects_just_below_threshold():
+    decision = profile.promotion_decision(
+        legacy_seconds=1.0,
+        candidate_seconds=math.nextafter(0.8, math.inf),
+        threshold=0.20,
+    )
+
+    assert decision["promoted"] is False
+    assert decision["reason"] == "end-to-end improvement is below threshold"
+
+
+def test_promotion_decision_never_promotes_slower_candidate():
+    decision = profile.promotion_decision(
+        legacy_seconds=1.0,
+        candidate_seconds=1.01,
+        threshold=0.20,
+    )
+
+    assert decision["improvement_fraction"] < 0
+    assert decision["promoted"] is False
+    assert decision["recommendation"] == "keep-experimental"
+    assert decision["reason"] == "candidate is slower than the established chunker"
+
+
+def test_promotion_decision_requires_parity():
+    decision = profile.promotion_decision(
+        legacy_seconds=1.0,
+        candidate_seconds=0.5,
+        parity=False,
+    )
+
+    assert decision["promoted"] is False
+    assert decision["reason"] == "semantic parity failed"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"legacy_seconds": 0.0, "candidate_seconds": 1.0},
+        {"legacy_seconds": math.nan, "candidate_seconds": 1.0},
+        {"legacy_seconds": math.inf, "candidate_seconds": 1.0},
+        {"legacy_seconds": 1.0, "candidate_seconds": 0.0},
+        {"legacy_seconds": 1.0, "candidate_seconds": math.nan},
+        {"legacy_seconds": 1.0, "candidate_seconds": math.inf},
+        {"legacy_seconds": 1.0, "candidate_seconds": 0.5, "threshold": 0.0},
+        {"legacy_seconds": 1.0, "candidate_seconds": 0.5, "threshold": 1.0},
+        {
+            "legacy_seconds": 1.0,
+            "candidate_seconds": 0.5,
+            "threshold": math.nan,
+        },
+        {"legacy_seconds": 1.0, "candidate_seconds": 0.5, "parity": 1},
+    ],
+)
+def test_promotion_decision_rejects_invalid_inputs(kwargs):
+    with pytest.raises(ValueError):
+        profile.promotion_decision(**kwargs)
+
+
+def test_summarize_samples_reports_distribution_and_rejects_non_finite():
+    assert profile.summarize_samples([0.4, 0.1, 0.2, 0.3]) == {
+        "samples": 4,
+        "min_seconds": 0.1,
+        "median_seconds": 0.25,
+        "p95_seconds": 0.4,
+        "max_seconds": 0.4,
+    }
+    with pytest.raises(ValueError, match="finite"):
+        profile.summarize_samples([0.1, math.nan])
+
+
+def test_chunk_parity_reports_first_difference():
+    left = CodeChunk("a", 0, 0, "function", "a", "sample.py", "sample.py:a()")
+    right = CodeChunk("b", 0, 0, "function", "a", "sample.py", "sample.py:a()")
+
+    with pytest.raises(AssertionError, match="chunk 0 differs"):
+        profile._assert_chunk_parity([left], [right])
+
+
+def test_arm_order_is_balanced_ab_ba():
+    orders = [profile._arm_order(iteration) for iteration in range(6)]
+
+    assert orders == [
+        ("off", "required"),
+        ("required", "off"),
+        ("off", "required"),
+        ("required", "off"),
+        ("off", "required"),
+        ("required", "off"),
+    ]
+
+
+def test_profile_rejects_unbalanced_iteration_count_before_loading_core(tmp_path):
+    with pytest.raises(ValueError, match="even"):
+        profile.profile_repository(repo_root=tmp_path, iterations=5)
+
+
+def test_run_arm_keeps_candidate_validation_outside_stopwatch(tmp_path, monkeypatch):
+    source = tmp_path / "sample.py"
+    source.write_text("def sample():\n    return 1\n", encoding="utf-8")
+    clock = {"value": 0.0}
+    events = []
+
+    class FakeChunker:
+        def chunk_file(self, *args, **kwargs):
+            events.append("chunk")
+            clock["value"] += 2.0
+            return []
+
+        @property
+        def native_chunk_backend(self):
+            events.append("backend-check")
+            clock["value"] += 10.0
+            return "native-tree-sitter-poc"
+
+        @property
+        def native_chunk_timings(self):
+            events.append("stage-aggregation")
+            clock["value"] += 10.0
+            return {"native_parse": 0.25}
+
+    monkeypatch.setattr(profile.time, "perf_counter", lambda: clock["value"])
+    monkeypatch.setattr(profile.gc, "isenabled", lambda: True)
+    monkeypatch.setattr(profile.gc, "collect", lambda: events.append("gc-collect"))
+    monkeypatch.setattr(profile.gc, "disable", lambda: events.append("gc-disable"))
+    monkeypatch.setattr(profile.gc, "enable", lambda: events.append("gc-enable"))
+    monkeypatch.setenv("CODENIB_NATIVE_PYTHON_CHUNKER", "auto")
+
+    chunks, elapsed, stages = profile._run_arm(
+        chunker=FakeChunker(),
+        files=[source],
+        repo_root=tmp_path,
+        mode="required",
+    )
+
+    assert chunks == []
+    assert elapsed == 2.0
+    assert stages == {"native_parse": 0.25}
+    assert events == [
+        "gc-collect",
+        "gc-disable",
+        "chunk",
+        "backend-check",
+        "stage-aggregation",
+        "gc-enable",
+    ]
+    assert os.environ["CODENIB_NATIVE_PYTHON_CHUNKER"] == "auto"
+
+
+def test_run_arm_restores_disabled_gc_and_environment_on_failure(tmp_path, monkeypatch):
+    source = tmp_path / "sample.py"
+    source.write_text("def sample():\n    return 1\n", encoding="utf-8")
+    events = []
+
+    class BrokenChunker:
+        def chunk_file(self, *args, **kwargs):
+            raise RuntimeError("synthetic failure")
+
+    monkeypatch.setattr(profile.gc, "isenabled", lambda: False)
+    monkeypatch.setattr(profile.gc, "collect", lambda: events.append("gc-collect"))
+    monkeypatch.setattr(profile.gc, "disable", lambda: events.append("gc-disable"))
+    monkeypatch.setattr(profile.gc, "enable", lambda: events.append("gc-enable"))
+    monkeypatch.delenv("CODENIB_NATIVE_PYTHON_CHUNKER", raising=False)
+
+    with pytest.raises(RuntimeError, match="synthetic failure"):
+        profile._run_arm(
+            chunker=BrokenChunker(),
+            files=[source],
+            repo_root=tmp_path,
+            mode="off",
+        )
+
+    assert events == ["gc-collect", "gc-disable", "gc-disable"]
+    assert "CODENIB_NATIVE_PYTHON_CHUNKER" not in os.environ
+
+
+def test_git_subject_identity_is_explicit_when_directory_is_not_a_repository(tmp_path):
+    assert profile._git_subject_identity(tmp_path) == {
+        "git_commit": None,
+        "git_dirty": None,
+    }
+
+
+def test_subject_identity_must_remain_stable_during_benchmark():
+    clean = {"git_commit": "abc123", "git_dirty": False}
+
+    assert profile._require_stable_subject_identity(clean, clean.copy()) == clean
+    with pytest.raises(RuntimeError, match="changed during the benchmark"):
+        profile._require_stable_subject_identity(
+            clean,
+            {"git_commit": "def456", "git_dirty": False},
+        )
+
+
+@pytest.mark.skipif(not _native_available(), reason="native chunk POC not built")
+def test_profile_repository_reports_parity_raw_samples_and_arm_order(tmp_path):
+    (tmp_path / "sample.py").write_text(
+        "class Example:\n"
+        "    def method(self):\n"
+        "        return 1\n\n"
+        "def top():\n"
+        "    return Example().method()\n",
+        encoding="utf-8",
+    )
+
+    report = profile.profile_repository(
+        repo_root=tmp_path,
+        iterations=2,
+        warmups=1,
+    )
+
+    assert report["schema_version"] == 1
+    assert report["parity"] == {"passed": True, "error": None}
+    assert report["subject"]["file_count"] == 1
+    assert report["subject"]["chunk_count"] == 2
+    assert report["subject"]["git_commit"] is None
+    assert report["subject"]["git_dirty"] is None
+    assert report["legacy"]["total"]["samples"] == 2
+    assert len(report["legacy"]["samples_seconds"]) == 2
+    assert len(report["candidate"]["samples_seconds"]) == 2
+    assert [round_["arm_order"] for round_ in report["measurements"]] == [
+        ["legacy", "candidate"],
+        ["candidate", "legacy"],
+    ]
+    native_parse = report["candidate"]["native_stages"]["native_parse"]
+    assert native_parse["samples"] == 2
+    assert len(native_parse["samples_seconds"]) == 2


### PR DESCRIPTION
## Summary

Retains the native Python chunk-span experiment as an isolated local/manual POC. Both build-time and runtime activation remain default OFF.

Exact `CodeChunk` parity passed, but the candidate was slower on both clean benchmark subjects and failed the required 20% end-to-end acceleration gate, so it is not promoted.

Closes #558.

## Changes

- Add an opt-in C++ tree-sitter span extractor with pinned dependencies, a versioned compact ABI, thread-local parsers, and GIL release around native work.
- Keep the maintained `build/core` extension and required CI explicitly POC-free; add reverse guards that reject experimental APIs there.
- Add Python `off`, `auto`, and `required` modes with strict contract/payload validation, per-file fallback, and shared source decoding.
- Add a balanced AB/BA repository benchmark with symmetric GC handling, per-round parity, stable Git identity receipts, raw samples, and a strict 20% promotion threshold.
- Add semantic parity, malformed-payload, fallback, concurrency, benchmark-fairness, and promotion-gate coverage.
- Document the experimental status, reproducible commands, negative benchmark results, and incremental parse reuse or repository batching as the next investigation paths.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `make core-chunk-poc-test` — 92 passed.
- `make core-test` — all C++ executables passed; Python tests reported 122 passed and 4 skipped; the maintained extension exposed no POC APIs.
- Full unit marker tier — 4,070 passed, 49 skipped, 192 deselected, and 3 existing SWIG warnings in 72.06s. The run explicitly excluded two local-environment baseline failures reproduced on clean `main`:
  - `test/artifacts/test_portable_views.py::test_normalize_rejects_untrained_active_ivf_before_runtime_first_search`
  - `test/compiler/test_cache_lock.py::test_creates_bounded_entries_without_chmodding_existing_parent`
- Default-off CI-policy and targeted test selection — 76 passed and 36 skipped.
- Additional 144-configuration semantic parity matrix — passed.
- Pre-commit hooks over all 15 changed files — passed.
- `python -m mkdocs build --strict` — passed.
- Clean CodeNib benchmark (`a33bb13118e3a04f8d3d76eabcfb2602f785477a`, 520 files, 6 rounds / 1 warmup): legacy 0.6430s, native 0.8088s; native was 25.8% slower.
- Clean HTTPie benchmark (`2105caa49bae87c5809c274e407619a0de2639d1`, 89 files, 20 rounds / 4 warmups): legacy 0.03588s, native 0.04294s; native was 19.7% slower.
- Both benchmark reports had stable before/after Git identity, exact parity, `git_dirty=false`, and `promoted=false`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
