### PR TITLE
perf(scip): gate lazy MCP query provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,12 @@ CLANGD_WORKLOAD_GATE_SUBJECT_MANIFEST ?= scripts/profiling/clangd_workload_subje
 CLANGD_WORKLOAD_GATE_SUBJECT_ID ?=
 CLANGD_WORKLOAD_GATE_GENERATION_SECONDS ?=
 CLANGD_WORKLOAD_GATE_EXTRA_ARGS ?=
+SCIP_MCP_CONSUMER_GATE_MANIFEST ?=
+SCIP_MCP_CONSUMER_GATE_PROJECT_ROOT ?=
+SCIP_MCP_CONSUMER_GATE_SUBJECT_ID ?=
+SCIP_MCP_CONSUMER_GATE_SUBJECT_MANIFEST ?= scripts/profiling/scip_mcp_consumer_subjects.json
+SCIP_MCP_CONSUMER_GATE_OUTPUT ?= $(CODENIB_RESULTS_DIR)/scip-mcp-consumer-gate.json
+SCIP_MCP_CONSUMER_GATE_EXTRA_ARGS ?=
 CLANGD_FACT_GENERATION_PROFILE_INDEX_DIR ?=
 CLANGD_FACT_GENERATION_PROFILE_PROJECT_ROOT ?=
 CLANGD_FACT_GENERATION_PROFILE_COMPILE_COMMANDS ?=
@@ -207,7 +213,7 @@ endef
 .PHONY: active-scip-tools active-lsp-tools active-scip-env active-system-deps-ubuntu
 .PHONY: go-tool scip-go-tool rust-tool scip-python-tool scip-typescript-tool scip-clang-tool
 .PHONY: node-workspace-tools zoekt-tool python-lsp-tool ty-tool typescript-lsp-tool gopls-tool clangd-tool
-.PHONY: core-system-deps-ubuntu core-python-deps core-build core-test fact-buffer-profile fact-query-profile clangd-fact-query-profile clangd-workload-gate clangd-fact-generation-profile
+.PHONY: core-system-deps-ubuntu core-python-deps core-build core-test fact-buffer-profile fact-query-profile clangd-fact-query-profile clangd-workload-gate scip-mcp-consumer-gate clangd-fact-generation-profile
 .PHONY: core-chunk-poc-build core-chunk-poc-test core-chunk-poc-profile
 .PHONY: scip-cold-start-tools scip-cold-start-tools-all scip-cold-start-env scip-cold-start-system-deps-ubuntu
 .PHONY: scip-candidates scip-candidates-all scip-candidate-env scip-candidate-system-deps-ubuntu
@@ -441,10 +447,12 @@ core-test: core-build
 		test/scip/test_fact_batch_buffer.py \
 		test/scip/test_fact_query_index.py \
 		test/scip/test_scip_query.py \
+		test/scip/test_scip_query_provider.py \
 		test/facts/test_model.py \
 		test/facts/test_adapters.py \
 		test/scripts/test_profile_fact_batch_buffer.py \
 		test/scripts/test_profile_fact_query_index.py \
+		test/scripts/test_profile_scip_mcp_consumer.py \
 		test/ls_index/test_clangd_fact_query.py
 
 fact-buffer-profile: core-build
@@ -491,6 +499,21 @@ clangd-workload-gate: core-build
 		$(if $(CLANGD_WORKLOAD_GATE_GENERATION_SECONDS),--clangd-generation-seconds "$(CLANGD_WORKLOAD_GATE_GENERATION_SECONDS)",) \
 		--output-json "$(CLANGD_WORKLOAD_GATE_OUTPUT)" \
 		$(CLANGD_WORKLOAD_GATE_EXTRA_ARGS)
+
+scip-mcp-consumer-gate: core-build
+	@test -n "$(SCIP_MCP_CONSUMER_GATE_MANIFEST)" || { echo "Set SCIP_MCP_CONSUMER_GATE_MANIFEST=/path/to/repo_manifest.json" >&2; exit 1; }
+	@test -n "$(SCIP_MCP_CONSUMER_GATE_PROJECT_ROOT)" || { echo "Set SCIP_MCP_CONSUMER_GATE_PROJECT_ROOT=/path/to/repository" >&2; exit 1; }
+	@test -n "$(SCIP_MCP_CONSUMER_GATE_SUBJECT_ID)" || { echo "Set SCIP_MCP_CONSUMER_GATE_SUBJECT_ID=<fixed-subject-id>" >&2; exit 1; }
+	PYTHONPATH="build/core:$$PYTHONPATH" python -m pytest -q \
+		test/scip/test_scip_query_provider.py \
+		test/scripts/test_profile_scip_mcp_consumer.py
+	PYTHONPATH="build/core:$$PYTHONPATH" python scripts/profiling/profile_scip_mcp_consumer.py \
+		--manifest "$(SCIP_MCP_CONSUMER_GATE_MANIFEST)" \
+		--project-root "$(SCIP_MCP_CONSUMER_GATE_PROJECT_ROOT)" \
+		--subject-id "$(SCIP_MCP_CONSUMER_GATE_SUBJECT_ID)" \
+		--subject-manifest "$(SCIP_MCP_CONSUMER_GATE_SUBJECT_MANIFEST)" \
+		--output "$(SCIP_MCP_CONSUMER_GATE_OUTPUT)" \
+		$(SCIP_MCP_CONSUMER_GATE_EXTRA_ARGS)
 
 clangd-fact-generation-profile: core-build
 	@test -n "$(CLANGD_FACT_GENERATION_PROFILE_INDEX_DIR)" || { echo "Set CLANGD_FACT_GENERATION_PROFILE_INDEX_DIR=/path/to/.cache/clangd/index" >&2; exit 1; }

--- a/codenib/scip_interface/scip_query.py
+++ b/codenib/scip_interface/scip_query.py
@@ -12,6 +12,7 @@ match the repository and filter identity recorded by the manifest.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import importlib
 import json
@@ -156,6 +157,24 @@ class FactQueryCandidate:
         """Preserve the FactQueryIndex query protocol for existing consumers."""
 
         return getattr(self.index, name)
+
+
+_FACT_QUERY_RECEIPT_KEYS = frozenset(
+    {
+        "schema_version",
+        "language",
+        "project_root",
+        "manifest",
+        "index",
+        "graph",
+        "fact_query",
+        "source",
+        "filters",
+        "native_input",
+        "filter_identity",
+        "receipt_sha256",
+    }
+)
 
 
 def _reject(message: str) -> FactQueryCandidateRejected:
@@ -1301,6 +1320,246 @@ def load_fact_query_candidate(
     return FactQueryCandidate(index=native.index, receipt=receipt, timings=timings)
 
 
+def observe_fact_query_snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Re-observe every mutable input bound by one admitted receipt.
+
+    The observer deliberately remains graph-free.  A lazy consumer calls it
+    immediately before and after loading the already-persisted ``graph.pkl``;
+    equality of the two returned observations proves that the graph, decoded
+    index, manifest, checkout, filter surface, and language metadata stayed on
+    one generation throughout publication.
+    """
+
+    receipt = _mapping(value, label="FactQuery candidate receipt")
+    _require_exact_keys(
+        receipt,
+        _FACT_QUERY_RECEIPT_KEYS,
+        label="FactQuery candidate receipt",
+    )
+    if (
+        type(receipt.get("schema_version")) is not int
+        or receipt["schema_version"] != FACT_QUERY_RECEIPT_SCHEMA_VERSION
+    ):
+        raise _reject("FactQuery candidate receipt schema is not v1")
+    recorded_digest = _sha256(
+        receipt.get("receipt_sha256"), label="FactQuery receipt_sha256"
+    )
+    unsigned = {
+        key: copy.deepcopy(item)
+        for key, item in receipt.items()
+        if key != "receipt_sha256"
+    }
+    if _canonical_json_digest(unsigned) != recorded_digest:
+        raise _reject("FactQuery candidate receipt digest does not match its fields")
+
+    raw_language = receipt.get("language")
+    if type(raw_language) is not str:
+        raise _reject("FactQuery candidate receipt language is malformed")
+    language = normalize_language(raw_language)
+    if language not in FACT_QUERY_PROMOTED_LANGUAGES or (
+        receipt.get("language") != language
+    ):
+        raise _reject("FactQuery candidate receipt language is not canonical")
+    project_root_value = receipt.get("project_root")
+    if type(project_root_value) is not str or not project_root_value:
+        raise _reject("FactQuery candidate project root is malformed")
+    try:
+        project_root = Path(project_root_value).resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise _reject("FactQuery candidate project root is unavailable") from exc
+    if not project_root.is_dir() or str(project_root) != project_root_value:
+        raise _reject("FactQuery candidate project root is not canonical")
+
+    manifest = _mapping(receipt.get("manifest"), label="FactQuery manifest receipt")
+    manifest_path_value = manifest.get("path")
+    if type(manifest_path_value) is not str or not manifest_path_value:
+        raise _reject("FactQuery manifest receipt path is malformed")
+    raw_manifest_path = Path(manifest_path_value)
+    if raw_manifest_path.is_symlink():
+        raise _reject("FactQuery manifest receipt must name a regular file")
+    try:
+        manifest_path = raw_manifest_path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise _reject("FactQuery manifest receipt is unavailable") from exc
+    if not manifest_path.is_file() or str(manifest_path) != manifest_path_value:
+        raise _reject("FactQuery manifest receipt path is not canonical")
+    manifest_size = _nonnegative_int(
+        manifest.get("size_bytes"), label="FactQuery manifest size_bytes"
+    )
+    manifest_digest = _sha256(manifest.get("sha256"), label="FactQuery manifest sha256")
+    try:
+        observed_manifest = regular_file_fingerprint(manifest_path)
+    except (OSError, ValueError) as exc:
+        raise _reject("FactQuery manifest changed after candidate admission") from exc
+    if observed_manifest != {"size": manifest_size, "sha256": manifest_digest}:
+        raise _reject("FactQuery manifest changed after candidate admission")
+
+    commit = manifest.get("commit")
+    if type(commit) is not str or (commit and _GIT_COMMIT.fullmatch(commit) is None):
+        raise _reject("FactQuery manifest commit is malformed")
+    checkout_head = _checkout_head(project_root)
+    if checkout_head != commit:
+        raise _reject("live repository commit changed after candidate admission")
+
+    entry_path_value = manifest.get("entry_path")
+    if type(entry_path_value) is not str or not entry_path_value:
+        raise _reject("FactQuery manifest entry path is malformed")
+    expected_entry_path = manifest_path.parent / "symbol_graph"
+    if Path(entry_path_value) != expected_entry_path:
+        raise _reject("FactQuery manifest entry path changed after admission")
+    try:
+        entry_path = Path(entry_path_value).resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise _reject("FactQuery symbol graph view is unavailable") from exc
+    if not entry_path.is_dir() or entry_path != expected_entry_path:
+        raise _reject("FactQuery symbol graph view is not canonical")
+
+    index = _mapping(receipt.get("index"), label="FactQuery decoded index receipt")
+    index_relative = _canonical_relative_path(
+        index.get("relative_path"), label="FactQuery decoded index relative_path"
+    )
+    if index_relative != "index.decoded":
+        raise _reject("FactQuery decoded index must be index.decoded")
+    index_size = _nonnegative_int(
+        index.get("size_bytes"), label="FactQuery decoded index size_bytes"
+    )
+    index_digest = _sha256(index.get("sha256"), label="FactQuery decoded index sha256")
+    graph = _mapping(receipt.get("graph"), label="FactQuery graph receipt")
+    graph_relative = _canonical_relative_path(
+        graph.get("relative_path"), label="FactQuery graph relative_path"
+    )
+    if graph_relative != "graph.pkl":
+        raise _reject("FactQuery graph receipt must name graph.pkl")
+    graph_size = _nonnegative_int(
+        graph.get("size_bytes"), label="FactQuery graph size_bytes"
+    )
+    graph_digest = _sha256(graph.get("sha256"), label="FactQuery graph sha256")
+    graph_query_digest = _sha256(
+        graph.get("query_surface_sha256"),
+        label="FactQuery graph query_surface_sha256",
+    )
+
+    index_path = entry_path / index_relative
+    graph_path = entry_path / graph_relative
+    try:
+        observed_index = regular_file_fingerprint(index_path)
+        observed_graph = regular_file_fingerprint(graph_path)
+    except (OSError, ValueError) as exc:
+        raise _reject("FactQuery artifact changed after candidate admission") from exc
+    if observed_index != {"size": index_size, "sha256": index_digest}:
+        raise _reject("FactQuery decoded index changed after candidate admission")
+    if observed_graph != {"size": graph_size, "sha256": graph_digest}:
+        raise _reject("FactQuery graph changed after candidate admission")
+
+    native_input = _validate_input_receipt(
+        receipt.get("native_input"),
+        index_path=index_path,
+        project_root=project_root,
+        language=language,
+    )
+    if native_input["index"] != {
+        "path": str(index_path),
+        "size_bytes": index_size,
+        "sha256": index_digest,
+    }:
+        raise _reject("FactQuery native input no longer matches the decoded index")
+
+    source = _mapping(receipt.get("source"), label="FactQuery source receipt")
+    source_fingerprint = source.get("fingerprint")
+    if (
+        type(source_fingerprint) is not str
+        or _SOURCE_FINGERPRINT.fullmatch(source_fingerprint) is None
+    ):
+        raise _reject("FactQuery source fingerprint is malformed")
+    source_file_count = _nonnegative_int(
+        source.get("file_count"), label="FactQuery source file_count"
+    )
+    filters = _mapping(receipt.get("filters"), label="FactQuery filter receipt")
+    patterns = filters.get("exclude_patterns")
+    if type(patterns) is not list or not all(type(item) is str for item in patterns):
+        raise _reject("FactQuery exclude patterns are malformed")
+    observed_source, allowed_files = _source_and_allowed_files(
+        project_root,
+        cache_root=manifest_path.parent,
+        exclude_patterns=patterns,
+        target_dir=None,
+    )
+    if (
+        observed_source.value != source_fingerprint
+        or observed_source.file_count != source_file_count
+    ):
+        raise _reject("FactQuery repository source changed after candidate admission")
+    allowed_count = _nonnegative_int(
+        filters.get("allowed_file_count"),
+        label="FactQuery filter allowed_file_count",
+    )
+    allowed_digest = _sha256(
+        filters.get("allowed_files_sha256"),
+        label="FactQuery filter allowed_files_sha256",
+    )
+    if len(allowed_files) != allowed_count or (
+        _allowed_files_digest(allowed_files) != allowed_digest
+    ):
+        raise _reject("FactQuery allowed file set changed after candidate admission")
+    if manifest.get("source_fingerprint") != source_fingerprint or (
+        manifest.get("file_count") != source_file_count
+    ):
+        raise _reject("FactQuery manifest/source receipt fields disagree")
+    if manifest.get("query_surface_sha256") != graph_query_digest:
+        raise _reject("FactQuery graph query surface receipt fields disagree")
+
+    try:
+        final_manifest = regular_file_fingerprint(manifest_path)
+        final_index = regular_file_fingerprint(index_path)
+        final_graph = regular_file_fingerprint(graph_path)
+    except (OSError, ValueError) as exc:
+        raise _reject("FactQuery inputs changed during snapshot observation") from exc
+    final_source = fingerprint_repository(
+        project_root,
+        exclude_roots=(manifest_path.parent,),
+    )
+    final_checkout_head = _checkout_head(project_root)
+    if (
+        final_manifest != observed_manifest
+        or final_index != observed_index
+        or final_graph != observed_graph
+        or final_source != observed_source
+        or final_checkout_head != checkout_head
+    ):
+        raise _reject("FactQuery inputs changed during snapshot observation")
+
+    return {
+        "schema_version": FACT_QUERY_RECEIPT_SCHEMA_VERSION,
+        "receipt_sha256": recorded_digest,
+        "language": language,
+        "project_root": str(project_root),
+        "checkout_head": checkout_head,
+        "manifest": {
+            "path": str(manifest_path),
+            "size_bytes": observed_manifest["size"],
+            "sha256": observed_manifest["sha256"],
+        },
+        "index": {
+            "path": str(index_path),
+            "size_bytes": observed_index["size"],
+            "sha256": observed_index["sha256"],
+        },
+        "graph": {
+            "path": str(graph_path),
+            "size_bytes": observed_graph["size"],
+            "sha256": observed_graph["sha256"],
+            "query_surface_sha256": graph_query_digest,
+        },
+        "source": {
+            "fingerprint": observed_source.value,
+            "file_count": observed_source.file_count,
+            "allowed_file_count": len(allowed_files),
+            "allowed_files_sha256": allowed_digest,
+        },
+        "native_metadata": copy.deepcopy(native_input["metadata"]),
+    }
+
+
 __all__ = [
     "FACT_QUERY_ABI_VERSION",
     "FACT_QUERY_CAPABILITIES",
@@ -1314,5 +1573,6 @@ __all__ = [
     "NativeFactQueryIndex",
     "decode_native_fact_query_index",
     "load_fact_query_candidate",
+    "observe_fact_query_snapshot",
     "validate_fact_query_contract",
 ]

--- a/codenib/scip_interface/scip_query_provider.py
+++ b/codenib/scip_interface/scip_query_provider.py
@@ -1,0 +1,656 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental lazy LSP provider over an admitted SCIP FactQueryIndex.
+
+This module is intentionally not connected to the production MCP selector.  It
+keeps symbol-only definition/reference calls graph-free and atomically loads
+the already-persisted graph for position and route calls.  Physical backend
+details remain in :meth:`SCIPHybridQueryProvider.diagnostics`; public LSP
+metadata stays byte-compatible with the established persisted-graph provider.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import threading
+import time
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from ..agent.lsp_provider import (
+    CAPABILITY_DEFINITION,
+    CAPABILITY_REFERENCES,
+    CAPABILITY_ROUTE,
+    STATIC_LSP_PROVIDER,
+    LSPProviderMetadata,
+    LSPProviderNodes,
+    StaticLSPProvider,
+    normalize_lsp_capability,
+)
+from ..compiler.manifest import RepoManifest
+from ..languages import normalize_language
+from .query_surface import query_surface_sha256
+from .scip_query import (
+    FactQueryCandidate,
+    load_fact_query_candidate,
+    observe_fact_query_snapshot,
+)
+
+SCIP_CONSUMER_QUERY_ENV = "CODENIB_SCIP_FACT_QUERY_PROVIDER"
+SCIP_CONSUMER_PROMOTED_LANGUAGES = frozenset()
+
+NATIVE_READY = "NATIVE_READY"
+GRAPH_LOADING = "GRAPH_LOADING"
+GRAPH_READY = "GRAPH_READY"
+FAILED = "FAILED"
+
+_PUBLIC_BACKEND = "persisted-symbol-graph-v1"
+_PUBLIC_BEHAVIOR_CONTRACT = "static_graph_lsp_v1"
+_PHYSICAL_NATIVE_BACKEND = "native-scip-fact-query-v1"
+_PHYSICAL_GRAPH_BACKEND = "lazy-persisted-symbol-graph-v1"
+_MODES = frozenset({"off", "auto", "required"})
+
+GraphLoader = Callable[[Path], Any]
+SnapshotObserver = Callable[[Mapping[str, Any]], Mapping[str, Any]]
+ProviderFactory = Callable[[], Any]
+
+
+def _normalize_mode(value: object) -> str:
+    if type(value) is not str:
+        raise ValueError(f"{SCIP_CONSUMER_QUERY_ENV} must be off, auto, or required")
+    normalized = value.strip().lower()
+    if normalized not in _MODES:
+        raise ValueError(
+            f"{SCIP_CONSUMER_QUERY_ENV} must be off, auto, or required; "
+            f"got {value!r}"
+        )
+    return normalized
+
+
+def scip_consumer_query_mode(
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    """Return the independent, default-off consumer experiment mode."""
+
+    source = os.environ if environ is None else environ
+    return _normalize_mode(source.get(SCIP_CONSUMER_QUERY_ENV, "off"))
+
+
+def _default_graph_loader(path: Path) -> Any:
+    # Keep CodeGraph and igraph absent until an admitted request needs them.
+    from ..graph.code_graph import CodeGraph
+
+    return CodeGraph.load_graph(str(path))
+
+
+def _manifest_language(
+    manifest_path: str | Path,
+    requested_language: str | None,
+) -> str | None:
+    if requested_language is not None:
+        return normalize_language(requested_language)
+    manifest = RepoManifest.load(manifest_path)
+    if len(manifest.languages) != 1:
+        return None
+    return normalize_language(manifest.languages[0])
+
+
+class SCIPHybridQueryProvider:
+    """Serve symbol calls natively with one atomic persisted-graph fallback."""
+
+    provider = STATIC_LSP_PROVIDER
+
+    def __init__(
+        self,
+        candidate: FactQueryCandidate,
+        *,
+        graph_loader: GraphLoader | None = None,
+        snapshot_observer: SnapshotObserver | None = None,
+        public_fallback_reason: str | None = None,
+    ) -> None:
+        self.query_index = candidate.index
+        self._candidate_receipt = copy.deepcopy(candidate.receipt)
+        self._graph_loader = graph_loader or _default_graph_loader
+        self._snapshot_observer = snapshot_observer or observe_fact_query_snapshot
+        self._public_fallback_reason = public_fallback_reason
+
+        manifest = self._receipt_mapping("manifest")
+        graph = self._receipt_mapping("graph")
+        project_root = self._candidate_receipt.get("project_root")
+        language = self._candidate_receipt.get("language")
+        node_count = manifest.get("node_count")
+        edge_count = manifest.get("edge_count")
+        if type(project_root) is not str or not project_root:
+            raise ValueError("FactQuery candidate receipt has no project root")
+        if type(language) is not str or not language:
+            raise ValueError("FactQuery candidate receipt has no language")
+        if type(node_count) is not int or node_count < 0:
+            raise ValueError("FactQuery candidate receipt has no node count")
+        if type(edge_count) is not int or edge_count < 0:
+            raise ValueError("FactQuery candidate receipt has no edge count")
+        query_digest = graph.get("query_surface_sha256")
+        if type(query_digest) is not str or len(query_digest) != 64:
+            raise ValueError("FactQuery candidate receipt has no graph query digest")
+
+        entry_path = manifest.get("entry_path")
+        relative_graph = graph.get("relative_path")
+        if type(entry_path) is not str or not entry_path:
+            raise ValueError("FactQuery candidate receipt has no graph view path")
+        if type(relative_graph) is not str or relative_graph != "graph.pkl":
+            raise ValueError("FactQuery candidate receipt has no graph.pkl binding")
+        graph_root = Path(entry_path).resolve()
+        graph_path = (graph_root / relative_graph).resolve()
+        try:
+            graph_path.relative_to(graph_root)
+        except ValueError as exc:
+            raise ValueError("FactQuery graph path escapes its receipt view") from exc
+
+        self.project_root = project_root
+        self.language = language
+        self.snapshot_id = f"symbol_graph:{project_root}:{node_count}:{edge_count}"
+        self._graph_path = graph_path
+        self._expected_node_count = node_count
+        self._expected_edge_count = edge_count
+        self._expected_query_surface_sha256 = query_digest
+        self._symbol_provider = StaticLSPProvider(
+            self.query_index,
+            snapshot_id=self.snapshot_id,
+            backend=_PUBLIC_BACKEND,
+            fallback_reason=public_fallback_reason,
+        )
+
+        self._condition = threading.Condition(threading.Lock())
+        self._state = NATIVE_READY
+        self._graph_provider: StaticLSPProvider | None = None
+        self._terminal_failure: Exception | None = None
+        self._snapshot_before: dict[str, Any] | None = None
+        self._snapshot_after: dict[str, Any] | None = None
+        self._graph_load_attempt_count = 0
+        self._graph_publication_count = 0
+        self._graph_waiter_count = 0
+        self._native_definition_count = 0
+        self._native_references_count = 0
+        self._fallback_call_count = 0
+        self._graph_materialization_seconds: float | None = None
+        self._receipt_observation_count = 0
+
+    @property
+    def candidate_receipt(self) -> dict[str, Any]:
+        """Return a detached copy of the immutable admission receipt."""
+
+        return copy.deepcopy(self._candidate_receipt)
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return thread-safe physical-backend and publication observations."""
+
+        with self._condition:
+            failure = self._terminal_failure
+            return {
+                "schema_version": 1,
+                "state": self._state,
+                "language": self.language,
+                "logical_backend": _PUBLIC_BACKEND,
+                "native_physical_backend": _PHYSICAL_NATIVE_BACKEND,
+                "fallback_physical_backend": _PHYSICAL_GRAPH_BACKEND,
+                "snapshot_id": self.snapshot_id,
+                "candidate_receipt_sha256": self._candidate_receipt.get(
+                    "receipt_sha256"
+                ),
+                "graph_load_attempt_count": self._graph_load_attempt_count,
+                "graph_load_count": self._graph_load_attempt_count,
+                "graph_publication_count": self._graph_publication_count,
+                "graph_waiter_count": self._graph_waiter_count,
+                "graph_materialization_seconds": (self._graph_materialization_seconds),
+                "receipt_observation_count": self._receipt_observation_count,
+                "native_definition_count": self._native_definition_count,
+                "native_references_count": self._native_references_count,
+                "native_symbol_call_count": (
+                    self._native_definition_count + self._native_references_count
+                ),
+                "fallback_call_count": self._fallback_call_count,
+                "graph_fallback_count": self._fallback_call_count,
+                "graph_call_count": self._fallback_call_count,
+                "snapshot_before": copy.deepcopy(self._snapshot_before),
+                "snapshot_after": copy.deepcopy(self._snapshot_after),
+                "terminal_failure": (
+                    {
+                        "type": type(failure).__name__,
+                        "message": str(failure),
+                    }
+                    if failure is not None
+                    else None
+                ),
+            }
+
+    def can_serve(self, capability: str) -> LSPProviderMetadata:
+        """Advertise the complete logical provider without loading the graph."""
+
+        normalized = normalize_lsp_capability(capability)
+        with self._condition:
+            if self._state == FAILED:
+                return self._metadata(
+                    normalized,
+                    status="unavailable",
+                    fallback_reason="scip_provider_terminal_failure",
+                )
+        if normalized not in {
+            CAPABILITY_DEFINITION,
+            CAPABILITY_REFERENCES,
+            CAPABILITY_ROUTE,
+        }:
+            return self._metadata(
+                normalized,
+                status="unsupported",
+                fallback_reason="unsupported_capability",
+            )
+        return self._metadata(normalized, status="ok")
+
+    def definition(self, **arguments: Any) -> LSPProviderNodes:
+        """Use native symbol lookup or the atomic graph fallback."""
+
+        if arguments.get("symbol"):
+            self._begin_symbol_call("definition")
+            return self._symbol_provider.definition(**arguments)
+        self._require_not_failed()
+        if not arguments.get("file_path") or arguments.get("line") is None:
+            raise ValueError(
+                "lsp_definition requires either symbol or file_path + line"
+            )
+        return self._fallback("definition", arguments)
+
+    def references(self, **arguments: Any) -> LSPProviderNodes:
+        """Use native symbol lookup or the atomic graph fallback."""
+
+        if arguments.get("symbol"):
+            self._begin_symbol_call("references")
+            return self._symbol_provider.references(**arguments)
+        self._require_not_failed()
+        if not arguments.get("file_path") or arguments.get("line") is None:
+            raise ValueError(
+                "lsp_references requires either symbol or file_path + line"
+            )
+        return self._fallback("references", arguments)
+
+    def route(self, **arguments: Any) -> LSPProviderNodes:
+        """Use the complete graph for non-empty route requests."""
+
+        self._require_not_failed()
+        if not (arguments.get("symbols") or []) and not arguments.get("query"):
+            return LSPProviderNodes(
+                [],
+                metadata=self._metadata(
+                    CAPABILITY_ROUTE,
+                    status="ok",
+                    position_granularity="symbol",
+                ),
+            )
+        return self._fallback("route", arguments)
+
+    def _fallback(
+        self,
+        capability: str,
+        arguments: Mapping[str, Any],
+    ) -> LSPProviderNodes:
+        with self._condition:
+            self._fallback_call_count += 1
+        provider, before = self._full_graph_provider()
+        with self._condition:
+            if self._state == FAILED:
+                self._raise_terminal_failure()
+            self._snapshot_before = copy.deepcopy(before)
+
+        result: LSPProviderNodes | None = None
+        query_failure: Exception | None = None
+        try:
+            result = getattr(provider, capability)(**dict(arguments))
+        except Exception as exc:
+            query_failure = exc
+
+        self._complete_graph_query(provider, before)
+        if query_failure is not None:
+            raise query_failure
+        assert result is not None
+        return result
+
+    def _full_graph_provider(
+        self,
+    ) -> tuple[StaticLSPProvider, dict[str, Any]]:
+        published_provider: StaticLSPProvider | None = None
+        published_snapshot: dict[str, Any] | None = None
+        with self._condition:
+            if self._state == GRAPH_READY:
+                assert self._graph_provider is not None
+                assert self._snapshot_after is not None
+                published_provider = self._graph_provider
+                published_snapshot = copy.deepcopy(self._snapshot_after)
+            if self._state == FAILED:
+                self._raise_terminal_failure()
+            if self._state == GRAPH_LOADING:
+                self._graph_waiter_count += 1
+                while self._state == GRAPH_LOADING:
+                    self._condition.wait()
+                if self._state == GRAPH_READY:
+                    assert self._graph_provider is not None
+                    assert self._snapshot_after is not None
+                    published_provider = self._graph_provider
+                    published_snapshot = copy.deepcopy(self._snapshot_after)
+                else:
+                    self._raise_terminal_failure()
+            if published_provider is None and self._state != NATIVE_READY:
+                raise RuntimeError(f"unknown SCIP provider state: {self._state}")
+            if published_provider is None:
+                self._state = GRAPH_LOADING
+                self._graph_load_attempt_count += 1
+
+        if published_provider is not None:
+            assert published_snapshot is not None
+            return self._revalidate_published_provider(
+                published_provider,
+                published_snapshot,
+            )
+
+        before: dict[str, Any] | None = None
+        after: dict[str, Any] | None = None
+        try:
+            before = self._observe_snapshot()
+            materialization_started = time.perf_counter()
+            try:
+                graph = self._graph_loader(self._graph_path)
+                self._validate_loaded_graph(graph)
+            finally:
+                materialization_seconds = time.perf_counter() - materialization_started
+                with self._condition:
+                    if self._graph_materialization_seconds is None:
+                        self._graph_materialization_seconds = materialization_seconds
+            after = self._observe_snapshot()
+            if after != before:
+                raise RuntimeError("FactQuery snapshot changed during lazy graph load")
+            graph_provider = StaticLSPProvider(
+                graph,
+                snapshot_id=self.snapshot_id,
+                backend=_PUBLIC_BACKEND,
+                fallback_reason=self._public_fallback_reason,
+            )
+        except Exception as exc:
+            with self._condition:
+                if before is not None:
+                    self._snapshot_before = copy.deepcopy(before)
+                if after is not None:
+                    self._snapshot_after = copy.deepcopy(after)
+                failure = self._set_terminal_failure_locked(exc)
+            raise failure
+
+        with self._condition:
+            self._snapshot_before = before
+            self._snapshot_after = after
+            self._graph_provider = graph_provider
+            self._graph_publication_count += 1
+            self._state = GRAPH_READY
+            self._condition.notify_all()
+            assert after is not None
+            return graph_provider, copy.deepcopy(after)
+
+    def _revalidate_published_provider(
+        self,
+        provider: StaticLSPProvider,
+        published_snapshot: Mapping[str, Any],
+    ) -> tuple[StaticLSPProvider, dict[str, Any]]:
+        try:
+            observed = self._observe_snapshot()
+        except Exception as exc:
+            with self._condition:
+                if self._state != FAILED:
+                    self._snapshot_after = {
+                        "observation_error": {
+                            "type": type(exc).__name__,
+                            "message": str(exc),
+                        }
+                    }
+                failure = self._set_terminal_failure_locked(exc)
+            raise failure
+
+        with self._condition:
+            if self._state == FAILED:
+                self._raise_terminal_failure()
+            if self._state != GRAPH_READY or self._graph_provider is not provider:
+                raise RuntimeError("SCIP graph provider changed during revalidation")
+            if observed != published_snapshot:
+                self._snapshot_after = copy.deepcopy(observed)
+                failure = self._set_terminal_failure_locked(
+                    RuntimeError(
+                        "FactQuery snapshot changed after lazy graph publication"
+                    )
+                )
+                raise failure
+            self._snapshot_after = copy.deepcopy(observed)
+            return provider, copy.deepcopy(observed)
+
+    def _complete_graph_query(
+        self,
+        provider: StaticLSPProvider,
+        before: Mapping[str, Any],
+    ) -> None:
+        try:
+            after = self._observe_snapshot()
+        except Exception as exc:
+            with self._condition:
+                if self._state != FAILED:
+                    self._snapshot_after = {
+                        "observation_error": {
+                            "type": type(exc).__name__,
+                            "message": str(exc),
+                        }
+                    }
+                failure = self._set_terminal_failure_locked(exc)
+            raise failure
+
+        with self._condition:
+            if self._state == FAILED:
+                self._raise_terminal_failure()
+            if self._state != GRAPH_READY or self._graph_provider is not provider:
+                failure = self._set_terminal_failure_locked(
+                    RuntimeError("SCIP graph provider changed during query execution")
+                )
+                raise failure
+            self._snapshot_after = copy.deepcopy(after)
+            if after != before:
+                failure = self._set_terminal_failure_locked(
+                    RuntimeError("FactQuery snapshot changed during graph query")
+                )
+                raise failure
+
+    def _observe_snapshot(self) -> dict[str, Any]:
+        with self._condition:
+            self._receipt_observation_count += 1
+        observed = self._snapshot_observer(copy.deepcopy(self._candidate_receipt))
+        if not isinstance(observed, Mapping):
+            raise RuntimeError("FactQuery snapshot observer returned a non-mapping")
+        return copy.deepcopy(dict(observed))
+
+    def _validate_loaded_graph(self, graph: Any) -> None:
+        storage = getattr(graph, "graph", None)
+        vcount = getattr(storage, "vcount", None)
+        ecount = getattr(storage, "ecount", None)
+        if not callable(vcount) or not callable(ecount):
+            raise RuntimeError("lazy graph loader returned an incompatible graph")
+        if int(vcount()) != self._expected_node_count or (
+            int(ecount()) != self._expected_edge_count
+        ):
+            raise RuntimeError("lazy graph shape does not match the candidate receipt")
+        loaded_root = getattr(graph, "project_root", None)
+        if (
+            loaded_root is None
+            or Path(str(loaded_root)).resolve() != Path(self.project_root).resolve()
+        ):
+            raise RuntimeError("lazy graph project root does not match the receipt")
+        if query_surface_sha256(graph) != self._expected_query_surface_sha256:
+            raise RuntimeError("lazy graph query surface does not match the receipt")
+
+    def _receipt_mapping(self, key: str) -> Mapping[str, Any]:
+        value = self._candidate_receipt.get(key)
+        if not isinstance(value, Mapping):
+            raise ValueError(f"FactQuery candidate receipt {key!r} is malformed")
+        return value
+
+    def _metadata(
+        self,
+        capability: str,
+        *,
+        status: str,
+        fallback_reason: str | None = None,
+        position_granularity: str = "line",
+    ) -> LSPProviderMetadata:
+        methods = {
+            CAPABILITY_DEFINITION: "textDocument/definition",
+            CAPABILITY_REFERENCES: "textDocument/references",
+            CAPABILITY_ROUTE: "codenib/lspRoute",
+        }
+        return LSPProviderMetadata(
+            provider=STATIC_LSP_PROVIDER,
+            capability=capability,
+            status=status,
+            lsp_method=methods.get(capability, capability),
+            backend=_PUBLIC_BACKEND,
+            index_snapshot=self.snapshot_id,
+            fallback_reason=(
+                fallback_reason
+                if fallback_reason is not None
+                else self._public_fallback_reason
+            ),
+            behavior_contract=_PUBLIC_BEHAVIOR_CONTRACT,
+            position_granularity=position_granularity,
+        )
+
+    def _raise_terminal_failure(self) -> None:
+        failure = self._terminal_failure
+        if failure is None:
+            raise RuntimeError("SCIP provider failed without a cached error")
+        raise failure
+
+    def _require_not_failed(self) -> None:
+        with self._condition:
+            if self._state == FAILED:
+                self._raise_terminal_failure()
+
+    def _begin_symbol_call(self, capability: str) -> None:
+        with self._condition:
+            while self._state == GRAPH_LOADING:
+                self._condition.wait()
+            if self._state == FAILED:
+                self._raise_terminal_failure()
+            if capability == "definition":
+                self._native_definition_count += 1
+            elif capability == "references":
+                self._native_references_count += 1
+            else:  # pragma: no cover - private invariant
+                raise RuntimeError(f"unknown native symbol capability: {capability}")
+
+    def _set_terminal_failure_locked(self, failure: Exception) -> Exception:
+        if self._state != FAILED:
+            self._terminal_failure = failure
+            self._state = FAILED
+            self._condition.notify_all()
+        assert self._terminal_failure is not None
+        return self._terminal_failure
+
+
+def load_scip_query_provider(
+    manifest_path: str | Path,
+    *,
+    language: str | None = None,
+    project_root: str | Path | None = None,
+    core_module: Any | None = None,
+    graph_loader: GraphLoader | None = None,
+    snapshot_observer: SnapshotObserver | None = None,
+    public_fallback_reason: str | None = None,
+) -> SCIPHybridQueryProvider:
+    """Load the required candidate path without making a fallback decision."""
+
+    candidate = load_fact_query_candidate(
+        manifest_path,
+        language=language,
+        project_root=project_root,
+        core_module=core_module,
+    )
+    return SCIPHybridQueryProvider(
+        candidate,
+        graph_loader=graph_loader,
+        snapshot_observer=snapshot_observer,
+        public_fallback_reason=public_fallback_reason,
+    )
+
+
+def select_scip_query_provider(
+    manifest_path: str | Path,
+    *,
+    legacy_provider_factory: ProviderFactory,
+    mode: str | None = None,
+    language: str | None = None,
+    project_root: str | Path | None = None,
+    core_module: Any | None = None,
+    graph_loader: GraphLoader | None = None,
+    snapshot_observer: SnapshotObserver | None = None,
+    public_fallback_reason: str | None = None,
+) -> Any:
+    """Select an experimental startup provider without wrapping later calls.
+
+    Only candidate construction is eligible for ``auto`` fallback.  Once this
+    function publishes a :class:`SCIPHybridQueryProvider`, any later receipt or
+    lazy-loader failure remains terminal and cannot switch generations.
+    """
+
+    selected_mode = (
+        scip_consumer_query_mode() if mode is None else _normalize_mode(mode)
+    )
+    if selected_mode == "off":
+        return legacy_provider_factory()
+    if selected_mode == "auto":
+        try:
+            candidate_language = _manifest_language(manifest_path, language)
+        except MemoryError:
+            raise
+        except Exception:
+            return legacy_provider_factory()
+        if candidate_language not in SCIP_CONSUMER_PROMOTED_LANGUAGES:
+            return legacy_provider_factory()
+        try:
+            return load_scip_query_provider(
+                manifest_path,
+                language=language,
+                project_root=project_root,
+                core_module=core_module,
+                graph_loader=graph_loader,
+                snapshot_observer=snapshot_observer,
+                public_fallback_reason=public_fallback_reason,
+            )
+        except MemoryError:
+            raise
+        except Exception:
+            return legacy_provider_factory()
+    return load_scip_query_provider(
+        manifest_path,
+        language=language,
+        project_root=project_root,
+        core_module=core_module,
+        graph_loader=graph_loader,
+        snapshot_observer=snapshot_observer,
+        public_fallback_reason=public_fallback_reason,
+    )
+
+
+__all__ = [
+    "FAILED",
+    "GRAPH_LOADING",
+    "GRAPH_READY",
+    "NATIVE_READY",
+    "SCIP_CONSUMER_PROMOTED_LANGUAGES",
+    "SCIP_CONSUMER_QUERY_ENV",
+    "SCIPHybridQueryProvider",
+    "load_scip_query_provider",
+    "scip_consumer_query_mode",
+    "select_scip_query_provider",
+]

--- a/core/README.md
+++ b/core/README.md
@@ -66,8 +66,9 @@ the Python `igraph` wheel.
 
 `make core-test` is also the maintained native gate used by trusted full CI.
 It runs every C++ test executable, verifies that the built extension exports
-the required clangd query ABI, and then runs the SCIP, Fact, clangd, and
-profiling-contract Python tests with `build/core` first on `PYTHONPATH`.
+the required clangd query ABI, and then runs the SCIP, Fact, lazy SCIP provider,
+consumer-profiler, clangd, and profiling-contract Python tests with
+`build/core` first on `PYTHONPATH`.
 
 Some parity tests use generated SCIP integration fixtures and are skipped when
 those caches are absent. Always inspect the skip report from `make core-test`.
@@ -154,6 +155,36 @@ serial filtered query-surface digest and every incoming reference has an
 allowed source anchor; it is never inferred from the native index alone. The
 first candidate contract admits Python and Rust only. This admission layer
 does not enable an MCP route or make an end-to-end performance claim.
+
+### SCIP MCP Consumer Experiment
+
+`load_scip_query_provider()` keeps admitted symbol definition/reference calls
+on `FactQueryIndex` and atomically lazy-loads the bound persisted graph for
+position and route calls. Invalid shapes do not load the graph, concurrent
+first fallback publishes one complete provider, later symbol calls stay
+native, and snapshot or loader failures are terminal. Canonically normalized
+public MCP JSON remains identical to the persisted-graph provider; physical
+routing is diagnostic-only. The gate compares complete tool-result payloads,
+not raw JSON-RPC transport envelopes.
+
+The experimental selector is not connected to production `ServerContext`.
+`CODENIB_SCIP_FACT_QUERY_PROVIDER` defaults to `off`; `auto` is limited to a
+separate consumer-promoted language set and `required` fails closed. The fixed
+Python and Rust consumer gates preserved exact behavior and all safety gates,
+but both missed the required 20% p50 and p95 improvement. The promoted set
+therefore remains empty and production routing is unchanged. Reproduce one
+fixed subject at a time with:
+
+```bash
+make scip-mcp-consumer-gate \
+  SCIP_MCP_CONSUMER_GATE_MANIFEST=/path/to/repo_manifest.json \
+  SCIP_MCP_CONSUMER_GATE_PROJECT_ROOT=/path/to/clean/checkout \
+  SCIP_MCP_CONSUMER_GATE_SUBJECT_ID=python-codenib \
+  SCIP_MCP_CONSUMER_GATE_OUTPUT=/tmp/scip-mcp-python.json
+```
+
+Use `rust-ruff` and the corresponding Ruff paths for the Rust run. The durable
+multi-language roadmap records exact timings, revisions, and receipts.
 
 ## Native clangd Symbol, Position, And Route Queries
 

--- a/core/scip_decode_rust.cpp
+++ b/core/scip_decode_rust.cpp
@@ -113,6 +113,32 @@ std::string strip_comment(std::string value) {
   return value;
 }
 
+bool proven_unrelated_array_table(const std::string &raw_section) {
+  const auto section = trim(raw_section);
+  if (section.empty())
+    return false;
+
+  std::size_t start = 0;
+  while (start <= section.size()) {
+    const auto dot = section.find('.', start);
+    const auto end = dot == std::string::npos ? section.size() : dot;
+    const auto component = section.substr(start, end - start);
+    if (component.empty() || component == "package" ||
+        component == "workspace" ||
+        !std::all_of(component.begin(), component.end(), [](char character) {
+          const auto byte = static_cast<unsigned char>(character);
+          return std::isalnum(byte) != 0 || character == '_' ||
+                 character == '-';
+        })) {
+      return false;
+    }
+    if (dot == std::string::npos)
+      break;
+    start = dot + 1;
+  }
+  return true;
+}
+
 bool parse_basic_string(const std::string &raw, std::string &output) {
   const auto value = trim(raw);
   if (value.size() < 2 || value.front() != '"')
@@ -176,6 +202,21 @@ MinimalCargoToml parse_cargo_toml(const std::string &content) {
     std::string trimmed = trim(strip_comment(line));
     if (trimmed.empty())
       continue;
+
+    if (trimmed.rfind("[[", 0) == 0) {
+      if (trimmed.size() < 5 ||
+          trimmed.compare(trimmed.size() - 2, 2, "]]") != 0) {
+        result.complete = false;
+      } else {
+        const auto array_section = trimmed.substr(2, trimmed.size() - 4);
+        if (!proven_unrelated_array_table(array_section))
+          result.complete = false;
+      }
+      // Keys in a proven-unrelated array-of-tables must not be interpreted as
+      // package or workspace metadata.
+      section = "__unrelated_array_table__";
+      continue;
+    }
 
     if (trimmed.front() == '[') {
       auto close = trimmed.find(']');

--- a/core/tests/scip_decode_test.cpp
+++ b/core/tests/scip_decode_test.cpp
@@ -468,11 +468,14 @@ int main(int argc, char **argv) {
   std::filesystem::create_directories(rust_root / "crates/b", rust_error);
   assert(!rust_error);
   write_text_file(rust_root / "Cargo.toml",
-                  "[workspace]\nmembers = [\n  \"crates/*\",\n]\n");
+                  "[workspace]\nmembers = [\n  \"crates/*\",\n]\n"
+                  "[[bench]]\nname = \"workspace-bench\"\n");
   write_text_file(rust_root / "crates/a/Cargo.toml",
-                  "[package]\nname = \"alpha\"\n");
+                  "[package]\nname = \"alpha\"\n"
+                  "[[bench]]\nname = \"alpha-bench\"\n");
   write_text_file(rust_root / "crates/b/Cargo.toml",
-                  "[package]\nname = \"beta\"\n");
+                  "[package]\nname = \"beta\"\n"
+                  "[[test]]\nname = \"beta-test\"\n");
   codenib::core::SCIPRustDecoder rust_decoder(index_path.string(),
                                               rust_root.string());
   (void)rust_decoder.decode_records();
@@ -530,6 +533,24 @@ int main(int argc, char **argv) {
 
   write_text_file(rust_root / "Cargo.toml",
                   "[\"workspace\"]\nmembers = [\"crates/a\"]\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+
+  write_text_file(rust_root / "Cargo.toml",
+                  "[workspace]\nmembers = [\"crates/a\"]\n"
+                  "[[workspace]]\nmembers = [\"crates/b\"]\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+
+  write_text_file(rust_root / "Cargo.toml",
+                  "[workspace]\nmembers = [\"crates/a\"]\n"
+                  "[[package.metadata]]\nname = \"ambiguous\"\n");
+  (void)rust_decoder.decode_records();
+  assert(!rust_decoder.last_input_receipt().metadata_complete);
+
+  write_text_file(rust_root / "Cargo.toml",
+                  "[workspace]\nmembers = [\"crates/a\"]\n"
+                  "[[bench]\nname = \"malformed\"\n");
   (void)rust_decoder.decode_records();
   assert(!rust_decoder.last_input_receipt().metadata_complete);
 

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -177,6 +177,54 @@ metadata contracts remain future work. The legacy `decode()` graph path
 remains unchanged, and this candidate is not a production MCP route until the
 separate consumer-boundary gate passes exact parity and the required speedup.
 
+### Lazy SCIP MCP consumer gate
+
+`load_scip_query_provider()` wraps one admitted Python or Rust
+`FactQueryIndex` with the existing persisted-graph provider. Symbol-shaped
+definition and reference requests stay native. Position-shaped definition and
+reference requests plus route requests revalidate the bound snapshot and
+lazily publish `graph.pkl` through one
+`NATIVE_READY -> GRAPH_LOADING -> GRAPH_READY | FAILED` condition state
+machine. Invalid request shapes fail before graph loading, concurrent first
+fallback materializes the graph once, and successful symbol calls remain
+native after publication. Loader and receipt failures are sticky, while
+`MemoryError` propagates unchanged. Public backend, fallback, snapshot,
+result, error, order, ambiguity, and metadata remain identical to the
+persisted-graph provider under canonical JSON serialization of the complete
+MCP tool-result payload. The gate does not claim raw JSON-RPC envelope byte
+parity; physical routing and counters are available only through diagnostics.
+
+`select_scip_query_provider()` is an experimental selector and is not wired
+into production `ServerContext`. `CODENIB_SCIP_FACT_QUERY_PROVIDER=off`, the
+default, selects the legacy provider. `auto` may fall back only during
+candidate startup and only for the independent consumer-promoted language
+set; `required` fails closed during startup. Once a candidate is published,
+later snapshot or lazy-load failures always fail closed. The consumer-promoted
+set remains empty because neither fixed subject passed the consumer-boundary
+performance gate, so production MCP and agent routing is unchanged.
+
+The fixed gate runs 20 measured samples per arm after four warmups, uses a
+fresh process for every balanced ABBA sample, and exercises 100 symbol seeds.
+Only symbol-only p50 and nearest-rank p95 participate in the 20% performance
+decision. Position-first, route-first, mixed, and 16-thread first-fallback
+workloads are correctness gates. Run each fixed subject separately:
+
+```bash
+make scip-mcp-consumer-gate \
+  SCIP_MCP_CONSUMER_GATE_MANIFEST=/path/to/repo_manifest.json \
+  SCIP_MCP_CONSUMER_GATE_PROJECT_ROOT=/path/to/clean/checkout \
+  SCIP_MCP_CONSUMER_GATE_SUBJECT_ID=python-codenib \
+  SCIP_MCP_CONSUMER_GATE_OUTPUT=/tmp/scip-mcp-python.json
+```
+
+Repeat with the Ruff paths, `SCIP_MCP_CONSUMER_GATE_SUBJECT_ID=rust-ruff`, and
+a distinct output file. The versioned subject manifest pins both repositories
+to full commits. Rust admission accepts syntactically proven unrelated Cargo
+array tables such as `[[bench]]` and `[[test]]`; malformed or
+package/workspace-relevant array tables still make the receipt incomplete and
+fail closed. Exact measurements and artifact receipts are recorded in the
+multi-language roadmap.
+
 ## Native clangd Symbol, Position, And Route Queries
 
 The C/C++ query-specific path starts from an existing project-local clangd

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -1141,11 +1141,79 @@ reference has an allowed source anchor. The first admitted languages are
 Python and Rust. This is safety/admission work only: it does not enable an MCP
 route and does not replace the M2 consumer-boundary measurement in #598.
 
-Production integration and additional FactQueryIndex languages get focused
-issues only after #598 passes for the relevant language. Warm-session
-incremental parse-tree reuse is timeboxed only after #600 records the bounded
-batch decision, especially if batching fails its gate. Storage RFC #199 and
-Guardian #309 remain independent programs.
+M2 implementation and gate status
+([#598](https://github.com/sysevol-ai/CodeNib/issues/598)): the experimental
+provider keeps symbol-shaped definitions and references on the admitted native
+index and revalidates the bound snapshot before atomically lazy-loading the
+existing `graph.pkl` for position and route calls. One condition state machine
+publishes a complete graph provider once; invalid shapes do not trigger the
+loader, concurrent callers reuse the publication, and symbol calls remain
+native afterward. Snapshot and loader failures are sticky, `MemoryError`
+propagates unchanged, and canonically normalized public payloads and
+persisted-graph metadata remain identical across arms.
+The independent runtime mode defaults to `off`; the selector is not connected
+to production `ServerContext`.
+
+The formal `scip_mcp_consumer_gate_v1` run on August 11, 2026 used benchmark
+commit `d7dab128ca3ed320111f7ac293bf43902abb4c7e`, 20 measured samples per arm
+after four warmups, a fresh process for every balanced ABBA sample, and 100
+seeds: 17 each canonical, display, bare, and quoted, plus 16 each ambiguous
+and missing. Each seed issued one definition and both reference declaration modes.
+The promotion rule independently required candidate symbol-only p50 and
+nearest-rank p95 to be no more than 80% of legacy. Position-first, route-first,
+mixed, and 16-thread concurrent first-fallback workloads were correctness-only
+gates. Filesystem page cache remained uncontrolled.
+
+| Subject | Legacy p50 / p95 | Candidate p50 / p95 | p50 / p95 improvement | Decision |
+| --- | ---: | ---: | ---: | --- |
+| CodeNib Python `6cf61b08310e165574c52fa217c66f0b6ae2a36d` | 1.417629s / 2.009662s | 2.456498s / 2.569240s | -73.282% / -27.844% | reject promotion |
+| Ruff Rust `75a24bbc67aa31b825b6326cfb6e6afdf3ca90d5` | 2.217309s / 2.702742s | 6.545577s / 7.005324s | -195.204% / -159.193% | reject promotion |
+
+Negative improvement denotes a regression. The exact artifact identities were:
+
+- CodeNib: 19,200 vertices and 90,102 edges; 82,776,883-byte
+  `index.decoded` SHA-256
+  `bcaebd3d5a053d0a9bcc70f840bb7fdc7c0ed3eafb64beb515cb5e7236e3f548`;
+  6,099,865-byte `graph.pkl` SHA-256
+  `7de7b0dde8c8d63cf44ebd2678922255867540edc757531c86b17b2e5262f870`;
+  query-surface SHA-256
+  `8f006b89bb41cdfbefae65a1efd118ca9c73c8ece50f92a9899f23aed255ab8b`;
+  candidate receipt
+  `4e601db58e7a5d3b6d988ccf5494956dc551dd58c565160dace29acd6dbb3ad9`;
+  raw report SHA-256
+  `af8404dcc2b64547279cdb27fb3241977c3957a0580c36e55750567bedb2ff4b`.
+- Ruff: 31,837 vertices and 231,458 edges; 130,542,689-byte
+  `index.decoded` SHA-256
+  `9f17e90da1ac0cdecb1754e235c525cad0f95dfe1aae9ce29180f8545edaa40d`;
+  13,388,156-byte `graph.pkl` SHA-256
+  `6dc1743e39a201d7fd0aa65495240fe3478c7b3834645db9cb7f642088e30d36`;
+  query-surface SHA-256
+  `5870b26c99e76186d64bd321650c3c4cec5921e110e76b93e4044e7ad128d28b`;
+  candidate receipt
+  `1d3ec1bfc6cd9f00e78743453c0b3ea574c696a81ca3f0aa59236c6ae94975bc`;
+  raw report SHA-256
+  `aff1dc4e6dcfa581a540a574223d6e0aba9b414ca8b9153ee344010d7a1e82c7`.
+
+For both languages, exact public result, error, order, ambiguity, and metadata
+parity passed under canonical JSON serialization of the complete MCP
+tool-result payload; raw JSON-RPC envelope byte parity was not claimed.
+Symbol-only candidate runs imported no Python igraph and recorded zero graph
+loads and fallbacks. Position-first,
+route-first, mixed, 16-thread exactly-once publication, immutable input and
+benchmark receipts, clean before/after identities, canonical protocol, and
+process isolation all passed. Only the multiplicative p50 and p95 gates failed.
+The raw machine JSON is not versioned; the report hashes above and the #598
+issue record identify it.
+
+Python and Rust are decided independently, but neither qualified. The
+consumer-promoted set therefore remains empty, production `ServerContext`, MCP,
+and agent routing for these Python/Rust SCIP paths stay on persisted
+`CodeGraph`, and #598 is a measured negative promotion decision rather than
+unfinished integration work. The ordered next issue is
+[#599](https://github.com/sysevol-ai/CodeNib/issues/599), which defines the
+repository-level chunk successor gate without adding a C++ batch implementation
+or production route. #600 remains the bounded repository-native implementation
+experiment. Storage RFC #199 and Guardian #309 remain independent programs.
 
 ## PR And Issue Flow
 
@@ -1182,6 +1250,8 @@ Current issue triage notes through August 11, 2026:
   explore/session ledger merged.
 - #558 is closed with exact parity but a negative per-file native chunking
   result; repository batching is tracked separately by #599/#600.
+- #598 is resolved with exact parity and safety but negative Python and Rust
+  consumer performance gates. No language is promoted; #599 is next.
 - #601 is the open tracker for consumer-boundary acceleration follow-up work.
 - #133 is closed. Its query-time skill-selection runtime landed through #149
   and the subsequent agent-runtime refactor; the original fitted A0--A6 table

--- a/scripts/profiling/profile_scip_mcp_consumer.py
+++ b/scripts/profiling/profile_scip_mcp_consumer.py
@@ -1,0 +1,1667 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-isolated promotion gate for the lazy SCIP MCP consumer.
+
+Only the graph-free ``symbol_only`` workload participates in the performance
+decision.  Position, route, mixed, and concurrent-first-fallback workloads are
+correctness observations.  Every arm sample runs in a fresh process so Python
+module state and graph materialization cannot leak between samples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_CORE_BUILD = _PROJECT_ROOT / "build/core"
+_DEFAULT_SUBJECT_MANIFEST = Path(__file__).with_name("scip_mcp_consumer_subjects.json")
+for _candidate in (_CORE_BUILD, _PROJECT_ROOT):
+    if str(_candidate) not in sys.path:
+        sys.path.insert(0, str(_candidate))
+
+DEFAULT_ITERATIONS = 20
+DEFAULT_WARMUPS = 4
+DEFAULT_QUERY_WORKLOAD_SIZE = 100
+DEFAULT_PROMOTION_THRESHOLD = 0.20
+DEFAULT_CONCURRENCY_WORKERS = 16
+DEFAULT_WORKER_TIMEOUT = 900.0
+PERFORMANCE_WORKLOAD = "symbol_only"
+CORRECTNESS_WORKLOADS = ("position_first", "route_first", "mixed")
+WORKLOADS = (PERFORMANCE_WORKLOAD, *CORRECTNESS_WORKLOADS)
+CONCURRENT_WORKLOAD = "concurrent_first_fallback"
+_ARMS = ("legacy", "candidate")
+_SYMBOL_QUERY_CATEGORIES = (
+    "canonical",
+    "display",
+    "bare",
+    "quoted",
+    "ambiguous",
+    "missing",
+)
+_MEMORY_ERROR_EXIT = 70
+_SHA256_RE = re.compile(r"(?:sha256:)?[0-9a-f]{64}\Z")
+_COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z")
+
+
+def _json_digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _file_receipt(path: Path) -> dict[str, Any]:
+    from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
+
+    raw_path = Path(path)
+    try:
+        if raw_path.is_symlink():
+            raise ValueError(f"benchmark artifact is a symlink: {raw_path}")
+        fingerprint = regular_file_fingerprint(raw_path)
+        resolved = raw_path.resolve(strict=True)
+    except OSError as exc:
+        raise ValueError(f"benchmark artifact is unavailable: {raw_path}") from exc
+    return {
+        "path": str(resolved),
+        "size_bytes": fingerprint["size"],
+        "sha256": fingerprint["sha256"],
+    }
+
+
+def _finite_nonnegative(value: object, *, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{label} must be a number")
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        raise ValueError(f"{label} must be finite and non-negative")
+    return number
+
+
+def _nearest_rank_p95(ordered: Sequence[float]) -> float:
+    if not ordered:
+        raise ValueError("at least one sample is required")
+    return ordered[math.ceil(0.95 * len(ordered)) - 1]
+
+
+def _summarize(values: Sequence[float | int]) -> dict[str, float | int]:
+    if not values:
+        raise ValueError("at least one numeric sample is required")
+    ordered = sorted(
+        _finite_nonnegative(value, label=f"sample[{index}]")
+        for index, value in enumerate(values)
+    )
+    return {
+        "samples": len(ordered),
+        "min": ordered[0],
+        "p50": statistics.median(ordered),
+        "p95": _nearest_rank_p95(ordered),
+        "max": ordered[-1],
+    }
+
+
+def _abba_schedule(samples_per_arm: int) -> list[dict[str, Any]]:
+    if isinstance(samples_per_arm, bool) or samples_per_arm < 0:
+        raise ValueError("samples_per_arm must be a non-negative even integer")
+    if samples_per_arm % 2:
+        raise ValueError("samples_per_arm must be even for balanced ABBA blocks")
+    schedule: list[dict[str, Any]] = []
+    for block in range(samples_per_arm // 2):
+        arms = (
+            ("legacy", "candidate", "candidate", "legacy")
+            if block % 2 == 0
+            else ("candidate", "legacy", "legacy", "candidate")
+        )
+        for slot, arm in enumerate(arms):
+            schedule.append({"block": block, "slot": slot, "arm": arm})
+    return schedule
+
+
+def _promotion_decision(
+    legacy: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    *,
+    threshold: float,
+    parity: bool,
+    graph_free: bool,
+) -> dict[str, Any]:
+    if not 0 <= threshold < 1:
+        raise ValueError("promotion threshold must be in [0, 1)")
+    ratio = 1.0 - threshold
+    legacy_p50 = _finite_nonnegative(legacy.get("p50"), label="legacy p50")
+    candidate_p50 = _finite_nonnegative(candidate.get("p50"), label="candidate p50")
+    legacy_p95 = _finite_nonnegative(legacy.get("p95"), label="legacy p95")
+    candidate_p95 = _finite_nonnegative(candidate.get("p95"), label="candidate p95")
+    if legacy_p50 <= 0 or legacy_p95 <= 0:
+        raise ValueError("legacy p50 and p95 must be positive")
+    p50_passed = candidate_p50 <= legacy_p50 * ratio
+    p95_passed = candidate_p95 <= legacy_p95 * ratio
+    return {
+        "threshold": threshold,
+        "required_candidate_ratio": ratio,
+        "p50": {
+            "legacy_seconds": legacy_p50,
+            "candidate_seconds": candidate_p50,
+            "improvement_fraction": (legacy_p50 - candidate_p50) / legacy_p50,
+            "passed": p50_passed,
+        },
+        "p95": {
+            "legacy_seconds": legacy_p95,
+            "candidate_seconds": candidate_p95,
+            "improvement_fraction": (legacy_p95 - candidate_p95) / legacy_p95,
+            "passed": p95_passed,
+        },
+        "parity": bool(parity),
+        "graph_free": bool(graph_free),
+        "passed": bool(parity and graph_free and p50_passed and p95_passed),
+    }
+
+
+def _current_rss_bytes() -> int | None:
+    try:
+        fields = Path("/proc/self/statm").read_text(encoding="ascii").split()
+        return int(fields[1]) * int(os.sysconf("SC_PAGE_SIZE"))
+    except (IndexError, OSError, ValueError):
+        return None
+
+
+def _peak_rss_bytes() -> int | None:
+    try:
+        import resource
+
+        peak = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    except (ImportError, OSError, ValueError):
+        return None
+    return peak if sys.platform == "darwin" else peak * 1024
+
+
+def _provider_metadata(result: object) -> list[dict[str, Any]]:
+    if not isinstance(result, list):
+        return []
+    return [
+        dict(row["lsp_provider"])
+        for row in result
+        if isinstance(row, Mapping) and isinstance(row.get("lsp_provider"), Mapping)
+    ]
+
+
+def _run_mcp_workload(
+    ctx: Any,
+    *,
+    workload: str,
+    symbol_queries: Sequence[Mapping[str, Any]],
+    positions: Sequence[Mapping[str, Any]],
+    route_symbols: Sequence[str],
+    route_queries: Sequence[str],
+    capture_payload: bool,
+) -> dict[str, Any]:
+    """Run actual MCP implementations and hash their complete public JSON."""
+
+    from codenib.mcp.tools.lsp import (
+        lsp_definition_impl,
+        lsp_references_impl,
+        lsp_route_impl,
+    )
+
+    if workload not in WORKLOADS:
+        raise ValueError(f"unknown MCP consumer workload: {workload}")
+    payload: list[dict[str, Any]] = []
+    calls = 0
+    results = 0
+    public_errors = 0
+    serialized_bytes = 0
+    observed_metadata: set[str] = set()
+
+    def record(
+        operation: str,
+        arguments: Mapping[str, Any],
+        result: Any,
+        *,
+        query_category: str | None = None,
+    ) -> None:
+        nonlocal calls, public_errors, results, serialized_bytes
+        row = {
+            "operation": operation,
+            "arguments": dict(arguments),
+            "result": result,
+        }
+        if query_category is not None:
+            row["query_category"] = query_category
+        encoded = json.dumps(
+            row,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+        serialized_bytes += len(encoded)
+        calls += 1
+        if isinstance(result, Mapping) and "error" in result:
+            public_errors += 1
+        elif isinstance(result, list):
+            results += len(result)
+        for metadata in _provider_metadata(result):
+            observed_metadata.add(
+                json.dumps(metadata, sort_keys=True, separators=(",", ":"))
+            )
+        payload.append(row)
+
+    def symbol_calls(selected: Sequence[Mapping[str, Any]]) -> None:
+        for query in selected:
+            symbol = str(query["symbol"])
+            category = str(query["category"])
+            definition_args = {"symbol": symbol, "top_k": 100}
+            record(
+                "definition_by_symbol",
+                definition_args,
+                lsp_definition_impl(ctx, **definition_args),
+                query_category=category,
+            )
+            for include_declaration in (False, True):
+                references_args = {
+                    "symbol": symbol,
+                    "include_declaration": include_declaration,
+                    "top_k": 100,
+                }
+                record(
+                    "references_by_symbol",
+                    references_args,
+                    lsp_references_impl(ctx, **references_args),
+                    query_category=category,
+                )
+
+    def position_calls() -> None:
+        for raw in positions:
+            arguments = {
+                "file_path": str(raw["file_path"]),
+                "line": int(raw["line"]),
+                "top_k": 100,
+            }
+            if raw.get("character") is not None:
+                arguments["character"] = int(raw["character"])
+            record(
+                "definition_by_position",
+                arguments,
+                lsp_definition_impl(ctx, **arguments),
+            )
+            reference_arguments = {**arguments, "include_declaration": True}
+            record(
+                "references_by_position",
+                reference_arguments,
+                lsp_references_impl(ctx, **reference_arguments),
+            )
+
+    def route_calls() -> None:
+        symbol_arguments = {
+            "symbols": list(route_symbols),
+            "query": "",
+            "top_k": 100,
+            "include_neighbors": True,
+        }
+        record(
+            "route_by_symbol",
+            symbol_arguments,
+            lsp_route_impl(ctx, **symbol_arguments),
+        )
+        for query in route_queries:
+            query_arguments = {
+                "symbols": [],
+                "query": query,
+                "top_k": 100,
+                "include_neighbors": True,
+            }
+            record(
+                "route_by_query",
+                query_arguments,
+                lsp_route_impl(ctx, **query_arguments),
+            )
+
+    if workload == PERFORMANCE_WORKLOAD:
+        symbol_calls(symbol_queries)
+    elif workload == "position_first":
+        position_calls()
+        symbol_calls(symbol_queries)
+    elif workload == "route_first":
+        route_calls()
+        symbol_calls(symbol_queries)
+    else:
+        midpoint = max(1, len(symbol_queries) // 2)
+        symbol_calls(symbol_queries[:midpoint])
+        position_calls()
+        symbol_calls(symbol_queries[midpoint:])
+        route_calls()
+
+    outcome: dict[str, Any] = {
+        "public_payload_sha256": _json_digest(payload),
+        "calls": calls,
+        "results": results,
+        "public_errors": public_errors,
+        "serialized_bytes": serialized_bytes,
+        "observed_public_metadata": [
+            json.loads(value) for value in sorted(observed_metadata)
+        ],
+        "symbol_query_category_counts": {
+            category: sum(query.get("category") == category for query in symbol_queries)
+            for category in _SYMBOL_QUERY_CATEGORIES
+        },
+    }
+    if capture_payload:
+        outcome["public_payload"] = payload
+    return outcome
+
+
+def _run_concurrent_first_fallback(
+    ctx: Any,
+    *,
+    route_symbols: Sequence[str],
+    workers: int,
+) -> dict[str, Any]:
+    import threading
+
+    from codenib.mcp.tools.lsp import lsp_route_impl
+
+    if workers < 2:
+        raise ValueError("concurrency_workers must be at least 2")
+    barrier = threading.Barrier(workers)
+
+    def call(_index: int) -> Any:
+        barrier.wait()
+        return lsp_route_impl(
+            ctx,
+            symbols=list(route_symbols),
+            query="",
+            top_k=100,
+            include_neighbors=True,
+        )
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(call, range(workers)))
+    digests = [_json_digest(result) for result in results]
+    return {
+        "public_payload_sha256": _json_digest(results),
+        "calls": workers,
+        "results": sum(len(result) for result in results if isinstance(result, list)),
+        "public_errors": sum(
+            int(isinstance(result, Mapping) and "error" in result) for result in results
+        ),
+        "serialized_bytes": len(
+            json.dumps(results, ensure_ascii=False, allow_nan=False).encode("utf-8")
+        ),
+        "thread_payload_sha256": sorted(set(digests)),
+        "thread_results_identical": len(set(digests)) == 1,
+    }
+
+
+def _worker(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Execute one arm in the current worker process."""
+
+    from codenib.mcp.context import ServerContext
+    from codenib.scip_interface.scip_query import observe_fact_query_snapshot
+
+    arm = config.get("arm")
+    workload = config.get("workload")
+    if arm not in _ARMS:
+        raise ValueError(f"unknown benchmark arm: {arm!r}")
+    if workload not in (*WORKLOADS, CONCURRENT_WORKLOAD):
+        raise ValueError(f"unknown benchmark workload: {workload!r}")
+    if workload == CONCURRENT_WORKLOAD and arm != "candidate":
+        raise ValueError("concurrent first fallback is candidate-only")
+
+    manifest_path = Path(str(config["manifest_path"])).resolve(strict=True)
+    project_root = Path(str(config["project_root"])).resolve(strict=True)
+    expected_receipt = config.get("candidate_receipt")
+    if not isinstance(expected_receipt, Mapping):
+        raise ValueError("worker candidate_receipt must be a mapping")
+    receipt_before = dict(observe_fact_query_snapshot(expected_receipt))
+    rss_start = _current_rss_bytes()
+    peak_start = _peak_rss_bytes()
+    cpu_started = time.process_time()
+    wall_started = time.perf_counter()
+    ctx: Any = None
+    provider: Any = None
+    try:
+        views = {"symbol_graph"} if arm == "legacy" else ()
+        ctx = ServerContext.load(manifest_path, views=views)
+        public_fallback_reason = ctx.lsp_provider_selection.get("fallback_reason")
+        expected_fallback_reason = config.get("public_fallback_reason")
+        if public_fallback_reason != expected_fallback_reason:
+            raise RuntimeError("public LSP fallback reason changed before a worker")
+        expected_selection = config.get("public_provider_selection")
+        if not isinstance(expected_selection, Mapping):
+            raise ValueError("worker public_provider_selection must be a mapping")
+
+        if arm == "legacy":
+            if ctx.symbol_graph is None or ctx.lsp_provider is None:
+                raise RuntimeError("legacy worker could not load the symbol graph")
+            if ctx.lsp_provider_selection != dict(expected_selection):
+                raise RuntimeError("legacy public provider selection changed")
+            provider = ctx.lsp_provider
+        else:
+            from codenib.scip_interface.scip_query_provider import (
+                load_scip_query_provider,
+            )
+
+            provider = load_scip_query_provider(
+                manifest_path,
+                language=str(config["language"]),
+                project_root=project_root,
+                public_fallback_reason=public_fallback_reason,
+            )
+            if provider.candidate_receipt != dict(expected_receipt):
+                raise RuntimeError(
+                    "candidate receipt changed before provider injection"
+                )
+            if provider.snapshot_id != expected_selection.get("index_snapshot"):
+                raise RuntimeError("candidate public snapshot differs from legacy")
+            ctx.lsp_provider = provider
+
+        startup_wall_seconds = time.perf_counter() - wall_started
+        workload_started = time.perf_counter()
+        if workload == CONCURRENT_WORKLOAD:
+            outcome = _run_concurrent_first_fallback(
+                ctx,
+                route_symbols=config["route_symbols"],
+                workers=int(config["concurrency_workers"]),
+            )
+        else:
+            outcome = _run_mcp_workload(
+                ctx,
+                workload=str(workload),
+                symbol_queries=config["symbol_queries"],
+                positions=config["positions"],
+                route_symbols=config["route_symbols"],
+                route_queries=config["route_queries"],
+                capture_payload=bool(config.get("capture_payload", False)),
+            )
+        workload_wall_seconds = time.perf_counter() - workload_started
+        wall_seconds = time.perf_counter() - wall_started
+        cpu_seconds = time.process_time() - cpu_started
+        diagnostics = provider.diagnostics() if arm == "candidate" else None
+        selection = dict(expected_selection)
+    finally:
+        if ctx is not None:
+            ctx.close()
+
+    receipt_after = dict(observe_fact_query_snapshot(expected_receipt))
+    peak_rss = _peak_rss_bytes()
+    return {
+        "arm": arm,
+        "workload": workload,
+        "process_id": os.getpid(),
+        "wall_seconds": wall_seconds,
+        "cpu_seconds": cpu_seconds,
+        "startup_wall_seconds": startup_wall_seconds,
+        "workload_wall_seconds": workload_wall_seconds,
+        "rss_start_bytes": rss_start,
+        "peak_rss_start_bytes": peak_start,
+        "peak_rss_bytes": peak_rss,
+        "peak_rss_growth_bytes": (
+            max(0, peak_rss - peak_start)
+            if peak_rss is not None and peak_start is not None
+            else None
+        ),
+        "provider_selection": selection,
+        "diagnostics": diagnostics,
+        "receipt_before": receipt_before,
+        "receipt_after": receipt_after,
+        "igraph_imported": "igraph" in sys.modules,
+        "code_graph_imported": "codenib.graph.code_graph" in sys.modules,
+        **outcome,
+    }
+
+
+def _worker_environment() -> dict[str, str]:
+    environment = dict(os.environ)
+    paths = [str(_CORE_BUILD), str(_PROJECT_ROOT)]
+    if environment.get("PYTHONPATH"):
+        paths.append(environment["PYTHONPATH"])
+    environment["PYTHONPATH"] = os.pathsep.join(paths)
+    environment.pop("CODENIB_CORE_PROFILE", None)
+    environment.pop("CODENIB_SCIP_FACT_QUERY_PROVIDER", None)
+    return environment
+
+
+def _run_isolated_worker(
+    config: Mapping[str, Any], *, timeout_seconds: float
+) -> dict[str, Any]:
+    process_started = time.perf_counter()
+    completed = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), "--worker"],
+        cwd=str(_PROJECT_ROOT),
+        env=_worker_environment(),
+        input=json.dumps(config, sort_keys=True, allow_nan=False),
+        text=True,
+        capture_output=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+    process_wall_seconds = time.perf_counter() - process_started
+    if completed.returncode == _MEMORY_ERROR_EXIT:
+        try:
+            failure = json.loads(completed.stderr)
+        except json.JSONDecodeError:
+            failure = {}
+        raise MemoryError(
+            str(failure.get("message") or "isolated SCIP MCP worker exhausted memory")
+        )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"isolated SCIP MCP worker failed ({completed.returncode}): "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "isolated SCIP MCP worker returned invalid JSON: "
+            f"{completed.stdout[-1000:]!r}; stderr={completed.stderr[-1000:]!r}"
+        ) from exc
+    if not isinstance(result, dict):
+        raise RuntimeError("isolated SCIP MCP worker returned a non-object")
+    result["process_wall_seconds"] = process_wall_seconds
+    return result
+
+
+def _git_command(project_root: Path, *arguments: str) -> str | None:
+    completed = subprocess.run(
+        ["git", "-C", str(project_root), *arguments],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    output = completed.stdout.strip()
+    return output if completed.returncode == 0 else None
+
+
+def _git_identity(project_root: Path) -> dict[str, Any]:
+    commit = _git_command(project_root, "rev-parse", "HEAD")
+    status = _git_command(
+        project_root,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+        "--ignore-submodules=none",
+    )
+    return {
+        "commit": commit if commit and _COMMIT_RE.fullmatch(commit) else None,
+        "dirty": bool(status) if status is not None else None,
+        "remote": _git_command(project_root, "remote", "get-url", "origin"),
+    }
+
+
+def _canonical_repository(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    repository = value.strip()
+    match = re.fullmatch(r"git@github\.com:(.+)", repository)
+    if match:
+        repository = f"https://github.com/{match.group(1)}"
+    if repository.endswith("/"):
+        repository = repository[:-1]
+    if not repository.endswith(".git"):
+        repository += ".git"
+    return repository
+
+
+def _load_subject_manifest(
+    path: Path, *, subject_id: str
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping) or payload.get("schema_version") != 1:
+        raise ValueError("SCIP MCP subject manifest must use schema_version 1")
+    if set(payload) != {"schema_version", "subjects"}:
+        raise ValueError("SCIP MCP subject manifest has unexpected fields")
+    subjects = payload.get("subjects")
+    if not isinstance(subjects, list) or not subjects:
+        raise ValueError("SCIP MCP subject manifest requires subjects")
+    ids: list[str] = []
+    for subject in subjects:
+        if not isinstance(subject, Mapping) or set(subject) != {
+            "id",
+            "language",
+            "repository",
+            "revision",
+        }:
+            raise ValueError("SCIP MCP subject entry has malformed fields")
+        identifier = subject.get("id")
+        language = subject.get("language")
+        repository = subject.get("repository")
+        revision = subject.get("revision")
+        if not isinstance(identifier, str) or not identifier:
+            raise ValueError("SCIP MCP subject id is malformed")
+        if language not in {"python", "rust"}:
+            raise ValueError(f"subject {identifier!r} language is unsupported")
+        if not isinstance(repository, str) or not repository.startswith("https://"):
+            raise ValueError(f"subject {identifier!r} repository is malformed")
+        if not isinstance(revision, str) or not _COMMIT_RE.fullmatch(revision):
+            raise ValueError(f"subject {identifier!r} revision is not a commit SHA")
+        ids.append(identifier)
+    if len(ids) != len(set(ids)):
+        raise ValueError("SCIP MCP subject ids must be unique")
+    matches = [subject for subject in subjects if subject["id"] == subject_id]
+    if len(matches) != 1:
+        raise ValueError(f"subject id is absent or duplicated: {subject_id!r}")
+    return dict(payload), dict(matches[0])
+
+
+def _symbol_query_variants(
+    graph: Any,
+    *,
+    definitions: Sequence[str],
+    target_count: int,
+) -> tuple[list[dict[str, str]], dict[str, int]]:
+    from codenib.agent.lsp_graph import _bare, resolve_symbol_candidates
+
+    pools: dict[str, list[str]] = {
+        category: [] for category in _SYMBOL_QUERY_CATEGORIES
+    }
+    ambiguous_seeds: list[str] = []
+
+    def add(category: str, seed: object) -> None:
+        if not isinstance(seed, str) or not seed or seed in pools[category]:
+            return
+        pools[category].append(seed)
+
+    for name in definitions:
+        info = graph.get_node_info_by_name(name) or {}
+        display = info.get("unified_name")
+        add("canonical", name)
+        if isinstance(display, str) and display:
+            candidates = resolve_symbol_candidates(graph, display)
+            if candidates == [name]:
+                add("display", display)
+            elif len(candidates) > 1:
+                ambiguous_seeds.append(display)
+        bare = _bare(str(display or name))
+        if bare:
+            candidates = resolve_symbol_candidates(graph, bare)
+            if candidates == [name]:
+                add("bare", bare)
+            elif len(candidates) > 1:
+                ambiguous_seeds.append(bare)
+        quoted = f"`{name}`"
+        if resolve_symbol_candidates(graph, quoted) == [name]:
+            add("quoted", quoted)
+
+    for seed in ambiguous_seeds:
+        if len(resolve_symbol_candidates(graph, seed)) > 1:
+            add("ambiguous", seed)
+
+    missing_index = 0
+    while len(pools["missing"]) < target_count:
+        seed = f"__codenib_missing_scip_consumer_symbol_{missing_index}__"
+        missing_index += 1
+        if not resolve_symbol_candidates(graph, seed):
+            add("missing", seed)
+        if missing_index > target_count * 100:
+            raise ValueError("fixed subject cannot prove a missing symbol seed")
+
+    absent = [category for category, seeds in pools.items() if not seeds]
+    if absent:
+        raise ValueError(
+            "fixed subject cannot produce required symbol query variants: "
+            + ", ".join(absent)
+        )
+
+    queries: list[dict[str, str]] = []
+    used: set[str] = set()
+    offsets = {category: 0 for category in _SYMBOL_QUERY_CATEGORIES}
+
+    def select(category: str) -> bool:
+        seeds = pools[category]
+        while offsets[category] < len(seeds):
+            seed = seeds[offsets[category]]
+            offsets[category] += 1
+            if seed in used:
+                continue
+            used.add(seed)
+            queries.append({"category": category, "symbol": seed})
+            return True
+        return False
+
+    for category in _SYMBOL_QUERY_CATEGORIES:
+        if not select(category):
+            raise ValueError(
+                f"fixed subject has no distinct {category} symbol query seed"
+            )
+    while len(queries) < target_count:
+        progressed = False
+        for category in _SYMBOL_QUERY_CATEGORIES:
+            if len(queries) >= target_count:
+                break
+            progressed = select(category) or progressed
+        if not progressed:
+            raise ValueError(
+                f"fixed subject provides fewer than {target_count} distinct "
+                "symbol query seeds"
+            )
+
+    counts = {
+        category: sum(query["category"] == category for query in queries)
+        for category in _SYMBOL_QUERY_CATEGORIES
+    }
+    if sum(counts.values()) != target_count or not all(counts.values()):
+        raise RuntimeError("symbol query variant partition is incomplete")
+    return queries, counts
+
+
+def _workload_inputs(graph: Any, *, query_workload_size: int) -> dict[str, Any]:
+    from codenib.agent.lsp_graph import _terms
+    from codenib.types import node_has_definition
+
+    names = list(getattr(graph, "name_to_vertex", {}) or {})
+    definitions = [
+        str(name)
+        for name in names
+        if node_has_definition(graph.get_node_info_by_name(name) or {})
+    ]
+    if not definitions:
+        raise ValueError("subject graph has no definition symbols")
+    symbol_queries, symbol_query_category_counts = _symbol_query_variants(
+        graph,
+        definitions=definitions,
+        target_count=query_workload_size,
+    )
+
+    positions: list[dict[str, Any]] = []
+    seen_positions: set[tuple[str, int]] = set()
+    position_limit = min(16, query_workload_size)
+    for name in definitions:
+        info = graph.get_node_info_by_name(name) or {}
+        file_path = info.get("file")
+        start_line = info.get("selection_line")
+        if start_line is None:
+            start_line = info.get("start_line")
+        if (
+            not isinstance(file_path, str)
+            or not file_path
+            or isinstance(start_line, bool)
+            or not isinstance(start_line, int)
+            or start_line < 0
+        ):
+            continue
+        key = (file_path, start_line)
+        if key in seen_positions:
+            continue
+        seen_positions.add(key)
+        positions.append({"file_path": file_path, "line": start_line + 1})
+        if len(positions) >= position_limit:
+            break
+    if not positions:
+        raise ValueError("subject graph has no position-query sample")
+
+    route_symbols = definitions[: min(4, len(definitions))]
+    if not route_symbols:
+        raise ValueError("subject graph has no route seed")
+    route_queries: list[str] = []
+    for name in definitions:
+        info = graph.get_node_info_by_name(name) or {}
+        display = str(info.get("unified_name") or name).rsplit(":", 1)[-1]
+        terms = sorted(_terms(display))
+        if len(terms) >= 2:
+            route_queries.append(" ".join(terms[:4]))
+            break
+    if not route_queries:
+        raise ValueError("fixed subject has no query-only route seed")
+    return {
+        "symbol_queries": symbol_queries,
+        "symbol_query_category_counts": symbol_query_category_counts,
+        "positions": positions,
+        "route_symbols": route_symbols,
+        "route_queries": route_queries,
+        "definition_symbol_count": len(definitions),
+        "graph_vertex_count": int(graph.graph.vcount()),
+        "graph_edge_count": int(graph.graph.ecount()),
+    }
+
+
+def _artifact_receipts(candidate_receipt: Mapping[str, Any]) -> dict[str, Any]:
+    manifest = candidate_receipt.get("manifest")
+    index = candidate_receipt.get("index")
+    graph = candidate_receipt.get("graph")
+    if not all(isinstance(value, Mapping) for value in (manifest, index, graph)):
+        raise ValueError("candidate receipt omits artifact bindings")
+    entry_path = Path(str(manifest["entry_path"]))
+    return {
+        "manifest": _file_receipt(Path(str(manifest["path"]))),
+        "index": _file_receipt(entry_path / str(index["relative_path"])),
+        "graph": _file_receipt(entry_path / str(graph["relative_path"])),
+    }
+
+
+def _observe_receipt(candidate_receipt: Mapping[str, Any]) -> dict[str, Any]:
+    from codenib.scip_interface.scip_query import observe_fact_query_snapshot
+
+    return dict(observe_fact_query_snapshot(candidate_receipt))
+
+
+def _prepare_subject(
+    *,
+    manifest_path: Path,
+    project_root: Path,
+    subject_manifest: Path,
+    subject_id: str,
+    query_workload_size: int,
+) -> dict[str, Any]:
+    from codenib.mcp.context import ServerContext
+    from codenib.scip_interface.scip_query_provider import load_scip_query_provider
+
+    if manifest_path.is_symlink():
+        raise ValueError("RepoManifest path must not be a symlink")
+    if subject_manifest.is_symlink():
+        raise ValueError("subject manifest path must not be a symlink")
+    manifest_path = manifest_path.resolve(strict=True)
+    project_root = project_root.resolve(strict=True)
+    subject_manifest = subject_manifest.resolve(strict=True)
+    subject_manifest_receipt = _file_receipt(subject_manifest)
+    manifest_payload, subject = _load_subject_manifest(
+        subject_manifest, subject_id=subject_id
+    )
+    if _file_receipt(subject_manifest) != subject_manifest_receipt:
+        raise RuntimeError("SCIP MCP subject manifest changed while loading")
+    git_before = _git_identity(project_root)
+    benchmark_git_before = _git_identity(_PROJECT_ROOT)
+    benchmark_sources_before = {
+        "harness": _file_receipt(Path(__file__)),
+        "provider": _file_receipt(
+            _PROJECT_ROOT / "codenib/scip_interface/scip_query_provider.py"
+        ),
+        "snapshot_observer": _file_receipt(
+            _PROJECT_ROOT / "codenib/scip_interface/scip_query.py"
+        ),
+    }
+    if git_before["commit"] != subject["revision"]:
+        raise ValueError(
+            f"subject {subject_id!r} requires commit {subject['revision']}; "
+            f"observed {git_before['commit']}"
+        )
+    if git_before["dirty"] is not False:
+        raise ValueError(f"subject {subject_id!r} checkout must be clean")
+    if _canonical_repository(git_before["remote"]) != _canonical_repository(
+        subject["repository"]
+    ):
+        raise ValueError(f"subject {subject_id!r} repository remote does not match")
+
+    candidate = load_scip_query_provider(
+        manifest_path,
+        language=subject["language"],
+        project_root=project_root,
+    )
+    candidate_receipt = candidate.candidate_receipt
+    if candidate_receipt.get("language") != subject["language"]:
+        raise RuntimeError("candidate language does not match the fixed subject")
+    initial_snapshot = _observe_receipt(candidate_receipt)
+    artifact_before = _artifact_receipts(candidate_receipt)
+
+    legacy_context = ServerContext.load(manifest_path, views={"symbol_graph"})
+    try:
+        if legacy_context.symbol_graph is None or legacy_context.lsp_provider is None:
+            raise RuntimeError("fixed subject has no usable legacy symbol graph")
+        public_fallback_reason = legacy_context.lsp_provider_selection.get(
+            "fallback_reason"
+        )
+        public_provider_selection = dict(legacy_context.lsp_provider_selection)
+        inputs = _workload_inputs(
+            legacy_context.symbol_graph,
+            query_workload_size=query_workload_size,
+        )
+    finally:
+        legacy_context.close()
+
+    return {
+        "manifest_path": str(manifest_path),
+        "project_root": str(project_root),
+        "subject_manifest": {
+            "path": str(subject_manifest),
+            "sha256": subject_manifest_receipt["sha256"],
+            "payload": manifest_payload,
+            "entry": subject,
+        },
+        "language": subject["language"],
+        "candidate_receipt": candidate_receipt,
+        "initial_snapshot": initial_snapshot,
+        "artifact_before": artifact_before,
+        "git_before": git_before,
+        "benchmark_git_before": benchmark_git_before,
+        "benchmark_sources_before": benchmark_sources_before,
+        "public_fallback_reason": public_fallback_reason,
+        "public_provider_selection": public_provider_selection,
+        "inputs": inputs,
+    }
+
+
+def _validate_worker_run(
+    run: Mapping[str, Any],
+    *,
+    arm: str,
+    workload: str,
+    expected_snapshot: Mapping[str, Any],
+) -> None:
+    if run.get("arm") != arm or run.get("workload") != workload:
+        raise RuntimeError("isolated worker returned the wrong arm or workload")
+    process_id = run.get("process_id")
+    if (
+        isinstance(process_id, bool)
+        or not isinstance(process_id, int)
+        or process_id <= 0
+    ):
+        raise RuntimeError("isolated worker returned an invalid process id")
+    for metric in (
+        "wall_seconds",
+        "process_wall_seconds",
+        "cpu_seconds",
+        "startup_wall_seconds",
+        "workload_wall_seconds",
+    ):
+        try:
+            _finite_nonnegative(run.get(metric), label=metric)
+        except ValueError as exc:
+            raise RuntimeError(f"isolated worker returned malformed {metric}") from exc
+    for metric in (
+        "rss_start_bytes",
+        "peak_rss_start_bytes",
+        "peak_rss_bytes",
+        "peak_rss_growth_bytes",
+    ):
+        value = run.get(metric)
+        if value is not None:
+            try:
+                _finite_nonnegative(value, label=metric)
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"isolated worker returned malformed {metric}"
+                ) from exc
+    if run.get("receipt_before") != dict(expected_snapshot):
+        raise RuntimeError("candidate snapshot changed before an isolated worker")
+    if run.get("receipt_after") != dict(expected_snapshot):
+        raise RuntimeError("candidate snapshot changed during an isolated worker")
+    digest = run.get("public_payload_sha256")
+    if not isinstance(digest, str) or not _SHA256_RE.fullmatch(digest):
+        raise RuntimeError("isolated worker returned a malformed public payload digest")
+    if arm == "candidate" and not isinstance(run.get("diagnostics"), Mapping):
+        raise RuntimeError("candidate worker omitted provider diagnostics")
+
+
+def _summarize_runs(runs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    if not runs:
+        raise ValueError("at least one isolated run is required")
+    metrics = (
+        "wall_seconds",
+        "process_wall_seconds",
+        "cpu_seconds",
+        "startup_wall_seconds",
+        "workload_wall_seconds",
+        "rss_start_bytes",
+        "peak_rss_start_bytes",
+        "peak_rss_bytes",
+        "peak_rss_growth_bytes",
+        "calls",
+        "results",
+        "public_errors",
+        "serialized_bytes",
+    )
+    summary: dict[str, Any] = {}
+    for metric in metrics:
+        values = [run[metric] for run in runs if run.get(metric) is not None]
+        if values:
+            summary[metric] = _summarize(values)
+    summary["public_payload_sha256"] = sorted(
+        {str(run["public_payload_sha256"]) for run in runs}
+    )
+    summary["process_ids"] = sorted({int(run["process_id"]) for run in runs})
+    return summary
+
+
+def _parity(
+    legacy_runs: Sequence[Mapping[str, Any]],
+    candidate_runs: Sequence[Mapping[str, Any]],
+) -> bool:
+    if not legacy_runs or not candidate_runs:
+        return False
+    fields = (
+        "public_payload_sha256",
+        "calls",
+        "results",
+        "public_errors",
+        "serialized_bytes",
+    )
+    return all(
+        len({run.get(field) for run in legacy_runs}) == 1
+        and {run.get(field) for run in legacy_runs}
+        == {run.get(field) for run in candidate_runs}
+        for field in fields
+    )
+
+
+def _symbol_candidate_graph_free(
+    run: Mapping[str, Any], *, expected_symbol_count: int
+) -> bool:
+    diagnostics = run.get("diagnostics")
+    if not isinstance(diagnostics, Mapping):
+        return False
+    return (
+        run.get("igraph_imported") is False
+        and run.get("code_graph_imported") is False
+        and diagnostics.get("state") == "NATIVE_READY"
+        and diagnostics.get("logical_backend") == "persisted-symbol-graph-v1"
+        and diagnostics.get("native_physical_backend") == "native-scip-fact-query-v1"
+        and diagnostics.get("native_definition_count") == expected_symbol_count
+        and diagnostics.get("native_references_count") == expected_symbol_count * 2
+        and diagnostics.get("native_symbol_call_count") == expected_symbol_count * 3
+        and diagnostics.get("native_symbol_call_count") == run.get("calls")
+        and diagnostics.get("receipt_observation_count") == 0
+        and diagnostics.get("graph_load_attempt_count") == 0
+        and diagnostics.get("graph_load_count") == 0
+        and diagnostics.get("graph_publication_count") == 0
+        and diagnostics.get("fallback_call_count") == 0
+        and diagnostics.get("graph_fallback_count") == 0
+        and diagnostics.get("graph_call_count") == 0
+        and diagnostics.get("graph_materialization_seconds") is None
+        and diagnostics.get("terminal_failure") is None
+    )
+
+
+def _expected_candidate_counts(
+    workload: str, inputs: Mapping[str, Any]
+) -> dict[str, int]:
+    symbol_count = len(inputs["symbol_queries"])
+    route_calls = 1 + len(inputs["route_queries"])
+    position_calls = 2 * len(inputs["positions"])
+    if workload == "position_first":
+        fallback_calls = position_calls
+    elif workload == "route_first":
+        fallback_calls = route_calls
+    elif workload == "mixed":
+        fallback_calls = position_calls + route_calls
+    else:
+        raise ValueError(f"unknown correctness workload: {workload}")
+    return {
+        "native_definition_count": symbol_count,
+        "native_references_count": symbol_count * 2,
+        "native_symbol_call_count": symbol_count * 3,
+        "fallback_call_count": fallback_calls,
+        # The first fallback observes before and after publication, then after
+        # the graph call. Every later fallback brackets its graph call with a
+        # fresh pre/post observation.
+        "receipt_observation_count": 2 * fallback_calls + 1,
+    }
+
+
+def _correctness_candidate_ready(
+    run: Mapping[str, Any], *, expected: Mapping[str, int]
+) -> bool:
+    diagnostics = run.get("diagnostics")
+    if not isinstance(diagnostics, Mapping):
+        return False
+    materialization = diagnostics.get("graph_materialization_seconds")
+    try:
+        materialization_seconds = _finite_nonnegative(
+            materialization, label="graph_materialization_seconds"
+        )
+    except ValueError:
+        return False
+    fallback_calls = expected.get(
+        "fallback_call_count", diagnostics.get("fallback_call_count")
+    )
+    return bool(
+        materialization_seconds >= 0
+        and diagnostics.get("state") == "GRAPH_READY"
+        and diagnostics.get("logical_backend") == "persisted-symbol-graph-v1"
+        and diagnostics.get("fallback_physical_backend")
+        == "lazy-persisted-symbol-graph-v1"
+        and diagnostics.get("graph_load_attempt_count") == 1
+        and diagnostics.get("graph_load_count") == 1
+        and diagnostics.get("graph_publication_count") == 1
+        and isinstance(fallback_calls, int)
+        and not isinstance(fallback_calls, bool)
+        and fallback_calls > 0
+        and diagnostics.get("native_definition_count")
+        == expected.get(
+            "native_definition_count", diagnostics.get("native_definition_count")
+        )
+        and diagnostics.get("native_references_count")
+        == expected.get(
+            "native_references_count", diagnostics.get("native_references_count")
+        )
+        and diagnostics.get("native_symbol_call_count")
+        == expected.get(
+            "native_symbol_call_count", diagnostics.get("native_symbol_call_count")
+        )
+        and diagnostics.get("fallback_call_count") == fallback_calls
+        and diagnostics.get("graph_fallback_count") == fallback_calls
+        and diagnostics.get("graph_call_count") == fallback_calls
+        and diagnostics.get("receipt_observation_count")
+        == expected.get(
+            "receipt_observation_count",
+            diagnostics.get("receipt_observation_count"),
+        )
+        and diagnostics.get("terminal_failure") is None
+    )
+
+
+def _concurrency_passed(run: Mapping[str, Any], *, workers: int) -> bool:
+    diagnostics = run.get("diagnostics")
+    return bool(
+        isinstance(diagnostics, Mapping)
+        and run.get("calls") == workers
+        and run.get("public_errors") == 0
+        and run.get("thread_results_identical") is True
+        and len(run.get("thread_payload_sha256") or ()) == 1
+        and diagnostics.get("state") == "GRAPH_READY"
+        and diagnostics.get("logical_backend") == "persisted-symbol-graph-v1"
+        and diagnostics.get("fallback_physical_backend")
+        == "lazy-persisted-symbol-graph-v1"
+        and diagnostics.get("graph_load_attempt_count") == 1
+        and diagnostics.get("graph_load_count") == 1
+        and diagnostics.get("graph_publication_count") == 1
+        and diagnostics.get("fallback_call_count") == workers
+        and diagnostics.get("graph_fallback_count") == workers
+        and diagnostics.get("graph_call_count") == workers
+        and diagnostics.get("receipt_observation_count", 0) >= 2
+        and diagnostics.get("terminal_failure") is None
+    )
+
+
+def _worker_config(
+    prepared: Mapping[str, Any],
+    *,
+    arm: str,
+    workload: str,
+    concurrency_workers: int,
+    capture_payload: bool,
+) -> dict[str, Any]:
+    inputs = prepared["inputs"]
+    return {
+        "arm": arm,
+        "workload": workload,
+        "manifest_path": prepared["manifest_path"],
+        "project_root": prepared["project_root"],
+        "language": prepared["language"],
+        "candidate_receipt": prepared["candidate_receipt"],
+        "public_fallback_reason": prepared["public_fallback_reason"],
+        "public_provider_selection": prepared["public_provider_selection"],
+        "symbol_queries": inputs["symbol_queries"],
+        "positions": inputs["positions"],
+        "route_symbols": inputs["route_symbols"],
+        "route_queries": inputs["route_queries"],
+        "concurrency_workers": concurrency_workers,
+        "capture_payload": capture_payload,
+    }
+
+
+def _run_checked(
+    prepared: Mapping[str, Any],
+    *,
+    arm: str,
+    workload: str,
+    concurrency_workers: int,
+    capture_payload: bool,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    run = _run_isolated_worker(
+        _worker_config(
+            prepared,
+            arm=arm,
+            workload=workload,
+            concurrency_workers=concurrency_workers,
+            capture_payload=capture_payload,
+        ),
+        timeout_seconds=timeout_seconds,
+    )
+    _validate_worker_run(
+        run,
+        arm=arm,
+        workload=workload,
+        expected_snapshot=prepared["initial_snapshot"],
+    )
+    if (
+        workload != CONCURRENT_WORKLOAD
+        and run.get("symbol_query_category_counts")
+        != prepared["inputs"]["symbol_query_category_counts"]
+    ):
+        raise RuntimeError("isolated worker changed the symbol query partition")
+    return run
+
+
+def _require_balanced_samples(
+    runs: Mapping[str, Sequence[Mapping[str, Any]]], *, expected: int
+) -> None:
+    if set(runs) != set(_ARMS):
+        raise RuntimeError("symbol samples omit a benchmark arm")
+    counts = {arm: len(runs[arm]) for arm in _ARMS}
+    if counts != {"legacy": expected, "candidate": expected}:
+        raise RuntimeError(
+            f"symbol sample imbalance: expected {expected} per arm, got {counts}"
+        )
+
+
+def _canonical_protocol(
+    *,
+    iterations: int,
+    warmups: int,
+    requested_query_workload_size: int,
+    observed_query_workload_size: int,
+    promotion_threshold: float,
+    concurrency_workers: int,
+) -> dict[str, Any]:
+    expected = {
+        "iterations_per_arm": DEFAULT_ITERATIONS,
+        "warmups_per_arm": DEFAULT_WARMUPS,
+        "requested_query_workload_size": DEFAULT_QUERY_WORKLOAD_SIZE,
+        "observed_query_workload_size": DEFAULT_QUERY_WORKLOAD_SIZE,
+        "promotion_threshold": DEFAULT_PROMOTION_THRESHOLD,
+        "concurrency_workers": DEFAULT_CONCURRENCY_WORKERS,
+    }
+    observed = {
+        "iterations_per_arm": iterations,
+        "warmups_per_arm": warmups,
+        "requested_query_workload_size": requested_query_workload_size,
+        "observed_query_workload_size": observed_query_workload_size,
+        "promotion_threshold": promotion_threshold,
+        "concurrency_workers": concurrency_workers,
+    }
+    return {"expected": expected, "observed": observed, "passed": observed == expected}
+
+
+def profile_scip_mcp_consumer(
+    *,
+    manifest_path: Path,
+    project_root: Path,
+    subject_id: str,
+    subject_manifest: Path = _DEFAULT_SUBJECT_MANIFEST,
+    iterations: int = DEFAULT_ITERATIONS,
+    warmups: int = DEFAULT_WARMUPS,
+    query_workload_size: int = DEFAULT_QUERY_WORKLOAD_SIZE,
+    promotion_threshold: float = DEFAULT_PROMOTION_THRESHOLD,
+    concurrency_workers: int = DEFAULT_CONCURRENCY_WORKERS,
+    worker_timeout_seconds: float = DEFAULT_WORKER_TIMEOUT,
+) -> dict[str, Any]:
+    """Measure one fixed Python or Rust subject and return its independent gate."""
+
+    if isinstance(iterations, bool) or iterations <= 0 or iterations % 2:
+        raise ValueError("iterations must be a positive even integer")
+    if isinstance(warmups, bool) or warmups < 0 or warmups % 2:
+        raise ValueError("warmups must be a non-negative even integer")
+    if isinstance(query_workload_size, bool) or query_workload_size < len(
+        _SYMBOL_QUERY_CATEGORIES
+    ):
+        raise ValueError(
+            "query_workload_size must cover all six symbol query categories"
+        )
+    if not 0 <= promotion_threshold < 1:
+        raise ValueError("promotion_threshold must be in [0, 1)")
+    if isinstance(concurrency_workers, bool) or concurrency_workers < 2:
+        raise ValueError("concurrency_workers must be at least 2")
+    if worker_timeout_seconds <= 0:
+        raise ValueError("worker_timeout_seconds must be positive")
+
+    prepared = _prepare_subject(
+        manifest_path=manifest_path,
+        project_root=project_root,
+        subject_manifest=subject_manifest,
+        subject_id=subject_id,
+        query_workload_size=query_workload_size,
+    )
+    canonical_protocol = _canonical_protocol(
+        iterations=iterations,
+        warmups=warmups,
+        requested_query_workload_size=query_workload_size,
+        observed_query_workload_size=len(prepared["inputs"]["symbol_queries"]),
+        promotion_threshold=promotion_threshold,
+        concurrency_workers=concurrency_workers,
+    )
+    warmup_schedule = _abba_schedule(warmups)
+    measured_schedule = _abba_schedule(iterations)
+
+    warmup_runs: list[dict[str, Any]] = []
+    for entry in warmup_schedule:
+        run = _run_checked(
+            prepared,
+            arm=entry["arm"],
+            workload=PERFORMANCE_WORKLOAD,
+            concurrency_workers=concurrency_workers,
+            capture_payload=False,
+            timeout_seconds=worker_timeout_seconds,
+        )
+        run["schedule"] = dict(entry)
+        warmup_runs.append(run)
+
+    symbol_runs: dict[str, list[dict[str, Any]]] = {
+        "legacy": [],
+        "candidate": [],
+    }
+    measured_runs: list[dict[str, Any]] = []
+    for entry in measured_schedule:
+        arm = str(entry["arm"])
+        run = _run_checked(
+            prepared,
+            arm=arm,
+            workload=PERFORMANCE_WORKLOAD,
+            concurrency_workers=concurrency_workers,
+            capture_payload=False,
+            timeout_seconds=worker_timeout_seconds,
+        )
+        run["schedule"] = dict(entry)
+        symbol_runs[arm].append(run)
+        measured_runs.append(run)
+    _require_balanced_samples(symbol_runs, expected=iterations)
+
+    correctness_orders = {
+        "position_first": ("legacy", "candidate"),
+        "route_first": ("candidate", "legacy"),
+        "mixed": ("legacy", "candidate"),
+    }
+    correctness_runs: dict[str, dict[str, dict[str, Any]]] = {}
+    for workload, order in correctness_orders.items():
+        correctness_runs[workload] = {}
+        for arm in order:
+            correctness_runs[workload][arm] = _run_checked(
+                prepared,
+                arm=arm,
+                workload=workload,
+                concurrency_workers=concurrency_workers,
+                capture_payload=False,
+                timeout_seconds=worker_timeout_seconds,
+            )
+
+    concurrency_run = _run_checked(
+        prepared,
+        arm="candidate",
+        workload=CONCURRENT_WORKLOAD,
+        concurrency_workers=concurrency_workers,
+        capture_payload=False,
+        timeout_seconds=worker_timeout_seconds,
+    )
+
+    final_snapshot = _observe_receipt(prepared["candidate_receipt"])
+    artifact_after = _artifact_receipts(prepared["candidate_receipt"])
+    git_after = _git_identity(Path(prepared["project_root"]))
+    benchmark_git_after = _git_identity(_PROJECT_ROOT)
+    benchmark_sources_after = {
+        "harness": _file_receipt(Path(__file__)),
+        "provider": _file_receipt(
+            _PROJECT_ROOT / "codenib/scip_interface/scip_query_provider.py"
+        ),
+        "snapshot_observer": _file_receipt(
+            _PROJECT_ROOT / "codenib/scip_interface/scip_query.py"
+        ),
+    }
+    immutable_benchmark = (
+        benchmark_git_after == prepared["benchmark_git_before"]
+        and benchmark_git_after.get("dirty") is False
+        and benchmark_sources_after == prepared["benchmark_sources_before"]
+    )
+    immutable_inputs = (
+        final_snapshot == prepared["initial_snapshot"]
+        and artifact_after == prepared["artifact_before"]
+        and git_after == prepared["git_before"]
+        and git_after.get("dirty") is False
+    )
+
+    all_runs = [
+        *warmup_runs,
+        *measured_runs,
+        *(
+            run
+            for workload_runs in correctness_runs.values()
+            for run in workload_runs.values()
+        ),
+        concurrency_run,
+    ]
+    process_ids = [int(run["process_id"]) for run in all_runs]
+    process_isolation = len(process_ids) == len(set(process_ids))
+
+    legacy_summary = _summarize_runs(symbol_runs["legacy"])
+    candidate_summary = _summarize_runs(symbol_runs["candidate"])
+    symbol_parity = _parity(symbol_runs["legacy"], symbol_runs["candidate"])
+    graph_free = all(
+        _symbol_candidate_graph_free(
+            run,
+            expected_symbol_count=len(prepared["inputs"]["symbol_queries"]),
+        )
+        for run in symbol_runs["candidate"]
+    )
+    promotion = _promotion_decision(
+        legacy_summary["wall_seconds"],
+        candidate_summary["wall_seconds"],
+        threshold=promotion_threshold,
+        parity=symbol_parity,
+        graph_free=graph_free,
+    )
+
+    correctness: dict[str, Any] = {}
+    correctness_passed = True
+    for workload in CORRECTNESS_WORKLOADS:
+        legacy = correctness_runs[workload]["legacy"]
+        candidate = correctness_runs[workload]["candidate"]
+        parity = _parity([legacy], [candidate])
+        expected_counts = _expected_candidate_counts(workload, prepared["inputs"])
+        lazy_graph_ready = _correctness_candidate_ready(
+            candidate, expected=expected_counts
+        )
+        passed = parity and lazy_graph_ready
+        correctness_passed = correctness_passed and passed
+        correctness[workload] = {
+            "performance_gated": False,
+            "parity": parity,
+            "lazy_graph_ready": lazy_graph_ready,
+            "expected_candidate_counts": expected_counts,
+            "passed": passed,
+            "arm_order": list(correctness_orders[workload]),
+            "legacy": _summarize_runs([legacy]),
+            "candidate": _summarize_runs([candidate]),
+            "raw": {"legacy": legacy, "candidate": candidate},
+        }
+
+    concurrent_passed = _concurrency_passed(
+        concurrency_run, workers=concurrency_workers
+    )
+    overall_passed = bool(
+        canonical_protocol["passed"]
+        and promotion["passed"]
+        and correctness_passed
+        and concurrent_passed
+        and immutable_inputs
+        and immutable_benchmark
+        and process_isolation
+    )
+    return {
+        "schema_version": 1,
+        "benchmark": "scip_mcp_consumer_gate_v1",
+        "language": prepared["language"],
+        "passed": overall_passed,
+        "subject": {
+            "id": subject_id,
+            "entry": prepared["subject_manifest"]["entry"],
+            "project_root": prepared["project_root"],
+            "manifest_path": prepared["manifest_path"],
+            "git_before": prepared["git_before"],
+            "git_after": git_after,
+            "immutable_checkout": immutable_inputs,
+            "definition_symbol_count": prepared["inputs"]["definition_symbol_count"],
+            "graph_vertex_count": prepared["inputs"]["graph_vertex_count"],
+            "graph_edge_count": prepared["inputs"]["graph_edge_count"],
+        },
+        "benchmark_checkout": {
+            "git_before": prepared["benchmark_git_before"],
+            "git_after": benchmark_git_after,
+            "sources_before": prepared["benchmark_sources_before"],
+            "sources_after": benchmark_sources_after,
+            "unchanged_and_clean": immutable_benchmark,
+        },
+        "subject_manifest": {
+            "path": prepared["subject_manifest"]["path"],
+            "sha256": prepared["subject_manifest"]["sha256"],
+            "schema_version": prepared["subject_manifest"]["payload"]["schema_version"],
+        },
+        "configuration": {
+            "performance_workload": PERFORMANCE_WORKLOAD,
+            "iterations_per_arm": iterations,
+            "warmups_per_arm": warmups,
+            "query_workload_size": len(prepared["inputs"]["symbol_queries"]),
+            "symbol_query_category_counts": prepared["inputs"][
+                "symbol_query_category_counts"
+            ],
+            "symbol_calls_per_seed": {
+                "definition": 1,
+                "references_include_declaration_false": 1,
+                "references_include_declaration_true": 1,
+            },
+            "promotion_threshold": promotion_threshold,
+            "percentile_method": "nearest-rank",
+            "warmup_arm_order": warmup_schedule,
+            "measured_arm_order": measured_schedule,
+            "correctness_arm_order": correctness_orders,
+            "concurrency_workers": concurrency_workers,
+            "worker_timeout_seconds": worker_timeout_seconds,
+            "fresh_process_per_sample": True,
+            "process_isolation_observed": process_isolation,
+            "cold_start_scope": "fresh process; filesystem page cache uncontrolled",
+            "promotion_metric": "wall_seconds from provider startup through workload",
+            "canonical_protocol": canonical_protocol,
+        },
+        "receipts": {
+            "candidate": prepared["candidate_receipt"],
+            "snapshot_before": prepared["initial_snapshot"],
+            "snapshot_after": final_snapshot,
+            "artifacts_before": prepared["artifact_before"],
+            "artifacts_after": artifact_after,
+            "unchanged": immutable_inputs,
+        },
+        "symbol_only": {
+            "performance_gated": True,
+            "parity": symbol_parity,
+            "graph_free": graph_free,
+            "legacy": legacy_summary,
+            "candidate": candidate_summary,
+            "promotion": promotion,
+        },
+        "correctness": correctness,
+        "concurrent_first_fallback": {
+            "performance_gated": False,
+            "workers": concurrency_workers,
+            "passed": concurrent_passed,
+            "observations": _summarize_runs([concurrency_run]),
+            "raw": concurrency_run,
+        },
+        "raw": {
+            "warmups": warmup_runs,
+            "symbol_measured": measured_runs,
+        },
+        "gates": {
+            "canonical_protocol": canonical_protocol["passed"],
+            "symbol_p50": promotion["p50"]["passed"],
+            "symbol_p95": promotion["p95"]["passed"],
+            "symbol_parity": symbol_parity,
+            "symbol_graph_free": graph_free,
+            "correctness_parity": correctness_passed,
+            "concurrent_single_publication": concurrent_passed,
+            "immutable_inputs": immutable_inputs,
+            "immutable_benchmark": immutable_benchmark,
+            "process_isolation": process_isolation,
+            "passed": overall_passed,
+        },
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--project-root", type=Path)
+    parser.add_argument("--subject-id")
+    parser.add_argument(
+        "--subject-manifest",
+        type=Path,
+        default=_DEFAULT_SUBJECT_MANIFEST,
+    )
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    parser.add_argument(
+        "--query-workload-size",
+        type=int,
+        default=DEFAULT_QUERY_WORKLOAD_SIZE,
+    )
+    parser.add_argument(
+        "--promotion-threshold",
+        type=float,
+        default=DEFAULT_PROMOTION_THRESHOLD,
+    )
+    parser.add_argument(
+        "--concurrency-workers",
+        type=int,
+        default=DEFAULT_CONCURRENCY_WORKERS,
+    )
+    parser.add_argument(
+        "--worker-timeout-seconds",
+        type=float,
+        default=DEFAULT_WORKER_TIMEOUT,
+    )
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.worker:
+        try:
+            config = json.load(sys.stdin)
+            if not isinstance(config, Mapping):
+                raise ValueError("worker input must be a JSON object")
+            result = _worker(config)
+        except MemoryError as exc:
+            print(
+                json.dumps(
+                    {"error_type": "MemoryError", "message": str(exc)},
+                    sort_keys=True,
+                ),
+                file=sys.stderr,
+            )
+            return _MEMORY_ERROR_EXIT
+        print(json.dumps(result, sort_keys=True, allow_nan=False))
+        return 0
+
+    if args.manifest is None or args.project_root is None or not args.subject_id:
+        _parser().error("--manifest, --project-root, and --subject-id are required")
+    report = profile_scip_mcp_consumer(
+        manifest_path=args.manifest,
+        project_root=args.project_root,
+        subject_id=args.subject_id,
+        subject_manifest=args.subject_manifest,
+        iterations=args.iterations,
+        warmups=args.warmups,
+        query_workload_size=args.query_workload_size,
+        promotion_threshold=args.promotion_threshold,
+        concurrency_workers=args.concurrency_workers,
+        worker_timeout_seconds=args.worker_timeout_seconds,
+    )
+    encoded = json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    else:
+        sys.stdout.write(encoded)
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/profiling/scip_mcp_consumer_subjects.json
+++ b/scripts/profiling/scip_mcp_consumer_subjects.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "subjects": [
+    {
+      "id": "python-codenib",
+      "language": "python",
+      "repository": "https://github.com/sysevol-ai/CodeNib.git",
+      "revision": "6cf61b08310e165574c52fa217c66f0b6ae2a36d"
+    },
+    {
+      "id": "rust-ruff",
+      "language": "rust",
+      "repository": "https://github.com/astral-sh/ruff.git",
+      "revision": "75a24bbc67aa31b825b6326cfb6e6afdf3ca90d5"
+    }
+  ]
+}

--- a/test/scip/test_scip_query_provider.py
+++ b/test/scip/test_scip_query_provider.py
@@ -1,0 +1,950 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph-free and atomic-publication tests for the SCIP query provider."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from codenib.agent.lsp_provider import LSPProviderNodes, StaticLSPProvider
+from codenib.compiler.artifact_fingerprints import regular_file_fingerprint
+from codenib.graph.code_graph import CodeGraph
+from codenib.mcp.tools.lsp import (
+    lsp_definition_impl,
+    lsp_references_impl,
+    lsp_route_impl,
+)
+from codenib.scip_interface.query_surface import query_surface_sha256
+from codenib.scip_interface.scip_query import (
+    FACT_QUERY_CAPABILITIES,
+    FactQueryCandidate,
+    FactQueryCandidateRejected,
+    _allowed_files_digest,
+    _source_and_allowed_files,
+    observe_fact_query_snapshot,
+)
+from codenib.scip_interface.scip_query_provider import (
+    FAILED,
+    GRAPH_READY,
+    NATIVE_READY,
+    SCIPHybridQueryProvider,
+    scip_consumer_query_mode,
+    select_scip_query_provider,
+)
+from codenib.source_fingerprint import fingerprint_repository
+from codenib.types import EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE
+
+
+class _NativeIndex:
+    """FactQueryIndex-shaped view over a fixture graph with call counters."""
+
+    fact_query_index = True
+    materializes_graph = False
+    supports_graph_routes = False
+    capabilities = FACT_QUERY_CAPABILITIES
+
+    def __init__(self, graph: CodeGraph) -> None:
+        self._fixture = graph
+        self.resolve_calls = 0
+
+    def resolve_symbol_candidates(self, symbol: str, limit: int = 8) -> list[str]:
+        self.resolve_calls += 1
+        from codenib.agent.lsp_graph import resolve_symbol_candidates
+
+        return resolve_symbol_candidates(self._fixture, symbol, limit)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._fixture, name)
+
+
+def _graph(root: Path) -> CodeGraph:
+    graph = CodeGraph(str(root))
+    graph._add_vertex(str(root), {"type": "root"})
+    graph._add_vertex("caller.py", {"type": "file", "file": "caller.py"})
+    graph._add_vertex("target.py", {"type": "file", "file": "target.py"})
+    graph._add_vertex(
+        "demo/caller().",
+        {
+            "type": "function",
+            "file": "caller.py",
+            "start_line": 0,
+            "end_line": 5,
+            "selection_line": 0,
+            "unified_name": "caller()",
+            "symbol_kind": "function",
+            "has_definition": True,
+        },
+    )
+    graph._add_vertex(
+        "demo/target().",
+        {
+            "type": "function",
+            "file": "target.py",
+            "start_line": 0,
+            "end_line": 2,
+            "selection_line": 0,
+            "unified_name": "target()",
+            "symbol_kind": "function",
+            "has_definition": True,
+        },
+    )
+    graph._add_edge(str(root), "caller.py", EDGE_TYPE_CONTAIN)
+    graph._add_edge(str(root), "target.py", EDGE_TYPE_CONTAIN)
+    graph._add_edge("caller.py", "demo/caller().", EDGE_TYPE_CONTAIN)
+    graph._add_edge("target.py", "demo/target().", EDGE_TYPE_CONTAIN)
+    graph._add_edge(
+        "demo/caller().",
+        "demo/target().",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="caller.py",
+        anchor_line=2,
+    )
+    graph.build_range_indexes()
+    return graph
+
+
+def _candidate(graph: CodeGraph, root: Path) -> tuple[FactQueryCandidate, _NativeIndex]:
+    artifact_root = root / "artifact" / "symbol_graph"
+    artifact_root.mkdir(parents=True)
+    native = _NativeIndex(graph)
+    receipt = {
+        "schema_version": 1,
+        "language": "python",
+        "project_root": str(root),
+        "manifest": {
+            "entry_path": str(artifact_root),
+            "node_count": graph.graph.vcount(),
+            "edge_count": graph.graph.ecount(),
+        },
+        "graph": {
+            "relative_path": "graph.pkl",
+            "query_surface_sha256": query_surface_sha256(graph),
+        },
+        "receipt_sha256": "f" * 64,
+    }
+    return FactQueryCandidate(index=native, receipt=receipt, timings={}), native
+
+
+def _provider(
+    graph: CodeGraph,
+    root: Path,
+    *,
+    graph_loader=None,
+    snapshot_observer=None,
+    public_fallback_reason: str | None = None,
+) -> tuple[SCIPHybridQueryProvider, _NativeIndex]:
+    candidate, native = _candidate(graph, root)
+    provider = SCIPHybridQueryProvider(
+        candidate,
+        graph_loader=graph_loader or (lambda _path: graph),
+        snapshot_observer=snapshot_observer or (lambda _receipt: {"generation": 1}),
+        public_fallback_reason=public_fallback_reason,
+    )
+    return provider, native
+
+
+def _serialized(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def test_provider_module_import_does_not_import_graph_or_igraph() -> None:
+    script = """
+import sys
+from codenib.scip_interface.scip_query_provider import (
+    SCIPHybridQueryProvider,
+    scip_consumer_query_mode,
+)
+assert SCIPHybridQueryProvider.__name__ == 'SCIPHybridQueryProvider'
+assert scip_consumer_query_mode({}) == 'off'
+for name in ('igraph', 'codenib.graph.code_graph', 'codenib.ls_router'):
+    assert name not in sys.modules, name
+"""
+    subprocess.run([sys.executable, "-c", script], check=True, text=True)
+
+
+def test_symbol_mcp_results_and_public_metadata_are_byte_exact(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    fallback_reason = "scip_fact_query_consumer_measurement"
+    provider, native = _provider(
+        graph,
+        tmp_path,
+        public_fallback_reason=fallback_reason,
+    )
+    snapshot_id = (
+        f"symbol_graph:{tmp_path}:{graph.graph.vcount()}:{graph.graph.ecount()}"
+    )
+    legacy_provider = StaticLSPProvider(
+        graph,
+        snapshot_id=snapshot_id,
+        backend="persisted-symbol-graph-v1",
+        fallback_reason=fallback_reason,
+    )
+    legacy = SimpleNamespace(lsp_provider=legacy_provider, symbol_graph=graph)
+    candidate = SimpleNamespace(lsp_provider=provider, symbol_graph=None)
+
+    calls = (
+        lambda context: lsp_definition_impl(context, symbol="demo/target().", top_k=8),
+        lambda context: lsp_references_impl(
+            context,
+            symbol="target",
+            include_declaration=False,
+            top_k=40,
+        ),
+        lambda context: lsp_references_impl(
+            context,
+            symbol="`target`",
+            include_declaration=True,
+            top_k=100,
+        ),
+        lambda context: lsp_definition_impl(context, symbol="missing", top_k=8),
+    )
+    for call in calls:
+        assert _serialized(call(candidate)) == _serialized(call(legacy))
+    for capability in ("definition", "references", "route", "unsupported"):
+        assert _serialized(provider.can_serve(capability).to_dict()) == _serialized(
+            legacy_provider.can_serve(capability).to_dict()
+        )
+
+    assert native.resolve_calls > 0
+    assert provider.diagnostics()["state"] == NATIVE_READY
+    assert provider.diagnostics()["graph_load_attempt_count"] == 0
+    assert provider.diagnostics()["fallback_call_count"] == 0
+    assert provider.diagnostics()["native_physical_backend"] == (
+        "native-scip-fact-query-v1"
+    )
+
+
+def test_position_route_and_mixed_calls_match_one_loaded_graph(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    loads = 0
+
+    def load(_path: Path) -> CodeGraph:
+        nonlocal loads
+        loads += 1
+        return graph
+
+    provider, native = _provider(graph, tmp_path, graph_loader=load)
+    snapshot_id = (
+        f"symbol_graph:{tmp_path}:{graph.graph.vcount()}:{graph.graph.ecount()}"
+    )
+    legacy_provider = StaticLSPProvider(
+        graph,
+        snapshot_id=snapshot_id,
+        backend="persisted-symbol-graph-v1",
+    )
+    legacy = SimpleNamespace(lsp_provider=legacy_provider, symbol_graph=graph)
+    candidate = SimpleNamespace(lsp_provider=provider, symbol_graph=None)
+
+    position_calls = (
+        lambda context: lsp_definition_impl(
+            context, file_path="caller.py", line=3, top_k=8
+        ),
+        lambda context: lsp_references_impl(
+            context,
+            file_path="caller.py",
+            line=3,
+            include_declaration=False,
+            top_k=40,
+        ),
+        lambda context: lsp_route_impl(
+            context,
+            symbols=["demo/target()."],
+            query="target caller",
+            top_k=12,
+            include_neighbors=True,
+        ),
+    )
+    for call in position_calls:
+        assert _serialized(call(candidate)) == _serialized(call(legacy))
+
+    native_before = native.resolve_calls
+    assert _serialized(
+        lsp_definition_impl(candidate, symbol="target", top_k=8)
+    ) == _serialized(lsp_definition_impl(legacy, symbol="target", top_k=8))
+    assert native.resolve_calls > native_before
+    diagnostics = provider.diagnostics()
+    assert loads == 1
+    assert diagnostics["state"] == GRAPH_READY
+    assert diagnostics["graph_load_attempt_count"] == 1
+    assert diagnostics["graph_load_count"] == 1
+    assert diagnostics["graph_publication_count"] == 1
+    assert diagnostics["graph_materialization_seconds"] >= 0
+    assert diagnostics["receipt_observation_count"] == 7
+    assert diagnostics["native_definition_count"] == 1
+    assert diagnostics["native_symbol_call_count"] == 1
+    assert diagnostics["graph_call_count"] == 3
+    assert diagnostics["graph_fallback_count"] == 3
+
+
+def test_invalid_shapes_and_empty_route_do_not_load_graph(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    loads = 0
+
+    def load(_path: Path) -> CodeGraph:
+        nonlocal loads
+        loads += 1
+        return graph
+
+    provider, _native = _provider(graph, tmp_path, graph_loader=load)
+
+    with pytest.raises(
+        ValueError,
+        match="lsp_definition requires either symbol or file_path \\+ line",
+    ):
+        provider.definition()
+    with pytest.raises(
+        ValueError,
+        match="lsp_references requires either symbol or file_path \\+ line",
+    ):
+        provider.references(file_path="caller.py")
+    empty = provider.route(symbols=[], query="", top_k=12)
+    assert empty == []
+    assert empty.provider_metadata_dict() == {
+        "provider": "codenib_static_index",
+        "capability": "route",
+        "status": "ok",
+        "lsp_method": "codenib/lspRoute",
+        "behavior_contract": "static_graph_lsp_v1",
+        "position_granularity": "symbol",
+        "backend": "persisted-symbol-graph-v1",
+        "index_snapshot": (
+            f"symbol_graph:{tmp_path}:{graph.graph.vcount()}:{graph.graph.ecount()}"
+        ),
+    }
+    assert loads == 0
+    assert provider.diagnostics()["fallback_call_count"] == 0
+
+
+def test_concurrent_first_fallback_publishes_one_complete_graph(
+    tmp_path: Path,
+) -> None:
+    graph = _graph(tmp_path)
+    load_count = 0
+    load_lock = threading.Lock()
+
+    def load(_path: Path) -> CodeGraph:
+        nonlocal load_count
+        time.sleep(0.03)
+        with load_lock:
+            load_count += 1
+        return graph
+
+    provider, _native = _provider(graph, tmp_path, graph_loader=load)
+    start = threading.Barrier(16)
+
+    def query(_index: int) -> bytes:
+        start.wait()
+        result = provider.definition(file_path="caller.py", line=2, top_k=8)
+        return _serialized(
+            {
+                "rows": [node.model_dump() for node in result],
+                "metadata": result.provider_metadata_dict(),
+            }
+        )
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        results = list(executor.map(query, range(16)))
+
+    assert len(set(results)) == 1
+    assert load_count == 1
+    diagnostics = provider.diagnostics()
+    assert diagnostics["state"] == GRAPH_READY
+    assert diagnostics["graph_load_attempt_count"] == 1
+    assert diagnostics["graph_publication_count"] == 1
+    assert diagnostics["graph_waiter_count"] >= 1
+    assert diagnostics["receipt_observation_count"] == 33
+
+
+@pytest.mark.parametrize("loader_fails", [False, True])
+def test_symbol_call_waits_for_graph_publication_result(
+    tmp_path: Path,
+    loader_fails: bool,
+) -> None:
+    graph = _graph(tmp_path)
+    load_started = threading.Event()
+    release_load = threading.Event()
+    symbol_start = threading.Barrier(2)
+    failure = RuntimeError("injected publication failure")
+
+    def load(_path: Path) -> CodeGraph:
+        load_started.set()
+        assert release_load.wait(timeout=2)
+        if loader_fails:
+            raise failure
+        return graph
+
+    provider, native = _provider(graph, tmp_path, graph_loader=load)
+
+    def symbol_query() -> LSPProviderNodes:
+        symbol_start.wait()
+        return provider.definition(symbol="target", top_k=8)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        graph_future = executor.submit(
+            provider.definition,
+            file_path="caller.py",
+            line=2,
+            top_k=8,
+        )
+        assert load_started.wait(timeout=2)
+        symbol_future = executor.submit(symbol_query)
+        symbol_start.wait()
+        time.sleep(0.03)
+        assert not symbol_future.done()
+        assert native.resolve_calls == 0
+        release_load.set()
+
+        if loader_fails:
+            with pytest.raises(RuntimeError) as graph_error:
+                graph_future.result(timeout=2)
+            with pytest.raises(RuntimeError) as symbol_error:
+                symbol_future.result(timeout=2)
+            assert graph_error.value is failure
+            assert symbol_error.value is failure
+        else:
+            assert graph_future.result(timeout=2)
+            assert symbol_future.result(timeout=2)
+            assert native.resolve_calls > 0
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_type"),
+    [
+        (RuntimeError("injected loader failure"), RuntimeError),
+        (MemoryError("injected allocation failure"), MemoryError),
+    ],
+)
+def test_loader_failure_is_terminal_cached_and_memoryerror_is_unchanged(
+    tmp_path: Path,
+    failure: Exception,
+    expected_type: type[Exception],
+) -> None:
+    graph = _graph(tmp_path)
+    loads = 0
+
+    def fail(_path: Path) -> CodeGraph:
+        nonlocal loads
+        loads += 1
+        raise failure
+
+    provider, _native = _provider(graph, tmp_path, graph_loader=fail)
+    observed = []
+    for _ in range(2):
+        with pytest.raises(expected_type) as caught:
+            provider.definition(file_path="caller.py", line=2, top_k=8)
+        observed.append(caught.value)
+
+    with pytest.raises(expected_type) as symbol_definition:
+        provider.definition(symbol="target", top_k=8)
+    with pytest.raises(expected_type) as symbol_references:
+        provider.references(symbol="target", top_k=40)
+    with pytest.raises(expected_type) as empty_route:
+        provider.route(symbols=[], query="", top_k=12)
+
+    assert observed == [failure, failure]
+    assert symbol_definition.value is failure
+    assert symbol_references.value is failure
+    assert empty_route.value is failure
+    assert provider.can_serve("definition").status == "unavailable"
+    assert loads == 1
+    diagnostics = provider.diagnostics()
+    assert diagnostics["state"] == FAILED
+    assert diagnostics["graph_load_attempt_count"] == 1
+    assert diagnostics["graph_publication_count"] == 0
+    assert diagnostics["terminal_failure"] == {
+        "type": expected_type.__name__,
+        "message": str(failure),
+    }
+
+
+def test_snapshot_mismatch_fails_before_publication_and_is_cached(
+    tmp_path: Path,
+) -> None:
+    graph = _graph(tmp_path)
+    observations = 0
+
+    def observe(_receipt: Any) -> dict[str, int]:
+        nonlocal observations
+        observations += 1
+        return {"generation": observations}
+
+    provider, _native = _provider(graph, tmp_path, snapshot_observer=observe)
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match="snapshot changed"):
+            provider.route(symbols=["target"], top_k=12)
+
+    assert observations == 2
+    diagnostics = provider.diagnostics()
+    assert diagnostics["state"] == FAILED
+    assert diagnostics["graph_load_attempt_count"] == 1
+    assert diagnostics["graph_publication_count"] == 0
+
+
+def test_candidate_receipt_and_diagnostics_are_detached(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    provider, _native = _provider(graph, tmp_path)
+
+    receipt = provider.candidate_receipt
+    receipt["language"] = "rust"
+    diagnostics = provider.diagnostics()
+    diagnostics["state"] = "tampered"
+
+    assert provider.candidate_receipt["language"] == "python"
+    assert provider.diagnostics()["state"] == NATIVE_READY
+
+
+def test_snapshot_observer_receives_a_fresh_detached_receipt(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    observations: list[dict[str, Any]] = []
+
+    def observe(receipt: dict[str, Any]) -> dict[str, int]:
+        observations.append(receipt)
+        receipt["language"] = "mutated-by-observer"
+        return {"generation": 1}
+
+    provider, _native = _provider(graph, tmp_path, snapshot_observer=observe)
+    assert provider.definition(file_path="caller.py", line=2, top_k=8)
+
+    assert len(observations) == 3
+    assert len({id(receipt) for receipt in observations}) == 3
+    assert all(receipt["language"] == "mutated-by-observer" for receipt in observations)
+    assert provider.candidate_receipt["language"] == "python"
+
+
+def test_consumer_mode_is_independent_and_default_off() -> None:
+    assert scip_consumer_query_mode({}) == "off"
+    for mode in ("off", "auto", "required"):
+        assert (
+            scip_consumer_query_mode({"CODENIB_SCIP_FACT_QUERY_PROVIDER": mode.upper()})
+            == mode
+        )
+    with pytest.raises(ValueError, match="must be off, auto, or required"):
+        scip_consumer_query_mode({"CODENIB_SCIP_FACT_QUERY_PROVIDER": "sometimes"})
+
+
+def test_selector_limits_fallback_to_auto_startup(monkeypatch, tmp_path: Path) -> None:
+    import codenib.scip_interface.scip_query_provider as module
+
+    legacy = object()
+    legacy_calls = 0
+
+    def legacy_factory() -> object:
+        nonlocal legacy_calls
+        legacy_calls += 1
+        return legacy
+
+    def reject(*_args, **_kwargs):
+        raise FactQueryCandidateRejected("candidate unavailable")
+
+    monkeypatch.setattr(module, "SCIP_CONSUMER_PROMOTED_LANGUAGES", {"python"})
+    monkeypatch.setattr(module, "load_scip_query_provider", reject)
+
+    assert (
+        select_scip_query_provider(
+            tmp_path / "manifest.json",
+            legacy_provider_factory=legacy_factory,
+            mode="off",
+            language="python",
+        )
+        is legacy
+    )
+    assert (
+        select_scip_query_provider(
+            tmp_path / "manifest.json",
+            legacy_provider_factory=legacy_factory,
+            mode="auto",
+            language="python",
+        )
+        is legacy
+    )
+    with pytest.raises(FactQueryCandidateRejected, match="candidate unavailable"):
+        select_scip_query_provider(
+            tmp_path / "manifest.json",
+            legacy_provider_factory=legacy_factory,
+            mode="required",
+            language="python",
+        )
+    assert legacy_calls == 2
+
+
+def test_selector_propagates_startup_memoryerror(monkeypatch, tmp_path: Path) -> None:
+    import codenib.scip_interface.scip_query_provider as module
+
+    def fail(*_args, **_kwargs):
+        raise MemoryError("injected allocation failure")
+
+    monkeypatch.setattr(module, "SCIP_CONSUMER_PROMOTED_LANGUAGES", {"python"})
+    monkeypatch.setattr(module, "load_scip_query_provider", fail)
+    with pytest.raises(MemoryError, match="injected allocation failure"):
+        select_scip_query_provider(
+            tmp_path / "manifest.json",
+            legacy_provider_factory=lambda: object(),
+            mode="auto",
+            language="python",
+        )
+
+
+def test_auto_selector_does_not_retry_a_failing_legacy_factory(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import codenib.scip_interface.scip_query_provider as module
+
+    legacy_calls = 0
+
+    def fail_legacy() -> object:
+        nonlocal legacy_calls
+        legacy_calls += 1
+        raise RuntimeError("legacy startup failure")
+
+    monkeypatch.setattr(module, "SCIP_CONSUMER_PROMOTED_LANGUAGES", frozenset())
+    with pytest.raises(RuntimeError, match="legacy startup failure"):
+        select_scip_query_provider(
+            tmp_path / "manifest.json",
+            legacy_provider_factory=fail_legacy,
+            mode="auto",
+            language="python",
+        )
+    assert legacy_calls == 1
+
+
+def test_auto_selector_does_not_wrap_post_publication_failure(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import codenib.scip_interface.scip_query_provider as module
+
+    graph = _graph(tmp_path)
+
+    def fail(_path: Path) -> CodeGraph:
+        raise RuntimeError("post-publication snapshot failure")
+
+    provider, _native = _provider(graph, tmp_path, graph_loader=fail)
+    legacy_calls = 0
+
+    def legacy_factory() -> object:
+        nonlocal legacy_calls
+        legacy_calls += 1
+        return object()
+
+    monkeypatch.setattr(module, "SCIP_CONSUMER_PROMOTED_LANGUAGES", {"python"})
+    monkeypatch.setattr(module, "load_scip_query_provider", lambda *_a, **_k: provider)
+    selected = select_scip_query_provider(
+        tmp_path / "manifest.json",
+        legacy_provider_factory=legacy_factory,
+        mode="auto",
+        language="python",
+    )
+    assert selected is provider
+    with pytest.raises(RuntimeError, match="post-publication snapshot failure"):
+        selected.route(symbols=["target"], top_k=12)
+    assert legacy_calls == 0
+    assert selected.diagnostics()["state"] == FAILED
+
+
+def _git(command: list[str], root: Path) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(root), *command],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _observer_receipt(tmp_path: Path) -> tuple[dict[str, Any], Path, Path]:
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "demo.py").write_text("def demo():\n    return 1\n", encoding="utf-8")
+    _git(["init", "-q"], root)
+    _git(["config", "user.email", "tests@example.com"], root)
+    _git(["config", "user.name", "CodeNib Tests"], root)
+    _git(["add", "demo.py"], root)
+    _git(["commit", "-qm", "fixture"], root)
+    commit = _git(["rev-parse", "HEAD"], root)
+
+    cache = tmp_path / "cache"
+    graph_root = cache / "symbol_graph"
+    graph_root.mkdir(parents=True)
+    manifest_path = cache / "repo_manifest.json"
+    manifest_path.write_text("{}\n", encoding="utf-8")
+    index_path = graph_root / "index.decoded"
+    graph_path = graph_root / "graph.pkl"
+    index_path.write_bytes(b"decoded-index")
+    graph_path.write_bytes(b"persisted-graph")
+    manifest_fp = regular_file_fingerprint(manifest_path)
+    index_fp = regular_file_fingerprint(index_path)
+    graph_fp = regular_file_fingerprint(graph_path)
+    source, allowed_files = _source_and_allowed_files(
+        root,
+        cache_root=cache,
+        exclude_patterns=[],
+        target_dir=None,
+    )
+    assert source == fingerprint_repository(root, exclude_roots=(cache,))
+    query_digest = hashlib.sha256(b"query-surface").hexdigest()
+    receipt: dict[str, Any] = {
+        "schema_version": 1,
+        "language": "python",
+        "project_root": str(root),
+        "manifest": {
+            "path": str(manifest_path),
+            "version": "1.1",
+            "size_bytes": manifest_fp["size"],
+            "sha256": manifest_fp["sha256"],
+            "commit": commit,
+            "builder_schema": 4,
+            "node_count": 4,
+            "edge_count": 3,
+            "document_count": 1,
+            "query_surface_sha256": query_digest,
+            "source_fingerprint": source.value,
+            "file_count": source.file_count,
+            "entry_path": str(graph_root),
+            "entry_commit": commit,
+            "entry_source_fingerprint": source.value,
+        },
+        "index": {
+            "relative_path": "index.decoded",
+            "size_bytes": index_fp["size"],
+            "sha256": index_fp["sha256"],
+        },
+        "graph": {
+            "relative_path": "graph.pkl",
+            "size_bytes": graph_fp["size"],
+            "sha256": graph_fp["sha256"],
+            "query_surface_sha256": query_digest,
+        },
+        "fact_query": {
+            "abi_version": 1,
+            "format": "fact-query-index-v1",
+            "capabilities": dict(FACT_QUERY_CAPABILITIES),
+        },
+        "source": {
+            "fingerprint": source.value,
+            "file_count": source.file_count,
+            "repository_filter_policy": 3,
+        },
+        "filters": {
+            "graph_route": "active",
+            "update_mode": "full_rebuild",
+            "repository_filter_policy": 3,
+            "exclude_patterns": [],
+            "target_dir": None,
+            "allow_partial_languages": False,
+            "allow_partial_index": False,
+            "source_coverage_fallback": False,
+            "allowed_file_count": len(allowed_files),
+            "allowed_files_sha256": _allowed_files_digest(allowed_files),
+        },
+        "native_input": {
+            "schema_version": 1,
+            "index": {
+                "path": str(index_path),
+                "size_bytes": index_fp["size"],
+                "sha256": index_fp["sha256"],
+            },
+            "metadata": {
+                "kind": "none",
+                "complete": True,
+                "inputs": [],
+                "internal_crates": [],
+            },
+        },
+        "filter_identity": {"identity": True},
+    }
+    unsigned = json.dumps(
+        receipt,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    receipt["receipt_sha256"] = hashlib.sha256(unsigned).hexdigest()
+    return receipt, graph_path, root / "demo.py"
+
+
+def _bind_receipt_to_graph(
+    receipt: dict[str, Any],
+    graph: CodeGraph,
+) -> None:
+    query_digest = query_surface_sha256(graph)
+    receipt["manifest"]["node_count"] = graph.graph.vcount()
+    receipt["manifest"]["edge_count"] = graph.graph.ecount()
+    receipt["manifest"]["query_surface_sha256"] = query_digest
+    receipt["graph"]["query_surface_sha256"] = query_digest
+    unsigned = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    receipt["receipt_sha256"] = hashlib.sha256(
+        json.dumps(
+            unsigned,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def test_snapshot_observer_rechecks_graph_and_source_inputs(tmp_path: Path) -> None:
+    receipt, graph_path, source_path = _observer_receipt(tmp_path)
+
+    before = observe_fact_query_snapshot(receipt)
+    assert before["receipt_sha256"] == receipt["receipt_sha256"]
+    assert before["graph"]["path"] == str(graph_path)
+    assert before["source"]["file_count"] == receipt["source"]["file_count"]
+
+    graph_path.write_bytes(b"mutated-graph")
+    with pytest.raises(FactQueryCandidateRejected, match="graph changed"):
+        observe_fact_query_snapshot(receipt)
+
+    graph_path.write_bytes(b"persisted-graph")
+    source_path.write_text("def demo():\n    return 2\n", encoding="utf-8")
+    with pytest.raises(FactQueryCandidateRejected, match="repository source changed"):
+        observe_fact_query_snapshot(receipt)
+
+
+def test_snapshot_observer_rechecks_artifacts_after_source_scan(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import codenib.scip_interface.scip_query as module
+
+    receipt, graph_path, _source_path = _observer_receipt(tmp_path)
+    real_source_and_allowed_files = module._source_and_allowed_files
+    calls = 0
+
+    def mutate_after_scan(*args, **kwargs):
+        nonlocal calls
+        result = real_source_and_allowed_files(*args, **kwargs)
+        calls += 1
+        if calls == 1:
+            graph_path.write_bytes(b"mutated-during-observation")
+        return result
+
+    monkeypatch.setattr(
+        module,
+        "_source_and_allowed_files",
+        mutate_after_scan,
+    )
+    with pytest.raises(
+        FactQueryCandidateRejected,
+        match="inputs changed during snapshot observation",
+    ):
+        observe_fact_query_snapshot(receipt)
+
+
+def test_published_graph_fails_closed_after_artifact_mutation(
+    tmp_path: Path,
+) -> None:
+    receipt, graph_path, _source_path = _observer_receipt(tmp_path)
+    project_root = Path(receipt["project_root"])
+    graph = _graph(project_root)
+    _bind_receipt_to_graph(receipt, graph)
+    native = _NativeIndex(graph)
+    provider = SCIPHybridQueryProvider(
+        FactQueryCandidate(index=native, receipt=receipt, timings={}),
+        graph_loader=lambda _path: graph,
+    )
+
+    provider.definition(file_path="caller.py", line=2, top_k=8)
+    assert provider.diagnostics()["state"] == GRAPH_READY
+    assert provider.diagnostics()["receipt_observation_count"] == 3
+
+    graph_path.write_bytes(b"mutated-after-publication")
+    observed = []
+    for _ in range(2):
+        with pytest.raises(FactQueryCandidateRejected, match="graph changed") as caught:
+            provider.definition(file_path="caller.py", line=2, top_k=8)
+        observed.append(caught.value)
+
+    assert observed[0] is observed[1]
+    diagnostics = provider.diagnostics()
+    assert diagnostics["state"] == FAILED
+    assert diagnostics["graph_load_count"] == 1
+    assert diagnostics["graph_publication_count"] == 1
+    assert diagnostics["receipt_observation_count"] == 4
+    assert diagnostics["snapshot_after"] == {
+        "observation_error": {
+            "type": "FactQueryCandidateRejected",
+            "message": "FactQuery graph changed after candidate admission",
+        }
+    }
+
+
+@pytest.mark.parametrize("already_ready", [False, True], ids=["first", "ready"])
+def test_graph_query_discards_result_when_source_changes_during_execution(
+    tmp_path: Path,
+    already_ready: bool,
+) -> None:
+    receipt, _graph_path, source_path = _observer_receipt(tmp_path)
+    project_root = Path(receipt["project_root"])
+    graph = _graph(project_root)
+    _bind_receipt_to_graph(receipt, graph)
+    provider = SCIPHybridQueryProvider(
+        FactQueryCandidate(index=_NativeIndex(graph), receipt=receipt, timings={}),
+        graph_loader=lambda _path: graph,
+    )
+    if already_ready:
+        assert provider.definition(file_path="caller.py", line=2, top_k=8)
+
+    query_result_ready = threading.Event()
+    release_query = threading.Event()
+    real_query_range = graph.query_range
+
+    def blocked_query_range(*args, **kwargs):
+        result = real_query_range(*args, **kwargs)
+        query_result_ready.set()
+        assert release_query.wait(timeout=2)
+        return result
+
+    graph.query_range = blocked_query_range
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(
+            provider.definition,
+            file_path="caller.py",
+            line=2,
+            top_k=8,
+        )
+        assert query_result_ready.wait(timeout=2)
+        source_path.write_text("def demo():\n    return 2\n", encoding="utf-8")
+        release_query.set()
+        with pytest.raises(
+            FactQueryCandidateRejected,
+            match="repository source changed",
+        ) as caught:
+            future.result(timeout=2)
+
+    with pytest.raises(FactQueryCandidateRejected) as cached:
+        provider.definition(file_path="caller.py", line=2, top_k=8)
+    assert cached.value is caught.value
+    diagnostics = provider.diagnostics()
+    assert diagnostics["state"] == FAILED
+    assert diagnostics["graph_load_count"] == 1
+    assert diagnostics["graph_publication_count"] == 1
+    assert diagnostics["snapshot_before"]["source"]["fingerprint"] == (
+        receipt["source"]["fingerprint"]
+    )
+    assert diagnostics["snapshot_after"] == {
+        "observation_error": {
+            "type": "FactQueryCandidateRejected",
+            "message": (
+                "FactQuery repository source changed after candidate admission"
+            ),
+        }
+    }

--- a/test/scripts/test_profile_scip_mcp_consumer.py
+++ b/test/scripts/test_profile_scip_mcp_consumer.py
@@ -1,0 +1,791 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import json
+import math
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scripts.profiling import profile_scip_mcp_consumer as profiler
+
+
+def test_abba_schedule_is_balanced_and_reverses_blocks() -> None:
+    schedule = profiler._abba_schedule(4)
+
+    assert [entry["arm"] for entry in schedule] == [
+        "legacy",
+        "candidate",
+        "candidate",
+        "legacy",
+        "candidate",
+        "legacy",
+        "legacy",
+        "candidate",
+    ]
+    assert sum(entry["arm"] == "legacy" for entry in schedule) == 4
+    assert sum(entry["arm"] == "candidate" for entry in schedule) == 4
+
+
+@pytest.mark.parametrize("samples", [-1, 1, 3])
+def test_abba_schedule_rejects_unbalanced_sample_counts(samples: int) -> None:
+    with pytest.raises(ValueError, match="even"):
+        profiler._abba_schedule(samples)
+
+
+def test_summary_uses_nearest_rank_p95() -> None:
+    summary = profiler._summarize(list(range(1, 21)))
+
+    assert summary == {
+        "samples": 20,
+        "min": 1.0,
+        "p50": 10.5,
+        "p95": 19.0,
+        "max": 20.0,
+    }
+
+
+@pytest.mark.parametrize("values", [[], [math.nan], [math.inf], [-1], [True]])
+def test_summary_rejects_empty_or_malformed_samples(values: list[Any]) -> None:
+    with pytest.raises(ValueError):
+        profiler._summarize(values)
+
+
+def test_promotion_exact_p50_and_p95_threshold_passes() -> None:
+    decision = profiler._promotion_decision(
+        {"p50": 10.0, "p95": 20.0},
+        {"p50": 8.0, "p95": 16.0},
+        threshold=0.20,
+        parity=True,
+        graph_free=True,
+    )
+
+    assert decision["p50"]["passed"] is True
+    assert decision["p95"]["passed"] is True
+    assert decision["passed"] is True
+
+
+def test_promotion_requires_both_percentiles() -> None:
+    decision = profiler._promotion_decision(
+        {"p50": 10.0, "p95": 20.0},
+        {"p50": 8.0, "p95": math.nextafter(16.0, math.inf)},
+        threshold=0.20,
+        parity=True,
+        graph_free=True,
+    )
+
+    assert decision["p50"]["passed"] is True
+    assert decision["p95"]["passed"] is False
+    assert decision["passed"] is False
+
+
+def test_full_public_metadata_changes_parity_digest() -> None:
+    legacy = [
+        {
+            "node": "f.py:1",
+            "lsp_provider": {
+                "backend": "persisted-symbol-graph-v1",
+                "fallback_reason": "local_source_not_verified",
+            },
+        }
+    ]
+    candidate = json.loads(json.dumps(legacy))
+    candidate[0]["lsp_provider"]["backend"] = "native-scip-fact-query-v1"
+
+    assert profiler._json_digest(legacy) != profiler._json_digest(candidate)
+
+
+def test_balanced_sample_validator_rejects_missing_samples() -> None:
+    with pytest.raises(RuntimeError, match="imbalance"):
+        profiler._require_balanced_samples(
+            {"legacy": [{}, {}], "candidate": [{}]}, expected=2
+        )
+
+
+def test_only_the_fixed_protocol_is_promotion_eligible() -> None:
+    canonical = {
+        "iterations": profiler.DEFAULT_ITERATIONS,
+        "warmups": profiler.DEFAULT_WARMUPS,
+        "requested_query_workload_size": profiler.DEFAULT_QUERY_WORKLOAD_SIZE,
+        "observed_query_workload_size": profiler.DEFAULT_QUERY_WORKLOAD_SIZE,
+        "promotion_threshold": profiler.DEFAULT_PROMOTION_THRESHOLD,
+        "concurrency_workers": profiler.DEFAULT_CONCURRENCY_WORKERS,
+    }
+
+    assert profiler._canonical_protocol(**canonical)["passed"] is True
+    for field, value in {
+        "iterations": 2,
+        "warmups": 0,
+        "requested_query_workload_size": 6,
+        "observed_query_workload_size": 99,
+        "promotion_threshold": 0.0,
+        "concurrency_workers": 2,
+    }.items():
+        changed = dict(canonical)
+        changed[field] = value
+        assert profiler._canonical_protocol(**changed)["passed"] is False
+
+
+def test_validate_worker_rejects_nan_and_snapshot_drift() -> None:
+    snapshot = {"snapshot": "fixed"}
+    run = _fake_run(
+        arm="legacy",
+        workload="symbol_only",
+        process_id=1,
+        snapshot=snapshot,
+    )
+    run["wall_seconds"] = math.nan
+    with pytest.raises(RuntimeError, match="wall_seconds"):
+        profiler._validate_worker_run(
+            run,
+            arm="legacy",
+            workload="symbol_only",
+            expected_snapshot=snapshot,
+        )
+
+    run["wall_seconds"] = 10.0
+    run["receipt_after"] = {"snapshot": "changed"}
+    with pytest.raises(RuntimeError, match="changed during"):
+        profiler._validate_worker_run(
+            run,
+            arm="legacy",
+            workload="symbol_only",
+            expected_snapshot=snapshot,
+        )
+
+
+def test_file_receipt_rejects_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.write_bytes(b"artifact")
+    link = tmp_path / "link"
+    link.symlink_to(target)
+
+    with pytest.raises(ValueError, match="symlink"):
+        profiler._file_receipt(link)
+
+
+def test_subject_manifest_fixes_python_and_rust_revisions() -> None:
+    manifest = Path(profiler.__file__).with_name("scip_mcp_consumer_subjects.json")
+    payload, python = profiler._load_subject_manifest(
+        manifest, subject_id="python-codenib"
+    )
+    _, rust = profiler._load_subject_manifest(manifest, subject_id="rust-ruff")
+
+    assert payload["schema_version"] == 1
+    assert python == {
+        "id": "python-codenib",
+        "language": "python",
+        "repository": "https://github.com/sysevol-ai/CodeNib.git",
+        "revision": "6cf61b08310e165574c52fa217c66f0b6ae2a36d",
+    }
+    assert rust["revision"] == "75a24bbc67aa31b825b6326cfb6e6afdf3ca90d5"
+
+
+class _VariantGraph:
+    def __init__(self, *, ambiguous: bool = True) -> None:
+        self.name_to_vertex = {
+            "canonical-alpha": 0,
+            "canonical-beta": 1,
+            "canonical-shared-left": 2,
+            "canonical-shared-right": 3,
+        }
+        self._info = {
+            "canonical-alpha": {
+                "type": "function",
+                "file": "alpha.py",
+                "start_line": 0,
+                "end_line": 1,
+                "selection_line": 0,
+                "unified_name": "module:UniqueAlpha()",
+                "has_definition": True,
+            },
+            "canonical-beta": {
+                "type": "function",
+                "file": "beta.py",
+                "start_line": 2,
+                "end_line": 3,
+                "selection_line": 2,
+                "unified_name": "module:UniqueBeta()",
+                "has_definition": True,
+            },
+            "canonical-shared-left": {
+                "type": "function",
+                "file": "left.py",
+                "start_line": 4,
+                "end_line": 5,
+                "selection_line": 4,
+                "unified_name": "left:Shared()",
+                "has_definition": True,
+            },
+            "canonical-shared-right": {
+                "type": "function",
+                "file": "right.py",
+                "start_line": 6,
+                "end_line": 7,
+                "selection_line": 6,
+                "unified_name": "right:Shared()",
+                "has_definition": True,
+            },
+        }
+        self.graph = SimpleNamespace(vcount=lambda: 4, ecount=lambda: 3)
+        self._ambiguous = ambiguous
+
+    def get_node_info_by_name(self, name: str) -> dict[str, Any]:
+        return dict(self._info[name])
+
+    def resolve_symbol_candidates(self, raw: str, limit: int = 8) -> list[str]:
+        seed = raw.strip().strip("`'\"")
+        if seed in self.name_to_vertex:
+            return [seed]
+        aliases = {
+            "module:UniqueAlpha()": ["canonical-alpha"],
+            "UniqueAlpha": ["canonical-alpha"],
+            "module:UniqueBeta()": ["canonical-beta"],
+            "UniqueBeta": ["canonical-beta"],
+            "left:Shared()": ["canonical-shared-left"],
+            "right:Shared()": ["canonical-shared-right"],
+            "Shared": (
+                ["canonical-shared-left", "canonical-shared-right"]
+                if self._ambiguous
+                else ["canonical-shared-left"]
+            ),
+        }
+        return aliases.get(seed, [])[:limit]
+
+
+def test_workload_inputs_cover_all_symbol_variants_and_route_query() -> None:
+    inputs = profiler._workload_inputs(_VariantGraph(), query_workload_size=6)
+
+    assert inputs["symbol_query_category_counts"] == {
+        category: 1 for category in profiler._SYMBOL_QUERY_CATEGORIES
+    }
+    assert {query["category"] for query in inputs["symbol_queries"]} == set(
+        profiler._SYMBOL_QUERY_CATEGORIES
+    )
+    assert len({query["symbol"] for query in inputs["symbol_queries"]}) == 6
+    assert inputs["route_queries"]
+
+
+def test_workload_inputs_fail_without_ambiguous_seed() -> None:
+    with pytest.raises(ValueError, match="ambiguous"):
+        profiler._workload_inputs(_VariantGraph(ambiguous=False), query_workload_size=6)
+
+
+def test_workload_inputs_fail_without_route_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.agent.lsp_graph as lsp_graph
+
+    monkeypatch.setattr(lsp_graph, "_terms", lambda _value: set())
+    with pytest.raises(ValueError, match="query-only route"):
+        profiler._workload_inputs(_VariantGraph(), query_workload_size=6)
+
+
+def test_symbol_workload_calls_both_reference_declaration_modes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.mcp.tools.lsp as lsp_tools
+
+    reference_modes: list[bool] = []
+    monkeypatch.setattr(lsp_tools, "lsp_definition_impl", lambda *_a, **_k: [])
+
+    def references(*_args: Any, **kwargs: Any) -> list[Any]:
+        reference_modes.append(kwargs["include_declaration"])
+        return []
+
+    monkeypatch.setattr(lsp_tools, "lsp_references_impl", references)
+    outcome = profiler._run_mcp_workload(
+        object(),
+        workload="symbol_only",
+        symbol_queries=[{"category": "canonical", "symbol": "exact"}],
+        positions=[],
+        route_symbols=[],
+        route_queries=[],
+        capture_payload=True,
+    )
+
+    assert reference_modes == [False, True]
+    assert outcome["calls"] == 3
+    assert [row["query_category"] for row in outcome["public_payload"]] == [
+        "canonical",
+        "canonical",
+        "canonical",
+    ]
+
+
+def test_correctness_gate_requires_exact_native_and_fallback_counts() -> None:
+    run = _fake_run(
+        arm="candidate",
+        workload="mixed",
+        process_id=1,
+        snapshot={"snapshot": "fixed"},
+    )
+    expected = {
+        "native_definition_count": 6,
+        "native_references_count": 12,
+        "native_symbol_call_count": 18,
+        "fallback_call_count": 4,
+        "receipt_observation_count": 9,
+    }
+
+    assert profiler._correctness_candidate_ready(run, expected=expected) is True
+    run["diagnostics"]["native_references_count"] = 11
+    assert profiler._correctness_candidate_ready(run, expected=expected) is False
+
+
+def _candidate_diagnostics(
+    *, workload: str, workers: int, symbol_count: int = 6
+) -> dict[str, Any]:
+    symbol_only = workload == "symbol_only"
+    concurrent = workload == "concurrent_first_fallback"
+    fallback_calls = {
+        "symbol_only": 0,
+        "position_first": 2,
+        "route_first": 2,
+        "mixed": 4,
+        "concurrent_first_fallback": workers,
+    }[workload]
+    load_count = 0 if symbol_only else 1
+    symbol_count = 0 if concurrent else symbol_count
+    return {
+        "state": "NATIVE_READY" if symbol_only else "GRAPH_READY",
+        "logical_backend": "persisted-symbol-graph-v1",
+        "native_physical_backend": "native-scip-fact-query-v1",
+        "fallback_physical_backend": "lazy-persisted-symbol-graph-v1",
+        "native_definition_count": symbol_count,
+        "native_references_count": symbol_count * 2,
+        "native_symbol_call_count": symbol_count * 3,
+        "receipt_observation_count": (
+            0 if symbol_only else (2 if concurrent else 2 * fallback_calls + 1)
+        ),
+        "graph_load_attempt_count": load_count,
+        "graph_load_count": load_count,
+        "graph_publication_count": load_count,
+        "fallback_call_count": fallback_calls,
+        "graph_fallback_count": fallback_calls,
+        "graph_call_count": fallback_calls,
+        "graph_materialization_seconds": None if symbol_only else 0.01,
+        "terminal_failure": None,
+    }
+
+
+def _fake_run(
+    *,
+    arm: str,
+    workload: str,
+    process_id: int,
+    snapshot: dict[str, Any],
+    workers: int = 16,
+    symbol_count: int = 6,
+    symbol_query_category_counts: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    wall = 10.0 if arm == "legacy" else 8.0
+    fallback_calls = {
+        "symbol_only": 0,
+        "position_first": 2,
+        "route_first": 2,
+        "mixed": 4,
+        "concurrent_first_fallback": workers,
+    }[workload]
+    calls = (
+        workers
+        if workload == "concurrent_first_fallback"
+        else symbol_count * 3 + fallback_calls
+    )
+    result = {
+        "arm": arm,
+        "workload": workload,
+        "process_id": process_id,
+        "wall_seconds": wall,
+        "process_wall_seconds": wall + 0.1,
+        "cpu_seconds": wall / 2,
+        "startup_wall_seconds": wall / 2,
+        "workload_wall_seconds": wall / 2,
+        "rss_start_bytes": 100,
+        "peak_rss_start_bytes": 100,
+        "peak_rss_bytes": 200,
+        "peak_rss_growth_bytes": 100,
+        "calls": calls,
+        "results": calls,
+        "public_errors": 0,
+        "serialized_bytes": 1000,
+        "public_payload_sha256": profiler._json_digest({"workload": workload}),
+        "provider_selection": {"backend": "persisted-symbol-graph-v1"},
+        "diagnostics": (
+            _candidate_diagnostics(
+                workload=workload,
+                workers=workers,
+                symbol_count=symbol_count,
+            )
+            if arm == "candidate"
+            else None
+        ),
+        "receipt_before": dict(snapshot),
+        "receipt_after": dict(snapshot),
+        "igraph_imported": arm == "legacy",
+        "code_graph_imported": arm == "legacy",
+    }
+    if workload != "concurrent_first_fallback":
+        result["symbol_query_category_counts"] = symbol_query_category_counts or {
+            category: 1 for category in profiler._SYMBOL_QUERY_CATEGORIES
+        }
+    if workload == "concurrent_first_fallback":
+        result.update(
+            {
+                "thread_results_identical": True,
+                "thread_payload_sha256": ["sha256:" + "a" * 64],
+                "public_payload": [],
+            }
+        )
+    return result
+
+
+def _prepared_subject(tmp_path: Path) -> dict[str, Any]:
+    snapshot = {"snapshot_id": "fixed"}
+    artifacts = {
+        "manifest": {"sha256": "1" * 64},
+        "index": {"sha256": "2" * 64},
+        "graph": {"sha256": "3" * 64},
+    }
+    git = {
+        "commit": "6cf61b08310e165574c52fa217c66f0b6ae2a36d",
+        "dirty": False,
+        "remote": "https://github.com/sysevol-ai/CodeNib.git",
+    }
+    benchmark_sources = {
+        "harness": profiler._file_receipt(Path(profiler.__file__)),
+        "provider": profiler._file_receipt(
+            profiler._PROJECT_ROOT / "codenib/scip_interface/scip_query_provider.py"
+        ),
+        "snapshot_observer": profiler._file_receipt(
+            profiler._PROJECT_ROOT / "codenib/scip_interface/scip_query.py"
+        ),
+    }
+    return {
+        "manifest_path": str(tmp_path / "repo_manifest.json"),
+        "project_root": str(tmp_path),
+        "subject_manifest": {
+            "path": str(tmp_path / "subjects.json"),
+            "sha256": "4" * 64,
+            "payload": {"schema_version": 1, "subjects": []},
+            "entry": {
+                "id": "python-codenib",
+                "language": "python",
+                "repository": git["remote"],
+                "revision": git["commit"],
+            },
+        },
+        "language": "python",
+        "candidate_receipt": {"receipt_sha256": "5" * 64},
+        "initial_snapshot": snapshot,
+        "artifact_before": artifacts,
+        "git_before": git,
+        "benchmark_git_before": git,
+        "benchmark_sources_before": benchmark_sources,
+        "public_fallback_reason": "local_source_not_verified",
+        "public_provider_selection": {
+            "provider": "static",
+            "backend": "persisted-symbol-graph-v1",
+            "status": "ok",
+            "index_snapshot": "symbol_graph:fixed:4:3",
+            "fallback_reason": "local_source_not_verified",
+        },
+        "inputs": {
+            "symbol_queries": [
+                {"category": category, "symbol": f"{category}-seed"}
+                for category in profiler._SYMBOL_QUERY_CATEGORIES
+            ],
+            "symbol_query_category_counts": {
+                category: 1 for category in profiler._SYMBOL_QUERY_CATEGORIES
+            },
+            "positions": [{"file_path": "src/a.py", "line": 1}],
+            "route_symbols": ["src/a.py:f()"],
+            "route_queries": ["route query"],
+            "definition_symbol_count": 1,
+            "graph_vertex_count": 4,
+            "graph_edge_count": 3,
+        },
+    }
+
+
+def test_controller_uses_fake_isolated_workers_and_gates_only_symbols(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    prepared = _prepared_subject(tmp_path)
+    symbol_queries = [
+        {
+            "category": profiler._SYMBOL_QUERY_CATEGORIES[
+                index % len(profiler._SYMBOL_QUERY_CATEGORIES)
+            ],
+            "symbol": f"seed-{index}",
+        }
+        for index in range(profiler.DEFAULT_QUERY_WORKLOAD_SIZE)
+    ]
+    category_counts = {
+        category: sum(query["category"] == category for query in symbol_queries)
+        for category in profiler._SYMBOL_QUERY_CATEGORIES
+    }
+    prepared["inputs"]["symbol_queries"] = symbol_queries
+    prepared["inputs"]["symbol_query_category_counts"] = category_counts
+    process_ids = iter(range(1000, 2000))
+    observed_configs: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(profiler, "_prepare_subject", lambda **_kwargs: prepared)
+    monkeypatch.setattr(
+        profiler,
+        "_observe_receipt",
+        lambda _receipt: dict(prepared["initial_snapshot"]),
+    )
+    monkeypatch.setattr(
+        profiler,
+        "_artifact_receipts",
+        lambda _receipt: dict(prepared["artifact_before"]),
+    )
+    monkeypatch.setattr(
+        profiler,
+        "_git_identity",
+        lambda _root: dict(prepared["git_before"]),
+    )
+
+    def fake_worker(
+        config: dict[str, Any], *, timeout_seconds: float
+    ) -> dict[str, Any]:
+        assert timeout_seconds == 5.0
+        observed_configs.append(dict(config))
+        return _fake_run(
+            arm=config["arm"],
+            workload=config["workload"],
+            process_id=next(process_ids),
+            snapshot=prepared["initial_snapshot"],
+            workers=config["concurrency_workers"],
+            symbol_count=len(config["symbol_queries"]),
+            symbol_query_category_counts=category_counts,
+        )
+
+    monkeypatch.setattr(profiler, "_run_isolated_worker", fake_worker)
+
+    report = profiler.profile_scip_mcp_consumer(
+        manifest_path=tmp_path / "repo_manifest.json",
+        project_root=tmp_path,
+        subject_id="python-codenib",
+        worker_timeout_seconds=5.0,
+    )
+
+    assert report["passed"] is True
+    assert report["symbol_only"]["promotion"]["passed"] is True
+    assert report["gates"]["canonical_protocol"] is True
+    assert report["symbol_only"]["legacy"]["wall_seconds"]["samples"] == 20
+    assert report["symbol_only"]["candidate"]["wall_seconds"]["samples"] == 20
+    assert all(
+        observation["performance_gated"] is False
+        for observation in report["correctness"].values()
+    )
+    assert report["concurrent_first_fallback"]["passed"] is True
+    assert report["configuration"]["process_isolation_observed"] is True
+    assert report["configuration"]["symbol_query_category_counts"] == category_counts
+    assert len(observed_configs) == 55  # 48 performance + 6 correctness + 1 race
+    assert sum(config["workload"] == "symbol_only" for config in observed_configs) == 48
+    assert all(config["capture_payload"] is False for config in observed_configs)
+
+    smoke_report = profiler.profile_scip_mcp_consumer(
+        manifest_path=tmp_path / "repo_manifest.json",
+        project_root=tmp_path,
+        subject_id="python-codenib",
+        iterations=2,
+        warmups=0,
+        query_workload_size=6,
+        worker_timeout_seconds=5.0,
+    )
+
+    assert smoke_report["symbol_only"]["promotion"]["passed"] is True
+    assert smoke_report["gates"]["canonical_protocol"] is False
+    assert smoke_report["passed"] is False
+
+
+def test_controller_fails_when_fake_workers_reuse_process(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    prepared = _prepared_subject(tmp_path)
+    monkeypatch.setattr(profiler, "_prepare_subject", lambda **_kwargs: prepared)
+    monkeypatch.setattr(
+        profiler,
+        "_observe_receipt",
+        lambda _receipt: dict(prepared["initial_snapshot"]),
+    )
+    monkeypatch.setattr(
+        profiler,
+        "_artifact_receipts",
+        lambda _receipt: dict(prepared["artifact_before"]),
+    )
+    monkeypatch.setattr(
+        profiler,
+        "_git_identity",
+        lambda _root: dict(prepared["git_before"]),
+    )
+    monkeypatch.setattr(
+        profiler,
+        "_run_isolated_worker",
+        lambda config, **_kwargs: _fake_run(
+            arm=config["arm"],
+            workload=config["workload"],
+            process_id=123,
+            snapshot=prepared["initial_snapshot"],
+            workers=config["concurrency_workers"],
+        ),
+    )
+
+    report = profiler.profile_scip_mcp_consumer(
+        manifest_path=tmp_path / "repo_manifest.json",
+        project_root=tmp_path,
+        subject_id="python-codenib",
+        iterations=2,
+        warmups=0,
+    )
+
+    assert report["configuration"]["process_isolation_observed"] is False
+    assert report["gates"]["process_isolation"] is False
+    assert report["passed"] is False
+
+
+def test_controller_fails_when_benchmark_checkout_is_dirty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    prepared = _prepared_subject(tmp_path)
+    process_ids = iter(range(2000, 3000))
+    monkeypatch.setattr(profiler, "_prepare_subject", lambda **_kwargs: prepared)
+    monkeypatch.setattr(
+        profiler,
+        "_observe_receipt",
+        lambda _receipt: dict(prepared["initial_snapshot"]),
+    )
+    monkeypatch.setattr(
+        profiler,
+        "_artifact_receipts",
+        lambda _receipt: dict(prepared["artifact_before"]),
+    )
+
+    def git_identity(root: Path) -> dict[str, Any]:
+        observed = dict(prepared["git_before"])
+        if root == profiler._PROJECT_ROOT:
+            observed["dirty"] = True
+        return observed
+
+    monkeypatch.setattr(profiler, "_git_identity", git_identity)
+    monkeypatch.setattr(
+        profiler,
+        "_run_isolated_worker",
+        lambda config, **_kwargs: _fake_run(
+            arm=config["arm"],
+            workload=config["workload"],
+            process_id=next(process_ids),
+            snapshot=prepared["initial_snapshot"],
+            workers=config["concurrency_workers"],
+        ),
+    )
+
+    report = profiler.profile_scip_mcp_consumer(
+        manifest_path=tmp_path / "repo_manifest.json",
+        project_root=tmp_path,
+        subject_id="python-codenib",
+        iterations=2,
+        warmups=0,
+        query_workload_size=6,
+    )
+
+    assert report["gates"]["immutable_benchmark"] is False
+    assert report["passed"] is False
+
+
+def test_isolated_worker_reraises_structured_memory_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        profiler.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=70,
+            stdout="",
+            stderr=json.dumps(
+                {"error_type": "MemoryError", "message": "allocation failed"}
+            ),
+        ),
+    )
+
+    with pytest.raises(MemoryError, match="allocation failed"):
+        profiler._run_isolated_worker({}, timeout_seconds=1.0)
+
+
+@pytest.mark.parametrize(("passed", "exit_code"), [(True, 0), (False, 1)])
+def test_controller_exit_code_reflects_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    passed: bool,
+    exit_code: int,
+) -> None:
+    monkeypatch.setattr(
+        profiler,
+        "profile_scip_mcp_consumer",
+        lambda **_kwargs: {"passed": passed},
+    )
+
+    observed = profiler.main(
+        [
+            "--manifest",
+            "manifest.json",
+            "--project-root",
+            ".",
+            "--subject-id",
+            "python-codenib",
+        ]
+    )
+
+    assert observed == exit_code
+    assert json.loads(capsys.readouterr().out) == {"passed": passed}
+
+
+def test_controller_creates_output_parent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        profiler,
+        "profile_scip_mcp_consumer",
+        lambda **_kwargs: {"passed": True},
+    )
+    output = tmp_path / "nested" / "report.json"
+
+    exit_code = profiler.main(
+        [
+            "--manifest",
+            "manifest.json",
+            "--project-root",
+            ".",
+            "--subject-id",
+            "python-codenib",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(output.read_text(encoding="utf-8")) == {"passed": True}
+
+
+def test_worker_cli_reports_memory_error_without_swallowing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(profiler.sys, "stdin", io.StringIO("{}"))
+    monkeypatch.setattr(
+        profiler,
+        "_worker",
+        lambda _config: (_ for _ in ()).throw(MemoryError("out of memory")),
+    )
+
+    assert profiler.main(["--worker"]) == 70
+    failure = json.loads(capsys.readouterr().err)
+    assert failure == {"error_type": "MemoryError", "message": "out of memory"}


### PR DESCRIPTION
## Summary

Gate a default-off lazy SCIP FactQueryIndex provider at the real MCP consumer boundary and record the independent Python/Rust promotion decision for #598.

Both fixed subjects preserve canonical MCP tool-result behavior, graph-free symbol execution, lazy fallback semantics, receipt stability, and exactly-once concurrent publication. Neither reaches the required multiplicative 20% p50 and p95 improvement, so the consumer-promoted language set remains empty and production routing is unchanged.

## Changes

- add a graph-free Python/Rust hybrid query provider with a fail-closed `NATIVE_READY -> GRAPH_LOADING -> GRAPH_READY | FAILED` state machine
- bind every fallback call to pre/post manifest, index, graph, source, Cargo, and checkout observations
- add a fixed process-isolated MCP gate with 20 measured samples per arm, four warmups, 100 six-category symbol seeds, balanced ABBA order, and 16-thread publication coverage
- pin CodeNib and Ruff subjects and expose a maintained Make target without wiring the selector into production
- accept only proven-unrelated Rust Cargo array tables such as `[[bench]]` and `[[test]]`, while keeping relevant or malformed tables fail-closed
- record exact formal timings, artifact/receipt/report hashes, and the negative promotion decision in the durable SCIP roadmap

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `make core-test` — 216 passed, 2 skipped, plus all maintained C++ executables
- focused provider/profiler/MCP/LSP regression — 128 passed
- `build/core/scip_decode_test`
- `pre-commit run --files <changed files>`
- `python -m mkdocs build --strict`
- formal Python gate: semantic/safety gates passed; p50 1.417629s -> 2.456498s, p95 2.009662s -> 2.569240s; report SHA-256 `af8404dcc2b64547279cdb27fb3241977c3957a0580c36e55750567bedb2ff4b`
- formal Rust gate: semantic/safety gates passed; p50 2.217309s -> 6.545577s, p95 2.702742s -> 7.005324s; report SHA-256 `aff1dc4e6dcfa581a540a574223d6e0aba9b414ca8b9153ee344010d7a1e82c7`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
