### PR TITLE
perf(scip): bind consumer-safe query receipts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -440,6 +440,7 @@ core-test: core-build
 		test/scip/test_scip_core_registry.py \
 		test/scip/test_fact_batch_buffer.py \
 		test/scip/test_fact_query_index.py \
+		test/scip/test_scip_query.py \
 		test/facts/test_model.py \
 		test/facts/test_adapters.py \
 		test/scripts/test_profile_fact_batch_buffer.py \

--- a/codenib/compiler/artifact_fingerprints.py
+++ b/codenib/compiler/artifact_fingerprints.py
@@ -7,19 +7,50 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import re
+import stat
 from pathlib import Path
 from typing import Any, Mapping
 
 _BM25_ARTIFACT_PATHS = (Path("documents.json"), Path("bm25_metadata.json"))
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
 
 
-def _file_fingerprint(path: Path) -> dict[str, Any]:
+def regular_file_fingerprint(path: str | Path) -> dict[str, Any]:
+    """Return the size and SHA-256 of one regular, non-symlink file."""
+
+    path = Path(path)
+    before_path = path.lstat()
+    if not stat.S_ISREG(before_path.st_mode):
+        raise ValueError(f"invalid artifact file: {path}")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
     digest = hashlib.sha256()
     size = 0
-    with path.open("rb") as handle:
-        while block := handle.read(1024 * 1024):
-            digest.update(block)
-            size += len(block)
+    try:
+        before_file = os.fstat(descriptor)
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            while block := handle.read(1024 * 1024):
+                digest.update(block)
+                size += len(block)
+        after_file = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    after_path = path.lstat()
+
+    def identity(value: os.stat_result) -> tuple[int, int, int, int]:
+        return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns
+
+    if (
+        not stat.S_ISREG(before_file.st_mode)
+        or not stat.S_ISREG(after_path.st_mode)
+        or identity(before_path) != identity(before_file)
+        or identity(before_file) != identity(after_file)
+        or identity(after_file) != identity(after_path)
+        or size != after_file.st_size
+    ):
+        raise ValueError(f"artifact file changed while hashing: {path}")
     return {"size": size, "sha256": digest.hexdigest()}
 
 
@@ -34,8 +65,104 @@ def bm25_artifact_file_fingerprints(
         path = artifact_root / relative
         if path.is_symlink() or not path.is_file():
             raise ValueError(f"invalid BM25 artifact file: {path}")
-        fingerprints[relative.as_posix()] = _file_fingerprint(path)
+        fingerprints[relative.as_posix()] = regular_file_fingerprint(path)
     return fingerprints
+
+
+def scip_decoded_artifact_fingerprints(
+    root: str | Path,
+    *,
+    receipts: Mapping[str, object],
+    languages: list[str],
+    multi_language_layout: bool = False,
+) -> dict[str, dict[str, Any]]:
+    """Validate decoded SCIP inputs that graph decoders actually consumed.
+
+    A non-SCIP graph route legitimately has no ``index.decoded``.  Such a
+    build reports no receipt and records an empty mapping.  This function never
+    discovers artifacts by scanning after a graph build: every persisted
+    fingerprint must come from the decoder's before/after consumption bracket.
+    """
+
+    artifact_root = Path(root).resolve()
+    if not isinstance(receipts, Mapping) or not all(
+        type(language) is str for language in receipts
+    ):
+        raise ValueError("decoded SCIP receipts must be a language mapping")
+    if not set(receipts).issubset(set(languages)):
+        raise ValueError("decoded SCIP receipt has an unavailable language")
+    fingerprints: dict[str, dict[str, Any]] = {}
+    for language, raw_receipt in receipts.items():
+        if not isinstance(raw_receipt, Mapping) or set(raw_receipt) != {
+            "path",
+            "size",
+            "sha256",
+        }:
+            raise ValueError(f"malformed decoded SCIP receipt for {language}")
+        relative = (
+            Path("graphs") / language / "index.decoded"
+            if multi_language_layout
+            else Path("index.decoded")
+        )
+        path = artifact_root / relative
+        expected_path = path.resolve(strict=True)
+        receipt_path = raw_receipt["path"]
+        if type(receipt_path) is not str or receipt_path != str(expected_path):
+            raise ValueError(f"decoded SCIP receipt path mismatch for {language}")
+        size = raw_receipt["size"]
+        digest = raw_receipt["sha256"]
+        if type(size) is not int or size < 0:
+            raise ValueError(f"decoded SCIP receipt size is invalid for {language}")
+        if type(digest) is not str or _SHA256_RE.fullmatch(digest) is None:
+            raise ValueError(f"decoded SCIP receipt digest is invalid for {language}")
+        observed = regular_file_fingerprint(path)
+        if observed != {"size": size, "sha256": digest}:
+            raise ValueError(f"decoded SCIP artifact changed after use for {language}")
+        fingerprints[language] = {
+            "relative_path": relative.as_posix(),
+            "size": size,
+            "sha256": digest,
+        }
+    return fingerprints
+
+
+def graph_output_artifact_fingerprint(
+    root: str | Path,
+    *,
+    receipt: object,
+) -> dict[str, Any]:
+    """Validate the graph generation receipt emitted by its responsible writer."""
+
+    artifact_root = Path(root).resolve()
+    path = artifact_root / "graph.pkl"
+    resolved = path.resolve(strict=True)
+    if not isinstance(receipt, Mapping) or set(receipt) != {
+        "path",
+        "size",
+        "sha256",
+        "query_surface_sha256",
+    }:
+        raise ValueError("malformed symbol graph writer receipt")
+    if type(receipt["path"]) is not str or receipt["path"] != str(resolved):
+        raise ValueError("symbol graph writer receipt path mismatch")
+    size = receipt["size"]
+    digest = receipt["sha256"]
+    if type(size) is not int or size < 0:
+        raise ValueError("symbol graph writer receipt size is invalid")
+    if type(digest) is not str or _SHA256_RE.fullmatch(digest) is None:
+        raise ValueError("symbol graph writer receipt digest is invalid")
+    query_digest = receipt["query_surface_sha256"]
+    if type(query_digest) is not str or _SHA256_RE.fullmatch(query_digest) is None:
+        raise ValueError("symbol graph writer query digest is invalid")
+    observed = regular_file_fingerprint(path)
+    if observed != {"size": size, "sha256": digest}:
+        raise ValueError("symbol graph artifact changed after its writer returned")
+    return {
+        "relative_path": "graph.pkl",
+        "size": size,
+        "sha256": digest,
+        "query_surface_sha256": query_digest,
+    }
 
 
 def bm25_artifact_files_match(
@@ -89,5 +216,8 @@ def require_bm25_manifest_artifact(entry: object) -> bool:
 __all__ = [
     "bm25_artifact_file_fingerprints",
     "bm25_artifact_files_match",
+    "graph_output_artifact_fingerprint",
+    "regular_file_fingerprint",
     "require_bm25_manifest_artifact",
+    "scip_decoded_artifact_fingerprints",
 ]

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -723,13 +723,14 @@ class SymbolGraphBuilder:
     def artifact_identity(self) -> Dict[str, Any]:
         graph_languages = self.languages or [self.language]
         return {
-            "builder_schema": 3,
+            "builder_schema": 4,
             "languages": list(graph_languages),
             "graph_route": self.graph_route,
             "exclude_patterns": sorted(self.exclude_patterns),
             "allow_partial_languages": self.allow_partial_languages,
             "allow_partial_index": self.allow_partial_index,
             "source_coverage_fallback": self.source_coverage_fallback,
+            "target_dir": None,
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
 
@@ -745,6 +746,12 @@ class SymbolGraphBuilder:
         output_dir: str = kwargs["output_dir"]
 
         from ..ls_router import build_graph_for_languages_with_report
+        from ..scip_interface.query_surface import query_surface_sha256
+        from .artifact_fingerprints import (
+            graph_output_artifact_fingerprint,
+            regular_file_fingerprint,
+            scip_decoded_artifact_fingerprints,
+        )
 
         os.makedirs(output_dir, exist_ok=True)
         graph_languages = self.languages or [self.language]
@@ -754,6 +761,7 @@ class SymbolGraphBuilder:
             "skip_level": None,
             "exclude_patterns": self.exclude_patterns,
             "graph_route": self.graph_route,
+            "capture_artifact_receipts": True,
         }
         if self.allow_partial_index:
             build_kwargs["allow_partial_index"] = True
@@ -763,6 +771,7 @@ class SymbolGraphBuilder:
             allow_partial=self.allow_partial_languages,
             **build_kwargs,
         )
+        graph_output_receipt = result.graph_output_receipt
 
         graph = result.graph
         compiler_graph_available = graph is not None and hasattr(graph, "graph")
@@ -838,9 +847,16 @@ class SymbolGraphBuilder:
                 "compiler_edges": compiler_edge_count,
                 **coverage_report,
             }
-            graph.save_graph(os.path.join(output_dir, "graph.pkl"))
+            graph_output_path = os.path.join(output_dir, "graph.pkl")
+            graph.save_graph(graph_output_path)
+            graph_output_receipt = {
+                "path": os.path.realpath(graph_output_path),
+                **regular_file_fingerprint(graph_output_path),
+                "query_surface_sha256": query_surface_sha256(graph),
+            }
 
         node_count = len(graph.graph.vs)
+        edge_count = len(graph.graph.es)
         if node_count == 0:
             raise RuntimeError("symbol graph builder returned an empty graph")
         available_languages = (
@@ -848,6 +864,23 @@ class SymbolGraphBuilder:
             if fallback_report is not None
             else result.available_languages
         )
+        scip_decoded_artifacts = scip_decoded_artifact_fingerprints(
+            output_dir,
+            receipts=result.decoded_input_receipts,
+            languages=list(result.available_languages),
+            multi_language_layout=len(graph_languages) != 1,
+        )
+        graph_artifact_receipt = graph_output_artifact_fingerprint(
+            output_dir,
+            receipt=graph_output_receipt,
+        )
+        writer_query_surface = graph_artifact_receipt.pop("query_surface_sha256")
+        observed_query_surface = query_surface_sha256(graph)
+        if writer_query_surface != observed_query_surface:
+            raise ValueError(
+                "symbol graph query surface changed after its writer returned"
+            )
+        graph_artifact = graph_artifact_receipt
 
         return IndexStatus(
             index_type="symbol_graph",
@@ -859,10 +892,15 @@ class SymbolGraphBuilder:
             metadata={
                 **self.artifact_identity(),
                 "node_count": node_count,
+                "edge_count": edge_count,
                 "language": available_languages[0],
                 "available_languages": available_languages,
                 "compiler_available_languages": result.available_languages,
                 "index_generation_reports": result.index_generation_reports,
+                "scip_decoded_artifacts": scip_decoded_artifacts,
+                "graph_artifact": graph_artifact,
+                "query_surface_sha256": observed_query_surface,
+                "update_mode": "full_rebuild",
                 "partial_index": bool(compiler_partial_languages),
                 "failed_languages": result.failed_languages,
                 "partial": result.partial,

--- a/codenib/ls_router.py
+++ b/codenib/ls_router.py
@@ -63,6 +63,8 @@ class GraphBuildResult:
     available_languages: List[str]
     failed_languages: Dict[str, str]
     index_generation_reports: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    decoded_input_receipts: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    graph_output_receipt: Optional[Dict[str, Any]] = None
 
     @property
     def partial(self) -> bool:
@@ -110,6 +112,21 @@ def _normalize_language(
         supported = ", ".join(sorted(set(LANGUAGE_ALIASES.keys())))
         raise ValueError(f"Unsupported language: {language!r}. Supported: {supported}")
     return key
+
+
+def _regular_file_receipt(path: str | Path, graph: object) -> Dict[str, Any]:
+    """Fingerprint an output immediately after the responsible writer returns."""
+
+    from .compiler.artifact_fingerprints import regular_file_fingerprint
+    from .scip_interface.query_surface import query_surface_sha256
+
+    output = Path(path)
+    fingerprint = regular_file_fingerprint(output)
+    return {
+        "path": str(output.resolve(strict=True)),
+        **fingerprint,
+        "query_surface_sha256": query_surface_sha256(graph),
+    }
 
 
 def _load_class(path: str) -> Type:
@@ -177,6 +194,7 @@ class LSIndexer:
         self.decoded_file = self._delegate.decoded_file
         self.graph_file = self._delegate.graph_file
         self.profiler = self._delegate.profiler
+        self._graph_output_receipt: Optional[Dict[str, Any]] = None
 
         logger.info(
             "Initialized LSIndexer for %s at %s (route=%s)",
@@ -270,15 +288,33 @@ class LSIndexer:
         *,
         reset_profiler: bool = True,
         report_profile: bool = True,
+        capture_artifact_receipts: bool = False,
         **kwargs,
     ) -> Union[CodeGraph, None]:
-        return self._delegate.run_pipeline(
+        if type(capture_artifact_receipts) is not bool:
+            raise ValueError("capture_artifact_receipts must be a boolean")
+        self._graph_output_receipt = None
+        pipeline_kwargs = dict(kwargs)
+        if capture_artifact_receipts and hasattr(
+            self._delegate, "_capture_artifact_receipts"
+        ):
+            pipeline_kwargs["capture_artifact_receipts"] = True
+        graph = self._delegate.run_pipeline(
             output_file=output_file,
             skip_level=skip_level,
             reset_profiler=reset_profiler,
             report_profile=report_profile,
-            **kwargs,
+            **pipeline_kwargs,
         )
+        if graph is None or skip_level == "graph" or not capture_artifact_receipts:
+            return graph
+        delegate_receipt = getattr(self._delegate, "graph_output_receipt", None)
+        self._graph_output_receipt = (
+            dict(delegate_receipt)
+            if isinstance(delegate_receipt, dict)
+            else _regular_file_receipt(output_file or self.graph_file, graph)
+        )
+        return graph
 
     def clear_cache(self, level: str = "all") -> bool:
         return self._delegate.clear_cache(level=level)
@@ -294,6 +330,18 @@ class LSIndexer:
         """Latest backend generation report, when the indexer provides one."""
 
         return getattr(self._delegate, "index_generation_report", None)
+
+    @property
+    def decoded_input_receipt(self):
+        """Decoded input generation consumed by graph construction, if any."""
+
+        return getattr(self._delegate, "decoded_input_receipt", None)
+
+    @property
+    def graph_output_receipt(self):
+        """Graph generation written by the pipeline invocation, if any."""
+
+        return self._graph_output_receipt
 
     @property
     def supports_partial_index(self) -> bool:
@@ -353,6 +401,7 @@ def build_graph_for_languages_with_report(
     graph_route: str = ACTIVE_GRAPH_ROUTE,
     allow_partial: bool = False,
     allow_partial_index: bool = False,
+    capture_artifact_receipts: bool = False,
 ) -> GraphBuildResult:
     """Build a graph and report per-language availability.
 
@@ -369,6 +418,8 @@ def build_graph_for_languages_with_report(
     supporting backend retain a parseable compiler prefix and reports that
     state separately from per-language availability.
     """
+    if type(capture_artifact_receipts) is not bool:
+        raise ValueError("capture_artifact_receipts must be a boolean")
     normalized = _normalize_language_sequence(languages, graph_route=graph_route)
     base_output = Path(output_dir)
     pname = project_name or base_output.name
@@ -383,6 +434,8 @@ def build_graph_for_languages_with_report(
         pipeline_kwargs["target_dir"] = target_dir
     if include_references:
         pipeline_kwargs["include_references"] = True
+    if capture_artifact_receipts:
+        pipeline_kwargs["capture_artifact_receipts"] = True
 
     def run_language(language: str, language_output: Path, language_project: str):
         indexer = LSIndexer(
@@ -403,13 +456,24 @@ def build_graph_for_languages_with_report(
             **language_pipeline_kwargs,
         )
         report = getattr(indexer, "index_generation_report", None)
-        return graph, dict(report) if isinstance(report, dict) else None
+        receipt = getattr(indexer, "decoded_input_receipt", None)
+        graph_receipt = getattr(indexer, "graph_output_receipt", None)
+        return (
+            graph,
+            dict(report) if isinstance(report, dict) else None,
+            dict(receipt) if isinstance(receipt, dict) else None,
+            dict(graph_receipt) if isinstance(graph_receipt, dict) else None,
+        )
 
     if len(normalized) == 1:
         language = normalized[0]
         generation_report = None
+        decoded_receipt = None
+        graph_receipt = None
         try:
-            graph, generation_report = run_language(language, base_output, pname)
+            graph, generation_report, decoded_receipt, graph_receipt = run_language(
+                language, base_output, pname
+            )
         except Exception as exc:
             if not allow_partial:
                 raise
@@ -426,16 +490,27 @@ def build_graph_for_languages_with_report(
             index_generation_reports=(
                 {language: generation_report} if generation_report is not None else {}
             ),
+            decoded_input_receipts=(
+                {language: decoded_receipt}
+                if graph is not None and decoded_receipt is not None
+                else {}
+            ),
+            graph_output_receipt=(
+                graph_receipt
+                if graph is not None and graph_receipt is not None
+                else None
+            ),
         )
 
     combined = CodeGraph(str(Path(project_root).absolute()))
     available: List[str] = []
     generation_reports: Dict[str, Dict[str, Any]] = {}
+    decoded_receipts: Dict[str, Dict[str, Any]] = {}
     for language in normalized:
         language_output = base_output / "graphs" / language
         language_project = f"{pname}-{language}"
         try:
-            graph, generation_report = run_language(
+            graph, generation_report, decoded_receipt, _graph_receipt = run_language(
                 language, language_output, language_project
             )
         except Exception as exc:
@@ -456,6 +531,8 @@ def build_graph_for_languages_with_report(
             failures[language] = message
             logger.warning("%s", message)
             continue
+        if decoded_receipt is not None:
+            decoded_receipts[language] = decoded_receipt
         combined.merge_from(graph)
         available.append(language)
 
@@ -466,10 +543,18 @@ def build_graph_for_languages_with_report(
             available_languages=[],
             failed_languages=failures,
             index_generation_reports=generation_reports,
+            decoded_input_receipts={},
+            graph_output_receipt=None,
         )
 
     base_output.mkdir(parents=True, exist_ok=True)
-    combined.save_graph(base_output / "graph.pkl")
+    combined_graph_path = base_output / "graph.pkl"
+    combined.save_graph(combined_graph_path)
+    combined_graph_receipt = (
+        _regular_file_receipt(combined_graph_path, combined)
+        if capture_artifact_receipts
+        else None
+    )
     logger.info(
         "Built combined graph for %s at %s",
         ", ".join(available),
@@ -481,6 +566,8 @@ def build_graph_for_languages_with_report(
         available_languages=available,
         failed_languages=failures,
         index_generation_reports=generation_reports,
+        decoded_input_receipts=decoded_receipts,
+        graph_output_receipt=combined_graph_receipt,
     )
 
 

--- a/codenib/scip_interface/query_surface.py
+++ b/codenib/scip_interface/query_surface.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical digest of the ordered symbol-query graph surface.
+
+The framing is shared with ``core/`` but this module depends only on Python's
+standard library.  Callers supply a CodeGraph-compatible duck type; importing
+this module never imports igraph or the persisted graph implementation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+from collections.abc import Mapping
+from typing import Any
+
+QUERY_SURFACE_SCHEMA_VERSION = 1
+_MAGIC = b"CodeNib-FactQuery-Surface\0"
+
+
+def _attributes(item: object, *, label: str) -> Mapping[str, Any]:
+    method = getattr(item, "attributes", None)
+    value = method() if callable(method) else item
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} attributes must be a mapping")
+    return value
+
+
+def _required_string(value: object, *, label: str) -> bytes:
+    if type(value) is not str:
+        raise ValueError(f"{label} must be a string")
+    try:
+        encoded = value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{label} must be strict UTF-8") from exc
+    return b"\x01" + struct.pack(">Q", len(encoded)) + encoded
+
+
+def _optional_string(value: object, *, label: str) -> bytes:
+    if value is None:
+        return b"\x00"
+    return _required_string(value, label=label)
+
+
+def _required_int(value: object, *, label: str) -> bytes:
+    if type(value) is not int:
+        raise ValueError(f"{label} must be an integer")
+    try:
+        return b"\x01" + struct.pack(">q", value)
+    except struct.error as exc:
+        raise ValueError(f"{label} is outside signed 64-bit range") from exc
+
+
+def _optional_int(value: object, *, label: str) -> bytes:
+    if value is None:
+        return b"\x00"
+    return _required_int(value, label=label)
+
+
+def _optional_bool(value: object, *, label: str) -> bytes:
+    if value is None:
+        return b"\x00"
+    if type(value) is not bool:
+        raise ValueError(f"{label} must be a boolean")
+    return b"\x02" if value else b"\x01"
+
+
+def query_surface_sha256(graph: object) -> str:
+    """Hash vertices and edges in their exact graph index order."""
+
+    storage = getattr(graph, "graph", graph)
+    vertices = list(storage.vs)
+    edges = list(storage.es)
+    digest = hashlib.sha256()
+    digest.update(_MAGIC)
+    digest.update(struct.pack(">I", QUERY_SURFACE_SCHEMA_VERSION))
+    digest.update(struct.pack(">Q", len(vertices)))
+
+    for position, vertex in enumerate(vertices):
+        attrs = _attributes(vertex, label=f"vertex[{position}]")
+        name = attrs.get("name")
+        digest.update(b"V")
+        digest.update(_required_string(name, label=f"vertex[{position}].name"))
+        digest.update(
+            _required_string(attrs.get("type"), label=f"vertex[{position}].type")
+        )
+        digest.update(
+            _optional_string(attrs.get("file"), label=f"vertex[{position}].file")
+        )
+        for field in ("start_line", "end_line", "selection_line"):
+            digest.update(
+                _optional_int(attrs.get(field), label=f"vertex[{position}].{field}")
+            )
+        for field in ("unified_name", "symbol_kind"):
+            digest.update(
+                _optional_string(attrs.get(field), label=f"vertex[{position}].{field}")
+            )
+        digest.update(
+            _optional_bool(
+                attrs.get("has_definition"),
+                label=f"vertex[{position}].has_definition",
+            )
+        )
+
+    digest.update(struct.pack(">Q", len(edges)))
+    for position, edge in enumerate(edges):
+        attrs = _attributes(edge, label=f"edge[{position}]")
+        source = getattr(edge, "source", None)
+        target = getattr(edge, "target", None)
+        if (
+            type(source) is not int
+            or type(target) is not int
+            or source < 0
+            or target < 0
+            or source >= len(vertices)
+            or target >= len(vertices)
+        ):
+            raise ValueError(f"edge[{position}] has an invalid endpoint")
+        digest.update(b"E")
+        digest.update(_required_int(source, label=f"edge[{position}].source"))
+        digest.update(_required_int(target, label=f"edge[{position}].target"))
+        digest.update(
+            _required_string(attrs.get("type"), label=f"edge[{position}].type")
+        )
+        digest.update(
+            _optional_string(
+                attrs.get("anchor_file"), label=f"edge[{position}].anchor_file"
+            )
+        )
+        digest.update(
+            _optional_int(
+                attrs.get("anchor_line"), label=f"edge[{position}].anchor_line"
+            )
+        )
+    return digest.hexdigest()
+
+
+__all__ = ["QUERY_SURFACE_SCHEMA_VERSION", "query_surface_sha256"]

--- a/codenib/scip_interface/scip_decode_core.py
+++ b/codenib/scip_interface/scip_decode_core.py
@@ -21,12 +21,20 @@ import hashlib
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Optional
 
 from ..graph.code_graph import CodeGraph
 from ..languages import core_decoder_languages, normalize_language
 from ..log_utils import get_logger
 from .fact_batch_buffer import FactBatchBufferView, validate_compiled_contract
+from .scip_query import (
+    FACT_QUERY_ABI_VERSION,
+    FACT_QUERY_CAPABILITIES,
+    FACT_QUERY_FORMAT,
+    FACT_QUERY_PROMOTED_LANGUAGES,
+    decode_native_fact_query_index,
+    validate_fact_query_contract,
+)
 
 logger = get_logger(__name__)
 
@@ -59,15 +67,10 @@ _FACT_QUERY_ENV = "CODENIB_NATIVE_FACT_QUERY_INDEX"
 _FACT_QUERY_OFF = frozenset({"0", "false", "no", "off", "disabled"})
 _FACT_QUERY_AUTO = frozenset({"", "1", "true", "yes", "on", "auto"})
 _FACT_QUERY_REQUIRED = frozenset({"required", "strict"})
-_FACT_QUERY_PROMOTED_LANGUAGES = frozenset({"python", "rust"})
-_FACT_QUERY_ABI_VERSION = 1
-_FACT_QUERY_FORMAT = "fact-query-index-v1"
-_FACT_QUERY_CAPABILITIES = {
-    "definition_by_symbol": True,
-    "references_by_symbol": True,
-    "position_queries": False,
-    "route_queries": False,
-}
+_FACT_QUERY_PROMOTED_LANGUAGES = FACT_QUERY_PROMOTED_LANGUAGES
+_FACT_QUERY_ABI_VERSION = FACT_QUERY_ABI_VERSION
+_FACT_QUERY_FORMAT = FACT_QUERY_FORMAT
+_FACT_QUERY_CAPABILITIES = FACT_QUERY_CAPABILITIES
 
 
 def _ensure_available() -> None:
@@ -191,24 +194,7 @@ def _fact_query_mode() -> str:
     )
 
 
-def _validate_fact_query_contract(contract: Mapping[str, Any]) -> None:
-    abi_version = contract.get("abi_version")
-    if type(abi_version) is not int or abi_version != _FACT_QUERY_ABI_VERSION:
-        raise RuntimeError(
-            "compiled FactQueryIndex contract mismatch: "
-            f"expected ABI {_FACT_QUERY_ABI_VERSION}, got {abi_version!r}"
-        )
-    if contract.get("format") != _FACT_QUERY_FORMAT:
-        raise RuntimeError(
-            "compiled FactQueryIndex contract mismatch: "
-            f"expected format {_FACT_QUERY_FORMAT!r}"
-        )
-    if contract.get("requires_anchored_references") is not True:
-        raise RuntimeError(
-            "compiled FactQueryIndex must fail closed on unanchored references"
-        )
-    if contract.get("capabilities") != _FACT_QUERY_CAPABILITIES:
-        raise RuntimeError("compiled FactQueryIndex capabilities do not match v1")
+_validate_fact_query_contract = validate_fact_query_contract
 
 
 class SCIPDecoderCore:
@@ -316,58 +302,13 @@ class SCIPDecoderCore:
     def _decode_native_fact_query_index(
         self,
     ) -> tuple[Any, dict[str, float | int]]:
-        if not hasattr(_cpp, "decode_scip_fact_query_index") or not hasattr(
-            _cpp, "fact_query_index_contract"
-        ):
-            raise RuntimeError("compiled core does not expose FactQueryIndex v1")
-        _validate_fact_query_contract(_cpp.fact_query_index_contract())
-
-        started = time.perf_counter()
-        payload = _cpp.decode_scip_fact_query_index(
+        result = decode_native_fact_query_index(
             index_file=self.index_file_path,
             project_root=self.project_root,
             language=self.language,
+            core_module=_cpp,
         )
-        binding_seconds = time.perf_counter() - started
-        if not isinstance(payload, Mapping):
-            raise RuntimeError("native FactQueryIndex returned a non-mapping payload")
-        if payload.get("format") != _FACT_QUERY_FORMAT:
-            raise RuntimeError("native FactQueryIndex returned an unknown format")
-        if payload.get("graph_materialized") is not False:
-            raise RuntimeError(
-                "native FactQueryIndex unexpectedly materialized a graph"
-            )
-
-        index = payload.get("index")
-        if index is None or getattr(index, "fact_query_index", None) is not True:
-            raise RuntimeError("native FactQueryIndex payload is missing its index")
-        if getattr(index, "materializes_graph", None) is not False:
-            raise RuntimeError(
-                "native FactQueryIndex does not guarantee graph-free use"
-            )
-        if getattr(index, "capabilities", None) != _FACT_QUERY_CAPABILITIES:
-            raise RuntimeError("native FactQueryIndex capabilities do not match v1")
-
-        native_decode = int(payload.get("native_decode_ns") or 0) / 1_000_000_000
-        native_index = int(payload.get("native_index_ns") or 0) / 1_000_000_000
-        timings: dict[str, float | int] = {
-            "core_decode": binding_seconds,
-            "native_decode": native_decode,
-            "native_fact_query_index": native_index,
-            "boundary_transport_residual": max(
-                0.0, binding_seconds - native_decode - native_index
-            ),
-            "node_count": int(getattr(index, "record_count", 0)),
-            "edge_count": int(getattr(index, "edge_count", 0)),
-            "definition_symbol_count": int(getattr(index, "symbol_count", 0)),
-            "reference_count": int(getattr(index, "reference_count", 0)),
-        }
-        for name, nanoseconds in (payload.get("decode_profile_ns") or {}).items():
-            if name in {"worker_count", "document_count"}:
-                timings[f"native_{name}"] = int(nanoseconds)
-            else:
-                timings[f"native_{name}"] = int(nanoseconds) / 1_000_000_000
-        return index, timings
+        return result.index, result.timings
 
     def decode_query_index(self) -> Any:
         """Return a graph-free symbol index or a compatible CodeGraph fallback.

--- a/codenib/scip_interface/scip_filter.py
+++ b/codenib/scip_interface/scip_filter.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-free path filtering shared by SCIP graph and query routes.
+
+The full-graph indexer historically owns these semantics.  Keeping them in a
+small module lets a graph-free query consumer prove that its complete native
+fact surface already satisfies the same filter without importing ``igraph``.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from ..repository_filters import repository_path_is_visible
+
+
+def normalize_scip_path(path: str | Path | None) -> str | None:
+    """Normalize an indexer path exactly as the legacy graph filter does."""
+
+    if path is None:
+        return None
+    normalized = Path(str(path).strip().replace("\\", "/")).as_posix().strip("/")
+    return normalized or None
+
+
+def definition_path(attributes: Mapping[str, object]) -> str | None:
+    """Return a symbol definition path encoded in ``unified_name`` if present."""
+
+    unified_name = attributes.get("unified_name")
+    if isinstance(unified_name, str) and ":" in unified_name:
+        return unified_name.split(":", 1)[0]
+    return None
+
+
+def matches_exclude_patterns(path: str, patterns: Iterable[str]) -> bool:
+    """Apply the SCIP route's established glob and ``/**`` prefix rules."""
+
+    for pattern in patterns:
+        normalized = normalize_scip_path(pattern)
+        if normalized is None:
+            continue
+        if fnmatch.fnmatch(path, normalized):
+            return True
+        if normalized.endswith("/**"):
+            prefix = normalized[:-3]
+            if path == prefix or path.startswith(f"{prefix}/"):
+                return True
+    return False
+
+
+def scip_path_is_allowed(
+    path: str | Path,
+    *,
+    target_dir: str | Path | None = None,
+    exclude_patterns: Iterable[str] = (),
+    allow_target_ancestor: bool = False,
+    enforce_repository_policy: bool = False,
+) -> bool:
+    """Return whether *path* survives the SCIP route filters.
+
+    ``enforce_repository_policy`` is opt-in so extracting this helper does not
+    change direct/full-graph decoder behavior.  Manifest-backed consumers turn
+    it on because their source fingerprint is defined by repository policy v3.
+    """
+
+    relative = normalize_scip_path(path)
+    if not relative:
+        return False
+    target = normalize_scip_path(target_dir)
+    if target:
+        in_target = relative == target or relative.startswith(f"{target}/")
+        is_target_ancestor = allow_target_ancestor and target.startswith(f"{relative}/")
+        if not in_target and not is_target_ancestor:
+            return False
+    if enforce_repository_policy and not repository_path_is_visible(relative):
+        return False
+    return not matches_exclude_patterns(relative, exclude_patterns)
+
+
+__all__ = [
+    "definition_path",
+    "matches_exclude_patterns",
+    "normalize_scip_path",
+    "scip_path_is_allowed",
+]

--- a/codenib/scip_interface/scip_indexer_base.py
+++ b/codenib/scip_interface/scip_indexer_base.py
@@ -9,7 +9,6 @@ Base class for SCIP indexers across different languages.
 """
 from __future__ import annotations
 
-import fnmatch
 import os
 import subprocess
 from abc import ABC, abstractmethod
@@ -20,6 +19,7 @@ from ..log_utils import get_logger
 from ..paths import temp_state_dir
 from ..profiler import Profiler
 from ..types import NODE_TYPE_DIRECTORY, NODE_TYPE_FILE, ROOT_NODE, is_symbol_node
+from .scip_filter import definition_path, normalize_scip_path, scip_path_is_allowed
 
 if TYPE_CHECKING:
     from ..graph.code_graph import CodeGraph
@@ -88,34 +88,6 @@ def extract_symbol(text: str) -> Optional[str]:
             i += 1
         return None
     return None
-
-
-def _normalize_rel_path(path: str | Path | None) -> str | None:
-    if path is None:
-        return None
-    normalized = Path(str(path).strip().replace("\\", "/")).as_posix().strip("/")
-    return normalized or None
-
-
-def _definition_path(attrs: dict) -> str | None:
-    unified_name = attrs.get("unified_name")
-    if isinstance(unified_name, str) and ":" in unified_name:
-        return unified_name.split(":", 1)[0]
-    return None
-
-
-def _matches_any(path: str, patterns: list[str]) -> bool:
-    for pattern in patterns:
-        normalized = _normalize_rel_path(pattern)
-        if normalized is None:
-            continue
-        if fnmatch.fnmatch(path, normalized):
-            return True
-        if normalized.endswith("/**"):
-            prefix = normalized[:-3]
-            if path == prefix or path.startswith(f"{prefix}/"):
-                return True
-    return False
 
 
 def extract_scip_blocks(text: str, keyword: str) -> List[str]:
@@ -231,6 +203,9 @@ class SCIPIndexerBase(ABC):
         self.lsp_index_file = self.output_dir / "lsp_index.pkl"
         self.exclude_patterns = exclude_patterns if exclude_patterns else []
         self._target_dir: str | None = None
+        self.decoded_input_receipt: dict[str, object] | None = None
+        self.graph_output_receipt: dict[str, object] | None = None
+        self._capture_artifact_receipts = False
         self.profiler = profiler or Profiler(f"scip_{language}_indexer")
 
         # Path to the scip.proto file (shared across all indexers)
@@ -408,11 +383,18 @@ class SCIPIndexerBase(ABC):
         Returns:
             CodeGraph: Processed graph object
         """
+        self.decoded_input_receipt = None
+        self.graph_output_receipt = None
         if not self.decoded_file.exists():
             logger.error(f"Decoded index file not found at {self.decoded_file}")
             return None
 
         try:
+            if self._capture_artifact_receipts:
+                from ..compiler.artifact_fingerprints import regular_file_fingerprint
+
+                decoded_path = self.decoded_file.resolve(strict=True)
+                decoded_before = regular_file_fingerprint(self.decoded_file)
             logger.info(
                 f"Starting SCIP index processing (backend={self.decoder_backend})..."
             )
@@ -436,6 +418,16 @@ class SCIPIndexerBase(ABC):
                     ),
                 )
             graph.lsp_occurrence_index = occurrence_index
+            if self._capture_artifact_receipts:
+                decoded_after = regular_file_fingerprint(self.decoded_file)
+                if decoded_after != decoded_before:
+                    raise RuntimeError(
+                        "decoded SCIP input changed while graph consumers read it"
+                    )
+                self.decoded_input_receipt = {
+                    "path": str(decoded_path),
+                    **decoded_before,
+                }
 
             # Build line-range indexes once the graph is fully assembled.
             # Must happen before save_graph so the indexes are persisted.
@@ -446,6 +438,15 @@ class SCIPIndexerBase(ABC):
                 with self.profiler.section("process_index.save_graph") as save_section:
                     output_path = Path(output_file)
                     graph.save_graph(str(output_path))
+                    if self._capture_artifact_receipts:
+                        from .query_surface import query_surface_sha256
+
+                        graph_fingerprint = regular_file_fingerprint(output_path)
+                        self.graph_output_receipt = {
+                            "path": str(output_path.resolve(strict=True)),
+                            **graph_fingerprint,
+                            "query_surface_sha256": query_surface_sha256(graph),
+                        }
                     occurrence_index.save(output_path.with_name("lsp_index.pkl"))
                 save_duration = save_section.duration
                 logger.info(f"Saved processed SCIP index to {output_path}")
@@ -465,6 +466,8 @@ class SCIPIndexerBase(ABC):
             return graph
 
         except Exception as e:
+            self.decoded_input_receipt = None
+            self.graph_output_receipt = None
             logger.error(f"Error processing SCIP index: {e}")
             return None
 
@@ -495,9 +498,15 @@ class SCIPIndexerBase(ABC):
             CodeGraph: Processed graph object
         """
         # Use default graph file if output_file not specified
+        self.decoded_input_receipt = None
+        self.graph_output_receipt = None
+        capture_artifact_receipts = kwargs.pop("capture_artifact_receipts", False)
+        if type(capture_artifact_receipts) is not bool:
+            raise ValueError("capture_artifact_receipts must be a boolean")
+        self._capture_artifact_receipts = capture_artifact_receipts
         if output_file is None:
             output_file = str(self.graph_file)
-        self._target_dir = _normalize_rel_path(kwargs.pop("target_dir", None))
+        self._target_dir = normalize_scip_path(kwargs.pop("target_dir", None))
 
         # Check graph cache if skip_level is 'graph'
         if skip_level == "graph" and self.graph_file.exists():
@@ -604,6 +613,7 @@ class SCIPIndexerBase(ABC):
 
             return graph
         finally:
+            self._capture_artifact_receipts = False
             if report_profile:
                 self.profiler.report(reset=reset_profiler)
 
@@ -708,21 +718,14 @@ class SCIPIndexerBase(ABC):
         if node_type in {NODE_TYPE_DIRECTORY, NODE_TYPE_FILE}:
             return self._path_allowed(str(name), allow_target_ancestor=True)
         if is_symbol_node(node_type):
-            path = _definition_path(attrs) or attrs.get("file")
+            path = definition_path(attrs) or attrs.get("file")
             return bool(path and self._path_allowed(str(path)))
         return True
 
     def _path_allowed(self, path: str, *, allow_target_ancestor: bool = False) -> bool:
-        rel_path = _normalize_rel_path(path)
-        if not rel_path:
-            return False
-        if self._target_dir:
-            in_target = rel_path == self._target_dir or rel_path.startswith(
-                f"{self._target_dir}/"
-            )
-            is_target_ancestor = allow_target_ancestor and self._target_dir.startswith(
-                f"{rel_path}/"
-            )
-            if not in_target and not is_target_ancestor:
-                return False
-        return not _matches_any(rel_path, self.exclude_patterns)
+        return scip_path_is_allowed(
+            path,
+            target_dir=self._target_dir,
+            exclude_patterns=self.exclude_patterns,
+            allow_target_ancestor=allow_target_ancestor,
+        )

--- a/codenib/scip_interface/scip_indexer_rust.py
+++ b/codenib/scip_interface/scip_indexer_rust.py
@@ -53,6 +53,31 @@ class SCIPRustIndexer(SCIPIndexerBase):
             language="rust",
             decoder_backend=decoder_backend,
         )
+        self.index_generation_report: Optional[dict] = None
+
+    def _discard_generation_outputs(self) -> bool:
+        """Remove artifacts that must never survive a failed full generation."""
+
+        removed = True
+        for path in (self.index_file, self.decoded_file):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as exc:
+                removed = False
+                logger.error(
+                    "Could not remove stale Rust SCIP artifact %s: %s", path, exc
+                )
+        return removed
+
+    @staticmethod
+    def _generation_report(*, status: str, complete: bool, document_count: int) -> dict:
+        return {
+            "backend": "rust-analyzer-scip",
+            "status": status,
+            "complete": complete,
+            "partial": False,
+            "document_count": document_count,
+        }
 
     def _check_indexer_available(self) -> bool:
         """
@@ -144,19 +169,65 @@ class SCIPRustIndexer(SCIPIndexerBase):
         Returns:
             bool: True if index generation was successful, False otherwise
         """
+        self.index_generation_report = None
+        if not self._discard_generation_outputs():
+            self.index_generation_report = self._generation_report(
+                status="failed", complete=False, document_count=0
+            )
+            return False
+
         # Check if Cargo.toml exists
         cargo_toml = self.project_root / "Cargo.toml"
-        if not cargo_toml.exists():
+        if cargo_toml.is_symlink() or not cargo_toml.is_file():
             logger.error(
                 f"Cargo.toml not found at {cargo_toml}. "
                 "This doesn't appear to be a Rust project."
             )
+            self.index_generation_report = self._generation_report(
+                status="failed", complete=False, document_count=0
+            )
             return False
 
-        return super().generate_index(
-            config_path=config_path,
-            exclude_vendored_libraries=exclude_vendored_libraries,
+        try:
+            success = super().generate_index(
+                config_path=config_path,
+                exclude_vendored_libraries=exclude_vendored_libraries,
+            )
+        except Exception:
+            self._discard_generation_outputs()
+            self.index_generation_report = self._generation_report(
+                status="failed", complete=False, document_count=0
+            )
+            raise
+
+        document_count = self._usable_index_document_count()
+        if success and not self.index_file.is_symlink() and self.index_file.is_file():
+            self.index_generation_report = self._generation_report(
+                status="complete", complete=True, document_count=document_count
+            )
+            return True
+
+        self._discard_generation_outputs()
+        self.index_generation_report = self._generation_report(
+            status="failed", complete=False, document_count=document_count
         )
+        return False
+
+    def _usable_index_document_count(self) -> int:
+        """Count path-addressable documents in a parseable SCIP artifact."""
+
+        if self.index_file.is_symlink() or not self.index_file.is_file():
+            return 0
+        try:
+            from google.protobuf.message import DecodeError
+
+            from .scip_pb2 import Index
+
+            index = Index()
+            index.ParseFromString(self.index_file.read_bytes())
+        except (OSError, DecodeError, ValueError):
+            return 0
+        return sum(bool(document.relative_path) for document in index.documents)
 
     def run_pipeline(
         self,

--- a/codenib/scip_interface/scip_query.py
+++ b/codenib/scip_interface/scip_query.py
@@ -1,0 +1,1318 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Manifest-bound, graph-free access to the native SCIP FactQueryIndex.
+
+This module deliberately has no dependency on ``CodeGraph``, ``igraph``, the
+SCIP indexer facade, or ``LSIndexer``.  It publishes a native candidate only
+when the persisted compiler inputs and the native fact surface are proven to
+match the repository and filter identity recorded by the manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import math
+import re
+import stat
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping, Sequence
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+from ..compiler.artifact_fingerprints import regular_file_fingerprint
+from ..compiler.manifest import MANIFEST_VERSION, IndexEntry, RepoManifest
+from ..languages import graph_indexer_path, normalize_language
+from ..repository_filters import REPOSITORY_FILTER_POLICY_VERSION, walk_repository_files
+from ..source_fingerprint import SourceFingerprint, fingerprint_repository
+from .scip_filter import scip_path_is_allowed
+
+FACT_QUERY_ABI_VERSION = 1
+FACT_QUERY_FORMAT = "fact-query-index-v1"
+FACT_QUERY_CAPABILITIES = {
+    "definition_by_symbol": True,
+    "references_by_symbol": True,
+    "position_queries": False,
+    "route_queries": False,
+}
+FACT_QUERY_PROMOTED_LANGUAGES = frozenset({"python", "rust"})
+_ACTIVE_SCIP_INDEXERS = {
+    "python": "codenib.scip_interface.scip_indexer_python:SCIPPythonIndexer",
+    "rust": "codenib.scip_interface.scip_indexer_rust:SCIPRustIndexer",
+}
+FACT_QUERY_RECEIPT_SCHEMA_VERSION = 1
+SCIP_INPUT_RECEIPT_SCHEMA_VERSION = 1
+FACT_QUERY_FILTER_PROOF_SCHEMA_VERSION = 1
+SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION = 4
+
+_HEX_DIGEST = re.compile(r"[0-9a-f]{64}")
+_SOURCE_FINGERPRINT = re.compile(r"sha256:[0-9a-f]{64}")
+_GIT_COMMIT = re.compile(r"[0-9a-f]{40}")
+_INPUT_RECEIPT_KEYS = frozenset({"schema_version", "index", "metadata"})
+_INPUT_INDEX_KEYS = frozenset({"path", "size_bytes", "sha256"})
+_INPUT_METADATA_KEYS = frozenset({"kind", "complete", "inputs", "internal_crates"})
+_INPUT_FILE_KEYS = frozenset({"path", "size_bytes", "sha256"})
+_INDEX_ENTRY_KEYS = frozenset(
+    {
+        "index_type",
+        "path",
+        "built_at",
+        "built_at_epoch",
+        "status",
+        "config",
+        "metadata",
+        "commit",
+        "source_fingerprint",
+    }
+)
+_GRAPH_ARTIFACT_KEYS = frozenset({"relative_path", "size", "sha256"})
+_FILTER_PROOF_KEYS = frozenset(
+    {
+        "schema_version",
+        "identity",
+        "allowed_file_count",
+        "allowed_files_sha256",
+        "record_count",
+        "directory_count",
+        "file_count",
+        "definition_count",
+        "reference_only_count",
+        "edge_count",
+        "reference_count",
+        "occurrence_count",
+        "query_surface_sha256",
+    }
+)
+_NATIVE_PAYLOAD_KEYS = frozenset(
+    {
+        "format",
+        "index",
+        "native_decode_ns",
+        "native_index_ns",
+        "decode_profile_ns",
+        "graph_materialized",
+        "input_receipt",
+    }
+)
+_SYMBOL_GRAPH_CONFIG_KEYS = frozenset(
+    {
+        "builder_schema",
+        "languages",
+        "graph_route",
+        "exclude_patterns",
+        "allow_partial_languages",
+        "allow_partial_index",
+        "source_coverage_fallback",
+        "target_dir",
+        "repository_filter_policy",
+        "node_count",
+        "edge_count",
+        "language",
+        "available_languages",
+        "compiler_available_languages",
+        "index_generation_reports",
+        "scip_decoded_artifacts",
+        "graph_artifact",
+        "query_surface_sha256",
+        "update_mode",
+        "partial_index",
+        "failed_languages",
+        "partial",
+    }
+)
+
+
+class FactQueryCandidateRejected(ValueError):
+    """Raised when a graph-free candidate cannot prove exact equivalence."""
+
+
+@dataclass(frozen=True, slots=True)
+class NativeFactQueryIndex:
+    """Validated raw native index plus the inputs the decoder actually read."""
+
+    index: Any
+    input_receipt: dict[str, Any]
+    timings: dict[str, float | int]
+
+
+@dataclass(frozen=True, slots=True)
+class FactQueryCandidate:
+    """A manifest-bound native index and its canonical consumer receipt."""
+
+    index: Any
+    receipt: dict[str, Any]
+    timings: dict[str, float | int]
+
+    def __getattr__(self, name: str) -> Any:
+        """Preserve the FactQueryIndex query protocol for existing consumers."""
+
+        return getattr(self.index, name)
+
+
+def _reject(message: str) -> FactQueryCandidateRejected:
+    return FactQueryCandidateRejected(message)
+
+
+def _mapping(value: object, *, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise _reject(f"{label} must be a mapping")
+    if not all(type(key) is str for key in value):
+        raise _reject(f"{label} keys must be strings")
+    return value
+
+
+def _require_exact_keys(
+    value: Mapping[str, Any], expected: frozenset[str], *, label: str
+) -> None:
+    observed = frozenset(value)
+    if observed != expected:
+        missing = sorted(expected - observed)
+        extra = sorted(observed - expected)
+        raise _reject(f"{label} keys mismatch: missing={missing}, extra={extra}")
+
+
+def _nonnegative_int(value: object, *, label: str) -> int:
+    if type(value) is not int or value < 0:
+        raise _reject(f"{label} must be a non-negative integer")
+    return value
+
+
+def _sha256(value: object, *, label: str) -> str:
+    if type(value) is not str or _HEX_DIGEST.fullmatch(value) is None:
+        raise _reject(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _canonical_relative_path(value: object, *, label: str) -> str:
+    if type(value) is not str or not value or "\x00" in value or "\\" in value:
+        raise _reject(f"{label} must be a canonical relative POSIX path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise _reject(f"{label} must be a canonical relative POSIX path")
+    if path.as_posix() != value:
+        raise _reject(f"{label} must be a canonical relative POSIX path")
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise _reject(f"{label} must be UTF-8 encodable") from exc
+    return value
+
+
+def _canonical_json_digest(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _read_stable_file(path: Path, *, label: str) -> tuple[bytes, tuple[int, ...]]:
+    """Read one file generation and return an identity for a final recheck."""
+
+    try:
+        before = path.stat()
+        payload = path.read_bytes()
+        after = path.stat()
+    except (OSError, RuntimeError) as exc:
+        raise _reject(f"{label} is unavailable") from exc
+    before_identity = (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+    )
+    after_identity = (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+    )
+    if before_identity != after_identity or len(payload) != after.st_size:
+        raise _reject(f"{label} changed while it was being read")
+    return payload, after_identity
+
+
+def _allowed_files_digest(paths: Sequence[str]) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        digest.update(path.encode("utf-8"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _checkout_head(project_root: Path) -> str:
+    """Return the live Git HEAD, or ``""`` for a non-Git/unborn checkout."""
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_root), "rev-parse", "--verify", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise _reject("live repository commit could not be observed") from exc
+    if result.returncode != 0:
+        return ""
+    head = result.stdout.strip().lower()
+    if _GIT_COMMIT.fullmatch(head) is None:
+        raise _reject("live repository returned a malformed Git commit")
+    return head
+
+
+def validate_fact_query_contract(contract: Mapping[str, Any]) -> None:
+    """Validate the exact compiled FactQueryIndex v1 capability contract."""
+
+    contract = _mapping(contract, label="FactQueryIndex contract")
+    _require_exact_keys(
+        contract,
+        frozenset(
+            {
+                "abi_version",
+                "format",
+                "requires_anchored_references",
+                "filter_identity_proof_schema_version",
+                "input_receipt_schema_version",
+                "capabilities",
+            }
+        ),
+        label="FactQueryIndex contract",
+    )
+    if type(contract.get("abi_version")) is not int or (
+        contract["abi_version"] != FACT_QUERY_ABI_VERSION
+    ):
+        raise RuntimeError(
+            "compiled FactQueryIndex contract mismatch: expected ABI "
+            f"{FACT_QUERY_ABI_VERSION}, got {contract.get('abi_version')!r}"
+        )
+    if contract.get("format") != FACT_QUERY_FORMAT:
+        raise RuntimeError(
+            "compiled FactQueryIndex contract mismatch: expected format "
+            f"{FACT_QUERY_FORMAT!r}"
+        )
+    if contract.get("requires_anchored_references") is not True:
+        raise RuntimeError(
+            "compiled FactQueryIndex must fail closed on unanchored references"
+        )
+    if type(contract.get("filter_identity_proof_schema_version")) is not int or (
+        contract["filter_identity_proof_schema_version"]
+        != FACT_QUERY_FILTER_PROOF_SCHEMA_VERSION
+    ):
+        raise RuntimeError("compiled FactQueryIndex filter proof schema is not v1")
+    if type(contract.get("input_receipt_schema_version")) is not int or (
+        contract["input_receipt_schema_version"] != SCIP_INPUT_RECEIPT_SCHEMA_VERSION
+    ):
+        raise RuntimeError("compiled FactQueryIndex input receipt schema is not v1")
+    capabilities = _mapping(
+        contract.get("capabilities"), label="FactQueryIndex capabilities"
+    )
+    if dict(capabilities) != FACT_QUERY_CAPABILITIES:
+        raise RuntimeError("compiled FactQueryIndex capabilities do not match v1")
+
+
+def _validate_file_receipt(
+    value: object,
+    *,
+    label: str,
+    root: Path | None = None,
+) -> dict[str, Any]:
+    receipt = _mapping(value, label=label)
+    _require_exact_keys(receipt, _INPUT_FILE_KEYS, label=label)
+    relative = _canonical_relative_path(receipt["path"], label=f"{label}.path")
+    size = _nonnegative_int(receipt["size_bytes"], label=f"{label}.size_bytes")
+    digest = _sha256(receipt["sha256"], label=f"{label}.sha256")
+    if root is not None:
+        path = root / relative
+        try:
+            observed = regular_file_fingerprint(path)
+        except (OSError, ValueError) as exc:
+            raise _reject(f"{label} no longer names a regular input file") from exc
+        if observed != {"size": size, "sha256": digest}:
+            raise _reject(f"{label} changed after native decode")
+    return {"path": relative, "size_bytes": size, "sha256": digest}
+
+
+def _legacy_rust_cargo_identity(project_root: Path) -> tuple[list[str], list[str]]:
+    """Recompute the serial Rust decoder's Cargo input and crate identity."""
+
+    root_cargo = project_root / "Cargo.toml"
+    if root_cargo.is_symlink() or not root_cargo.is_file():
+        raise _reject("Rust project root has no regular Cargo.toml")
+    try:
+        with root_cargo.open("rb") as handle:
+            cargo_data = tomllib.load(handle)
+    except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
+        raise _reject("Rust root Cargo.toml cannot be parsed exactly") from exc
+    if not isinstance(cargo_data, Mapping):
+        raise _reject("Rust root Cargo.toml is not a table")
+    workspace = cargo_data.get("workspace", {})
+    package = cargo_data.get("package", {})
+    if not isinstance(workspace, Mapping) or not isinstance(package, Mapping):
+        raise _reject("Rust Cargo workspace/package metadata is malformed")
+    member_patterns = workspace.get("members", [])
+    if type(member_patterns) is not list:
+        raise _reject("Rust workspace.members must be an array")
+
+    root_name = package.get("name")
+    if root_name is not None and (type(root_name) is not str or not root_name):
+        raise _reject("Rust root package name is malformed")
+    crates: set[str] = {root_name} if root_name else set()
+    inputs = {"Cargo.toml"}
+    for raw_pattern in member_patterns:
+        pattern = str(raw_pattern).strip().rstrip("/")
+        if not pattern or pattern.startswith("/"):
+            continue
+        try:
+            members = list(project_root.glob(pattern))
+        except (ValueError, IndexError, OSError) as exc:
+            raise _reject("Rust workspace member glob cannot be proven") from exc
+        for member_dir in members:
+            if not member_dir.is_dir():
+                continue
+            member_cargo = member_dir / "Cargo.toml"
+            if not member_cargo.exists():
+                continue
+            try:
+                relative = member_cargo.relative_to(project_root).as_posix()
+                relative = _canonical_relative_path(
+                    relative, label="Rust workspace Cargo.toml path"
+                )
+                if member_cargo.is_symlink() or not member_cargo.is_file():
+                    raise _reject("Rust workspace Cargo.toml is not a regular file")
+                with member_cargo.open("rb") as handle:
+                    member_data = tomllib.load(handle)
+            except FactQueryCandidateRejected:
+                raise
+            except (OSError, ValueError, tomllib.TOMLDecodeError):
+                # This exactly mirrors the serial decoder: an unreadable member
+                # contributes neither an input nor an internal crate.
+                continue
+            if not isinstance(member_data, Mapping):
+                continue
+            member_package = member_data.get("package", {})
+            if not isinstance(member_package, Mapping):
+                continue
+            crate_name = member_package.get("name")
+            if crate_name is not None and (
+                type(crate_name) is not str or not crate_name
+            ):
+                raise _reject("Rust workspace package name is malformed")
+            inputs.add(relative)
+            if crate_name:
+                crates.add(crate_name)
+    return (
+        sorted(inputs, key=lambda item: item.encode("utf-8")),
+        sorted(crates),
+    )
+
+
+def _validate_input_receipt(
+    value: object,
+    *,
+    index_path: Path,
+    project_root: Path | None,
+    language: str,
+) -> dict[str, Any]:
+    receipt = _mapping(value, label="native input receipt")
+    _require_exact_keys(receipt, _INPUT_RECEIPT_KEYS, label="native input receipt")
+    if (
+        receipt.get("schema_version") != SCIP_INPUT_RECEIPT_SCHEMA_VERSION
+        or type(receipt.get("schema_version")) is not int
+    ):
+        raise _reject("native input receipt schema is not v1")
+
+    index = _mapping(receipt.get("index"), label="native input receipt.index")
+    _require_exact_keys(index, _INPUT_INDEX_KEYS, label="native input receipt.index")
+    recorded_path = index.get("path")
+    if type(recorded_path) is not str or recorded_path != str(index_path):
+        raise _reject("native input receipt does not bind the resolved index path")
+    index_size = _nonnegative_int(
+        index.get("size_bytes"), label="native input receipt.index.size_bytes"
+    )
+    index_digest = _sha256(
+        index.get("sha256"), label="native input receipt.index.sha256"
+    )
+    try:
+        observed_index = regular_file_fingerprint(index_path)
+    except (OSError, ValueError) as exc:
+        raise _reject("native input index changed after decode") from exc
+    if observed_index != {"size": index_size, "sha256": index_digest}:
+        raise _reject("native input receipt does not match the decoded index")
+
+    metadata = _mapping(receipt.get("metadata"), label="native input receipt.metadata")
+    _require_exact_keys(
+        metadata, _INPUT_METADATA_KEYS, label="native input receipt.metadata"
+    )
+    expected_kind = "rust-cargo" if language == "rust" else "none"
+    if metadata.get("kind") != expected_kind:
+        raise _reject("native input receipt metadata kind does not match the language")
+    if metadata.get("complete") is not True:
+        raise _reject("native decoder metadata inputs are incomplete")
+
+    raw_inputs = metadata.get("inputs")
+    if type(raw_inputs) is not list:
+        raise _reject("native input receipt.metadata.inputs must be a list")
+    inputs = [
+        _validate_file_receipt(
+            item,
+            label=f"native input receipt.metadata.inputs[{position}]",
+            root=project_root,
+        )
+        for position, item in enumerate(raw_inputs)
+    ]
+    input_paths = [item["path"] for item in inputs]
+    if input_paths != sorted(input_paths, key=lambda item: item.encode("utf-8")) or len(
+        input_paths
+    ) != len(set(input_paths)):
+        raise _reject("native metadata input paths must be unique and sorted")
+
+    raw_crates = metadata.get("internal_crates")
+    if type(raw_crates) is not list or not all(
+        type(crate) is str and crate for crate in raw_crates
+    ):
+        raise _reject("native internal crate names must be non-empty strings")
+    crates = list(raw_crates)
+    if crates != sorted(crates) or len(crates) != len(set(crates)):
+        raise _reject("native internal crate names must be unique and sorted")
+    if language == "rust":
+        if project_root is None or not inputs:
+            raise _reject("Rust native decode did not prove its Cargo inputs")
+        expected_inputs, expected_crates = _legacy_rust_cargo_identity(project_root)
+        if input_paths != expected_inputs or crates != expected_crates:
+            raise _reject(
+                "native Cargo identity does not match the serial Rust decoder"
+            )
+    elif inputs or crates:
+        raise _reject("non-Rust native decode unexpectedly read Cargo metadata")
+
+    return {
+        "schema_version": SCIP_INPUT_RECEIPT_SCHEMA_VERSION,
+        "index": {
+            "path": str(index_path),
+            "size_bytes": index_size,
+            "sha256": index_digest,
+        },
+        "metadata": {
+            "kind": expected_kind,
+            "complete": True,
+            "inputs": inputs,
+            "internal_crates": crates,
+        },
+    }
+
+
+def decode_native_fact_query_index(
+    *,
+    index_file: str | Path,
+    project_root: str | Path | None,
+    language: str,
+    core_module: Any | None = None,
+) -> NativeFactQueryIndex:
+    """Decode and validate a raw graph-free index without importing graph code.
+
+    This is the compatibility primitive used by ``SCIPDecoderCore``.  It proves
+    what the native decoder read, but only :func:`load_fact_query_candidate`
+    additionally binds the index to compiler source and filter identity.
+    """
+
+    canonical_language = normalize_language(language)
+    if canonical_language is None:
+        raise ValueError(f"unsupported FactQueryIndex language: {language!r}")
+    raw_index_path = Path(index_file).expanduser()
+    if raw_index_path.is_symlink():
+        raise _reject("FactQueryIndex input must be a regular, non-symlink file")
+    try:
+        index_path = raw_index_path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise _reject("FactQueryIndex input file is unavailable") from exc
+    if not index_path.is_file():
+        raise _reject("FactQueryIndex input must be a regular, non-symlink file")
+    try:
+        root = (
+            Path(project_root).expanduser().resolve(strict=True)
+            if project_root is not None
+            else None
+        )
+    except (OSError, RuntimeError) as exc:
+        raise _reject("FactQueryIndex project root is unavailable") from exc
+    if root is not None and not root.is_dir():
+        raise _reject("FactQueryIndex project root must be a directory")
+
+    core = core_module or importlib.import_module("codenib_core")
+    if not hasattr(core, "decode_scip_fact_query_index") or not hasattr(
+        core, "fact_query_index_contract"
+    ):
+        raise RuntimeError("compiled core does not expose FactQueryIndex v1")
+    validate_fact_query_contract(core.fact_query_index_contract())
+
+    started = time.perf_counter()
+    payload = core.decode_scip_fact_query_index(
+        index_file=str(index_path),
+        project_root=str(root) if root is not None else None,
+        language=canonical_language,
+    )
+    binding_seconds = time.perf_counter() - started
+    payload = _mapping(payload, label="native FactQueryIndex payload")
+    _require_exact_keys(payload, _NATIVE_PAYLOAD_KEYS, label="native payload")
+    if payload.get("format") != FACT_QUERY_FORMAT:
+        raise _reject("native FactQueryIndex returned an unknown format")
+    if payload.get("graph_materialized") is not False:
+        raise _reject("native FactQueryIndex unexpectedly materialized a graph")
+
+    index = payload.get("index")
+    if index is None or getattr(index, "fact_query_index", None) is not True:
+        raise _reject("native FactQueryIndex payload is missing its index")
+    if getattr(index, "materializes_graph", None) is not False:
+        raise _reject("native FactQueryIndex does not guarantee graph-free use")
+    if getattr(index, "capabilities", None) != FACT_QUERY_CAPABILITIES:
+        raise _reject("native FactQueryIndex capabilities do not match v1")
+
+    input_receipt = _validate_input_receipt(
+        payload.get("input_receipt"),
+        index_path=index_path,
+        project_root=root,
+        language=canonical_language,
+    )
+    native_decode_ns = _nonnegative_int(
+        payload.get("native_decode_ns"), label="native_decode_ns"
+    )
+    native_index_ns = _nonnegative_int(
+        payload.get("native_index_ns"), label="native_index_ns"
+    )
+    profile = _mapping(payload.get("decode_profile_ns"), label="decode_profile_ns")
+    profile_values: dict[str, int] = {}
+    for name, value in profile.items():
+        profile_values[name] = _nonnegative_int(
+            value, label=f"decode_profile_ns[{name!r}]"
+        )
+
+    native_decode = native_decode_ns / 1_000_000_000
+    native_index = native_index_ns / 1_000_000_000
+    timings: dict[str, float | int] = {
+        "core_decode": binding_seconds,
+        "native_decode": native_decode,
+        "native_fact_query_index": native_index,
+        "boundary_transport_residual": max(
+            0.0, binding_seconds - native_decode - native_index
+        ),
+        "node_count": _nonnegative_int(
+            getattr(index, "record_count", None), label="index.record_count"
+        ),
+        "edge_count": _nonnegative_int(
+            getattr(index, "edge_count", None), label="index.edge_count"
+        ),
+        "definition_symbol_count": _nonnegative_int(
+            getattr(index, "symbol_count", None), label="index.symbol_count"
+        ),
+        "reference_count": _nonnegative_int(
+            getattr(index, "reference_count", None), label="index.reference_count"
+        ),
+        "occurrence_count": _nonnegative_int(
+            getattr(index, "occurrence_count", None), label="index.occurrence_count"
+        ),
+    }
+    for name, nanoseconds in profile_values.items():
+        timings[f"native_{name}"] = (
+            nanoseconds
+            if name in {"worker_count", "document_count"}
+            else nanoseconds / 1_000_000_000
+        )
+    return NativeFactQueryIndex(
+        index=index,
+        input_receipt=input_receipt,
+        timings=timings,
+    )
+
+
+def _manifest_language(
+    manifest: RepoManifest, entry: IndexEntry, requested: str | None
+) -> tuple[str, list[str]]:
+    languages = entry.config.get("languages")
+    if type(languages) is not list or not all(type(item) is str for item in languages):
+        raise _reject("symbol graph manifest languages are missing or malformed")
+    canonical = [normalize_language(item) for item in languages]
+    if len(canonical) != 1 or canonical[0] is None:
+        raise _reject("FactQueryIndex v1 requires one canonical graph language")
+    language = canonical[0]
+    if language not in FACT_QUERY_PROMOTED_LANGUAGES:
+        raise _reject(f"FactQueryIndex is not promoted for {language!r}")
+    if graph_indexer_path(language) != _ACTIVE_SCIP_INDEXERS[language]:
+        raise _reject(f"FactQueryIndex requires the active SCIP route for {language!r}")
+    if requested is not None and normalize_language(requested) != language:
+        raise _reject("requested language does not match the symbol graph manifest")
+    if manifest.languages != [language]:
+        raise _reject("FactQueryIndex v1 requires a single-language manifest")
+    if languages != [language]:
+        raise _reject("symbol graph language must use its canonical registry name")
+    return language, list(languages)
+
+
+def _validate_builder_entry(
+    manifest: RepoManifest,
+    entry: IndexEntry,
+    *,
+    requested_language: str | None,
+) -> tuple[str, list[str], int, int, int, str]:
+    if entry.index_type != "symbol_graph":
+        raise _reject("symbol graph manifest entry has the wrong index type")
+    if entry.status != "fresh" or not manifest.index_is_current("symbol_graph"):
+        raise _reject("symbol graph manifest entry is not current")
+    language, languages = _manifest_language(manifest, entry, requested_language)
+    config = _mapping(entry.config, label="symbol graph config")
+    metadata = _mapping(entry.metadata, label="symbol graph metadata")
+    if set(config) != _SYMBOL_GRAPH_CONFIG_KEYS:
+        raise _reject("symbol graph config fields do not match builder schema v4")
+    if set(metadata) != set(config) | {"build_duration_seconds"}:
+        raise _reject(
+            "symbol graph config/metadata fields are not an exact build record"
+        )
+    duration = metadata.get("build_duration_seconds")
+    if (
+        type(duration) not in {int, float}
+        or not math.isfinite(duration)
+        or duration < 0
+    ):
+        raise _reject("symbol graph build duration is malformed")
+    for key, value in config.items():
+        if (
+            key not in metadata
+            or metadata[key] != value
+            or type(metadata[key]) is not type(value)
+        ):
+            raise _reject(f"symbol graph config/metadata disagree for field {key!r}")
+
+    required_config = {
+        "builder_schema": SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION,
+        "languages": languages,
+        "graph_route": "active",
+        "allow_partial_languages": False,
+        "allow_partial_index": False,
+        "source_coverage_fallback": False,
+        "target_dir": None,
+        "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+    }
+    for key, expected in required_config.items():
+        if (
+            key not in config
+            or config[key] != expected
+            or type(config[key]) is not type(expected)
+        ):
+            raise _reject(f"symbol graph config {key!r} is not candidate-safe")
+
+    patterns = config.get("exclude_patterns")
+    if type(patterns) is not list or not all(type(item) is str for item in patterns):
+        raise _reject("symbol graph exclude_patterns are malformed")
+    if patterns != sorted(patterns):
+        raise _reject("symbol graph exclude_patterns must be sorted")
+    node_count = _nonnegative_int(config.get("node_count"), label="graph node_count")
+    edge_count = _nonnegative_int(config.get("edge_count"), label="graph edge_count")
+    query_surface_digest = _sha256(
+        config.get("query_surface_sha256"), label="graph query_surface_sha256"
+    )
+    if node_count == 0:
+        raise _reject("symbol graph manifest records an empty graph")
+
+    required_metadata = {
+        **required_config,
+        "exclude_patterns": patterns,
+        "language": language,
+        "available_languages": [language],
+        "compiler_available_languages": [language],
+        "failed_languages": {},
+        "partial": False,
+        "partial_index": False,
+        "update_mode": "full_rebuild",
+    }
+    for key, expected in required_metadata.items():
+        if (
+            key not in metadata
+            or metadata[key] != expected
+            or type(metadata[key]) is not type(expected)
+        ):
+            raise _reject(f"symbol graph metadata {key!r} is not candidate-safe")
+    if "source_coverage_report" in metadata:
+        raise _reject("source coverage fallback artifacts cannot publish a candidate")
+
+    reports = metadata.get("index_generation_reports")
+    if not isinstance(reports, Mapping):
+        raise _reject("symbol graph index generation reports are missing")
+    if set(reports) != {language}:
+        raise _reject(f"{language} graph build must have one generation report")
+    report = _mapping(
+        reports[language], label=f"index generation report for {language}"
+    )
+    if set(report) != {
+        "backend",
+        "status",
+        "complete",
+        "partial",
+        "document_count",
+    }:
+        raise _reject(f"{language} graph generation report fields are malformed")
+    expected_backend = "scip-python" if language == "python" else "rust-analyzer-scip"
+    if (
+        report.get("backend") != expected_backend
+        or report.get("partial") is not False
+        or report.get("complete") is not True
+        or report.get("status") != "complete"
+    ):
+        raise _reject("symbol graph compiler index is not complete")
+    document_count = _nonnegative_int(
+        report.get("document_count"), label=f"{language} graph document_count"
+    )
+    if document_count == 0:
+        raise _reject("symbol graph generation report has no source documents")
+    return (
+        language,
+        patterns,
+        node_count,
+        edge_count,
+        document_count,
+        query_surface_digest,
+    )
+
+
+def _resolve_artifact(
+    entry: IndexEntry,
+    *,
+    language: str,
+    expected_root: Path,
+) -> tuple[Path, str, dict[str, Any]]:
+    entry_root_raw = Path(entry.path).expanduser()
+    if not entry_root_raw.is_absolute() or entry_root_raw.is_symlink():
+        raise _reject("symbol graph entry path must be an absolute artifact directory")
+    if entry_root_raw != expected_root:
+        raise _reject("symbol graph entry path is not the manifest symbol_graph view")
+    try:
+        entry_root = entry_root_raw.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise _reject("symbol graph artifact directory is unavailable") from exc
+    if not entry_root.is_dir():
+        raise _reject("symbol graph artifact path is not a directory")
+
+    config_artifacts = _mapping(
+        entry.config.get("scip_decoded_artifacts"),
+        label="symbol graph SCIP artifact records",
+    )
+    metadata_artifacts = _mapping(
+        entry.metadata.get("scip_decoded_artifacts"),
+        label="symbol graph SCIP artifact metadata",
+    )
+    if dict(config_artifacts) != dict(metadata_artifacts):
+        raise _reject("symbol graph SCIP artifact records disagree")
+    if set(config_artifacts) != {language}:
+        raise _reject("manifest does not bind one decoded SCIP artifact")
+    record = _mapping(
+        config_artifacts[language], label=f"decoded SCIP artifact for {language}"
+    )
+    _require_exact_keys(
+        record,
+        frozenset({"relative_path", "size", "sha256"}),
+        label=f"decoded SCIP artifact for {language}",
+    )
+    relative = _canonical_relative_path(
+        record.get("relative_path"), label="decoded SCIP artifact relative_path"
+    )
+    if relative != "index.decoded":
+        raise _reject("single-language SCIP artifact must be index.decoded")
+    size = _nonnegative_int(record.get("size"), label="decoded SCIP artifact size")
+    digest = _sha256(record.get("sha256"), label="decoded SCIP artifact sha256")
+    artifact = entry_root / relative
+    try:
+        resolved = artifact.resolve(strict=True)
+        resolved.relative_to(entry_root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise _reject("decoded SCIP artifact escapes its manifest directory") from exc
+    if artifact.is_symlink() or not resolved.is_file():
+        raise _reject("decoded SCIP artifact must be a regular, non-symlink file")
+    expected = {"size": size, "sha256": digest}
+    try:
+        observed = regular_file_fingerprint(resolved)
+    except (OSError, ValueError) as exc:
+        raise _reject("decoded SCIP artifact could not be fingerprinted") from exc
+    if observed != expected:
+        raise _reject("decoded SCIP artifact does not match its manifest fingerprint")
+    return resolved, relative, expected
+
+
+def _resolve_graph_artifact(
+    entry: IndexEntry,
+    *,
+    expected_root: Path,
+) -> tuple[Path, dict[str, Any]]:
+    record = _mapping(
+        entry.config.get("graph_artifact"), label="symbol graph artifact record"
+    )
+    _require_exact_keys(record, _GRAPH_ARTIFACT_KEYS, label="symbol graph artifact")
+    relative = _canonical_relative_path(
+        record.get("relative_path"), label="symbol graph artifact relative_path"
+    )
+    if relative != "graph.pkl":
+        raise _reject("symbol graph artifact must be graph.pkl")
+    size = _nonnegative_int(record.get("size"), label="symbol graph artifact size")
+    digest = _sha256(record.get("sha256"), label="symbol graph artifact sha256")
+    artifact = expected_root / relative
+    try:
+        resolved = artifact.resolve(strict=True)
+        resolved.relative_to(expected_root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise _reject("symbol graph artifact escapes its manifest directory") from exc
+    if artifact.is_symlink() or not resolved.is_file():
+        raise _reject("symbol graph artifact must be a regular, non-symlink file")
+    expected = {"size": size, "sha256": digest}
+    try:
+        observed = regular_file_fingerprint(resolved)
+    except (OSError, ValueError) as exc:
+        raise _reject("symbol graph artifact could not be fingerprinted") from exc
+    if observed != expected:
+        raise _reject("symbol graph artifact does not match its manifest fingerprint")
+    return resolved, expected
+
+
+def _source_and_allowed_files(
+    project_root: Path,
+    *,
+    cache_root: Path,
+    exclude_patterns: Iterable[str],
+    target_dir: str | None,
+) -> tuple[SourceFingerprint, list[str]]:
+    source = fingerprint_repository(project_root, exclude_roots=(cache_root,))
+    allowed: list[str] = []
+    seen: set[str] = set()
+    for path in walk_repository_files(project_root, exclude_roots=(cache_root,)):
+        try:
+            mode = path.lstat().st_mode
+        except OSError as exc:
+            raise _reject("repository file disappeared during traversal") from exc
+        if not (stat.S_ISREG(mode) or stat.S_ISLNK(mode)):
+            continue
+        relative = _canonical_relative_path(
+            path.relative_to(project_root).as_posix(), label="repository file path"
+        )
+        if not scip_path_is_allowed(
+            relative,
+            target_dir=target_dir,
+            exclude_patterns=exclude_patterns,
+            enforce_repository_policy=True,
+        ):
+            continue
+        if relative in seen:
+            raise _reject("repository traversal returned a duplicate path")
+        seen.add(relative)
+        allowed.append(relative)
+    allowed.sort(key=lambda item: item.encode("utf-8"))
+    return source, allowed
+
+
+def _validate_filter_proof(
+    value: object,
+    *,
+    allowed_files: Sequence[str],
+    native: NativeFactQueryIndex,
+    expected_record_count: int,
+    expected_edge_count: int,
+    expected_query_surface_sha256: str,
+) -> dict[str, Any]:
+    proof = _mapping(value, label="native filter identity proof")
+    _require_exact_keys(proof, _FILTER_PROOF_KEYS, label="native filter proof")
+    if (
+        proof.get("schema_version") != FACT_QUERY_FILTER_PROOF_SCHEMA_VERSION
+        or type(proof.get("schema_version")) is not int
+    ):
+        raise _reject("native filter identity proof schema is not v1")
+    if proof.get("identity") is not True:
+        raise _reject("native fact surface did not prove filter identity")
+
+    counts: dict[str, int] = {}
+    for key in _FILTER_PROOF_KEYS - {
+        "schema_version",
+        "identity",
+        "allowed_files_sha256",
+        "query_surface_sha256",
+    }:
+        counts[key] = _nonnegative_int(proof.get(key), label=f"filter proof {key}")
+    expected_digest = _allowed_files_digest(allowed_files)
+    if (
+        counts["allowed_file_count"] != len(allowed_files)
+        or _sha256(
+            proof.get("allowed_files_sha256"), label="filter proof allowed_files_sha256"
+        )
+        != expected_digest
+    ):
+        raise _reject("native filter proof does not bind the allowed file set")
+    proof_query_surface = _sha256(
+        proof.get("query_surface_sha256"), label="filter proof query_surface_sha256"
+    )
+    if proof_query_surface != expected_query_surface_sha256:
+        raise _reject("native query surface disagrees with the compiled symbol graph")
+    if counts["record_count"] != native.timings["node_count"]:
+        raise _reject("native filter proof record count disagrees with the index")
+    if counts["record_count"] != expected_record_count:
+        raise _reject("native filter proof record count disagrees with the manifest")
+    if counts["edge_count"] != native.timings["edge_count"]:
+        raise _reject("native filter proof edge count disagrees with the index")
+    if counts["edge_count"] != expected_edge_count:
+        raise _reject("native filter proof edge count disagrees with the manifest")
+    if counts["definition_count"] != native.timings["definition_symbol_count"]:
+        raise _reject("native filter proof definition count disagrees with the index")
+    if counts["reference_count"] != native.timings["reference_count"]:
+        raise _reject("native filter proof reference count disagrees with the index")
+    if counts["file_count"] > counts["allowed_file_count"]:
+        raise _reject("native filter proof contains more files than were allowed")
+    if counts["file_count"] == 0 or counts["definition_count"] == 0:
+        raise _reject("native filter proof has no queryable source definitions")
+    if (
+        1
+        + counts["directory_count"]
+        + counts["file_count"]
+        + counts["definition_count"]
+        + counts["reference_only_count"]
+        != counts["record_count"]
+    ):
+        raise _reject("native filter proof contains an unknown record class")
+    if counts["occurrence_count"] != 0:
+        raise _reject("native filter proof occurrence count must be zero")
+    if counts["occurrence_count"] != native.timings["occurrence_count"]:
+        raise _reject("native filter proof occurrence count disagrees with the index")
+    return {
+        "schema_version": FACT_QUERY_FILTER_PROOF_SCHEMA_VERSION,
+        "identity": True,
+        "allowed_files_sha256": expected_digest,
+        "query_surface_sha256": proof_query_surface,
+        **counts,
+    }
+
+
+def load_fact_query_candidate(
+    manifest_path: str | Path,
+    *,
+    language: str | None = None,
+    project_root: str | Path | None = None,
+    core_module: Any | None = None,
+) -> FactQueryCandidate:
+    """Load one consumer-safe native candidate or reject the whole attempt.
+
+    No row-level filtering or fallback occurs here.  Callers that want a full
+    graph fallback must perform it outside this graph-free module after a
+    rejection.
+    """
+
+    total_started = time.perf_counter()
+    raw_manifest_path = Path(manifest_path).expanduser()
+    if raw_manifest_path.is_symlink():
+        raise _reject("RepoManifest must be a regular, non-symlink file")
+    try:
+        resolved_manifest = raw_manifest_path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise _reject("RepoManifest is unavailable") from exc
+    if not resolved_manifest.is_file():
+        raise _reject("RepoManifest must be a regular, non-symlink file")
+    manifest_bytes, manifest_stat_identity = _read_stable_file(
+        resolved_manifest, label="RepoManifest"
+    )
+    manifest_file_fingerprint = {
+        "size": len(manifest_bytes),
+        "sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+    }
+    try:
+        raw_manifest = json.loads(manifest_bytes.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise _reject("RepoManifest is not readable canonical JSON") from exc
+    raw_manifest = _mapping(raw_manifest, label="RepoManifest")
+    if (
+        type(raw_manifest.get("version")) is not str
+        or raw_manifest.get("version") != MANIFEST_VERSION
+    ):
+        raise _reject("RepoManifest must explicitly record version 1.1")
+    raw_repo = _mapping(raw_manifest.get("repo"), label="RepoManifest.repo")
+    for required in ("path", "commit", "source_fingerprint", "file_count"):
+        if required not in raw_repo:
+            raise _reject(f"RepoManifest.repo is missing {required!r}")
+    if type(raw_repo["path"]) is not str or not raw_repo["path"]:
+        raise _reject("RepoManifest repository path is malformed")
+    if type(raw_repo["commit"]) is not str or (
+        raw_repo["commit"] and _GIT_COMMIT.fullmatch(raw_repo["commit"]) is None
+    ):
+        raise _reject("RepoManifest commit is malformed")
+    if (
+        type(raw_repo["source_fingerprint"]) is not str
+        or _SOURCE_FINGERPRINT.fullmatch(raw_repo["source_fingerprint"]) is None
+    ):
+        raise _reject("RepoManifest source fingerprint is malformed")
+    if type(raw_repo["file_count"]) is not int or raw_repo["file_count"] < 0:
+        raise _reject("RepoManifest file_count is malformed")
+    raw_indexes = _mapping(raw_manifest.get("indexes"), label="RepoManifest.indexes")
+    raw_entry = _mapping(
+        raw_indexes.get("symbol_graph"), label="RepoManifest symbol_graph entry"
+    )
+    _require_exact_keys(
+        raw_entry, _INDEX_ENTRY_KEYS, label="RepoManifest symbol_graph entry"
+    )
+    if raw_entry.get("index_type") != "symbol_graph":
+        raise _reject("RepoManifest symbol_graph index_type is malformed")
+    if type(raw_entry.get("path")) is not str or not raw_entry["path"]:
+        raise _reject("RepoManifest symbol_graph path is malformed")
+    if type(raw_entry.get("built_at")) is not str or not raw_entry["built_at"]:
+        raise _reject("RepoManifest symbol_graph built_at is malformed")
+    built_at_epoch = raw_entry.get("built_at_epoch")
+    if (
+        type(built_at_epoch) not in {int, float}
+        or not math.isfinite(built_at_epoch)
+        or built_at_epoch < 0
+    ):
+        raise _reject("RepoManifest symbol_graph built_at_epoch is malformed")
+    if raw_entry.get("status") != "fresh":
+        raise _reject("RepoManifest symbol_graph status is not fresh")
+    _mapping(raw_entry.get("config"), label="RepoManifest symbol_graph config")
+    _mapping(raw_entry.get("metadata"), label="RepoManifest symbol_graph metadata")
+    raw_entry_commit = raw_entry.get("commit")
+    if type(raw_entry_commit) is not str or (
+        raw_entry_commit and _GIT_COMMIT.fullmatch(raw_entry_commit) is None
+    ):
+        raise _reject("RepoManifest symbol_graph commit is malformed")
+    if raw_entry_commit != raw_repo["commit"]:
+        raise _reject("RepoManifest symbol_graph commit provenance is incomplete")
+    raw_entry_source = raw_entry.get("source_fingerprint")
+    if (
+        type(raw_entry_source) is not str
+        or _SOURCE_FINGERPRINT.fullmatch(raw_entry_source) is None
+    ):
+        raise _reject("RepoManifest symbol_graph source fingerprint is malformed")
+    if raw_entry_source != raw_repo["source_fingerprint"]:
+        raise _reject(
+            "RepoManifest symbol_graph source fingerprint provenance is incomplete"
+        )
+    try:
+        manifest = RepoManifest.from_dict(dict(raw_manifest))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise _reject("RepoManifest fields are malformed") from exc
+    if manifest.version != MANIFEST_VERSION:
+        raise _reject(
+            f"RepoManifest version must be {MANIFEST_VERSION!r} for FactQueryIndex"
+        )
+    if type(manifest.file_count) is not int or manifest.file_count < 0:
+        raise _reject("RepoManifest file_count is malformed")
+    if type(manifest.source_fingerprint) is not str or not manifest.source_fingerprint:
+        raise _reject("RepoManifest source fingerprint is missing")
+
+    try:
+        manifest_root = Path(manifest.repo_path).expanduser().resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise _reject("RepoManifest repository path is unavailable") from exc
+    if not manifest_root.is_dir():
+        raise _reject("RepoManifest repository path is not a directory")
+    if project_root is not None:
+        try:
+            supplied_root = Path(project_root).expanduser().resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise _reject("supplied repository root is unavailable") from exc
+        if supplied_root != manifest_root:
+            raise _reject("supplied repository root does not match RepoManifest")
+
+    entry = manifest.indexes.get("symbol_graph")
+    if entry is None:
+        raise _reject("RepoManifest has no symbol graph entry")
+    (
+        canonical_language,
+        exclude_patterns,
+        node_count,
+        edge_count,
+        document_count,
+        query_surface_digest,
+    ) = _validate_builder_entry(manifest, entry, requested_language=language)
+    artifact_root = resolved_manifest.parent / "symbol_graph"
+    index_path, index_relative, expected_index = _resolve_artifact(
+        entry,
+        language=canonical_language,
+        expected_root=artifact_root,
+    )
+    graph_path, expected_graph = _resolve_graph_artifact(
+        entry,
+        expected_root=artifact_root,
+    )
+    cache_root = resolved_manifest.parent.resolve()
+    checkout_head_before = _checkout_head(manifest_root)
+    if checkout_head_before != manifest.commit:
+        raise _reject("live repository commit does not match RepoManifest")
+    source_before, allowed_files = _source_and_allowed_files(
+        manifest_root,
+        cache_root=cache_root,
+        exclude_patterns=exclude_patterns,
+        target_dir=None,
+    )
+    if (
+        source_before.value != manifest.source_fingerprint
+        or source_before.file_count != manifest.file_count
+        or entry.source_fingerprint != manifest.source_fingerprint
+        or entry.commit != manifest.commit
+    ):
+        raise _reject("repository source does not match the symbol graph manifest")
+    source_before_decode = fingerprint_repository(
+        manifest_root, exclude_roots=(cache_root,)
+    )
+    if source_before_decode != source_before:
+        raise _reject("repository source changed while computing allowed files")
+
+    native = decode_native_fact_query_index(
+        index_file=index_path,
+        project_root=manifest_root,
+        language=canonical_language,
+        core_module=core_module,
+    )
+    native_index = native.input_receipt["index"]
+    if (
+        native_index["size_bytes"] != expected_index["size"]
+        or native_index["sha256"] != expected_index["sha256"]
+    ):
+        raise _reject("native decoder read a different index generation")
+    if native.timings.get("native_document_count") != document_count:
+        raise _reject(
+            "native decoder document count disagrees with the generation report"
+        )
+    allowed_file_set = set(allowed_files)
+    for metadata_input in native.input_receipt["metadata"]["inputs"]:
+        if metadata_input["path"] not in allowed_file_set:
+            raise _reject(
+                "native metadata input is outside the manifest source surface"
+            )
+
+    prove = getattr(native.index, "prove_filter_identity", None)
+    if not callable(prove):
+        raise _reject("native FactQueryIndex cannot prove filter identity")
+    try:
+        raw_proof = prove(list(allowed_files), query_surface_digest)
+    except (TypeError, ValueError) as exc:
+        raise _reject("native filter identity proof rejected candidate") from exc
+    proof = _validate_filter_proof(
+        raw_proof,
+        allowed_files=allowed_files,
+        native=native,
+        expected_record_count=node_count,
+        expected_edge_count=edge_count,
+        expected_query_surface_sha256=query_surface_digest,
+    )
+
+    source_after = fingerprint_repository(manifest_root, exclude_roots=(cache_root,))
+    try:
+        index_after = regular_file_fingerprint(index_path)
+        graph_after = regular_file_fingerprint(graph_path)
+    except (OSError, ValueError) as exc:
+        raise _reject("symbol graph artifacts disappeared during construction") from exc
+    if source_after != source_before:
+        raise _reject("repository source changed during candidate construction")
+    checkout_head_after = _checkout_head(manifest_root)
+    if checkout_head_after != checkout_head_before:
+        raise _reject("live repository commit changed during candidate construction")
+    if index_after != expected_index:
+        raise _reject("decoded SCIP artifact changed during candidate construction")
+    if graph_after != expected_graph:
+        raise _reject("symbol graph artifact changed during candidate construction")
+    try:
+        final_manifest_identity = resolved_manifest.stat()
+        manifest_after = regular_file_fingerprint(resolved_manifest)
+    except (OSError, ValueError) as exc:
+        raise _reject("RepoManifest disappeared during candidate construction") from exc
+    final_stat_identity = (
+        final_manifest_identity.st_dev,
+        final_manifest_identity.st_ino,
+        final_manifest_identity.st_size,
+        final_manifest_identity.st_mtime_ns,
+    )
+    if (
+        resolved_manifest.is_symlink()
+        or final_stat_identity != manifest_stat_identity
+        or manifest_after != manifest_file_fingerprint
+    ):
+        raise _reject("RepoManifest changed during candidate construction")
+
+    receipt: dict[str, Any] = {
+        "schema_version": FACT_QUERY_RECEIPT_SCHEMA_VERSION,
+        "language": canonical_language,
+        "project_root": str(manifest_root),
+        "manifest": {
+            "path": str(resolved_manifest),
+            "version": manifest.version,
+            "size_bytes": manifest_file_fingerprint["size"],
+            "sha256": manifest_file_fingerprint["sha256"],
+            "commit": manifest.commit,
+            "builder_schema": SYMBOL_GRAPH_BUILDER_SCHEMA_VERSION,
+            "node_count": node_count,
+            "edge_count": edge_count,
+            "document_count": document_count,
+            "query_surface_sha256": query_surface_digest,
+            "source_fingerprint": manifest.source_fingerprint,
+            "file_count": manifest.file_count,
+            "entry_path": str(index_path.parent),
+            "entry_commit": entry.commit,
+            "entry_source_fingerprint": entry.source_fingerprint,
+        },
+        "index": {
+            "relative_path": index_relative,
+            "size_bytes": expected_index["size"],
+            "sha256": expected_index["sha256"],
+        },
+        "graph": {
+            "relative_path": "graph.pkl",
+            "size_bytes": expected_graph["size"],
+            "sha256": expected_graph["sha256"],
+            "query_surface_sha256": query_surface_digest,
+        },
+        "fact_query": {
+            "abi_version": FACT_QUERY_ABI_VERSION,
+            "format": FACT_QUERY_FORMAT,
+            "capabilities": dict(FACT_QUERY_CAPABILITIES),
+        },
+        "source": {
+            "fingerprint": source_before.value,
+            "file_count": source_before.file_count,
+            "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+        },
+        "filters": {
+            "graph_route": "active",
+            "update_mode": "full_rebuild",
+            "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+            "exclude_patterns": list(exclude_patterns),
+            "target_dir": None,
+            "allow_partial_languages": False,
+            "allow_partial_index": False,
+            "source_coverage_fallback": False,
+            "allowed_file_count": len(allowed_files),
+            "allowed_files_sha256": _allowed_files_digest(allowed_files),
+        },
+        "native_input": native.input_receipt,
+        "filter_identity": proof,
+    }
+    receipt["receipt_sha256"] = _canonical_json_digest(receipt)
+    timings = dict(native.timings)
+    timings["candidate_total"] = time.perf_counter() - total_started
+    timings["allowed_file_count"] = len(allowed_files)
+    return FactQueryCandidate(index=native.index, receipt=receipt, timings=timings)
+
+
+__all__ = [
+    "FACT_QUERY_ABI_VERSION",
+    "FACT_QUERY_CAPABILITIES",
+    "FACT_QUERY_FILTER_PROOF_SCHEMA_VERSION",
+    "FACT_QUERY_FORMAT",
+    "FACT_QUERY_PROMOTED_LANGUAGES",
+    "FACT_QUERY_RECEIPT_SCHEMA_VERSION",
+    "SCIP_INPUT_RECEIPT_SCHEMA_VERSION",
+    "FactQueryCandidate",
+    "FactQueryCandidateRejected",
+    "NativeFactQueryIndex",
+    "decode_native_fact_query_index",
+    "load_fact_query_candidate",
+    "validate_fact_query_contract",
+]

--- a/core/README.md
+++ b/core/README.md
@@ -126,6 +126,35 @@ make fact-query-profile \
   FACT_QUERY_PROFILE_OUTPUT=/tmp/fact-query-report.json
 ```
 
+The low-level decode payload also exposes an `input_receipt` for the exact
+`index.decoded` bytes consumed by C++. Rust receipts additionally enumerate
+the exact root/member `Cargo.toml` inputs and the resulting internal-crate
+set. `FactQueryIndex.prove_filter_identity(allowed_files,
+expected_query_surface_sha256)` requires canonical, UTF-8 bytewise-sorted
+unique paths and performs a read-only O(F+V+E) scan over the file set and
+immutable records: every structural path, definition, and reference anchor
+must already belong to the supplied repository surface. It never deletes or
+renumbers a row, so a proof cannot change ambiguity resolution, ordering, or
+`top_k` behavior. The required digest comes from the trusted serial-writer
+receipt; the proof independently returns its order-sensitive digest over every
+immutable vertex and edge so both surfaces must agree on identity, fields, and
+insertion order rather than counts alone.
+
+Consumer code should use
+`codenib.scip_interface.scip_query.load_fact_query_candidate(...)`, not the
+raw binding. That graph-free facade binds the native receipt and filter proof
+to a current single-language compiler manifest, source fingerprint, builder
+and filter policy, resolved project root, persisted graph-writer receipt, and
+query-surface digest. Receipt capture is an explicit compiler-build opt-in;
+ordinary `run_pipeline()` callers retain the default path without the extra
+artifact scans. Incremental, partial, multi-language, source-coverage fallback,
+mutated, or otherwise unproven inputs reject the whole candidate. A
+reference-only external target is retained only when it is part of the exact
+serial filtered query-surface digest and every incoming reference has an
+allowed source anchor; it is never inferred from the native index alone. The
+first candidate contract admits Python and Rust only. This admission layer
+does not enable an MCP route or make an end-to-end performance claim.
+
 ## Native clangd Symbol, Position, And Route Queries
 
 For C and C++ projects with an existing project-local clangd index,

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -123,6 +123,50 @@ reference_to_dict(const codenib::core::FactQueryIndex::Reference &reference) {
   return result;
 }
 
+py::dict
+input_file_receipt_to_dict(const codenib::core::SCIPInputFileReceipt &receipt) {
+  py::dict result;
+  result["path"] = receipt.path;
+  result["size_bytes"] = receipt.size_bytes;
+  result["sha256"] = receipt.sha256;
+  return result;
+}
+
+py::dict input_receipt_to_dict(const codenib::core::SCIPInputReceipt &receipt) {
+  py::dict result;
+  result["schema_version"] = receipt.schema_version;
+  result["index"] = input_file_receipt_to_dict(receipt.index);
+  py::dict metadata;
+  metadata["kind"] = receipt.metadata_kind;
+  metadata["complete"] = receipt.metadata_complete;
+  py::list inputs;
+  for (const auto &input : receipt.metadata_inputs)
+    inputs.append(input_file_receipt_to_dict(input));
+  metadata["inputs"] = std::move(inputs);
+  metadata["internal_crates"] = receipt.internal_crates;
+  result["metadata"] = std::move(metadata);
+  return result;
+}
+
+py::dict filter_identity_proof_to_dict(
+    const codenib::core::FactQueryIndex::FilterIdentityProof &proof) {
+  py::dict result;
+  result["schema_version"] = proof.schema_version;
+  result["identity"] = proof.identity;
+  result["allowed_file_count"] = proof.allowed_file_count;
+  result["allowed_files_sha256"] = proof.allowed_files_sha256;
+  result["query_surface_sha256"] = proof.query_surface_sha256;
+  result["record_count"] = proof.record_count;
+  result["directory_count"] = proof.directory_count;
+  result["file_count"] = proof.file_count;
+  result["definition_count"] = proof.definition_count;
+  result["reference_only_count"] = proof.reference_only_count;
+  result["edge_count"] = proof.edge_count;
+  result["reference_count"] = proof.reference_count;
+  result["occurrence_count"] = proof.occurrence_count;
+  return result;
+}
+
 py::dict decode_scip(const std::string &index_file,
                      std::optional<std::string> project_root,
                      const std::string &language) {
@@ -383,6 +427,7 @@ py::dict decode_scip_fact_query_index(const std::string &index_file,
   clock::time_point decode_finished;
   clock::time_point index_finished;
   codenib::core::SCIPDecodeProfile decode_profile;
+  codenib::core::SCIPInputReceipt input_receipt;
   std::shared_ptr<codenib::core::FactQueryIndex> index;
   {
     py::gil_scoped_release release;
@@ -391,6 +436,7 @@ py::dict decode_scip_fact_query_index(const std::string &index_file,
         decoder->decode_records());
     decode_finished = clock::now();
     decode_profile = decoder->last_profile();
+    input_receipt = decoder->last_input_receipt();
     index = std::make_shared<codenib::core::FactQueryIndex>(records);
     index_finished = clock::now();
   }
@@ -405,6 +451,7 @@ py::dict decode_scip_fact_query_index(const std::string &index_file,
   result["native_decode_ns"] = elapsed_ns(decode_started, decode_finished);
   result["native_index_ns"] = elapsed_ns(decode_finished, index_finished);
   result["decode_profile_ns"] = decode_profile_to_dict(decode_profile);
+  result["input_receipt"] = input_receipt_to_dict(input_receipt);
   result["graph_materialized"] = false;
   return result;
 }
@@ -414,6 +461,10 @@ py::dict fact_query_index_contract() {
   result["abi_version"] = codenib::core::FACT_QUERY_INDEX_ABI_VERSION;
   result["format"] = codenib::core::FACT_QUERY_INDEX_FORMAT;
   result["requires_anchored_references"] = true;
+  result["input_receipt_schema_version"] =
+      codenib::core::SCIP_INPUT_RECEIPT_SCHEMA_VERSION;
+  result["filter_identity_proof_schema_version"] =
+      codenib::core::FILTER_IDENTITY_PROOF_SCHEMA_VERSION;
   result["capabilities"] = fact_query_capabilities();
   return result;
 }
@@ -609,6 +660,21 @@ PYBIND11_MODULE(codenib_core, m) {
           &codenib::core::FactQueryIndex::requires_anchored_references)
       .def_property_readonly("snapshot_id",
                              &codenib::core::FactQueryIndex::snapshot_id)
+      .def(
+          "prove_filter_identity",
+          [](const codenib::core::FactQueryIndex &index,
+             const std::vector<std::string> &allowed_files,
+             const std::string &expected_query_surface_sha256) {
+            codenib::core::FactQueryIndex::FilterIdentityProof proof;
+            {
+              py::gil_scoped_release release;
+              proof = index.prove_filter_identity(
+                  allowed_files, expected_query_surface_sha256);
+            }
+            return filter_identity_proof_to_dict(proof);
+          },
+          py::arg("allowed_files"), py::arg("expected_query_surface_sha256"),
+          R"pbdoc(Prove that repository filtering preserves every native fact.)pbdoc")
       .def("has_symbol", &codenib::core::FactQueryIndex::has_symbol)
       .def("get_node_info_by_name",
            [](const codenib::core::FactQueryIndex &index,

--- a/core/fact_query_index.cpp
+++ b/core/fact_query_index.cpp
@@ -6,11 +6,14 @@
 
 #include "fact_query_index.h"
 
+#include "content_digest.h"
+
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
 #include <limits>
 #include <stdexcept>
+#include <string_view>
 #include <tuple>
 #include <unordered_set>
 #include <utility>
@@ -29,6 +32,159 @@ bool has_definition(const CodeGraph::VertexData &vertex) {
     return *vertex.has_definition;
   return is_symbol_type(vertex.type) && vertex.file.has_value() &&
          vertex.start_line.has_value() && vertex.end_line.has_value();
+}
+
+bool is_valid_utf8(const std::string &value) {
+  const auto *bytes = reinterpret_cast<const unsigned char *>(value.data());
+  std::size_t index = 0;
+  while (index < value.size()) {
+    const auto lead = bytes[index];
+    if (lead <= 0x7fU) {
+      ++index;
+      continue;
+    }
+    std::size_t width = 0;
+    std::uint32_t code_point = 0;
+    if (lead >= 0xc2U && lead <= 0xdfU) {
+      width = 2;
+      code_point = lead & 0x1fU;
+    } else if (lead >= 0xe0U && lead <= 0xefU) {
+      width = 3;
+      code_point = lead & 0x0fU;
+    } else if (lead >= 0xf0U && lead <= 0xf4U) {
+      width = 4;
+      code_point = lead & 0x07U;
+    } else {
+      return false;
+    }
+    if (index + width > value.size())
+      return false;
+    for (std::size_t offset = 1; offset < width; ++offset) {
+      const auto continuation = bytes[index + offset];
+      if ((continuation & 0xc0U) != 0x80U)
+        return false;
+      code_point = (code_point << 6U) | (continuation & 0x3fU);
+    }
+    const bool overlong = (width == 2 && code_point < 0x80U) ||
+                          (width == 3 && code_point < 0x800U) ||
+                          (width == 4 && code_point < 0x10000U);
+    if (overlong || (code_point >= 0xd800U && code_point <= 0xdfffU) ||
+        code_point > 0x10ffffU) {
+      return false;
+    }
+    index += width;
+  }
+  return true;
+}
+
+bool is_canonical_repository_path(const std::string &path) {
+  if (path.empty() || !is_valid_utf8(path) ||
+      path.find('\\') != std::string::npos ||
+      path.find('\0') != std::string::npos || path.front() == '/' ||
+      (path.size() >= 2 && std::isalpha(static_cast<unsigned char>(path[0])) &&
+       path[1] == ':')) {
+    return false;
+  }
+  std::size_t start = 0;
+  while (start <= path.size()) {
+    const auto slash = path.find('/', start);
+    const auto end = slash == std::string::npos ? path.size() : slash;
+    const auto component = path.substr(start, end - start);
+    if (component.empty() || component == "." || component == "..")
+      return false;
+    if (end == path.size())
+      break;
+    start = end + 1;
+  }
+  return true;
+}
+
+bool is_known_symbol_type(const std::string &type) {
+  return type == NODE_TYPE_SYMBOL || type == NODE_TYPE_CLASS ||
+         type == NODE_TYPE_FUNCTION || type == NODE_TYPE_METHOD ||
+         type == NODE_TYPE_FIELD;
+}
+
+bool is_known_edge_type(const std::string &type) {
+  return type == EDGE_TYPE_CONTAIN || type == EDGE_TYPE_REFERENCE ||
+         type == EDGE_TYPE_IMPORT || type == EDGE_TYPE_TYPE_USE;
+}
+
+bool bytewise_less(const std::string &left, const std::string &right) {
+  return std::lexicographical_compare(
+      left.begin(), left.end(), right.begin(), right.end(),
+      [](char left_byte, char right_byte) {
+        return static_cast<unsigned char>(left_byte) <
+               static_cast<unsigned char>(right_byte);
+      });
+}
+
+void append_u32_be(Sha256 &digest, std::uint32_t value) {
+  std::uint8_t bytes[4];
+  for (std::size_t index = 0; index < 4; ++index) {
+    bytes[3 - index] = static_cast<std::uint8_t>(value & 0xffU);
+    value >>= 8U;
+  }
+  digest.update(bytes, sizeof(bytes));
+}
+
+void append_u64_be(Sha256 &digest, std::uint64_t value) {
+  std::uint8_t bytes[8];
+  for (std::size_t index = 0; index < 8; ++index) {
+    bytes[7 - index] = static_cast<std::uint8_t>(value & 0xffU);
+    value >>= 8U;
+  }
+  digest.update(bytes, sizeof(bytes));
+}
+
+void append_i64_be(Sha256 &digest, std::int64_t value) {
+  const auto encoded = value >= 0
+                           ? static_cast<std::uint64_t>(value)
+                           : std::numeric_limits<std::uint64_t>::max() -
+                                 static_cast<std::uint64_t>(-(value + 1));
+  append_u64_be(digest, encoded);
+}
+
+void append_present_string(Sha256 &digest, const std::string &value) {
+  if (!is_valid_utf8(value)) {
+    throw std::invalid_argument(
+        "FactQueryIndex query surface contains invalid UTF-8");
+  }
+  constexpr std::uint8_t PRESENT = 1;
+  digest.update(&PRESENT, 1);
+  append_u64_be(digest, static_cast<std::uint64_t>(value.size()));
+  digest.update(value);
+}
+
+void append_optional_string(Sha256 &digest,
+                            const std::optional<std::string> &value) {
+  if (!value.has_value()) {
+    constexpr std::uint8_t ABSENT = 0;
+    digest.update(&ABSENT, 1);
+    return;
+  }
+  append_present_string(digest, *value);
+}
+
+void append_present_i64(Sha256 &digest, std::int64_t value) {
+  constexpr std::uint8_t PRESENT = 1;
+  digest.update(&PRESENT, 1);
+  append_i64_be(digest, value);
+}
+
+void append_optional_int(Sha256 &digest, const std::optional<int> &value) {
+  if (!value.has_value()) {
+    constexpr std::uint8_t ABSENT = 0;
+    digest.update(&ABSENT, 1);
+    return;
+  }
+  append_present_i64(digest, static_cast<std::int64_t>(*value));
+}
+
+void append_optional_bool(Sha256 &digest, const std::optional<bool> &value) {
+  const std::uint8_t encoded =
+      !value.has_value() ? 0 : static_cast<std::uint8_t>(*value ? 2 : 1);
+  digest.update(&encoded, 1);
 }
 
 bool has_suffix(const std::string &value, const std::string &suffix) {
@@ -315,6 +471,275 @@ FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
       postings.prefix_max_end.push_back(maximum);
     }
   }
+}
+
+FactQueryIndex::FilterIdentityProof FactQueryIndex::prove_filter_identity(
+    const std::vector<std::string> &allowed_files,
+    const std::string &expected_query_surface_sha256) const {
+  if (!records_->query_resolution_order.empty() ||
+      !records_->route_vertex_order.empty() ||
+      records_->route_adjacency_complete || !records_->occurrences.empty()) {
+    throw std::invalid_argument(
+        "FactQueryIndex filter proof v1 rejects unbound query metadata");
+  }
+  if (expected_query_surface_sha256.size() != 64 ||
+      !std::all_of(expected_query_surface_sha256.begin(),
+                   expected_query_surface_sha256.end(), [](char character) {
+                     return (character >= '0' && character <= '9') ||
+                            (character >= 'a' && character <= 'f');
+                   })) {
+    throw std::invalid_argument(
+        "FactQueryIndex filter proof requires a lowercase SHA-256 surface "
+        "digest");
+  }
+
+  std::unordered_set<std::string> allowed;
+  allowed.reserve(allowed_files.size());
+  Sha256 allowed_digest;
+  constexpr char NUL = '\0';
+  for (std::size_t index = 0; index < allowed_files.size(); ++index) {
+    const auto &path = allowed_files[index];
+    if (!is_canonical_repository_path(path)) {
+      throw std::invalid_argument(
+          "FactQueryIndex filter proof requires canonical relative POSIX "
+          "allowed paths");
+    }
+    if (!allowed.insert(path).second) {
+      throw std::invalid_argument(
+          "FactQueryIndex filter proof rejects duplicate allowed paths");
+    }
+    if (index != 0 && !bytewise_less(allowed_files[index - 1], path)) {
+      throw std::invalid_argument(
+          "FactQueryIndex filter proof requires bytewise-sorted allowed "
+          "paths");
+    }
+    allowed_digest.update(path);
+    allowed_digest.update(&NUL, 1);
+  }
+
+  Sha256 query_surface_digest;
+  constexpr std::string_view QUERY_SURFACE_DOMAIN = "CodeNib-FactQuery-Surface";
+  query_surface_digest.update(QUERY_SURFACE_DOMAIN);
+  query_surface_digest.update(&NUL, 1);
+  append_u32_be(query_surface_digest, FILTER_IDENTITY_PROOF_SCHEMA_VERSION);
+  append_u64_be(query_surface_digest,
+                static_cast<std::uint64_t>(records_->vertices.size()));
+
+  std::unordered_set<std::string> allowed_directories;
+  allowed_directories.reserve(allowed_files.size());
+  for (const auto &path : allowed_files) {
+    auto slash = path.find('/');
+    while (slash != std::string::npos) {
+      allowed_directories.insert(path.substr(0, slash));
+      slash = path.find('/', slash + 1);
+    }
+  }
+
+  enum class ProvenVertex : std::uint8_t {
+    root,
+    directory,
+    file,
+    definition,
+    reference_only,
+  };
+  std::vector<ProvenVertex> vertex_kinds;
+  vertex_kinds.reserve(records_->vertices.size());
+  std::vector<bool> reference_only_target_observed(records_->vertices.size(),
+                                                   false);
+  FilterIdentityProof proof;
+  proof.allowed_file_count = allowed_files.size();
+  proof.allowed_files_sha256 = allowed_digest.hex_digest();
+  proof.record_count = records_->vertices.size();
+  proof.edge_count = records_->edges.size();
+  proof.occurrence_count = records_->occurrences.size();
+
+  std::size_t root_count = 0;
+  for (const auto &vertex : records_->vertices) {
+    constexpr char VERTEX_TAG = 'V';
+    query_surface_digest.update(&VERTEX_TAG, 1);
+    append_present_string(query_surface_digest, vertex.name);
+    append_present_string(query_surface_digest, vertex.type);
+    append_optional_string(query_surface_digest, vertex.file);
+    append_optional_int(query_surface_digest, vertex.start_line);
+    append_optional_int(query_surface_digest, vertex.end_line);
+    append_optional_int(query_surface_digest, vertex.selection_line);
+    append_optional_string(query_surface_digest, vertex.unified_name);
+    append_optional_string(query_surface_digest, vertex.symbol_kind);
+    append_optional_bool(query_surface_digest, vertex.has_definition);
+    const auto structural_attributes_absent = [&]() {
+      return !vertex.file.has_value() && !vertex.start_line.has_value() &&
+             !vertex.end_line.has_value() &&
+             !vertex.selection_line.has_value() &&
+             !vertex.symbol_kind.has_value() &&
+             !vertex.has_definition.has_value();
+    };
+    if (vertex.type == "root") {
+      if (vertex.name != ROOT_NODE || !structural_attributes_absent() ||
+          vertex.unified_name.has_value()) {
+        throw std::invalid_argument(
+            "FactQueryIndex filter proof rejected an invalid root record");
+      }
+      ++root_count;
+      vertex_kinds.push_back(ProvenVertex::root);
+      continue;
+    }
+    if (vertex.type == NODE_TYPE_DIRECTORY) {
+      if (!is_canonical_repository_path(vertex.name) ||
+          allowed_directories.find(vertex.name) == allowed_directories.end() ||
+          !structural_attributes_absent() ||
+          (vertex.unified_name.has_value() &&
+           *vertex.unified_name != vertex.name)) {
+        throw std::invalid_argument(
+            "FactQueryIndex filter proof rejected an unproven directory");
+      }
+      ++proof.directory_count;
+      vertex_kinds.push_back(ProvenVertex::directory);
+      continue;
+    }
+    if (vertex.type == NODE_TYPE_FILE) {
+      if (!is_canonical_repository_path(vertex.name) ||
+          allowed.find(vertex.name) == allowed.end() ||
+          !structural_attributes_absent() ||
+          (vertex.unified_name.has_value() &&
+           *vertex.unified_name != vertex.name)) {
+        throw std::invalid_argument(
+            "FactQueryIndex filter proof rejected an unproven file");
+      }
+      ++proof.file_count;
+      vertex_kinds.push_back(ProvenVertex::file);
+      continue;
+    }
+    if (!is_known_symbol_type(vertex.type)) {
+      throw std::invalid_argument(
+          "FactQueryIndex filter proof rejected an unknown vertex type");
+    }
+    if (!vertex.has_definition.has_value()) {
+      throw std::invalid_argument(
+          "FactQueryIndex filter proof requires explicit symbol provenance");
+    }
+    if (!*vertex.has_definition) {
+      if (vertex.start_line.has_value() || vertex.end_line.has_value() ||
+          vertex.selection_line.has_value()) {
+        throw std::invalid_argument(
+            "FactQueryIndex reference-only symbol carries a definition "
+            "range");
+      }
+      ++proof.reference_only_count;
+      vertex_kinds.push_back(ProvenVertex::reference_only);
+      continue;
+    }
+    if (!vertex.file.has_value() ||
+        !is_canonical_repository_path(*vertex.file) ||
+        allowed.find(*vertex.file) == allowed.end() ||
+        !vertex.start_line.has_value() || !vertex.end_line.has_value() ||
+        *vertex.start_line < 0 || *vertex.end_line < *vertex.start_line ||
+        (vertex.selection_line.has_value() && *vertex.selection_line < 0)) {
+      throw std::invalid_argument(
+          "FactQueryIndex filter proof requires every symbol to have an "
+          "allowed definition");
+    }
+    if (vertex.unified_name.has_value()) {
+      const auto separator = vertex.unified_name->find(':');
+      if (separator == std::string::npos ||
+          vertex.unified_name->substr(0, separator) != *vertex.file) {
+        throw std::invalid_argument(
+            "FactQueryIndex filter proof rejected an unproven unified path");
+      }
+    }
+    ++proof.definition_count;
+    vertex_kinds.push_back(ProvenVertex::definition);
+  }
+  if (root_count != 1 || records_->vertices.empty() ||
+      vertex_kinds.front() != ProvenVertex::root) {
+    throw std::invalid_argument(
+        "FactQueryIndex filter proof requires one leading root record");
+  }
+  if (proof.record_count != root_count + proof.directory_count +
+                                proof.file_count + proof.definition_count +
+                                proof.reference_only_count) {
+    throw std::logic_error(
+        "FactQueryIndex filter proof record partition is inconsistent");
+  }
+  if (proof.definition_count != symbol_count()) {
+    throw std::logic_error(
+        "FactQueryIndex filter proof definition count disagrees with index");
+  }
+
+  append_u64_be(query_surface_digest,
+                static_cast<std::uint64_t>(records_->edges.size()));
+  for (const auto &edge : records_->edges) {
+    if (edge.source < 0 || edge.target < 0 ||
+        static_cast<std::size_t>(edge.source) >= vertex_kinds.size() ||
+        static_cast<std::size_t>(edge.target) >= vertex_kinds.size()) {
+      throw std::invalid_argument(
+          "FactQueryIndex filter proof rejected an unproven edge endpoint");
+    }
+    constexpr char EDGE_TAG = 'E';
+    query_surface_digest.update(&EDGE_TAG, 1);
+    append_present_i64(query_surface_digest,
+                       static_cast<std::int64_t>(edge.source));
+    append_present_i64(query_surface_digest,
+                       static_cast<std::int64_t>(edge.target));
+    append_present_string(query_surface_digest, edge.type);
+    append_optional_string(query_surface_digest, edge.anchor_file);
+    append_optional_int(query_surface_digest, edge.anchor_line);
+    if (!is_known_edge_type(edge.type)) {
+      throw std::invalid_argument(
+          "FactQueryIndex filter proof rejected an unknown edge type");
+    }
+    const auto source_kind =
+        vertex_kinds[static_cast<std::size_t>(edge.source)];
+    const auto target_kind =
+        vertex_kinds[static_cast<std::size_t>(edge.target)];
+    if (source_kind == ProvenVertex::reference_only ||
+        (target_kind == ProvenVertex::reference_only &&
+         edge.type != EDGE_TYPE_REFERENCE)) {
+      throw std::invalid_argument(
+          "FactQueryIndex reference-only symbol must only be the target of a "
+          "reference edge");
+    }
+    if (edge.type == EDGE_TYPE_REFERENCE) {
+      if ((source_kind != ProvenVertex::definition &&
+           source_kind != ProvenVertex::file) ||
+          (target_kind != ProvenVertex::definition &&
+           target_kind != ProvenVertex::reference_only) ||
+          !edge.anchor_file.has_value() || !edge.anchor_line.has_value() ||
+          *edge.anchor_line < 0 ||
+          !is_canonical_repository_path(*edge.anchor_file) ||
+          allowed.find(*edge.anchor_file) == allowed.end()) {
+        throw std::invalid_argument(
+            "FactQueryIndex filter proof rejected an unproven reference");
+      }
+      if (target_kind == ProvenVertex::reference_only) {
+        reference_only_target_observed[static_cast<std::size_t>(edge.target)] =
+            true;
+      }
+      ++proof.reference_count;
+    } else if (edge.anchor_file.has_value() || edge.anchor_line.has_value()) {
+      throw std::invalid_argument(
+          "FactQueryIndex filter proof rejected an anchored non-reference");
+    }
+  }
+
+  if (proof.reference_count != reference_count_) {
+    throw std::logic_error(
+        "FactQueryIndex filter proof reference count disagrees with index");
+  }
+  for (std::size_t index = 0; index < vertex_kinds.size(); ++index) {
+    if (vertex_kinds[index] == ProvenVertex::reference_only &&
+        !reference_only_target_observed[index]) {
+      throw std::invalid_argument(
+          "FactQueryIndex reference-only symbol lacks a proven incoming "
+          "reference");
+    }
+  }
+  proof.query_surface_sha256 = query_surface_digest.hex_digest();
+  if (proof.query_surface_sha256 != expected_query_surface_sha256) {
+    throw std::invalid_argument(
+        "FactQueryIndex native query surface does not match the trusted "
+        "serial-writer receipt");
+  }
+  return proof;
 }
 
 bool FactQueryIndex::has_symbol(const std::string &name) const {

--- a/core/fact_query_index.h
+++ b/core/fact_query_index.h
@@ -21,6 +21,7 @@ namespace codenib::core {
 
 inline constexpr std::uint32_t FACT_QUERY_INDEX_ABI_VERSION = 1;
 inline constexpr char FACT_QUERY_INDEX_FORMAT[] = "fact-query-index-v1";
+inline constexpr std::uint32_t FILTER_IDENTITY_PROOF_SCHEMA_VERSION = 1;
 
 // Graph-free read index for definition/reference subsets of the LSP-shaped
 // API. The index owns one immutable DecodedRecords allocation and stores only
@@ -28,6 +29,27 @@ inline constexpr char FACT_QUERY_INDEX_FORMAT[] = "fact-query-index-v1";
 // adjacency independently; an absent capability must fail closed.
 class FactQueryIndex {
 public:
+  struct FilterIdentityProof {
+    std::uint32_t schema_version{FILTER_IDENTITY_PROOF_SCHEMA_VERSION};
+    bool identity{true};
+    std::size_t allowed_file_count{0};
+    // SHA-256 over bytewise-sorted canonical UTF-8 paths, each followed by a
+    // single NUL byte. NUL is forbidden in an input path; the empty set hashes
+    // the empty byte string. This framing is part of proof schema v1.
+    std::string allowed_files_sha256;
+    // Stable binary digest of every query-visible vertex and edge field in
+    // immutable record order. See prove_filter_identity() for schema v1.
+    std::string query_surface_sha256;
+    std::size_t record_count{0};
+    std::size_t directory_count{0};
+    std::size_t file_count{0};
+    std::size_t definition_count{0};
+    std::size_t reference_only_count{0};
+    std::size_t edge_count{0};
+    std::size_t reference_count{0};
+    std::size_t occurrence_count{0};
+  };
+
   struct Reference {
     CodeGraph::VertexId source;
     std::optional<std::string> anchor_file;
@@ -97,6 +119,30 @@ public:
   bool has_occurrence_at(const std::string &file_path, int line,
                          int character) const;
   std::vector<Location> position_samples(std::size_t limit = 100) const;
+
+  // Prove that applying the supplied repository file filter would preserve
+  // every immutable record and its ordering. ``allowed_files`` must be
+  // canonical, unique, and strictly increasing in UTF-8 byte order. This is
+  // an O(F + V + E) scan. Proof schema v1 rejects occurrences, explicit query
+  // resolution order, and route metadata because those surfaces are not
+  // covered by its digest. It never filters or remaps records and throws
+  // std::invalid_argument on the first unproven fact. The required expected
+  // surface digest comes from the trusted serial-writer receipt; proof v1 is
+  // valid only when the independently computed native surface exactly matches
+  // it.
+  // ``query_surface_sha256`` schema v1 is framed as:
+  //   "CodeNib-FactQuery-Surface\0" || u32be(1) || u64be(V) ||
+  //   each vertex in immutable order || u64be(E) || each edge in immutable
+  //   order. A record starts with 'V' or 'E'. Required strings/integers start
+  //   with 0x01, followed by u64be(length)+UTF-8 or signed i64be. Optional
+  //   values use 0x00 for absent and otherwise the required encoding;
+  //   optional bool uses 0x00 absent, 0x01 false, 0x02 true. Vertex fields are
+  //   name,type,file,start_line,end_line,selection_line,unified_name,
+  //   symbol_kind,has_definition; edge fields are source,target,type,
+  //   anchor_file,anchor_line.
+  FilterIdentityProof
+  prove_filter_identity(const std::vector<std::string> &allowed_files,
+                        const std::string &expected_query_surface_sha256) const;
 
   const std::string &project_root() const { return records_->project_root; }
   std::size_t record_count() const { return records_->vertices.size(); }

--- a/core/scip_decode_base.cpp
+++ b/core/scip_decode_base.cpp
@@ -4,16 +4,20 @@
 
 #include "scip_decode_base.h"
 
+#include "content_digest.h"
+
 #include <algorithm>
 #include <cctype>
 #include <chrono>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <future>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
+#include <system_error>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -182,21 +186,70 @@ SCIPDecoderBase::SCIPDecoderBase(std::string index_file_path,
       project_root_(std::move(project_root)),
       code_graph_(project_root_ ? *project_root_ : std::string{}) {}
 
+void SCIPDecoderBase::set_metadata_receipt(
+    std::string kind, bool complete, std::vector<SCIPInputFileReceipt> inputs,
+    std::vector<std::string> internal_crates) {
+  if (kind.empty())
+    throw std::invalid_argument("SCIP metadata receipt kind must not be empty");
+  const auto bytewise_less = [](const std::string &left,
+                                const std::string &right) {
+    return std::lexicographical_compare(
+        left.begin(), left.end(), right.begin(), right.end(),
+        [](char left_byte, char right_byte) {
+          return static_cast<unsigned char>(left_byte) <
+                 static_cast<unsigned char>(right_byte);
+        });
+  };
+  std::sort(inputs.begin(), inputs.end(),
+            [&](const auto &left, const auto &right) {
+              return bytewise_less(left.path, right.path);
+            });
+  for (std::size_t index = 1; index < inputs.size(); ++index) {
+    if (inputs[index - 1].path == inputs[index].path)
+      throw std::invalid_argument(
+          "SCIP metadata receipt contains a duplicate input path");
+  }
+  std::sort(internal_crates.begin(), internal_crates.end(), bytewise_less);
+  internal_crates.erase(
+      std::unique(internal_crates.begin(), internal_crates.end()),
+      internal_crates.end());
+  last_input_receipt_.metadata_kind = std::move(kind);
+  last_input_receipt_.metadata_complete = complete;
+  last_input_receipt_.metadata_inputs = std::move(inputs);
+  last_input_receipt_.internal_crates = std::move(internal_crates);
+}
+
 SCIPDecodedRecords SCIPDecoderBase::decode_records_impl() {
   using clock = std::chrono::steady_clock;
   auto t0 = clock::now();
 
+  last_input_receipt_ = SCIPInputReceipt{};
+
   load_metadata();
   auto t_meta = clock::now();
 
-  std::ifstream input(index_file_path_);
+  std::error_code path_error;
+  const auto resolved_index =
+      std::filesystem::canonical(index_file_path_, path_error);
+  if (path_error) {
+    throw std::runtime_error("Failed to resolve SCIP index file at " +
+                             index_file_path_ + ": " + path_error.message());
+  }
+  std::ifstream input(resolved_index, std::ios::binary);
   if (!input.is_open()) {
     throw std::runtime_error("Failed to open SCIP index file at " +
                              index_file_path_);
   }
   std::ostringstream buffer;
   buffer << input.rdbuf();
+  if (input.bad()) {
+    throw std::runtime_error("Failed to read SCIP index file at " +
+                             index_file_path_);
+  }
   std::string content = buffer.str();
+  last_input_receipt_.index = SCIPInputFileReceipt{
+      resolved_index.generic_string(),
+      static_cast<std::uint64_t>(content.size()), sha256_hex(content)};
   auto t_read = clock::now();
 
   std::vector<std::string> document_blocks =
@@ -310,19 +363,33 @@ SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) const {
   //   - Later REFERENCE leaves existing attrs alone (matches serial
   //     add_symbol_reference's "only create if missing").
   std::unordered_map<std::string, Subgraph::Node> merged_nodes;
+  std::vector<std::string> merged_node_order;
   std::vector<Subgraph::Edge> all_edges;
 
   std::size_t estimated = 0;
   for (const auto &sg : subgraphs)
     estimated += sg.nodes.size();
   merged_nodes.reserve(estimated);
+  merged_node_order.reserve(estimated);
   all_edges.reserve(estimated * 3);
 
   for (const auto &sg : subgraphs) {
-    for (const auto &[name, node] : sg.nodes) {
+    if (sg.node_order.size() != sg.nodes.size()) {
+      throw std::logic_error(
+          "SCIP subgraph node order does not cover every node");
+    }
+    for (const auto &name : sg.node_order) {
+      const auto node_it = sg.nodes.find(name);
+      if (node_it == sg.nodes.end()) {
+        throw std::logic_error("SCIP subgraph node order contains an unknown "
+                               "node");
+      }
+      const auto &node = node_it->second;
       auto it = merged_nodes.find(name);
       if (it == merged_nodes.end()) {
         merged_nodes.emplace(name, node);
+        if (name != ROOT_NODE)
+          merged_node_order.push_back(name);
       } else {
         if (node.is_definition) {
           Subgraph::Node &existing = it->second;
@@ -372,9 +439,12 @@ SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) const {
   root.name = ROOT_NODE;
   root.type = "root";
   records.vertices.push_back(std::move(root));
-  for (auto &[name, node] : merged_nodes) {
-    if (name != ROOT_NODE)
-      records.vertices.emplace_back(std::move(node.data));
+  for (const auto &name : merged_node_order) {
+    auto node = merged_nodes.find(name);
+    if (node == merged_nodes.end()) {
+      throw std::logic_error("SCIP merged node order contains an unknown node");
+    }
+    records.vertices.emplace_back(std::move(node->second.data));
   }
 
   std::unordered_map<std::string, CodeGraph::VertexId> vertex_ids;
@@ -387,14 +457,18 @@ SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) const {
   struct StructuralKey {
     CodeGraph::VertexId source;
     CodeGraph::VertexId target;
+    std::string type;
     bool operator==(const StructuralKey &other) const {
-      return source == other.source && target == other.target;
+      return source == other.source && target == other.target &&
+             type == other.type;
     }
   };
   struct StructuralHash {
     std::size_t operator()(const StructuralKey &key) const {
-      return std::hash<CodeGraph::VertexId>{}(key.source) ^
-             (std::hash<CodeGraph::VertexId>{}(key.target) << 1U);
+      std::size_t hash = std::hash<CodeGraph::VertexId>{}(key.source);
+      hash ^= std::hash<CodeGraph::VertexId>{}(key.target) << 1U;
+      hash ^= std::hash<std::string>{}(key.type) << 2U;
+      return hash;
     }
   };
   struct AnchoredKey {
@@ -436,7 +510,7 @@ SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) const {
         !edge.anchor_file.has_value() && !edge.anchor_line.has_value();
     if (structural) {
       if (!structural_edges
-               .insert(StructuralKey{source->second, target->second})
+               .insert(StructuralKey{source->second, target->second, edge.type})
                .second)
         continue;
     } else if (!anchored_edges

--- a/core/scip_decode_base.h
+++ b/core/scip_decode_base.h
@@ -18,6 +18,28 @@
 
 namespace codenib::core {
 
+inline constexpr std::uint32_t SCIP_INPUT_RECEIPT_SCHEMA_VERSION = 1;
+
+// Content receipt for a file that the native decoder actually read. Paths in
+// ``metadata_inputs`` are canonical project-root-relative POSIX paths. The
+// index path is the resolved absolute path of the caller-supplied artifact.
+struct SCIPInputFileReceipt {
+  std::string path;
+  std::uint64_t size_bytes{0};
+  std::string sha256;
+};
+
+// Native-only portion of the consumer receipt. Language, repository, source
+// snapshot, and filter policy are bound by the graph-free Python facade.
+struct SCIPInputReceipt {
+  std::uint32_t schema_version{SCIP_INPUT_RECEIPT_SCHEMA_VERSION};
+  SCIPInputFileReceipt index;
+  std::string metadata_kind{"none"};
+  bool metadata_complete{true};
+  std::vector<SCIPInputFileReceipt> metadata_inputs;
+  std::vector<std::string> internal_crates;
+};
+
 struct SCIPDecodeProfile {
   std::uint64_t load_metadata_ns{0};
   std::uint64_t file_read_ns{0};
@@ -54,6 +76,9 @@ public:
   CodeGraph decode();
   SCIPDecodedRecords decode_records();
   const SCIPDecodeProfile &last_profile() const { return last_profile_; }
+  const SCIPInputReceipt &last_input_receipt() const {
+    return last_input_receipt_;
+  }
 
 protected:
   virtual Subgraph
@@ -76,6 +101,10 @@ protected:
   SCIPDecodedRecords
   merge_subgraphs(const std::vector<Subgraph> &subgraphs) const;
 
+  void set_metadata_receipt(std::string kind, bool complete,
+                            std::vector<SCIPInputFileReceipt> inputs = {},
+                            std::vector<std::string> internal_crates = {});
+
   std::string index_file_path_;
   std::optional<std::string> project_root_;
   CodeGraph code_graph_;
@@ -84,6 +113,7 @@ protected:
 private:
   SCIPDecodedRecords decode_records_impl();
   void log_profile() const;
+  SCIPInputReceipt last_input_receipt_;
 };
 
 // Shared helpers — brace-matching block extractor and integer-list regex.

--- a/core/scip_decode_common.cpp
+++ b/core/scip_decode_common.cpp
@@ -92,6 +92,7 @@ Subgraph::Node &SubgraphBuilder::ensure_node(const std::string &name) {
   Subgraph::Node record;
   record.data.name = name;
   auto inserted = subgraph_.nodes.emplace(name, std::move(record));
+  subgraph_.node_order.push_back(name);
   return inserted.first->second;
 }
 
@@ -240,6 +241,11 @@ void SubgraphBuilder::add_edge(const std::string &source,
                                const std::string &edge_type,
                                std::optional<std::string> anchor_file,
                                std::optional<int> anchor_line) {
+  // Python CodeGraph._add_edge creates missing endpoints immediately. Record
+  // those insertions here as well so a later document update preserves the
+  // same global vertex id and first-seen semantics.
+  (void)ensure_node(source);
+  (void)ensure_node(target);
   subgraph_.edges.push_back(Subgraph::Edge{
       source, target, edge_type, std::move(anchor_file), anchor_line});
 }

--- a/core/scip_decode_common.h
+++ b/core/scip_decode_common.h
@@ -58,6 +58,10 @@ struct Subgraph {
   };
 
   std::unordered_map<std::string, Node> nodes;
+  // First-insertion order within this document. The map keeps O(1) updates,
+  // while this sequence lets the parent merge reproduce the serial decoder's
+  // stable vertex ids after workers finish out of order.
+  std::vector<std::string> node_order;
   std::vector<Edge> edges;
 };
 

--- a/core/scip_decode_rust.cpp
+++ b/core/scip_decode_rust.cpp
@@ -4,10 +4,15 @@
 
 #include "scip_decode_rust.h"
 
+#include "content_digest.h"
+
+#include <algorithm>
 #include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <re2/re2.h>
+#include <sstream>
+#include <system_error>
 
 namespace codenib::core {
 
@@ -19,141 +24,435 @@ namespace {
 struct MinimalCargoToml {
   std::string package_name;
   std::vector<std::string> workspace_members;
+  bool complete{true};
+  bool saw_package_table{false};
+  bool saw_workspace_table{false};
+  bool saw_workspace_members{false};
 };
 
-MinimalCargoToml parse_cargo_toml(const std::filesystem::path &path) {
+bool valid_utf8(const std::string &value) {
+  const auto *bytes = reinterpret_cast<const unsigned char *>(value.data());
+  std::size_t index = 0;
+  while (index < value.size()) {
+    const auto lead = bytes[index];
+    if (lead <= 0x7fU) {
+      ++index;
+      continue;
+    }
+    std::size_t width = 0;
+    std::uint32_t code_point = 0;
+    if (lead >= 0xc2U && lead <= 0xdfU) {
+      width = 2;
+      code_point = lead & 0x1fU;
+    } else if (lead >= 0xe0U && lead <= 0xefU) {
+      width = 3;
+      code_point = lead & 0x0fU;
+    } else if (lead >= 0xf0U && lead <= 0xf4U) {
+      width = 4;
+      code_point = lead & 0x07U;
+    } else {
+      return false;
+    }
+    if (index + width > value.size())
+      return false;
+    for (std::size_t offset = 1; offset < width; ++offset) {
+      const auto continuation = bytes[index + offset];
+      if ((continuation & 0xc0U) != 0x80U)
+        return false;
+      code_point = (code_point << 6U) | (continuation & 0x3fU);
+    }
+    const bool overlong = (width == 2 && code_point < 0x80U) ||
+                          (width == 3 && code_point < 0x800U) ||
+                          (width == 4 && code_point < 0x10000U);
+    if (overlong || (code_point >= 0xd800U && code_point <= 0xdfffU) ||
+        code_point > 0x10ffffU) {
+      return false;
+    }
+    index += width;
+  }
+  return true;
+}
+
+bool valid_basic_string_contents(const std::string &value) {
+  if (value.empty() || !valid_utf8(value) ||
+      value.find('\\') != std::string::npos ||
+      value.find('\0') != std::string::npos) {
+    return false;
+  }
+  return std::none_of(value.begin(), value.end(), [](char character) {
+    const auto byte = static_cast<unsigned char>(character);
+    return byte <= 0x1fU || byte == 0x7fU;
+  });
+}
+
+std::string trim(std::string value) {
+  auto whitespace = [](unsigned char character) {
+    return std::isspace(character) != 0;
+  };
+  value.erase(value.begin(),
+              std::find_if_not(value.begin(), value.end(), whitespace));
+  value.erase(std::find_if_not(value.rbegin(), value.rend(), whitespace).base(),
+              value.end());
+  return value;
+}
+
+std::string strip_comment(std::string value) {
+  bool quoted = false;
+  for (std::size_t index = 0; index < value.size(); ++index) {
+    if (value[index] == '\\') {
+      ++index;
+      continue;
+    }
+    if (value[index] == '"')
+      quoted = !quoted;
+    if (value[index] == '#' && !quoted) {
+      value.resize(index);
+      break;
+    }
+  }
+  return value;
+}
+
+bool parse_basic_string(const std::string &raw, std::string &output) {
+  const auto value = trim(raw);
+  if (value.size() < 2 || value.front() != '"')
+    return false;
+  const auto close = value.find('"', 1);
+  if (close == std::string::npos || !trim(value.substr(close + 1)).empty())
+    return false;
+  output = value.substr(1, close - 1);
+  return valid_basic_string_contents(output);
+}
+
+bool parse_basic_string_array(const std::string &raw,
+                              std::vector<std::string> &output) {
+  const auto value = trim(raw);
+  if (value.size() < 2 || value.front() != '[')
+    return false;
+  std::size_t cursor = 1;
+  while (true) {
+    while (cursor < value.size() &&
+           std::isspace(static_cast<unsigned char>(value[cursor])))
+      ++cursor;
+    if (cursor >= value.size())
+      return false;
+    if (value[cursor] == ']') {
+      ++cursor;
+      return trim(value.substr(cursor)).empty();
+    }
+    if (value[cursor] != '"')
+      return false;
+    const auto close = value.find('"', cursor + 1);
+    if (close == std::string::npos)
+      return false;
+    std::string item = value.substr(cursor + 1, close - cursor - 1);
+    if (!valid_basic_string_contents(item)) {
+      return false;
+    }
+    output.push_back(std::move(item));
+    cursor = close + 1;
+    while (cursor < value.size() &&
+           std::isspace(static_cast<unsigned char>(value[cursor])))
+      ++cursor;
+    if (cursor >= value.size())
+      return false;
+    if (value[cursor] == ']') {
+      ++cursor;
+      return trim(value.substr(cursor)).empty();
+    }
+    if (value[cursor] != ',')
+      return false;
+    ++cursor;
+  }
+}
+
+MinimalCargoToml parse_cargo_toml(const std::string &content) {
   MinimalCargoToml result;
-  std::ifstream in(path);
-  if (!in.is_open())
-    return result;
+  result.complete = valid_utf8(content);
+  std::istringstream in(content);
   std::string line;
   std::string section;
   while (std::getline(in, line)) {
-    // strip comments
-    auto hash = line.find('#');
-    if (hash != std::string::npos)
-      line = line.substr(0, hash);
-    // strip trailing
-    while (!line.empty() &&
-           (line.back() == '\r' || line.back() == ' ' || line.back() == '\t'))
-      line.pop_back();
-
-    std::size_t start = 0;
-    while (start < line.size() &&
-           std::isspace(static_cast<unsigned char>(line[start])))
-      ++start;
-    std::string trimmed = line.substr(start);
+    std::string trimmed = trim(strip_comment(line));
     if (trimmed.empty())
       continue;
 
     if (trimmed.front() == '[') {
       auto close = trimmed.find(']');
-      if (close != std::string::npos)
+      if (close != std::string::npos &&
+          trim(trimmed.substr(close + 1)).empty()) {
         section = trimmed.substr(1, close - 1);
+        if (section == "package")
+          result.saw_package_table = true;
+        if (section == "workspace")
+          result.saw_workspace_table = true;
+        if ((section.find("package") != std::string::npos ||
+             section.find("workspace") != std::string::npos) &&
+            section.find_first_of("\"'") != std::string::npos) {
+          result.complete = false;
+        }
+      } else {
+        result.complete = false;
+      }
       continue;
     }
 
     auto eq = trimmed.find('=');
     if (eq == std::string::npos)
       continue;
-    std::string key = trimmed.substr(0, eq);
-    std::string val = trimmed.substr(eq + 1);
-    // strip key/value whitespace
-    while (!key.empty() && std::isspace(static_cast<unsigned char>(key.back())))
-      key.pop_back();
-    std::size_t vs = 0;
-    while (vs < val.size() && std::isspace(static_cast<unsigned char>(val[vs])))
-      ++vs;
-    val = val.substr(vs);
+    std::string key = trim(trimmed.substr(0, eq));
+    std::string val = trim(trimmed.substr(eq + 1));
 
     if (section == "package" && key == "name") {
-      if (!val.empty() && val.front() == '"') {
-        auto end = val.find('"', 1);
-        if (end != std::string::npos)
-          result.package_name = val.substr(1, end - 1);
+      if (!result.package_name.empty() ||
+          !parse_basic_string(val, result.package_name)) {
+        result.complete = false;
       }
     } else if (section == "workspace" && key == "members") {
-      // val starts with '['; collect until ']' (may span multiple lines)
+      if (result.saw_workspace_members)
+        result.complete = false;
+      result.saw_workspace_members = true;
       std::string collected = val;
       while (collected.find(']') == std::string::npos) {
-        if (!std::getline(in, line))
+        if (!std::getline(in, line)) {
+          result.complete = false;
           break;
-        collected += " " + line;
+        }
+        collected += " " + trim(strip_comment(line));
       }
-      // extract quoted strings
-      std::size_t p = 0;
-      while (p < collected.size()) {
-        auto q1 = collected.find('"', p);
-        if (q1 == std::string::npos)
-          break;
-        auto q2 = collected.find('"', q1 + 1);
-        if (q2 == std::string::npos)
-          break;
-        result.workspace_members.emplace_back(
-            collected.substr(q1 + 1, q2 - q1 - 1));
-        p = q2 + 1;
-      }
+      std::vector<std::string> members;
+      if (!parse_basic_string_array(collected, members))
+        result.complete = false;
+      result.workspace_members.insert(result.workspace_members.end(),
+                                      members.begin(), members.end());
+    } else if (section == "workspace" && key == "exclude") {
+      // Exclusions change the expansion of ``members``. The deliberately
+      // small parser cannot prove that expansion yet, so reject the receipt.
+      result.complete = false;
+    } else if (key == "workspace.members" || key == "package.name" ||
+               (key == "workspace" &&
+                val.find("members") != std::string::npos) ||
+               key.find("members.") != std::string::npos ||
+               (section == "workspace" &&
+                key.find("members") != std::string::npos) ||
+               (section == "package" &&
+                key.find("name") != std::string::npos)) {
+      // Dotted and inline-table spellings are valid TOML, but not part of the
+      // strictly proven parser subset.
+      result.complete = false;
     }
   }
   return result;
 }
 
-// Minimal glob: supports leading path segments + trailing "*" wildcard on the
-// final component (e.g. "crates/*"). Returns matching directories.
-std::vector<std::filesystem::path>
-resolve_glob(const std::filesystem::path &root, const std::string &pattern) {
-  std::vector<std::filesystem::path> out;
-  auto slash = pattern.rfind('/');
-  std::filesystem::path base =
-      (slash == std::string::npos) ? root : root / pattern.substr(0, slash);
-  std::string leaf =
-      (slash == std::string::npos) ? pattern : pattern.substr(slash + 1);
+bool canonical_relative_path(const std::string &path, bool allow_final_star) {
+  if (path.empty() || path.find('\\') != std::string::npos ||
+      path.find('\0') != std::string::npos || path.front() == '/' ||
+      (path.size() >= 2 && std::isalpha(static_cast<unsigned char>(path[0])) &&
+       path[1] == ':')) {
+    return false;
+  }
+  std::size_t start = 0;
+  while (start <= path.size()) {
+    const auto slash = path.find('/', start);
+    const auto end = slash == std::string::npos ? path.size() : slash;
+    const auto component = path.substr(start, end - start);
+    const bool final = end == path.size();
+    if (component.empty() || component == "." || component == "..")
+      return false;
+    if (component.find_first_of("*?[") != std::string::npos &&
+        !(allow_final_star && final && component == "*")) {
+      return false;
+    }
+    if (final)
+      break;
+    start = end + 1;
+  }
+  return true;
+}
 
+bool safe_workspace_pattern(const std::string &path) {
+  if (path.empty() || path.find('\\') != std::string::npos ||
+      path.find('\0') != std::string::npos || path.front() == '/' ||
+      (path.size() >= 2 && std::isalpha(static_cast<unsigned char>(path[0])) &&
+       path[1] == ':')) {
+    return false;
+  }
+  std::size_t start = 0;
+  while (start <= path.size()) {
+    const auto slash = path.find('/', start);
+    const auto end = slash == std::string::npos ? path.size() : slash;
+    const auto component = path.substr(start, end - start);
+    if (component == "..")
+      return false;
+    if (end == path.size())
+      break;
+    start = end + 1;
+  }
+  return true;
+}
+
+bool path_is_within(const std::filesystem::path &path,
+                    const std::filesystem::path &root) {
+  auto path_part = path.begin();
+  for (auto root_part = root.begin(); root_part != root.end();
+       ++root_part, ++path_part) {
+    if (path_part == path.end() || *path_part != *root_part)
+      return false;
+  }
+  return true;
+}
+
+std::optional<std::string> read_binary_file(const std::filesystem::path &path) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input.is_open())
+    return std::nullopt;
+  std::ostringstream buffer;
+  buffer << input.rdbuf();
+  if (input.bad())
+    return std::nullopt;
+  return buffer.str();
+}
+
+SCIPInputFileReceipt input_receipt(const std::string &relative_path,
+                                   const std::string &content) {
+  return SCIPInputFileReceipt{relative_path,
+                              static_cast<std::uint64_t>(content.size()),
+                              sha256_hex(content)};
+}
+
+bool resolve_workspace_dirs(const std::filesystem::path &root,
+                            const std::string &pattern,
+                            std::vector<std::filesystem::path> &output) {
+  if (!safe_workspace_pattern(pattern))
+    return false;
+  const bool proven_pattern = canonical_relative_path(pattern, true);
+  const auto slash = pattern.rfind('/');
+  const std::string leaf =
+      slash == std::string::npos ? pattern : pattern.substr(slash + 1);
+  const auto base =
+      slash == std::string::npos ? root : root / pattern.substr(0, slash);
+  std::error_code error;
   if (leaf.find('*') == std::string::npos) {
-    std::filesystem::path candidate = base / leaf;
-    if (std::filesystem::is_directory(candidate))
-      out.push_back(candidate);
-    return out;
+    const auto candidate = base / leaf;
+    if (!std::filesystem::is_directory(candidate, error) || error)
+      return false;
+    output.push_back(candidate);
+    return proven_pattern;
   }
-
-  // Trailing-* support only (good enough for common Cargo.toml members).
-  if (!std::filesystem::is_directory(base))
-    return out;
-  for (const auto &entry : std::filesystem::directory_iterator(base)) {
-    if (!entry.is_directory())
-      continue;
-    out.push_back(entry.path());
+  if (!std::filesystem::is_directory(base, error) || error)
+    return false;
+  std::filesystem::directory_iterator iterator(base, error);
+  const std::filesystem::directory_iterator end;
+  if (error)
+    return false;
+  for (; iterator != end; iterator.increment(error)) {
+    if (error)
+      return false;
+    if (iterator->is_directory(error) && !error)
+      output.push_back(iterator->path());
+    if (error)
+      return false;
   }
-  return out;
+  std::sort(output.begin(), output.end());
+  return proven_pattern && !output.empty();
 }
 
 } // namespace
 
 void SCIPRustDecoder::load_metadata() {
-  if (!project_root_.has_value())
+  internal_crates_.clear();
+  std::vector<SCIPInputFileReceipt> inputs;
+  bool complete = true;
+  if (!project_root_.has_value()) {
+    set_metadata_receipt("rust-cargo", false);
     return;
-  std::filesystem::path root(*project_root_);
-  std::filesystem::path cargo_toml = root / "Cargo.toml";
-  if (!std::filesystem::exists(cargo_toml))
+  }
+  std::error_code error;
+  const auto absolute_root =
+      std::filesystem::absolute(*project_root_, error).lexically_normal();
+  if (error) {
+    set_metadata_receipt("rust-cargo", false);
     return;
-
-  MinimalCargoToml cargo = parse_cargo_toml(cargo_toml);
+  }
+  const auto root = std::filesystem::canonical(*project_root_, error);
+  if (error) {
+    set_metadata_receipt("rust-cargo", false);
+    return;
+  }
+  complete = root == absolute_root;
+  const auto cargo_toml = root / "Cargo.toml";
+  const auto resolved_root_cargo =
+      std::filesystem::canonical(cargo_toml, error);
+  if (error || resolved_root_cargo != cargo_toml.lexically_normal())
+    complete = false;
+  error.clear();
+  const auto root_content = read_binary_file(cargo_toml);
+  if (!root_content.has_value()) {
+    set_metadata_receipt("rust-cargo", false);
+    return;
+  }
+  inputs.push_back(input_receipt("Cargo.toml", *root_content));
+  MinimalCargoToml cargo = parse_cargo_toml(*root_content);
+  complete = complete && cargo.complete &&
+             (!cargo.saw_package_table || !cargo.package_name.empty()) &&
+             (!cargo.package_name.empty() || cargo.saw_workspace_table);
   if (!cargo.package_name.empty())
     internal_crates_.insert(cargo.package_name);
 
-  if (cargo.workspace_members.empty())
-    return;
-
+  std::unordered_set<std::string> observed_members;
   for (const auto &pattern : cargo.workspace_members) {
-    for (const auto &dir : resolve_glob(root, pattern)) {
-      std::filesystem::path member_cargo = dir / "Cargo.toml";
-      if (!std::filesystem::exists(member_cargo))
+    std::vector<std::filesystem::path> directories;
+    if (!resolve_workspace_dirs(root, pattern, directories))
+      complete = false;
+    if (directories.empty())
+      continue;
+    for (const auto &directory : directories) {
+      const auto resolved_directory =
+          std::filesystem::canonical(directory, error);
+      if (error || !path_is_within(resolved_directory, root)) {
+        error.clear();
+        complete = false;
         continue;
-      MinimalCargoToml m = parse_cargo_toml(member_cargo);
+      }
+      const auto absolute_directory =
+          std::filesystem::absolute(directory, error).lexically_normal();
+      if (error || absolute_directory != resolved_directory) {
+        error.clear();
+        complete = false;
+      }
+      const auto relative_directory =
+          std::filesystem::relative(resolved_directory, root, error)
+              .generic_string();
+      if (error || !canonical_relative_path(relative_directory, false) ||
+          !observed_members.insert(relative_directory).second) {
+        error.clear();
+        complete = false;
+        continue;
+      }
+      const auto relative_cargo = relative_directory + "/Cargo.toml";
+      const auto member_cargo = resolved_directory / "Cargo.toml";
+      const auto resolved_member_cargo =
+          std::filesystem::canonical(member_cargo, error);
+      if (error || resolved_member_cargo != member_cargo.lexically_normal())
+        complete = false;
+      error.clear();
+      const auto member_content = read_binary_file(member_cargo);
+      if (!member_content.has_value()) {
+        complete = false;
+        continue;
+      }
+      inputs.push_back(input_receipt(relative_cargo, *member_content));
+      MinimalCargoToml m = parse_cargo_toml(*member_content);
+      complete = complete && m.complete && !m.package_name.empty();
       if (!m.package_name.empty())
         internal_crates_.insert(m.package_name);
     }
   }
+  std::vector<std::string> crates(internal_crates_.begin(),
+                                  internal_crates_.end());
+  set_metadata_receipt("rust-cargo", complete, std::move(inputs),
+                       std::move(crates));
 }
 
 std::string SCIPRustDecoder::unify_symbol_name(const std::string &symbol) {

--- a/core/tests/fact_query_index_test.cpp
+++ b/core/tests/fact_query_index_test.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <future>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -353,6 +354,261 @@ void assert_compact_route_adjacency() {
   }
 }
 
+constexpr const char *BASE_FILTER_SURFACE =
+    "0112871fe1aafef3930d910a15c12b7632f73803fd55f5620f219c9dd87d64df";
+constexpr const char *ROOT_FILTER_SURFACE =
+    "5f22cb22ddb5647ecd8b9a58c611f32fc5b67c5ad63bf0db4f5977f2a4f80179";
+constexpr const char *EXTERNAL_FILTER_SURFACE =
+    "f719c83c8abe745e9473aa287ce64a19865e8dac5691f6ce2c8ca2f5881b2e77";
+
+std::shared_ptr<DecodedRecords> make_filter_proof_records() {
+  auto records = std::make_shared<DecodedRecords>();
+  CodeGraph::VertexData root;
+  root.name = codenib::core::ROOT_NODE;
+  root.type = "root";
+  CodeGraph::VertexData directory;
+  directory.name = "src";
+  directory.type = codenib::core::NODE_TYPE_DIRECTORY;
+  directory.unified_name = "src";
+  CodeGraph::VertexData file;
+  file.name = "src/main.py";
+  file.type = codenib::core::NODE_TYPE_FILE;
+  file.unified_name = "src/main.py";
+  records->vertices = {
+      root,
+      directory,
+      file,
+      definition("canonical-caller", "src/main.py:caller()", 8),
+      definition("canonical-target", "src/main.py:target()", 2),
+  };
+  records->edges = {
+      {0, 1, codenib::core::EDGE_TYPE_CONTAIN, std::nullopt, std::nullopt},
+      {1, 2, codenib::core::EDGE_TYPE_CONTAIN, std::nullopt, std::nullopt},
+      {2, 3, codenib::core::EDGE_TYPE_CONTAIN, std::nullopt, std::nullopt},
+      {3, 4, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 9},
+  };
+  return records;
+}
+
+void assert_filter_identity_proof() {
+  FactQueryIndex index(make_filter_proof_records());
+  const auto proof = index.prove_filter_identity(
+      {"src/helper.py", "src/main.py"}, BASE_FILTER_SURFACE);
+  assert(proof.schema_version == 1);
+  assert(proof.identity);
+  assert(proof.allowed_file_count == 2);
+  assert(proof.allowed_files_sha256 ==
+         "eba6f15171dd9ec7a051c2e9d51b0d72989bf55c6b0c1108d11fd929c636f6b3");
+  assert(proof.query_surface_sha256 ==
+         "0112871fe1aafef3930d910a15c12b7632f73803fd55f5620f219c9dd87d64df");
+  assert(proof.record_count == 5);
+  assert(proof.directory_count == 1);
+  assert(proof.file_count == 1);
+  assert(proof.definition_count == 2);
+  assert(proof.reference_only_count == 0);
+  assert(proof.edge_count == 4);
+  assert(proof.reference_count == 1);
+  assert(proof.occurrence_count == 0);
+  std::vector<std::future<FactQueryIndex::FilterIdentityProof>> concurrent;
+  for (int worker = 0; worker < 4; ++worker) {
+    concurrent.emplace_back(std::async(std::launch::async, [&index]() {
+      return index.prove_filter_identity({"src/helper.py", "src/main.py"},
+                                         BASE_FILTER_SURFACE);
+    }));
+  }
+  for (auto &result : concurrent)
+    assert(result.get().query_surface_sha256 == proof.query_surface_sha256);
+  const auto narrower =
+      index.prove_filter_identity({"src/main.py"}, BASE_FILTER_SURFACE);
+  assert(narrower.allowed_files_sha256 != proof.allowed_files_sha256);
+  assert(narrower.query_surface_sha256 == proof.query_surface_sha256);
+
+  auto changed_selection = make_filter_proof_records();
+  changed_selection->vertices[4].selection_line = 3;
+  const auto changed_selection_proof =
+      FactQueryIndex(changed_selection)
+          .prove_filter_identity({"src/main.py"},
+                                 "f9605a33aeabcc7a9dc8217df0cf2799eab9e2e5c762d"
+                                 "16f98a8a2bf979e9365");
+  assert(changed_selection_proof.record_count == proof.record_count);
+  assert(changed_selection_proof.edge_count == proof.edge_count);
+  assert(changed_selection_proof.query_surface_sha256 !=
+         proof.query_surface_sha256);
+
+  auto changed_anchor = make_filter_proof_records();
+  changed_anchor->edges.back().anchor_line = 10;
+  const auto changed_anchor_proof =
+      FactQueryIndex(changed_anchor)
+          .prove_filter_identity({"src/main.py"},
+                                 "4843be465daee641c550915a75873739879b5e89f0814"
+                                 "c932a964ef5713106cd");
+  assert(changed_anchor_proof.record_count == proof.record_count);
+  assert(changed_anchor_proof.edge_count == proof.edge_count);
+  assert(changed_anchor_proof.query_surface_sha256 !=
+         proof.query_surface_sha256);
+
+  auto root_only = std::make_shared<DecodedRecords>();
+  CodeGraph::VertexData root;
+  root.name = codenib::core::ROOT_NODE;
+  root.type = "root";
+  root_only->vertices.push_back(root);
+  const auto empty =
+      FactQueryIndex(root_only).prove_filter_identity({}, ROOT_FILTER_SURFACE);
+  assert(empty.allowed_file_count == 0);
+  assert(empty.allowed_files_sha256 ==
+         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  const auto unicode = FactQueryIndex(root_only).prove_filter_identity(
+      {"src/a.py", "src/\xc3\xa9.py"}, ROOT_FILTER_SURFACE);
+  assert(unicode.allowed_files_sha256 ==
+         "d2d8f5e99942bf3b1dde637675b3b908e1b68e0c78bda25fe9ef6eb197a9aed8");
+
+  auto rejects = [](std::shared_ptr<DecodedRecords> records,
+                    std::vector<std::string> allowed_files,
+                    const std::string &expected_surface = BASE_FILTER_SURFACE) {
+    try {
+      (void)FactQueryIndex(std::move(records))
+          .prove_filter_identity(allowed_files, expected_surface);
+      assert(false && "unsafe filter proof must fail closed");
+    } catch (const std::invalid_argument &) {
+    }
+  };
+
+  rejects(make_filter_proof_records(), {"src/main.py"}, std::string(64, '0'));
+  rejects(make_filter_proof_records(), {"src/main.py"}, "invalid");
+  rejects(make_filter_proof_records(), {"src/main.py"}, std::string(64, 'A'));
+
+  rejects(make_filter_proof_records(), {"src/main.py", "src/main.py"});
+  rejects(make_filter_proof_records(), {"src/main.py", "src/helper.py"});
+  for (const auto &path :
+       {std::string{}, std::string{"/src/main.py"}, std::string{"src\\main.py"},
+        std::string{"src/./main.py"}, std::string{"src/../main.py"},
+        std::string{"src//main.py"}, std::string{"src/main.py/"},
+        std::string{"C:/src/main.py"}, std::string{"src/ma\0in.py", 13},
+        std::string{"src/"
+                    "\xc0\xaf"
+                    "main.py"}}) {
+    rejects(make_filter_proof_records(), {path});
+  }
+  rejects(make_filter_proof_records(), {"src/helper.py"});
+
+  auto filtered_anchor = make_filter_proof_records();
+  filtered_anchor->edges.back().anchor_file = "vendor/main.py";
+  rejects(filtered_anchor, {"src/main.py"});
+
+  auto occurrence_metadata = make_filter_proof_records();
+  occurrence_metadata->occurrences = {
+      occurrence(9, 2, 8, codenib::core::OCCURRENCE_ROLE_REFERENCE, 4, 3),
+  };
+  rejects(occurrence_metadata, {"src/main.py"});
+
+  auto query_order_metadata = make_filter_proof_records();
+  query_order_metadata->query_resolution_order = {0, 1, 2, 3, 4};
+  rejects(query_order_metadata, {"src/main.py"});
+
+  auto route_order_metadata = make_filter_proof_records();
+  route_order_metadata->route_vertex_order = {0, 1, 2, 3, 4};
+  rejects(route_order_metadata, {"src/main.py"});
+
+  auto route_adjacency_metadata = make_filter_proof_records();
+  route_adjacency_metadata->route_adjacency_complete = true;
+  rejects(route_adjacency_metadata, {"src/main.py"});
+
+  auto external = make_filter_proof_records();
+  external->vertices.push_back(
+      reference_only("external-target", "vendor/lib.py:external()"));
+  external->edges.push_back(
+      {3, 5, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 10});
+  const auto external_proof = FactQueryIndex(external).prove_filter_identity(
+      {"src/main.py"}, EXTERNAL_FILTER_SURFACE);
+  assert(external_proof.reference_only_count == 1);
+  assert(external_proof.query_surface_sha256 == EXTERNAL_FILTER_SURFACE);
+
+  auto reference_without_provenance = make_filter_proof_records();
+  auto null_reference =
+      reference_only("external-target", "vendor/lib.py:external()");
+  null_reference.has_definition.reset();
+  reference_without_provenance->vertices.push_back(null_reference);
+  reference_without_provenance->edges.push_back(
+      {3, 5, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 10});
+  rejects(reference_without_provenance, {"src/main.py"},
+          "7c5301fc83aae5751d1414c2db1ee527d887f778a2bdd6d41978fa92e16cf72f");
+
+  auto ranged_reference = make_filter_proof_records();
+  auto invalid_reference =
+      reference_only("external-target", "vendor/lib.py:external()");
+  invalid_reference.start_line = 1;
+  invalid_reference.end_line = 2;
+  invalid_reference.selection_line = 1;
+  ranged_reference->vertices.push_back(invalid_reference);
+  ranged_reference->edges.push_back(
+      {3, 5, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 10});
+  rejects(ranged_reference, {"src/main.py"},
+          "841dca4d50387287e714ae580c4a406ca3b98cc749ddc90a97554c45a6e73c03");
+
+  auto orphan_reference = make_filter_proof_records();
+  orphan_reference->vertices.push_back(
+      reference_only("external-target", "vendor/lib.py:external()"));
+  rejects(orphan_reference, {"src/main.py"});
+
+  auto reference_source = make_filter_proof_records();
+  reference_source->vertices.push_back(
+      reference_only("external-target", "vendor/lib.py:external()"));
+  reference_source->edges.push_back(
+      {5, 4, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 10});
+  rejects(reference_source, {"src/main.py"});
+
+  auto structural_reference_target = make_filter_proof_records();
+  structural_reference_target->vertices.push_back(
+      reference_only("external-target", "vendor/lib.py:external()"));
+  structural_reference_target->edges.push_back(
+      {3, 5, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 10});
+  structural_reference_target->edges.push_back(
+      {2, 5, codenib::core::EDGE_TYPE_CONTAIN, std::nullopt, std::nullopt});
+  rejects(structural_reference_target, {"src/main.py"});
+
+  auto unknown_edge = make_filter_proof_records();
+  unknown_edge->edges.push_back({3, 4, "unknown", std::nullopt, std::nullopt});
+  rejects(unknown_edge, {"src/main.py"});
+
+  auto unknown_vertex = make_filter_proof_records();
+  CodeGraph::VertexData unknown;
+  unknown.name = "unknown-record";
+  unknown.type = "unknown";
+  unknown_vertex->vertices.push_back(unknown);
+  rejects(unknown_vertex, {"src/main.py"});
+
+  auto root_reference = make_filter_proof_records();
+  root_reference->edges.push_back(
+      {0, 4, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 11});
+  rejects(root_reference, {"src/main.py"});
+
+  auto mismatched_unified = make_filter_proof_records();
+  mismatched_unified->vertices[4].unified_name = "vendor/main.py:target()";
+  rejects(mismatched_unified, {"src/main.py"});
+
+  auto invalid_utf8_name = make_filter_proof_records();
+  invalid_utf8_name->vertices[4].name = "symbol-\xc0\xaf";
+  rejects(invalid_utf8_name, {"src/main.py"});
+
+  auto anchored_containment = make_filter_proof_records();
+  anchored_containment->edges.front().anchor_file = "src/main.py";
+  anchored_containment->edges.front().anchor_line = 1;
+  rejects(anchored_containment, {"src/main.py"});
+
+  auto colon_path = std::make_shared<DecodedRecords>();
+  CodeGraph::VertexData colon_file;
+  colon_file.name = "a:b.py";
+  colon_file.type = codenib::core::NODE_TYPE_FILE;
+  auto colon_definition = definition("colon-symbol", "a:b.py:thing()", 1);
+  colon_definition.file = "a:b.py";
+  colon_path->vertices = {root, colon_file, colon_definition};
+  colon_path->edges = {
+      {0, 1, codenib::core::EDGE_TYPE_CONTAIN, std::nullopt, std::nullopt},
+      {1, 2, codenib::core::EDGE_TYPE_CONTAIN, std::nullopt, std::nullopt},
+  };
+  rejects(colon_path, {"a:b.py"});
+}
+
 } // namespace
 
 int main() {
@@ -361,6 +617,7 @@ int main() {
   assert_exact_occurrence_ranges_and_fallbacks();
   assert_invalid_occurrences_fail_closed();
   assert_compact_route_adjacency();
+  assert_filter_identity_proof();
   std::cout << "fact_query_index_test: OK\n";
   return 0;
 }

--- a/core/tests/scip_decode_test.cpp
+++ b/core/tests/scip_decode_test.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "fact_query_index.h"
 #include "scip_decode.h"
 
 #include <cassert>
@@ -9,13 +10,16 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 using codenib::core::CodeGraph;
+using codenib::core::FactQueryIndex;
 using codenib::core::NODE_TYPE_CLASS;
 using codenib::core::NODE_TYPE_DIRECTORY;
 using codenib::core::NODE_TYPE_FILE;
@@ -86,6 +90,16 @@ def sample_call() -> int:
 )";
 }
 
+void write_text_file(const std::filesystem::path &path,
+                     const std::string &content) {
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  if (!output.is_open())
+    throw std::runtime_error("Failed to write test input at " + path.string());
+  output << content;
+  if (!output)
+    throw std::runtime_error("Failed to finish test input at " + path.string());
+}
+
 std::filesystem::path
 write_test_index(const std::filesystem::path &project_root) {
   const std::string scip_content = R"(documents {
@@ -128,6 +142,183 @@ write_test_index(const std::filesystem::path &project_root) {
   output << scip_content;
   output.close();
   return index_path;
+}
+
+void assert_parallel_document_order(const std::filesystem::path &project_root) {
+  const auto index_path = project_root / "ordered-index.scip";
+  write_text_file(index_path, R"scip(documents {
+  relative_path: "src/alpha.py"
+  occurrences {
+    range: 0
+    range: 0
+    range: 3
+    symbol: "src.alpha`/run()."
+    symbol_roles: 1
+    enclosing_range: 0
+    enclosing_range: 0
+    enclosing_range: 4
+    enclosing_range: 0
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 7
+    symbol: "src.beta`/run()."
+    symbol_roles: 8
+  }
+}
+documents {
+  relative_path: "src/beta.py"
+  occurrences {
+    range: 0
+    range: 0
+    range: 3
+    symbol: "src.beta`/run()."
+    symbol_roles: 1
+    enclosing_range: 0
+    enclosing_range: 0
+    enclosing_range: 4
+    enclosing_range: 0
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 7
+    symbol: "src.alpha`/run()."
+    symbol_roles: 8
+  }
+}
+)scip");
+
+  const std::vector<std::string> expected_names = {
+      ROOT_NODE,           "src",         "src/alpha.py", "src/alpha.py:run()",
+      "src/beta.py:run()", "src/beta.py",
+  };
+  for (int attempt = 0; attempt < 8; ++attempt) {
+    SCIPGraphDecoder decoder(index_path.string(), project_root.string());
+    auto records = decoder.decode_records();
+    std::vector<std::string> names;
+    names.reserve(records.vertices.size());
+    for (const auto &vertex : records.vertices)
+      names.push_back(vertex.name);
+    assert(names == expected_names);
+    assert(records.edges.size() == 7);
+    assert(records.edges[0].source == 0 && records.edges[0].target == 1);
+    assert(records.edges[1].source == 1 && records.edges[1].target == 2);
+    assert(records.edges[2].source == 2 && records.edges[2].target == 3);
+    assert(records.edges[3].source == 3 && records.edges[3].target == 4);
+    assert(records.edges[3].type == codenib::core::EDGE_TYPE_REFERENCE);
+    assert(records.edges[3].anchor_file == "src/alpha.py");
+    assert(records.edges[3].anchor_line == 2);
+    assert(records.edges[4].source == 1 && records.edges[4].target == 5);
+    assert(records.edges[5].source == 5 && records.edges[5].target == 4);
+    assert(records.edges[6].source == 4 && records.edges[6].target == 3);
+    assert(records.edges[6].type == codenib::core::EDGE_TYPE_REFERENCE);
+    assert(records.edges[6].anchor_file == "src/beta.py");
+    assert(records.edges[6].anchor_line == 2);
+
+    auto shared_records =
+        std::make_shared<codenib::core::DecodedRecords>(std::move(records));
+    const FactQueryIndex query_index(std::move(shared_records));
+    const auto proof = query_index.prove_filter_identity(
+        {"src/alpha.py", "src/beta.py"},
+        "dbab38dc2744ef46fd00cd8df1b22bc70212ca7020ef4f5daabb99feaf3d5ed4");
+    assert(proof.query_surface_sha256 ==
+           "dbab38dc2744ef46fd00cd8df1b22bc70212ca7020ef4f5daabb99feaf3d5ed4");
+  }
+}
+
+void assert_parallel_rust_document_order(
+    const std::filesystem::path &temp_root) {
+  const auto project_root = temp_root / "ordered-rust";
+  std::error_code error;
+  std::filesystem::create_directories(project_root, error);
+  assert(!error);
+  write_text_file(project_root / "Cargo.toml",
+                  "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n");
+  const auto index_path = project_root / "ordered-index.scip";
+  write_text_file(index_path, R"scip(documents {
+  relative_path: "src/alpha.rs"
+  occurrences {
+    range: 0
+    range: 0
+    range: 3
+    symbol: "rust-analyzer cargo demo 0.1 alpha/run()."
+    symbol_roles: 1
+    enclosing_range: 0
+    enclosing_range: 0
+    enclosing_range: 4
+    enclosing_range: 0
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 7
+    symbol: "rust-analyzer cargo demo 0.1 beta/run()."
+    symbol_roles: 8
+  }
+}
+documents {
+  relative_path: "src/beta.rs"
+  occurrences {
+    range: 0
+    range: 0
+    range: 3
+    symbol: "rust-analyzer cargo demo 0.1 beta/run()."
+    symbol_roles: 1
+    enclosing_range: 0
+    enclosing_range: 0
+    enclosing_range: 4
+    enclosing_range: 0
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 7
+    symbol: "rust-analyzer cargo demo 0.1 alpha/run()."
+    symbol_roles: 8
+  }
+}
+)scip");
+
+  const std::vector<std::string> expected_names = {
+      ROOT_NODE,        "src",           "src/alpha.rs",
+      "demo/alpha/run", "demo/beta/run", "src/beta.rs",
+  };
+  for (int attempt = 0; attempt < 8; ++attempt) {
+    codenib::core::SCIPRustDecoder decoder(index_path.string(),
+                                           project_root.string());
+    auto records = decoder.decode_records();
+    std::vector<std::string> names;
+    names.reserve(records.vertices.size());
+    for (const auto &vertex : records.vertices)
+      names.push_back(vertex.name);
+    assert(names == expected_names);
+    assert(records.edges.size() == 7);
+    const std::vector<std::pair<CodeGraph::VertexId, CodeGraph::VertexId>>
+        expected_endpoints = {
+            {0, 1}, {1, 2}, {2, 3}, {3, 4}, {1, 5}, {5, 4}, {4, 3},
+        };
+    for (std::size_t index = 0; index < records.edges.size(); ++index) {
+      assert(records.edges[index].source == expected_endpoints[index].first);
+      assert(records.edges[index].target == expected_endpoints[index].second);
+    }
+    assert(records.edges[3].type == codenib::core::EDGE_TYPE_REFERENCE);
+    assert(records.edges[3].anchor_file == "src/alpha.rs");
+    assert(records.edges[3].anchor_line == 2);
+    assert(records.edges[6].type == codenib::core::EDGE_TYPE_REFERENCE);
+    assert(records.edges[6].anchor_file == "src/beta.rs");
+    assert(records.edges[6].anchor_line == 2);
+
+    auto shared_records =
+        std::make_shared<codenib::core::DecodedRecords>(std::move(records));
+    const FactQueryIndex query_index(std::move(shared_records));
+    const auto proof = query_index.prove_filter_identity(
+        {"Cargo.toml", "src/alpha.rs", "src/beta.rs"},
+        "d7a2026249c1545f20827eda5cd4804a10a8deaa8d75576c7435361ec7113377");
+    assert(proof.query_surface_sha256 ==
+           "d7a2026249c1545f20827eda5cd4804a10a8deaa8d75576c7435361ec7113377");
+  }
 }
 
 void assert_decoder_registry() {
@@ -177,6 +368,8 @@ int main(int argc, char **argv) {
   }
 
   TempDirectory temp_project;
+  assert_parallel_document_order(temp_project.path());
+  assert_parallel_rust_document_order(temp_project.path());
   write_python_source(temp_project.path());
   const auto index_path = write_test_index(temp_project.path());
 
@@ -187,6 +380,26 @@ int main(int argc, char **argv) {
   assert(!records.vertices.empty());
   assert(records.vertices.front().name == ROOT_NODE);
   assert(!records.edges.empty());
+  const auto first_receipt = records_decoder.last_input_receipt();
+  assert(first_receipt.schema_version == 1);
+  assert(first_receipt.index.path ==
+         std::filesystem::canonical(index_path).generic_string());
+  assert(first_receipt.index.size_bytes ==
+         std::filesystem::file_size(index_path));
+  assert(first_receipt.index.sha256.size() == 64);
+  assert(first_receipt.metadata_kind == "none");
+  assert(first_receipt.metadata_complete);
+  assert(first_receipt.metadata_inputs.empty());
+  assert(first_receipt.internal_crates.empty());
+  {
+    std::ofstream append(index_path, std::ios::binary | std::ios::app);
+    append << '\n';
+  }
+  (void)records_decoder.decode_records();
+  const auto second_receipt = records_decoder.last_input_receipt();
+  assert(second_receipt.index.size_bytes == first_receipt.index.size_bytes + 1);
+  assert(second_receipt.index.sha256 != first_receipt.index.sha256);
+  assert(second_receipt.metadata_kind == "none");
 
   SCIPGraphDecoder decoder(index_path.string(), temp_project.path().string());
   CodeGraph graph = decoder.decode();
@@ -247,6 +460,126 @@ int main(int argc, char **argv) {
       std::istreambuf_iterator<char>());
   assert(serialized.find("\"symbol_kind\": null") != std::string::npos);
   assert(serialized.find("\"has_definition\": true") != std::string::npos);
+
+  const auto rust_root = temp_project.path() / "rust-project";
+  std::error_code rust_error;
+  std::filesystem::create_directories(rust_root / "crates/a", rust_error);
+  assert(!rust_error);
+  std::filesystem::create_directories(rust_root / "crates/b", rust_error);
+  assert(!rust_error);
+  write_text_file(rust_root / "Cargo.toml",
+                  "[workspace]\nmembers = [\n  \"crates/*\",\n]\n");
+  write_text_file(rust_root / "crates/a/Cargo.toml",
+                  "[package]\nname = \"alpha\"\n");
+  write_text_file(rust_root / "crates/b/Cargo.toml",
+                  "[package]\nname = \"beta\"\n");
+  codenib::core::SCIPRustDecoder rust_decoder(index_path.string(),
+                                              rust_root.string());
+  (void)rust_decoder.decode_records();
+  const auto rust_receipt = rust_decoder.last_input_receipt();
+  assert(rust_receipt.metadata_kind == "rust-cargo");
+  assert(rust_receipt.metadata_complete);
+  assert(rust_receipt.metadata_inputs.size() == 3);
+  assert(rust_receipt.metadata_inputs[0].path == "Cargo.toml");
+  assert(rust_receipt.metadata_inputs[1].path == "crates/a/Cargo.toml");
+  assert(rust_receipt.metadata_inputs[2].path == "crates/b/Cargo.toml");
+  for (const auto &input : rust_receipt.metadata_inputs) {
+    assert(input.size_bytes > 0);
+    assert(input.sha256.size() == 64);
+    assert(input.path.front() != '/');
+    assert(input.path.find('\\') == std::string::npos);
+    assert(input.path.find("..") == std::string::npos);
+  }
+  assert((rust_receipt.internal_crates ==
+          std::vector<std::string>{"alpha", "beta"}));
+
+  write_text_file(rust_root / "crates/a/Cargo.toml",
+                  "[package]\nname = \"gamma\"\n");
+  (void)rust_decoder.decode_records();
+  const auto changed_rust_receipt = rust_decoder.last_input_receipt();
+  assert(changed_rust_receipt.metadata_complete);
+  assert((changed_rust_receipt.internal_crates ==
+          std::vector<std::string>{"beta", "gamma"}));
+  assert(changed_rust_receipt.metadata_inputs[1].sha256 !=
+         rust_receipt.metadata_inputs[1].sha256);
+
+  const auto member_cargo = rust_root / "crates/a/Cargo.toml";
+  const auto member_cargo_real = rust_root / "crates/a/Cargo.real.toml";
+  std::filesystem::rename(member_cargo, member_cargo_real, rust_error);
+  assert(!rust_error);
+  std::filesystem::create_symlink(member_cargo_real.filename(), member_cargo,
+                                  rust_error);
+  if (!rust_error) {
+    (void)rust_decoder.decode_records();
+    assert(!rust_decoder.last_input_receipt().metadata_complete);
+    std::filesystem::remove(member_cargo, rust_error);
+    assert(!rust_error);
+  }
+  std::filesystem::rename(member_cargo_real, member_cargo, rust_error);
+  assert(!rust_error);
+
+  write_text_file(rust_root / "Cargo.toml",
+                  "[workspace]\nmembers = ['crates/a']\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+
+  write_text_file(rust_root / "Cargo.toml",
+                  std::string{"[package]\nname = \""} + "\xc0\xaf" + "\"\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+
+  write_text_file(rust_root / "Cargo.toml",
+                  "[\"workspace\"]\nmembers = [\"crates/a\"]\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+
+  write_text_file(rust_root / "Cargo.toml",
+                  "workspace.members = [\"crates/a\"]\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+
+  write_text_file(rust_root / "Cargo.toml",
+                  "[workspace]\nmembers = [\"crates/\\u0061\"]\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+
+  // Preserve the established decoder's broad wildcard expansion while the
+  // receipt marks anything except a final "*" component unproven.
+  write_text_file(rust_root / "Cargo.toml",
+                  "[workspace]\nmembers = [\"crates/a*\"]\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+  assert((rust_decoder.last_input_receipt().internal_crates ==
+          std::vector<std::string>{"beta", "gamma"}));
+
+  write_text_file(rust_root / "Cargo.toml",
+                  "[workspace]\nmembers = [\"crates/a\", 1]\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+
+  write_text_file(rust_root / "Cargo.toml",
+                  "[workspace]\nmembers = [\"crates/a\"]\n"
+                  "exclude = [\"crates/a\"]\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+
+  std::filesystem::create_directories(rust_root / "crates/missing", rust_error);
+  assert(!rust_error);
+  write_text_file(rust_root / "Cargo.toml",
+                  "[workspace]\nmembers = [\"crates/missing\"]\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+  assert(rust_decoder.last_input_receipt().metadata_inputs.size() == 1);
+
+  const auto root_cargo = rust_root / "Cargo.toml";
+  const auto root_cargo_saved = rust_root / "Cargo.saved.toml";
+  std::filesystem::rename(root_cargo, root_cargo_saved, rust_error);
+  assert(!rust_error);
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+  assert(rust_decoder.last_input_receipt().metadata_inputs.empty());
+  std::filesystem::rename(root_cargo_saved, root_cargo, rust_error);
+  assert(!rust_error);
 
   return 0;
 }

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -148,6 +148,35 @@ make fact-query-profile \
 Pass `--external-index-seconds` through `FACT_QUERY_PROFILE_EXTRA_ARGS` when a
 separate cold-start analysis should include unchanged SCIP generation time.
 
+For a consumer-safe candidate, the native decode payload includes a v1 input
+receipt over the exact `index.decoded` bytes it parsed. Rust adds the exact
+root/member Cargo inputs and the internal-crate set produced from them. The
+native `prove_filter_identity(allowed_files, expected_query_surface_sha256)`
+API requires canonical, UTF-8 bytewise-sorted unique paths, then scans the file
+set plus every immutable vertex, edge, and reference anchor in O(F+V+E), without
+filtering or remapping records. Its allowed-path digest and partition counts are
+independently checked in Python. The required digest comes from the trusted
+serial-writer receipt, and the independently computed native digest must match
+it exactly, covering vertex and edge identity, fields, and insertion order
+rather than only aggregate counts.
+
+`codenib.scip_interface.scip_query.load_fact_query_candidate(...)` is the
+graph-free admission boundary. It requires a current builder-schema-v4,
+single-language full rebuild; verifies the manifest, source, decoded artifact,
+persisted graph-writer receipt, query-surface digest, repository filter policy,
+and Rust Cargo identity before and after decode; and returns the index only
+after the native proof succeeds. Receipt capture is enabled only by the
+compiler build that publishes schema-v4 evidence; ordinary graph pipelines do
+not incur the extra scans. Partial, incremental, multi-language,
+source-coverage fallback, symlinked cache artifacts, mutated inputs, or facts
+absent from the bound serial filtered query surface fail closed.
+Reference-only external targets are admitted only when the exact serial
+query-surface digest retains them and every incoming reference carries an
+allowed source anchor. The first admitted languages are Python and Rust; other
+metadata contracts remain future work. The legacy `decode()` graph path
+remains unchanged, and this candidate is not a production MCP route until the
+separate consumer-boundary gate passes exact parity and the required speedup.
+
 ## Native clangd Symbol, Position, And Route Queries
 
 The C/C++ query-specific path starts from an existing project-local clangd

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -1124,6 +1124,23 @@ new, ordered program rather than extending the archived Phase 0--6 queue:
    repository call with bounded native workers and an ordered flat buffer. A
    failed gate removes the POC implementation and retains only the receipt.
 
+M1 implementation status ([#597](https://github.com/sysevol-ai/CodeNib/issues/597)):
+the candidate boundary is deliberately split into two proofs. C++ records the
+exact decoded-index and Rust Cargo bytes it consumed and performs an
+O(F+V+E) filter-identity scan without deleting or remapping facts. The
+order-sensitive native query-surface digest must exactly equal the compiler's
+serial graph digest. The graph-free Python facade binds that evidence to a
+current builder-schema-v4 compiler manifest, source fingerprint, repository
+filter policy, resolved root, and graph-writer artifact receipt. Only the
+publishing compiler build opts into the additional receipt scans; ordinary
+graph pipelines retain their default behavior. Incremental, partial,
+multi-language, source-coverage fallback, mutated, or otherwise unproven inputs
+are rejected atomically. Reference-only external targets are retained only
+when the exact serial filtered surface contains them and every incoming
+reference has an allowed source anchor. The first admitted languages are
+Python and Rust. This is safety/admission work only: it does not enable an MCP
+route and does not replace the M2 consumer-boundary measurement in #598.
+
 Production integration and additional FactQueryIndex languages get focused
 issues only after #598 passes for the relevant language. Warm-session
 incremental parse-tree reuse is timeboxed only after #600 records the bounded

--- a/test/compiler/test_artifact_fingerprints.py
+++ b/test/compiler/test_artifact_fingerprints.py
@@ -10,6 +10,7 @@ import pytest
 
 from codenib.compiler.artifact_fingerprints import (
     bm25_artifact_file_fingerprints,
+    regular_file_fingerprint,
     require_bm25_manifest_artifact,
 )
 
@@ -64,3 +65,33 @@ def test_manifest_bm25_integrity_does_not_hide_malformed_config_record(tmp_path)
 
     with pytest.raises(ValueError, match="manifest fingerprints"):
         require_bm25_manifest_artifact(entry)
+
+
+def test_regular_file_fingerprint_rejects_a_changed_open_generation(
+    tmp_path, monkeypatch
+):
+    import codenib.compiler.artifact_fingerprints as fingerprints
+
+    path = tmp_path / "artifact.bin"
+    path.write_bytes(b"stable bytes")
+    real_fstat = fingerprints.os.fstat
+    calls = 0
+
+    def changing_fstat(descriptor):
+        nonlocal calls
+        observed = real_fstat(descriptor)
+        calls += 1
+        if calls == 2:
+            return SimpleNamespace(
+                st_mode=observed.st_mode,
+                st_dev=observed.st_dev,
+                st_ino=observed.st_ino,
+                st_size=observed.st_size + 1,
+                st_mtime_ns=observed.st_mtime_ns,
+            )
+        return observed
+
+    monkeypatch.setattr(fingerprints.os, "fstat", changing_fstat)
+
+    with pytest.raises(ValueError, match="changed while hashing"):
+        regular_file_fingerprint(path)

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -18,6 +18,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
 from codenib.compiler.index_builders import (
     BM25IndexBuilder,
     IndexBuilderRegistry,
@@ -51,6 +52,22 @@ from codenib.repository_filters import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _write_fake_graph_artifact(output_dir: str | Path) -> Path:
+    path = Path(output_dir) / "graph.pkl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"test-symbol-graph\n")
+    return path
+
+
+def _fake_graph_output_receipt(output_dir: str | Path) -> dict:
+    path = _write_fake_graph_artifact(output_dir)
+    return {
+        "path": str(path.resolve()),
+        **regular_file_fingerprint(path),
+        "query_surface_sha256": "c" * 64,
+    }
 
 
 def _mock_builder(index_type: str = "mock", file_count: int = 42):
@@ -557,6 +574,13 @@ class TestVectorIndexBuilder:
 
 
 class TestSymbolGraphBuilder:
+    @pytest.fixture(autouse=True)
+    def _stable_query_surface_digest(self, monkeypatch):
+        monkeypatch.setattr(
+            "codenib.scip_interface.query_surface.query_surface_sha256",
+            lambda _graph: "c" * 64,
+        )
+
     def test_build_returns_status(self, monkeypatch, tmp_path):
         from codenib import ls_router
 
@@ -566,11 +590,17 @@ class TestSymbolGraphBuilder:
 
         def fake_build_graph_for_languages(*args, **kwargs):
             calls.append((args, kwargs))
+            graph_receipt = _fake_graph_output_receipt(args[1])
+            (Path(args[1]) / "index.decoded").write_text(
+                "post-hoc artifact without a consumed receipt",
+                encoding="utf-8",
+            )
             return GraphBuildResult(
                 graph=mock_graph,
                 requested_languages=["python"],
                 available_languages=["python"],
                 failed_languages={},
+                graph_output_receipt=graph_receipt,
             )
 
         monkeypatch.setattr(
@@ -590,8 +620,19 @@ class TestSymbolGraphBuilder:
         assert status.index_type == "symbol_graph"
         assert status.state == IndexState.FRESH
         assert status.metadata["node_count"] == 50
+        assert status.metadata["edge_count"] == 0
         assert status.metadata["language"] == "python"
         assert status.metadata["languages"] == ["python"]
+        assert status.metadata["builder_schema"] == 4
+        assert status.metadata["target_dir"] is None
+        assert status.metadata["update_mode"] == "full_rebuild"
+        assert status.metadata["scip_decoded_artifacts"] == {}
+        assert status.metadata["graph_artifact"] == {
+            "relative_path": "graph.pkl",
+            "size": len(b"test-symbol-graph\n"),
+            "sha256": regular_file_fingerprint(Path(output) / "graph.pkl")["sha256"],
+        }
+        assert status.metadata["query_surface_sha256"] == "c" * 64
         assert calls == [
             (
                 ("/fake/repo", output),
@@ -602,9 +643,112 @@ class TestSymbolGraphBuilder:
                     "skip_level": None,
                     "exclude_patterns": default_exclude_patterns(),
                     "graph_route": "active",
+                    "capture_artifact_receipts": True,
                 },
             )
         ]
+
+    def test_build_records_existing_decoded_scip_artifact(self, monkeypatch, tmp_path):
+        from codenib import ls_router
+        from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
+
+        mock_graph = MagicMock()
+        mock_graph.graph.vs = [MagicMock()]
+        output = tmp_path / "graph"
+        output.mkdir()
+        graph_receipt = _fake_graph_output_receipt(output)
+        decoded = output / "index.decoded"
+        decoded.write_text("documents {}\n", encoding="utf-8")
+        decoded_receipt = {
+            "path": str(decoded.resolve()),
+            **regular_file_fingerprint(decoded),
+        }
+
+        monkeypatch.setattr(
+            ls_router,
+            "build_graph_for_languages_with_report",
+            lambda *args, **kwargs: GraphBuildResult(
+                graph=mock_graph,
+                requested_languages=["python"],
+                available_languages=["python"],
+                failed_languages={},
+                decoded_input_receipts={"python": decoded_receipt},
+                graph_output_receipt=graph_receipt,
+            ),
+        )
+
+        status = SymbolGraphBuilder(language="python").build(
+            scope="current_repo",
+            repo_path="/fake/repo",
+            output_dir=str(output),
+        )
+
+        assert status.metadata["scip_decoded_artifacts"] == {
+            "python": {
+                "relative_path": "index.decoded",
+                **regular_file_fingerprint(decoded),
+            }
+        }
+
+    def test_build_rejects_graph_replaced_after_writer_receipt(
+        self, monkeypatch, tmp_path
+    ):
+        from codenib import ls_router
+
+        mock_graph = MagicMock()
+        mock_graph.graph.vs = [MagicMock()]
+        mock_graph.graph.es = []
+        output = tmp_path / "graph"
+        graph_receipt = _fake_graph_output_receipt(output)
+        (output / "graph.pkl").write_bytes(b"replacement graph\n")
+        monkeypatch.setattr(
+            ls_router,
+            "build_graph_for_languages_with_report",
+            lambda *args, **kwargs: GraphBuildResult(
+                graph=mock_graph,
+                requested_languages=["python"],
+                available_languages=["python"],
+                failed_languages={},
+                graph_output_receipt=graph_receipt,
+            ),
+        )
+
+        with pytest.raises(ValueError, match="changed after its writer"):
+            SymbolGraphBuilder(language="python").build(
+                scope="current_repo",
+                repo_path="/fake/repo",
+                output_dir=str(output),
+            )
+
+    def test_build_rejects_same_count_query_surface_mutation(
+        self, monkeypatch, tmp_path
+    ):
+        from codenib import ls_router
+
+        mock_graph = MagicMock()
+        mock_graph.graph.vs = [MagicMock()]
+        mock_graph.graph.es = []
+        output = tmp_path / "graph"
+        graph_receipt = _fake_graph_output_receipt(output)
+        graph_receipt["query_surface_sha256"] = "d" * 64
+        monkeypatch.setattr(
+            ls_router,
+            "build_graph_for_languages_with_report",
+            lambda *args, **kwargs: GraphBuildResult(
+                graph=mock_graph,
+                requested_languages=["python"],
+                available_languages=["python"],
+                failed_languages={},
+                graph_output_receipt=graph_receipt,
+            ),
+        )
+
+        with pytest.raises(ValueError, match="query surface changed"):
+            SymbolGraphBuilder(language="python").build(
+                scope="current_repo",
+                repo_path="/fake/repo",
+                output_dir=str(output),
+            )
 
     def test_build_rejects_none_graph(self, monkeypatch, tmp_path):
         from codenib import ls_router
@@ -742,11 +886,13 @@ class TestSymbolGraphBuilder:
 
         def fake_build_graph_for_languages(*args, **kwargs):
             calls.append((args, kwargs))
+            graph_receipt = _fake_graph_output_receipt(args[1])
             return GraphBuildResult(
                 graph=mock_graph,
                 requested_languages=["python", "go"],
                 available_languages=["python", "go"],
                 failed_languages={},
+                graph_output_receipt=graph_receipt,
             )
 
         monkeypatch.setattr(
@@ -777,11 +923,13 @@ class TestSymbolGraphBuilder:
 
         def fake_build_graph_for_languages(*args, **kwargs):
             calls.append((args, kwargs))
+            graph_receipt = _fake_graph_output_receipt(args[1])
             return GraphBuildResult(
                 graph=mock_graph,
                 requested_languages=["java"],
                 available_languages=["java"],
                 failed_languages={},
+                graph_output_receipt=graph_receipt,
             )
 
         monkeypatch.setattr(
@@ -807,6 +955,9 @@ class TestSymbolGraphBuilder:
         mock_graph = MagicMock()
         mock_graph.graph.vs = [MagicMock()]
         mock_graph.graph.es = []
+        mock_graph.save_graph.side_effect = lambda path: Path(path).write_bytes(
+            b"test-symbol-graph\n"
+        )
         calls = []
         report = {
             "coverage_before": 0.5,
@@ -887,11 +1038,13 @@ class TestSymbolGraphBuilder:
 
         def fake_build(*args, **kwargs):
             calls.append((args, kwargs))
+            graph_receipt = _fake_graph_output_receipt(args[1])
             return GraphBuildResult(
                 graph=mock_graph,
                 requested_languages=["python", "cpp"],
                 available_languages=["python"],
                 failed_languages={"cpp": "compilation database missing"},
+                graph_output_receipt=graph_receipt,
             )
 
         monkeypatch.setattr(
@@ -2094,6 +2247,7 @@ class TestSymbolGraphIncremental:
         assert status.metadata["verification_details"] == {
             "method": "empty-relevant-diff"
         }
+        assert "scip_decoded_artifacts" not in status.metadata
         graph.save_graph.assert_called_once_with(str(out / "graph.pkl"))
 
     def test_contract_rebuild_is_requested_before_lsp_start(

--- a/test/scip/test_fact_query_index.py
+++ b/test/scip/test_fact_query_index.py
@@ -84,6 +84,8 @@ def test_compiled_contract_and_capabilities_are_explicit() -> None:
         "abi_version": 1,
         "format": "fact-query-index-v1",
         "requires_anchored_references": True,
+        "filter_identity_proof_schema_version": 1,
+        "input_receipt_schema_version": 1,
         "capabilities": {
             "definition_by_symbol": True,
             "references_by_symbol": True,

--- a/test/scip/test_scip_query.py
+++ b/test/scip/test_scip_query.py
@@ -1,0 +1,1443 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph-free manifest and receipt gates for native SCIP symbol queries."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from functools import partial
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.repository_filters import (
+    REPOSITORY_FILTER_POLICY_VERSION,
+    default_exclude_patterns,
+)
+from codenib.scip_interface.scip_filter import (
+    matches_exclude_patterns,
+    normalize_scip_path,
+    scip_path_is_allowed,
+)
+from codenib.scip_interface.scip_query import (
+    FACT_QUERY_CAPABILITIES,
+    FactQueryCandidateRejected,
+    load_fact_query_candidate,
+)
+from codenib.source_fingerprint import fingerprint_repository
+
+_PYTHON_PARITY_INDEX = r"""
+documents {
+  relative_path: "src/alpha.py"
+  occurrences {
+    range: 0
+    range: 0
+    range: 3
+    symbol: "src.alpha`/run()."
+    symbol_roles: 1
+    enclosing_range: 0
+    enclosing_range: 0
+    enclosing_range: 4
+    enclosing_range: 0
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 7
+    symbol: "src.beta`/run()."
+    symbol_roles: 8
+  }
+  occurrences {
+    range: 3
+    range: 4
+    range: 8
+    symbol: "scip-python python demo 0.1 `requests.models`/Response#"
+    symbol_roles: 8
+  }
+}
+documents {
+  relative_path: "src/beta.py"
+  occurrences {
+    range: 0
+    range: 0
+    range: 3
+    symbol: "src.beta`/run()."
+    symbol_roles: 1
+    enclosing_range: 0
+    enclosing_range: 0
+    enclosing_range: 4
+    enclosing_range: 0
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 7
+    symbol: "src.alpha`/run()."
+    symbol_roles: 8
+  }
+}
+"""
+
+_RUST_PARITY_INDEX = r"""
+documents {
+  relative_path: "src/alpha.rs"
+  occurrences {
+    range: 0
+    range: 0
+    range: 3
+    symbol: "rust-analyzer cargo demo 0.1 alpha/run()."
+    symbol_roles: 1
+    enclosing_range: 0
+    enclosing_range: 0
+    enclosing_range: 4
+    enclosing_range: 0
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 7
+    symbol: "rust-analyzer cargo demo 0.1 beta/run()."
+    symbol_roles: 8
+  }
+  occurrences {
+    range: 3
+    range: 4
+    range: 8
+    symbol: "rust-analyzer cargo demo 0.1 missing/External#"
+    symbol_roles: 8
+  }
+}
+documents {
+  relative_path: "src/beta.rs"
+  occurrences {
+    range: 0
+    range: 0
+    range: 3
+    symbol: "rust-analyzer cargo demo 0.1 beta/run()."
+    symbol_roles: 1
+    enclosing_range: 0
+    enclosing_range: 0
+    enclosing_range: 4
+    enclosing_range: 0
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 7
+    symbol: "rust-analyzer cargo demo 0.1 alpha/run()."
+    symbol_roles: 8
+  }
+}
+"""
+
+
+def _allowed_digest(paths: list[str]) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        digest.update(path.encode("utf-8"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _outcome(call: Callable[[], Any]) -> tuple[Any, ...]:
+    try:
+        return "ok", call()
+    except Exception as exc:  # noqa: BLE001 - public error parity is required
+        return "error", type(exc).__name__, str(exc)
+
+
+class _MockIndex:
+    fact_query_index = True
+    materializes_graph = False
+    capabilities = FACT_QUERY_CAPABILITIES
+    record_count = 5
+    edge_count = 4
+    symbol_count = 1
+    reference_count = 1
+    occurrence_count = 0
+    query_surface_sha256 = "0" * 64
+
+    def __init__(self, *, proof_updates: dict[str, Any] | None = None):
+        self._proof_updates = proof_updates or {}
+        self.allowed_files: list[str] = []
+        self.expected_query_surface_sha256: str | None = None
+
+    def prove_filter_identity(
+        self,
+        allowed_files: list[str],
+        expected_query_surface_sha256: str,
+    ) -> dict[str, Any]:
+        self.allowed_files = list(allowed_files)
+        self.expected_query_surface_sha256 = expected_query_surface_sha256
+        if expected_query_surface_sha256 != self.query_surface_sha256:
+            raise ValueError("query surface digest mismatch")
+        proof = {
+            "schema_version": 1,
+            "identity": True,
+            "allowed_file_count": len(allowed_files),
+            "allowed_files_sha256": _allowed_digest(allowed_files),
+            "record_count": self.record_count,
+            "directory_count": 1,
+            "file_count": 1,
+            "definition_count": 1,
+            "reference_only_count": 1,
+            "edge_count": self.edge_count,
+            "reference_count": self.reference_count,
+            "occurrence_count": self.occurrence_count,
+            "query_surface_sha256": self.query_surface_sha256,
+        }
+        proof.update(self._proof_updates)
+        return proof
+
+    def has_symbol(self, name: str) -> bool:
+        return name == "demo"
+
+
+class _MockCore:
+    def __init__(
+        self,
+        *,
+        index: _MockIndex | None = None,
+        receipt_updates: dict[str, Any] | None = None,
+        failure: BaseException | None = None,
+    ):
+        self.index = index or _MockIndex()
+        self.receipt_updates = receipt_updates or {}
+        self.failure = failure
+        self.calls: list[dict[str, Any]] = []
+
+    @staticmethod
+    def fact_query_index_contract() -> dict[str, Any]:
+        return {
+            "abi_version": 1,
+            "format": "fact-query-index-v1",
+            "requires_anchored_references": True,
+            "filter_identity_proof_schema_version": 1,
+            "input_receipt_schema_version": 1,
+            "capabilities": dict(FACT_QUERY_CAPABILITIES),
+        }
+
+    def decode_scip_fact_query_index(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        if self.failure is not None:
+            raise self.failure
+        index_path = Path(kwargs["index_file"])
+        fingerprint = regular_file_fingerprint(index_path)
+        language = kwargs["language"]
+        root = Path(kwargs["project_root"])
+        from codenib.scip_interface.query_surface import query_surface_sha256
+
+        decoder_class = (
+            __import__(
+                "codenib.scip_interface.scip_decode_rust",
+                fromlist=["SCIPRustGraphDecoder"],
+            ).SCIPRustGraphDecoder
+            if language == "rust"
+            else __import__(
+                "codenib.scip_interface.scip_decode_python",
+                fromlist=["SCIPPythonGraphDecoder"],
+            ).SCIPPythonGraphDecoder
+        )
+        serial_graph = decoder_class(str(index_path), project_root=str(root)).decode()
+        self.index.query_surface_sha256 = query_surface_sha256(serial_graph)
+        metadata: dict[str, Any] = {
+            "kind": "none",
+            "complete": True,
+            "inputs": [],
+            "internal_crates": [],
+        }
+        if language == "rust":
+            cargo_paths = [root / "Cargo.toml"]
+            cargo_paths.extend(sorted(root.glob("crates/*/Cargo.toml")))
+            inputs = []
+            crates = []
+            for cargo_path in cargo_paths:
+                cargo = regular_file_fingerprint(cargo_path)
+                inputs.append(
+                    {
+                        "path": cargo_path.relative_to(root).as_posix(),
+                        "size_bytes": cargo["size"],
+                        "sha256": cargo["sha256"],
+                    }
+                )
+                with cargo_path.open("rb") as handle:
+                    package = tomllib.load(handle).get("package", {})
+                if package.get("name"):
+                    crates.append(package["name"])
+            metadata = {
+                "kind": "rust-cargo",
+                "complete": True,
+                "inputs": inputs,
+                "internal_crates": sorted(crates),
+            }
+        receipt = {
+            "schema_version": 1,
+            "index": {
+                "path": str(index_path),
+                "size_bytes": fingerprint["size"],
+                "sha256": fingerprint["sha256"],
+            },
+            "metadata": metadata,
+        }
+        receipt.update(copy.deepcopy(self.receipt_updates))
+        return {
+            "format": "fact-query-index-v1",
+            "index": self.index,
+            "native_decode_ns": 10,
+            "native_index_ns": 5,
+            "decode_profile_ns": {
+                "worker_count": 1,
+                "document_count": 1,
+                "parse": 4,
+            },
+            "graph_materialized": False,
+            "input_receipt": receipt,
+        }
+
+
+def _write_candidate_manifest(
+    tmp_path: Path,
+    *,
+    language: str = "python",
+    rust_workspace: bool = False,
+    node_count: int = 5,
+    edge_count: int = 4,
+) -> tuple[Path, RepoManifest]:
+    root = tmp_path / "repo"
+    root.mkdir(parents=True)
+    if language == "rust":
+        cargo_text = '[package]\nname = "demo"\nversion = "0.1.0"\n'
+        if rust_workspace:
+            cargo_text += '[workspace]\nmembers = ["crates/*"]\n'
+        (root / "Cargo.toml").write_text(cargo_text, encoding="utf-8")
+        if rust_workspace:
+            for directory, crate in (("a", "alpha"), ("b", "beta")):
+                member = root / "crates" / directory
+                member.mkdir(parents=True)
+                (member / "Cargo.toml").write_text(
+                    f'[package]\nname = {json.dumps(crate)}\nversion = "0.1.0"\n',
+                    encoding="utf-8",
+                )
+        source_path = root / "src" / "lib.rs"
+        source_path.parent.mkdir()
+        source_path.write_text("pub fn demo() {}\n", encoding="utf-8")
+    else:
+        source_path = root / "src" / "main.py"
+        source_path.parent.mkdir()
+        source_path.write_text("def demo():\n    return 1\n", encoding="utf-8")
+
+    cache = root / ".codenib_cache"
+    artifact_root = cache / "symbol_graph"
+    artifact_root.mkdir(parents=True)
+    decoded = artifact_root / "index.decoded"
+    symbol = (
+        "rust-analyzer cargo demo 0.1 demo()."
+        if language == "rust"
+        else "src.main`/demo()."
+    )
+    external_symbol = (
+        "rust-analyzer cargo demo 0.1 missing/External#"
+        if language == "rust"
+        else "scip-python python demo 0.1 `requests.models`/Response#"
+    )
+    source_relative = "src/lib.rs" if language == "rust" else "src/main.py"
+    decoded.write_text(
+        "documents {\n"
+        f"  relative_path: {json.dumps(source_relative)}\n"
+        "  occurrences {\n"
+        "    range: 0\n"
+        "    range: 0\n"
+        "    range: 4\n"
+        f"    symbol: {json.dumps(symbol)}\n"
+        "    symbol_roles: 1\n"
+        "    enclosing_range: 0\n"
+        "    enclosing_range: 0\n"
+        "    enclosing_range: 4\n"
+        "    enclosing_range: 0\n"
+        "  }\n"
+        "  occurrences {\n"
+        "    range: 1\n"
+        "    range: 4\n"
+        "    range: 8\n"
+        f"    symbol: {json.dumps(external_symbol)}\n"
+        "    symbol_roles: 8\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    from codenib.scip_interface.query_surface import query_surface_sha256
+
+    decoder_class = (
+        __import__(
+            "codenib.scip_interface.scip_decode_rust",
+            fromlist=["SCIPRustGraphDecoder"],
+        ).SCIPRustGraphDecoder
+        if language == "rust"
+        else __import__(
+            "codenib.scip_interface.scip_decode_python",
+            fromlist=["SCIPPythonGraphDecoder"],
+        ).SCIPPythonGraphDecoder
+    )
+    serial_graph = decoder_class(str(decoded), project_root=str(root)).decode()
+    query_digest = query_surface_sha256(serial_graph)
+    graph_file = artifact_root / "graph.pkl"
+    serial_graph.save_graph(str(graph_file))
+    index_fingerprint = regular_file_fingerprint(decoded)
+    graph_fingerprint = regular_file_fingerprint(graph_file)
+    source = fingerprint_repository(root, exclude_roots=(cache,))
+    patterns = sorted(default_exclude_patterns())
+    artifacts = {
+        language: {
+            "relative_path": "index.decoded",
+            "size": index_fingerprint["size"],
+            "sha256": index_fingerprint["sha256"],
+        }
+    }
+    reports: dict[str, Any] = {}
+    if language == "python":
+        reports = {
+            "python": {
+                "backend": "scip-python",
+                "status": "complete",
+                "complete": True,
+                "partial": False,
+                "document_count": 1,
+            }
+        }
+    else:
+        reports = {
+            "rust": {
+                "backend": "rust-analyzer-scip",
+                "status": "complete",
+                "complete": True,
+                "partial": False,
+                "document_count": 1,
+            }
+        }
+    metadata = {
+        "builder_schema": 4,
+        "languages": [language],
+        "graph_route": "active",
+        "exclude_patterns": patterns,
+        "allow_partial_languages": False,
+        "allow_partial_index": False,
+        "source_coverage_fallback": False,
+        "target_dir": None,
+        "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+        "node_count": node_count,
+        "edge_count": edge_count,
+        "language": language,
+        "available_languages": [language],
+        "compiler_available_languages": [language],
+        "index_generation_reports": reports,
+        "scip_decoded_artifacts": artifacts,
+        "graph_artifact": {
+            "relative_path": "graph.pkl",
+            **graph_fingerprint,
+        },
+        "query_surface_sha256": query_digest,
+        "update_mode": "full_rebuild",
+        "partial_index": False,
+        "failed_languages": {},
+        "partial": False,
+    }
+    entry = IndexEntry(
+        index_type="symbol_graph",
+        path=str(artifact_root),
+        built_at="2026-01-01T00:00:00+00:00",
+        built_at_epoch=0.0,
+        status="fresh",
+        config=copy.deepcopy(metadata),
+        metadata={**copy.deepcopy(metadata), "build_duration_seconds": 1.0},
+        commit="",
+        source_fingerprint=source.value,
+    )
+    manifest = RepoManifest(
+        repo_path=str(root),
+        source_fingerprint=source.value,
+        last_indexed_source_fingerprint=source.value,
+        languages=[language],
+        file_count=source.file_count,
+        indexes={"symbol_graph": entry},
+    )
+    manifest_path = cache / "repo_manifest.json"
+    manifest.save(manifest_path)
+    return manifest_path, manifest
+
+
+def test_graph_free_module_import_and_candidate_wrapper_do_not_import_graph() -> None:
+    script = """
+import sys
+from codenib.scip_interface.scip_query import FactQueryCandidate
+
+candidate = FactQueryCandidate(index=object(), receipt={}, timings={})
+assert candidate.index is not None
+for name in (
+    'igraph',
+    'codenib.graph.code_graph',
+    'codenib.scip_interface.scip_indexer_base',
+    'codenib.ls_router',
+):
+    assert name not in sys.modules, name
+"""
+    subprocess.run([sys.executable, "-c", script], check=True, text=True)
+
+
+def test_candidate_rejects_language_without_active_scip_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path, _manifest = _write_candidate_manifest(tmp_path)
+    monkeypatch.setattr(
+        "codenib.scip_interface.scip_query.graph_indexer_path",
+        lambda _language: "codenib.ls_index.lsp_indexer:GenericLSPIndexer",
+    )
+
+    with pytest.raises(FactQueryCandidateRejected, match="active SCIP route"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+
+def test_clean_process_loads_real_candidate_without_importing_graph(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("codenib_core")
+    manifest_path, _ = _write_candidate_manifest(tmp_path)
+    script = """
+import sys
+from codenib.scip_interface.scip_query import load_fact_query_candidate
+
+candidate = load_fact_query_candidate(sys.argv[1])
+assert candidate.fact_query_index is True
+for name in (
+    'igraph',
+    'codenib.graph.code_graph',
+    'codenib.scip_interface.scip_indexer_base',
+    'codenib.ls_router',
+):
+    assert name not in sys.modules, name
+"""
+    subprocess.run(
+        [sys.executable, "-c", script, str(manifest_path)],
+        check=True,
+        text=True,
+    )
+
+
+def test_real_candidate_admits_reference_only_surface_and_preserves_errors(
+    tmp_path: Path,
+) -> None:
+    codenib_core = pytest.importorskip("codenib_core")
+    from codenib.agent.lsp_graph import lsp_definition, lsp_references
+    from codenib.graph.code_graph import CodeGraph
+
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    candidate = load_fact_query_candidate(
+        manifest_path,
+        core_module=codenib_core,
+    )
+    graph = CodeGraph.load_graph(
+        str(Path(manifest.indexes["symbol_graph"].path) / "graph.pkl")
+    )
+    node_name = "requests/models.py:Response"
+    query_symbol = "requests.models:Response"
+    info = graph.get_node_info_by_name(node_name)
+
+    assert info is not None
+    assert info["has_definition"] is False
+    assert candidate.receipt["filter_identity"]["reference_only_count"] == 1
+    assert _outcome(
+        lambda: lsp_definition(graph, symbol=query_symbol, top_k=10)
+    ) == _outcome(
+        lambda: lsp_definition(candidate.index, symbol=query_symbol, top_k=10)
+    )
+    for include_declaration in (False, True):
+        assert _outcome(
+            lambda include_declaration=include_declaration: lsp_references(
+                graph,
+                symbol=query_symbol,
+                include_declaration=include_declaration,
+                top_k=10,
+            )
+        ) == _outcome(
+            lambda include_declaration=include_declaration: lsp_references(
+                candidate.index,
+                symbol=query_symbol,
+                include_declaration=include_declaration,
+                top_k=10,
+            )
+        )
+
+
+def test_filter_helpers_preserve_route_semantics_and_add_repository_policy() -> None:
+    assert normalize_scip_path(r"src\pkg\demo.py") == "src/pkg/demo.py"
+    assert matches_exclude_patterns("vendor/pkg/a.py", ["vendor/**"])
+    assert scip_path_is_allowed(
+        "src/pkg/demo.py",
+        target_dir="src/pkg",
+        exclude_patterns=["**/tests/**"],
+    )
+    assert not scip_path_is_allowed(
+        "src/tests/test_demo.py",
+        target_dir="src",
+        exclude_patterns=["**/tests/**"],
+    )
+    assert not scip_path_is_allowed(
+        ".codenib-private/demo.py",
+        enforce_repository_policy=True,
+    )
+
+
+def test_query_surface_digest_matches_cpp_known_vector() -> None:
+    from codenib.scip_interface.query_surface import query_surface_sha256
+
+    class Vertex:
+        __slots__ = ("attrs",)
+
+        def __init__(self, **attrs: Any) -> None:
+            self.attrs = attrs
+
+        def attributes(self) -> dict[str, Any]:
+            return self.attrs
+
+    class Edge(Vertex):
+        __slots__ = ("source", "target")
+
+        def __init__(self, source: int, target: int, **attrs: Any) -> None:
+            super().__init__(**attrs)
+            self.source = source
+            self.target = target
+
+    class Storage:
+        __slots__ = ("vs", "es")
+
+        def __init__(self, vertices: list[Vertex], edges: list[Edge]) -> None:
+            self.vs = vertices
+            self.es = edges
+
+    class Graph:
+        __slots__ = ("graph",)
+
+        def __init__(self, vertices: list[Vertex], edges: list[Edge]) -> None:
+            self.graph = Storage(vertices, edges)
+
+    vertices = [
+        Vertex(name=".", type="root"),
+        Vertex(name="src", type="directory", unified_name="src"),
+        Vertex(name="src/main.py", type="file", unified_name="src/main.py"),
+        Vertex(
+            name="canonical-caller",
+            type="function",
+            file="src/main.py",
+            start_line=8,
+            end_line=10,
+            selection_line=8,
+            unified_name="src/main.py:caller()",
+            has_definition=True,
+        ),
+        Vertex(
+            name="canonical-target",
+            type="function",
+            file="src/main.py",
+            start_line=2,
+            end_line=4,
+            selection_line=2,
+            unified_name="src/main.py:target()",
+            has_definition=True,
+        ),
+    ]
+    edges = [
+        Edge(0, 1, type="contain"),
+        Edge(1, 2, type="contain"),
+        Edge(2, 3, type="contain"),
+        Edge(
+            3,
+            4,
+            type="reference",
+            anchor_file="src/main.py",
+            anchor_line=9,
+        ),
+    ]
+    graph = Graph(vertices, edges)
+
+    assert query_surface_sha256(graph) == (
+        "0112871fe1aafef3930d910a15c12b7632f73803fd55f5620f219c9dd87d64df"
+    )
+    vertices[-1].attrs["selection_line"] = 3
+    assert query_surface_sha256(graph) != (
+        "0112871fe1aafef3930d910a15c12b7632f73803fd55f5620f219c9dd87d64df"
+    )
+
+
+def test_scip_process_records_only_a_stable_consumed_decoded_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codenib.scip_interface.scip_indexer_base import SCIPIndexerBase
+
+    class GraphStorage:
+        vs: list[Any] = []
+        es: list[Any] = []
+
+        @staticmethod
+        def vcount() -> int:
+            return 1
+
+        @staticmethod
+        def ecount() -> int:
+            return 0
+
+    class Graph:
+        graph = GraphStorage()
+
+        @staticmethod
+        def build_range_indexes() -> None:
+            return None
+
+        @staticmethod
+        def save_graph(path: str) -> None:
+            Path(path).write_bytes(b"stable graph output\n")
+
+    class Decoder:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        @staticmethod
+        def decode() -> Graph:
+            return Graph()
+
+    class Indexer(SCIPIndexerBase):
+        def _check_indexer_available(self) -> bool:
+            return True
+
+        def _build_index_command(self, **kwargs: Any) -> list[str]:
+            return []
+
+        def _get_decoder_class(self):
+            return Decoder
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    indexer = Indexer(root, output_dir=tmp_path / "out", language="python")
+    indexer.decoded_file.write_text(
+        'documents { relative_path: "src/main.py" }\n', encoding="utf-8"
+    )
+    expected = regular_file_fingerprint(indexer.decoded_file)
+
+    import codenib.compiler.artifact_fingerprints as fingerprint_module
+    import codenib.scip_interface.query_surface as query_surface_module
+
+    def unexpected_capture(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("default SCIP processing must not capture artifact receipts")
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            fingerprint_module, "regular_file_fingerprint", unexpected_capture
+        )
+        scoped.setattr(query_surface_module, "query_surface_sha256", unexpected_capture)
+        assert indexer.process_index() is not None
+    assert indexer.decoded_input_receipt is None
+    assert indexer.graph_output_receipt is None
+    indexer._capture_artifact_receipts = True
+    graph = indexer.process_index(str(indexer.graph_file))
+
+    assert graph is not None
+    assert indexer.decoded_input_receipt == {
+        "path": str(indexer.decoded_file.resolve()),
+        **expected,
+    }
+    assert indexer.graph_output_receipt == {
+        "path": str(indexer.graph_file.resolve()),
+        **regular_file_fingerprint(indexer.graph_file),
+        "query_surface_sha256": indexer.graph_output_receipt["query_surface_sha256"],
+    }
+    indexer.decoded_file.unlink()
+    assert indexer.process_index() is None
+    assert indexer.decoded_input_receipt is None
+    assert indexer.graph_output_receipt is None
+    indexer.decoded_file.write_text(
+        'documents { relative_path: "src/main.py" }\n', encoding="utf-8"
+    )
+
+    class MutatingDecoder:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        @staticmethod
+        def decode() -> Graph:
+            indexer.decoded_file.write_text(
+                'documents { relative_path: "src/replaced.py" }\n',
+                encoding="utf-8",
+            )
+            return Graph()
+
+    monkeypatch.setattr(indexer, "_get_decoder_class", lambda: MutatingDecoder)
+    assert indexer.process_index() is None
+    assert indexer.decoded_input_receipt is None
+
+
+def test_rust_full_generation_reports_complete_and_discards_failed_stale_inputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codenib.scip_interface.scip_indexer_rust import SCIPRustIndexer
+    from codenib.scip_interface.scip_pb2 import Index
+
+    manifest_path, manifest = _write_candidate_manifest(tmp_path, language="rust")
+    root = Path(manifest.repo_path)
+    output = Path(manifest.indexes["symbol_graph"].path)
+    indexer = SCIPRustIndexer(root, output_dir=output)
+    indexer.index_file.write_bytes(b"stale raw")
+    indexer.decoded_file.write_text("stale decoded", encoding="utf-8")
+    generated = Index()
+    generated.documents.add(relative_path="src/lib.rs")
+
+    monkeypatch.setattr(indexer, "_check_indexer_available", lambda: True)
+
+    def successful_run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess:
+        indexer.index_file.write_bytes(generated.SerializeToString())
+        return subprocess.CompletedProcess([], 0, "", "")
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(subprocess, "run", successful_run)
+        assert indexer.generate_index() is True
+    assert not indexer.decoded_file.exists()
+    assert indexer.index_generation_report == {
+        "backend": "rust-analyzer-scip",
+        "status": "complete",
+        "complete": True,
+        "partial": False,
+        "document_count": 1,
+    }
+
+    indexer.decoded_file.write_text("stale decoded", encoding="utf-8")
+
+    def failed_run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess:
+        raise subprocess.CalledProcessError(1, ["rust-analyzer", "scip"])
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(subprocess, "run", failed_run)
+        assert indexer.run_pipeline(report_profile=False) is None
+    assert not indexer.index_file.exists()
+    assert not indexer.decoded_file.exists()
+    assert indexer.decoded_input_receipt is None
+    assert indexer.index_generation_report == {
+        "backend": "rust-analyzer-scip",
+        "status": "failed",
+        "complete": False,
+        "partial": False,
+        "document_count": 0,
+    }
+    with pytest.raises(FactQueryCandidateRejected, match="artifact"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+
+def test_manifest_candidate_binds_source_filter_index_and_native_receipts(
+    tmp_path: Path,
+) -> None:
+    manifest_path, _ = _write_candidate_manifest(tmp_path)
+    core = _MockCore()
+
+    candidate = load_fact_query_candidate(manifest_path, core_module=core)
+
+    assert candidate.has_symbol("demo") is True
+    assert candidate.receipt["language"] == "python"
+    assert candidate.receipt["manifest"]["version"] == "1.1"
+    manifest_fingerprint = regular_file_fingerprint(manifest_path)
+    assert candidate.receipt["manifest"]["size_bytes"] == manifest_fingerprint["size"]
+    assert candidate.receipt["manifest"]["sha256"] == manifest_fingerprint["sha256"]
+    assert candidate.receipt["manifest"]["builder_schema"] == 4
+    assert candidate.receipt["manifest"]["document_count"] == 1
+    assert candidate.receipt["graph"]["relative_path"] == "graph.pkl"
+    assert candidate.receipt["filters"]["repository_filter_policy"] == 3
+    assert candidate.receipt["filter_identity"]["identity"] is True
+    assert candidate.receipt["filter_identity"]["reference_only_count"] == 1
+    assert (
+        core.index.expected_query_surface_sha256
+        == candidate.receipt["graph"]["query_surface_sha256"]
+    )
+    assert len(candidate.receipt["receipt_sha256"]) == 64
+    assert core.calls[0]["language"] == "python"
+
+
+def test_manifest_change_during_native_decode_rejects_mixed_generation(
+    tmp_path: Path,
+) -> None:
+    manifest_path, _ = _write_candidate_manifest(tmp_path)
+
+    class MutatingCore(_MockCore):
+        def decode_scip_fact_query_index(self, **kwargs: Any) -> dict[str, Any]:
+            payload = super().decode_scip_fact_query_index(**kwargs)
+            manifest_path.write_text("{}", encoding="utf-8")
+            return payload
+
+    with pytest.raises(FactQueryCandidateRejected, match="changed"):
+        load_fact_query_candidate(manifest_path, core_module=MutatingCore())
+
+
+def test_graph_change_during_native_decode_rejects_mixed_generation(
+    tmp_path: Path,
+) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    graph_file = Path(manifest.indexes["symbol_graph"].path) / "graph.pkl"
+
+    class MutatingCore(_MockCore):
+        def decode_scip_fact_query_index(self, **kwargs: Any) -> dict[str, Any]:
+            payload = super().decode_scip_fact_query_index(**kwargs)
+            graph_file.write_bytes(b"replacement-graph\n")
+            return payload
+
+    with pytest.raises(FactQueryCandidateRejected, match="graph artifact changed"):
+        load_fact_query_candidate(manifest_path, core_module=MutatingCore())
+
+
+def test_candidate_ignores_non_regular_repository_entries(tmp_path: Path) -> None:
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("FIFO creation is unavailable")
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    fifo = Path(manifest.repo_path) / "events.pipe"
+    os.mkfifo(fifo)
+    index = _MockIndex()
+
+    load_fact_query_candidate(manifest_path, core_module=_MockCore(index=index))
+
+    assert "events.pipe" not in index.allowed_files
+
+
+@pytest.mark.parametrize(("field", "value"), [("node_count", 6), ("edge_count", 5)])
+def test_candidate_binds_manifest_graph_counts(
+    tmp_path: Path, field: str, value: int
+) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    entry = manifest.indexes["symbol_graph"]
+    entry.config[field] = value
+    entry.metadata[field] = value
+    manifest.save(manifest_path)
+
+    with pytest.raises(FactQueryCandidateRejected, match="manifest"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+
+def test_candidate_rejects_same_count_query_surface_mismatch(tmp_path: Path) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    entry = manifest.indexes["symbol_graph"]
+    entry.config["query_surface_sha256"] = "d" * 64
+    entry.metadata["query_surface_sha256"] = "d" * 64
+    manifest.save(manifest_path)
+
+    with pytest.raises(FactQueryCandidateRejected, match="proof rejected candidate"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+
+def test_candidate_rejects_unknown_builder_field_and_report_shape(
+    tmp_path: Path,
+) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    entry = manifest.indexes["symbol_graph"]
+    entry.config["unknown"] = "unsafe"
+    entry.metadata["unknown"] = "unsafe"
+    manifest.save(manifest_path)
+    with pytest.raises(FactQueryCandidateRejected, match="schema v4"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+    manifest_path, manifest = _write_candidate_manifest(tmp_path / "report")
+    report = manifest.indexes["symbol_graph"].config["index_generation_reports"][
+        "python"
+    ]
+    report["extra"] = True
+    manifest.indexes["symbol_graph"].metadata["index_generation_reports"] = (
+        copy.deepcopy(
+            manifest.indexes["symbol_graph"].config["index_generation_reports"]
+        )
+    )
+    manifest.save(manifest_path)
+    with pytest.raises(FactQueryCandidateRejected, match="report fields"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+
+def test_candidate_rejects_empty_or_mismatched_generation_report(
+    tmp_path: Path,
+) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    reports = manifest.indexes["symbol_graph"].config["index_generation_reports"]
+    reports["python"]["document_count"] = 0
+    manifest.indexes["symbol_graph"].metadata["index_generation_reports"] = (
+        copy.deepcopy(reports)
+    )
+    manifest.save(manifest_path)
+    with pytest.raises(FactQueryCandidateRejected, match="no source documents"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+    manifest_path, _ = _write_candidate_manifest(tmp_path / "mismatch")
+
+    class WrongDocumentCount(_MockCore):
+        def decode_scip_fact_query_index(self, **kwargs: Any) -> dict[str, Any]:
+            payload = super().decode_scip_fact_query_index(**kwargs)
+            payload["decode_profile_ns"]["document_count"] = 2
+            return payload
+
+    with pytest.raises(FactQueryCandidateRejected, match="document count disagrees"):
+        load_fact_query_candidate(manifest_path, core_module=WrongDocumentCount())
+
+
+@pytest.mark.parametrize("field", ["built_at_epoch", "build_duration_seconds"])
+def test_candidate_rejects_nonfinite_manifest_times(tmp_path: Path, field: str) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    entry = manifest.indexes["symbol_graph"]
+    if field == "built_at_epoch":
+        entry.built_at_epoch = float("inf")
+    else:
+        entry.metadata[field] = float("nan")
+    manifest.save(manifest_path)
+
+    with pytest.raises(FactQueryCandidateRejected, match="malformed"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+
+def test_candidate_binds_live_git_head_before_decode(tmp_path: Path) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    root = Path(manifest.repo_path)
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(root), "config", "user.name", "CodeNib Test"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(root), "add", "src/main.py"], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "commit", "-q", "-m", "initial"], check=True
+    )
+    head = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    manifest.commit = head
+    manifest.indexes["symbol_graph"].commit = head
+    manifest.save(manifest_path)
+    load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    raw["indexes"]["symbol_graph"]["commit"] = ""
+    manifest_path.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(FactQueryCandidateRejected, match="commit provenance"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+    manifest.save(manifest_path)
+
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "commit",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "move head",
+        ],
+        check=True,
+    )
+    with pytest.raises(FactQueryCandidateRejected, match="live repository commit"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("builder_schema", 3),
+        ("target_dir", "src"),
+        ("update_mode", "incremental"),
+        ("partial", True),
+        ("partial_index", True),
+        ("source_coverage_fallback", True),
+    ],
+)
+def test_manifest_candidate_rejects_unsafe_builder_states(
+    tmp_path: Path, field: str, value: Any
+) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    entry = manifest.indexes["symbol_graph"]
+    entry.config[field] = value
+    entry.metadata[field] = value
+    manifest.save(manifest_path)
+
+    with pytest.raises(FactQueryCandidateRejected):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+
+def test_manifest_candidate_rejects_source_or_index_mutation(tmp_path: Path) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    source = Path(manifest.repo_path) / "src" / "main.py"
+    source.write_text("def changed(): pass\n", encoding="utf-8")
+    with pytest.raises(FactQueryCandidateRejected, match="source"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+    manifest_path, manifest = _write_candidate_manifest(tmp_path / "other")
+    decoded = Path(manifest.indexes["symbol_graph"].path) / "index.decoded"
+    decoded.write_text("mutated\n", encoding="utf-8")
+    with pytest.raises(FactQueryCandidateRejected, match="artifact"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+    manifest_path, manifest = _write_candidate_manifest(tmp_path / "graph")
+    graph_file = Path(manifest.indexes["symbol_graph"].path) / "graph.pkl"
+    graph_file.write_bytes(b"tampered-graph!\n")
+    with pytest.raises(FactQueryCandidateRejected, match="graph artifact"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+
+def test_manifest_candidate_rejects_malformed_or_false_native_proof(
+    tmp_path: Path,
+) -> None:
+    manifest_path, _ = _write_candidate_manifest(tmp_path)
+    core = _MockCore(index=_MockIndex(proof_updates={"identity": False}))
+    with pytest.raises(FactQueryCandidateRejected, match="identity"):
+        load_fact_query_candidate(manifest_path, core_module=core)
+
+    core = _MockCore(index=_MockIndex(proof_updates={"unexpected": 1}))
+    with pytest.raises(FactQueryCandidateRejected, match="keys mismatch"):
+        load_fact_query_candidate(manifest_path, core_module=core)
+
+    core = _MockCore(index=_MockIndex(proof_updates={"directory_count": 2}))
+    with pytest.raises(FactQueryCandidateRejected, match="record class"):
+        load_fact_query_candidate(manifest_path, core_module=core)
+
+    occurrence_index = _MockIndex()
+    occurrence_index.occurrence_count = 1
+    core = _MockCore(index=occurrence_index)
+    with pytest.raises(
+        FactQueryCandidateRejected, match="occurrence count must be zero"
+    ):
+        load_fact_query_candidate(manifest_path, core_module=core)
+
+    manifest_path, _ = _write_candidate_manifest(
+        tmp_path / "no-definitions", node_count=3, edge_count=2
+    )
+    empty_index = _MockIndex(proof_updates={"definition_count": 0})
+    empty_index.record_count = 3
+    empty_index.edge_count = 2
+    empty_index.symbol_count = 0
+    with pytest.raises(FactQueryCandidateRejected, match="no queryable"):
+        load_fact_query_candidate(
+            manifest_path, core_module=_MockCore(index=empty_index)
+        )
+
+
+def test_manifest_candidate_rejects_malformed_receipt_and_propagates_memory(
+    tmp_path: Path,
+) -> None:
+    manifest_path, _ = _write_candidate_manifest(tmp_path)
+    core = _MockCore(receipt_updates={"unexpected": True})
+    with pytest.raises(FactQueryCandidateRejected, match="keys mismatch"):
+        load_fact_query_candidate(manifest_path, core_module=core)
+
+    with pytest.raises(MemoryError, match="allocation"):
+        load_fact_query_candidate(
+            manifest_path,
+            core_module=_MockCore(failure=MemoryError("allocation exhausted")),
+        )
+
+
+def test_rust_candidate_recomputes_serial_cargo_identity(tmp_path: Path) -> None:
+    manifest_path, _ = _write_candidate_manifest(tmp_path, language="rust")
+    candidate = load_fact_query_candidate(manifest_path, core_module=_MockCore())
+    assert candidate.receipt["native_input"]["metadata"] == {
+        "kind": "rust-cargo",
+        "complete": True,
+        "inputs": [
+            {
+                "path": "Cargo.toml",
+                "size_bytes": (tmp_path / "repo" / "Cargo.toml").stat().st_size,
+                "sha256": regular_file_fingerprint(tmp_path / "repo" / "Cargo.toml")[
+                    "sha256"
+                ],
+            }
+        ],
+        "internal_crates": ["demo"],
+    }
+
+    class WrongCrates(_MockCore):
+        def decode_scip_fact_query_index(self, **kwargs: Any) -> dict[str, Any]:
+            payload = super().decode_scip_fact_query_index(**kwargs)
+            payload["input_receipt"]["metadata"]["internal_crates"] = ["wrong"]
+            return payload
+
+    with pytest.raises(FactQueryCandidateRejected, match="serial Rust"):
+        load_fact_query_candidate(manifest_path, core_module=WrongCrates())
+
+
+def test_rust_workspace_receipt_matches_all_serial_cargo_inputs(tmp_path: Path) -> None:
+    manifest_path, _ = _write_candidate_manifest(
+        tmp_path, language="rust", rust_workspace=True
+    )
+    candidate = load_fact_query_candidate(manifest_path, core_module=_MockCore())
+    metadata = candidate.receipt["native_input"]["metadata"]
+    assert [item["path"] for item in metadata["inputs"]] == [
+        "Cargo.toml",
+        "crates/a/Cargo.toml",
+        "crates/b/Cargo.toml",
+    ]
+    assert metadata["internal_crates"] == ["alpha", "beta", "demo"]
+
+    class WrongCargoDigest(_MockCore):
+        def decode_scip_fact_query_index(self, **kwargs: Any) -> dict[str, Any]:
+            payload = super().decode_scip_fact_query_index(**kwargs)
+            payload["input_receipt"]["metadata"]["inputs"][1]["sha256"] = "0" * 64
+            return payload
+
+    with pytest.raises(FactQueryCandidateRejected, match="changed after native"):
+        load_fact_query_candidate(manifest_path, core_module=WrongCargoDigest())
+
+
+def test_rust_cargo_input_outside_source_surface_rejects_candidate(
+    tmp_path: Path,
+) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path, language="rust")
+    root = Path(manifest.repo_path)
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "demo"\nversion = "0.1.0"\n'
+        '[workspace]\nmembers = ["vendor/*"]\n',
+        encoding="utf-8",
+    )
+    vendor = root / "vendor" / "hidden"
+    vendor.mkdir(parents=True)
+    vendor_cargo = vendor / "Cargo.toml"
+    vendor_cargo.write_text(
+        '[package]\nname = "hidden"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    source = fingerprint_repository(root, exclude_roots=(manifest_path.parent,))
+    manifest.source_fingerprint = source.value
+    manifest.last_indexed_source_fingerprint = source.value
+    manifest.file_count = source.file_count
+    manifest.indexes["symbol_graph"].source_fingerprint = source.value
+    manifest.save(manifest_path)
+
+    class VendorCargoCore(_MockCore):
+        def decode_scip_fact_query_index(self, **kwargs: Any) -> dict[str, Any]:
+            payload = super().decode_scip_fact_query_index(**kwargs)
+            fingerprint = regular_file_fingerprint(vendor_cargo)
+            metadata = payload["input_receipt"]["metadata"]
+            metadata["inputs"].append(
+                {
+                    "path": "vendor/hidden/Cargo.toml",
+                    "size_bytes": fingerprint["size"],
+                    "sha256": fingerprint["sha256"],
+                }
+            )
+            metadata["internal_crates"] = ["demo", "hidden"]
+            return payload
+
+    with pytest.raises(FactQueryCandidateRejected, match="source surface"):
+        load_fact_query_candidate(manifest_path, core_module=VendorCargoCore())
+
+
+def test_candidate_rejects_symlinks_old_manifest_and_missing_build_keys(
+    tmp_path: Path,
+) -> None:
+    manifest_path, manifest = _write_candidate_manifest(tmp_path)
+    manifest_link = manifest_path.with_name("manifest-link.json")
+    manifest_link.symlink_to(manifest_path)
+    with pytest.raises(FactQueryCandidateRejected, match="non-symlink"):
+        load_fact_query_candidate(manifest_link, core_module=_MockCore())
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    raw.pop("version")
+    manifest_path.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(FactQueryCandidateRejected, match="explicitly"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+    manifest_path, _ = _write_candidate_manifest(tmp_path / "missing-entry-commit")
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del raw["indexes"]["symbol_graph"]["commit"]
+    manifest_path.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(FactQueryCandidateRejected, match="entry keys mismatch"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+    manifest_path, manifest = _write_candidate_manifest(tmp_path / "missing-key")
+    entry = manifest.indexes["symbol_graph"]
+    del entry.config["target_dir"]
+    del entry.metadata["target_dir"]
+    manifest.save(manifest_path)
+    with pytest.raises(FactQueryCandidateRejected, match="schema v4"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+    manifest_path, manifest = _write_candidate_manifest(tmp_path / "artifact-link")
+    artifact = Path(manifest.indexes["symbol_graph"].path) / "index.decoded"
+    target = artifact.with_name("actual.decoded")
+    artifact.rename(target)
+    artifact.symlink_to(target)
+    with pytest.raises(FactQueryCandidateRejected, match="non-symlink"):
+        load_fact_query_candidate(manifest_path, core_module=_MockCore())
+
+
+@pytest.mark.parametrize(
+    ("language", "decoded_text", "source_suffix"),
+    [
+        ("python", _PYTHON_PARITY_INDEX, ".py"),
+        ("rust", _RUST_PARITY_INDEX, ".rs"),
+    ],
+)
+def test_native_python_and_rust_query_results_match_filtered_legacy_graph(
+    tmp_path: Path,
+    language: str,
+    decoded_text: str,
+    source_suffix: str,
+) -> None:
+    codenib_core = pytest.importorskip("codenib_core")
+    from codenib.agent.lsp_graph import lsp_definition, lsp_references
+    from codenib.scip_interface.query_surface import query_surface_sha256
+    from codenib.scip_interface.scip_decode_python import SCIPPythonGraphDecoder
+    from codenib.scip_interface.scip_decode_rust import SCIPRustGraphDecoder
+    from codenib.scip_interface.scip_indexer_base import SCIPIndexerBase
+    from codenib.scip_interface.scip_query import decode_native_fact_query_index
+
+    class FilterOnlyIndexer(SCIPIndexerBase):
+        def _check_indexer_available(self) -> bool:
+            return True
+
+        def _build_index_command(self, **kwargs: Any) -> list[str]:
+            return []
+
+        def _get_decoder_class(self):
+            raise NotImplementedError
+
+    root = tmp_path / language
+    (root / "src").mkdir(parents=True)
+    for stem in ("alpha", "beta"):
+        (root / "src" / f"{stem}{source_suffix}").write_text(
+            "fn run() {}\n" if language == "rust" else "def run(): pass\n",
+            encoding="utf-8",
+        )
+    if language == "rust":
+        (root / "Cargo.toml").write_text(
+            '[package]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8"
+        )
+    index_path = root / ".codenib_cache" / "index.decoded"
+    index_path.parent.mkdir()
+    index_path.write_text(decoded_text, encoding="utf-8")
+
+    decoder_class = (
+        SCIPPythonGraphDecoder if language == "python" else SCIPRustGraphDecoder
+    )
+    graph = decoder_class(str(index_path), project_root=str(root)).decode()
+    filter_indexer = FilterOnlyIndexer(
+        root,
+        output_dir=root / ".filter",
+        exclude_patterns=sorted(default_exclude_patterns()),
+        language=language,
+    )
+    graph = filter_indexer._filter_project_graph(graph)
+
+    native = decode_native_fact_query_index(
+        index_file=index_path,
+        project_root=root,
+        language=language,
+        core_module=codenib_core,
+    )
+    allowed = sorted(
+        [f"src/alpha{source_suffix}", f"src/beta{source_suffix}"]
+        + (["Cargo.toml"] if language == "rust" else []),
+        key=lambda item: item.encode("utf-8"),
+    )
+    serial_query_digest = query_surface_sha256(graph)
+    proof = native.index.prove_filter_identity(allowed, serial_query_digest)
+    assert proof["identity"] is True
+    assert proof["allowed_files_sha256"] == _allowed_digest(allowed)
+    assert proof["query_surface_sha256"] == serial_query_digest
+    assert set(native.input_receipt) == {"schema_version", "index", "metadata"}
+    assert native.input_receipt["index"] == {
+        "path": str(index_path.resolve()),
+        "size_bytes": index_path.stat().st_size,
+        "sha256": regular_file_fingerprint(index_path)["sha256"],
+    }
+    assert set(native.input_receipt["metadata"]) == {
+        "kind",
+        "complete",
+        "inputs",
+        "internal_crates",
+    }
+    with pytest.raises(TypeError):
+        native.index.prove_filter_identity(allowed)
+    with pytest.raises(ValueError):
+        native.index.prove_filter_identity(list(reversed(allowed)), serial_query_digest)
+    with pytest.raises(ValueError):
+        native.index.prove_filter_identity([*allowed, allowed[-1]], serial_query_digest)
+    with pytest.raises(ValueError):
+        native.index.prove_filter_identity(allowed, "0" * 64)
+
+    names = [
+        name
+        for name in graph.name_to_vertex
+        if (graph.get_node_info_by_name(name) or {}).get("type")
+        in {"symbol", "class", "function", "method", "field"}
+    ]
+    reference_only_names = [
+        name
+        for name in names
+        if (graph.get_node_info_by_name(name) or {}).get("has_definition") is False
+    ]
+    assert proof["reference_only_count"] == len(reference_only_names)
+    if language == "python":
+        assert reference_only_names == ["requests/models.py:Response"]
+    else:
+        assert reference_only_names == ["demo/missing/External"]
+    seeds = list(names)
+    for name in names:
+        unified = str((graph.get_node_info_by_name(name) or {}).get("unified_name"))
+        bare = unified.split(":")[-1].split("/")[-1].split(".")[-1]
+        bare = bare.rstrip("()")
+        seeds.extend((unified, bare, f"`{bare}`"))
+    seeds.append("definitely-missing-symbol")
+
+    for seed in dict.fromkeys(seeds):
+        for top_k in (1, 2, 10_000):
+            assert _outcome(
+                lambda seed=seed, top_k=top_k: lsp_definition(
+                    graph, symbol=seed, top_k=top_k
+                )
+            ) == _outcome(
+                lambda seed=seed, top_k=top_k: lsp_definition(
+                    native.index, symbol=seed, top_k=top_k
+                )
+            ), (
+                language,
+                seed,
+                top_k,
+            )
+            for include_declaration in (False, True):
+                assert _outcome(
+                    partial(
+                        lsp_references,
+                        graph,
+                        symbol=seed,
+                        include_declaration=include_declaration,
+                        top_k=top_k,
+                    )
+                ) == _outcome(
+                    partial(
+                        lsp_references,
+                        native.index,
+                        symbol=seed,
+                        include_declaration=include_declaration,
+                        top_k=top_k,
+                    )
+                ), (
+                    language,
+                    seed,
+                    top_k,
+                    include_declaration,
+                )

--- a/test/test_ls_router_registry.py
+++ b/test/test_ls_router_registry.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from codenib import ls_router
@@ -152,6 +154,29 @@ def test_ls_indexer_passes_decoder_backend_only_to_scip(tmp_path):
 
     assert cpp_indexer._delegate.__class__.__name__ == "ClangdIndexer"
     assert not hasattr(cpp_indexer._delegate, "decoder_backend")
+
+
+def test_ls_indexer_artifact_receipt_capture_is_default_off(tmp_path, monkeypatch):
+    indexer = LSIndexer(
+        tmp_path / "repo",
+        language="python",
+        output_dir=tmp_path / "out",
+    )
+    graph = CodeGraph(str(tmp_path / "repo"))
+    graph.add_root_node("root")
+    monkeypatch.setattr(
+        indexer._delegate,
+        "run_pipeline",
+        lambda **_kwargs: graph,
+    )
+    monkeypatch.setattr(
+        ls_router,
+        "_regular_file_receipt",
+        lambda *_args, **_kwargs: pytest.fail("unexpected artifact fingerprint"),
+    )
+
+    assert indexer.run_pipeline(skip_level=None) is graph
+    assert indexer.graph_output_receipt is None
 
 
 @pytest.mark.parametrize(
@@ -538,6 +563,13 @@ def test_build_graph_for_languages_reports_index_generation(tmp_path, monkeypatc
 
         def __init__(self, project_root, **_kwargs):
             self.project_root = project_root
+            self.output_dir = Path(_kwargs["output_dir"])
+            self.graph_output_receipt = None
+            self.decoded_input_receipt = {
+                "path": str(tmp_path / "out" / "index.decoded"),
+                "size": 12,
+                "sha256": "a" * 64,
+            }
             self.index_generation_report = {
                 "status": "partial",
                 "complete": False,
@@ -550,6 +582,16 @@ def test_build_graph_for_languages_reports_index_generation(tmp_path, monkeypatc
             graph = CodeGraph(str(self.project_root))
             graph.add_file_node("partial.py")
             graph.build_range_indexes()
+            graph_path = self.output_dir / "graph.pkl"
+            graph_path.parent.mkdir(parents=True, exist_ok=True)
+            graph.save_graph(graph_path)
+            from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
+
+            self.graph_output_receipt = {
+                "path": str(graph_path.resolve()),
+                **regular_file_fingerprint(graph_path),
+                "query_surface_sha256": "c" * 64,
+            }
             return graph
 
     monkeypatch.setattr(ls_router, "LSIndexer", FakeIndexer)
@@ -560,6 +602,7 @@ def test_build_graph_for_languages_reports_index_generation(tmp_path, monkeypatc
         languages=["python"],
         skip_level=None,
         allow_partial_index=True,
+        capture_artifact_receipts=True,
     )
 
     assert result.graph is not None
@@ -570,4 +613,17 @@ def test_build_graph_for_languages_reports_index_generation(tmp_path, monkeypatc
             "partial": True,
             "document_count": 3,
         }
+    }
+    assert result.decoded_input_receipts == {
+        "python": {
+            "path": str(tmp_path / "out" / "index.decoded"),
+            "size": 12,
+            "sha256": "a" * 64,
+        }
+    }
+    assert result.graph_output_receipt == {
+        "path": str((tmp_path / "out" / "graph.pkl").resolve()),
+        "size": (tmp_path / "out" / "graph.pkl").stat().st_size,
+        "sha256": result.graph_output_receipt["sha256"],
+        "query_surface_sha256": "c" * 64,
     }


### PR DESCRIPTION
## Summary

Establish a consumer-safe, graph-free FactQueryIndex candidate for Python and Rust without enabling an MCP or agent route.

The candidate now binds native queries to the current compiler manifest, repository source snapshot, decoded and persisted artifacts, repository filter policy, Rust Cargo inputs, and an order-sensitive serial/native query-surface digest. Partial, incremental, mutated, or otherwise unproven inputs fail closed.

Closes #597.

## Changes

- Add stdlib-only SCIP filter, query-surface, and manifest-bound query modules that do not import CodeGraph, LSIndexer, SCIPIndexerBase, or igraph.
- Publish builder-schema-v4 decoded-input, graph-writer, source, filter, and ordered query-surface receipts only when the compiler explicitly requests them; ordinary graph pipelines keep their default path.
- Extend the native decoder with exact input receipts and a read-only O(F+V+E) filter-identity proof that cannot delete or remap facts.
- Preserve serial vertex and edge insertion order across parallel C++ decode, and admit reference-only targets only when the trusted serial surface retains them and every incoming reference has an allowed anchor.
- Make Rust full generation discard stale outputs and publish an exact complete generation report.
- Add C++ and Python adversarial, mutation, import-boundary, Python/Rust parity, and real binding coverage; document the admission boundary and #598 follow-up.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `make core-test`: 164 passed, 2 skipped.
- `PYTHONPATH=build/core pytest -q test/scip/test_scip_query.py test/scip/test_fact_query_index.py test/compiler/test_index_compiler.py test/test_ls_router_registry.py`: 189 passed.
- Full changed-file pre-commit suite: passed.
- `python -m mkdocs build --strict`: passed.
- Real HTTPie serial/native proof: 2,121 records, 8,164 edges, 12 retained reference-only targets, exact shared query-surface digest.
- The broad unit tier was also sampled twice. It stopped on two independently reproducible pre-existing environment failures outside this diff: the FAISS untrained-IVF portable-view assertion and the cache-lock parent-permission assertion. Relevant files are unchanged from `origin/main`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published