### PR TITLE
feat(artifacts): add strict BM25 publication

### DIFF
--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -31,6 +31,12 @@ from .runtime import (
     query_context_artifact,
     verify_context_artifact,
 )
+from .strict_bm25 import (
+    PlannedBm25View,
+    normalize_owned_query_view_strict,
+    plan_bm25_view_strict,
+    publish_planned_bm25_view_strict,
+)
 
 __all__ = [
     "CONTEXT_ARTIFACT_MANIFEST",
@@ -41,12 +47,16 @@ __all__ = [
     "GitHubArtifactFetchResult",
     "GitHubArtifactRecord",
     "MCP_CONFIG_HOSTS",
+    "PlannedBm25View",
     "SourceTrust",
     "VerifiedContextArtifact",
     "bind_context_artifact",
     "extract_context_artifact_archive",
     "fetch_github_context_artifact",
     "normalize_owned_query_view",
+    "normalize_owned_query_view_strict",
+    "plan_bm25_view_strict",
+    "publish_planned_bm25_view_strict",
     "query_context_artifact",
     "validate_portable_query_view",
     "resolve_github_context_artifact",

--- a/codenib/artifacts/strict_bm25.py
+++ b/codenib/artifacts/strict_bm25.py
@@ -1,0 +1,1099 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strict, authority-bound publication for portable BM25 generations."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+from collections.abc import Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .._atomic_directory import (
+    PublicationAuthenticatedFile,
+    PublicationDirectoryReader,
+    TreeFileRecord,
+    _annotate_secondary_error,
+    directory_ownership_digest,
+    directory_ownership_file_records,
+    directory_ownership_inventory,
+    lexical_directory_path,
+)
+from .._bounded_json import (
+    canonical_json_array_chunks,
+    canonical_json_value_chunks,
+    iter_bounded_json_array,
+    validate_bounded_json_stream,
+    validate_json_complexity,
+)
+from .._captured_directory import (
+    PublishedWorkspaceReceipt,
+    PublishedWorkspaceReceiptOwner,
+    WorkspaceFile,
+    WorkspacePlan,
+    require_owned_workspace_publication_support,
+)
+from .._secret_fields import assert_no_secret_fields
+from .._workspace_provider import (
+    StrictWorkspaceProvider,
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_strict_workspace,
+)
+from ..source_fingerprint import RepositorySourceBinding
+from .security import assert_publishable_json_value
+
+_MAX_CONFIG_JSON_BYTES = 16 * 1024 * 1024
+_MAX_DOCUMENTS_JSON_BYTES = 256 * 1024 * 1024
+_MAX_SOURCE_PATH_BYTES = 4_096
+_MAX_SOURCE_PATH_COMPONENTS = 256
+_JSON_READ_CHUNK_BYTES = 1024 * 1024
+_WINDOWS_DRIVE_PREFIX = tuple(
+    f"{letter}:" for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+)
+_STRICT_BM25_PLAN_DOMAIN = b"codenib-portable-bm25-strict-workspace-v1"
+_STRICT_BM25_FILES = frozenset({"documents.json", "bm25_metadata.json"})
+
+
+def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        value[key] = item
+    return value
+
+
+def _reject_nonfinite_number(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _bounded_canonical_json_bytes(
+    value: Any,
+    *,
+    max_bytes: int,
+    label: str,
+) -> bytes:
+    payload = bytearray()
+    for chunk in canonical_json_value_chunks(value):
+        payload.extend(chunk)
+        if len(payload) + 1 > max_bytes:
+            raise ValueError(f"{label} exceeds its {max_bytes}-byte limit")
+    payload.extend(b"\n")
+    return bytes(payload)
+
+
+def _json_object_snapshot(
+    value: Mapping[str, Any],
+    *,
+    label: str,
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} requires a mapping")
+    detached = dict(value)
+    validate_json_complexity(detached, label=label)
+    try:
+        payload = _bounded_canonical_json_bytes(
+            detached,
+            max_bytes=_MAX_CONFIG_JSON_BYTES,
+            label=label,
+        )
+        snapshot = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+        )
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise ValueError(f"{label} is not canonical JSON data") from exc
+    if not isinstance(snapshot, dict):  # pragma: no cover - detached is a dict
+        raise AssertionError(f"{label} snapshot is not an object")
+    return snapshot
+
+
+def _environment_snapshot(environ: Mapping[str, str] | None) -> dict[str, str]:
+    source = os.environ if environ is None else environ
+    if not isinstance(source, Mapping):
+        raise TypeError("strict BM25 environment must be a mapping")
+    snapshot = dict(source)
+    if any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in snapshot.items()
+    ):
+        raise TypeError("strict BM25 environment must contain text pairs")
+    return snapshot
+
+
+def _preflight_publication_authorities(
+    *,
+    source_generation: PublishedWorkspaceReceiptOwner,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+) -> None:
+    """Reject unusable authority before config, source, or provider mutation."""
+
+    if type(source_generation) is not PublishedWorkspaceReceiptOwner:
+        raise TypeError("strict BM25 source must be a workspace receipt owner")
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("strict BM25 repository source has an invalid type")
+    if type(output_receipt_owner) is not PublishedWorkspaceReceiptOwner:
+        raise TypeError("strict BM25 output receipt owner has an invalid type")
+    if source_generation is output_receipt_owner:
+        raise ValueError("strict BM25 source and output receipt owners must differ")
+    if not source_generation.active:
+        raise RuntimeError("strict BM25 source generation must be active")
+    if not repository_source.usable:
+        raise RuntimeError("strict BM25 repository source is not usable")
+    if output_receipt_owner.state != "empty":
+        raise RuntimeError("strict BM25 output receipt owner must be empty")
+
+    # Match run_strict_workspace: the platform gate precedes even provider
+    # descriptor lookup. Provider support itself is invoked exactly once by
+    # run_strict_workspace after caller inputs and the exact plan are frozen.
+    require_owned_workspace_publication_support()
+    for member in ("require_support", "run_workspace"):
+        try:
+            raw = inspect.getattr_static(workspace_provider, member)
+        except AttributeError as exc:
+            raise TypeError(
+                "strict workspace provider has an invalid contract"
+            ) from exc
+        if isinstance(raw, (classmethod, staticmethod)):
+            raw = raw.__func__
+        if not callable(raw):
+            raise TypeError("strict workspace provider has an invalid contract")
+
+
+def _require_disjoint_view_path(
+    path: Path,
+    repository_source: RepositorySourceBinding,
+) -> Path:
+    """Return one lexical view path that cannot contain or enter the repo."""
+
+    candidate = lexical_directory_path(path)
+    repository = lexical_directory_path(repository_source.root)
+
+    def overlaps(left: Path, right: Path) -> bool:
+        return left == right or left in right.parents or right in left.parents
+
+    if overlaps(candidate, repository):
+        raise ValueError(
+            "strict BM25 view must not overlap the source repository: " f"{candidate}"
+        )
+    try:
+        physical_candidate = candidate.resolve(strict=False)
+        physical_repository = repository.resolve(strict=False)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError("strict BM25 view location cannot be authenticated") from exc
+    if overlaps(physical_candidate, physical_repository):
+        raise ValueError(
+            "strict BM25 view must not overlap the source repository: " f"{candidate}"
+        )
+    return candidate
+
+
+def _preflight_view_location(
+    destination: Path,
+    *,
+    source_generation: PublishedWorkspaceReceiptOwner,
+    repository_source: RepositorySourceBinding,
+) -> tuple[PublishedWorkspaceReceipt, Path]:
+    """Bind replacement to its source path before source bytes are consumed."""
+
+    source_receipt = source_generation.receipt
+    source_path = _require_disjoint_view_path(
+        source_receipt.path,
+        repository_source,
+    )
+    lexical_destination = _require_disjoint_view_path(
+        destination,
+        repository_source,
+    )
+    if lexical_destination != source_path:
+        raise ValueError(
+            "strict BM25 normalization must replace its exact source generation"
+        )
+    return source_receipt, lexical_destination
+
+
+def _entry_policy(relative: str, kind: str, mode: int, size: int) -> None:
+    del mode
+    if kind != "file" or relative not in _STRICT_BM25_FILES:
+        raise ValueError(f"portable BM25 view has an invalid entry: {relative}")
+    limit = (
+        _MAX_DOCUMENTS_JSON_BYTES
+        if relative == "documents.json"
+        else _MAX_CONFIG_JSON_BYTES
+    )
+    if size < 0 or size > limit:
+        raise ValueError(
+            f"portable BM25 entry exceeds its {limit}-byte limit: {relative}"
+        )
+
+
+class _PublicationBm25Reader:
+    """BM25 facade over one callback-scoped publication reader."""
+
+    def __init__(
+        self,
+        publication: PublicationDirectoryReader,
+        ownership: object,
+    ) -> None:
+        self.root = Path("/__codenib_publication_bm25__")
+        self.ownership = ownership
+        self._publication = publication
+        self._records = {
+            record.path: record
+            for record in directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+        }
+
+    def _relative(self, path: Path | PurePosixPath | str) -> PurePosixPath:
+        if isinstance(path, Path):
+            return PurePosixPath(path.relative_to(self.root).as_posix())
+        return PurePosixPath(path)
+
+    def record(self, path: Path | PurePosixPath | str) -> TreeFileRecord:
+        relative = self._relative(path)
+        try:
+            return self._records[relative.as_posix()]
+        except KeyError as exc:
+            raise ValueError(
+                f"strict BM25 view has no captured file: {relative}"
+            ) from exc
+
+    @contextmanager
+    def open_file(
+        self,
+        path: Path | PurePosixPath | str,
+        *,
+        max_bytes: int,
+    ) -> Iterator[PublicationAuthenticatedFile]:
+        relative = self._relative(path)
+        expected = self.record(relative)
+        with self._publication.open_authenticated_file(
+            relative,
+            max_bytes=max_bytes,
+        ) as source:
+            yield source
+        if source.record != expected:
+            raise RuntimeError(f"strict BM25 file changed while reading: {relative}")
+
+    def read_bytes(
+        self,
+        path: Path | PurePosixPath | str,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        payload = bytearray()
+        with self.open_file(path, max_bytes=max_bytes) as source:
+            for chunk in source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES):
+                payload.extend(chunk)
+        return bytes(payload)
+
+    def verify_root(self) -> None:
+        observed = self._publication.capture_ownership(entry_policy=_entry_policy)
+        if observed != self.ownership:
+            raise RuntimeError("strict BM25 view changed during validation")
+
+
+def _load_json_object(
+    reader: _PublicationBm25Reader,
+    relative: str,
+    *,
+    label: str,
+) -> dict[str, Any]:
+    with reader.open_file(relative, max_bytes=_MAX_CONFIG_JSON_BYTES) as source:
+        validate_bounded_json_stream(
+            source,
+            label=label,
+            max_bytes=_MAX_CONFIG_JSON_BYTES,
+        )
+    payload = reader.read_bytes(relative, max_bytes=_MAX_CONFIG_JSON_BYTES)
+    try:
+        value = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+        )
+    except (RecursionError, ValueError) as exc:
+        raise ValueError(f"{label} is invalid UTF-8 JSON") from exc
+    validate_json_complexity(value, label=label)
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _assert_authenticated_publishable_json_value(
+    value: Any,
+    *,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+    label: str,
+) -> None:
+    assert_publishable_json_value(
+        value,
+        forbidden_paths=(),
+        environ=environ,
+        label=label,
+    )
+    forbidden: set[str] = set()
+    for path in forbidden_paths:
+        expanded = path.expanduser()
+        raw = os.fsdecode(os.fspath(expanded))
+        lexical = os.path.abspath(raw)
+        if os.path.isabs(raw):
+            forbidden.add(raw)
+        forbidden.update((lexical, Path(lexical).as_posix()))
+    patterns = tuple(sorted(pattern for pattern in forbidden if pattern))
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            for key, child in current.items():
+                if any(pattern in key for pattern in patterns):
+                    raise ValueError(f"{label} contains an absolute build-machine path")
+                stack.append(child)
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+        elif isinstance(current, str) and any(
+            pattern in current for pattern in patterns
+        ):
+            raise ValueError(f"{label} contains an absolute build-machine path")
+
+
+def _source_path(
+    value: object,
+    repository_root: Path,
+    *,
+    source: str,
+    authenticated_source_files: frozenset[str],
+) -> str:
+    if value is None or value == "":
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"{source} must be a text repository-relative path")
+    raw = value
+    try:
+        encoded = raw.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{source} is not a valid UTF-8 path") from exc
+    if len(encoded) > _MAX_SOURCE_PATH_BYTES:
+        raise ValueError(f"{source} exceeds {_MAX_SOURCE_PATH_BYTES} UTF-8 path bytes")
+    if any(ord(character) < 32 or ord(character) == 127 for character in raw):
+        raise ValueError(f"{source} is not a portable repository-relative path")
+
+    path = Path(raw)
+    if path.is_absolute():
+        try:
+            path = path.relative_to(repository_root)
+        except ValueError as exc:
+            raise ValueError(f"{source} points outside the repository") from exc
+        raw = path.as_posix()
+    else:
+        native = path.as_posix()
+        if native != raw:
+            raw_parts = raw.replace("\\", "/").split("/")
+            if any(part in {"", ".", ".."} for part in raw_parts):
+                raise ValueError(f"{source} is not repository-relative")
+            raw = native
+        elif (
+            raw.startswith("//") or raw.startswith(_WINDOWS_DRIVE_PREFIX) or "\\" in raw
+        ):
+            raise ValueError(f"{source} is not a portable repository-relative path")
+
+    raw_parts = raw.split("/")
+    normalized = PurePosixPath(raw)
+    if (
+        normalized.is_absolute()
+        or any(part in {"", ".", ".."} for part in raw_parts)
+        or raw != normalized.as_posix()
+        or len(normalized.parts) > _MAX_SOURCE_PATH_COMPONENTS
+    ):
+        raise ValueError(f"{source} is not repository-relative")
+    normalized_text = normalized.as_posix()
+    if normalized_text not in authenticated_source_files:
+        raise ValueError(f"{source} is not in the authenticated repository source")
+    return normalized_text
+
+
+def _normalized_documents(
+    reader: _PublicationBm25Reader,
+    repository_root: Path,
+    *,
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+    authenticated_source_files: frozenset[str],
+) -> Iterable[dict[str, Any]]:
+    with reader.open_file(
+        "documents.json",
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+    ) as source:
+        documents = iter_bounded_json_array(
+            source,
+            label="portable BM25 documents",
+        )
+        for index, document in enumerate(documents):
+            if not isinstance(document, dict) or set(document) != {
+                "page_content",
+                "metadata",
+            }:
+                raise ValueError(f"portable BM25 document {index} has an invalid shape")
+            page_content = document["page_content"]
+            metadata = document["metadata"]
+            if not isinstance(page_content, str) or not isinstance(metadata, dict):
+                raise ValueError(
+                    f"portable BM25 document {index} has invalid content or metadata"
+                )
+            assert_no_secret_fields(
+                metadata,
+                source=f"portable BM25 document {index} metadata",
+            )
+            raw_file = metadata.get("file")
+            if raw_file is not None and not isinstance(raw_file, str):
+                raise ValueError(
+                    f"portable BM25 document {index} has an invalid source path"
+                )
+            normalized_metadata = dict(metadata)
+            if raw_file is not None:
+                normalized_metadata["file"] = _source_path(
+                    raw_file,
+                    repository_root,
+                    source=f"portable BM25 document {index} file",
+                    authenticated_source_files=authenticated_source_files,
+                )
+            normalized = {
+                "page_content": page_content,
+                "metadata": normalized_metadata,
+            }
+            _assert_authenticated_publishable_json_value(
+                normalized,
+                forbidden_paths=forbidden_paths,
+                environ=environ,
+                label=f"portable BM25 document {index}",
+            )
+            yield normalized
+
+
+def _record_chunks(
+    relative: str,
+    chunks: Iterable[bytes],
+    *,
+    max_bytes: int,
+) -> TreeFileRecord:
+    iterator = iter(chunks)
+    digest = hashlib.sha256()
+    size = 0
+    primary_error: BaseException | None = None
+    try:
+        for chunk in iterator:
+            if not isinstance(chunk, bytes):
+                raise TypeError("strict BM25 output chunks must be bytes")
+            size += len(chunk)
+            if size > max_bytes:
+                raise ValueError(
+                    f"strict BM25 output exceeds its {max_bytes}-byte limit: {relative}"
+                )
+            digest.update(chunk)
+    except BaseException as exc:  # noqa: B036 - preserve generation fault
+        primary_error = exc
+    try:
+        close = getattr(iterator, "close", None)
+        if callable(close):
+            close()
+    except BaseException as close_error:  # noqa: B036 - cleanup is secondary
+        if primary_error is None:
+            raise
+        _annotate_secondary_error(
+            primary_error,
+            "strict BM25 output iterator close also failed",
+            close_error,
+        )
+    if primary_error is not None:
+        raise primary_error.with_traceback(primary_error.__traceback__)
+    return TreeFileRecord(
+        path=relative,
+        mode=0o600,
+        size=size,
+        sha256=digest.hexdigest(),
+    )
+
+
+def _payloads(
+    reader: _PublicationBm25Reader,
+    repository_root: Path,
+    *,
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+    authenticated_source_files: frozenset[str],
+) -> tuple[bytes, Iterable[bytes]]:
+    # Apply the whole-file lexical budgets, including string and atom limits,
+    # before the element iterator allocates any decoded document object.
+    with reader.open_file(
+        "documents.json",
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+    ) as source:
+        validate_bounded_json_stream(
+            source,
+            label="portable BM25 documents",
+            max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        )
+    metadata = _load_json_object(
+        reader,
+        "bm25_metadata.json",
+        label="portable BM25 metadata",
+    )
+    assert_no_secret_fields(metadata, source="portable BM25 metadata")
+    if not set(metadata) <= {"project_root", "max_k", "language"}:
+        raise ValueError("portable BM25 metadata has an invalid shape")
+    max_k = metadata.get("max_k", 10)
+    if isinstance(max_k, bool) or not isinstance(max_k, int) or max_k <= 0:
+        raise ValueError("portable BM25 metadata max_k must be positive")
+    language = metadata.get("language", "english")
+    if (
+        not isinstance(language, str)
+        or not language.strip()
+        or "\x00" in language
+        or len(language) > 256
+    ):
+        raise ValueError("portable BM25 metadata language is invalid")
+    if metadata.get("project_root") is not None and not isinstance(
+        metadata.get("project_root"), str
+    ):
+        raise ValueError("portable BM25 metadata project_root is invalid")
+    normalized_metadata = {
+        "project_root": "source",
+        "max_k": max_k,
+        "language": language,
+    }
+    _assert_authenticated_publishable_json_value(
+        normalized_metadata,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+        label="portable BM25 metadata",
+    )
+    metadata_bytes = _bounded_canonical_json_bytes(
+        normalized_metadata,
+        max_bytes=_MAX_CONFIG_JSON_BYTES,
+        label="portable BM25 metadata",
+    )
+    documents = canonical_json_array_chunks(
+        _normalized_documents(
+            reader,
+            repository_root,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+            authenticated_source_files=authenticated_source_files,
+        )
+    )
+    return metadata_bytes, documents
+
+
+def _frame(digest: Any, label: bytes, payload: bytes) -> None:
+    digest.update(len(label).to_bytes(2, "big"))
+    digest.update(label)
+    digest.update(len(payload).to_bytes(8, "big"))
+    digest.update(payload)
+
+
+def _record_frame(digest: Any, scope: bytes, record: TreeFileRecord) -> None:
+    _frame(digest, scope + b"-path", record.path.encode("utf-8"))
+    _frame(digest, scope + b"-mode", record.mode.to_bytes(4, "big"))
+    _frame(digest, scope + b"-size", record.size.to_bytes(8, "big"))
+    _frame(digest, scope + b"-sha256", bytes.fromhex(record.sha256))
+
+
+def _subject_digest(
+    *,
+    source_digest: str,
+    source_records: tuple[TreeFileRecord, ...],
+    output_records: tuple[TreeFileRecord, ...],
+    view_config_digest: str,
+    repository_fingerprint: str,
+) -> str:
+    digest = hashlib.sha256()
+    _frame(digest, b"domain", _STRICT_BM25_PLAN_DOMAIN)
+    _frame(digest, b"source-tree-sha256", bytes.fromhex(source_digest))
+    _frame(digest, b"view-config-sha256", bytes.fromhex(view_config_digest))
+    _frame(
+        digest,
+        b"repository-fingerprint",
+        repository_fingerprint.encode("utf-8"),
+    )
+    for record in source_records:
+        _record_frame(digest, b"source-record", record)
+    for record in output_records:
+        _record_frame(digest, b"output-record", record)
+    return digest.hexdigest()
+
+
+def _workspace_plan(
+    *,
+    source_digest: str,
+    source_records: tuple[TreeFileRecord, ...],
+    output_records: tuple[TreeFileRecord, ...],
+    view_config_digest: str,
+    repository_fingerprint: str,
+) -> WorkspacePlan:
+    return WorkspacePlan(
+        subject_digest=_subject_digest(
+            source_digest=source_digest,
+            source_records=source_records,
+            output_records=output_records,
+            view_config_digest=view_config_digest,
+            repository_fingerprint=repository_fingerprint,
+        ),
+        files=tuple(
+            WorkspaceFile(
+                PurePosixPath(record.path),
+                mode=record.mode,
+                max_bytes=record.size,
+            )
+            for record in output_records
+        ),
+        root_mode=0o700,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedBm25View:
+    """Immutable exact output plan for one authenticated BM25 generation."""
+
+    plan: WorkspacePlan
+    source_ownership: object
+    source_digest: str
+    source_records: tuple[TreeFileRecord, ...]
+    output_records: tuple[TreeFileRecord, ...]
+    view_config_digest: str
+    repository_fingerprint: str
+
+    def __post_init__(self) -> None:
+        source_records = tuple(self.source_records)
+        output_records = tuple(self.output_records)
+        if type(self.plan) is not WorkspacePlan:
+            raise TypeError("strict BM25 plan must contain an exact WorkspacePlan")
+        if any(type(record) is not TreeFileRecord for record in source_records):
+            raise TypeError("strict BM25 source records have an invalid type")
+        if any(type(record) is not TreeFileRecord for record in output_records):
+            raise TypeError("strict BM25 output records have an invalid type")
+        if source_records != tuple(sorted(source_records, key=lambda item: item.path)):
+            raise ValueError("strict BM25 source records must be canonical")
+        if output_records != tuple(sorted(output_records, key=lambda item: item.path)):
+            raise ValueError("strict BM25 output records must be canonical")
+        if {record.path for record in output_records} != _STRICT_BM25_FILES or any(
+            record.mode != 0o600 for record in output_records
+        ):
+            raise ValueError("strict BM25 output records are not exact")
+        object.__setattr__(self, "source_records", source_records)
+        object.__setattr__(self, "output_records", output_records)
+
+    @property
+    def adjustments(self) -> dict[str, Any]:
+        return {
+            "artifact_file_fingerprints": {
+                record.path: {
+                    "size": record.size,
+                    "sha256": record.sha256,
+                }
+                for record in self.output_records
+            }
+        }
+
+
+def _source_view(
+    receipt: PublishedWorkspaceReceipt,
+    publication: PublicationDirectoryReader,
+) -> tuple[object, tuple[TreeFileRecord, ...], _PublicationBm25Reader]:
+    ownership = publication.capture_ownership(entry_policy=_entry_policy)
+    if ownership != receipt.ownership:
+        raise RuntimeError("strict BM25 source generation changed")
+    records = tuple(directory_ownership_file_records(ownership))  # type: ignore[arg-type]
+    if {record.path for record in records} != _STRICT_BM25_FILES:
+        raise ValueError("strict BM25 source generation is incomplete")
+    return ownership, records, _PublicationBm25Reader(publication, ownership)
+
+
+def _repository_files(
+    repository_source: RepositorySourceBinding,
+) -> frozenset[str]:
+    records = tuple(repository_source.file_records)
+    paths = frozenset(record.path for record in records)
+    if len(paths) != len(records):
+        raise RuntimeError("authenticated repository source repeats a file")
+    return paths
+
+
+def _policy(
+    repository_source: RepositorySourceBinding,
+    view_config: Mapping[str, Any],
+    *,
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+) -> tuple[str, tuple[Path, ...], frozenset[str]]:
+    if not repository_source.usable:
+        raise RuntimeError("strict BM25 repository source is not usable")
+    forbidden = (repository_source.root, *forbidden_paths)
+    assert_no_secret_fields(view_config, source="portable BM25 view config")
+    _assert_authenticated_publishable_json_value(
+        view_config,
+        forbidden_paths=forbidden,
+        environ=environ,
+        label="portable BM25 view config",
+    )
+    config_bytes = _bounded_canonical_json_bytes(
+        dict(view_config),
+        max_bytes=_MAX_CONFIG_JSON_BYTES,
+        label="portable BM25 view config",
+    )
+    return (
+        hashlib.sha256(config_bytes).hexdigest(),
+        forbidden,
+        _repository_files(repository_source),
+    )
+
+
+def plan_bm25_view_strict(
+    source_generation: PublishedWorkspaceReceiptOwner,
+    *,
+    repository_source: RepositorySourceBinding,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> PlannedBm25View:
+    """Plan exact canonical BM25 bytes from one retained source generation."""
+
+    if type(source_generation) is not PublishedWorkspaceReceiptOwner:
+        raise TypeError("strict BM25 source must be a workspace receipt owner")
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("strict BM25 repository source has an invalid type")
+    if not source_generation.active:
+        raise RuntimeError("strict BM25 source generation must be active")
+    if not repository_source.usable:
+        raise RuntimeError("strict BM25 repository source is not usable")
+    _require_disjoint_view_path(
+        source_generation.receipt.path,
+        repository_source,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="portable BM25 view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden_tail = tuple(forbidden_paths)
+    config_digest, forbidden, authenticated_files = _policy(
+        repository_source,
+        config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+
+    def consume_source(
+        receipt: PublishedWorkspaceReceipt,
+        publication: PublicationDirectoryReader,
+    ) -> PlannedBm25View:
+        ownership, source_records, reader = _source_view(receipt, publication)
+        metadata_bytes, document_chunks = _payloads(
+            reader,
+            repository_source.root,
+            forbidden_paths=forbidden,
+            environ=environment,
+            authenticated_source_files=authenticated_files,
+        )
+        documents_record = _record_chunks(
+            "documents.json",
+            document_chunks,
+            max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        )
+        metadata_record = TreeFileRecord(
+            path="bm25_metadata.json",
+            mode=0o600,
+            size=len(metadata_bytes),
+            sha256=hashlib.sha256(metadata_bytes).hexdigest(),
+        )
+        reader.verify_root()
+        output_records = tuple(
+            sorted((documents_record, metadata_record), key=lambda item: item.path)
+        )
+        source_digest = directory_ownership_digest(ownership)  # type: ignore[arg-type]
+        plan = _workspace_plan(
+            source_digest=source_digest,
+            source_records=source_records,
+            output_records=output_records,
+            view_config_digest=config_digest,
+            repository_fingerprint=repository_source.fingerprint,
+        )
+        return PlannedBm25View(
+            plan=plan,
+            source_ownership=ownership,
+            source_digest=source_digest,
+            source_records=source_records,
+            output_records=output_records,
+            view_config_digest=config_digest,
+            repository_fingerprint=repository_source.fingerprint,
+        )
+
+    with repository_source.read_session():
+        return source_generation.consume(consume_source)
+
+
+def _require_plan(
+    planned: PlannedBm25View,
+    *,
+    source_receipt: PublishedWorkspaceReceipt,
+    repository_source: RepositorySourceBinding,
+    view_config_digest: str,
+) -> None:
+    if type(planned) is not PlannedBm25View:
+        raise TypeError("strict BM25 execution requires a PlannedBm25View")
+    if (
+        planned.source_ownership != source_receipt.ownership
+        or planned.source_records
+        != tuple(directory_ownership_file_records(source_receipt.ownership))  # type: ignore[arg-type]
+        or planned.source_digest
+        != directory_ownership_digest(source_receipt.ownership)  # type: ignore[arg-type]
+    ):
+        raise ValueError("strict BM25 plan belongs to another source generation")
+    if planned.repository_fingerprint != repository_source.fingerprint:
+        raise ValueError("strict BM25 plan belongs to another repository source")
+    if planned.view_config_digest != view_config_digest:
+        raise ValueError("strict BM25 plan belongs to another view config")
+    expected = _workspace_plan(
+        source_digest=planned.source_digest,
+        source_records=planned.source_records,
+        output_records=planned.output_records,
+        view_config_digest=planned.view_config_digest,
+        repository_fingerprint=planned.repository_fingerprint,
+    )
+    if planned.plan != expected:
+        raise ValueError("strict BM25 workspace plan is not canonical")
+
+
+def _candidate_records(
+    candidate: PublicationDirectoryReader,
+    *,
+    planned: PlannedBm25View,
+    repository_source: RepositorySourceBinding,
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+    authenticated_source_files: frozenset[str],
+) -> tuple[TreeFileRecord, ...]:
+    ownership = candidate.capture_ownership(entry_policy=_entry_policy)
+    observed = tuple(directory_ownership_file_records(ownership))  # type: ignore[arg-type]
+    if (
+        directory_ownership_inventory(ownership)  # type: ignore[arg-type]
+        != (
+            ("bm25_metadata.json", "file"),
+            ("documents.json", "file"),
+        )
+        or observed != planned.output_records
+    ):
+        raise RuntimeError("strict BM25 candidate differs from its exact plan")
+    reader = _PublicationBm25Reader(candidate, ownership)
+    metadata_bytes, document_chunks = _payloads(
+        reader,
+        repository_source.root,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+        authenticated_source_files=authenticated_source_files,
+    )
+    records = tuple(
+        sorted(
+            (
+                _record_chunks(
+                    "documents.json",
+                    document_chunks,
+                    max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+                ),
+                TreeFileRecord(
+                    path="bm25_metadata.json",
+                    mode=0o600,
+                    size=len(metadata_bytes),
+                    sha256=hashlib.sha256(metadata_bytes).hexdigest(),
+                ),
+            ),
+            key=lambda item: item.path,
+        )
+    )
+    reader.verify_root()
+    return records
+
+
+def publish_planned_bm25_view_strict(
+    destination: Path,
+    *,
+    planned: PlannedBm25View,
+    source_generation: PublishedWorkspaceReceiptOwner,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Replay and durably publish one exact strict BM25 plan."""
+
+    _preflight_publication_authorities(
+        source_generation=source_generation,
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    source_receipt, lexical_destination = _preflight_view_location(
+        destination,
+        source_generation=source_generation,
+        repository_source=repository_source,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="portable BM25 view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden_tail = tuple(forbidden_paths)
+    config_digest, forbidden, authenticated_files = _policy(
+        repository_source,
+        config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+    _require_plan(
+        planned,
+        source_receipt=source_receipt,
+        repository_source=repository_source,
+        view_config_digest=config_digest,
+    )
+    request = StrictWorkspaceRequest(
+        purpose="portable-bm25-normalization",
+        destination=lexical_destination,
+        plan=planned.plan,
+        destination_expectation="provider-bound-exact",
+    )
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        if session.request != request:
+            raise RuntimeError("strict BM25 provider changed its request")
+
+        def replay_source(
+            receipt: PublishedWorkspaceReceipt,
+            publication: PublicationDirectoryReader,
+        ) -> None:
+            ownership, source_records, reader = _source_view(receipt, publication)
+            if (
+                ownership != planned.source_ownership
+                or source_records != planned.source_records
+            ):
+                raise ValueError("strict BM25 source changed after planning")
+            metadata_bytes, document_chunks = _payloads(
+                reader,
+                repository_source.root,
+                forbidden_paths=forbidden,
+                environ=environment,
+                authenticated_source_files=authenticated_files,
+            )
+            written = tuple(
+                sorted(
+                    (
+                        session.write_file("documents.json", document_chunks),
+                        session.write_file("bm25_metadata.json", (metadata_bytes,)),
+                    ),
+                    key=lambda item: item.path,
+                )
+            )
+            reader.verify_root()
+            if written != planned.output_records:
+                raise RuntimeError("strict BM25 replay differs from its exact plan")
+
+        def validate_candidate(candidate: PublicationDirectoryReader) -> None:
+            with repository_source.read_session():
+                if (
+                    _candidate_records(
+                        candidate,
+                        planned=planned,
+                        repository_source=repository_source,
+                        forbidden_paths=forbidden,
+                        environ=environment,
+                        authenticated_source_files=authenticated_files,
+                    )
+                    != planned.output_records
+                ):
+                    raise RuntimeError("strict BM25 candidate is not canonical")
+
+        with repository_source.read_session():
+            source_generation.consume(replay_source)
+        session.publish_validated(validate_candidate)
+
+    run_strict_workspace(
+        workspace_provider,
+        request,
+        receipt_owner=output_receipt_owner,
+        operation=operation,
+    )
+    if not output_receipt_owner.active:
+        raise RuntimeError("strict BM25 publication returned without a receipt")
+    return planned.adjustments
+
+
+def normalize_owned_query_view_strict(
+    destination: Path,
+    *,
+    source_generation: PublishedWorkspaceReceiptOwner,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_type: str,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Plan and publish BM25 through retained source and workspace authority."""
+
+    if view_type != "bm25":
+        raise ValueError("strict portable normalization currently supports only bm25")
+    _preflight_publication_authorities(
+        source_generation=source_generation,
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    _preflight_view_location(
+        destination,
+        source_generation=source_generation,
+        repository_source=repository_source,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="portable BM25 view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden = tuple(forbidden_paths)
+    planned = plan_bm25_view_strict(
+        source_generation,
+        repository_source=repository_source,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden,
+        environ=environment,
+    )
+    return publish_planned_bm25_view_strict(
+        destination,
+        planned=planned,
+        source_generation=source_generation,
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden,
+        environ=environment,
+    )
+
+
+__all__ = [
+    "PlannedBm25View",
+    "normalize_owned_query_view_strict",
+    "plan_bm25_view_strict",
+    "publish_planned_bm25_view_strict",
+]

--- a/codenib/artifacts/strict_bm25.py
+++ b/codenib/artifacts/strict_bm25.py
@@ -47,7 +47,10 @@ from .._workspace_provider import (
     StrictWorkspaceSession,
     run_strict_workspace,
 )
-from ..source_fingerprint import RepositorySourceBinding
+from ..source_fingerprint import (
+    RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
+)
 from .security import assert_publishable_json_value
 
 _MAX_CONFIG_JSON_BYTES = 16 * 1024 * 1024
@@ -171,14 +174,23 @@ def _preflight_publication_authorities(
             raise TypeError("strict workspace provider has an invalid contract")
 
 
+def _authenticated_repository_identity(
+    repository_source: RepositorySourceBinding,
+) -> RepositorySourceIdentitySnapshot:
+    identity = repository_source.authenticated_identity_snapshot()
+    if type(identity) is not RepositorySourceIdentitySnapshot:
+        raise TypeError("strict BM25 repository identity has an invalid type")
+    return identity
+
+
 def _require_disjoint_view_path(
     path: Path,
-    repository_source: RepositorySourceBinding,
+    repository_root: Path,
 ) -> Path:
     """Return one lexical view path that cannot contain or enter the repo."""
 
     candidate = lexical_directory_path(path)
-    repository = lexical_directory_path(repository_source.root)
+    repository = lexical_directory_path(repository_root)
 
     def overlaps(left: Path, right: Path) -> bool:
         return left == right or left in right.parents or right in left.parents
@@ -203,18 +215,18 @@ def _preflight_view_location(
     destination: Path,
     *,
     source_generation: PublishedWorkspaceReceiptOwner,
-    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
 ) -> tuple[PublishedWorkspaceReceipt, Path]:
     """Bind replacement to its source path before source bytes are consumed."""
 
     source_receipt = source_generation.receipt
     source_path = _require_disjoint_view_path(
         source_receipt.path,
-        repository_source,
+        repository_identity.root,
     )
     lexical_destination = _require_disjoint_view_path(
         destination,
-        repository_source,
+        repository_identity.root,
     )
     if lexical_destination != source_path:
         raise ValueError(
@@ -720,9 +732,9 @@ def _source_view(
 
 
 def _repository_files(
-    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
 ) -> frozenset[str]:
-    records = tuple(repository_source.file_records)
+    records = repository_identity.file_records
     paths = frozenset(record.path for record in records)
     if len(paths) != len(records):
         raise RuntimeError("authenticated repository source repeats a file")
@@ -730,15 +742,13 @@ def _repository_files(
 
 
 def _policy(
-    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
     view_config: Mapping[str, Any],
     *,
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
 ) -> tuple[str, tuple[Path, ...], frozenset[str]]:
-    if not repository_source.usable:
-        raise RuntimeError("strict BM25 repository source is not usable")
-    forbidden = (repository_source.root, *forbidden_paths)
+    forbidden = (repository_identity.root, *forbidden_paths)
     assert_no_secret_fields(view_config, source="portable BM25 view config")
     _assert_authenticated_publishable_json_value(
         view_config,
@@ -754,43 +764,24 @@ def _policy(
     return (
         hashlib.sha256(config_bytes).hexdigest(),
         forbidden,
-        _repository_files(repository_source),
+        _repository_files(repository_identity),
     )
 
 
-def plan_bm25_view_strict(
+def _plan_bm25_view_with_identity(
     source_generation: PublishedWorkspaceReceiptOwner,
     *,
     repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
     view_config: Mapping[str, Any],
-    forbidden_paths: Iterable[Path] = (),
-    environ: Mapping[str, str] | None = None,
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
 ) -> PlannedBm25View:
-    """Plan exact canonical BM25 bytes from one retained source generation."""
-
-    if type(source_generation) is not PublishedWorkspaceReceiptOwner:
-        raise TypeError("strict BM25 source must be a workspace receipt owner")
-    if type(repository_source) is not RepositorySourceBinding:
-        raise TypeError("strict BM25 repository source has an invalid type")
-    if not source_generation.active:
-        raise RuntimeError("strict BM25 source generation must be active")
-    if not repository_source.usable:
-        raise RuntimeError("strict BM25 repository source is not usable")
-    _require_disjoint_view_path(
-        source_generation.receipt.path,
-        repository_source,
-    )
-    config_snapshot = _json_object_snapshot(
-        view_config,
-        label="portable BM25 view config",
-    )
-    environment = _environment_snapshot(environ)
-    forbidden_tail = tuple(forbidden_paths)
     config_digest, forbidden, authenticated_files = _policy(
-        repository_source,
-        config_snapshot,
-        forbidden_paths=forbidden_tail,
-        environ=environment,
+        repository_identity,
+        view_config,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
     )
 
     def consume_source(
@@ -800,9 +791,9 @@ def plan_bm25_view_strict(
         ownership, source_records, reader = _source_view(receipt, publication)
         metadata_bytes, document_chunks = _payloads(
             reader,
-            repository_source.root,
+            repository_identity.root,
             forbidden_paths=forbidden,
-            environ=environment,
+            environ=environ,
             authenticated_source_files=authenticated_files,
         )
         documents_record = _record_chunks(
@@ -826,7 +817,7 @@ def plan_bm25_view_strict(
             source_records=source_records,
             output_records=output_records,
             view_config_digest=config_digest,
-            repository_fingerprint=repository_source.fingerprint,
+            repository_fingerprint=repository_identity.fingerprint,
         )
         return PlannedBm25View(
             plan=plan,
@@ -835,18 +826,57 @@ def plan_bm25_view_strict(
             source_records=source_records,
             output_records=output_records,
             view_config_digest=config_digest,
-            repository_fingerprint=repository_source.fingerprint,
+            repository_fingerprint=repository_identity.fingerprint,
         )
 
     with repository_source.read_session():
         return source_generation.consume(consume_source)
 
 
+def plan_bm25_view_strict(
+    source_generation: PublishedWorkspaceReceiptOwner,
+    *,
+    repository_source: RepositorySourceBinding,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> PlannedBm25View:
+    """Plan exact canonical BM25 bytes from one retained source generation."""
+
+    if type(source_generation) is not PublishedWorkspaceReceiptOwner:
+        raise TypeError("strict BM25 source must be a workspace receipt owner")
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("strict BM25 repository source has an invalid type")
+    if not source_generation.active:
+        raise RuntimeError("strict BM25 source generation must be active")
+    if not repository_source.usable:
+        raise RuntimeError("strict BM25 repository source is not usable")
+    repository_identity = _authenticated_repository_identity(repository_source)
+    _require_disjoint_view_path(
+        source_generation.receipt.path,
+        repository_identity.root,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="portable BM25 view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden_tail = tuple(forbidden_paths)
+    return _plan_bm25_view_with_identity(
+        source_generation,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+
+
 def _require_plan(
     planned: PlannedBm25View,
     *,
     source_receipt: PublishedWorkspaceReceipt,
-    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
     view_config_digest: str,
 ) -> None:
     if type(planned) is not PlannedBm25View:
@@ -859,7 +889,7 @@ def _require_plan(
         != directory_ownership_digest(source_receipt.ownership)  # type: ignore[arg-type]
     ):
         raise ValueError("strict BM25 plan belongs to another source generation")
-    if planned.repository_fingerprint != repository_source.fingerprint:
+    if planned.repository_fingerprint != repository_identity.fingerprint:
         raise ValueError("strict BM25 plan belongs to another repository source")
     if planned.view_config_digest != view_config_digest:
         raise ValueError("strict BM25 plan belongs to another view config")
@@ -878,7 +908,7 @@ def _candidate_records(
     candidate: PublicationDirectoryReader,
     *,
     planned: PlannedBm25View,
-    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
     forbidden_paths: tuple[Path, ...],
     environ: Mapping[str, str],
     authenticated_source_files: frozenset[str],
@@ -897,7 +927,7 @@ def _candidate_records(
     reader = _PublicationBm25Reader(candidate, ownership)
     metadata_bytes, document_chunks = _payloads(
         reader,
-        repository_source.root,
+        repository_identity.root,
         forbidden_paths=forbidden_paths,
         environ=environ,
         authenticated_source_files=authenticated_source_files,
@@ -924,47 +954,30 @@ def _candidate_records(
     return records
 
 
-def publish_planned_bm25_view_strict(
-    destination: Path,
+def _publish_planned_bm25_view_with_identity(
     *,
     planned: PlannedBm25View,
     source_generation: PublishedWorkspaceReceiptOwner,
+    source_receipt: PublishedWorkspaceReceipt,
     repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
     workspace_provider: StrictWorkspaceProvider,
     output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    lexical_destination: Path,
     view_config: Mapping[str, Any],
-    forbidden_paths: Iterable[Path] = (),
-    environ: Mapping[str, str] | None = None,
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
 ) -> dict[str, Any]:
-    """Replay and durably publish one exact strict BM25 plan."""
-
-    _preflight_publication_authorities(
-        source_generation=source_generation,
-        repository_source=repository_source,
-        workspace_provider=workspace_provider,
-        output_receipt_owner=output_receipt_owner,
-    )
-    source_receipt, lexical_destination = _preflight_view_location(
-        destination,
-        source_generation=source_generation,
-        repository_source=repository_source,
-    )
-    config_snapshot = _json_object_snapshot(
-        view_config,
-        label="portable BM25 view config",
-    )
-    environment = _environment_snapshot(environ)
-    forbidden_tail = tuple(forbidden_paths)
     config_digest, forbidden, authenticated_files = _policy(
-        repository_source,
-        config_snapshot,
-        forbidden_paths=forbidden_tail,
-        environ=environment,
+        repository_identity,
+        view_config,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
     )
     _require_plan(
         planned,
         source_receipt=source_receipt,
-        repository_source=repository_source,
+        repository_identity=repository_identity,
         view_config_digest=config_digest,
     )
     request = StrictWorkspaceRequest(
@@ -990,9 +1003,9 @@ def publish_planned_bm25_view_strict(
                 raise ValueError("strict BM25 source changed after planning")
             metadata_bytes, document_chunks = _payloads(
                 reader,
-                repository_source.root,
+                repository_identity.root,
                 forbidden_paths=forbidden,
-                environ=environment,
+                environ=environ,
                 authenticated_source_files=authenticated_files,
             )
             written = tuple(
@@ -1014,9 +1027,9 @@ def publish_planned_bm25_view_strict(
                     _candidate_records(
                         candidate,
                         planned=planned,
-                        repository_source=repository_source,
+                        repository_identity=repository_identity,
                         forbidden_paths=forbidden,
-                        environ=environment,
+                        environ=environ,
                         authenticated_source_files=authenticated_files,
                     )
                     != planned.output_records
@@ -1036,6 +1049,53 @@ def publish_planned_bm25_view_strict(
     if not output_receipt_owner.active:
         raise RuntimeError("strict BM25 publication returned without a receipt")
     return planned.adjustments
+
+
+def publish_planned_bm25_view_strict(
+    destination: Path,
+    *,
+    planned: PlannedBm25View,
+    source_generation: PublishedWorkspaceReceiptOwner,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Replay and durably publish one exact strict BM25 plan."""
+
+    _preflight_publication_authorities(
+        source_generation=source_generation,
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    repository_identity = _authenticated_repository_identity(repository_source)
+    source_receipt, lexical_destination = _preflight_view_location(
+        destination,
+        source_generation=source_generation,
+        repository_identity=repository_identity,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="portable BM25 view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden_tail = tuple(forbidden_paths)
+    return _publish_planned_bm25_view_with_identity(
+        planned=planned,
+        source_generation=source_generation,
+        source_receipt=source_receipt,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        lexical_destination=lexical_destination,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
 
 
 def normalize_owned_query_view_strict(
@@ -1060,33 +1120,43 @@ def normalize_owned_query_view_strict(
         workspace_provider=workspace_provider,
         output_receipt_owner=output_receipt_owner,
     )
-    _preflight_view_location(
+    repository_identity = _authenticated_repository_identity(repository_source)
+    source_receipt, lexical_destination = _preflight_view_location(
         destination,
         source_generation=source_generation,
-        repository_source=repository_source,
+        repository_identity=repository_identity,
     )
     config_snapshot = _json_object_snapshot(
         view_config,
         label="portable BM25 view config",
     )
     environment = _environment_snapshot(environ)
-    forbidden = tuple(forbidden_paths)
-    planned = plan_bm25_view_strict(
+    forbidden_tail = tuple(forbidden_paths)
+    planned = _plan_bm25_view_with_identity(
         source_generation,
         repository_source=repository_source,
+        repository_identity=repository_identity,
         view_config=config_snapshot,
-        forbidden_paths=forbidden,
+        forbidden_paths=forbidden_tail,
         environ=environment,
     )
-    return publish_planned_bm25_view_strict(
-        destination,
-        planned=planned,
+    _preflight_publication_authorities(
         source_generation=source_generation,
         repository_source=repository_source,
         workspace_provider=workspace_provider,
         output_receipt_owner=output_receipt_owner,
+    )
+    return _publish_planned_bm25_view_with_identity(
+        planned=planned,
+        source_generation=source_generation,
+        source_receipt=source_receipt,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        lexical_destination=lexical_destination,
         view_config=config_snapshot,
-        forbidden_paths=forbidden,
+        forbidden_paths=forbidden_tail,
         environ=environment,
     )
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -332,8 +332,15 @@ retained publication receipt owner. Session writes, validation, publication,
 and revocation share one cancellation-safe gate so a provider callback cannot
 publish after it escapes. The gate records the exact callback result or
 `BaseException`; a provider cannot substitute its return value or swallow a
-callback failure. No production provider or BM25/context producer is wired to
-that strict contract yet, so M1 remains in progress.
+callback failure. The strict BM25 producer now plans canonical document and
+metadata bytes from one retained source generation, binds the source/output
+records, repository fingerprint, and caller configuration into an exact
+workspace plan, then replays and validates the same bytes through that contract
+before and after replacement. Its `PlannedBm25View` is a short-lived in-process
+replay subject, not a catalog profile or durable job payload. No production
+provider, compiler integration, or whole-context producer is wired to the
+strict contract yet, so M1 remains in progress and the M2 BM25 profile adapter
+is still outstanding.
 
 Schema v2 now adds
 canonical idempotent job requests, immutable

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -332,15 +332,16 @@ retained publication receipt owner. Session writes, validation, publication,
 and revocation share one cancellation-safe gate so a provider callback cannot
 publish after it escapes. The gate records the exact callback result or
 `BaseException`; a provider cannot substitute its return value or swallow a
-callback failure. The strict BM25 producer now plans canonical document and
-metadata bytes from one retained source generation, binds the source/output
-records, repository fingerprint, and caller configuration into an exact
-workspace plan, then replays and validates the same bytes through that contract
-before and after replacement. Its `PlannedBm25View` is a short-lived in-process
-replay subject, not a catalog profile or durable job payload. No production
-provider, compiler integration, or whole-context producer is wired to the
-strict contract yet, so M1 remains in progress and the M2 BM25 profile adapter
-is still outstanding.
+callback failure. The strict BM25 producer now captures one detached,
+authenticated repository identity, plans canonical document and metadata bytes
+from one retained source generation, and binds the source/output records,
+repository fingerprint, and caller configuration into an exact workspace plan.
+It then replays and validates the same bytes through that contract before and
+after replacement without consulting mutable public source projections. Its
+`PlannedBm25View` is a short-lived in-process replay subject, not a catalog
+profile or durable job payload. No production provider, compiler integration,
+or whole-context producer is wired to the strict contract yet, so M1 remains in
+progress and the M2 BM25 profile adapter is still outstanding.
 
 Schema v2 now adds
 canonical idempotent job requests, immutable

--- a/test/artifacts/test_strict_bm25_publication.py
+++ b/test/artifacts/test_strict_bm25_publication.py
@@ -1,0 +1,1187 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, TypeVar
+
+import pytest
+
+import codenib.artifacts.strict_bm25 as strict_bm25_module
+from codenib._atomic_directory import TreeFileRecord
+from codenib._bounded_json import canonical_json_value_chunks
+from codenib._captured_directory import (
+    OwnedWorkspaceAuthority,
+    PublishedWorkspaceReceiptOwner,
+    WorkspaceFile,
+    WorkspacePlan,
+)
+from codenib._workspace_provider import (
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_adopted_workspace_operation,
+    run_strict_workspace,
+)
+from codenib.artifacts import (
+    PlannedBm25View,
+    normalize_owned_query_view_strict,
+    plan_bm25_view_strict,
+    publish_planned_bm25_view_strict,
+    validate_portable_query_view,
+)
+from codenib.artifacts.strict_bm25 import _record_chunks
+from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
+from codenib.source_fingerprint import capture_repository_source
+
+_Result = TypeVar("_Result")
+_Value = TypeVar("_Value")
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return b"".join(canonical_json_value_chunks(value)) + b"\n"
+
+
+class _ReadOnceMapping(Mapping[str, _Value]):
+    def __init__(self, values: dict[str, _Value]) -> None:
+        self.values = values
+        self.iterations = 0
+
+    def __getitem__(self, key: str) -> _Value:
+        return self.values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        self.iterations += 1
+        if self.iterations > 1:
+            raise AssertionError("caller mapping was read more than once")
+        return iter(self.values)
+
+    def __len__(self) -> int:
+        return len(self.values)
+
+
+class _TestWorkspaceProvider:
+    """Quiescent test provisioner; not a production security boundary."""
+
+    def __init__(
+        self,
+        *,
+        expected_destination: object | None,
+        workspace_plan: WorkspacePlan | None = None,
+        support_hook: Callable[[], None] | None = None,
+    ) -> None:
+        self.expected_destination = expected_destination
+        self.workspace_plan = workspace_plan
+        self.support_hook = support_hook
+        self.support_count = 0
+        self.run_count = 0
+        self.requests: list[StrictWorkspaceRequest] = []
+
+    def require_support(self) -> None:
+        self.support_count += 1
+        if self.support_hook is not None:
+            self.support_hook()
+
+    def run_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        *,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], _Result],
+    ) -> _Result:
+        self.run_count += 1
+        self.requests.append(request)
+        plan = request.plan if self.workspace_plan is None else self.workspace_plan
+        parent = request.destination.parent
+        parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        stage = parent / (
+            f".{request.destination.name}.strict-{id(self):x}-{self.run_count}"
+        )
+        stage.mkdir(mode=plan.root_mode)
+        for directory in plan.directories:
+            (stage / directory.path.as_posix()).mkdir(mode=directory.mode)
+
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        parent_descriptor = os.open(parent, flags)
+        root_descriptor = os.open(stage, flags)
+        directory_descriptors = {
+            directory.path.as_posix(): os.open(
+                stage / directory.path.as_posix(),
+                flags,
+            )
+            for directory in plan.directories
+        }
+        workspace = OwnedWorkspaceAuthority()
+        try:
+            workspace.adopt(
+                destination=request.destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_descriptor,
+                root_descriptor=root_descriptor,
+                directory_descriptors=directory_descriptors,
+                plan=plan,
+                expected_destination=self.expected_destination,
+            )
+            try:
+                return run_adopted_workspace_operation(
+                    request,
+                    workspace=workspace,
+                    receipt_owner=receipt_owner,
+                    operation=operation,
+                )
+            except BaseException:
+                if receipt_owner.state == "empty":
+                    workspace.close()
+                raise
+        finally:
+            for descriptor in directory_descriptors.values():
+                os.close(descriptor)
+            os.close(root_descriptor)
+            os.close(parent_descriptor)
+
+
+def _repository(root: Path) -> Path:
+    repository = root / "repo"
+    repository.mkdir()
+    (repository / "sample.py").write_text("VALUE = 1\n", encoding="utf-8")
+    return repository
+
+
+def _publish_source(
+    root: Path,
+    repository: Path,
+    *,
+    documents: bytes | None = None,
+    metadata: bytes | None = None,
+) -> tuple[Path, PublishedWorkspaceReceiptOwner]:
+    destination = root / "state" / "bm25"
+    documents = documents or _canonical_bytes(
+        [
+            {
+                "page_content": "alpha VALUE omega",
+                "metadata": {
+                    "file": str(repository / "sample.py"),
+                    "node_id": "sample.VALUE",
+                },
+            },
+            {
+                "page_content": "beta helper",
+                "metadata": {"file": "sample.py", "node_id": "sample.helper"},
+            },
+        ]
+    )
+    metadata = metadata or _canonical_bytes(
+        {
+            "project_root": str(repository),
+            "max_k": 17,
+            "language": "english",
+        }
+    )
+    plan = WorkspacePlan(
+        subject_digest=hashlib.sha256(b"strict-bm25-source").hexdigest(),
+        files=(
+            WorkspaceFile("documents.json", max_bytes=len(documents)),
+            WorkspaceFile("bm25_metadata.json", max_bytes=len(metadata)),
+        ),
+    )
+    request = StrictWorkspaceRequest(
+        purpose="portable-bm25-test-source",
+        destination=destination,
+        plan=plan,
+    )
+    owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(expected_destination=None)
+
+    def publish(session: StrictWorkspaceSession) -> None:
+        written = session.write_file("documents.json", (documents,))
+        assert written == TreeFileRecord(
+            path="documents.json",
+            mode=0o600,
+            size=len(documents),
+            sha256=hashlib.sha256(documents).hexdigest(),
+        )
+        session.write_file("bm25_metadata.json", (metadata,))
+        session.publish_validated(lambda _reader: None)
+
+    run_strict_workspace(
+        provider,
+        request,
+        receipt_owner=owner,
+        operation=publish,
+    )
+    return destination, owner
+
+
+@pytest.fixture
+def strict_generation(tmp_path: Path):
+    repository = _repository(tmp_path)
+    destination, source_owner = _publish_source(tmp_path, repository)
+    repository_source = capture_repository_source(repository)
+    try:
+        yield SimpleNamespace(
+            repository=repository,
+            destination=destination,
+            source_owner=source_owner,
+            repository_source=repository_source,
+        )
+    finally:
+        source_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_plans_replays_and_serves_same_query_semantics(
+    strict_generation,
+) -> None:
+    fixture = strict_generation
+    view_config = {"builder_schema": 2, "tokenizer": "code-aware-v1"}
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config=view_config,
+        environ={},
+    )
+    assert isinstance(planned, PlannedBm25View)
+    assert tuple(record.path for record in planned.output_records) == (
+        "bm25_metadata.json",
+        "documents.json",
+    )
+    assert tuple(file.path.as_posix() for file in planned.plan.files) == (
+        "bm25_metadata.json",
+        "documents.json",
+    )
+
+    source_documents = json.loads(
+        (fixture.destination / "documents.json").read_text(encoding="utf-8")
+    )
+    source_metadata = json.loads(
+        (fixture.destination / "bm25_metadata.json").read_text(encoding="utf-8")
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=fixture.source_owner.receipt.ownership,
+    )
+    try:
+        adjustments = publish_planned_bm25_view_strict(
+            fixture.destination,
+            planned=planned,
+            source_generation=fixture.source_owner,
+            repository_source=fixture.repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_config=view_config,
+            environ={},
+        )
+        assert provider.run_count == 1
+        assert provider.support_count == 1
+        assert provider.requests[0].destination_expectation == "provider-bound-exact"
+        assert output_owner.active
+        assert fixture.source_owner.active
+        assert output_owner.receipt.plan == planned.plan
+
+        output_documents = json.loads(
+            (fixture.destination / "documents.json").read_text(encoding="utf-8")
+        )
+        output_metadata = json.loads(
+            (fixture.destination / "bm25_metadata.json").read_text(encoding="utf-8")
+        )
+        assert [item["page_content"] for item in output_documents] == [
+            item["page_content"] for item in source_documents
+        ]
+        assert output_documents[0]["metadata"]["file"] == "sample.py"
+        assert output_metadata == {
+            "project_root": "source",
+            "max_k": source_metadata["max_k"],
+            "language": source_metadata["language"],
+        }
+        validate_portable_query_view(
+            fixture.destination,
+            repo_path=fixture.repository,
+            view_type="bm25",
+            view_config={**view_config, **adjustments},
+            environ={},
+        )
+
+        before = BM25CodeIndexer()
+        before.load_index_values(source_documents, source_metadata)
+        after = BM25CodeIndexer()
+        after.load_index_values(output_documents, output_metadata)
+        assert [doc.page_content for doc in before.retriever.invoke("VALUE")] == [
+            doc.page_content for doc in after.retriever.invoke("VALUE")
+        ]
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_high_level_freezes_caller_mappings_once(
+    strict_generation,
+) -> None:
+    fixture = strict_generation
+    config = _ReadOnceMapping({"builder_schema": 2})
+    environment = _ReadOnceMapping({"SAFE_VALUE": "public"})
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=fixture.source_owner.receipt.ownership,
+    )
+    try:
+        normalize_owned_query_view_strict(
+            fixture.destination,
+            source_generation=fixture.source_owner,
+            repository_source=fixture.repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_type="bm25",
+            view_config=config,
+            environ=environment,
+        )
+        assert config.iterations == 1
+        assert environment.iterations == 1
+        assert output_owner.active
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_plan_binds_view_config_into_subject(
+    strict_generation,
+) -> None:
+    fixture = strict_generation
+    first = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={"tokenizer": "first"},
+        environ={},
+    )
+    repeated = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={"tokenizer": "first"},
+        environ={},
+    )
+    changed = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={"tokenizer": "second"},
+        environ={},
+    )
+    assert first == repeated
+    assert first.output_records == changed.output_records
+    assert first.view_config_digest != changed.view_config_digest
+    assert first.plan.subject_digest != changed.plan.subject_digest
+
+
+def test_strict_bm25_invokes_provider_support_once_after_freezing_inputs(
+    strict_generation,
+) -> None:
+    fixture = strict_generation
+    view_config = {"tokenizer": "initial"}
+    environ = {"CODENIB_STRICT_TEST": "initial"}
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config=view_config,
+        environ=environ,
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+
+    def mutate_caller_inputs() -> None:
+        view_config["tokenizer"] = "mutated"
+        environ["CODENIB_STRICT_TEST"] = "mutated"
+
+    provider = _TestWorkspaceProvider(
+        expected_destination=fixture.source_owner.receipt.ownership,
+        support_hook=mutate_caller_inputs,
+    )
+    try:
+        publish_planned_bm25_view_strict(
+            fixture.destination,
+            planned=planned,
+            source_generation=fixture.source_owner,
+            repository_source=fixture.repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_config=view_config,
+            environ=environ,
+        )
+        assert provider.support_count == 1
+        assert provider.run_count == 1
+        assert view_config == {"tokenizer": "mutated"}
+        assert environ == {"CODENIB_STRICT_TEST": "mutated"}
+        assert output_owner.active
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_rejects_invalid_authority_before_source_consume(
+    strict_generation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = strict_generation
+    output_owner = PublishedWorkspaceReceiptOwner()
+    consume_calls = 0
+    real_consume = PublishedWorkspaceReceiptOwner.consume
+
+    def counted_consume(self, callback):
+        nonlocal consume_calls
+        consume_calls += 1
+        return real_consume(self, callback)
+
+    monkeypatch.setattr(PublishedWorkspaceReceiptOwner, "consume", counted_consume)
+
+    class InvalidProvider:
+        @property
+        def require_support(self):
+            raise RuntimeError("invalid provider getter reached")
+
+    class ForgedSourceOwner(PublishedWorkspaceReceiptOwner):
+        pass
+
+    forged_source = ForgedSourceOwner()
+
+    with pytest.raises(TypeError, match="output receipt owner"):
+        normalize_owned_query_view_strict(
+            fixture.destination,
+            source_generation=fixture.source_owner,
+            repository_source=fixture.repository_source,
+            workspace_provider=object(),
+            output_receipt_owner=None,  # type: ignore[arg-type]
+            view_type="bm25",
+            view_config={},
+        )
+    with pytest.raises(TypeError, match="provider has an invalid contract"):
+        normalize_owned_query_view_strict(
+            fixture.destination,
+            source_generation=fixture.source_owner,
+            repository_source=fixture.repository_source,
+            workspace_provider=InvalidProvider(),  # type: ignore[arg-type]
+            output_receipt_owner=output_owner,
+            view_type="bm25",
+            view_config={},
+        )
+    with pytest.raises(ValueError, match="source and output"):
+        normalize_owned_query_view_strict(
+            fixture.destination,
+            source_generation=fixture.source_owner,
+            repository_source=fixture.repository_source,
+            workspace_provider=object(),
+            output_receipt_owner=fixture.source_owner,
+            view_type="bm25",
+            view_config={},
+        )
+    with pytest.raises(TypeError, match="source must"):
+        normalize_owned_query_view_strict(
+            fixture.destination,
+            source_generation=forged_source,
+            repository_source=fixture.repository_source,
+            workspace_provider=object(),
+            output_receipt_owner=output_owner,
+            view_type="bm25",
+            view_config={},
+        )
+    assert consume_calls == 0
+    assert output_owner.state == "empty"
+    forged_source.close()
+    output_owner.close()
+
+
+def test_strict_bm25_shared_support_gate_precedes_provider_getters(
+    strict_generation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = strict_generation
+    output_owner = PublishedWorkspaceReceiptOwner()
+    consume_calls = 0
+    real_consume = PublishedWorkspaceReceiptOwner.consume
+
+    def counted_consume(self, callback):
+        nonlocal consume_calls
+        consume_calls += 1
+        return real_consume(self, callback)
+
+    class ExplosiveProvider:
+        def __getattribute__(self, _name):
+            raise AssertionError("provider getter ran before the shared support gate")
+
+    def unsupported() -> None:
+        raise RuntimeError("shared publication support is unavailable")
+
+    monkeypatch.setattr(PublishedWorkspaceReceiptOwner, "consume", counted_consume)
+    monkeypatch.setattr(
+        strict_bm25_module,
+        "require_owned_workspace_publication_support",
+        unsupported,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="support is unavailable"):
+            normalize_owned_query_view_strict(
+                fixture.destination,
+                source_generation=fixture.source_owner,
+                repository_source=fixture.repository_source,
+                workspace_provider=ExplosiveProvider(),  # type: ignore[arg-type]
+                output_receipt_owner=output_owner,
+                view_type="bm25",
+                view_config={},
+                environ={},
+            )
+        assert consume_calls == 0
+        assert output_owner.state == "empty"
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_rejects_physical_repository_alias_before_source_consume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(tmp_path)
+    alias = tmp_path / "view-alias"
+    destination, source_owner = _publish_source(alias, repository)
+    retained = tmp_path / "retained-view"
+    alias.rename(retained)
+    alias.symlink_to(repository, target_is_directory=True)
+    repository_source = capture_repository_source(repository)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=source_owner.receipt.ownership,
+    )
+    retained_destination = retained / "state" / "bm25"
+    original_documents = (retained_destination / "documents.json").read_bytes()
+    original_metadata = (retained_destination / "bm25_metadata.json").read_bytes()
+    consume_calls = 0
+    real_consume = PublishedWorkspaceReceiptOwner.consume
+
+    def counted_consume(self, callback):
+        nonlocal consume_calls
+        consume_calls += 1
+        return real_consume(self, callback)
+
+    monkeypatch.setattr(PublishedWorkspaceReceiptOwner, "consume", counted_consume)
+    try:
+        with pytest.raises(ValueError, match="must not overlap"):
+            normalize_owned_query_view_strict(
+                destination,
+                source_generation=source_owner,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_type="bm25",
+                view_config={},
+                environ={},
+            )
+        assert consume_calls == 0
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+        assert (
+            retained_destination / "documents.json"
+        ).read_bytes() == original_documents
+        assert (
+            retained_destination / "bm25_metadata.json"
+        ).read_bytes() == original_metadata
+    finally:
+        output_owner.close()
+        repository_source.close()
+        source_owner.close()
+
+
+def test_strict_bm25_rejects_repository_overlap_before_source_consume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(tmp_path)
+    destination, source_owner = _publish_source(repository, repository)
+    repository_source = capture_repository_source(repository)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=source_owner.receipt.ownership,
+    )
+    original_documents = (destination / "documents.json").read_bytes()
+    original_metadata = (destination / "bm25_metadata.json").read_bytes()
+    consume_calls = 0
+    real_consume = PublishedWorkspaceReceiptOwner.consume
+
+    def counted_consume(self, callback):
+        nonlocal consume_calls
+        consume_calls += 1
+        return real_consume(self, callback)
+
+    monkeypatch.setattr(PublishedWorkspaceReceiptOwner, "consume", counted_consume)
+    try:
+        with pytest.raises(ValueError, match="must not overlap"):
+            plan_bm25_view_strict(
+                source_owner,
+                repository_source=repository_source,
+                view_config={},
+                environ={},
+            )
+        with pytest.raises(ValueError, match="must not overlap"):
+            normalize_owned_query_view_strict(
+                destination,
+                source_generation=source_owner,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_type="bm25",
+                view_config={},
+                environ={},
+            )
+        assert consume_calls == 0
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+        assert (destination / "documents.json").read_bytes() == original_documents
+        assert (destination / "bm25_metadata.json").read_bytes() == original_metadata
+        for overlapping in (repository, repository / "nested", repository.parent):
+            with pytest.raises(ValueError, match="must not overlap"):
+                strict_bm25_module._require_disjoint_view_path(
+                    overlapping,
+                    repository_source,
+                )
+    finally:
+        output_owner.close()
+        repository_source.close()
+        source_owner.close()
+
+
+def test_strict_bm25_rejects_wrong_destination_before_source_consume(
+    strict_generation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = strict_generation
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=fixture.source_owner.receipt.ownership,
+    )
+    consume_calls = 0
+    real_consume = PublishedWorkspaceReceiptOwner.consume
+
+    def counted_consume(self, callback):
+        nonlocal consume_calls
+        consume_calls += 1
+        return real_consume(self, callback)
+
+    monkeypatch.setattr(PublishedWorkspaceReceiptOwner, "consume", counted_consume)
+    try:
+        with pytest.raises(ValueError, match="exact source generation"):
+            normalize_owned_query_view_strict(
+                fixture.destination.parent / "wrong",
+                source_generation=fixture.source_owner,
+                repository_source=fixture.repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_type="bm25",
+                view_config={},
+                environ={},
+            )
+        assert consume_calls == 0
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_rejects_deep_config_before_source_consume(
+    strict_generation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = strict_generation
+    deep: dict[str, Any] = {}
+    cursor = deep
+    for _ in range(140):
+        child: dict[str, Any] = {}
+        cursor["child"] = child
+        cursor = child
+
+    def forbidden_consume(*_args, **_kwargs):
+        raise AssertionError("source consume ran before config complexity gate")
+
+    monkeypatch.setattr(
+        PublishedWorkspaceReceiptOwner,
+        "consume",
+        forbidden_consume,
+    )
+    with pytest.raises(ValueError, match="depth"):
+        plan_bm25_view_strict(
+            fixture.source_owner,
+            repository_source=fixture.repository_source,
+            view_config=deep,
+            environ={},
+        )
+
+
+def test_strict_bm25_metadata_is_bounded_before_dom(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    metadata = b'{"extra":' + (b"[" * 140) + b"0" + (b"]" * 140) + b"}\n"
+    destination, source_owner = _publish_source(
+        tmp_path,
+        repository,
+        metadata=metadata,
+    )
+    repository_source = capture_repository_source(repository)
+    try:
+        with pytest.raises(ValueError, match="depth"):
+            plan_bm25_view_strict(
+                source_owner,
+                repository_source=repository_source,
+                view_config={},
+                environ={},
+            )
+        assert destination.is_dir()
+    finally:
+        source_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_documents_are_bounded_before_element_dom(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    documents = (
+        b'[{"page_content":"ok","metadata":{"nested":'
+        + (b"[" * 140)
+        + b"0"
+        + (b"]" * 140)
+        + b"}}]\n"
+    )
+    _destination, source_owner = _publish_source(
+        tmp_path,
+        repository,
+        documents=documents,
+    )
+    repository_source = capture_repository_source(repository)
+    try:
+        with pytest.raises(ValueError, match="depth"):
+            plan_bm25_view_strict(
+                source_owner,
+                repository_source=repository_source,
+                view_config={},
+                environ={},
+            )
+    finally:
+        source_owner.close()
+        repository_source.close()
+
+
+@pytest.mark.parametrize(
+    "metadata,match",
+    [
+        (b'\xef\xbb\xbf{"max_k": 10}\n', "trailing data|UTF-8 JSON"),
+        (b'{"max_k": 10, "max_k": 20}\n', "invalid UTF-8 JSON"),
+        (b'{"max_k": NaN}\n', "invalid UTF-8 JSON"),
+    ],
+)
+def test_strict_bm25_metadata_rejects_nonportable_json(
+    tmp_path: Path,
+    metadata: bytes,
+    match: str,
+) -> None:
+    repository = _repository(tmp_path)
+    _destination, source_owner = _publish_source(
+        tmp_path,
+        repository,
+        metadata=metadata,
+    )
+    repository_source = capture_repository_source(repository)
+    try:
+        with pytest.raises(ValueError, match=match):
+            plan_bm25_view_strict(
+                source_owner,
+                repository_source=repository_source,
+                view_config={},
+                environ={},
+            )
+    finally:
+        source_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_rejects_tampered_plan_before_provider(
+    strict_generation,
+) -> None:
+    fixture = strict_generation
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={},
+        environ={},
+    )
+    tampered = replace(
+        planned,
+        plan=WorkspacePlan(
+            subject_digest=hashlib.sha256(b"wrong-plan").hexdigest(),
+            files=planned.plan.files,
+        ),
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=fixture.source_owner.receipt.ownership,
+    )
+
+    class ForgedPlan(PlannedBm25View):
+        pass
+
+    class ForgedWorkspacePlan(WorkspacePlan):
+        pass
+
+    class ForgedRecord(TreeFileRecord):
+        pass
+
+    with pytest.raises(TypeError, match="exact WorkspacePlan"):
+        replace(
+            planned,
+            plan=ForgedWorkspacePlan(
+                planned.plan.subject_digest,
+                directories=planned.plan.directories,
+                files=planned.plan.files,
+                root_mode=planned.plan.root_mode,
+                digest=planned.plan.digest,
+            ),
+        )
+    first_record, *remaining_records = planned.output_records
+    with pytest.raises(TypeError, match="output records"):
+        replace(
+            planned,
+            output_records=(
+                ForgedRecord(
+                    first_record.path,
+                    first_record.mode,
+                    first_record.size,
+                    first_record.sha256,
+                ),
+                *remaining_records,
+            ),
+        )
+
+    forged = ForgedPlan(
+        plan=planned.plan,
+        source_ownership=planned.source_ownership,
+        source_digest=planned.source_digest,
+        source_records=planned.source_records,
+        output_records=planned.output_records,
+        view_config_digest=planned.view_config_digest,
+        repository_fingerprint=planned.repository_fingerprint,
+    )
+    try:
+        with pytest.raises(ValueError, match="not canonical"):
+            publish_planned_bm25_view_strict(
+                fixture.destination,
+                planned=tampered,
+                source_generation=fixture.source_owner,
+                repository_source=fixture.repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+        with pytest.raises(TypeError, match="PlannedBm25View"):
+            publish_planned_bm25_view_strict(
+                fixture.destination,
+                planned=forged,
+                source_generation=fixture.source_owner,
+                repository_source=fixture.repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert provider.run_count == 0
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_detects_source_drift_between_plan_and_replay(
+    strict_generation,
+) -> None:
+    fixture = strict_generation
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={},
+        environ={},
+    )
+    (fixture.destination / "documents.json").write_bytes(_canonical_bytes([]))
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=fixture.source_owner.receipt.ownership,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="changed|differs"):
+            publish_planned_bm25_view_strict(
+                fixture.destination,
+                planned=planned,
+                source_generation=fixture.source_owner,
+                repository_source=fixture.repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert output_owner.state == "empty"
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_rolls_back_when_repository_changes_during_publication(
+    strict_generation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = strict_generation
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={},
+        environ={},
+    )
+    original_documents = (fixture.destination / "documents.json").read_bytes()
+    original_metadata = (fixture.destination / "bm25_metadata.json").read_bytes()
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=fixture.source_owner.receipt.ownership,
+    )
+    candidate_calls = 0
+    real_candidate_records = strict_bm25_module._candidate_records
+
+    def mutate_after_validation(*args, **kwargs):
+        nonlocal candidate_calls
+        records = real_candidate_records(*args, **kwargs)
+        candidate_calls += 1
+        if candidate_calls == 2:
+            (fixture.repository / "sample.py").write_text(
+                "VALUE = 2\n",
+                encoding="utf-8",
+            )
+        return records
+
+    monkeypatch.setattr(
+        strict_bm25_module,
+        "_candidate_records",
+        mutate_after_validation,
+    )
+    try:
+        with pytest.raises(
+            (RuntimeError, ValueError),
+            match="changed|identity failed validation",
+        ):
+            publish_planned_bm25_view_strict(
+                fixture.destination,
+                planned=planned,
+                source_generation=fixture.source_owner,
+                repository_source=fixture.repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert candidate_calls == 2
+        assert output_owner.state == "cleanup"
+        assert fixture.source_owner.active
+        assert (
+            fixture.destination / "documents.json"
+        ).read_bytes() == original_documents
+        assert (
+            fixture.destination / "bm25_metadata.json"
+        ).read_bytes() == original_metadata
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_rejects_provider_plan_and_expectation_mismatch(
+    strict_generation,
+) -> None:
+    fixture = strict_generation
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={},
+        environ={},
+    )
+    wrong_plan = WorkspacePlan(
+        subject_digest=hashlib.sha256(b"wrong-workspace-plan").hexdigest(),
+        files=planned.plan.files,
+    )
+    providers = (
+        _TestWorkspaceProvider(
+            expected_destination=fixture.source_owner.receipt.ownership,
+            workspace_plan=wrong_plan,
+        ),
+        _TestWorkspaceProvider(expected_destination=None),
+    )
+    for provider in providers:
+        output_owner = PublishedWorkspaceReceiptOwner()
+        try:
+            with pytest.raises(
+                (RuntimeError, ValueError),
+                match="plan|expectation|expected missing",
+            ):
+                publish_planned_bm25_view_strict(
+                    fixture.destination,
+                    planned=planned,
+                    source_generation=fixture.source_owner,
+                    repository_source=fixture.repository_source,
+                    workspace_provider=provider,
+                    output_receipt_owner=output_owner,
+                    view_config={},
+                    environ={},
+                )
+            assert provider.run_count == 1
+            assert output_owner.state == "empty"
+        finally:
+            output_owner.close()
+
+
+def test_strict_bm25_validates_staged_and_published_generations(
+    strict_generation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = strict_generation
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config={},
+        environ={},
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=fixture.source_owner.receipt.ownership,
+    )
+    calls = 0
+    real_candidate_records = strict_bm25_module._candidate_records
+
+    def counted_candidate_records(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_candidate_records(*args, **kwargs)
+
+    monkeypatch.setattr(
+        strict_bm25_module,
+        "_candidate_records",
+        counted_candidate_records,
+    )
+    try:
+        publish_planned_bm25_view_strict(
+            fixture.destination,
+            planned=planned,
+            source_generation=fixture.source_owner,
+            repository_source=fixture.repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_config={},
+            environ={},
+        )
+        assert calls == 2
+        assert output_owner.active
+    finally:
+        output_owner.close()
+
+
+def test_strict_bm25_rejects_unbound_document_source(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    documents = _canonical_bytes(
+        [
+            {
+                "page_content": "outside",
+                "metadata": {"file": "missing.py"},
+            }
+        ]
+    )
+    _destination, source_owner = _publish_source(
+        tmp_path,
+        repository,
+        documents=documents,
+    )
+    repository_source = capture_repository_source(repository)
+    try:
+        with pytest.raises(ValueError, match="authenticated repository source"):
+            plan_bm25_view_strict(
+                source_owner,
+                repository_source=repository_source,
+                view_config={},
+                environ={},
+            )
+    finally:
+        source_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_never_falls_back_for_vector(
+    strict_generation,
+) -> None:
+    fixture = strict_generation
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=fixture.source_owner.receipt.ownership,
+    )
+    try:
+        with pytest.raises(ValueError, match="only bm25"):
+            normalize_owned_query_view_strict(
+                fixture.destination,
+                source_generation=fixture.source_owner,
+                repository_source=fixture.repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_type="vector",
+                view_config={},
+            )
+        assert provider.support_count == 0
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+    finally:
+        output_owner.close()
+
+
+class _FaultyChunks:
+    def __init__(
+        self,
+        *,
+        work_error: BaseException | None,
+        close_error: BaseException,
+    ) -> None:
+        self.work_error = work_error
+        self.close_error = close_error
+        self.step = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> bytes:
+        if self.step == 0 and self.work_error is not None:
+            self.step += 1
+            return b"first"
+        if self.work_error is not None:
+            raise self.work_error
+        raise StopIteration
+
+    def close(self) -> None:
+        raise self.close_error
+
+
+def test_strict_bm25_recording_keeps_work_failure_primary() -> None:
+    primary = KeyboardInterrupt("generation interrupted")
+    secondary = SystemExit("iterator cleanup failed")
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _record_chunks(
+            "documents.json",
+            _FaultyChunks(work_error=primary, close_error=secondary),
+            max_bytes=128,
+        )
+    assert caught.value is primary
+    notes = (
+        *getattr(primary, "__notes__", ()),
+        *getattr(primary, "_codenib_cleanup_notes", ()),
+    )
+    assert any("iterator close" in note for note in notes)
+
+
+def test_strict_bm25_recording_propagates_lone_close_failure() -> None:
+    primary = SystemExit("iterator cleanup failed")
+    with pytest.raises(SystemExit) as caught:
+        _record_chunks(
+            "documents.json",
+            _FaultyChunks(work_error=None, close_error=primary),
+            max_bytes=128,
+        )
+    assert caught.value is primary

--- a/test/artifacts/test_strict_bm25_publication.py
+++ b/test/artifacts/test_strict_bm25_publication.py
@@ -343,6 +343,7 @@ def test_strict_bm25_high_level_freezes_caller_mappings_once(
         )
         assert config.iterations == 1
         assert environment.iterations == 1
+        assert provider.support_count == 1
         assert output_owner.active
     finally:
         output_owner.close()

--- a/test/artifacts/test_strict_bm25_publication.py
+++ b/test/artifacts/test_strict_bm25_publication.py
@@ -39,7 +39,11 @@ from codenib.artifacts import (
 )
 from codenib.artifacts.strict_bm25 import _record_chunks
 from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
-from codenib.source_fingerprint import capture_repository_source
+from codenib.source_fingerprint import (
+    RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
+    capture_repository_source,
+)
 
 _Result = TypeVar("_Result")
 _Value = TypeVar("_Value")
@@ -349,6 +353,74 @@ def test_strict_bm25_high_level_freezes_caller_mappings_once(
         output_owner.close()
 
 
+def test_strict_bm25_high_level_uses_one_detached_source_identity(
+    strict_generation,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fixture = strict_generation
+    binding = fixture.repository_source
+    original_root = binding.root
+    original_fingerprint = binding.fingerprint
+    original_file_count = binding.file_count
+    original_file_records = binding.file_records
+    forged_root = tmp_path / "forged-public-root"
+    snapshot_calls = 0
+    policy_identities: list[RepositorySourceIdentitySnapshot] = []
+    real_snapshot = RepositorySourceBinding.authenticated_identity_snapshot
+    real_policy = strict_bm25_module._policy
+
+    def counted_snapshot(self):
+        nonlocal snapshot_calls
+        snapshot_calls += 1
+        return real_snapshot(self)
+
+    def mutate_public_projection(repository_identity, *args, **kwargs):
+        assert type(repository_identity) is RepositorySourceIdentitySnapshot
+        policy_identities.append(repository_identity)
+        binding.root = forged_root
+        binding.fingerprint = f"sha256-v2:{'0' * 64}"
+        binding.file_count = 0
+        binding.file_records = ()
+        try:
+            return real_policy(repository_identity, *args, **kwargs)
+        finally:
+            binding.root = original_root
+            binding.fingerprint = original_fingerprint
+            binding.file_count = original_file_count
+            binding.file_records = original_file_records
+
+    monkeypatch.setattr(
+        RepositorySourceBinding,
+        "authenticated_identity_snapshot",
+        counted_snapshot,
+    )
+    monkeypatch.setattr(strict_bm25_module, "_policy", mutate_public_projection)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=fixture.source_owner.receipt.ownership,
+    )
+    try:
+        normalize_owned_query_view_strict(
+            fixture.destination,
+            source_generation=fixture.source_owner,
+            repository_source=binding,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_type="bm25",
+            view_config={},
+            environ={},
+        )
+        assert snapshot_calls == 1
+        assert len(policy_identities) == 2
+        assert policy_identities[0] is policy_identities[1]
+        assert policy_identities[0].root == original_root
+        assert policy_identities[0].fingerprint == original_fingerprint
+        assert output_owner.active
+    finally:
+        output_owner.close()
+
+
 def test_strict_bm25_plan_binds_view_config_into_subject(
     strict_generation,
 ) -> None:
@@ -640,7 +712,7 @@ def test_strict_bm25_rejects_repository_overlap_before_source_consume(
             with pytest.raises(ValueError, match="must not overlap"):
                 strict_bm25_module._require_disjoint_view_path(
                     overlapping,
-                    repository_source,
+                    repository,
                 )
     finally:
         output_owner.close()


### PR DESCRIPTION
## Summary
Restacks the isolated strict BM25 publication producer on current main. It plans and replays exact canonical BM25 generations through retained source and strict workspace authority without changing legacy SourceTrust or native-vector production routes.

## Changes
- Add PlannedBm25View plus strict plan, replay, and high-level normalization APIs.
- Bind source and output records, repository fingerprint, and caller configuration into one exact workspace subject.
- Capture one detached authenticated repository identity for the complete high-level operation so mutable public projections cannot redirect policy, paths, or fingerprints.
- Enforce bounded UTF-8 JSON, duplicate and nonfinite rejection, exact inventories, repository separation, and staged and published verification.
- Export the isolated API and update the storage roadmap; no production provider or compiler route is enabled.
- Add adversarial coverage for overlap aliases, repository drift rollback, provider mismatches, forged plans, source drift, identity ABA, and BM25 query compatibility.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Focused publication, source, provider, and artifact suites: 800 passed, 15 skipped.
- Unit tier under umask 022: 5,490 passed, 71 skipped, 191 deselected; the sole additional deselection is the locally installed 0.2.0 distribution metadata mismatch against source version 0.2.1, already reproduced on clean main and covered by clean CI.
- Exact-head Full CI light: 5,492 unit tests passed and 36 integration tests passed.
- Exact-head formal PR CI: 5,490 unit tests passed.
- Exact-head Docs and CodeNib Publish Smoke passed. Every release artifact build, Python 3.10-3.14 install, upgrade, CodeGraph, Wiki/MCP, and Ask verification job passed; the workflow-dispatch-only MCP Registry environment gate rejected this non-tag branch before running steps and is not a PR check.
- Pre-commit, py_compile, git diff --check, and python -m mkdocs build --strict.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published