### PR TITLE
fix(storage): add retained manifest import gates

### DIFF
--- a/codenib/storage/__init__.py
+++ b/codenib/storage/__init__.py
@@ -29,7 +29,12 @@ from .models import (
     ViewGeneration,
     ViewProfile,
 )
-from .protocols import IndexCatalog, JobCatalog, ObjectStore
+from .protocols import (
+    IndexCatalog,
+    JobCatalog,
+    ObjectStore,
+    ReceiptVerifyingObjectStore,
+)
 from .sqlite_catalog import (
     DEFAULT_NAMESPACE_ID,
     CatalogConflictError,
@@ -50,6 +55,7 @@ from .view_bundle import (
     ViewBundleRecord,
     build_view_bundle,
     materialize_view_bundle,
+    validate_view_bundle_physical_size,
     verify_view_bundle,
 )
 
@@ -81,6 +87,7 @@ __all__ = [
     "PublishedSnapshot",
     "RefJobLease",
     "RefState",
+    "ReceiptVerifyingObjectStore",
     "RepositoryIdentity",
     "SQLiteCatalog",
     "SnapshotView",
@@ -98,5 +105,6 @@ __all__ = [
     "ViewProfile",
     "build_view_bundle",
     "materialize_view_bundle",
+    "validate_view_bundle_physical_size",
     "verify_view_bundle",
 ]

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -64,7 +64,12 @@ _CASResult = TypeVar("_CASResult")
 
 @dataclass(frozen=True, slots=True)
 class BlobInfo:
-    """Identity and location of one immutable CAS object."""
+    """Point-in-time identity receipt for one immutable CAS object.
+
+    This value is not a retention lease.  Revalidate it at each later metadata
+    boundary and authenticate bytes inside the actual read operation until an
+    explicit pin contract exists.
+    """
 
     digest: str
     byte_size: int
@@ -554,6 +559,43 @@ class LocalCAS:
             return self._blob_info(digest, byte_size)
 
         return self._run_strict_operation(verify_object)
+
+    def verify_receipt(self, expected: BlobInfo) -> BlobInfo:
+        """Revalidate an exact object receipt without claiming a retention pin.
+
+        The full digest/size/storage-key tuple is compared after one backend
+        verification.  This is deliberately a point-in-time validation gate:
+        future pin- and lease-aware GC must provide any longer-lived retention
+        guarantee.
+        """
+
+        if (
+            type(expected) is not BlobInfo
+            or type(expected.digest) is not str
+            or type(expected.byte_size) is not int
+            or type(expected.storage_key) is not str
+        ):
+            raise TypeError("expected object receipt must be BlobInfo")
+        digest = _validate_digest(expected.digest)
+        if isinstance(expected.byte_size, bool) or not isinstance(
+            expected.byte_size, int
+        ):
+            raise StorageValidationError(
+                "object receipt byte size must be a nonnegative integer"
+            )
+        if expected.byte_size < 0:
+            raise StorageValidationError(
+                "object receipt byte size must be a nonnegative integer"
+            )
+        canonical = self._blob_info(digest, expected.byte_size)
+        if expected != canonical:
+            raise StorageValidationError("object receipt is not canonical")
+        observed = self.verify(digest)
+        if observed != expected:
+            raise StorageIntegrityError(
+                f"verified CAS object receipt does not match expected receipt: {digest}"
+            )
+        return observed
 
     def materialize(self, digest: str, destination: str | Path) -> Path:
         """Atomically copy a verified object to a regular destination path."""

--- a/codenib/storage/protocols.py
+++ b/codenib/storage/protocols.py
@@ -15,7 +15,17 @@ from .models import IndexJobCompletion, IndexJobRecord, IndexJobViewRecord, RefJ
 
 @runtime_checkable
 class ObjectStore(Protocol):
-    """Immutable byte-object operations required by artifact publication."""
+    """Immutable byte-object operations required by artifact publication.
+
+    ``BlobInfo`` is an immutable identity receipt, not a retention pin.  A
+    receipt says which bytes were durably observed at one completed operation;
+    it does not promise that a future GC cannot remove an unleased object.
+    Consumers that require exact receipt revalidation can additionally require
+    :class:`ReceiptVerifyingObjectStore` without breaking existing object-store
+    implementations.  A separate ``open`` after verification is not pinned by
+    that earlier result.  This protocol gains a longer lifetime only with an
+    explicit pin or lease.
+    """
 
     def put_bytes(self, data: bytes) -> BlobInfo: ...
 
@@ -23,13 +33,32 @@ class ObjectStore(Protocol):
 
     def has(self, digest: str) -> bool: ...
 
-    def open(self, digest: str) -> BinaryIO: ...
+    def open(self, digest: str) -> BinaryIO:
+        """Open an unverified stream whose bytes the caller must authenticate."""
 
-    def read_bytes(self, digest: str) -> bytes: ...
+        ...
+
+    def read_bytes(self, digest: str) -> bytes:
+        """Return bytes authenticated against the digest during this read."""
+
+        ...
 
     def verify(self, digest: str) -> BlobInfo: ...
 
-    def materialize(self, digest: str, destination: str | Path) -> Path: ...
+    def materialize(self, digest: str, destination: str | Path) -> Path:
+        """Materialize bytes authenticated during the copy; return a locator."""
+
+        ...
+
+
+@runtime_checkable
+class ReceiptVerifyingObjectStore(ObjectStore, Protocol):
+    """Additive capability for exact point-in-time receipt revalidation."""
+
+    def verify_receipt(self, expected: BlobInfo) -> BlobInfo:
+        """Revalidate one exact digest/size/storage-key receipt."""
+
+        ...
 
 
 @runtime_checkable
@@ -115,7 +144,10 @@ class IndexCatalog(Protocol):
         ref_name: str = "main",
     ) -> dict[str, Any]: ...
 
-    def get_manifest_summary(self, snapshot_id: str) -> dict[str, Any]: ...
+    def get_manifest_summary(self, snapshot_id: str) -> dict[str, Any]:
+        """Return a ready snapshot with namespace/repository identity closure."""
+
+        ...
 
 
 @runtime_checkable
@@ -169,4 +201,9 @@ class JobCatalog(Protocol):
     ) -> IndexJobRecord: ...
 
 
-__all__ = ["IndexCatalog", "JobCatalog", "ObjectStore"]
+__all__ = [
+    "IndexCatalog",
+    "JobCatalog",
+    "ObjectStore",
+    "ReceiptVerifyingObjectStore",
+]

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -2867,7 +2867,7 @@ class SQLiteCatalog:
             }
 
     def get_manifest_summary(self, snapshot_id: str) -> dict[str, Any]:
-        """Return the immutable summary for a published, ready snapshot."""
+        """Return the identity-closed summary for a published, ready snapshot."""
         normalized_snapshot = _required_text(snapshot_id, "snapshot ID")
         with self._transaction(immediate=False):
             return self._manifest_summary(normalized_snapshot)
@@ -2881,6 +2881,9 @@ class SQLiteCatalog:
         _persisted_utc_timestamp(snapshot["published_at"], "snapshot published_at")
         repository = self._require_record(
             "repositories", "repository_id", snapshot["repository_id"]
+        )
+        namespace = self._require_record(
+            "namespaces", "namespace_id", repository["namespace_id"]
         )
         source = self._require_record(
             "source_revisions", "source_revision_id", snapshot["source_revision_id"]
@@ -3018,6 +3021,14 @@ class SQLiteCatalog:
         return {
             "snapshot_id": snapshot["snapshot_id"],
             "repository_id": snapshot["repository_id"],
+            "namespace": {
+                "namespace_id": namespace["namespace_id"],
+                "name": namespace["name"],
+            },
+            "repository": {
+                "namespace_id": repository["namespace_id"],
+                "repository_key": repository["repository_key"],
+            },
             "status": snapshot["status"],
             "published_at": snapshot["published_at"],
             "source": {

--- a/codenib/storage/view_bundle.py
+++ b/codenib/storage/view_bundle.py
@@ -392,7 +392,7 @@ def verify_view_bundle(
             raise StorageIntegrityError(
                 "view bundle archive size does not match the expected object"
             )
-        _validate_archive_physical_size(
+        validate_view_bundle_physical_size(
             signature[3],
             max_files=max_files,
             max_bytes=max_bytes,
@@ -496,7 +496,7 @@ def materialize_view_bundle(
                     raise StorageIntegrityError(
                         "view bundle archive size does not match the expected object"
                     )
-                _validate_archive_physical_size(
+                validate_view_bundle_physical_size(
                     signature[3],
                     max_files=max_files,
                     max_bytes=max_bytes,
@@ -643,20 +643,37 @@ def _validate_expected_size(value: int | None) -> int | None:
     return value
 
 
-def _validate_archive_physical_size(
+def validate_view_bundle_physical_size(
     byte_size: int,
     *,
     max_files: int,
     max_bytes: int,
     max_metadata_bytes: int,
 ) -> None:
+    """Reject an archive receipt that cannot fit configured bundle limits.
+
+    Callers that start from catalog or object metadata must execute this gate
+    before ``ObjectStore.verify``, ``open``, or ``materialize`` so an oversized
+    physical object is rejected before backend byte access.
+    """
+
+    _validate_limits(max_files, max_bytes, max_metadata_bytes)
+    if byte_size is None:
+        raise StorageValidationError(
+            "view bundle archive size must be a nonnegative integer"
+        )
+    normalized_size = _validate_expected_size(byte_size)
+    if normalized_size is None:  # pragma: no cover - guarded above for type narrowing
+        raise StorageValidationError(
+            "view bundle archive size must be a nonnegative integer"
+        )
     maximum = (
         max_bytes
         + max_metadata_bytes
         + (max_files + 1) * _MAX_ZIP_ENTRY_OVERHEAD
         + _MAX_ZIP_ENVELOPE_BYTES
     )
-    if byte_size > maximum:
+    if normalized_size > maximum:
         raise StorageValidationError(
             f"view bundle archive exceeds its {maximum}-byte physical limit"
         )
@@ -3093,5 +3110,6 @@ __all__ = [
     "ViewBundleRecord",
     "build_view_bundle",
     "materialize_view_bundle",
+    "validate_view_bundle_physical_size",
     "verify_view_bundle",
 ]

--- a/codenib/storage/view_bundle.py
+++ b/codenib/storage/view_bundle.py
@@ -636,7 +636,7 @@ def _validate_limits(max_files: int, max_bytes: int, max_metadata_bytes: int) ->
 def _validate_expected_size(value: int | None) -> int | None:
     if value is None:
         return None
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+    if type(value) is not int or value < 0:
         raise StorageValidationError(
             "expected archive size must be a nonnegative integer"
         )

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -360,6 +360,20 @@ import legacy manifests into the catalog, or publish the resulting receipt as
 an M2 generation. Those adapters remain outstanding, so M1 and M2 remain in
 progress.
 
+Retained manifest import now has additional backend-neutral prerequisite
+gates. `BlobInfo` is an exact point-in-time CAS receipt, and
+the additive `ReceiptVerifyingObjectStore.verify_receipt` capability
+revalidates its digest, byte size, and canonical storage key before a metadata
+boundary without pretending to pin the object against future GC. A public
+physical archive-size gate lets import coordinators reject impossible view
+bundles before object-store byte access. Published snapshot summaries also
+close namespace and repository identity alongside source, profile, generation,
+object, and view identity. Retained materialized-bundle consumption still needs
+a non-forgeable owner and tracked streaming-resource lifecycle; no path or
+ordinary dataclass is treated as that authority. These gates do not yet plan or
+execute a legacy `RepoManifest` import, upload retained view bytes, or advance a
+ref, so M1 remains in progress.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/test/storage/test_contracts.py
+++ b/test/storage/test_contracts.py
@@ -4,17 +4,26 @@
 
 from __future__ import annotations
 
-from codenib.storage.cas import LocalCAS
+import pytest
+
+from codenib.storage.cas import BlobInfo, LocalCAS
 from codenib.storage.models import (
     ObjectRecord,
     PublishedSnapshot,
     RepositoryIdentity,
     SnapshotView,
     SourceRevision,
+    StorageIntegrityError,
+    StorageValidationError,
     ViewGeneration,
     ViewProfile,
 )
-from codenib.storage.protocols import IndexCatalog, JobCatalog, ObjectStore
+from codenib.storage.protocols import (
+    IndexCatalog,
+    JobCatalog,
+    ObjectStore,
+    ReceiptVerifyingObjectStore,
+)
 from codenib.storage.sqlite_catalog import DEFAULT_NAMESPACE_ID, SQLiteCatalog
 
 
@@ -23,10 +32,151 @@ def test_embedded_backends_implement_storage_protocols(tmp_path) -> None:
     catalog = SQLiteCatalog(tmp_path / "catalog.sqlite3")
     try:
         assert isinstance(object_store, ObjectStore)
+        assert isinstance(object_store, ReceiptVerifyingObjectStore)
         assert isinstance(catalog, IndexCatalog)
         assert isinstance(catalog, JobCatalog)
     finally:
         catalog.close()
+
+
+def test_receipt_verification_is_an_additive_object_store_capability() -> None:
+    class LegacyObjectStore:
+        def put_bytes(self, data):
+            raise NotImplementedError
+
+        def put_file(self, source):
+            raise NotImplementedError
+
+        def has(self, digest):
+            raise NotImplementedError
+
+        def open(self, digest):
+            raise NotImplementedError
+
+        def read_bytes(self, digest):
+            raise NotImplementedError
+
+        def verify(self, digest):
+            raise NotImplementedError
+
+        def materialize(self, digest, destination):
+            raise NotImplementedError
+
+    legacy = LegacyObjectStore()
+
+    assert isinstance(legacy, ObjectStore)
+    assert not isinstance(legacy, ReceiptVerifyingObjectStore)
+
+
+def test_object_receipt_revalidation_is_executable_and_does_not_pin_lifetime(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    object_store = LocalCAS(tmp_path / "objects")
+    receipt = object_store.put_bytes(b"durable at the verified read boundary")
+    verified: list[str] = []
+    real_verify = object_store.verify
+
+    def count_verify(digest: str) -> BlobInfo:
+        verified.append(digest)
+        return real_verify(digest)
+
+    monkeypatch.setattr(object_store, "verify", count_verify)
+
+    assert object_store.verify_receipt(receipt) == receipt
+    assert verified == [receipt.digest]
+    with pytest.raises(
+        StorageIntegrityError,
+        match="receipt does not match",
+    ):
+        object_store.verify_receipt(
+            BlobInfo(
+                digest=receipt.digest,
+                byte_size=receipt.byte_size + 1,
+                storage_key=receipt.storage_key,
+            )
+        )
+    assert verified == [receipt.digest, receipt.digest]
+    with pytest.raises(StorageValidationError, match="not canonical"):
+        object_store.verify_receipt(
+            BlobInfo(
+                digest=receipt.digest,
+                byte_size=receipt.byte_size,
+                storage_key=f"objects/{receipt.digest}",
+            )
+        )
+    assert verified == [receipt.digest, receipt.digest]
+
+    # A BlobInfo is an immutable identity receipt, not a retention lease.  A
+    # future GC may remove unpinned bytes, so each read boundary must execute
+    # the exact-receipt gate again instead of inferring a pin from API shape.
+    (object_store.root / receipt.storage_key).unlink()
+    with pytest.raises(FileNotFoundError):
+        object_store.verify_receipt(receipt)
+    assert verified == [receipt.digest, receipt.digest, receipt.digest]
+
+
+def test_object_receipt_revalidation_rejects_equality_forged_subclasses(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    class ForgedBlobInfo(BlobInfo):
+        def __eq__(self, _other: object) -> bool:
+            return True
+
+        def __ne__(self, _other: object) -> bool:
+            return False
+
+    class ForgedString(str):
+        def __eq__(self, _other: object) -> bool:
+            return True
+
+        def __ne__(self, _other: object) -> bool:
+            return False
+
+    class ForgedInteger(int):
+        def __eq__(self, _other: object) -> bool:
+            return True
+
+        def __ne__(self, _other: object) -> bool:
+            return False
+
+    object_store = LocalCAS(tmp_path / "objects")
+    receipt = object_store.put_bytes(b"exact receipt")
+    verified = False
+
+    def reject_verify(_digest: str) -> BlobInfo:
+        nonlocal verified
+        verified = True
+        raise AssertionError("backend verification ran for a forged receipt type")
+
+    monkeypatch.setattr(object_store, "verify", reject_verify)
+
+    for forged in (
+        ForgedBlobInfo(
+            digest=receipt.digest,
+            byte_size=receipt.byte_size + 99,
+            storage_key="attacker/key",
+        ),
+        BlobInfo(
+            digest=ForgedString(receipt.digest),
+            byte_size=receipt.byte_size,
+            storage_key=receipt.storage_key,
+        ),
+        BlobInfo(
+            digest=receipt.digest,
+            byte_size=ForgedInteger(receipt.byte_size + 99),
+            storage_key=receipt.storage_key,
+        ),
+        BlobInfo(
+            digest=receipt.digest,
+            byte_size=receipt.byte_size,
+            storage_key=ForgedString("attacker/key"),
+        ),
+    ):
+        with pytest.raises(TypeError, match="must be BlobInfo"):
+            object_store.verify_receipt(forged)
+    assert verified is False
 
 
 def test_domain_and_sqlite_content_identities_match(tmp_path) -> None:

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -13,6 +13,15 @@ from threading import Barrier
 import pytest
 
 from codenib.storage.cas import LocalCAS
+from codenib.storage.models import (
+    ObjectRecord,
+    PublishedSnapshot,
+    RepositoryIdentity,
+    SnapshotView,
+    SourceRevision,
+    ViewGeneration,
+    ViewProfile,
+)
 from codenib.storage.sqlite_catalog import (
     DEFAULT_NAMESPACE_ID,
     LATEST_SCHEMA_VERSION,
@@ -509,6 +518,24 @@ def test_publish_resolves_complete_pinned_manifest(tmp_path):
         assert published["updated_at"] == resolved["updated_at"]
         assert resolved["manifest"] == direct
         assert direct["status"] == "ready"
+        assert direct["namespace"] == {
+            "namespace_id": DEFAULT_NAMESPACE_ID,
+            "name": "default",
+        }
+        assert direct["repository"] == {
+            "namespace_id": DEFAULT_NAMESPACE_ID,
+            "repository_key": "owner/repo",
+        }
+        repository_identity = RepositoryIdentity(**direct["repository"])
+        assert repository_identity.repository_id == direct["repository_id"]
+        source_identity = SourceRevision(
+            repository_id=direct["repository_id"],
+            source_kind=direct["source"]["kind"],
+            commit_sha=direct["source"]["commit_sha"],
+            tree_sha=direct["source"]["tree_sha"],
+            source_fingerprint=direct["source"]["source_fingerprint"],
+        )
+        assert source_identity.source_revision_id == source_revision_id
         assert direct["source"]["source_revision_id"] == source_revision_id
         assert direct["source"]["kind"] == "clean"
         assert direct["views"]["bm25"]["profile"] == {
@@ -524,11 +551,79 @@ def test_publish_resolves_complete_pinned_manifest(tmp_path):
         assert list(direct["views"]) == ["bm25", "vector"]
         assert direct["views"]["bm25"]["object"]["byte_size"] == 20
         assert direct["views"]["vector"]["object"]["byte_size"] == 30
+        snapshot_views = []
+        for view_type, raw in direct["views"].items():
+            profile = ViewProfile.create(
+                view_type,
+                raw["profile"]["config"],
+                name=raw["profile"]["name"],
+            )
+            assert profile.profile_id == raw["profile"]["profile_id"]
+            generation = ViewGeneration.create(
+                source_identity,
+                profile,
+                ObjectRecord(
+                    digest=raw["object"]["digest"],
+                    storage_key=raw["object"]["storage_key"],
+                    byte_size=raw["object"]["byte_size"],
+                    media_type=raw["object"]["media_type"],
+                ),
+                schema_version=raw["schema_version"],
+                metadata=raw["metadata"],
+            )
+            assert generation.view_generation_id == raw["view_generation_id"]
+            snapshot_views.append(SnapshotView(generation))
+        assert (
+            PublishedSnapshot(
+                direct["repository_id"],
+                source_revision_id,
+                tuple(snapshot_views),
+            ).snapshot_id
+            == direct["snapshot_id"]
+        )
 
         statuses = catalog._connection.execute(
             "SELECT DISTINCT status FROM view_generations"
         ).fetchall()
         assert [row["status"] for row in statuses] == ["ready"]
+
+
+def test_manifest_summary_closes_custom_namespace_and_repository_identity(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        namespace_id = catalog.create_namespace("team-one")
+        repository_id = catalog.create_repository(
+            "owner/repo",
+            namespace_id=namespace_id,
+        )
+        source_revision_id = _source(catalog, repository_id)
+        profile_id = catalog.create_view_profile("bm25")
+        generation_id = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            profile_id,
+            _object(catalog, "c"),
+        )
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [generation_id],
+            expected_generation=0,
+        )
+
+        summary = catalog.get_manifest_summary(published["snapshot_id"])
+
+        assert summary["namespace"] == {
+            "namespace_id": namespace_id,
+            "name": "team-one",
+        }
+        assert summary["repository"] == {
+            "namespace_id": namespace_id,
+            "repository_key": "owner/repo",
+        }
+        assert (
+            RepositoryIdentity(**summary["repository"]).repository_id == repository_id
+        )
 
 
 def test_publish_retry_for_current_snapshot_is_desired_state_idempotent(tmp_path):

--- a/test/storage/test_view_bundle.py
+++ b/test/storage/test_view_bundle.py
@@ -26,6 +26,7 @@ from codenib.storage import (
     StorageValidationError,
     build_view_bundle,
     materialize_view_bundle,
+    validate_view_bundle_physical_size,
     verify_view_bundle,
 )
 from codenib.storage.models import canonical_json
@@ -41,6 +42,33 @@ def _source(root: Path) -> Path:
     executable.write_bytes(b"immutable shard")
     executable.chmod(0o751)
     return source
+
+
+def test_public_physical_size_gate_rejects_before_archive_access() -> None:
+    validate_view_bundle_physical_size(
+        1,
+        max_files=1,
+        max_bytes=1,
+        max_metadata_bytes=1,
+    )
+    with pytest.raises(StorageValidationError, match="physical limit"):
+        validate_view_bundle_physical_size(
+            2 * 1024 * 1024,
+            max_files=1,
+            max_bytes=1,
+            max_metadata_bytes=1,
+        )
+
+
+@pytest.mark.parametrize("byte_size", [None, True, -1, 1.5, "1"])
+def test_public_physical_size_gate_rejects_malformed_size(byte_size: object) -> None:
+    with pytest.raises(StorageValidationError, match="nonnegative integer"):
+        validate_view_bundle_physical_size(
+            byte_size,  # type: ignore[arg-type]
+            max_files=1,
+            max_bytes=1,
+            max_metadata_bytes=1,
+        )
 
 
 def _moved_publication_root(destination: Path) -> Path:

--- a/test/storage/test_view_bundle.py
+++ b/test/storage/test_view_bundle.py
@@ -71,6 +71,23 @@ def test_public_physical_size_gate_rejects_malformed_size(byte_size: object) -> 
         )
 
 
+def test_public_physical_size_gate_rejects_integer_subclass_before_comparison() -> None:
+    class ForgedSize(int):
+        def __lt__(self, other: object) -> bool:
+            raise AssertionError("integer subclass comparison must not run")
+
+        def __gt__(self, other: object) -> bool:
+            raise AssertionError("integer subclass comparison must not run")
+
+    with pytest.raises(StorageValidationError, match="nonnegative integer"):
+        validate_view_bundle_physical_size(
+            ForgedSize(2 * 1024 * 1024),
+            max_files=1,
+            max_bytes=1,
+            max_metadata_bytes=1,
+        )
+
+
 def _moved_publication_root(destination: Path) -> Path:
     matches = tuple(
         path


### PR DESCRIPTION
## Summary
Add the backend-neutral receipt, archive-size, and catalog identity gates needed before retained manifests can safely enter the storage control plane. This is a focused prerequisite layer and does not claim manifest import or ref publication is complete.

## Changes
- Add an additive `ReceiptVerifyingObjectStore` capability and exact `LocalCAS.verify_receipt` validation without changing the existing `ObjectStore` runtime contract.
- Reject forged receipt and scalar subclasses before backend access while documenting the point-in-time, non-pinning lifetime.
- Expose a conservative physical view-bundle size gate for coordinators to run before object-store byte access.
- Include namespace and repository identity closure in SQLite snapshot summaries and verify complete snapshot identity reconstruction.
- Record the completed gates and the still-deferred non-forgeable retained bundle owner, manifest planner, CAS upload, and ref publication work.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

- `umask 022; pytest -q test/storage --tb=short`: 310 passed.
- Unit tier (excluding only the shared-environment installed-version mismatch): 5559 passed, 71 skipped, 191 deselected.
- `pre-commit run --from-ref origin/main --to-ref HEAD`: passed.
- `python -m mkdocs build --strict`: passed.
- `git diff --check origin/main...HEAD`: passed.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

#605 is merged and its Docs, Release, and publish-smoke checks are green. This PR is restacked directly on the resulting `main`; it does not enable a production importer or claim object retention beyond point-in-time receipt verification.