### PR TITLE
feat(artifacts): add strict context publication

### DIFF
--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -22,6 +22,7 @@ from .mcp_config import MCP_CONFIG_HOSTS, render_artifact_mcp_config
 from .portable_views import (
     SourceTrust,
     normalize_owned_query_view,
+    validate_content_bound_portable_query_view_reader,
     validate_portable_query_view,
 )
 from .runtime import (
@@ -37,6 +38,13 @@ from .strict_bm25 import (
     plan_bm25_view_strict,
     publish_planned_bm25_view_strict,
 )
+from .strict_context import (
+    PlannedContextArtifact,
+    PlannedContextView,
+    plan_context_artifact_strict,
+    publish_planned_context_artifact_strict,
+    stage_context_artifact_strict,
+)
 
 __all__ = [
     "CONTEXT_ARTIFACT_MANIFEST",
@@ -48,6 +56,8 @@ __all__ = [
     "GitHubArtifactRecord",
     "MCP_CONFIG_HOSTS",
     "PlannedBm25View",
+    "PlannedContextArtifact",
+    "PlannedContextView",
     "SourceTrust",
     "VerifiedContextArtifact",
     "bind_context_artifact",
@@ -56,11 +66,15 @@ __all__ = [
     "normalize_owned_query_view",
     "normalize_owned_query_view_strict",
     "plan_bm25_view_strict",
+    "plan_context_artifact_strict",
     "publish_planned_bm25_view_strict",
+    "publish_planned_context_artifact_strict",
     "query_context_artifact",
     "validate_portable_query_view",
     "resolve_github_context_artifact",
     "render_artifact_mcp_config",
     "stage_context_artifact",
+    "stage_context_artifact_strict",
+    "validate_content_bound_portable_query_view_reader",
     "verify_context_artifact",
 ]

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -54,7 +54,10 @@ from ..native_index_authorization import (
     require_native_index_authorization_preflight,
 )
 from ..provider_routes import normalize_provider, resolve_embedding_artifact_route
-from ..source_fingerprint import RepositorySourceBinding
+from ..source_fingerprint import (
+    RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
+)
 from .security import assert_publishable_json_value
 
 _VECTOR_LEVELS = ("l0", "l2")
@@ -3022,10 +3025,11 @@ def _validate_portable_vector_view(
             )
 
 
-def validate_content_bound_portable_query_view_reader(
+def _validate_content_bound_portable_query_view_reader_with_identity(
     publication: PublicationDirectoryReader,
     *,
     repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
     view_type: str,
     view_config: Mapping[str, Any] | None = None,
     forbidden_paths: Iterable[Path] = (),
@@ -3041,6 +3045,8 @@ def validate_content_bound_portable_query_view_reader(
         raise TypeError("portable view requires a publication directory reader")
     if type(repository_source) is not RepositorySourceBinding:
         raise TypeError("portable view repository source has an invalid type")
+    if type(repository_identity) is not RepositorySourceIdentitySnapshot:
+        raise TypeError("portable view repository identity has an invalid type")
     if view_type not in {"bm25", "vector"}:
         raise ValueError(f"unsupported portable query view: {view_type!r}")
     if not isinstance(view_config, Mapping):
@@ -3063,7 +3069,7 @@ def validate_content_bound_portable_query_view_reader(
     forbidden = tuple(forbidden_paths)
     if any(not isinstance(path, Path) for path in forbidden):
         raise TypeError("portable validation forbidden paths must be Path values")
-    repository_records = tuple(repository_source.file_records)
+    repository_records = repository_identity.file_records
     authenticated_source_files = frozenset(record.path for record in repository_records)
     if len(authenticated_source_files) != len(repository_records):
         raise RuntimeError("authenticated repository source repeats a file record")
@@ -3073,7 +3079,7 @@ def validate_content_bound_portable_query_view_reader(
 
     def validate_semantics() -> None:
         with repository_source.read_session():
-            policy_paths = (repository_source.root, *forbidden)
+            policy_paths = (repository_identity.root, *forbidden)
             _assert_authenticated_publishable_json_value(
                 config_snapshot,
                 forbidden_paths=policy_paths,
@@ -3083,7 +3089,7 @@ def validate_content_bound_portable_query_view_reader(
             if view_type == "bm25":
                 _validate_portable_bm25_view(
                     reader.root,
-                    repository_source.root,
+                    repository_identity.root,
                     view_config=config_snapshot,
                     forbidden=policy_paths,
                     environment=environment,
@@ -3094,7 +3100,7 @@ def validate_content_bound_portable_query_view_reader(
             else:
                 _validate_portable_vector_view(
                     reader.root,
-                    repository_source.root,
+                    repository_identity.root,
                     view_config=config_snapshot,
                     forbidden=policy_paths,
                     environment=environment,
@@ -3115,6 +3121,39 @@ def validate_content_bound_portable_query_view_reader(
                 reader.close,
             ),
         ),
+    )
+
+
+def validate_content_bound_portable_query_view_reader(
+    publication: PublicationDirectoryReader,
+    *,
+    repository_source: RepositorySourceBinding,
+    view_type: str,
+    view_config: Mapping[str, Any] | None = None,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    """Validate one portable view through retained view and source authorities."""
+
+    if type(publication) is not PublicationDirectoryReader:
+        raise TypeError("portable view requires a publication directory reader")
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("portable view repository source has an invalid type")
+    if view_type not in {"bm25", "vector"}:
+        raise ValueError(f"unsupported portable query view: {view_type!r}")
+    if not isinstance(view_config, Mapping):
+        raise ValueError(f"portable {view_type} validation requires its view config")
+    repository_identity = repository_source.authenticated_identity_snapshot()
+    if type(repository_identity) is not RepositorySourceIdentitySnapshot:
+        raise TypeError("portable view repository identity has an invalid type")
+    _validate_content_bound_portable_query_view_reader_with_identity(
+        publication,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        view_type=view_type,
+        view_config=view_config,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
     )
 
 

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -14,16 +14,28 @@ import os
 import re
 import stat
 import sys
+from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable, Literal, Mapping
+from typing import Any, Iterable, Iterator, Literal, Mapping
 
 from .. import compat_pickle
 from .._atomic_directory import (
+    PublicationAuthenticatedFile,
+    PublicationDirectoryReader,
+    TreeFileRecord,
     _annotate_secondary_error,
+    _run_callback_with_post_validations,
     capture_directory_ownership,
     directory_ownership_file_records,
     directory_ownership_inventory,
     directory_ownership_root_identity,
+)
+from .._bounded_json import (
+    canonical_json_array_chunks,
+    canonical_json_value_chunks,
+    iter_bounded_json_array,
+    validate_bounded_json_stream,
+    validate_json_complexity,
 )
 from .._contained_source import validate_repository_file
 from .._secret_fields import assert_no_secret_fields
@@ -31,7 +43,10 @@ from ..index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
     VECTOR_VIEW_UPDATE_MARKER,
 )
-from ..index.embedding.model_policy import resolve_embedding_load_policy_from_options
+from ..index.embedding.model_policy import (
+    resolve_embedding_artifact_load_policy_from_options,
+    resolve_embedding_load_policy_from_options,
+)
 from ..native_index_authorization import (
     MissingNativeIndexAuthorizationError,
     NativeIndexAuthorization,
@@ -39,6 +54,7 @@ from ..native_index_authorization import (
     require_native_index_authorization_preflight,
 )
 from ..provider_routes import normalize_provider, resolve_embedding_artifact_route
+from ..source_fingerprint import RepositorySourceBinding
 from .security import assert_publishable_json_value
 
 _VECTOR_LEVELS = ("l0", "l2")
@@ -64,6 +80,8 @@ _MAX_CONFIG_JSON_BYTES = 16 * 1024 * 1024
 _MAX_DOCUMENTS_JSON_BYTES = 256 * 1024 * 1024
 _MAX_FAISS_INDEX_BYTES = 8 * 1024 * 1024 * 1024
 _JSON_READ_CHUNK_BYTES = 1024 * 1024
+_MAX_SOURCE_PATH_BYTES = 4_096
+_MAX_SOURCE_PATH_COMPONENTS = 256
 SourceTrust = Literal["portable-inert", "trusted-local"]
 
 
@@ -734,6 +752,156 @@ class _OwnedViewReader:
         return index
 
 
+class _PublicationViewReader:
+    """Portable-view facade over one callback-scoped publication authority."""
+
+    def __init__(
+        self,
+        publication: PublicationDirectoryReader,
+        ownership: object,
+    ) -> None:
+        # Synthetic only: callers use it for relative path arithmetic, never as
+        # a filesystem authority.
+        self.root = Path("/__codenib_publication_view__")
+        self.ownership = ownership
+        self._publication = publication
+        records = tuple(
+            directory_ownership_file_records(ownership)  # type: ignore[arg-type]
+        )
+        self._records = {record.path: record for record in records}
+        if len(self._records) != len(records):
+            raise RuntimeError("publication view repeats a file record")
+
+    def _relative_path(self, path: Path | PurePosixPath) -> PurePosixPath:
+        if isinstance(path, Path):
+            try:
+                relative = PurePosixPath(path.relative_to(self.root).as_posix())
+            except ValueError as exc:
+                raise ValueError("publication view path is outside its root") from exc
+        elif isinstance(path, PurePosixPath):
+            relative = path
+        else:  # pragma: no cover - private callers are statically constrained
+            raise TypeError("publication view path must be path-like")
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or len(relative.as_posix().encode("utf-8", errors="strict"))
+            > _MAX_SOURCE_PATH_BYTES
+            or len(relative.parts) > _MAX_SOURCE_PATH_COMPONENTS
+        ):
+            raise ValueError(f"publication view path is invalid: {relative}")
+        return relative
+
+    def record(self, path: Path | PurePosixPath) -> TreeFileRecord:
+        relative = self._relative_path(path)
+        try:
+            return self._records[relative.as_posix()]
+        except KeyError as exc:
+            raise ValueError(
+                f"publication view has no initial file record: {relative}"
+            ) from exc
+
+    @contextmanager
+    def open_file(
+        self,
+        path: Path | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> Iterator[PublicationAuthenticatedFile]:
+        relative = self._relative_path(path)
+        expected = self.record(relative)
+        limit = expected.size if max_bytes is None else max_bytes
+        with self._publication.open_authenticated_file(
+            relative,
+            max_bytes=limit,
+        ) as source:
+            yield source
+        observed = source.record
+        if observed != expected:
+            raise RuntimeError(
+                f"publication view file differs from its initial record: {relative}"
+            )
+
+    def read_bytes(self, path: Path, *, max_bytes: int) -> bytes:
+        relative = self._relative_path(path)
+        payload = bytearray()
+        with self.open_file(relative, max_bytes=max_bytes) as source:
+            for chunk in source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES):
+                payload.extend(chunk)
+        return bytes(payload)
+
+    def validate_json(self, path: Path, *, label: str, max_bytes: int) -> None:
+        """Apply bounded lexical JSON policy before any DOM allocation."""
+
+        record = self.record(path)
+        lexical_budget = max(1, record.size)
+        with self.open_file(path, max_bytes=max_bytes) as source:
+            validate_bounded_json_stream(
+                source,
+                label=label,
+                max_bytes=max_bytes,
+                max_nodes=lexical_budget,
+                max_lexical_tokens=lexical_budget,
+            )
+
+    def require_fingerprint(
+        self,
+        path: Path,
+        expected: object,
+    ) -> PurePosixPath:
+        relative = self._relative_path(path)
+        record = self.record(relative)
+        if not isinstance(expected, Mapping):
+            raise ValueError(f"portable view fingerprint is invalid: {relative}")
+        expected_fields = {"size", "sha256"}
+        if "file" in expected:
+            expected_fields.add("file")
+        if set(expected) != expected_fields or (
+            "file" in expected and expected.get("file") != relative.name
+        ):
+            raise ValueError(f"portable view fingerprint is invalid: {relative}")
+        if expected.get("size") != record.size or expected.get("sha256") != (
+            record.sha256
+        ):
+            raise ValueError(f"portable view fingerprint mismatch: {relative}")
+        return relative
+
+    def authenticate(
+        self,
+        path: Path,
+        expected: object,
+        *,
+        cache_bytes: bool,
+        max_bytes: int | None = None,
+        keep_descriptor: bool = False,
+    ) -> None:
+        # ``keep_descriptor`` is deliberately ignored. Content-bound portable
+        # validation never grants native parsing authority.
+        del keep_descriptor
+        relative = self.require_fingerprint(path, expected)
+        limit = self.record(relative).size if max_bytes is None else max_bytes
+        del cache_bytes
+        with self.open_file(relative, max_bytes=limit) as source:
+            for _chunk in source.iter_bytes(chunk_size=_JSON_READ_CHUNK_BYTES):
+                pass
+
+    def verify_root(self) -> None:
+        if self._publication.capture_ownership() != self.ownership:
+            raise RuntimeError("publication view changed during validation")
+
+    def close(self) -> None:
+        return None
+
+    def faiss_index(self, _path: Path, _faiss: Any) -> Any:
+        raise RuntimeError(
+            "content-bound portable validation keeps native indexes inert"
+        )
+
+
+_ViewReader = _OwnedViewReader | _PublicationViewReader
+
+
 def _reject_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:
@@ -759,6 +927,90 @@ def _json_bytes(value: Any) -> bytes:
         )
         + "\n"
     ).encode("utf-8")
+
+
+def _bounded_json_object_snapshot(
+    value: Mapping[str, Any],
+    *,
+    label: str,
+) -> dict[str, Any]:
+    """Detach caller-owned config into one bounded JSON object."""
+
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} requires a mapping")
+    detached = dict(value)
+    validate_json_complexity(detached, label=label)
+    payload = bytearray()
+    try:
+        for chunk in canonical_json_value_chunks(detached):
+            payload.extend(chunk)
+            if len(payload) + 1 > _MAX_CONFIG_JSON_BYTES:
+                raise ValueError(
+                    f"{label} exceeds its {_MAX_CONFIG_JSON_BYTES}-byte limit"
+                )
+        payload.extend(b"\n")
+        snapshot = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_object,
+            parse_constant=_reject_nonfinite_number,
+        )
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise ValueError(f"{label} is not canonical JSON data") from exc
+    if not isinstance(snapshot, dict):  # pragma: no cover - detached is a dict
+        raise AssertionError(f"{label} snapshot is not an object")
+    return snapshot
+
+
+def _environment_snapshot(environ: Mapping[str, str] | None) -> dict[str, str]:
+    source = os.environ if environ is None else environ
+    if not isinstance(source, Mapping):
+        raise TypeError("portable validation environment must be a mapping")
+    snapshot = dict(source)
+    if any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in snapshot.items()
+    ):
+        raise TypeError("portable validation environment must contain text pairs")
+    return snapshot
+
+
+def _assert_authenticated_publishable_json_value(
+    value: Any,
+    *,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+    label: str,
+) -> None:
+    """Apply publication policy without resolving authority display paths."""
+
+    assert_publishable_json_value(
+        value,
+        forbidden_paths=(),
+        environ=environ,
+        label=label,
+    )
+    forbidden: set[str] = set()
+    for path in forbidden_paths:
+        raw = os.fsdecode(os.fspath(path))
+        lexical = os.path.abspath(raw)
+        if os.path.isabs(raw):
+            forbidden.add(raw)
+        forbidden.update((lexical, Path(lexical).as_posix()))
+    patterns = tuple(sorted(pattern for pattern in forbidden if pattern))
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            for key, child in current.items():
+                if any(pattern in key for pattern in patterns):
+                    raise ValueError(f"{label} contains an absolute build-machine path")
+                stack.append(child)
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+        elif isinstance(current, str) and any(
+            pattern in current for pattern in patterns
+        ):
+            raise ValueError(f"{label} contains an absolute build-machine path")
 
 
 def _json_file_signature(metadata: os.stat_result) -> tuple[int, ...]:
@@ -829,8 +1081,10 @@ def _load_json(
     label: str,
     max_bytes: int,
     require_canonical: bool = False,
-    reader: _OwnedViewReader | None = None,
+    reader: _ViewReader | None = None,
 ) -> Any:
+    if isinstance(reader, _PublicationViewReader):
+        reader.validate_json(path, label=label, max_bytes=max_bytes)
     payload = (
         _read_bounded_json(path, label=label, max_bytes=max_bytes)
         if reader is None
@@ -855,7 +1109,7 @@ def _load_json_object(
     label: str,
     max_bytes: int = _MAX_CONFIG_JSON_BYTES,
     require_canonical: bool = False,
-    reader: _OwnedViewReader | None = None,
+    reader: _ViewReader | None = None,
 ) -> dict[str, Any]:
     value = _load_json(
         path,
@@ -892,14 +1146,49 @@ def _owned_view_root(root: Path, repo_path: Path) -> tuple[Path, Path]:
     return resolved, repository
 
 
-def _portable_source_path(value: object, repo_path: Path, *, source: str) -> str:
+def _portable_source_path(
+    value: object,
+    repo_path: Path,
+    *,
+    source: str,
+    authenticated_source_files: frozenset[str] | None = None,
+) -> str:
     raw = str(value or "")
     if not raw:
         return ""
+    try:
+        encoded = raw.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{source} is not a valid UTF-8 path") from exc
+    if len(encoded) > _MAX_SOURCE_PATH_BYTES:
+        raise ValueError(f"{source} exceeds {_MAX_SOURCE_PATH_BYTES} UTF-8 path bytes")
     if any(ord(character) < 32 or ord(character) == 127 for character in raw):
         raise ValueError(
             f"{source} is not a portable repository-relative path: {raw!r}"
         )
+
+    if authenticated_source_files is not None:
+        raw_parts = raw.split("/")
+        normalized = PurePosixPath(raw)
+        if (
+            raw.startswith("~")
+            or raw.startswith("/")
+            or "\\" in raw
+            or _WINDOWS_DRIVE_RE.match(raw)
+            or normalized.is_absolute()
+            or any(part in {"", ".", "..", "~"} for part in raw_parts)
+            or raw != normalized.as_posix()
+            or len(normalized.parts) > _MAX_SOURCE_PATH_COMPONENTS
+        ):
+            raise ValueError(
+                f"{source} is not a portable repository-relative path: {raw!r}"
+            )
+        normalized_text = normalized.as_posix()
+        if normalized_text not in authenticated_source_files:
+            raise ValueError(
+                f"{source} is not in the authenticated repository source: {raw}"
+            )
+        return normalized_text
 
     path = Path(raw).expanduser()
     if path.is_absolute():
@@ -926,15 +1215,17 @@ def _portable_source_path(value: object, repo_path: Path, *, source: str) -> str
         normalized.is_absolute()
         or any(part in {"", ".", ".."} for part in raw_parts)
         or raw != normalized.as_posix()
+        or len(normalized.parts) > _MAX_SOURCE_PATH_COMPONENTS
     ):
         raise ValueError(f"{source} is not repository-relative: {raw}")
+    normalized_text = normalized.as_posix()
     try:
-        validate_repository_file(repo_path, normalized.as_posix())
+        validate_repository_file(repo_path, normalized_text)
     except ValueError as exc:
         raise ValueError(
             f"{source} is not a stable contained source file: {raw}"
         ) from exc
-    return normalized.as_posix()
+    return normalized_text
 
 
 def _normalize_pickle_documents(
@@ -998,7 +1289,7 @@ def _owned_inventory_paths(root: Path, ownership: object, *, kind: str) -> set[P
 
 
 def _authenticate_initial_file(
-    reader: _OwnedViewReader,
+    reader: _ViewReader,
     root: Path,
     ownership: object,
     path: Path,
@@ -1050,7 +1341,8 @@ def _normalize_json_documents(
     path: Path,
     repo_path: Path,
     *,
-    reader: _OwnedViewReader | None = None,
+    reader: _ViewReader | None = None,
+    authenticated_source_files: frozenset[str] | None = None,
 ) -> list[dict[str, Any]]:
     documents = _load_json(
         path,
@@ -1091,6 +1383,7 @@ def _normalize_json_documents(
             raw_file,
             repo_path,
             source=f"vector document {index} file",
+            authenticated_source_files=authenticated_source_files,
         )
         payload.append(
             {
@@ -1099,6 +1392,106 @@ def _normalize_json_documents(
             }
         )
     return payload
+
+
+def _iter_content_bound_documents(
+    path: Path,
+    repo_path: Path,
+    *,
+    reader: _PublicationViewReader,
+    view_type: str,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+    authenticated_source_files: frozenset[str],
+) -> Iterable[dict[str, Any]]:
+    relative = PurePosixPath(path.relative_to(reader.root).as_posix())
+    with reader.open_file(relative, max_bytes=_MAX_DOCUMENTS_JSON_BYTES) as source:
+        documents = iter_bounded_json_array(
+            source,
+            label=f"portable {view_type} documents",
+        )
+        for index, document in enumerate(documents):
+            if not isinstance(document, dict) or set(document) != {
+                "page_content",
+                "metadata",
+            }:
+                raise ValueError(
+                    f"portable {view_type} document {index} has an invalid shape"
+                )
+            page_content = document["page_content"]
+            metadata = document["metadata"]
+            if not isinstance(page_content, str) or not isinstance(metadata, dict):
+                raise ValueError(
+                    f"portable {view_type} document {index} has invalid content or "
+                    "metadata"
+                )
+            assert_no_secret_fields(
+                metadata,
+                source=f"portable {view_type} document {index} metadata",
+            )
+            raw_file = metadata.get("file")
+            if raw_file is not None and not isinstance(raw_file, str):
+                raise ValueError(
+                    f"portable {view_type} document {index} has an invalid source path"
+                )
+            normalized_metadata = dict(metadata)
+            if view_type.startswith("vector") or raw_file is not None:
+                normalized_metadata["file"] = _portable_source_path(
+                    raw_file,
+                    repo_path,
+                    source=f"portable {view_type} document {index} file",
+                    authenticated_source_files=authenticated_source_files,
+                )
+            normalized_document = {
+                "page_content": page_content,
+                "metadata": normalized_metadata,
+            }
+            _assert_authenticated_publishable_json_value(
+                normalized_document,
+                forbidden_paths=forbidden_paths,
+                environ=environ,
+                label=f"portable {view_type} document {index}",
+            )
+            yield normalized_document
+
+
+def _require_content_bound_canonical_documents(
+    path: Path,
+    repo_path: Path,
+    *,
+    reader: _PublicationViewReader,
+    view_type: str,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+    authenticated_source_files: frozenset[str],
+) -> int:
+    count = 0
+    size = 0
+    digest = hashlib.sha256()
+
+    def values() -> Iterable[dict[str, Any]]:
+        nonlocal count
+        for document in _iter_content_bound_documents(
+            path,
+            repo_path,
+            reader=reader,
+            view_type=view_type,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+            authenticated_source_files=authenticated_source_files,
+        ):
+            count += 1
+            yield document
+
+    for chunk in canonical_json_array_chunks(values()):
+        size += len(chunk)
+        if size > _MAX_DOCUMENTS_JSON_BYTES:
+            raise ValueError(f"portable {view_type} documents exceed their byte limit")
+        digest.update(chunk)
+    record = reader.record(path)
+    if size != record.size or digest.hexdigest() != record.sha256:
+        raise ValueError(f"portable {view_type} documents are not canonical JSON")
+    return count
 
 
 def _normalize_bm25_documents(
@@ -1222,12 +1615,23 @@ def _validate_vector_model_policy(
 def _validate_vector_semantics(
     config: Mapping[str, Any],
     view_config: Mapping[str, Any],
+    *,
+    portable_artifact_policy: bool = False,
 ) -> tuple[str, int, str | None, str, str]:
     """Close the manifest-route to persisted-config compatibility contract."""
 
-    route = resolve_embedding_artifact_route(view_config)
+    route_environment = {} if portable_artifact_policy else None
+    load_policy_resolver = (
+        resolve_embedding_artifact_load_policy_from_options
+        if portable_artifact_policy
+        else resolve_embedding_load_policy_from_options
+    )
+    route = resolve_embedding_artifact_route(
+        view_config,
+        environ=route_environment,
+    )
     expected_revision = (
-        resolve_embedding_load_policy_from_options(
+        load_policy_resolver(
             route.model,
             route.compatibility_options,
         ).revision
@@ -1299,7 +1703,10 @@ def _validate_vector_semantics(
     if persisted_identity is not None:
         if not isinstance(persisted_identity, Mapping):
             raise ValueError("portable vector persistence artifact identity is invalid")
-        persisted_route = resolve_embedding_artifact_route(persisted_identity)
+        persisted_route = resolve_embedding_artifact_route(
+            persisted_identity,
+            environ=route_environment,
+        )
         if persisted_route.public_identity() != route.public_identity():
             raise ValueError(
                 "portable vector persistence route identity does not match its view "
@@ -1315,7 +1722,7 @@ def _validate_vector_semantics(
                 "its view config"
             )
         persisted_revision = (
-            resolve_embedding_load_policy_from_options(
+            load_policy_resolver(
                 persisted_route.model,
                 persisted_route.compatibility_options,
             ).revision
@@ -1340,7 +1747,10 @@ def _validate_vector_semantics(
     elif "embedding_kwargs" in config:
         # Legacy configs sometimes expose the semantic options directly. When
         # present, absence is not treated as a wildcard.
-        persisted_route = resolve_embedding_artifact_route(config)
+        persisted_route = resolve_embedding_artifact_route(
+            config,
+            environ=route_environment,
+        )
         if persisted_route.public_identity() != route.public_identity():
             raise ValueError(
                 "portable vector persistence options do not match its view route"
@@ -1400,7 +1810,7 @@ def _validate_level_semantics(
     metric: object,
     index_type: str,
     count: int,
-    reader: _OwnedViewReader,
+    reader: _ViewReader,
     canonicalize: bool = True,
 ) -> None:
     if not present:
@@ -1478,8 +1888,11 @@ def _validate_vector_layout(
     expected_metric: str,
     expected_index_type: str,
     native_authorized: bool,
-    reader: _OwnedViewReader,
+    reader: _ViewReader,
     canonicalize_level_configs: bool = True,
+    authenticated_source_files: frozenset[str] | None = None,
+    document_forbidden_paths: Iterable[Path] = (),
+    document_environ: Mapping[str, str] | None = None,
 ) -> tuple[
     str,
     dict[Path, list[dict[str, Any]]],
@@ -1574,13 +1987,36 @@ def _validate_vector_layout(
             )
             payload = _normalize_pickle_documents(path, repo_path, reader=reader)
         else:
-            payload = _normalize_json_documents(path, repo_path, reader=reader)
-        if count is not None and len(payload) != count:
+            if authenticated_source_files is not None:
+                if not isinstance(reader, _PublicationViewReader):
+                    raise RuntimeError(
+                        "authenticated source validation requires a publication reader"
+                    )
+                actual_count = _require_content_bound_canonical_documents(
+                    path,
+                    repo_path,
+                    reader=reader,
+                    view_type=f"vector {level}",
+                    forbidden_paths=document_forbidden_paths,
+                    environ={} if document_environ is None else document_environ,
+                    authenticated_source_files=authenticated_source_files,
+                )
+                payload = []
+            else:
+                payload = _normalize_json_documents(
+                    path,
+                    repo_path,
+                    reader=reader,
+                )
+                actual_count = len(payload)
+        if document_format == "pkl":
+            actual_count = len(payload)
+        if count is not None and actual_count != count:
             raise ValueError(
                 f"portable vector {level} count differs from {path.name}: "
-                f"expected {count}, found {len(payload)}"
+                f"expected {count}, found {actual_count}"
             )
-        count = len(payload)
+        count = actual_count
         _authenticate_initial_file(
             reader,
             root,
@@ -2214,8 +2650,24 @@ def _validate_normalized_document_sources(
     view_type: str,
     forbidden_paths: Iterable[Path],
     environ: Mapping[str, str],
-    reader: _OwnedViewReader | None = None,
+    reader: _ViewReader | None = None,
+    authenticated_source_files: frozenset[str] | None = None,
 ) -> None:
+    if authenticated_source_files is not None:
+        if not isinstance(reader, _PublicationViewReader):
+            raise RuntimeError(
+                "authenticated source validation requires a publication reader"
+            )
+        _require_content_bound_canonical_documents(
+            path,
+            repo_path,
+            reader=reader,
+            view_type=view_type,
+            forbidden_paths=forbidden_paths,
+            environ=environ,
+            authenticated_source_files=authenticated_source_files,
+        )
+        return
     documents = _load_json(
         path,
         label=f"portable {view_type} documents",
@@ -2260,6 +2712,7 @@ def _validate_normalized_document_sources(
                 raw_file,
                 repo_path,
                 source=f"portable {view_type} document {index} file",
+                authenticated_source_files=authenticated_source_files,
             )
             if raw_file != normalized_file:
                 raise ValueError(
@@ -2268,7 +2721,7 @@ def _validate_normalized_document_sources(
 
 
 def _authenticate_vector_generation(
-    reader: _OwnedViewReader,
+    reader: _ViewReader,
     root: Path,
     *,
     model_suffix: str,
@@ -2365,7 +2818,8 @@ def _validate_portable_bm25_view(
     forbidden: tuple[Path, ...],
     environment: Mapping[str, str],
     initial_tree: object,
-    reader: _OwnedViewReader,
+    reader: _ViewReader,
+    authenticated_source_files: frozenset[str] | None = None,
 ) -> None:
     assert_no_secret_fields(view_config, source="portable BM25 view config")
     fingerprints = view_config.get("artifact_file_fingerprints")
@@ -2405,7 +2859,12 @@ def _validate_portable_bm25_view(
         reader=reader,
     )
     assert_no_secret_fields(metadata, source="portable BM25 metadata")
-    assert_publishable_json_value(
+    publishable_guard = (
+        assert_publishable_json_value
+        if authenticated_source_files is None
+        else _assert_authenticated_publishable_json_value
+    )
+    publishable_guard(
         metadata,
         forbidden_paths=forbidden,
         environ=environment,
@@ -2432,6 +2891,7 @@ def _validate_portable_bm25_view(
         forbidden_paths=forbidden,
         environ=environment,
         reader=reader,
+        authenticated_source_files=authenticated_source_files,
     )
 
 
@@ -2443,10 +2903,15 @@ def _validate_portable_vector_view(
     forbidden: tuple[Path, ...],
     environment: Mapping[str, str],
     initial_tree: object,
-    reader: _OwnedViewReader,
+    reader: _ViewReader,
+    authenticated_source_files: frozenset[str] | None = None,
 ) -> None:
     assert_no_secret_fields(view_config, source="portable vector view config")
-    route = resolve_embedding_artifact_route(view_config)
+    portable_artifact_policy = authenticated_source_files is not None
+    route = resolve_embedding_artifact_route(
+        view_config,
+        environ={} if portable_artifact_policy else None,
+    )
     expected_suffix = route.model.replace("/", "__")
     inventory_files = _owned_inventory_paths(root, initial_tree, kind="file")
     root_configs = sorted(
@@ -2478,7 +2943,12 @@ def _validate_portable_vector_view(
         expected_config=expected_config,
     )
     assert_no_secret_fields(config, source="portable vector config")
-    assert_publishable_json_value(
+    publishable_guard = (
+        assert_publishable_json_value
+        if authenticated_source_files is None
+        else _assert_authenticated_publishable_json_value
+    )
+    publishable_guard(
         config,
         forbidden_paths=forbidden,
         environ=environment,
@@ -2490,7 +2960,11 @@ def _validate_portable_vector_view(
         expected_revision,
         expected_metric,
         expected_index_type,
-    ) = _validate_vector_semantics(config, view_config)
+    ) = _validate_vector_semantics(
+        config,
+        view_config,
+        portable_artifact_policy=portable_artifact_policy,
+    )
     if semantic_suffix != model_suffix:
         raise ValueError("portable vector config embedding model does not match")
     document_format, _documents, counts, stale_paths = _validate_vector_layout(
@@ -2508,6 +2982,9 @@ def _validate_portable_vector_view(
         native_authorized=False,
         canonicalize_level_configs=False,
         reader=reader,
+        authenticated_source_files=authenticated_source_files,
+        document_forbidden_paths=forbidden,
+        document_environ=environment,
     )
     if document_format != "json" or stale_paths:
         raise ValueError("portable vector view is not in its normalized final form")
@@ -2523,7 +3000,7 @@ def _validate_portable_vector_view(
         level_root = root / level
         level_config = level_root / f"config_{model_suffix}.json"
         if level_config in inventory_files:
-            assert_publishable_json_value(
+            publishable_guard(
                 _load_json_object(
                     level_config,
                     label=f"portable vector {level} config",
@@ -2534,14 +3011,111 @@ def _validate_portable_vector_view(
                 environ=environment,
                 label=f"portable vector {level} config",
             )
-        _validate_normalized_document_sources(
-            level_root / f"documents_{model_suffix}.json",
-            repository,
-            view_type=f"vector {level}",
-            forbidden_paths=forbidden,
-            environ=environment,
-            reader=reader,
-        )
+        if authenticated_source_files is None:
+            _validate_normalized_document_sources(
+                level_root / f"documents_{model_suffix}.json",
+                repository,
+                view_type=f"vector {level}",
+                forbidden_paths=forbidden,
+                environ=environment,
+                reader=reader,
+            )
+
+
+def validate_content_bound_portable_query_view_reader(
+    publication: PublicationDirectoryReader,
+    *,
+    repository_source: RepositorySourceBinding,
+    view_type: str,
+    view_config: Mapping[str, Any] | None = None,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    """Validate one portable view through retained view and source authorities.
+
+    Document source paths are matched only against the repository binding's
+    frozen records. Vector native indexes remain opaque authenticated bytes.
+    """
+
+    if type(publication) is not PublicationDirectoryReader:
+        raise TypeError("portable view requires a publication directory reader")
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("portable view repository source has an invalid type")
+    if view_type not in {"bm25", "vector"}:
+        raise ValueError(f"unsupported portable query view: {view_type!r}")
+    if not isinstance(view_config, Mapping):
+        raise ValueError(f"portable {view_type} validation requires its view config")
+
+    config_snapshot = _bounded_json_object_snapshot(
+        view_config,
+        label=f"portable {view_type} view config",
+    )
+    if view_type == "vector":
+        route = resolve_embedding_artifact_route(config_snapshot, environ={})
+        if route.provider == "huggingface":
+            resolve_embedding_artifact_load_policy_from_options(
+                route.model,
+                route.compatibility_options,
+            )
+    if not repository_source.usable:
+        raise RuntimeError("portable view repository source is not usable")
+    environment = _environment_snapshot(environ)
+    forbidden = tuple(forbidden_paths)
+    if any(not isinstance(path, Path) for path in forbidden):
+        raise TypeError("portable validation forbidden paths must be Path values")
+    repository_records = tuple(repository_source.file_records)
+    authenticated_source_files = frozenset(record.path for record in repository_records)
+    if len(authenticated_source_files) != len(repository_records):
+        raise RuntimeError("authenticated repository source repeats a file record")
+
+    initial_tree = publication.capture_ownership()
+    reader = _PublicationViewReader(publication, initial_tree)
+
+    def validate_semantics() -> None:
+        with repository_source.read_session():
+            policy_paths = (repository_source.root, *forbidden)
+            _assert_authenticated_publishable_json_value(
+                config_snapshot,
+                forbidden_paths=policy_paths,
+                environ=environment,
+                label=f"portable {view_type} view config",
+            )
+            if view_type == "bm25":
+                _validate_portable_bm25_view(
+                    reader.root,
+                    repository_source.root,
+                    view_config=config_snapshot,
+                    forbidden=policy_paths,
+                    environment=environment,
+                    initial_tree=initial_tree,
+                    reader=reader,
+                    authenticated_source_files=authenticated_source_files,
+                )
+            else:
+                _validate_portable_vector_view(
+                    reader.root,
+                    repository_source.root,
+                    view_config=config_snapshot,
+                    forbidden=policy_paths,
+                    environment=environment,
+                    initial_tree=initial_tree,
+                    reader=reader,
+                    authenticated_source_files=authenticated_source_files,
+                )
+
+    _run_callback_with_post_validations(
+        validate_semantics,
+        (
+            (
+                "portable view final ownership validation also failed",
+                reader.verify_root,
+            ),
+            (
+                "portable view reader cleanup also failed",
+                reader.close,
+            ),
+        ),
+    )
 
 
 def validate_portable_query_view(
@@ -2608,5 +3182,6 @@ def validate_portable_query_view(
 __all__ = [
     "SourceTrust",
     "normalize_owned_query_view",
+    "validate_content_bound_portable_query_view_reader",
     "validate_portable_query_view",
 ]

--- a/codenib/artifacts/security.py
+++ b/codenib/artifacts/security.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 import math
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping
 
 from .._atomic_directory import PublicationDirectoryReader
@@ -43,6 +43,7 @@ _SENSITIVE_ENV_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET")
 _SCAN_CHUNK_BYTES = 1024 * 1024
 _MAX_CANONICAL_SCALAR_BYTES = 1_024
 _MAX_PUBLISHABLE_JSON_BYTES = 64 * 1024 * 1024
+_MAX_STREAMING_PUBLISHABLE_JSON_BYTES = 256 * 1024 * 1024
 _MAX_PUBLISHABLE_JSON_NODES = DEFAULT_MAX_NODES_PER_ELEMENT
 _MAX_PUBLISHABLE_JSON_TOKENS = DEFAULT_MAX_LEXICAL_TOKENS
 _MAX_PUBLISHABLE_JSON_DEPTH = DEFAULT_MAX_DEPTH
@@ -265,11 +266,15 @@ def assert_publishable_tree_reader(
     environ: Mapping[str, str],
     label: str,
     max_json_bytes: int = _MAX_PUBLISHABLE_JSON_BYTES,
+    streaming_json_paths: Iterable[str | PurePosixPath] = (),
 ) -> None:
     """Apply publication policy through one authenticated tree authority.
 
     Publication JSON is UTF-8 without a byte-order mark. Its lexical resource
     budgets are enforced before strict UTF-8 decoding and DOM allocation.
+    ``streaming_json_paths`` must enumerate exact JSON paths whose semantic
+    validator already consumed their canonical form; those files still receive
+    bounded lexical validation and a complete path/credential byte scan here.
     """
 
     if (
@@ -279,6 +284,38 @@ def assert_publishable_tree_reader(
         or max_json_bytes > _MAX_PUBLISHABLE_JSON_BYTES
     ):
         raise ValueError("publishable JSON byte limit is out of bounds")
+    streaming_json: set[str] = set()
+    for raw_relative in streaming_json_paths:
+        if isinstance(raw_relative, PurePosixPath):
+            raw_text: object = raw_relative.as_posix()
+        else:
+            raw_text = raw_relative
+        if not isinstance(raw_text, str):
+            raise ValueError("streaming publication JSON path is invalid")
+        try:
+            relative = PurePosixPath(raw_text)
+            encoded = raw_text.encode("utf-8", errors="strict")
+        except ValueError as exc:
+            raise ValueError("streaming publication JSON path is invalid") from exc
+        normalized = relative.as_posix()
+        if (
+            not raw_text
+            or raw_text != normalized
+            or relative.is_absolute()
+            or not relative.parts
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or "\\" in raw_text
+            or relative.suffix != ".json"
+            or len(encoded) > 4_096
+            or len(relative.parts) > 256
+            or any(
+                ord(character) < 32 or ord(character) == 127 for character in raw_text
+            )
+        ):
+            raise ValueError("streaming publication JSON path is invalid")
+        if normalized in streaming_json:
+            raise ValueError("streaming publication JSON path is duplicated")
+        streaming_json.add(normalized)
     roots = tuple(forbidden_paths)
     forbidden = _serialized_patterns(_forbidden_path_strings(roots))
     secrets = _secret_values(environ)
@@ -291,15 +328,66 @@ def assert_publishable_tree_reader(
         encoded = path.encode("utf-8", errors="strict")
         if any(secret in encoded for secret in secrets):
             raise ValueError(f"{label} contains a configured credential in {path}")
-        if kind == "file" and is_json_path(path) and size > max_json_bytes:
+        if (
+            kind == "file"
+            and path in streaming_json
+            and size > _MAX_STREAMING_PUBLISHABLE_JSON_BYTES
+        ):
+            raise ValueError(
+                f"{label} streaming JSON file exceeds its "
+                f"{_MAX_STREAMING_PUBLISHABLE_JSON_BYTES}-byte limit: {path}"
+            )
+        if (
+            kind == "file"
+            and is_json_path(path)
+            and path not in streaming_json
+            and size > max_json_bytes
+        ):
             raise ValueError(
                 f"{label} JSON file exceeds its {max_json_bytes}-byte limit: {path}"
             )
 
     reader.capture_ownership(entry_policy=entry_policy)
-    for record in reader.file_records():
+    records = reader.file_records()
+    missing_streaming_json = streaming_json - {record.path for record in records}
+    if missing_streaming_json:
+        raise ValueError(
+            "streaming publication JSON path is absent: "
+            f"{sorted(missing_streaming_json)[0]}"
+        )
+    for record in records:
         relative = record.path
-        if is_json_path(relative):
+        if relative in streaming_json:
+            json_label = f"{label} JSON {relative}"
+            with reader.open_authenticated_file(
+                relative,
+                max_bytes=_MAX_STREAMING_PUBLISHABLE_JSON_BYTES,
+            ) as source:
+                # The semantic owner applies per-element budgets. This pass is
+                # intentionally lexical-only, with counts bounded by the file
+                # size so a legitimate large array is not forced into one DOM.
+                lexical_budget = max(1, record.size)
+                validate_bounded_json_stream(
+                    source,
+                    label=json_label,
+                    max_bytes=_MAX_STREAMING_PUBLISHABLE_JSON_BYTES,
+                    max_nodes=lexical_budget,
+                    max_lexical_tokens=lexical_budget,
+                    max_depth=_MAX_PUBLISHABLE_JSON_DEPTH,
+                    max_key_bytes=_MAX_PUBLISHABLE_JSON_KEY_BYTES,
+                    max_string_bytes=_MAX_PUBLISHABLE_JSON_STRING_BYTES,
+                    max_atom_bytes=_MAX_PUBLISHABLE_JSON_ATOM_BYTES,
+                )
+            with reader.open_authenticated_file(
+                relative,
+                max_bytes=record.size,
+            ) as source:
+                match = _matching_kind_blocks(
+                    source.iter_bytes(chunk_size=_SCAN_CHUNK_BYTES),
+                    forbidden=forbidden,
+                    secrets=secrets,
+                )
+        elif is_json_path(relative):
             json_label = f"{label} JSON {relative}"
             with reader.open_authenticated_file(
                 relative,

--- a/codenib/artifacts/strict_context.py
+++ b/codenib/artifacts/strict_context.py
@@ -43,6 +43,7 @@ from ..compiler.snapshot_store import normalize_repo
 from ..provider_routes import resolve_embedding_artifact_route
 from ..source_fingerprint import (
     RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
     is_secure_source_fingerprint_v2,
 )
 from .context import (
@@ -51,7 +52,9 @@ from .context import (
     PORTABLE_CONTEXT_VIEWS,
     ContextArtifactResult,
 )
-from .portable_views import validate_content_bound_portable_query_view_reader
+from .portable_views import (
+    _validate_content_bound_portable_query_view_reader_with_identity,
+)
 from .runtime import verify_context_artifact_reader
 from .security import assert_publishable_tree_reader
 from .strict_bm25 import (
@@ -344,6 +347,7 @@ class _FrozenContextInputs:
     manifest: dict[str, Any]
     repository: str
     repository_source: RepositorySourceBinding
+    repository_identity: RepositorySourceIdentitySnapshot
     view_generations: tuple[tuple[str, PublishedWorkspaceReceiptOwner], ...]
     environment: dict[str, str]
 
@@ -403,6 +407,9 @@ def _freeze_inputs(
         raise TypeError("strict context repository source has an invalid type")
     if not repository_source.usable:
         raise RuntimeError("strict context repository source is not usable")
+    repository_identity = repository_source.authenticated_identity_snapshot()
+    if type(repository_identity) is not RepositorySourceIdentitySnapshot:
+        raise TypeError("strict context repository identity has an invalid type")
     if not isinstance(repository, str):
         raise TypeError("strict context repository must be text")
     normalized_repository = normalize_repo(repository)
@@ -414,6 +421,7 @@ def _freeze_inputs(
         manifest=_snapshot_manifest(manifest),
         repository=normalized_repository,
         repository_source=repository_source,
+        repository_identity=repository_identity,
         view_generations=_snapshot_view_generations(view_generations),
         environment=_environment_snapshot(environ),
     )
@@ -421,7 +429,7 @@ def _freeze_inputs(
 
 def _validate_manifest_identity(inputs: _FrozenContextInputs) -> RepoManifest:
     manifest = RepoManifest.from_dict(inputs.manifest)
-    source = inputs.repository_source
+    source = inputs.repository_identity
     if manifest.version != MANIFEST_VERSION:
         raise ValueError(
             "strict context repository manifest version is incompatible: "
@@ -454,7 +462,7 @@ def _overlaps(left: Path, right: Path) -> bool:
 
 
 def _require_disjoint_paths(inputs: _FrozenContextInputs) -> tuple[Path, ...]:
-    repository = lexical_directory_path(inputs.repository_source.root)
+    repository = lexical_directory_path(inputs.repository_identity.root)
     sources: list[Path] = []
     physical: list[Path] = []
     for view, owner in inputs.view_generations:
@@ -489,7 +497,7 @@ def _require_destination_disjoint(
     source_paths: tuple[Path, ...],
 ) -> Path:
     candidate = lexical_directory_path(destination)
-    repository = lexical_directory_path(inputs.repository_source.root)
+    repository = lexical_directory_path(inputs.repository_identity.root)
     if _overlaps(candidate, repository) or any(
         _overlaps(candidate, source) for source in source_paths
     ):
@@ -547,9 +555,10 @@ def _validate_source_view(
         before = publication.capture_ownership()
         if before != expected_ownership:
             raise RuntimeError(f"strict context {view} generation changed")
-        validate_content_bound_portable_query_view_reader(
+        _validate_content_bound_portable_query_view_reader_with_identity(
             publication,
             repository_source=inputs.repository_source,
+            repository_identity=inputs.repository_identity,
             view_type=view,
             view_config=config,
             forbidden_paths=(),
@@ -586,7 +595,7 @@ def _planned_view(
     config = entry["config"]
     _assert_authenticated_publishable_json_value(
         entry,
-        forbidden_paths=(inputs.repository_source.root, receipt.path),
+        forbidden_paths=(inputs.repository_identity.root, receipt.path),
         environ=inputs.environment,
         label=f"strict context {view} manifest entry",
     )
@@ -751,7 +760,7 @@ def _build_plan(inputs: _FrozenContextInputs) -> PlannedContextArtifact:
     }
     _assert_authenticated_publishable_json_value(
         metadata,
-        forbidden_paths=(inputs.repository_source.root,),
+        forbidden_paths=(inputs.repository_identity.root,),
         environ=inputs.environment,
         label="strict context metadata",
     )
@@ -895,7 +904,7 @@ def _validate_candidate(
         raise RuntimeError("strict context candidate differs from its exact plan")
     assert_publishable_tree_reader(
         candidate,
-        forbidden_paths=(inputs.repository_source.root, *forbidden_paths),
+        forbidden_paths=(inputs.repository_identity.root, *forbidden_paths),
         environ=inputs.environment,
         label="strict context artifact",
         streaming_json_paths=planned.streaming_json_paths,

--- a/codenib/artifacts/strict_context.py
+++ b/codenib/artifacts/strict_context.py
@@ -1,0 +1,1180 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strict, authority-bound publication for portable context generations."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .._atomic_directory import (
+    PublicationDirectoryReader,
+    TreeFileRecord,
+    directory_ownership_digest,
+    directory_ownership_file_records,
+    directory_ownership_inventory,
+    lexical_directory_path,
+)
+from .._captured_directory import (
+    PublishedWorkspaceReceipt,
+    PublishedWorkspaceReceiptOwner,
+    WorkspaceDirectory,
+    WorkspaceFile,
+    WorkspacePlan,
+    require_owned_workspace_publication_support,
+)
+from .._version import package_version
+from .._workspace_provider import (
+    StrictWorkspaceProvider,
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_strict_workspace,
+)
+from ..compiler.manifest import MANIFEST_FILENAME, MANIFEST_VERSION, RepoManifest
+from ..compiler.snapshot_store import normalize_repo
+from ..provider_routes import resolve_embedding_artifact_route
+from ..source_fingerprint import (
+    RepositorySourceBinding,
+    is_secure_source_fingerprint_v2,
+)
+from .context import (
+    CONTEXT_ARTIFACT_MANIFEST,
+    CONTEXT_ARTIFACT_SCHEMA,
+    PORTABLE_CONTEXT_VIEWS,
+    ContextArtifactResult,
+)
+from .portable_views import validate_content_bound_portable_query_view_reader
+from .runtime import verify_context_artifact_reader
+from .security import assert_publishable_tree_reader
+from .strict_bm25 import (
+    _assert_authenticated_publishable_json_value,
+    _environment_snapshot,
+    _json_object_snapshot,
+)
+
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+_REPOSITORY_RE = re.compile(r"^[a-z0-9_.-]+(?:/[a-z0-9_.-]+)*$")
+_MAX_METADATA_BYTES = 16 * 1024 * 1024
+_MAX_DOCUMENTS_BYTES = 256 * 1024 * 1024
+_STRICT_CONTEXT_PLAN_DOMAIN = "codenib-portable-context-strict-workspace-v1"
+_MISSING = object()
+
+
+def _canonical_json_bytes(value: Any, *, label: str) -> bytes:
+    """Return one bounded deterministic JSON representation."""
+
+    try:
+        payload = (
+            json.dumps(
+                value,
+                allow_nan=False,
+                ensure_ascii=True,
+                indent=2,
+                sort_keys=True,
+                separators=(",", ": "),
+            )
+            + "\n"
+        ).encode("utf-8", errors="strict")
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise ValueError(f"{label} is not canonical JSON data") from exc
+    if len(payload) > _MAX_METADATA_BYTES:
+        raise ValueError(f"{label} exceeds its {_MAX_METADATA_BYTES}-byte limit")
+    return payload
+
+
+def _record_payload(record: TreeFileRecord) -> dict[str, Any]:
+    return {
+        "path": record.path,
+        "mode": record.mode,
+        "size": record.size,
+        "sha256": record.sha256,
+    }
+
+
+def _output_record(relative: str, payload: bytes) -> TreeFileRecord:
+    return TreeFileRecord(
+        path=relative,
+        mode=0o600,
+        size=len(payload),
+        sha256=hashlib.sha256(payload).hexdigest(),
+    )
+
+
+def _prefixed_record(prefix: PurePosixPath, record: TreeFileRecord) -> TreeFileRecord:
+    return TreeFileRecord(
+        path=(prefix / PurePosixPath(record.path)).as_posix(),
+        mode=record.mode,
+        size=record.size,
+        sha256=record.sha256,
+    )
+
+
+def _portable_capabilities(
+    capabilities: Mapping[str, bool],
+    views: Iterable[str],
+) -> dict[str, bool]:
+    selected = set(views)
+    result = dict(capabilities)
+    if any(not isinstance(value, bool) for value in result.values()):
+        raise ValueError("strict context capabilities must be boolean")
+    result.update(
+        {
+            "sparse_search": "bm25" in selected,
+            "dense_search": "vector" in selected,
+            "hybrid_search": {"bm25", "vector"} <= selected,
+            "symbol_navigation": "symbol_graph" in selected,
+        }
+    )
+    return result
+
+
+def _merge_adjustments(
+    entry: dict[str, Any],
+    adjustments: Mapping[str, Any],
+    *,
+    view: str,
+) -> None:
+    for section_name in ("config", "metadata"):
+        section = entry.get(section_name)
+        if not isinstance(section, dict):
+            raise ValueError(f"strict context {view} {section_name} must be an object")
+        for key, value in adjustments.items():
+            previous = section.get(key, _MISSING)
+            if previous is not _MISSING and previous != value:
+                raise ValueError(
+                    f"strict context {view} {section_name} conflicts with "
+                    f"its retained generation: {key}"
+                )
+            section[key] = value
+
+
+def _view_adjustments(
+    view: str,
+    records: tuple[TreeFileRecord, ...],
+    view_config: Mapping[str, Any],
+) -> dict[str, Any]:
+    by_path = {record.path: record for record in records}
+    if len(by_path) != len(records):
+        raise RuntimeError(f"strict context {view} source repeats a file")
+    if view == "bm25":
+        required = {"documents.json", "bm25_metadata.json"}
+        if set(by_path) != required:
+            raise ValueError("strict context BM25 generation is incomplete")
+        return {
+            "artifact_file_fingerprints": {
+                relative: {
+                    "size": by_path[relative].size,
+                    "sha256": by_path[relative].sha256,
+                }
+                for relative in sorted(required)
+            }
+        }
+
+    route = resolve_embedding_artifact_route(view_config, environ={})
+    config_name = f"config_{route.model.replace('/', '__')}.json"
+    config_record = by_path.get(config_name)
+    if config_record is None:
+        raise ValueError("strict context vector generation has no root config")
+    return {
+        "artifact_scope": "query-serving",
+        "portable_document_format": "codenib.vector-documents.v1",
+        "persistence_config_fingerprint": {
+            "file": config_name,
+            "size": config_record.size,
+            "sha256": config_record.sha256,
+        },
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedContextView:
+    """One retained portable view bound into an exact context plan."""
+
+    name: str
+    source_plan_digest: str
+    source_ownership: object
+    source_digest: str
+    source_inventory: tuple[tuple[str, str], ...]
+    source_records: tuple[TreeFileRecord, ...]
+    output_records: tuple[TreeFileRecord, ...]
+    config_payload: bytes
+    entry_digest: str
+
+    def __post_init__(self) -> None:
+        inventory = tuple(self.source_inventory)
+        source_records = tuple(self.source_records)
+        output_records = tuple(self.output_records)
+        if self.name not in PORTABLE_CONTEXT_VIEWS:
+            raise ValueError("strict context plan has an unsupported view")
+        for label, value in (
+            ("source plan", self.source_plan_digest),
+            ("source tree", self.source_digest),
+            ("entry", self.entry_digest),
+        ):
+            if (
+                not isinstance(value, str)
+                or len(value) != 64
+                or any(character not in "0123456789abcdef" for character in value)
+            ):
+                raise ValueError(f"strict context {label} digest is invalid")
+        if not isinstance(self.config_payload, bytes):
+            raise TypeError("strict context view config payload must be bytes")
+        if any(type(record) is not TreeFileRecord for record in source_records):
+            raise TypeError("strict context source records have an invalid type")
+        if any(type(record) is not TreeFileRecord for record in output_records):
+            raise TypeError("strict context output records have an invalid type")
+        if source_records != tuple(sorted(source_records, key=lambda item: item.path)):
+            raise ValueError("strict context source records must be canonical")
+        if output_records != tuple(sorted(output_records, key=lambda item: item.path)):
+            raise ValueError("strict context output records must be canonical")
+        prefix = f"views/{self.name}/"
+        expected = tuple(
+            _prefixed_record(PurePosixPath("views") / self.name, record)
+            for record in source_records
+        )
+        if output_records != expected or any(
+            not record.path.startswith(prefix) for record in output_records
+        ):
+            raise ValueError("strict context view output records are not exact")
+        object.__setattr__(self, "source_inventory", inventory)
+        object.__setattr__(self, "source_records", source_records)
+        object.__setattr__(self, "output_records", output_records)
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedContextArtifact:
+    """Immutable exact output plan for one portable context generation."""
+
+    plan: WorkspacePlan
+    manifest_digest: str
+    repository: str
+    commit: str
+    repository_fingerprint: str
+    repository_file_count: int
+    views: tuple[str, ...]
+    view_plans: tuple[PlannedContextView, ...]
+    output_records: tuple[TreeFileRecord, ...]
+    manifest_payload: bytes
+    metadata_payload: bytes
+    streaming_json_paths: tuple[str, ...]
+    file_count: int
+    byte_count: int
+
+    def __post_init__(self) -> None:
+        views = tuple(self.views)
+        view_plans = tuple(self.view_plans)
+        output_records = tuple(self.output_records)
+        streaming_paths = tuple(self.streaming_json_paths)
+        if type(self.plan) is not WorkspacePlan:
+            raise TypeError("strict context plan must contain an exact WorkspacePlan")
+        if views != tuple(sorted(views)) or not views or len(set(views)) != len(views):
+            raise ValueError("strict context views must be non-empty and canonical")
+        if tuple(view.name for view in view_plans) != views:
+            raise ValueError("strict context view plans differ from selected views")
+        if any(type(view) is not PlannedContextView for view in view_plans):
+            raise TypeError("strict context view plans have an invalid type")
+        if output_records != tuple(sorted(output_records, key=lambda item: item.path)):
+            raise ValueError("strict context output records must be canonical")
+        if any(type(record) is not TreeFileRecord for record in output_records):
+            raise TypeError("strict context output records have an invalid type")
+        if hashlib.sha256(self.manifest_payload).hexdigest() != self.manifest_digest:
+            raise ValueError("strict context manifest digest differs from its bytes")
+        if not _COMMIT_RE.fullmatch(self.commit):
+            raise ValueError("strict context commit must be a full lowercase Git SHA")
+        if self.repository != normalize_repo(
+            self.repository
+        ) or not _REPOSITORY_RE.fullmatch(self.repository):
+            raise ValueError("strict context repository is not canonical")
+        if (
+            isinstance(self.repository_file_count, bool)
+            or not isinstance(self.repository_file_count, int)
+            or self.repository_file_count < 0
+        ):
+            raise ValueError("strict context repository file count is invalid")
+        if (
+            isinstance(self.file_count, bool)
+            or not isinstance(self.file_count, int)
+            or self.file_count <= 0
+            or isinstance(self.byte_count, bool)
+            or not isinstance(self.byte_count, int)
+            or self.byte_count < 0
+        ):
+            raise ValueError("strict context output counts are invalid")
+        if not isinstance(self.manifest_payload, bytes) or not isinstance(
+            self.metadata_payload, bytes
+        ):
+            raise TypeError("strict context JSON payloads must be bytes")
+        if streaming_paths != tuple(sorted(set(streaming_paths))):
+            raise ValueError("strict context streaming paths must be canonical")
+        output_by_path = {record.path: record for record in output_records}
+        if len(output_by_path) != len(output_records):
+            raise ValueError("strict context output records repeat a path")
+        try:
+            planned_files = tuple(
+                TreeFileRecord(
+                    path=item.path.as_posix(),
+                    mode=item.mode,
+                    size=item.max_bytes,
+                    sha256=output_by_path[item.path.as_posix()].sha256,
+                )
+                for item in self.plan.files
+            )
+        except KeyError as exc:
+            raise ValueError(
+                "strict context workspace names an unknown output file"
+            ) from exc
+        if planned_files != output_records:
+            raise ValueError("strict context workspace files differ from exact output")
+        object.__setattr__(self, "views", views)
+        object.__setattr__(self, "view_plans", view_plans)
+        object.__setattr__(self, "output_records", output_records)
+        object.__setattr__(self, "streaming_json_paths", streaming_paths)
+
+
+@dataclass(frozen=True, slots=True)
+class _FrozenContextInputs:
+    manifest: dict[str, Any]
+    repository: str
+    repository_source: RepositorySourceBinding
+    view_generations: tuple[tuple[str, PublishedWorkspaceReceiptOwner], ...]
+    environment: dict[str, str]
+
+
+def _snapshot_manifest(manifest: RepoManifest) -> dict[str, Any]:
+    if type(manifest) is not RepoManifest:
+        raise TypeError("strict context manifest must be a RepoManifest")
+    snapshot = _json_object_snapshot(
+        manifest.to_dict(),
+        label="strict context repository manifest",
+    )
+    try:
+        reconstructed = RepoManifest.from_dict(snapshot)
+        canonical = reconstructed.to_dict()
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("strict context repository manifest is invalid") from exc
+    if canonical != snapshot:
+        raise ValueError("strict context repository manifest is not canonical")
+    return snapshot
+
+
+def _snapshot_view_generations(
+    view_generations: Mapping[str, PublishedWorkspaceReceiptOwner],
+) -> tuple[tuple[str, PublishedWorkspaceReceiptOwner], ...]:
+    if not isinstance(view_generations, Mapping):
+        raise TypeError("strict context view generations must be a mapping")
+    generations = dict(view_generations)
+    if not generations:
+        raise ValueError("strict context requires at least one portable view")
+    if any(not isinstance(name, str) for name in generations):
+        raise TypeError("strict context view names must be text")
+    unsupported = sorted(set(generations) - PORTABLE_CONTEXT_VIEWS)
+    if unsupported:
+        raise ValueError(
+            "strict context does not support views: " + ", ".join(unsupported)
+        )
+    ordered = tuple(sorted(generations.items()))
+    owners = tuple(owner for _name, owner in ordered)
+    if any(type(owner) is not PublishedWorkspaceReceiptOwner for owner in owners):
+        raise TypeError("strict context views must be workspace receipt owners")
+    if len({id(owner) for owner in owners}) != len(owners):
+        raise ValueError("strict context views must use distinct receipt owners")
+    if any(not owner.active for owner in owners):
+        raise RuntimeError("strict context view generation must be active")
+    return ordered
+
+
+def _freeze_inputs(
+    manifest: RepoManifest,
+    *,
+    repository: str,
+    repository_source: RepositorySourceBinding,
+    view_generations: Mapping[str, PublishedWorkspaceReceiptOwner],
+    environ: Mapping[str, str] | None,
+) -> _FrozenContextInputs:
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("strict context repository source has an invalid type")
+    if not repository_source.usable:
+        raise RuntimeError("strict context repository source is not usable")
+    if not isinstance(repository, str):
+        raise TypeError("strict context repository must be text")
+    normalized_repository = normalize_repo(repository)
+    if normalized_repository != repository or not _REPOSITORY_RE.fullmatch(
+        normalized_repository
+    ):
+        raise ValueError("strict context repository must be a canonical slug")
+    return _FrozenContextInputs(
+        manifest=_snapshot_manifest(manifest),
+        repository=normalized_repository,
+        repository_source=repository_source,
+        view_generations=_snapshot_view_generations(view_generations),
+        environment=_environment_snapshot(environ),
+    )
+
+
+def _validate_manifest_identity(inputs: _FrozenContextInputs) -> RepoManifest:
+    manifest = RepoManifest.from_dict(inputs.manifest)
+    source = inputs.repository_source
+    if manifest.version != MANIFEST_VERSION:
+        raise ValueError(
+            "strict context repository manifest version is incompatible: "
+            f"{manifest.version!r}"
+        )
+    if not _COMMIT_RE.fullmatch(manifest.commit):
+        raise ValueError("strict context requires a full lowercase Git commit")
+    if not is_secure_source_fingerprint_v2(manifest.source_fingerprint):
+        raise ValueError("strict context requires source fingerprint v2")
+    if manifest.source_fingerprint != source.fingerprint:
+        raise ValueError("strict context manifest belongs to another source generation")
+    if manifest.file_count != source.file_count:
+        raise ValueError("strict context manifest file count differs from its source")
+    if not all(isinstance(language, str) for language in manifest.languages):
+        raise ValueError("strict context manifest languages must be text")
+    selected = tuple(name for name, _owner in inputs.view_generations)
+    for view in selected:
+        entry = manifest.indexes.get(view)
+        if (
+            entry is None
+            or entry.index_type != view
+            or not manifest.index_is_current(view)
+        ):
+            raise ValueError(f"strict context requires a current {view} view")
+    return manifest
+
+
+def _overlaps(left: Path, right: Path) -> bool:
+    return left == right or left in right.parents or right in left.parents
+
+
+def _require_disjoint_paths(inputs: _FrozenContextInputs) -> tuple[Path, ...]:
+    repository = lexical_directory_path(inputs.repository_source.root)
+    sources: list[Path] = []
+    physical: list[Path] = []
+    for view, owner in inputs.view_generations:
+        path = lexical_directory_path(owner.receipt.path)
+        if _overlaps(path, repository):
+            raise ValueError(
+                f"strict context {view} generation overlaps the repository source"
+            )
+        try:
+            physical_path = path.resolve(strict=False)
+            physical_repository = repository.resolve(strict=False)
+        except (OSError, RuntimeError) as exc:
+            raise ValueError(
+                "strict context view location cannot be authenticated"
+            ) from exc
+        if _overlaps(physical_path, physical_repository):
+            raise ValueError(
+                f"strict context {view} generation overlaps the repository source"
+            )
+        if any(_overlaps(path, previous) for previous in sources) or any(
+            _overlaps(physical_path, previous) for previous in physical
+        ):
+            raise ValueError("strict context view generations overlap")
+        sources.append(path)
+        physical.append(physical_path)
+    return tuple(sources)
+
+
+def _require_destination_disjoint(
+    destination: Path,
+    inputs: _FrozenContextInputs,
+    source_paths: tuple[Path, ...],
+) -> Path:
+    candidate = lexical_directory_path(destination)
+    repository = lexical_directory_path(inputs.repository_source.root)
+    if _overlaps(candidate, repository) or any(
+        _overlaps(candidate, source) for source in source_paths
+    ):
+        raise ValueError("strict context destination overlaps an input authority")
+    try:
+        physical_candidate = candidate.resolve(strict=False)
+        forbidden = (repository.resolve(strict=False),) + tuple(
+            source.resolve(strict=False) for source in source_paths
+        )
+    except (OSError, RuntimeError) as exc:
+        raise ValueError("strict context destination cannot be authenticated") from exc
+    if any(_overlaps(physical_candidate, path) for path in forbidden):
+        raise ValueError("strict context destination overlaps an input authority")
+    return candidate
+
+
+def _require_missing_destination(destination: Path) -> None:
+    """Perform an early denial-only missing check before consuming sources.
+
+    The provider remains authoritative for the race-free missing expectation;
+    this check only prevents known-invalid requests from spending retained
+    receipt or provider authority.
+    """
+
+    try:
+        destination.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise ValueError(
+            "strict context destination cannot be inspected safely"
+        ) from exc
+    raise ValueError("strict context destination must be missing")
+
+
+def _validate_source_view(
+    *,
+    view: str,
+    owner: PublishedWorkspaceReceiptOwner,
+    expected_receipt: PublishedWorkspaceReceipt,
+    expected_ownership: object,
+    config: Mapping[str, Any],
+    inputs: _FrozenContextInputs,
+) -> None:
+    def validate(
+        receipt: PublishedWorkspaceReceipt,
+        publication: PublicationDirectoryReader,
+    ) -> None:
+        if (
+            receipt is not expected_receipt
+            or receipt.ownership != expected_ownership
+            or receipt.plan_digest != expected_receipt.plan_digest
+        ):
+            raise RuntimeError(f"strict context {view} receipt changed")
+        before = publication.capture_ownership()
+        if before != expected_ownership:
+            raise RuntimeError(f"strict context {view} generation changed")
+        validate_content_bound_portable_query_view_reader(
+            publication,
+            repository_source=inputs.repository_source,
+            view_type=view,
+            view_config=config,
+            forbidden_paths=(),
+            environ=inputs.environment,
+        )
+        if publication.capture_ownership() != before:
+            raise RuntimeError(f"strict context {view} generation changed")
+
+    owner.consume(validate)
+
+
+def _planned_view(
+    view: str,
+    owner: PublishedWorkspaceReceiptOwner,
+    *,
+    manifest: RepoManifest,
+    inputs: _FrozenContextInputs,
+) -> tuple[PlannedContextView, dict[str, Any]]:
+    receipt = owner.receipt
+    if not receipt.durable:
+        raise RuntimeError(f"strict context {view} generation is not durable")
+    ownership = receipt.ownership
+    inventory = tuple(directory_ownership_inventory(ownership))  # type: ignore[arg-type]
+    records = tuple(directory_ownership_file_records(ownership))  # type: ignore[arg-type]
+    if records != tuple(sorted(records, key=lambda item: item.path)):
+        raise RuntimeError(f"strict context {view} records are not canonical")
+    entry = manifest.indexes[view].to_dict()
+    config = entry.get("config")
+    if not isinstance(config, dict):
+        raise ValueError(f"strict context {view} config must be an object")
+    adjustments = _view_adjustments(view, records, config)
+    _merge_adjustments(entry, adjustments, view=view)
+    entry["path"] = f"views/{view}"
+    config = entry["config"]
+    _assert_authenticated_publishable_json_value(
+        entry,
+        forbidden_paths=(inputs.repository_source.root, receipt.path),
+        environ=inputs.environment,
+        label=f"strict context {view} manifest entry",
+    )
+    entry_payload = _canonical_json_bytes(
+        entry,
+        label=f"strict context {view} manifest entry",
+    )
+    config_payload = _canonical_json_bytes(
+        config,
+        label=f"strict context {view} config",
+    )
+    _validate_source_view(
+        view=view,
+        owner=owner,
+        expected_receipt=receipt,
+        expected_ownership=ownership,
+        config=config,
+        inputs=inputs,
+    )
+    prefix = PurePosixPath("views") / view
+    outputs = tuple(_prefixed_record(prefix, record) for record in records)
+    return (
+        PlannedContextView(
+            name=view,
+            source_plan_digest=receipt.plan_digest,
+            source_ownership=ownership,
+            source_digest=directory_ownership_digest(ownership),  # type: ignore[arg-type]
+            source_inventory=inventory,
+            source_records=records,
+            output_records=outputs,
+            config_payload=config_payload,
+            entry_digest=hashlib.sha256(entry_payload).hexdigest(),
+        ),
+        entry,
+    )
+
+
+def _workspace_directories(
+    view_plans: tuple[PlannedContextView, ...],
+) -> tuple[WorkspaceDirectory, ...]:
+    paths = {"views"}
+    for view in view_plans:
+        prefix = PurePosixPath("views") / view.name
+        paths.add(prefix.as_posix())
+        for relative, kind in view.source_inventory:
+            if kind == "directory":
+                paths.add((prefix / PurePosixPath(relative)).as_posix())
+    return tuple(WorkspaceDirectory(PurePosixPath(path)) for path in sorted(paths))
+
+
+def _workspace_subject(
+    *,
+    repository: str,
+    manifest: RepoManifest,
+    manifest_digest: str,
+    metadata_digest: str,
+    view_plans: tuple[PlannedContextView, ...],
+    output_records: tuple[TreeFileRecord, ...],
+) -> str:
+    identity = {
+        "domain": _STRICT_CONTEXT_PLAN_DOMAIN,
+        "schema": CONTEXT_ARTIFACT_SCHEMA,
+        "repository": repository,
+        "commit": manifest.commit,
+        "source_fingerprint": manifest.source_fingerprint,
+        "source_file_count": manifest.file_count,
+        "manifest_sha256": manifest_digest,
+        "metadata_sha256": metadata_digest,
+        "views": [
+            {
+                "name": view.name,
+                "source_plan_digest": view.source_plan_digest,
+                "source_tree_digest": view.source_digest,
+                "entry_digest": view.entry_digest,
+                "source_inventory": [list(item) for item in view.source_inventory],
+                "source_records": [
+                    _record_payload(record) for record in view.source_records
+                ],
+            }
+            for view in view_plans
+        ],
+        "output_records": [_record_payload(record) for record in output_records],
+    }
+    return hashlib.sha256(
+        _canonical_json_bytes(identity, label="strict context plan identity")
+    ).hexdigest()
+
+
+def _build_plan(inputs: _FrozenContextInputs) -> PlannedContextArtifact:
+    manifest = _validate_manifest_identity(inputs)
+    _require_disjoint_paths(inputs)
+    selected = tuple(name for name, _owner in inputs.view_generations)
+    planned_entries: list[tuple[PlannedContextView, dict[str, Any]]] = []
+    with inputs.repository_source.read_session():
+        for view, owner in inputs.view_generations:
+            planned_entries.append(
+                _planned_view(view, owner, manifest=manifest, inputs=inputs)
+            )
+    view_plans = tuple(item[0] for item in planned_entries)
+
+    portable = json.loads(
+        _canonical_json_bytes(
+            inputs.manifest,
+            label="strict context repository manifest snapshot",
+        )
+    )
+    portable["repo"]["path"] = "source"
+    portable["indexes"] = {
+        planned_view.name: entry for planned_view, entry in planned_entries
+    }
+    portable["capabilities"] = _portable_capabilities(
+        manifest.capabilities,
+        selected,
+    )
+    manifest_payload = _canonical_json_bytes(
+        portable,
+        label="strict context portable repository manifest",
+    )
+    manifest_record = _output_record(MANIFEST_FILENAME, manifest_payload)
+
+    inventoried_records = tuple(
+        sorted(
+            (manifest_record,)
+            + tuple(record for view in view_plans for record in view.output_records),
+            key=lambda item: item.path,
+        )
+    )
+    metadata = {
+        "schema": CONTEXT_ARTIFACT_SCHEMA,
+        "repository": {
+            "slug": inputs.repository,
+            "commit": manifest.commit,
+            "source_fingerprint": manifest.source_fingerprint,
+            "languages": list(manifest.languages),
+        },
+        "builder": {
+            "codenib_version": package_version(),
+            "manifest_version": manifest.version,
+            "compiled_at": manifest.compiled_at,
+        },
+        "manifest": {
+            "path": MANIFEST_FILENAME,
+            "repository_path": "source",
+            "paths": "artifact-relative-posix",
+        },
+        "source_locations": {
+            "path": "repository-relative-posix",
+            "line_base": 1,
+            "end_line": "inclusive",
+            "commit": manifest.commit,
+        },
+        "views": list(selected),
+        "capabilities": portable["capabilities"],
+        "files": [
+            {
+                "path": record.path,
+                "bytes": record.size,
+                "sha256": record.sha256,
+            }
+            for record in inventoried_records
+        ],
+    }
+    _assert_authenticated_publishable_json_value(
+        metadata,
+        forbidden_paths=(inputs.repository_source.root,),
+        environ=inputs.environment,
+        label="strict context metadata",
+    )
+    metadata_payload = _canonical_json_bytes(
+        metadata,
+        label="strict context metadata",
+    )
+    metadata_record = _output_record(CONTEXT_ARTIFACT_MANIFEST, metadata_payload)
+    output_records = tuple(
+        sorted((*inventoried_records, metadata_record), key=lambda item: item.path)
+    )
+    manifest_digest = manifest_record.sha256
+    subject_digest = _workspace_subject(
+        repository=inputs.repository,
+        manifest=manifest,
+        manifest_digest=manifest_digest,
+        metadata_digest=metadata_record.sha256,
+        view_plans=view_plans,
+        output_records=output_records,
+    )
+    workspace = WorkspacePlan(
+        subject_digest=subject_digest,
+        directories=_workspace_directories(view_plans),
+        files=tuple(
+            WorkspaceFile(
+                PurePosixPath(record.path),
+                mode=record.mode,
+                max_bytes=record.size,
+            )
+            for record in output_records
+        ),
+    )
+    streaming_json_paths = tuple(
+        sorted(
+            record.path
+            for record in output_records
+            if PurePosixPath(record.path).name.startswith("documents")
+            and PurePosixPath(record.path).suffix == ".json"
+        )
+    )
+    return PlannedContextArtifact(
+        plan=workspace,
+        manifest_digest=manifest_digest,
+        repository=inputs.repository,
+        commit=manifest.commit,
+        repository_fingerprint=manifest.source_fingerprint,
+        repository_file_count=manifest.file_count,
+        views=selected,
+        view_plans=view_plans,
+        output_records=output_records,
+        manifest_payload=manifest_payload,
+        metadata_payload=metadata_payload,
+        streaming_json_paths=streaming_json_paths,
+        file_count=len(inventoried_records),
+        byte_count=sum(record.size for record in inventoried_records),
+    )
+
+
+def plan_context_artifact_strict(
+    manifest: RepoManifest,
+    *,
+    repository: str,
+    repository_source: RepositorySourceBinding,
+    view_generations: Mapping[str, PublishedWorkspaceReceiptOwner],
+    environ: Mapping[str, str] | None = None,
+) -> PlannedContextArtifact:
+    """Plan one exact context generation from retained portable views."""
+
+    inputs = _freeze_inputs(
+        manifest,
+        repository=repository,
+        repository_source=repository_source,
+        view_generations=view_generations,
+        environ=environ,
+    )
+    return _build_plan(inputs)
+
+
+def _preflight_output_authority(
+    planned: PlannedContextArtifact,
+    *,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+) -> None:
+    if type(planned) is not PlannedContextArtifact:
+        raise TypeError("strict context execution requires a PlannedContextArtifact")
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("strict context repository source has an invalid type")
+    if type(output_receipt_owner) is not PublishedWorkspaceReceiptOwner:
+        raise TypeError("strict context output receipt owner has an invalid type")
+    if not repository_source.usable:
+        raise RuntimeError("strict context repository source is not usable")
+    if output_receipt_owner.state != "empty":
+        raise RuntimeError("strict context output receipt owner must be empty")
+    require_owned_workspace_publication_support()
+    for member in ("require_support", "run_workspace"):
+        try:
+            raw = inspect.getattr_static(workspace_provider, member)
+        except AttributeError as exc:
+            raise TypeError(
+                "strict workspace provider has an invalid contract"
+            ) from exc
+        if isinstance(raw, (classmethod, staticmethod)):
+            raw = raw.__func__
+        if not callable(raw):
+            raise TypeError("strict workspace provider has an invalid contract")
+
+
+def _require_expected_plan(
+    planned: PlannedContextArtifact,
+    inputs: _FrozenContextInputs,
+) -> None:
+    expected = _build_plan(inputs)
+    if planned != expected:
+        raise ValueError("strict context plan differs from its exact inputs")
+
+
+def _candidate_inventory(
+    planned: PlannedContextArtifact,
+) -> tuple[tuple[str, str], ...]:
+    directories = tuple(
+        (directory.path.as_posix(), "directory")
+        for directory in planned.plan.directories
+    )
+    files = tuple((record.path, "file") for record in planned.output_records)
+    return tuple(sorted((*directories, *files)))
+
+
+def _validate_candidate(
+    candidate: PublicationDirectoryReader,
+    *,
+    planned: PlannedContextArtifact,
+    inputs: _FrozenContextInputs,
+    forbidden_paths: tuple[Path, ...],
+) -> None:
+    before = candidate.capture_ownership()
+    records = tuple(directory_ownership_file_records(before))  # type: ignore[arg-type]
+    inventory = tuple(directory_ownership_inventory(before))  # type: ignore[arg-type]
+    if records != planned.output_records or inventory != _candidate_inventory(planned):
+        raise RuntimeError("strict context candidate differs from its exact plan")
+    assert_publishable_tree_reader(
+        candidate,
+        forbidden_paths=(inputs.repository_source.root, *forbidden_paths),
+        environ=inputs.environment,
+        label="strict context artifact",
+        streaming_json_paths=planned.streaming_json_paths,
+    )
+    verified = verify_context_artifact_reader(
+        candidate,
+        expected_repository=planned.repository,
+        expected_commit=planned.commit,
+    )
+    if (
+        verified.views != planned.views
+        or verified.source_fingerprint != planned.repository_fingerprint
+        or verified.file_count != planned.file_count
+        or verified.byte_count != planned.byte_count
+    ):
+        raise RuntimeError("strict context candidate identity differs from its plan")
+    after = candidate.capture_ownership()
+    if after != before:
+        raise RuntimeError("strict context candidate changed during validation")
+
+
+def _replay_view(
+    session: StrictWorkspaceSession,
+    *,
+    planned_view: PlannedContextView,
+    owner: PublishedWorkspaceReceiptOwner,
+) -> None:
+    def replay(
+        receipt: PublishedWorkspaceReceipt,
+        publication: PublicationDirectoryReader,
+    ) -> None:
+        if (
+            receipt.plan_digest != planned_view.source_plan_digest
+            or receipt.ownership != planned_view.source_ownership
+        ):
+            raise ValueError(
+                f"strict context {planned_view.name} source changed after planning"
+            )
+        before = publication.capture_ownership()
+        if before != planned_view.source_ownership:
+            raise RuntimeError(
+                f"strict context {planned_view.name} source changed during replay"
+            )
+        written: list[TreeFileRecord] = []
+        prefix = PurePosixPath("views") / planned_view.name
+        for source_record in planned_view.source_records:
+            with publication.open_authenticated_file(
+                source_record.path,
+                max_bytes=source_record.size,
+            ) as source:
+                written.append(
+                    session.write_file(
+                        prefix / PurePosixPath(source_record.path),
+                        source.iter_bytes(),
+                    )
+                )
+            if source.record != source_record:
+                raise RuntimeError(
+                    f"strict context {planned_view.name} source file changed"
+                )
+        if tuple(written) != planned_view.output_records:
+            raise RuntimeError(
+                f"strict context {planned_view.name} replay differs from its plan"
+            )
+        if publication.capture_ownership() != before:
+            raise RuntimeError(
+                f"strict context {planned_view.name} source changed during replay"
+            )
+
+    owner.consume(replay)
+
+
+def _publish_frozen(
+    destination: Path,
+    *,
+    planned: PlannedContextArtifact,
+    inputs: _FrozenContextInputs,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    require_expected_plan: bool,
+) -> ContextArtifactResult:
+    if any(owner is output_receipt_owner for _view, owner in inputs.view_generations):
+        raise ValueError("strict context input and output receipt owners must differ")
+    source_paths = _require_disjoint_paths(inputs)
+    lexical_destination = _require_destination_disjoint(
+        destination,
+        inputs,
+        source_paths,
+    )
+    _require_missing_destination(lexical_destination)
+    if require_expected_plan:
+        _require_expected_plan(planned, inputs)
+    request = StrictWorkspaceRequest(
+        purpose="portable-context-generation",
+        destination=lexical_destination,
+        plan=planned.plan,
+        destination_expectation="missing",
+    )
+
+    owners = dict(inputs.view_generations)
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        if session.request != request:
+            raise RuntimeError("strict context provider changed its request")
+        with inputs.repository_source.read_session():
+            written = [
+                session.write_file(MANIFEST_FILENAME, (planned.manifest_payload,)),
+                session.write_file(
+                    CONTEXT_ARTIFACT_MANIFEST,
+                    (planned.metadata_payload,),
+                ),
+            ]
+            for planned_view in planned.view_plans:
+                _replay_view(
+                    session,
+                    planned_view=planned_view,
+                    owner=owners[planned_view.name],
+                )
+            expected_static = {
+                MANIFEST_FILENAME,
+                CONTEXT_ARTIFACT_MANIFEST,
+            }
+            if (
+                any(
+                    record
+                    != next(
+                        item
+                        for item in planned.output_records
+                        if item.path == record.path
+                    )
+                    for record in written
+                )
+                or {record.path for record in written} != expected_static
+            ):
+                raise RuntimeError(
+                    "strict context metadata replay differs from its plan"
+                )
+
+        def validate(candidate: PublicationDirectoryReader) -> None:
+            # Each staged/published callback owns its source postcondition.
+            # In particular, the published-side check must finish inside the
+            # directory transaction's rollback window, not after commit.
+            with inputs.repository_source.read_session():
+                _validate_candidate(
+                    candidate,
+                    planned=planned,
+                    inputs=inputs,
+                    forbidden_paths=source_paths,
+                )
+
+        session.publish_validated(validate)
+
+    run_strict_workspace(
+        workspace_provider,
+        request,
+        receipt_owner=output_receipt_owner,
+        operation=operation,
+    )
+    if not output_receipt_owner.active:
+        raise RuntimeError("strict context publication returned without a receipt")
+    receipt = output_receipt_owner.receipt
+    if receipt.path != lexical_destination or receipt.plan != planned.plan:
+        raise RuntimeError("strict context receipt differs from its plan")
+    return ContextArtifactResult(
+        output_dir=lexical_destination,
+        metadata_path=lexical_destination / CONTEXT_ARTIFACT_MANIFEST,
+        manifest_path=lexical_destination / MANIFEST_FILENAME,
+        repository=planned.repository,
+        commit=planned.commit,
+        views=planned.views,
+        file_count=planned.file_count,
+        byte_count=planned.byte_count,
+    )
+
+
+def publish_planned_context_artifact_strict(
+    destination: Path,
+    *,
+    planned: PlannedContextArtifact,
+    manifest: RepoManifest,
+    repository: str,
+    repository_source: RepositorySourceBinding,
+    view_generations: Mapping[str, PublishedWorkspaceReceiptOwner],
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    environ: Mapping[str, str] | None = None,
+) -> ContextArtifactResult:
+    """Replay and durably publish one exact strict context plan."""
+
+    _preflight_output_authority(
+        planned,
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    inputs = _freeze_inputs(
+        manifest,
+        repository=repository,
+        repository_source=repository_source,
+        view_generations=view_generations,
+        environ=environ,
+    )
+    return _publish_frozen(
+        destination,
+        planned=planned,
+        inputs=inputs,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        require_expected_plan=True,
+    )
+
+
+def stage_context_artifact_strict(
+    destination: Path,
+    *,
+    manifest: RepoManifest,
+    repository: str,
+    repository_source: RepositorySourceBinding,
+    view_generations: Mapping[str, PublishedWorkspaceReceiptOwner],
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    environ: Mapping[str, str] | None = None,
+) -> ContextArtifactResult:
+    """Plan and publish one immutable context generation through strict authority."""
+
+    # Reject unusable output authority before consuming any source generation.
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("strict context repository source has an invalid type")
+    if type(output_receipt_owner) is not PublishedWorkspaceReceiptOwner:
+        raise TypeError("strict context output receipt owner has an invalid type")
+    if not repository_source.usable:
+        raise RuntimeError("strict context repository source is not usable")
+    if output_receipt_owner.state != "empty":
+        raise RuntimeError("strict context output receipt owner must be empty")
+    require_owned_workspace_publication_support()
+    for member in ("require_support", "run_workspace"):
+        try:
+            raw = inspect.getattr_static(workspace_provider, member)
+        except AttributeError as exc:
+            raise TypeError(
+                "strict workspace provider has an invalid contract"
+            ) from exc
+        if isinstance(raw, (classmethod, staticmethod)):
+            raw = raw.__func__
+        if not callable(raw):
+            raise TypeError("strict workspace provider has an invalid contract")
+    inputs = _freeze_inputs(
+        manifest,
+        repository=repository,
+        repository_source=repository_source,
+        view_generations=view_generations,
+        environ=environ,
+    )
+    if any(owner is output_receipt_owner for _view, owner in inputs.view_generations):
+        raise ValueError("strict context input and output receipt owners must differ")
+    # Destination authorization is independent of source semantics. Reject it
+    # before consuming any retained view or asking the provider to provision.
+    source_paths = _require_disjoint_paths(inputs)
+    lexical_destination = _require_destination_disjoint(
+        destination,
+        inputs,
+        source_paths,
+    )
+    _require_missing_destination(lexical_destination)
+    planned = _build_plan(inputs)
+    return _publish_frozen(
+        destination,
+        planned=planned,
+        inputs=inputs,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        require_expected_plan=False,
+    )
+
+
+__all__ = [
+    "PlannedContextArtifact",
+    "PlannedContextView",
+    "plan_context_artifact_strict",
+    "publish_planned_context_artifact_strict",
+    "stage_context_artifact_strict",
+]

--- a/codenib/index/embedding/model_policy.py
+++ b/codenib/index/embedding/model_policy.py
@@ -17,6 +17,7 @@ DEFAULT_EMBEDDING_DIMENSION = 768
 DEFAULT_EMBEDDING_REVISION = "3c4b60807d71f79b43f3c4363786d9493691f8b1"
 
 _IMMUTABLE_REVISION_RE = re.compile(r"[0-9a-f]{40}\Z")
+_WINDOWS_DRIVE_RE = re.compile(r"[A-Za-z]:")
 _UNSET = object()
 
 
@@ -28,26 +29,23 @@ class EmbeddingLoadPolicy:
     trust_remote_code: bool
 
 
-def resolve_embedding_load_policy(
-    model: str,
-    *,
-    revision: Optional[str] = None,
-    trust_remote_code: Optional[bool] = None,
-) -> EmbeddingLoadPolicy:
-    """Resolve a deterministic, least-privilege model-loading policy.
-
-    CodeNib's bundled embedding model requires Hugging Face remote code. The
-    default path trusts only the immutable revision audited with this release.
-    Other models and caller-supplied revisions remain untrusted unless the
-    caller explicitly opts in.
-    """
-
+def _validate_load_policy_options(
+    revision: Optional[str],
+    trust_remote_code: Optional[bool],
+) -> None:
     if revision is not None and not isinstance(revision, str):
         raise TypeError("embedding revision must be a string or None")
     if trust_remote_code is not None and not isinstance(trust_remote_code, bool):
         raise TypeError("trust_remote_code must be a bool or None")
 
-    is_local_model = Path(model).expanduser().is_dir()
+
+def _resolved_embedding_load_policy(
+    model: str,
+    *,
+    revision: Optional[str],
+    trust_remote_code: Optional[bool],
+    is_local_model: bool,
+) -> EmbeddingLoadPolicy:
     is_bundled_remote_model = model == DEFAULT_EMBEDDING_MODEL and not is_local_model
     bundled_revision = DEFAULT_EMBEDDING_REVISION if is_bundled_remote_model else None
     resolved_revision = revision if revision is not None else bundled_revision
@@ -74,12 +72,85 @@ def resolve_embedding_load_policy(
     )
 
 
-def resolve_embedding_load_policy_from_options(
-    model: str,
-    options: Mapping[str, Any] | None,
-) -> EmbeddingLoadPolicy:
-    """Resolve identity controls accepted at either wrapper option level."""
+def _filesystem_shaped_artifact_model(model: str) -> bool:
+    """Classify local-path spellings without consulting process state.
 
+    URI schemes are case-insensitive, so every capitalization of ``file:`` is
+    local-shaped and rejected.
+    """
+
+    lower = model.casefold()
+    if (
+        not model
+        or model != model.strip()
+        or any(
+            character.isspace() or ord(character) < 32 or ord(character) == 127
+            for character in model
+        )
+        or model.startswith(("/", "~"))
+        or lower.startswith("file:")
+        or "\\" in model
+        or _WINDOWS_DRIVE_RE.match(model)
+    ):
+        return True
+    return any(part in {"", ".", "..", "~"} for part in model.split("/"))
+
+
+def resolve_embedding_load_policy(
+    model: str,
+    *,
+    revision: Optional[str] = None,
+    trust_remote_code: Optional[bool] = None,
+) -> EmbeddingLoadPolicy:
+    """Resolve a deterministic, least-privilege model-loading policy.
+
+    CodeNib's bundled embedding model requires Hugging Face remote code. The
+    default path trusts only the immutable revision audited with this release.
+    Other models and caller-supplied revisions remain untrusted unless the
+    caller explicitly opts in.
+    """
+
+    _validate_load_policy_options(revision, trust_remote_code)
+
+    is_local_model = Path(model).expanduser().is_dir()
+    return _resolved_embedding_load_policy(
+        model,
+        revision=revision,
+        trust_remote_code=trust_remote_code,
+        is_local_model=is_local_model,
+    )
+
+
+def resolve_embedding_artifact_load_policy(
+    model: str,
+    *,
+    revision: Optional[str] = None,
+    trust_remote_code: Optional[bool] = None,
+) -> EmbeddingLoadPolicy:
+    """Resolve an artifact model identity without filesystem discovery.
+
+    Published artifacts may name only deterministic remote model identities.
+    Filesystem-shaped values are rejected lexically, before a caller opens or
+    stats any publication or source path.
+    """
+
+    _validate_load_policy_options(revision, trust_remote_code)
+    if not isinstance(model, str):
+        raise TypeError("artifact embedding model must be a string")
+    if _filesystem_shaped_artifact_model(model):
+        raise ValueError(
+            "artifact embedding model must be a remote model identifier, not a "
+            "filesystem-shaped path"
+        )
+    return _resolved_embedding_load_policy(
+        model,
+        revision=revision,
+        trust_remote_code=trust_remote_code,
+        is_local_model=False,
+    )
+
+
+def _load_policy_options(options: Mapping[str, Any] | None) -> tuple[Any, Any]:
     values = dict(options or {})
     nested = values.get("model_kwargs") or {}
     if not isinstance(nested, Mapping):
@@ -100,10 +171,35 @@ def resolve_embedding_load_policy_from_options(
             return nested_value
         return None
 
+    return select("revision"), select("trust_remote_code")
+
+
+def resolve_embedding_load_policy_from_options(
+    model: str,
+    options: Mapping[str, Any] | None,
+) -> EmbeddingLoadPolicy:
+    """Resolve identity controls accepted at either wrapper option level."""
+
+    revision, trust_remote_code = _load_policy_options(options)
+
     return resolve_embedding_load_policy(
         model,
-        revision=select("revision"),
-        trust_remote_code=select("trust_remote_code"),
+        revision=revision,
+        trust_remote_code=trust_remote_code,
+    )
+
+
+def resolve_embedding_artifact_load_policy_from_options(
+    model: str,
+    options: Mapping[str, Any] | None,
+) -> EmbeddingLoadPolicy:
+    """Resolve artifact identity controls without filesystem discovery."""
+
+    revision, trust_remote_code = _load_policy_options(options)
+    return resolve_embedding_artifact_load_policy(
+        model,
+        revision=revision,
+        trust_remote_code=trust_remote_code,
     )
 
 
@@ -112,6 +208,8 @@ __all__ = [
     "DEFAULT_EMBEDDING_MODEL",
     "DEFAULT_EMBEDDING_REVISION",
     "EmbeddingLoadPolicy",
+    "resolve_embedding_artifact_load_policy",
+    "resolve_embedding_artifact_load_policy_from_options",
     "resolve_embedding_load_policy",
     "resolve_embedding_load_policy_from_options",
 ]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -343,6 +343,21 @@ profile or durable job payload. No production provider, compiler integration,
 or whole-context producer is wired to the strict contract yet, so M1 remains in
 progress and the M2 BM25 profile adapter is still outstanding.
 
+Strict whole-context publication can now aggregate already-normalized BM25 and
+vector generations retained by active workspace receipt owners. The plan binds
+the portable `RepoManifest` projection, repository source-fingerprint-v2
+authority, every input generation plan and exact file record, and the complete
+context output inventory. Replay copies authenticated source bytes into one
+missing-only workspace generation; staged and published callbacks repeat the
+content-bound portable-view, credential/path, context-manifest, and exact-tree
+checks before the caller receives a durable output receipt. Large canonical
+documents remain element-streamed, and vector indexes stay authenticated but
+native-inert throughout context assembly. This slice does not normalize native
+vector state, provision a production workspace provider, route compiler output,
+import legacy manifests into the catalog, or publish the resulting receipt as
+an M2 generation. Those adapters remain outstanding, so M1 and M2 remain in
+progress.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -345,15 +345,17 @@ progress and the M2 BM25 profile adapter is still outstanding.
 
 Strict whole-context publication can now aggregate already-normalized BM25 and
 vector generations retained by active workspace receipt owners. The plan binds
-the portable `RepoManifest` projection, repository source-fingerprint-v2
-authority, every input generation plan and exact file record, and the complete
-context output inventory. Replay copies authenticated source bytes into one
-missing-only workspace generation; staged and published callbacks repeat the
-content-bound portable-view, credential/path, context-manifest, and exact-tree
-checks before the caller receives a durable output receipt. Large canonical
-documents remain element-streamed, and vector indexes stay authenticated but
-native-inert throughout context assembly. This slice does not normalize native
-vector state, provision a production workspace provider, route compiler output,
+the portable `RepoManifest` projection, one detached authenticated
+source-fingerprint-v2 identity, every input generation plan and exact file
+record, and the complete context output inventory. Replay copies authenticated
+source bytes into one missing-only workspace generation; staged and published
+callbacks repeat the content-bound portable-view, credential/path,
+context-manifest, and exact-tree checks before the caller receives a durable
+output receipt. Large canonical documents remain element-streamed, and vector
+indexes stay authenticated but native-inert throughout context assembly.
+Planning and publication never consult mutable public source projections after
+that identity is captured. This slice does not normalize native vector state,
+provision a production workspace provider, route compiler output,
 import legacy manifests into the catalog, or publish the resulting receipt as
 an M2 generation. Those adapters remain outstanding, so M1 and M2 remain in
 progress.

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import json
 import os
 import pickle
@@ -15,6 +16,12 @@ from types import SimpleNamespace
 
 import pytest
 
+import codenib.artifacts.portable_views as portable_views_module
+from codenib._atomic_directory import (
+    PublicationDirectoryReader,
+    capture_directory_ownership,
+    reopen_authenticated_directory,
+)
 from codenib.artifacts import normalize_owned_query_view, validate_portable_query_view
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.index.embedding.artifact_integrity import (
@@ -25,6 +32,11 @@ from codenib.index.embedding.artifact_integrity import (
 )
 from codenib.native_index_authorization import _mint_trusted_local_admin_authorization
 from codenib.provider_routes import resolve_inference_route
+from codenib.source_fingerprint import (
+    RepositoryChangedError,
+    RepositorySourceBinding,
+    capture_repository_source,
+)
 
 _VECTOR_CONFIG = {
     "builder_schema": 2,
@@ -2611,3 +2623,490 @@ def test_normalize_owned_view_rejects_repository_overlap(tmp_path: Path) -> None
             view_type="bm25",
             view_config={},
         )
+
+
+def _validate_content_bound_view(
+    view: Path,
+    *,
+    repository_source: RepositorySourceBinding,
+    view_type: str,
+    view_config: dict[str, object],
+) -> None:
+    ownership = capture_directory_ownership(view)
+
+    def validate(publication: PublicationDirectoryReader) -> None:
+        portable_views_module.validate_content_bound_portable_query_view_reader(
+            publication,
+            repository_source=repository_source,
+            view_type=view_type,
+            view_config=view_config,
+            environ={},
+        )
+
+    reopen_authenticated_directory(view, ownership, validate)
+
+
+def test_content_bound_portable_reader_has_stable_public_signature() -> None:
+    validator = portable_views_module.validate_content_bound_portable_query_view_reader
+    signature = inspect.signature(validator)
+
+    assert list(signature.parameters) == [
+        "publication",
+        "repository_source",
+        "view_type",
+        "view_config",
+        "forbidden_paths",
+        "environ",
+    ]
+    assert (
+        signature.parameters["publication"].kind
+        is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    )
+    for name in (
+        "repository_source",
+        "view_type",
+        "view_config",
+        "forbidden_paths",
+        "environ",
+    ):
+        assert signature.parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+    assert signature.parameters["view_config"].default is None
+    assert signature.parameters["forbidden_paths"].default == ()
+    assert signature.parameters["environ"].default is None
+    assert validator.__name__ in portable_views_module.__all__
+
+    assert list(inspect.signature(normalize_owned_query_view).parameters) == [
+        "root",
+        "repo_path",
+        "view_type",
+        "view_config",
+        "source_trust",
+        "native_index_authorization",
+    ]
+    assert list(inspect.signature(validate_portable_query_view).parameters) == [
+        "root",
+        "repo_path",
+        "view_type",
+        "view_config",
+        "forbidden_paths",
+        "environ",
+    ]
+
+
+def test_content_bound_portable_reader_validates_bm25_without_documents_dom(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "sample.py"},
+            }
+        ],
+    )
+    view_config = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    real_load_json = portable_views_module._load_json
+
+    def reject_documents_dom(path: Path, *args: object, **kwargs: object) -> object:
+        if path.name == "documents.json":
+            pytest.fail("content-bound BM25 documents used a whole-file DOM")
+        return real_load_json(path, *args, **kwargs)
+
+    real_read_bytes = portable_views_module._PublicationViewReader.read_bytes
+
+    def reject_documents_read_bytes(
+        reader: object,
+        path: Path,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        if path.name == "documents.json":
+            pytest.fail("content-bound BM25 documents used a whole-file byte read")
+        return real_read_bytes(reader, path, max_bytes=max_bytes)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(portable_views_module, "_load_json", reject_documents_dom)
+    monkeypatch.setattr(
+        portable_views_module._PublicationViewReader,
+        "read_bytes",
+        reject_documents_read_bytes,
+    )
+
+    with capture_repository_source(repo) as repository_source:
+        _validate_content_bound_view(
+            bm25,
+            repository_source=repository_source,
+            view_type="bm25",
+            view_config=view_config,
+        )
+
+
+def test_content_bound_portable_reader_validates_vector_without_native_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, vector, original_config = _production_vector_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=original_config,
+    )
+    view_config = {**original_config, **adjustments}
+
+    def forbidden_native(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("content-bound vector validation invoked native parsing")
+
+    real_load_json = portable_views_module._load_json
+
+    def reject_documents_dom(path: Path, *args: object, **kwargs: object) -> object:
+        if path.name.startswith("documents_"):
+            pytest.fail("content-bound vector documents used a whole-file DOM")
+        return real_load_json(path, *args, **kwargs)
+
+    real_read_bytes = portable_views_module._PublicationViewReader.read_bytes
+
+    def reject_documents_read_bytes(
+        reader: object,
+        path: Path,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        if path.name.startswith("documents_"):
+            pytest.fail("content-bound vector documents used a whole-file byte read")
+        return real_read_bytes(reader, path, max_bytes=max_bytes)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(portable_views_module, "_faiss_contract", forbidden_native)
+    monkeypatch.setattr(portable_views_module.compat_pickle, "load", forbidden_native)
+    monkeypatch.setattr(portable_views_module, "_load_json", reject_documents_dom)
+    monkeypatch.setattr(
+        portable_views_module._PublicationViewReader,
+        "read_bytes",
+        reject_documents_read_bytes,
+    )
+
+    with capture_repository_source(repo) as repository_source:
+        _validate_content_bound_view(
+            vector,
+            repository_source=repository_source,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+def test_content_bound_vector_does_not_probe_model_or_source_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, vector, original_config = _production_vector_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=original_config,
+    )
+    view_config = {**original_config, **adjustments}
+    (tmp_path / "test" / "model").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    def fail_ambient_probe(
+        _path: Path,
+        *_args: object,
+        **_kwargs: object,
+    ) -> Path | bool:
+        pytest.fail("content-bound validation probed an ambient filesystem path")
+
+    with capture_repository_source(repo) as repository_source:
+        ownership = capture_directory_ownership(vector)
+
+        def validate(publication: PublicationDirectoryReader) -> None:
+            with monkeypatch.context() as probes:
+                probes.setattr(Path, "is_dir", fail_ambient_probe)
+                probes.setattr(Path, "expanduser", fail_ambient_probe)
+                portable_views_module.validate_content_bound_portable_query_view_reader(
+                    publication,
+                    repository_source=repository_source,
+                    view_type="vector",
+                    view_config=view_config,
+                    environ={},
+                )
+
+        reopen_authenticated_directory(vector, ownership, validate)
+
+
+def test_content_bound_vector_rejects_absolute_local_model_before_fs_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, vector, original_config = _production_vector_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=original_config,
+    )
+    model = str(tmp_path / "local-model")
+    options = {"revision": _REVISION, "trust_remote_code": False}
+    route = resolve_inference_route(
+        operation="embeddings",
+        provider="huggingface",
+        model=model,
+        dimension=4,
+        compatibility_options=options,
+        environ={},
+    )
+    view_config = {
+        **original_config,
+        **adjustments,
+        "embedding_model": model,
+        "embedding_route": route.public_identity(),
+        "embedding_fingerprint": route.compatibility_fingerprint,
+    }
+
+    with capture_repository_source(repo) as repository_source:
+        ownership = capture_directory_ownership(vector)
+
+        def validate(publication: PublicationDirectoryReader) -> None:
+            def fail_ambient_probe(
+                _path: Path,
+                *_args: object,
+                **_kwargs: object,
+            ) -> object:
+                pytest.fail("local artifact model reached a filesystem probe")
+
+            with monkeypatch.context() as probes:
+                probes.setattr(Path, "is_dir", fail_ambient_probe)
+                probes.setattr(Path, "stat", fail_ambient_probe)
+                with pytest.raises(ValueError, match="filesystem-shaped path"):
+                    portable_views_module.validate_content_bound_portable_query_view_reader(
+                        publication,
+                        repository_source=repository_source,
+                        view_type="vector",
+                        view_config=view_config,
+                        environ={},
+                    )
+
+        reopen_authenticated_directory(vector, ownership, validate)
+
+
+@pytest.mark.parametrize(
+    "source_path",
+    [
+        "~other/sample.py",
+        "/outside/sample.py",
+        "C:/repo/sample.py",
+        "C:\\repo\\sample.py",
+        "//server/share/sample.py",
+        "\\\\server\\share\\sample.py",
+        "./sample.py",
+        "../sample.py",
+    ],
+)
+def test_content_bound_bm25_rejects_filesystem_shaped_sources_without_expansion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_path: str,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    (bm25 / "documents.json").write_bytes(
+        _canonical_json_bytes(
+            [
+                {
+                    "page_content": "VALUE = 1",
+                    "metadata": {"file": source_path},
+                }
+            ]
+        )
+    )
+    view_config = {"artifact_file_fingerprints": bm25_artifact_file_fingerprints(bm25)}
+
+    with capture_repository_source(repo) as repository_source:
+        ownership = capture_directory_ownership(bm25)
+
+        def validate(publication: PublicationDirectoryReader) -> None:
+            with monkeypatch.context() as probes:
+                probes.setattr(
+                    Path,
+                    "expanduser",
+                    lambda _path: pytest.fail(
+                        "content-bound source validation expanded an ambient path"
+                    ),
+                )
+                portable_views_module.validate_content_bound_portable_query_view_reader(
+                    publication,
+                    repository_source=repository_source,
+                    view_type="bm25",
+                    view_config=view_config,
+                    environ={},
+                )
+
+        with pytest.raises(ValueError, match="portable repository-relative path"):
+            reopen_authenticated_directory(bm25, ownership, validate)
+
+
+def test_content_bound_portable_reader_rejects_source_outside_frozen_records(
+    tmp_path: Path,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "LATE = 1",
+                "metadata": {"file": "late.py"},
+            }
+        ],
+    )
+    late_source = repo / "late.py"
+    late_source.write_text("LATE = 1\n", encoding="utf-8")
+    view_config = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    late_source.unlink()
+
+    with capture_repository_source(repo) as repository_source:
+        with pytest.raises(ValueError, match="authenticated repository source"):
+            _validate_content_bound_view(
+                bm25,
+                repository_source=repository_source,
+                view_type="bm25",
+                view_config=view_config,
+            )
+
+
+def test_content_bound_portable_reader_rejects_source_drift(
+    tmp_path: Path,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    view_config = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+
+    with capture_repository_source(repo) as repository_source:
+        (repo / "sample.py").write_text("VALUE = 2\n", encoding="utf-8")
+        with pytest.raises(RepositoryChangedError):
+            _validate_content_bound_view(
+                bm25,
+                repository_source=repository_source,
+                view_type="bm25",
+                view_config=view_config,
+            )
+
+
+def test_content_bound_vector_rejects_extra_document_store(tmp_path: Path) -> None:
+    repo, vector, original_config = _production_vector_view(tmp_path)
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=original_config,
+    )
+    view_config = {**original_config, **adjustments}
+    extra = vector / "l2" / "documents_uncommitted.json"
+    extra.write_text("[]\n", encoding="utf-8")
+
+    with capture_repository_source(repo) as repository_source:
+        with pytest.raises(ValueError, match="unexpected|other-model"):
+            _validate_content_bound_view(
+                vector,
+                repository_source=repository_source,
+                view_type="vector",
+                view_config=view_config,
+            )
+
+
+def test_content_bound_reader_keeps_semantic_primary_through_all_final_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    view_config = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    ownership = capture_directory_ownership(bm25)
+    primary = ValueError("semantic primary")
+    cleanup_failure = RuntimeError("reader cleanup secondary")
+    final_calls: list[str] = []
+    real_verify = portable_views_module._PublicationViewReader.verify_root
+
+    def fail_semantics(*_args: object, **_kwargs: object) -> None:
+        (repo / "sample.py").write_text("VALUE = 2\n", encoding="utf-8")
+        (bm25 / "documents.json").write_text("[ ]\n", encoding="utf-8")
+        raise primary
+
+    def verify_reader(reader: object) -> None:
+        final_calls.append("reader")
+        real_verify(reader)  # type: ignore[arg-type]
+
+    def fail_close(_reader: object) -> None:
+        final_calls.append("close")
+        raise cleanup_failure
+
+    monkeypatch.setattr(
+        portable_views_module,
+        "_validate_portable_bm25_view",
+        fail_semantics,
+    )
+    monkeypatch.setattr(
+        portable_views_module._PublicationViewReader,
+        "verify_root",
+        verify_reader,
+    )
+    monkeypatch.setattr(
+        portable_views_module._PublicationViewReader,
+        "close",
+        fail_close,
+    )
+
+    def validate(publication: PublicationDirectoryReader) -> None:
+        portable_views_module.validate_content_bound_portable_query_view_reader(
+            publication,
+            repository_source=repository_source,
+            view_type="bm25",
+            view_config=view_config,
+            environ={},
+        )
+
+    repository_source = capture_repository_source(repo)
+    try:
+        with pytest.raises(ValueError, match="semantic primary") as exc:
+            reopen_authenticated_directory(
+                bm25,
+                ownership,
+                validate,
+            )
+    finally:
+        repository_source.close()
+
+    assert exc.value is primary
+    assert final_calls == ["reader", "close"]
+    assert repository_source.failure_reason is not None
+    notes = "\n".join(
+        (
+            *getattr(primary, "__notes__", ()),
+            *getattr(primary, "_codenib_cleanup_notes", ()),
+        )
+    )
+    assert "final ownership validation" in notes
+    assert "reader cleanup" in notes
+    assert "reader cleanup secondary" in notes

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -35,6 +35,7 @@ from codenib.provider_routes import resolve_inference_route
 from codenib.source_fingerprint import (
     RepositoryChangedError,
     RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
     capture_repository_source,
 )
 
@@ -2691,6 +2692,72 @@ def test_content_bound_portable_reader_has_stable_public_signature() -> None:
         "forbidden_paths",
         "environ",
     ]
+
+
+def test_content_bound_reader_uses_one_detached_source_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, bm25 = _bm25_view(tmp_path)
+    view_config = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+    binding = capture_repository_source(repo)
+    original_root = binding.root
+    original_fingerprint = binding.fingerprint
+    original_file_count = binding.file_count
+    original_file_records = binding.file_records
+    forged_root = tmp_path / "forged-public-root"
+    snapshot_calls = 0
+    observed_roots: list[Path] = []
+    real_snapshot = RepositorySourceBinding.authenticated_identity_snapshot
+    real_validate = portable_views_module._validate_portable_bm25_view
+
+    def counted_snapshot(self):
+        nonlocal snapshot_calls
+        snapshot_calls += 1
+        identity = real_snapshot(self)
+        assert type(identity) is RepositorySourceIdentitySnapshot
+        return identity
+
+    def mutate_public_projection(root, repository, *args, **kwargs):
+        observed_roots.append(repository)
+        binding.root = forged_root
+        binding.fingerprint = f"sha256-v2:{'0' * 64}"
+        binding.file_count = 0
+        binding.file_records = ()
+        try:
+            return real_validate(root, repository, *args, **kwargs)
+        finally:
+            binding.root = original_root
+            binding.fingerprint = original_fingerprint
+            binding.file_count = original_file_count
+            binding.file_records = original_file_records
+
+    monkeypatch.setattr(
+        RepositorySourceBinding,
+        "authenticated_identity_snapshot",
+        counted_snapshot,
+    )
+    monkeypatch.setattr(
+        portable_views_module,
+        "_validate_portable_bm25_view",
+        mutate_public_projection,
+    )
+    try:
+        _validate_content_bound_view(
+            bm25,
+            repository_source=binding,
+            view_type="bm25",
+            view_config=view_config,
+        )
+        assert snapshot_calls == 1
+        assert observed_roots == [original_root]
+    finally:
+        binding.close()
 
 
 def test_content_bound_portable_reader_validates_bm25_without_documents_dom(

--- a/test/artifacts/test_publish.py
+++ b/test/artifacts/test_publish.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import subprocess
 from pathlib import Path
@@ -608,3 +609,141 @@ def test_publishability_reader_preserves_decoded_secret_rejection(
             root,
             environ={"CUSTOM_TOKEN": "runtime-secret-value"},
         )
+
+
+def test_publishability_reader_streams_exact_caller_validated_json(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    (root / "documents.json").write_text(
+        json.dumps([{"page_content": "safe", "metadata": {}}]),
+        encoding="utf-8",
+    )
+    ownership = capture_directory_ownership(root)
+
+    def validate(reader: PublicationDirectoryReader) -> None:
+        assert_publishable_tree_reader(
+            reader,
+            forbidden_paths=(),
+            environ={},
+            label="streamed tree",
+            max_json_bytes=8,
+            streaming_json_paths=("documents.json",),
+        )
+
+    reopen_authenticated_directory(root, ownership, validate)
+
+
+def test_publishability_reader_streaming_paths_is_explicit_keyword_api() -> None:
+    signature = inspect.signature(assert_publishable_tree_reader)
+
+    assert list(signature.parameters) == [
+        "reader",
+        "forbidden_paths",
+        "environ",
+        "label",
+        "max_json_bytes",
+        "streaming_json_paths",
+    ]
+    assert signature.parameters["streaming_json_paths"].kind is (
+        inspect.Parameter.KEYWORD_ONLY
+    )
+    assert signature.parameters["streaming_json_paths"].default == ()
+
+
+def test_publishability_reader_streamed_json_still_has_lexical_validation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    # The security layer rechecks bounded lexical framing; the caller-owned
+    # semantic validator is authoritative for exact JSON grammar/canonicality.
+    (root / "documents.json").write_bytes(b'{"truncated": [1, 2')
+    ownership = capture_directory_ownership(root)
+
+    def validate(reader: PublicationDirectoryReader) -> None:
+        assert_publishable_tree_reader(
+            reader,
+            forbidden_paths=(),
+            environ={},
+            label="streamed tree",
+            max_json_bytes=8,
+            streaming_json_paths=("documents.json",),
+        )
+
+    with pytest.raises(ValueError, match="invalid JSON|truncated JSON"):
+        reopen_authenticated_directory(root, ownership, validate)
+
+
+def test_publishability_reader_streamed_json_still_has_full_secret_scan(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    secret = "configured-secret-value"
+    (root / "documents.json").write_text(
+        json.dumps([{"page_content": secret, "metadata": {}}]),
+        encoding="utf-8",
+    )
+    ownership = capture_directory_ownership(root)
+
+    def validate(reader: PublicationDirectoryReader) -> None:
+        assert_publishable_tree_reader(
+            reader,
+            forbidden_paths=(),
+            environ={"CODENIB_DEMO_API_KEY": secret},
+            label="streamed tree",
+            max_json_bytes=8,
+            streaming_json_paths=("documents.json",),
+        )
+
+    with pytest.raises(ValueError, match="configured credential"):
+        reopen_authenticated_directory(root, ownership, validate)
+
+
+def test_publishability_reader_does_not_whitelist_json_by_basename(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "publication"
+    (root / "nested").mkdir(parents=True)
+    (root / "documents.json").write_text("[]\n", encoding="utf-8")
+    (root / "nested" / "documents.json").write_text(
+        json.dumps([{"unexpected": "large-enough"}]),
+        encoding="utf-8",
+    )
+    ownership = capture_directory_ownership(root)
+
+    def validate(reader: PublicationDirectoryReader) -> None:
+        assert_publishable_tree_reader(
+            reader,
+            forbidden_paths=(),
+            environ={},
+            label="streamed tree",
+            max_json_bytes=8,
+            streaming_json_paths=("documents.json",),
+        )
+
+    with pytest.raises(ValueError, match="nested/documents.json"):
+        reopen_authenticated_directory(root, ownership, validate)
+
+
+def test_publishability_reader_requires_every_streaming_json_path(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    (root / "config.json").write_text("{}\n", encoding="utf-8")
+    ownership = capture_directory_ownership(root)
+
+    def validate(reader: PublicationDirectoryReader) -> None:
+        assert_publishable_tree_reader(
+            reader,
+            forbidden_paths=(),
+            environ={},
+            label="streamed tree",
+            streaming_json_paths=("documents.json",),
+        )
+
+    with pytest.raises(ValueError, match="path is absent: documents.json"):
+        reopen_authenticated_directory(root, ownership, validate)

--- a/test/artifacts/test_strict_context_publication.py
+++ b/test/artifacts/test_strict_context_publication.py
@@ -40,7 +40,11 @@ from codenib.artifacts import (
 )
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.artifact_integrity import VECTOR_PERSISTENCE_SCHEMA
-from codenib.source_fingerprint import capture_repository_source
+from codenib.source_fingerprint import (
+    RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
+    capture_repository_source,
+)
 
 _Result = TypeVar("_Result")
 _COMMIT = "a" * 40
@@ -472,6 +476,80 @@ def test_strict_context_freezes_inputs_before_single_provider_support_call(
             (destination / "repo_manifest.json").read_text(encoding="utf-8")
         )
         assert published["indexes"]["bm25"]["config"]["tokenizer"] == "frozen"
+        assert output_owner.active
+    finally:
+        output_owner.close()
+        fixture.close()
+
+
+def test_strict_context_uses_one_detached_source_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _fixture(tmp_path, ("bm25",))
+    binding = fixture.repository_source
+    original_root = binding.root
+    original_fingerprint = binding.fingerprint
+    original_file_count = binding.file_count
+    original_file_records = binding.file_records
+    forged_root = tmp_path / "forged-public-root"
+    snapshot_calls = 0
+    observed_identities: list[RepositorySourceIdentitySnapshot] = []
+    real_snapshot = RepositorySourceBinding.authenticated_identity_snapshot
+    real_planned_view = strict_context_module._planned_view
+
+    def counted_snapshot(self):
+        nonlocal snapshot_calls
+        snapshot_calls += 1
+        return real_snapshot(self)
+
+    def mutate_public_projection(view, owner, *, manifest, inputs):
+        assert type(inputs.repository_identity) is RepositorySourceIdentitySnapshot
+        observed_identities.append(inputs.repository_identity)
+        binding.root = forged_root
+        binding.fingerprint = f"sha256-v2:{'0' * 64}"
+        binding.file_count = 0
+        binding.file_records = ()
+        try:
+            return real_planned_view(
+                view,
+                owner,
+                manifest=manifest,
+                inputs=inputs,
+            )
+        finally:
+            binding.root = original_root
+            binding.fingerprint = original_fingerprint
+            binding.file_count = original_file_count
+            binding.file_records = original_file_records
+
+    monkeypatch.setattr(
+        RepositorySourceBinding,
+        "authenticated_identity_snapshot",
+        counted_snapshot,
+    )
+    monkeypatch.setattr(
+        strict_context_module,
+        "_planned_view",
+        mutate_public_projection,
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    destination = tmp_path / "published" / "context"
+    try:
+        stage_context_artifact_strict(
+            destination,
+            manifest=fixture.manifest,
+            repository="owner/repo",
+            repository_source=binding,
+            view_generations=fixture.owners,
+            workspace_provider=_TestWorkspaceProvider(),
+            output_receipt_owner=output_owner,
+            environ={},
+        )
+        assert snapshot_calls == 1
+        assert len(observed_identities) == 1
+        assert observed_identities[0].root == original_root
+        assert observed_identities[0].fingerprint == original_fingerprint
         assert output_owner.active
     finally:
         output_owner.close()

--- a/test/artifacts/test_strict_context_publication.py
+++ b/test/artifacts/test_strict_context_publication.py
@@ -1,0 +1,837 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path, PurePosixPath
+from typing import Any, TypeVar
+
+import pytest
+
+import codenib.artifacts as artifacts_module
+import codenib.artifacts.portable_views as portable_views_module
+import codenib.artifacts.strict_context as strict_context_module
+from codenib._captured_directory import (
+    OwnedWorkspaceAuthority,
+    PublishedWorkspaceReceiptOwner,
+    WorkspaceDirectory,
+    WorkspaceFile,
+    WorkspacePlan,
+)
+from codenib._workspace_provider import (
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_adopted_workspace_operation,
+    run_strict_workspace,
+)
+from codenib.artifacts import (
+    PlannedContextArtifact,
+    plan_context_artifact_strict,
+    publish_planned_context_artifact_strict,
+    stage_context_artifact_strict,
+    verify_context_artifact,
+)
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import VECTOR_PERSISTENCE_SCHEMA
+from codenib.source_fingerprint import capture_repository_source
+
+_Result = TypeVar("_Result")
+_COMMIT = "a" * 40
+_VECTOR_CONFIG = {
+    "builder_schema": 2,
+    "embedding_model": "test/model",
+    "embedding_provider": "huggingface",
+    "embedding_dimension": 4,
+    "dimension": 4,
+    "embedding_kwargs": {},
+    "index_metric": "ip",
+}
+
+
+class _ReadOnceMapping(Mapping[str, Any]):
+    def __init__(self, values: Mapping[str, Any]) -> None:
+        self.values = dict(values)
+        self.iterations = 0
+
+    def __getitem__(self, key: str) -> Any:
+        return self.values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        self.iterations += 1
+        if self.iterations > 1:
+            raise AssertionError("strict context input mapping was read twice")
+        return iter(self.values)
+
+    def __len__(self) -> int:
+        return len(self.values)
+
+
+def test_strict_context_symbols_are_public_package_exports() -> None:
+    expected = {
+        "PlannedContextArtifact",
+        "PlannedContextView",
+        "plan_context_artifact_strict",
+        "publish_planned_context_artifact_strict",
+        "stage_context_artifact_strict",
+        "validate_content_bound_portable_query_view_reader",
+    }
+
+    assert expected <= set(artifacts_module.__all__)
+    assert all(hasattr(artifacts_module, name) for name in artifacts_module.__all__)
+    assert (
+        artifacts_module.validate_content_bound_portable_query_view_reader
+        is portable_views_module.validate_content_bound_portable_query_view_reader
+    )
+
+    assert list(inspect.signature(stage_context_artifact_strict).parameters) == [
+        "destination",
+        "manifest",
+        "repository",
+        "repository_source",
+        "view_generations",
+        "workspace_provider",
+        "output_receipt_owner",
+        "environ",
+    ]
+    assert list(
+        inspect.signature(publish_planned_context_artifact_strict).parameters
+    ) == [
+        "destination",
+        "planned",
+        "manifest",
+        "repository",
+        "repository_source",
+        "view_generations",
+        "workspace_provider",
+        "output_receipt_owner",
+        "environ",
+    ]
+
+
+def _json_bytes(value: Any) -> bytes:
+    return (
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _fingerprint(name: str, payload: bytes) -> dict[str, object]:
+    return {
+        "file": name,
+        "size": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+class _TestWorkspaceProvider:
+    """Quiescent provisioner used only to exercise the real authority layer."""
+
+    def __init__(
+        self,
+        *,
+        workspace_plan: WorkspacePlan | None = None,
+        support_hook: Callable[[], None] | None = None,
+    ) -> None:
+        self.workspace_plan = workspace_plan
+        self.support_hook = support_hook
+        self.support_count = 0
+        self.run_count = 0
+        self.requests: list[StrictWorkspaceRequest] = []
+
+    def require_support(self) -> None:
+        self.support_count += 1
+        if self.support_hook is not None:
+            self.support_hook()
+
+    def run_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        *,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], _Result],
+    ) -> _Result:
+        self.run_count += 1
+        self.requests.append(request)
+        plan = request.plan if self.workspace_plan is None else self.workspace_plan
+        parent = request.destination.parent
+        parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        stage = parent / (
+            f".{request.destination.name}.strict-{id(self):x}-{self.run_count}"
+        )
+        stage.mkdir(mode=plan.root_mode)
+        for directory in plan.directories:
+            (stage / directory.path.as_posix()).mkdir(mode=directory.mode)
+
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        parent_descriptor = os.open(parent, flags)
+        root_descriptor = os.open(stage, flags)
+        directory_descriptors = {
+            directory.path.as_posix(): os.open(stage / directory.path.as_posix(), flags)
+            for directory in plan.directories
+        }
+        workspace = OwnedWorkspaceAuthority()
+        try:
+            workspace.adopt(
+                destination=request.destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_descriptor,
+                root_descriptor=root_descriptor,
+                directory_descriptors=directory_descriptors,
+                plan=plan,
+                expected_destination=None,
+            )
+            try:
+                return run_adopted_workspace_operation(
+                    request,
+                    workspace=workspace,
+                    receipt_owner=receipt_owner,
+                    operation=operation,
+                )
+            except BaseException:
+                if receipt_owner.state == "empty":
+                    workspace.close()
+                raise
+        finally:
+            for descriptor in directory_descriptors.values():
+                os.close(descriptor)
+            os.close(root_descriptor)
+            os.close(parent_descriptor)
+
+
+def _publish_generation(
+    destination: Path,
+    files: Mapping[str, bytes],
+) -> PublishedWorkspaceReceiptOwner:
+    directories = {
+        parent.as_posix()
+        for relative in files
+        for parent in PurePosixPath(relative).parents
+        if parent != PurePosixPath(".")
+    }
+    identity = [
+        (relative, len(payload), hashlib.sha256(payload).hexdigest())
+        for relative, payload in sorted(files.items())
+    ]
+    plan = WorkspacePlan(
+        subject_digest=hashlib.sha256(_json_bytes(identity)).hexdigest(),
+        directories=tuple(
+            WorkspaceDirectory(PurePosixPath(path)) for path in sorted(directories)
+        ),
+        files=tuple(
+            WorkspaceFile(PurePosixPath(relative), max_bytes=len(payload))
+            for relative, payload in sorted(files.items())
+        ),
+    )
+    request = StrictWorkspaceRequest(
+        purpose="strict-context-test-source",
+        destination=destination,
+        plan=plan,
+    )
+    owner = PublishedWorkspaceReceiptOwner()
+
+    def publish(session: StrictWorkspaceSession) -> None:
+        for relative, payload in sorted(files.items()):
+            session.write_file(relative, (payload,))
+        session.publish_validated(lambda _reader: None)
+
+    run_strict_workspace(
+        _TestWorkspaceProvider(),
+        request,
+        receipt_owner=owner,
+        operation=publish,
+    )
+    return owner
+
+
+def _bm25_files() -> dict[str, bytes]:
+    return {
+        "bm25_metadata.json": _json_bytes(
+            {"project_root": "source", "max_k": 17, "language": "english"}
+        ),
+        "documents.json": _json_bytes(
+            [
+                {
+                    "page_content": "VALUE = 1",
+                    "metadata": {"file": "sample.py", "node_id": "sample.VALUE"},
+                }
+            ]
+        ),
+    }
+
+
+def _vector_files() -> dict[str, bytes]:
+    documents_name = "documents_test__model.json"
+    index_name = "index_test__model.faiss"
+    documents = _json_bytes(
+        [
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "sample.py", "node_id": "sample.VALUE"},
+            }
+        ]
+    )
+    # Publication treats an authenticated native index as inert bytes.
+    index = b"not-loaded-as-native-faiss\x00\x01"
+    config = _json_bytes(
+        {
+            "embedding_model": "test/model",
+            "embedding_provider": "huggingface",
+            "dimension": 4,
+            "index_type": "flat",
+            "index_metric": "ip",
+            "l0_documents": 0,
+            "l2_documents": 1,
+            "persistence_schema": VECTOR_PERSISTENCE_SCHEMA,
+            "level_artifacts": {
+                "l2": {
+                    "documents": _fingerprint(documents_name, documents),
+                    "index": _fingerprint(index_name, index),
+                }
+            },
+        }
+    )
+    return {
+        "config_test__model.json": config,
+        f"l2/{documents_name}": documents,
+        f"l2/{index_name}": index,
+    }
+
+
+def _entry(
+    view: str,
+    *,
+    source_fingerprint: str,
+) -> IndexEntry:
+    config = {} if view == "bm25" else dict(_VECTOR_CONFIG)
+    return IndexEntry(
+        index_type=view,
+        path=f"state/{view}",
+        built_at="2026-01-01T00:00:00Z",
+        built_at_epoch=1.0,
+        status="fresh",
+        config=config,
+        metadata={},
+        commit=_COMMIT,
+        source_fingerprint=source_fingerprint,
+    )
+
+
+@dataclass
+class _Fixture:
+    root: Path
+    repository: Path
+    repository_source: Any
+    manifest: RepoManifest
+    owners: dict[str, PublishedWorkspaceReceiptOwner]
+
+    def close(self) -> None:
+        for owner in self.owners.values():
+            owner.close()
+        self.repository_source.close()
+
+
+def _fixture(tmp_path: Path, views: tuple[str, ...]) -> _Fixture:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    (repository / "sample.py").write_text("VALUE = 1\n", encoding="utf-8")
+    repository_source = capture_repository_source(repository)
+    owners: dict[str, PublishedWorkspaceReceiptOwner] = {}
+    try:
+        for view in views:
+            files = _bm25_files() if view == "bm25" else _vector_files()
+            owners[view] = _publish_generation(tmp_path / "state" / view, files)
+        indexes = {
+            view: _entry(view, source_fingerprint=repository_source.fingerprint)
+            for view in views
+        }
+        manifest = RepoManifest(
+            repo_path=str(repository),
+            commit=_COMMIT,
+            last_indexed_commit=_COMMIT,
+            source_fingerprint=repository_source.fingerprint,
+            last_indexed_source_fingerprint=repository_source.fingerprint,
+            languages=["python"],
+            file_count=repository_source.file_count,
+            indexes=indexes,
+            compiled_at="2026-01-01T00:00:00Z",
+            compiled_at_epoch=1.0,
+        )
+        manifest.derive_capabilities()
+        return _Fixture(
+            root=tmp_path,
+            repository=repository,
+            repository_source=repository_source,
+            manifest=manifest,
+            owners=owners,
+        )
+    except BaseException:
+        for owner in owners.values():
+            owner.close()
+        repository_source.close()
+        raise
+
+
+@pytest.mark.parametrize(
+    "views",
+    [("bm25",), ("vector",), ("bm25", "vector")],
+)
+def test_strict_context_publishes_portable_view_combinations(
+    tmp_path: Path,
+    views: tuple[str, ...],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _fixture(tmp_path, views)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    destination = tmp_path / "published" / "context"
+    provider = _TestWorkspaceProvider()
+
+    def reject_native(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("strict context publication invoked native vector parsing")
+
+    monkeypatch.setattr(portable_views_module, "_faiss_contract", reject_native)
+    try:
+        result = stage_context_artifact_strict(
+            destination,
+            manifest=fixture.manifest,
+            repository="owner/repo",
+            repository_source=fixture.repository_source,
+            view_generations=fixture.owners,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            environ={},
+        )
+
+        assert result.output_dir == destination
+        assert result.views == tuple(sorted(views))
+        assert output_owner.active
+        assert all(owner.active for owner in fixture.owners.values())
+        assert provider.support_count == 1
+        assert provider.run_count == 1
+        assert provider.requests[0].destination_expectation == "missing"
+        verified = verify_context_artifact(
+            destination,
+            expected_repository="owner/repo",
+            expected_commit=_COMMIT,
+        )
+        assert verified.views == tuple(sorted(views))
+        assert verified.file_count == result.file_count
+        assert verified.byte_count == result.byte_count
+    finally:
+        output_owner.close()
+        fixture.close()
+
+
+def test_strict_context_freezes_inputs_before_single_provider_support_call(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path, ("bm25",))
+    fixture.manifest.indexes["bm25"].config["tokenizer"] = "frozen"
+    generations = _ReadOnceMapping(fixture.owners)
+    environment = _ReadOnceMapping({"SAFE_VALUE": "frozen"})
+    output_owner = PublishedWorkspaceReceiptOwner()
+    destination = tmp_path / "published" / "context"
+
+    def mutate_caller_inputs() -> None:
+        fixture.manifest.indexes["bm25"].config["tokenizer"] = "mutated"
+        generations.values.clear()
+        environment.values["SAFE_VALUE"] = "mutated"
+
+    provider = _TestWorkspaceProvider(support_hook=mutate_caller_inputs)
+    try:
+        stage_context_artifact_strict(
+            destination,
+            manifest=fixture.manifest,
+            repository="owner/repo",
+            repository_source=fixture.repository_source,
+            view_generations=generations,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            environ=environment,
+        )
+
+        assert generations.iterations == 1
+        assert environment.iterations == 1
+        assert provider.support_count == 1
+        assert provider.run_count == 1
+        published = json.loads(
+            (destination / "repo_manifest.json").read_text(encoding="utf-8")
+        )
+        assert published["indexes"]["bm25"]["config"]["tokenizer"] == "frozen"
+        assert output_owner.active
+    finally:
+        output_owner.close()
+        fixture.close()
+
+
+def test_strict_context_plan_is_deterministic_and_binds_manifest_config(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path, ("bm25", "vector"))
+    try:
+        first = plan_context_artifact_strict(
+            fixture.manifest,
+            repository="owner/repo",
+            repository_source=fixture.repository_source,
+            view_generations=fixture.owners,
+            environ={},
+        )
+        repeated = plan_context_artifact_strict(
+            fixture.manifest,
+            repository="owner/repo",
+            repository_source=fixture.repository_source,
+            view_generations=dict(reversed(tuple(fixture.owners.items()))),
+            environ={},
+        )
+        assert first == repeated
+        assert isinstance(first, PlannedContextArtifact)
+        assert first.views == ("bm25", "vector")
+
+        fixture.manifest.indexes["bm25"].config["tokenizer"] = "changed"
+        changed = plan_context_artifact_strict(
+            fixture.manifest,
+            repository="owner/repo",
+            repository_source=fixture.repository_source,
+            view_generations=fixture.owners,
+            environ={},
+        )
+        assert changed.plan.subject_digest != first.plan.subject_digest
+        assert changed.manifest_digest != first.manifest_digest
+    finally:
+        fixture.close()
+
+
+def test_strict_context_vector_plan_resolves_artifact_route_without_ambient_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _fixture(tmp_path, ("vector",))
+    real_resolve = strict_context_module.resolve_embedding_artifact_route
+    calls: list[Mapping[str, str] | None] = []
+
+    def resolve_without_ambient_env(
+        config: Mapping[str, Any],
+        *,
+        credential_env: str | None = None,
+        environ: Mapping[str, str] | None = None,
+    ) -> Any:
+        calls.append(environ)
+        assert environ == {}
+        return real_resolve(
+            config,
+            credential_env=credential_env,
+            environ=environ,
+        )
+
+    monkeypatch.setattr(
+        strict_context_module,
+        "resolve_embedding_artifact_route",
+        resolve_without_ambient_env,
+    )
+    try:
+        plan_context_artifact_strict(
+            fixture.manifest,
+            repository="owner/repo",
+            repository_source=fixture.repository_source,
+            view_generations=fixture.owners,
+            environ={},
+        )
+
+        assert calls == [{}]
+    finally:
+        fixture.close()
+
+
+def test_strict_context_planned_publish_rejects_forgery_and_input_drift(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path, ("bm25",))
+    planned = plan_context_artifact_strict(
+        fixture.manifest,
+        repository="owner/repo",
+        repository_source=fixture.repository_source,
+        view_generations=fixture.owners,
+        environ={},
+    )
+    destination = tmp_path / "published" / "context"
+    try:
+        forged = replace(planned, repository="other/repo")
+        output_owner = PublishedWorkspaceReceiptOwner()
+        provider = _TestWorkspaceProvider()
+        try:
+            with pytest.raises(ValueError, match="exact inputs"):
+                publish_planned_context_artifact_strict(
+                    destination,
+                    planned=forged,
+                    manifest=fixture.manifest,
+                    repository="owner/repo",
+                    repository_source=fixture.repository_source,
+                    view_generations=fixture.owners,
+                    workspace_provider=provider,
+                    output_receipt_owner=output_owner,
+                    environ={},
+                )
+            assert provider.run_count == 0
+            assert output_owner.state == "empty"
+            assert not destination.exists()
+        finally:
+            output_owner.close()
+
+        fixture.manifest.indexes["bm25"].config["tokenizer"] = "changed"
+        output_owner = PublishedWorkspaceReceiptOwner()
+        provider = _TestWorkspaceProvider()
+        try:
+            with pytest.raises(ValueError, match="exact inputs"):
+                publish_planned_context_artifact_strict(
+                    destination,
+                    planned=planned,
+                    manifest=fixture.manifest,
+                    repository="owner/repo",
+                    repository_source=fixture.repository_source,
+                    view_generations=fixture.owners,
+                    workspace_provider=provider,
+                    output_receipt_owner=output_owner,
+                    environ={},
+                )
+            assert provider.run_count == 0
+            assert output_owner.state == "empty"
+            assert not destination.exists()
+        finally:
+            output_owner.close()
+    finally:
+        fixture.close()
+
+
+def test_strict_context_rejects_invalid_destination_before_source_consume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _fixture(tmp_path, ("bm25",))
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider()
+    consume_calls = 0
+    real_consume = PublishedWorkspaceReceiptOwner.consume
+
+    def counted_consume(self, callback):
+        nonlocal consume_calls
+        consume_calls += 1
+        return real_consume(self, callback)
+
+    monkeypatch.setattr(PublishedWorkspaceReceiptOwner, "consume", counted_consume)
+    try:
+        with pytest.raises(ValueError, match="destination overlaps"):
+            stage_context_artifact_strict(
+                fixture.repository / "context",
+                manifest=fixture.manifest,
+                repository="owner/repo",
+                repository_source=fixture.repository_source,
+                view_generations=fixture.owners,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                environ={},
+            )
+        assert consume_calls == 0
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+        assert not (fixture.repository / "context").exists()
+    finally:
+        output_owner.close()
+        fixture.close()
+
+
+@pytest.mark.parametrize("kind", ["directory", "file", "dangling-symlink"])
+def test_strict_context_rejects_existing_destination_before_source_consume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+) -> None:
+    fixture = _fixture(tmp_path, ("bm25",))
+    destination = tmp_path / "published" / "context"
+    destination.parent.mkdir()
+    if kind == "directory":
+        destination.mkdir()
+    elif kind == "file":
+        destination.write_bytes(b"occupied")
+    else:
+        destination.symlink_to(tmp_path / "absent-target")
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider()
+    consume_calls = 0
+    real_consume = PublishedWorkspaceReceiptOwner.consume
+
+    def counted_consume(self, callback):
+        nonlocal consume_calls
+        consume_calls += 1
+        return real_consume(self, callback)
+
+    monkeypatch.setattr(PublishedWorkspaceReceiptOwner, "consume", counted_consume)
+    try:
+        with pytest.raises(ValueError, match="destination must be missing"):
+            stage_context_artifact_strict(
+                destination,
+                manifest=fixture.manifest,
+                repository="owner/repo",
+                repository_source=fixture.repository_source,
+                view_generations=fixture.owners,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                environ={},
+            )
+        assert consume_calls == 0
+        assert provider.run_count == 0
+        assert provider.support_count == 0
+        assert output_owner.state == "empty"
+        assert os.path.lexists(destination)
+    finally:
+        output_owner.close()
+        fixture.close()
+
+
+def test_strict_context_planned_publish_rejects_existing_destination_before_replan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _fixture(tmp_path, ("bm25",))
+    planned = plan_context_artifact_strict(
+        fixture.manifest,
+        repository="owner/repo",
+        repository_source=fixture.repository_source,
+        view_generations=fixture.owners,
+        environ={},
+    )
+    destination = tmp_path / "published" / "context"
+    destination.parent.mkdir()
+    destination.write_bytes(b"occupied")
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider()
+    consume_calls = 0
+    real_consume = PublishedWorkspaceReceiptOwner.consume
+
+    def counted_consume(self, callback):
+        nonlocal consume_calls
+        consume_calls += 1
+        return real_consume(self, callback)
+
+    monkeypatch.setattr(PublishedWorkspaceReceiptOwner, "consume", counted_consume)
+    try:
+        with pytest.raises(ValueError, match="destination must be missing"):
+            publish_planned_context_artifact_strict(
+                destination,
+                planned=planned,
+                manifest=fixture.manifest,
+                repository="owner/repo",
+                repository_source=fixture.repository_source,
+                view_generations=fixture.owners,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                environ={},
+            )
+        assert consume_calls == 0
+        assert provider.run_count == 0
+        assert provider.support_count == 0
+        assert output_owner.state == "empty"
+        assert destination.read_bytes() == b"occupied"
+    finally:
+        output_owner.close()
+        fixture.close()
+
+
+def test_strict_context_published_source_drift_rolls_back_missing_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _fixture(tmp_path, ("bm25",))
+    output_owner = PublishedWorkspaceReceiptOwner()
+    destination = tmp_path / "published" / "context"
+    provider = _TestWorkspaceProvider()
+    real_validate = strict_context_module._validate_candidate
+    validations = 0
+
+    def validate_then_drift(*args: object, **kwargs: object) -> None:
+        nonlocal validations
+        real_validate(*args, **kwargs)
+        validations += 1
+        if validations == 2:
+            (fixture.repository / "sample.py").write_text(
+                "VALUE = 2\n", encoding="utf-8"
+            )
+
+    monkeypatch.setattr(
+        strict_context_module, "_validate_candidate", validate_then_drift
+    )
+    try:
+        with pytest.raises(
+            Exception,
+            match="changed|failed validation|quarantined",
+        ):
+            stage_context_artifact_strict(
+                destination,
+                manifest=fixture.manifest,
+                repository="owner/repo",
+                repository_source=fixture.repository_source,
+                view_generations=fixture.owners,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                environ={},
+            )
+        assert validations == 2
+        assert not destination.exists()
+        # The atomic layer retains the quarantined generation as explicit,
+        # caller-cleanable authority rather than degrading it to an empty slot.
+        assert output_owner.state == "cleanup"
+        assert fixture.owners["bm25"].active
+        output_owner.close()
+        assert output_owner.closed
+    finally:
+        output_owner.close()
+        fixture.close()
+
+
+def test_strict_context_provider_plan_substitution_has_no_publication(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path, ("bm25",))
+    planned = plan_context_artifact_strict(
+        fixture.manifest,
+        repository="owner/repo",
+        repository_source=fixture.repository_source,
+        view_generations=fixture.owners,
+        environ={},
+    )
+    wrong_plan = WorkspacePlan(subject_digest=hashlib.sha256(b"wrong").hexdigest())
+    provider = _TestWorkspaceProvider(workspace_plan=wrong_plan)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    destination = tmp_path / "published" / "context"
+    try:
+        with pytest.raises(ValueError, match="plan differs"):
+            publish_planned_context_artifact_strict(
+                destination,
+                planned=planned,
+                manifest=fixture.manifest,
+                repository="owner/repo",
+                repository_source=fixture.repository_source,
+                view_generations=fixture.owners,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                environ={},
+            )
+        assert not destination.exists()
+        assert output_owner.state == "empty"
+        assert fixture.owners["bm25"].active
+    finally:
+        output_owner.close()
+        fixture.close()

--- a/test/index/test_embedding_model_policy.py
+++ b/test/index/test_embedding_model_policy.py
@@ -2,11 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+
 import pytest
 
 from codenib.index.embedding.model_policy import (
     DEFAULT_EMBEDDING_MODEL,
     DEFAULT_EMBEDDING_REVISION,
+    resolve_embedding_artifact_load_policy,
     resolve_embedding_load_policy,
 )
 
@@ -88,6 +91,69 @@ def test_local_path_named_like_bundled_model_is_not_implicitly_trusted(
 
     assert policy.revision is None
     assert policy.trust_remote_code is False
+
+
+def test_artifact_policy_treats_model_id_as_remote_without_filesystem_probe(
+    tmp_path, monkeypatch
+):
+    local_collision = tmp_path / "vendor" / "custom-embedding"
+    local_collision.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    def fail_is_dir(_path: Path) -> bool:
+        pytest.fail("artifact embedding policy probed the ambient filesystem")
+
+    monkeypatch.setattr(Path, "is_dir", fail_is_dir)
+
+    policy = resolve_embedding_artifact_load_policy("vendor/custom-embedding")
+
+    assert policy.revision is None
+    assert policy.trust_remote_code is False
+
+
+def test_artifact_policy_keeps_bundled_remote_identity_deterministic(
+    tmp_path, monkeypatch
+):
+    local_collision = tmp_path / DEFAULT_EMBEDDING_MODEL
+    local_collision.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    def fail_is_dir(_path: Path) -> bool:
+        pytest.fail("artifact embedding policy probed the ambient filesystem")
+
+    monkeypatch.setattr(Path, "is_dir", fail_is_dir)
+
+    policy = resolve_embedding_artifact_load_policy(DEFAULT_EMBEDDING_MODEL)
+
+    assert policy.revision == DEFAULT_EMBEDDING_REVISION
+    assert policy.trust_remote_code is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "/opt/models/embedding",
+        "C:/models/embedding",
+        "C:\\models\\embedding",
+        "C:embedding",
+        "//server/share/embedding",
+        "\\\\server\\share\\embedding",
+        "./embedding",
+        "../embedding",
+        "vendor/../embedding",
+        "~/embedding",
+        "~other/embedding",
+        "vendor\\embedding",
+        "vendor//embedding",
+        "file:/opt/models/embedding",
+        "FILE:relative-model",
+        "vendor/model name",
+        "vendor/model\x7f",
+    ],
+)
+def test_artifact_policy_rejects_filesystem_shaped_models(model):
+    with pytest.raises(ValueError, match="filesystem-shaped path"):
+        resolve_embedding_artifact_load_policy(model)
 
 
 @pytest.mark.parametrize("value", [1, "false"])


### PR DESCRIPTION
## Summary

Adds strict, authority-bound whole-context publication on current `main`. The PR assembles retained portable BM25 and vector generations without reopening ambient paths or activating native vector indexes.

The strict path remains provider-neutral and is not connected to a production compiler, catalog, or runtime route. Related to #199; this slice does not complete M1 or M2.

## Changes

- Add content-bound portable-view validation using retained publication and repository-source authorities.
- Capture one detached authenticated source identity per validation or strict context operation, and use it throughout planning, replay, and publication.
- Stream and canonically validate large document stores without whole-file DOM or byte caching.
- Keep vector native indexes inert and remove ambient filesystem influence from artifact model policy.
- Add deterministic strict context planning, replay, staging, and durable publication.
- Bind exact manifests, fingerprints, retained source records, output inventories, and staged/published validation.
- Record the strict whole-context publication boundary and remaining adapters in the storage roadmap.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Direct changed-surface matrix: `214 passed`.
- Extended artifact/runtime/model-policy matrix: `333 passed`.
- Local unit tier: `5,549 passed, 71 skipped, 191 deselected`; the one additional deselection beyond the configured marker set is the installed-distribution metadata check because this shared environment still has CodeNib 0.2.0 while the checkout is 0.2.1. Clean GitHub installs cover that check.
- Project pre-commit hooks, `git diff --check`, and `python -m mkdocs build --strict` passed.
- The #602 dependency and its post-merge Full CI, Docs, Release, and publish smoke are green on `main`.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published