### PR TITLE
feat(storage): plan retained manifest imports

### DIFF
--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -29,6 +29,14 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     from codenib.compiler.index_builders import IndexBuilderRegistry
     from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
     from codenib.compiler.manifest import ManifestIndexStateStore, RepoManifest
+    from codenib.compiler.manifest_storage import (
+        RepoManifestImportPlan,
+        SourceIntent,
+        ViewImportIntent,
+        ViewSelection,
+        plan_repo_manifest_import,
+        plan_repo_manifest_import_bytes,
+    )
     from codenib.compiler.params import ResolvedParams, SessionContext, resolve_params
     from codenib.compiler.resources import (
         IndexRequirement,
@@ -56,6 +64,24 @@ _EXPORTS = {
     "ManifestIndexStateStore": (
         "codenib.compiler.manifest",
         "ManifestIndexStateStore",
+    ),
+    "RepoManifestImportPlan": (
+        "codenib.compiler.manifest_storage",
+        "RepoManifestImportPlan",
+    ),
+    "SourceIntent": ("codenib.compiler.manifest_storage", "SourceIntent"),
+    "ViewImportIntent": (
+        "codenib.compiler.manifest_storage",
+        "ViewImportIntent",
+    ),
+    "ViewSelection": ("codenib.compiler.manifest_storage", "ViewSelection"),
+    "plan_repo_manifest_import": (
+        "codenib.compiler.manifest_storage",
+        "plan_repo_manifest_import",
+    ),
+    "plan_repo_manifest_import_bytes": (
+        "codenib.compiler.manifest_storage",
+        "plan_repo_manifest_import_bytes",
     ),
     "ResourceResolver": ("codenib.compiler.resources", "ResourceResolver"),
     "ResourcePlan": ("codenib.compiler.resources", "ResourcePlan"),
@@ -86,6 +112,12 @@ __all__ = [
     # Manifest
     "RepoManifest",
     "ManifestIndexStateStore",
+    "RepoManifestImportPlan",
+    "SourceIntent",
+    "ViewImportIntent",
+    "ViewSelection",
+    "plan_repo_manifest_import",
+    "plan_repo_manifest_import_bytes",
     # Resources
     "ResourceResolver",
     "ResourcePlan",

--- a/codenib/compiler/manifest_storage.py
+++ b/codenib/compiler/manifest_storage.py
@@ -1,0 +1,2445 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure retained-import planning for :class:`RepoManifest` v1.1 documents.
+
+This module deliberately stops before filesystem or storage authority begins.
+It parses one manifest with bounded, unambiguous JSON rules and turns it into
+an immutable import *intent*.  The plan contains no catalog IDs, object-store
+receipts, source-verification claims, or finalized projection envelope.
+
+Later adapter stages may use the plan only after separately authenticating the
+repository source and each referenced artifact.  In particular, a source
+fingerprint v2 value is content-bound input that is eligible for that later
+verification; it is not proof that verification has already happened.  A v1
+fingerprint remains available for diagnostics but makes the plan inert.
+"""
+
+from __future__ import annotations
+
+import codecs
+import hashlib
+import io
+import json
+import math
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from .._bounded_json import validate_bounded_json_stream
+from .._secret_fields import SecretFieldError, assert_no_secret_fields
+from ..index.embedding.model_policy import (
+    resolve_embedding_artifact_load_policy_from_options,
+)
+from ..provider_routes import resolve_embedding_artifact_route
+from ..source_fingerprint import source_fingerprint_version
+from ..storage.models import StorageValidationError, ViewProfile, canonical_json
+from .manifest import MANIFEST_VERSION, IndexEntry, RepoManifest
+
+REPO_MANIFEST_IMPORT_PLAN_SCHEMA = "codenib.repo-manifest-import-plan.v1"
+REPO_MANIFEST_PROFILE_CONTRACT = "codenib.repo-manifest-profile.v1"
+REPO_MANIFEST_PROFILE_NAME = "repo-manifest-explicit"
+REPO_MANIFEST_BM25_GENERATION_CONTRACT = "codenib.repo-manifest-bm25-generation.v1"
+REPO_MANIFEST_VECTOR_GENERATION_CONTRACT = "codenib.repo-manifest-vector-generation.v1"
+
+PORTABLE_STORAGE_VIEWS = frozenset({"bm25", "vector"})
+CURRENT_PORTABLE_BUILDER_SCHEMAS = {"bm25": 8, "vector": 6}
+
+DEFAULT_MAX_MANIFEST_BYTES = 16 * 1024 * 1024
+_MAX_JSON_DEPTH = 64
+_MAX_JSON_NODES = 250_000
+_MAX_JSON_LEXICAL_TOKENS = 500_000
+_MAX_JSON_KEY_BYTES = 4_096
+_MAX_JSON_ATOM_BYTES = 128
+_MAX_INDEXES = 128
+_MAX_LANGUAGES = 256
+_MAX_CAPABILITIES = 256
+_MAX_TEXT = 32_768
+_MAX_NAME = 256
+_MAX_VIEW_NAME = 128
+_MAX_CONFIG_BYTES = 16 * 1024 * 1024
+_MAX_DOCUMENTS_BYTES = 256 * 1024 * 1024
+_INT64_MAX = 9_223_372_036_854_775_807
+_DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+_DIAGNOSTIC_FIELD_NAMES = frozenset(
+    {"error", "errormessage", "stalereason", "traceback", "exception"}
+)
+_DIAGNOSTIC_FIELD_FRAGMENTS = (
+    "diagnostic",
+    "error",
+    "exception",
+    "failuremessage",
+    "failurereason",
+    "stacktrace",
+    "stalereason",
+    "traceback",
+)
+_AUTHORITY_CLAIM_FIELD_NAMES = frozenset(
+    {
+        "repositoryid",
+        "namespaceid",
+        "sourcerevisionid",
+        "profileid",
+        "generationid",
+        "viewgenerationid",
+        "objectid",
+        "object",
+        "storagekey",
+        "snapshotid",
+        "catalogsnapshotid",
+        "receipt",
+        "pinid",
+        "sourceverified",
+        "commitverified",
+        "checkoutverified",
+        "verificationscope",
+        "nativeindexauthorization",
+        "authority",
+        "ownership",
+        "repositorysourcebinding",
+        "sourcebinding",
+        "workspaceauthority",
+        "verified",
+        "isverified",
+        "verifiedsource",
+        "authorized",
+        "isauthorized",
+        "durable",
+        "pinned",
+    }
+)
+_AUTHORITY_CLAIM_FIELD_FRAGMENTS = (
+    "authority",
+    "authorization",
+    "authorized",
+    "catalogid",
+    "canonicalpath",
+    "directoryfd",
+    "directoryhandle",
+    "durable",
+    "filedescriptor",
+    "filehandle",
+    "generationid",
+    "namespaceid",
+    "objectid",
+    "ownership",
+    "pinid",
+    "pinned",
+    "profileid",
+    "realpath",
+    "receipt",
+    "repositoryid",
+    "resolvedpath",
+    "snapshotid",
+    "sourcebinding",
+    "sourcerevisionid",
+    "storagekey",
+    "verification",
+    "verified",
+    "workspacebinding",
+)
+_SELECTION_SKIP_REASONS = frozenset(
+    {"not_current", "incomplete_profile", "incomplete_generation_record"}
+)
+_MISSING_ENTRY_FIELD = object()
+
+BM25_PROFILE_AXES = (
+    "builder_schema",
+    "languages",
+    "max_k",
+    "max_lines_per_chunk",
+    "chunking_failure_policy",
+    "include_header_epilogue",
+    "repository_filter_policy",
+)
+VECTOR_PROFILE_AXES = (
+    "builder_schema",
+    "embedding_model",
+    "embedding_provider",
+    "embedding_dimension",
+    "dimension",
+    "embedding_endpoint",
+    "embedding_kwargs",
+    "embedding_route",
+    "embedding_fingerprint",
+    "index_metric",
+    "languages",
+    "levels",
+    "max_lines_per_chunk",
+    "chunking_failure_policy",
+    "repository_filter_policy",
+)
+
+_BM25_NON_PROFILE_CONFIG_FIELDS = frozenset(
+    {
+        "artifact_file_fingerprints",
+        "artifact_scope",
+        "chunk_count",
+        "file_count",
+        "portable_document_format",
+        "source_file_count",
+    }
+)
+_VECTOR_NON_PROFILE_CONFIG_FIELDS = frozenset(
+    {
+        "artifact_scope",
+        "cache_hit_rate",
+        "chunks_from_cache",
+        "chunks_reembedded",
+        "document_count",
+        "incremental_fallback_reason",
+        "last_commit",
+        "new_commit",
+        "persistence_config_fingerprint",
+        "portable_document_format",
+        "update_mode",
+    }
+)
+_VECTOR_INCREMENTAL_FIELDS = (
+    "chunks_reembedded",
+    "chunks_from_cache",
+    "cache_hit_rate",
+    "new_commit",
+)
+_VECTOR_FALLBACK_FIELDS = ("update_mode", "incremental_fallback_reason")
+_VECTOR_UPDATE_MODES = frozenset({"full_rebuild"})
+_NON_PROFILE_METADATA_FIELDS = frozenset({"build_duration_seconds"})
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {"version", "repo", "indexes", "capabilities", "compiled_at", "compiled_at_epoch"}
+)
+_REPO_FIELDS = frozenset(
+    {
+        "path",
+        "commit",
+        "last_indexed_commit",
+        "source_fingerprint",
+        "last_indexed_source_fingerprint",
+        "languages",
+        "file_count",
+    }
+)
+_ENTRY_FIELDS = frozenset(
+    {
+        "index_type",
+        "path",
+        "built_at",
+        "built_at_epoch",
+        "status",
+        "config",
+        "metadata",
+        "commit",
+        "source_fingerprint",
+    }
+)
+
+
+class _AmbiguousJSONError(ValueError):
+    """A JSON document has more than one possible decoded meaning."""
+
+
+class _IncompleteProfile(ValueError):
+    """A view cannot form a complete compatibility profile."""
+
+
+class _IncompleteGenerationRecord(ValueError):
+    """A view lacks its explicit artifact-generation fingerprint record."""
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _canonical_bytes(value: Mapping[str, Any]) -> bytes:
+    return canonical_json(value).encode("ascii")
+
+
+@dataclass(frozen=True, slots=True)
+class SourceIntent:
+    """Manifest-declared source identity awaiting a real source authority."""
+
+    fingerprint: str
+    fingerprint_version: int
+    file_count: int
+    display_commit: str
+
+    def __post_init__(self) -> None:
+        if type(self) is not SourceIntent:
+            raise StorageValidationError("source intent must use the exact intent type")
+        try:
+            if (
+                type(self.fingerprint) is not str
+                or type(self.display_commit) is not str
+            ):
+                raise StorageValidationError("source intent text fields must be exact")
+            _bounded_text(
+                self.fingerprint,
+                "source intent fingerprint",
+                max_length=128,
+                allow_empty=False,
+            )
+            if (
+                type(self.fingerprint_version) is not int
+                or self.fingerprint_version not in {1, 2}
+                or source_fingerprint_version(self.fingerprint)
+                != self.fingerprint_version
+            ):
+                raise StorageValidationError(
+                    "source intent fingerprint and version must be canonical"
+                )
+            if type(self.file_count) is not int:
+                raise StorageValidationError("source intent file count must be exact")
+            _nonnegative_int(self.file_count, "source intent file count")
+            _bounded_text(self.display_commit, "source intent display commit")
+        except StorageValidationError:
+            raise
+        except Exception as exc:
+            raise StorageValidationError("source intent is invalid") from exc
+
+    @property
+    def disposition(self) -> str:
+        return "content-bound" if self.fingerprint_version == 2 else "legacy-diagnostic"
+
+    @property
+    def eligible_for_verification(self) -> bool:
+        """Whether a later authority may attempt content verification.
+
+        This is intentionally weaker than ``source_verified`` and cannot
+        authorize live source reads, native parsing, reuse, or publication.
+        """
+
+        return self.fingerprint_version == 2
+
+    @property
+    def identity_digest(self) -> str:
+        """Digest only the content-bearing intent, excluding display commit."""
+
+        return _sha256(
+            _canonical_bytes(
+                {
+                    "contract": "codenib.repo-manifest-source-intent.v1",
+                    "source_fingerprint": self.fingerprint,
+                    "fingerprint_version": self.fingerprint_version,
+                    "file_count": self.file_count,
+                }
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract": "codenib.repo-manifest-source-intent.v1",
+            "disposition": self.disposition,
+            "eligible_for_verification": self.eligible_for_verification,
+            "fingerprint_version": self.fingerprint_version,
+            "source_fingerprint": self.fingerprint,
+            "file_count": self.file_count,
+            "display_commit": self.display_commit,
+            "identity_digest": self.identity_digest,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ViewImportIntent:
+    """One selected view's data-only profile and generation intent."""
+
+    view_type: str
+    required: bool
+    manifest_entry_json: str
+    profile: ViewProfile
+    generation_record_json: str
+
+    def __post_init__(self) -> None:
+        if type(self) is not ViewImportIntent:
+            raise StorageValidationError(
+                "view import intent must use the exact intent type"
+            )
+        try:
+            _validate_view_import_intent(self)
+        except StorageValidationError:
+            raise
+        except Exception as exc:
+            raise StorageValidationError("view import intent is invalid") from exc
+
+    @property
+    def manifest_entry(self) -> dict[str, Any]:
+        value = json.loads(self.manifest_entry_json)
+        assert isinstance(value, dict)
+        return value
+
+    @property
+    def manifest_entry_digest(self) -> str:
+        return _sha256(self.manifest_entry_json.encode("ascii"))
+
+    @property
+    def profile_id(self) -> str:
+        return self.profile.profile_id
+
+    @property
+    def generation_record(self) -> dict[str, Any]:
+        value = json.loads(self.generation_record_json)
+        assert isinstance(value, dict)
+        return value
+
+    @property
+    def generation_record_digest(self) -> str:
+        return _sha256(self.generation_record_json.encode("ascii"))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "view_type": self.view_type,
+            "required": self.required,
+            "manifest_entry_digest": self.manifest_entry_digest,
+            "profile": {
+                "profile_id": self.profile_id,
+                "name": self.profile.name,
+                "config": self.profile.config,
+            },
+            "generation_record": self.generation_record,
+            "generation_record_digest": self.generation_record_digest,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ViewSelection:
+    """Canonical required/optional selection and explicit skip decisions."""
+
+    required_views: tuple[str, ...]
+    optional_views: tuple[str, ...]
+    selected_views: tuple[str, ...]
+    skipped_items: tuple[tuple[str, str], ...]
+
+    def __post_init__(self) -> None:
+        if type(self) is not ViewSelection:
+            raise StorageValidationError(
+                "view selection must use the exact selection type"
+            )
+        try:
+            _validate_view_selection(self)
+        except StorageValidationError:
+            raise
+        except Exception as exc:
+            raise StorageValidationError("view selection is invalid") from exc
+
+    @property
+    def skipped_views(self) -> Mapping[str, str]:
+        return MappingProxyType(dict(self.skipped_items))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "required_views": list(self.required_views),
+            "optional_views": list(self.optional_views),
+            "selected_views": list(self.selected_views),
+            "skipped_views": dict(self.skipped_items),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RepoManifestImportPlan:
+    """Immutable, non-authoritative plan for a future manifest import."""
+
+    manifest_json: str
+    source: SourceIntent
+    selection: ViewSelection
+    views: tuple[ViewImportIntent, ...]
+
+    def __post_init__(self) -> None:
+        if type(self) is not RepoManifestImportPlan:
+            raise StorageValidationError("import plan must use the exact plan type")
+        try:
+            _validate_import_plan(self)
+        except StorageValidationError:
+            raise
+        except Exception as exc:
+            raise StorageValidationError("import plan is invalid") from exc
+
+    @property
+    def schema(self) -> str:
+        return REPO_MANIFEST_IMPORT_PLAN_SCHEMA
+
+    @property
+    def canonical_manifest_bytes(self) -> bytes:
+        return self.manifest_json.encode("ascii")
+
+    @property
+    def manifest_digest(self) -> str:
+        return _sha256(self.canonical_manifest_bytes)
+
+    @property
+    def manifest(self) -> RepoManifest:
+        value = json.loads(self.manifest_json)
+        assert isinstance(value, dict)
+        return _repo_manifest_v11_from_data(value)
+
+    @property
+    def view_map(self) -> Mapping[str, ViewImportIntent]:
+        return MappingProxyType({view.view_type: view for view in self.views})
+
+    @property
+    def inert(self) -> bool:
+        """Whether source compatibility forbids continuing to authority checks."""
+
+        return not self.source.eligible_for_verification
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "manifest": {
+                "version": MANIFEST_VERSION,
+                "digest": self.manifest_digest,
+                "byte_size": len(self.canonical_manifest_bytes),
+            },
+            "source": self.source.to_dict(),
+            "selection": self.selection.to_dict(),
+            "views": {view.view_type: view.to_dict() for view in self.views},
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _canonical_bytes(self.to_dict())
+
+    @property
+    def plan_digest(self) -> str:
+        return _sha256(self.canonical_bytes)
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _AmbiguousJSONError(f"duplicate object key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise _AmbiguousJSONError(f"non-finite JSON number: {value}")
+
+
+def _parse_bounded_json_int(value: str) -> int:
+    digits = value[1:] if value.startswith("-") else value
+    if len(digits) > 19:
+        raise _AmbiguousJSONError("JSON integer exceeds the signed 64-bit limit")
+    try:
+        parsed = int(value)
+    except (OverflowError, ValueError) as exc:
+        raise _AmbiguousJSONError("JSON integer is invalid") from exc
+    if parsed < -(_INT64_MAX + 1) or parsed > _INT64_MAX:
+        raise _AmbiguousJSONError("JSON integer exceeds the signed 64-bit limit")
+    return parsed
+
+
+def _parse_bounded_json_float(value: str) -> float:
+    if len(value) > 128:
+        raise _AmbiguousJSONError("JSON number exceeds its lexical limit")
+    try:
+        parsed = float(value)
+    except (OverflowError, ValueError) as exc:
+        raise _AmbiguousJSONError("JSON number is invalid") from exc
+    if not math.isfinite(parsed):
+        raise _AmbiguousJSONError("JSON number must be finite")
+    return parsed
+
+
+def _positive_limit(value: int, field: str) -> int:
+    if type(value) is not int or value <= 0:
+        raise StorageValidationError(f"{field} must be a positive integer")
+    return value
+
+
+def _manifest_limit(value: int) -> int:
+    limit = _positive_limit(value, "manifest byte limit")
+    if limit > DEFAULT_MAX_MANIFEST_BYTES:
+        raise StorageValidationError(
+            "manifest byte limit must not exceed the fixed "
+            f"{DEFAULT_MAX_MANIFEST_BYTES}-byte ceiling"
+        )
+    return limit
+
+
+def _strict_json_loads(payload: str, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            payload,
+            object_pairs_hook=_strict_json_object,
+            parse_int=_parse_bounded_json_int,
+            parse_float=_parse_bounded_json_float,
+            parse_constant=_reject_nonfinite_json,
+        )
+    except (ValueError, OverflowError, RecursionError) as exc:
+        raise StorageValidationError(f"{label} is invalid or ambiguous JSON") from exc
+    if not isinstance(value, dict):
+        raise StorageValidationError(f"{label} must be a JSON object")
+    return value
+
+
+def _preflight_json_bytes(payload: bytes, *, label: str, max_bytes: int) -> None:
+    """Bound JSON framing before constructing a decoded object graph."""
+
+    try:
+        validate_bounded_json_stream(
+            io.BytesIO(payload),
+            label=label,
+            max_bytes=max_bytes,
+            max_nodes=_MAX_JSON_NODES,
+            max_lexical_tokens=_MAX_JSON_LEXICAL_TOKENS,
+            max_depth=_MAX_JSON_DEPTH,
+            max_key_bytes=_MAX_JSON_KEY_BYTES,
+            max_string_bytes=max_bytes,
+            max_atom_bytes=_MAX_JSON_ATOM_BYTES,
+        )
+    except (TypeError, ValueError) as exc:
+        raise StorageValidationError(
+            f"{label} is invalid or ambiguous JSON or exceeds its complexity budget"
+        ) from exc
+
+
+def _validate_json_budget(value: Any, *, label: str) -> None:
+    stack: list[tuple[Any, int]] = [(value, 1)]
+    nodes = 0
+    while stack:
+        current, depth = stack.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES:
+            raise StorageValidationError(
+                f"{label} exceeds the {_MAX_JSON_NODES}-node limit"
+            )
+        if depth > _MAX_JSON_DEPTH:
+            raise StorageValidationError(
+                f"{label} exceeds the {_MAX_JSON_DEPTH}-level depth limit"
+            )
+        if isinstance(current, Mapping):
+            for key, child in current.items():
+                if not isinstance(key, str):
+                    raise StorageValidationError(f"{label} object keys must be text")
+                try:
+                    encoded_key = key.encode("utf-8", errors="strict")
+                except UnicodeError as exc:
+                    raise StorageValidationError(
+                        f"{label} object keys must be valid UTF-8 text"
+                    ) from exc
+                if len(encoded_key) > _MAX_JSON_KEY_BYTES:
+                    raise StorageValidationError(
+                        f"{label} object keys exceed the byte limit"
+                    )
+                stack.append((child, depth + 1))
+        elif isinstance(current, (list, tuple)):
+            stack.extend((child, depth + 1) for child in current)
+        elif isinstance(current, int) and not isinstance(current, bool):
+            if current < -(_INT64_MAX + 1) or current > _INT64_MAX:
+                raise StorageValidationError(
+                    f"{label} integers must fit signed 64-bit storage"
+                )
+        elif isinstance(current, float) and not math.isfinite(current):
+            raise StorageValidationError(f"{label} numbers must be finite")
+        elif isinstance(current, str):
+            try:
+                current.encode("utf-8", errors="strict")
+            except UnicodeError as exc:
+                raise StorageValidationError(
+                    f"{label} strings must be valid UTF-8 text"
+                ) from exc
+        elif current is not None and not isinstance(current, (str, bool, int, float)):
+            raise StorageValidationError(
+                f"{label} contains unsupported {type(current).__name__} data"
+            )
+
+
+def _json_string_size(
+    value: str,
+    *,
+    label: str,
+    max_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+) -> int:
+    """Return the exact ensure-ASCII JSON string size without encoding it."""
+
+    size = 2
+    for character in value:
+        codepoint = ord(character)
+        if 0xD800 <= codepoint <= 0xDFFF:
+            raise StorageValidationError(f"{label} strings must be valid UTF-8 text")
+        if character in {'"', "\\", "\b", "\f", "\n", "\r", "\t"}:
+            size += 2
+        elif codepoint < 0x20 or codepoint == 0x7F or 0x80 <= codepoint <= 0xFFFF:
+            size += 6
+        elif codepoint > 0xFFFF:
+            size += 12
+        else:
+            size += 1
+        if size > max_bytes:
+            raise StorageValidationError(f"{label} exceeds its byte limit")
+    return size
+
+
+def _snapshot_json_value(
+    value: Any,
+    *,
+    label: str,
+    depth: int = 1,
+    state: dict[str, Any] | None = None,
+    max_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+) -> tuple[Any, int]:
+    """Consume caller JSON exactly once into bounded built-in containers."""
+
+    if state is None:
+        state = {
+            "nodes": 0,
+            "active": set(),
+            # Retain the original objects, rather than only their ids, so a
+            # short-lived projection cannot be freed and have its id reused.
+            "seen": {},
+            "max_bytes": max_bytes,
+        }
+
+    if type(value) is RepoManifest:
+        identity = id(value)
+        if identity in state["seen"]:
+            raise StorageValidationError(
+                f"{label} contains a repeated or cyclic container"
+            )
+        state["seen"][identity] = value
+        try:
+            languages = value.languages
+            indexes = value.indexes
+            capabilities = value.capabilities
+            if type(languages) is not list or list.__len__(languages) > _MAX_LANGUAGES:
+                raise StorageValidationError(
+                    "repository manifest languages must be a bounded exact list"
+                )
+            if type(indexes) is not dict or dict.__len__(indexes) > _MAX_INDEXES:
+                raise StorageValidationError(
+                    "repository manifest indexes must be a bounded exact object"
+                )
+            if (
+                type(capabilities) is not dict
+                or dict.__len__(capabilities) > _MAX_CAPABILITIES
+            ):
+                raise StorageValidationError(
+                    "repository manifest capabilities must be a bounded exact object"
+                )
+            projected = {
+                "version": value.version,
+                "repo": {
+                    "path": value.repo_path,
+                    "commit": value.commit,
+                    "last_indexed_commit": value.last_indexed_commit,
+                    "source_fingerprint": value.source_fingerprint,
+                    "last_indexed_source_fingerprint": (
+                        value.last_indexed_source_fingerprint
+                    ),
+                    "languages": languages,
+                    "file_count": value.file_count,
+                },
+                "indexes": indexes,
+                "capabilities": capabilities,
+                "compiled_at": value.compiled_at,
+                "compiled_at_epoch": value.compiled_at_epoch,
+            }
+        except StorageValidationError:
+            raise
+        except Exception as exc:
+            raise StorageValidationError(
+                f"{label} is missing or failed to expose manifest fields"
+            ) from exc
+        return _snapshot_json_value(
+            projected,
+            label=label,
+            depth=depth,
+            state=state,
+        )
+
+    if type(value) is IndexEntry:
+        identity = id(value)
+        if identity in state["seen"]:
+            raise StorageValidationError(
+                f"{label} contains a repeated or cyclic container"
+            )
+        state["seen"][identity] = value
+        try:
+            config = value.config
+            metadata = value.metadata
+            if type(config) is not dict or type(metadata) is not dict:
+                raise StorageValidationError(
+                    "repository manifest index config and metadata must be exact objects"
+                )
+            projected = {
+                "index_type": value.index_type,
+                "path": value.path,
+                "built_at": value.built_at,
+                "built_at_epoch": value.built_at_epoch,
+                "status": value.status,
+                "config": config,
+                "metadata": metadata,
+                "commit": value.commit,
+                "source_fingerprint": value.source_fingerprint,
+            }
+        except StorageValidationError:
+            raise
+        except Exception as exc:
+            raise StorageValidationError(
+                f"{label} is missing or failed to expose index fields"
+            ) from exc
+        return _snapshot_json_value(
+            projected,
+            label=label,
+            depth=depth,
+            state=state,
+        )
+
+    state["nodes"] += 1
+    if state["nodes"] > _MAX_JSON_NODES:
+        raise StorageValidationError(
+            f"{label} exceeds the {_MAX_JSON_NODES}-node limit"
+        )
+    if depth > _MAX_JSON_DEPTH:
+        raise StorageValidationError(
+            f"{label} exceeds the {_MAX_JSON_DEPTH}-level depth limit"
+        )
+
+    if isinstance(value, Mapping):
+        identity = id(value)
+        if identity in state["seen"]:
+            raise StorageValidationError(
+                f"{label} contains a repeated or cyclic container"
+            )
+        state["seen"][identity] = value
+        state["active"].add(identity)
+        result: dict[str, Any] = {}
+        size = 2
+        try:
+            iterator = iter(value.items())
+            while True:
+                try:
+                    item = next(iterator)
+                except StopIteration:
+                    break
+                if type(item) is not tuple or len(item) != 2:
+                    raise StorageValidationError(
+                        f"{label} mapping items must be key-value pairs"
+                    )
+                key, child = item
+                if type(key) is not str:
+                    raise StorageValidationError(
+                        f"{label} object keys must be exact strings"
+                    )
+                if key in result:
+                    raise StorageValidationError(
+                        f"{label} contains a duplicate object key: {key}"
+                    )
+                child_snapshot, child_size = _snapshot_json_value(
+                    child,
+                    label=label,
+                    depth=depth + 1,
+                    state=state,
+                )
+                if result:
+                    size += 1
+                size += (
+                    _json_string_size(
+                        key,
+                        label=label,
+                        max_bytes=state["max_bytes"],
+                    )
+                    + 1
+                    + child_size
+                )
+                if size > state["max_bytes"]:
+                    raise StorageValidationError(f"{label} exceeds its byte limit")
+                result[key] = child_snapshot
+        except StorageValidationError:
+            raise
+        except Exception as exc:
+            raise StorageValidationError(
+                f"{label} changed or failed while being snapshotted"
+            ) from exc
+        finally:
+            state["active"].discard(identity)
+        return result, size
+
+    if type(value) in {list, tuple}:
+        identity = id(value)
+        if identity in state["seen"]:
+            raise StorageValidationError(
+                f"{label} contains a repeated or cyclic container"
+            )
+        state["seen"][identity] = value
+        state["active"].add(identity)
+        result_list: list[Any] = []
+        size = 2
+        try:
+            for child in value:
+                child_snapshot, child_size = _snapshot_json_value(
+                    child,
+                    label=label,
+                    depth=depth + 1,
+                    state=state,
+                )
+                if result_list:
+                    size += 1
+                size += child_size
+                if size > state["max_bytes"]:
+                    raise StorageValidationError(f"{label} exceeds its byte limit")
+                result_list.append(child_snapshot)
+        finally:
+            state["active"].discard(identity)
+        return result_list, size
+
+    if value is None:
+        return None, 4
+    if type(value) is bool:
+        return value, 4 if value else 5
+    if type(value) is int:
+        if value < -(_INT64_MAX + 1) or value > _INT64_MAX:
+            raise StorageValidationError(
+                f"{label} integers must fit signed 64-bit storage"
+            )
+        return value, len(str(value))
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise StorageValidationError(f"{label} numbers must be finite")
+        encoded = json.dumps(value, allow_nan=False)
+        if len(encoded) > _MAX_JSON_ATOM_BYTES:
+            raise StorageValidationError(f"{label} number exceeds its lexical limit")
+        return value, len(encoded)
+    if type(value) is str:
+        return value, _json_string_size(
+            value,
+            label=label,
+            max_bytes=state["max_bytes"],
+        )
+    raise StorageValidationError(
+        f"{label} contains unsupported {type(value).__name__} data"
+    )
+
+
+def _require_exact_fields(
+    value: Mapping[str, Any], expected: frozenset[str], *, label: str
+) -> None:
+    missing = sorted(expected - set(value))
+    unknown = sorted(set(value) - expected)
+    if missing or unknown:
+        details: list[str] = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if unknown:
+            details.append("unknown " + ", ".join(unknown))
+        raise StorageValidationError(
+            f"{label} has an invalid shape ({'; '.join(details)})"
+        )
+
+
+def _bounded_text(
+    value: object,
+    field: str,
+    *,
+    max_length: int = _MAX_TEXT,
+    allow_empty: bool = True,
+) -> str:
+    if type(value) is not str:
+        raise StorageValidationError(f"{field} must be text")
+    if str.__len__(value) > max_length or "\x00" in value:
+        raise StorageValidationError(f"{field} is not bounded text")
+    if not allow_empty and not str.strip(value):
+        raise StorageValidationError(f"{field} must not be empty")
+    try:
+        str.encode(value, "utf-8", errors="strict")
+    except UnicodeError as exc:
+        raise StorageValidationError(f"{field} must be valid UTF-8 text") from exc
+    return value
+
+
+def _nonnegative_int(value: object, field: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > _INT64_MAX
+    ):
+        raise StorageValidationError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _positive_int(value: object, field: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value <= 0
+        or value > _INT64_MAX
+    ):
+        raise _IncompleteProfile(f"{field} must be a positive integer")
+    return value
+
+
+def _epoch(value: object, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise StorageValidationError(f"{field} must be a number")
+    if isinstance(value, int):
+        if value < 0 or value > _INT64_MAX:
+            raise StorageValidationError(
+                f"{field} must be finite, non-negative, and bounded"
+            )
+        return float(value)
+    if not math.isfinite(value) or value < 0 or value >= float(_INT64_MAX + 1):
+        raise StorageValidationError(f"{field} must be finite and non-negative")
+    return value
+
+
+def _text_list(
+    value: object,
+    field: str,
+    *,
+    allowed: frozenset[str] | None = None,
+) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise _IncompleteProfile(f"{field} must be a non-empty list")
+    if len(value) > _MAX_LANGUAGES:
+        raise _IncompleteProfile(f"{field} has too many values")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item or "\x00" in item:
+            raise _IncompleteProfile(f"{field} must contain bounded text")
+        if len(item) > _MAX_NAME:
+            raise _IncompleteProfile(f"{field} must contain bounded text")
+        if allowed is not None and item not in allowed:
+            raise _IncompleteProfile(f"{field} contains an unsupported value: {item}")
+        result.append(item)
+    if len(set(result)) != len(result):
+        raise _IncompleteProfile(f"{field} must not contain duplicates")
+    return result
+
+
+def _assert_no_diagnostic_fields(value: Any, *, source: str) -> None:
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            for key, child in current.items():
+                normalized = _normalized_field_name(key)
+                if normalized in _DIAGNOSTIC_FIELD_NAMES or any(
+                    fragment in normalized for fragment in _DIAGNOSTIC_FIELD_FRAGMENTS
+                ):
+                    raise StorageValidationError(
+                        f"{source} must not contain diagnostic field: {key}"
+                    )
+                stack.append(child)
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+
+
+def _normalized_field_name(value: object) -> str:
+    return "".join(
+        character
+        for character in str(value).casefold()
+        if character.isascii() and character.isalnum()
+    )
+
+
+def _assert_no_authority_claim_fields(value: Any, *, source: str) -> None:
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            for key, child in current.items():
+                normalized = _normalized_field_name(key)
+                if normalized in _AUTHORITY_CLAIM_FIELD_NAMES or any(
+                    fragment in normalized
+                    for fragment in _AUTHORITY_CLAIM_FIELD_FRAGMENTS
+                ):
+                    raise StorageValidationError(
+                        f"{source} must not contain authority claim field: {key}"
+                    )
+                stack.append(child)
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+
+
+def _validate_manifest_publication_policy(value: Mapping[str, Any]) -> None:
+    try:
+        assert_no_secret_fields(value, source="repository manifest")
+    except SecretFieldError as exc:
+        raise StorageValidationError(str(exc)) from exc
+    _assert_no_diagnostic_fields(value, source="repository manifest")
+    _assert_no_authority_claim_fields(value, source="repository manifest")
+
+
+def _validate_publishable_entry(entry: IndexEntry, *, view_type: str) -> None:
+    expected_path = f"views/{view_type}"
+    if entry.path != expected_path:
+        raise StorageValidationError(
+            f"selected view {view_type!r} path must be exactly {expected_path!r}"
+        )
+    for section, value in (("config", entry.config), ("metadata", entry.metadata)):
+        source = f"view {view_type!r} {section}"
+        try:
+            assert_no_secret_fields(value, source=source)
+        except SecretFieldError as exc:
+            raise StorageValidationError(str(exc)) from exc
+        _assert_no_diagnostic_fields(value, source=source)
+
+
+def _repo_manifest_v11_from_data(data: dict[str, Any]) -> RepoManifest:
+    """Validate and detach one exact RepoManifest v1.1 object."""
+
+    _validate_json_budget(data, label="repository manifest")
+    _require_exact_fields(data, _TOP_LEVEL_FIELDS, label="repository manifest")
+    if data.get("version") != MANIFEST_VERSION:
+        raise StorageValidationError(
+            f"repository manifest version must be {MANIFEST_VERSION}"
+        )
+
+    repo = data.get("repo")
+    indexes = data.get("indexes")
+    capabilities = data.get("capabilities")
+    if not isinstance(repo, dict):
+        raise StorageValidationError("repository manifest repo must be an object")
+    if not isinstance(indexes, dict):
+        raise StorageValidationError("repository manifest indexes must be an object")
+    if not isinstance(capabilities, dict):
+        raise StorageValidationError(
+            "repository manifest capabilities must be an object"
+        )
+    _require_exact_fields(repo, _REPO_FIELDS, label="repository manifest repo")
+    if len(indexes) > _MAX_INDEXES:
+        raise StorageValidationError("repository manifest has too many indexes")
+    if len(capabilities) > _MAX_CAPABILITIES:
+        raise StorageValidationError("repository manifest has too many capabilities")
+
+    repo_path = _bounded_text(
+        repo.get("path"), "repository manifest path", allow_empty=False
+    )
+    commit = _bounded_text(repo.get("commit"), "repository manifest commit")
+    last_commit = _bounded_text(
+        repo.get("last_indexed_commit"),
+        "repository manifest last indexed commit",
+    )
+    source = _bounded_text(
+        repo.get("source_fingerprint"),
+        "repository manifest source fingerprint",
+        allow_empty=False,
+    )
+    source_version = source_fingerprint_version(source)
+    if source_version not in {1, 2}:
+        raise StorageValidationError(
+            "repository manifest source fingerprint must be canonical v1 or v2"
+        )
+    last_source = _bounded_text(
+        repo.get("last_indexed_source_fingerprint"),
+        "repository manifest last indexed source fingerprint",
+    )
+    if last_source and source_fingerprint_version(last_source) not in {1, 2}:
+        raise StorageValidationError(
+            "repository manifest last indexed source fingerprint is unsupported"
+        )
+    raw_languages = repo.get("languages")
+    if not isinstance(raw_languages, list) or len(raw_languages) > _MAX_LANGUAGES:
+        raise StorageValidationError("repository manifest languages must be a list")
+    languages = [
+        _bounded_text(
+            language,
+            "repository manifest language",
+            max_length=_MAX_NAME,
+            allow_empty=False,
+        )
+        for language in raw_languages
+    ]
+    if len(set(languages)) != len(languages):
+        raise StorageValidationError(
+            "repository manifest languages must not contain duplicates"
+        )
+    file_count = _nonnegative_int(
+        repo.get("file_count"), "repository manifest file count"
+    )
+
+    entries: dict[str, IndexEntry] = {}
+    for name, raw_entry in indexes.items():
+        view_name = _bounded_text(
+            name,
+            "repository manifest view name",
+            max_length=_MAX_VIEW_NAME,
+            allow_empty=False,
+        )
+        if not isinstance(raw_entry, dict):
+            raise StorageValidationError(
+                f"repository manifest view {view_name!r} must be an object"
+            )
+        _require_exact_fields(
+            raw_entry,
+            _ENTRY_FIELDS,
+            label=f"repository manifest view {view_name!r}",
+        )
+        config = raw_entry.get("config")
+        metadata = raw_entry.get("metadata")
+        if not isinstance(config, dict) or not isinstance(metadata, dict):
+            raise StorageValidationError(
+                f"repository manifest view {view_name!r} metadata must be objects"
+            )
+        status = _bounded_text(
+            raw_entry.get("status"),
+            f"view {view_name!r} status",
+            allow_empty=False,
+        )
+        if status not in {"fresh", "stale", "failed"}:
+            raise StorageValidationError(f"view {view_name!r} has an invalid status")
+        entry_source = _bounded_text(
+            raw_entry.get("source_fingerprint"),
+            f"view {view_name!r} source fingerprint",
+        )
+        if entry_source and source_fingerprint_version(entry_source) not in {1, 2}:
+            raise StorageValidationError(
+                f"view {view_name!r} source fingerprint is unsupported"
+            )
+        index_type = _bounded_text(
+            raw_entry.get("index_type"),
+            f"view {view_name!r} index type",
+            max_length=_MAX_VIEW_NAME,
+            allow_empty=False,
+        )
+        if index_type != view_name:
+            raise StorageValidationError(
+                f"repository manifest view {view_name!r} index type does not match"
+            )
+        entries[view_name] = IndexEntry(
+            index_type=index_type,
+            path=_bounded_text(
+                raw_entry.get("path"),
+                f"view {view_name!r} path",
+                allow_empty=False,
+            ),
+            built_at=_bounded_text(
+                raw_entry.get("built_at"), f"view {view_name!r} built at"
+            ),
+            built_at_epoch=_epoch(
+                raw_entry.get("built_at_epoch"),
+                f"view {view_name!r} built_at_epoch",
+            ),
+            status=status,
+            config=config,
+            metadata=metadata,
+            commit=_bounded_text(raw_entry.get("commit"), f"view {view_name!r} commit"),
+            source_fingerprint=entry_source,
+        )
+
+    normalized_capabilities: dict[str, bool] = {}
+    for name, enabled in capabilities.items():
+        capability = _bounded_text(
+            name,
+            "repository manifest capability",
+            max_length=_MAX_NAME,
+            allow_empty=False,
+        )
+        if not isinstance(enabled, bool):
+            raise StorageValidationError(
+                "repository manifest capabilities must map text to booleans"
+            )
+        normalized_capabilities[capability] = enabled
+
+    manifest = RepoManifest(
+        version=MANIFEST_VERSION,
+        repo_path=repo_path,
+        commit=commit,
+        last_indexed_commit=last_commit,
+        source_fingerprint=source,
+        last_indexed_source_fingerprint=last_source,
+        languages=languages,
+        file_count=file_count,
+        indexes=entries,
+        capabilities=normalized_capabilities,
+        compiled_at=_bounded_text(
+            data.get("compiled_at"), "repository manifest compiled_at"
+        ),
+        compiled_at_epoch=_epoch(
+            data.get("compiled_at_epoch"), "repository manifest compiled_at_epoch"
+        ),
+    )
+    try:
+        canonical_json(manifest.to_dict())
+    except StorageValidationError:
+        raise
+    except (TypeError, ValueError) as exc:
+        raise StorageValidationError(
+            "repository manifest is not canonical JSON"
+        ) from exc
+    return manifest
+
+
+def _normalize_requested(
+    requested: Sequence[str] | None, *, field: str
+) -> tuple[str, ...]:
+    if requested is None:
+        return ()
+    if isinstance(requested, (str, bytes)):
+        raise StorageValidationError(f"{field} must be a sequence")
+    values: list[str] = []
+    try:
+        iterator = iter(requested)
+        for _index in range(_MAX_INDEXES + 1):
+            try:
+                value = next(iterator)
+            except StopIteration:
+                break
+            if type(value) is not str:
+                raise StorageValidationError(
+                    f"{field} must contain only exact view names"
+                )
+            bounded_value = _bounded_text(
+                value,
+                f"{field} view name",
+                max_length=_MAX_VIEW_NAME,
+                allow_empty=False,
+            )
+            normalized_value = str.strip(bounded_value)
+            if not normalized_value:
+                raise StorageValidationError(f"{field} contains an empty view name")
+            values.append(normalized_value)
+        else:
+            raise StorageValidationError(f"{field} has too many view names")
+    except StorageValidationError:
+        raise
+    except Exception as exc:
+        raise StorageValidationError(f"{field} must be a bounded sequence") from exc
+    normalized = tuple(dict.fromkeys(values))
+    unsupported = sorted(set(normalized) - PORTABLE_STORAGE_VIEWS)
+    if unsupported:
+        raise StorageValidationError(
+            "manifest storage planning supports only bm25 and vector views: "
+            + ", ".join(unsupported)
+        )
+    return tuple(sorted(normalized))
+
+
+def _entry_is_current(manifest: RepoManifest, view_type: str) -> tuple[bool, str]:
+    entry = manifest.indexes.get(view_type)
+    if entry is None:
+        return False, "missing"
+    if entry.index_type != view_type:
+        return False, "mismatched_index_type"
+    if entry.path != f"views/{view_type}":
+        return False, "artifact_path_mismatch"
+    if entry.status != "fresh":
+        return False, "not_fresh"
+    if entry.commit != manifest.commit or (
+        entry.source_fingerprint != manifest.source_fingerprint
+    ):
+        return False, "source_mismatch"
+    return True, ""
+
+
+def _initial_selection(
+    manifest: RepoManifest,
+    *,
+    views: Sequence[str] | None,
+    required_views: Sequence[str] | None,
+    optional_views: Sequence[str] | None,
+) -> tuple[tuple[str, ...], tuple[str, ...], dict[str, str]]:
+    if views is not None and (required_views is not None or optional_views is not None):
+        raise StorageValidationError(
+            "views cannot be combined with required_views or optional_views"
+        )
+
+    required: tuple[str, ...]
+    optional: tuple[str, ...]
+    if views is not None:
+        required = _normalize_requested(views, field="views")
+        optional = ()
+    elif required_views is None and optional_views is None:
+        bm25_current, _ = _entry_is_current(manifest, "bm25")
+        vector_current, _ = _entry_is_current(manifest, "vector")
+        if bm25_current:
+            required = ("bm25",)
+            optional = ("vector",) if vector_current else ()
+        elif vector_current:
+            required = ("vector",)
+            optional = ()
+        else:
+            required = ()
+            optional = ()
+    else:
+        required = _normalize_requested(required_views, field="required_views")
+        optional = _normalize_requested(optional_views, field="optional_views")
+
+    overlap = sorted(set(required) & set(optional))
+    if overlap:
+        raise StorageValidationError(
+            "views cannot be both required and optional: " + ", ".join(overlap)
+        )
+
+    skipped: dict[str, str] = {}
+    for view_type in required:
+        current, reason = _entry_is_current(manifest, view_type)
+        if not current:
+            raise StorageValidationError(
+                f"required view {view_type!r} is not current: {reason}"
+            )
+    retained_optional: list[str] = []
+    for view_type in optional:
+        current, _reason = _entry_is_current(manifest, view_type)
+        if current:
+            retained_optional.append(view_type)
+        else:
+            skipped[view_type] = "not_current"
+    optional = tuple(retained_optional)
+    if not required and not optional:
+        raise StorageValidationError(
+            "manifest storage planning requires a current bm25 or vector view"
+        )
+    return required, optional, skipped
+
+
+def _reject_unknown_config_fields(
+    config: Mapping[str, Any],
+    *,
+    view_type: str,
+    profile_axes: tuple[str, ...],
+    non_profile_fields: frozenset[str],
+) -> None:
+    unknown = sorted(set(config) - set(profile_axes) - non_profile_fields)
+    if unknown:
+        raise _IncompleteProfile(
+            f"view {view_type!r} has unclassified config fields: " + ", ".join(unknown)
+        )
+
+
+def _reject_unknown_metadata_fields(
+    metadata: Mapping[str, Any],
+    *,
+    view_type: str,
+    profile_axes: tuple[str, ...],
+    non_profile_fields: frozenset[str],
+) -> None:
+    unknown = sorted(
+        set(metadata)
+        - set(profile_axes)
+        - non_profile_fields
+        - _NON_PROFILE_METADATA_FIELDS
+    )
+    if unknown:
+        raise _IncompleteProfile(
+            f"view {view_type!r} has unclassified metadata fields: "
+            + ", ".join(unknown)
+        )
+
+
+def _require_profile_axes(
+    config: Mapping[str, Any], *, view_type: str, axes: tuple[str, ...]
+) -> None:
+    missing = [axis for axis in axes if axis not in config]
+    if missing:
+        raise _IncompleteProfile(
+            f"view {view_type!r} profile is missing required axes: "
+            + ", ".join(missing)
+        )
+
+
+def _profile_config(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
+    config = entry.config
+    axes: tuple[str, ...]
+    non_profile: frozenset[str]
+    embedding_load_policy: dict[str, Any] | None = None
+    if view_type == "bm25":
+        axes = BM25_PROFILE_AXES
+        non_profile = _BM25_NON_PROFILE_CONFIG_FIELDS
+    elif view_type == "vector":
+        axes = VECTOR_PROFILE_AXES
+        non_profile = _VECTOR_NON_PROFILE_CONFIG_FIELDS
+    else:  # pragma: no cover - selection excludes unsupported views
+        raise _IncompleteProfile(f"unsupported view profile: {view_type}")
+    _require_profile_axes(config, view_type=view_type, axes=axes)
+    _reject_unknown_config_fields(
+        config,
+        view_type=view_type,
+        profile_axes=axes,
+        non_profile_fields=non_profile,
+    )
+    _reject_unknown_metadata_fields(
+        entry.metadata,
+        view_type=view_type,
+        profile_axes=axes,
+        non_profile_fields=non_profile,
+    )
+    for axis in axes:
+        if axis not in entry.metadata:
+            continue
+        try:
+            config_value = _canonical_bytes({"value": config[axis]})
+            metadata_value = _canonical_bytes({"value": entry.metadata[axis]})
+        except (TypeError, ValueError) as exc:
+            raise _IncompleteProfile(
+                f"view {view_type!r} profile axis {axis!r} is not canonical JSON"
+            ) from exc
+        if config_value != metadata_value:
+            raise _IncompleteProfile(
+                f"view {view_type!r} profile axis {axis!r} conflicts with metadata"
+            )
+
+    builder_schema = _positive_int(
+        config["builder_schema"], f"view {view_type!r} builder_schema"
+    )
+    if builder_schema != CURRENT_PORTABLE_BUILDER_SCHEMAS[view_type]:
+        raise _IncompleteProfile(
+            f"view {view_type!r} builder_schema is not the current portable schema"
+        )
+    _text_list(config["languages"], f"view {view_type!r} languages")
+    _positive_int(
+        config["max_lines_per_chunk"],
+        f"view {view_type!r} max_lines_per_chunk",
+    )
+    failure_policy = config["chunking_failure_policy"]
+    if (
+        not isinstance(failure_policy, str)
+        or not failure_policy.strip()
+        or "\x00" in failure_policy
+        or len(failure_policy) > _MAX_NAME
+    ):
+        raise _IncompleteProfile(
+            f"view {view_type!r} chunking_failure_policy must be text"
+        )
+    _positive_int(
+        config["repository_filter_policy"],
+        f"view {view_type!r} repository_filter_policy",
+    )
+
+    if view_type == "bm25":
+        _positive_int(config["max_k"], "view 'bm25' max_k")
+        if not isinstance(config["include_header_epilogue"], bool):
+            raise _IncompleteProfile(
+                "view 'bm25' include_header_epilogue must be a boolean"
+            )
+    else:
+        _positive_int(config["embedding_dimension"], "vector embedding_dimension")
+        _positive_int(config["dimension"], "vector dimension")
+        if config["embedding_dimension"] != config["dimension"]:
+            raise _IncompleteProfile("view 'vector' embedding dimensions must agree")
+        if not isinstance(config["embedding_kwargs"], Mapping):
+            raise _IncompleteProfile("view 'vector' embedding_kwargs must be an object")
+        if not isinstance(config["embedding_route"], Mapping):
+            raise _IncompleteProfile("view 'vector' embedding_route must be an object")
+        if (
+            not isinstance(config["embedding_fingerprint"], str)
+            or not config["embedding_fingerprint"]
+        ):
+            raise _IncompleteProfile("view 'vector' embedding_fingerprint must be text")
+        if not isinstance(config["index_metric"], str) or config[
+            "index_metric"
+        ] not in {"ip", "l2"}:
+            raise _IncompleteProfile("view 'vector' index_metric is unsupported")
+        _text_list(
+            config["levels"],
+            "view 'vector' levels",
+            allowed=frozenset({"l0", "l2"}),
+        )
+        try:
+            route = resolve_embedding_artifact_route(config, environ={})
+            if route.provider == "huggingface":
+                policy = resolve_embedding_artifact_load_policy_from_options(
+                    route.model,
+                    route.compatibility_options,
+                )
+                embedding_load_policy = {
+                    "revision": policy.revision,
+                    "trust_remote_code": policy.trust_remote_code,
+                }
+            else:
+                embedding_load_policy = {
+                    "revision": None,
+                    "trust_remote_code": False,
+                }
+        except (TypeError, ValueError) as exc:
+            raise _IncompleteProfile(
+                "view 'vector' embedding route or model policy is incomplete or "
+                "inconsistent"
+            ) from exc
+
+    compatibility = {axis: config[axis] for axis in axes if axis != "builder_schema"}
+    if embedding_load_policy is not None:
+        # The load policy is derived without filesystem discovery.  Keeping it
+        # explicit prevents policy defaults from becoming an identity wildcard.
+        compatibility["embedding_load_policy"] = embedding_load_policy
+    return {
+        "contract": REPO_MANIFEST_PROFILE_CONTRACT,
+        "manifest_version": MANIFEST_VERSION,
+        "builder_schema": config["builder_schema"],
+        "compatibility": compatibility,
+    }
+
+
+def _generation_nonnegative_int(value: object, field: str) -> int:
+    try:
+        return _nonnegative_int(value, field)
+    except StorageValidationError as exc:
+        raise _IncompleteGenerationRecord(str(exc)) from exc
+
+
+def _generation_positive_int(value: object, field: str) -> int:
+    parsed = _generation_nonnegative_int(value, field)
+    if parsed == 0:
+        raise _IncompleteGenerationRecord(f"{field} must be a positive integer")
+    return parsed
+
+
+def _generation_bounded_text(
+    value: object,
+    field: str,
+    *,
+    allow_empty: bool = True,
+) -> str:
+    try:
+        return _bounded_text(
+            value,
+            field,
+            max_length=_MAX_NAME,
+            allow_empty=allow_empty,
+        )
+    except StorageValidationError as exc:
+        raise _IncompleteGenerationRecord(str(exc)) from exc
+
+
+def _non_profile_field(entry: IndexEntry, field: str) -> object:
+    values = [
+        section[field] for section in (entry.config, entry.metadata) if field in section
+    ]
+    if not values:
+        return _MISSING_ENTRY_FIELD
+    try:
+        encoded = [_canonical_bytes({"value": value}) for value in values]
+    except (TypeError, ValueError) as exc:
+        raise _IncompleteGenerationRecord(
+            f"view {entry.index_type!r} {field} is not canonical JSON"
+        ) from exc
+    if any(value != encoded[0] for value in encoded[1:]):
+        raise _IncompleteGenerationRecord(
+            f"view {entry.index_type!r} has conflicting {field} records"
+        )
+    return values[0]
+
+
+def _validate_non_profile_config(entry: IndexEntry, *, view_type: str) -> None:
+    config = entry.config
+    artifact_scope = _non_profile_field(entry, "artifact_scope")
+    if artifact_scope is not _MISSING_ENTRY_FIELD and artifact_scope != "query-serving":
+        raise _IncompleteGenerationRecord(
+            f"view {view_type!r} artifact_scope must be 'query-serving'"
+        )
+
+    portable_format = _non_profile_field(entry, "portable_document_format")
+    expected_format = (
+        "codenib.bm25-documents.v1"
+        if view_type == "bm25"
+        else "codenib.vector-documents.v1"
+    )
+    if (
+        portable_format is not _MISSING_ENTRY_FIELD
+        and portable_format != expected_format
+    ):
+        raise _IncompleteGenerationRecord(
+            f"view {view_type!r} portable_document_format is unsupported"
+        )
+
+    if view_type == "bm25":
+        counts: dict[str, int] = {}
+        for field in ("chunk_count", "file_count", "source_file_count"):
+            value = _non_profile_field(entry, field)
+            if value is not _MISSING_ENTRY_FIELD:
+                counts[field] = _generation_nonnegative_int(
+                    value, f"view 'bm25' {field}"
+                )
+        if (
+            "chunk_count" in counts
+            and "file_count" in counts
+            and counts["chunk_count"] != counts["file_count"]
+        ):
+            raise _IncompleteGenerationRecord(
+                "view 'bm25' chunk_count and file_count must agree"
+            )
+        chunk_count = counts.get("chunk_count", counts.get("file_count"))
+        if chunk_count is not None and counts.get("source_file_count", 0) > chunk_count:
+            raise _IncompleteGenerationRecord(
+                "view 'bm25' source_file_count exceeds its chunk count"
+            )
+        return
+
+    document_count = _non_profile_field(entry, "document_count")
+    if document_count is not _MISSING_ENTRY_FIELD:
+        if not isinstance(document_count, Mapping):
+            raise _IncompleteGenerationRecord(
+                "view 'vector' document_count must be an object"
+            )
+        if not set(document_count) <= {"l0", "l2"}:
+            raise _IncompleteGenerationRecord(
+                "view 'vector' document_count has an unsupported level"
+            )
+        configured_levels = config.get("levels")
+        if isinstance(configured_levels, list) and not set(document_count) <= set(
+            configured_levels
+        ):
+            raise _IncompleteGenerationRecord(
+                "view 'vector' document_count conflicts with configured levels"
+            )
+        for level, count in document_count.items():
+            _generation_positive_int(count, f"view 'vector' {level} document count")
+
+    last_commit = _non_profile_field(entry, "last_commit")
+    if last_commit is not _MISSING_ENTRY_FIELD:
+        last_commit = _generation_bounded_text(
+            last_commit,
+            "view 'vector' last_commit",
+        )
+        if last_commit and last_commit != entry.commit:
+            raise _IncompleteGenerationRecord(
+                "view 'vector' last_commit conflicts with its manifest entry commit"
+            )
+
+    incremental = {
+        field: _non_profile_field(entry, field) for field in _VECTOR_INCREMENTAL_FIELDS
+    }
+    incremental_present = {
+        field
+        for field, value in incremental.items()
+        if value is not _MISSING_ENTRY_FIELD
+    }
+    if incremental_present and incremental_present != set(_VECTOR_INCREMENTAL_FIELDS):
+        raise _IncompleteGenerationRecord(
+            "view 'vector' incremental provenance record is incomplete"
+        )
+    if incremental_present:
+        _generation_nonnegative_int(
+            incremental["chunks_reembedded"],
+            "view 'vector' chunks_reembedded",
+        )
+        _generation_nonnegative_int(
+            incremental["chunks_from_cache"],
+            "view 'vector' chunks_from_cache",
+        )
+        cache_hit_rate = incremental["cache_hit_rate"]
+        if (
+            isinstance(cache_hit_rate, bool)
+            or not isinstance(cache_hit_rate, (int, float))
+            or not math.isfinite(cache_hit_rate)
+            or cache_hit_rate < 0
+            or cache_hit_rate > 1
+        ):
+            raise _IncompleteGenerationRecord(
+                "view 'vector' cache_hit_rate must be finite and between 0 and 1"
+            )
+        new_commit = _generation_bounded_text(
+            incremental["new_commit"],
+            "view 'vector' new_commit",
+            allow_empty=False,
+        )
+        if new_commit != entry.commit:
+            raise _IncompleteGenerationRecord(
+                "view 'vector' new_commit conflicts with its manifest entry commit"
+            )
+        if last_commit is not _MISSING_ENTRY_FIELD:
+            raise _IncompleteGenerationRecord(
+                "view 'vector' incremental provenance conflicts with last_commit"
+            )
+    elif last_commit is _MISSING_ENTRY_FIELD:
+        raise _IncompleteGenerationRecord(
+            "view 'vector' full-build provenance is missing last_commit"
+        )
+
+    fallback = {
+        field: _non_profile_field(entry, field) for field in _VECTOR_FALLBACK_FIELDS
+    }
+    fallback_present = {
+        field for field, value in fallback.items() if value is not _MISSING_ENTRY_FIELD
+    }
+    if fallback_present and fallback_present != set(_VECTOR_FALLBACK_FIELDS):
+        raise _IncompleteGenerationRecord(
+            "view 'vector' incremental fallback provenance record is incomplete"
+        )
+    if fallback_present:
+        update_mode = _generation_bounded_text(
+            fallback["update_mode"],
+            "view 'vector' update_mode",
+            allow_empty=False,
+        )
+        if update_mode not in _VECTOR_UPDATE_MODES:
+            raise _IncompleteGenerationRecord(
+                "view 'vector' update_mode is unsupported"
+            )
+        _generation_bounded_text(
+            fallback["incremental_fallback_reason"],
+            "view 'vector' incremental_fallback_reason",
+            allow_empty=False,
+        )
+        if incremental_present:
+            raise _IncompleteGenerationRecord(
+                "view 'vector' incremental and fallback provenance conflict"
+            )
+
+
+def _record_from_entry(entry: IndexEntry, field: str, *, view_type: str) -> Any:
+    found = [
+        section[field] for section in (entry.config, entry.metadata) if field in section
+    ]
+    if not found:
+        raise _IncompleteGenerationRecord(f"view {view_type!r} is missing {field}")
+    try:
+        canonical_values = [_canonical_bytes({"record": value}) for value in found]
+    except (TypeError, ValueError) as exc:
+        raise _IncompleteGenerationRecord(
+            f"view {view_type!r} has an invalid {field} record"
+        ) from exc
+    if any(value != canonical_values[0] for value in canonical_values[1:]):
+        raise _IncompleteGenerationRecord(
+            f"view {view_type!r} has conflicting {field} records"
+        )
+    return found[0]
+
+
+def _fingerprint_record(
+    value: object,
+    *,
+    label: str,
+    expected_file: str | None,
+    max_bytes: int,
+    include_file: bool,
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise _IncompleteGenerationRecord(f"{label} must be an object")
+    expected = {"size", "sha256"} | ({"file"} if include_file else set())
+    if set(value) != expected:
+        raise _IncompleteGenerationRecord(f"{label} has an invalid shape")
+    size = value.get("size")
+    if (
+        isinstance(size, bool)
+        or not isinstance(size, int)
+        or size < 0
+        or size > max_bytes
+    ):
+        raise _IncompleteGenerationRecord(f"{label} has an invalid size")
+    digest = value.get("sha256")
+    if not isinstance(digest, str) or _DIGEST_RE.fullmatch(digest) is None:
+        raise _IncompleteGenerationRecord(f"{label} has an invalid SHA-256 digest")
+    result: dict[str, Any] = {"size": size, "sha256": digest}
+    if include_file:
+        filename = value.get("file")
+        if not isinstance(filename, str) or filename != expected_file:
+            raise _IncompleteGenerationRecord(f"{label} has an invalid file name")
+        result = {"file": filename, **result}
+    return result
+
+
+def _generation_record(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
+    if view_type == "bm25":
+        raw = _record_from_entry(
+            entry,
+            "artifact_file_fingerprints",
+            view_type=view_type,
+        )
+        if not isinstance(raw, Mapping) or set(raw) != {
+            "documents.json",
+            "bm25_metadata.json",
+        }:
+            raise _IncompleteGenerationRecord(
+                "view 'bm25' artifact fingerprints are incomplete"
+            )
+        files = {
+            "bm25_metadata.json": _fingerprint_record(
+                raw["bm25_metadata.json"],
+                label="BM25 metadata fingerprint",
+                expected_file=None,
+                max_bytes=_MAX_CONFIG_BYTES,
+                include_file=False,
+            ),
+            "documents.json": _fingerprint_record(
+                raw["documents.json"],
+                label="BM25 documents fingerprint",
+                expected_file=None,
+                max_bytes=_MAX_DOCUMENTS_BYTES,
+                include_file=False,
+            ),
+        }
+        return {
+            "contract": REPO_MANIFEST_BM25_GENERATION_CONTRACT,
+            "files": files,
+        }
+
+    raw = _record_from_entry(
+        entry,
+        "persistence_config_fingerprint",
+        view_type=view_type,
+    )
+    route = resolve_embedding_artifact_route(entry.config, environ={})
+    expected = f"config_{route.model.replace('/', '__')}.json"
+    config_record = _fingerprint_record(
+        raw,
+        label="vector persistence config fingerprint",
+        expected_file=expected,
+        max_bytes=_MAX_CONFIG_BYTES,
+        include_file=True,
+    )
+    return {
+        "contract": REPO_MANIFEST_VECTOR_GENERATION_CONTRACT,
+        "persistence_config": config_record,
+    }
+
+
+def _view_import_intent(
+    entry: IndexEntry, *, view_type: str, required: bool
+) -> ViewImportIntent:
+    _validate_publishable_entry(entry, view_type=view_type)
+    profile_config = _profile_config(entry, view_type=view_type)
+    try:
+        profile = ViewProfile.create(
+            view_type,
+            profile_config,
+            name=REPO_MANIFEST_PROFILE_NAME,
+        )
+    except (TypeError, ValueError) as exc:
+        raise _IncompleteProfile(
+            f"view {view_type!r} profile is not canonical JSON"
+        ) from exc
+    _validate_non_profile_config(entry, view_type=view_type)
+    generation = _generation_record(entry, view_type=view_type)
+    return ViewImportIntent(
+        view_type=view_type,
+        required=required,
+        manifest_entry_json=canonical_json(entry.to_dict()),
+        profile=profile,
+        generation_record_json=canonical_json(generation),
+    )
+
+
+def _canonical_object_json(payload: object, *, label: str) -> dict[str, Any]:
+    if type(payload) is not str or payload.startswith("\ufeff"):
+        raise StorageValidationError(f"{label} must be canonical JSON text")
+    try:
+        encoded = _encode_bounded_manifest_text(
+            payload,
+            limit=DEFAULT_MAX_MANIFEST_BYTES,
+        )
+    except UnicodeError as exc:
+        raise StorageValidationError(f"{label} must be valid UTF-8 text") from exc
+    _preflight_json_bytes(
+        encoded,
+        label=label,
+        max_bytes=DEFAULT_MAX_MANIFEST_BYTES,
+    )
+    value = _strict_json_loads(payload, label=label)
+    _validate_json_budget(value, label=label)
+    if canonical_json(value) != payload:
+        raise StorageValidationError(f"{label} is not canonical JSON")
+    return value
+
+
+def _intent_entry_from_data(data: dict[str, Any], *, view_type: str) -> IndexEntry:
+    _require_exact_fields(data, _ENTRY_FIELDS, label="view import manifest entry")
+    if not isinstance(data.get("config"), dict) or not isinstance(
+        data.get("metadata"), dict
+    ):
+        raise StorageValidationError("view import entry metadata must be objects")
+    try:
+        entry = IndexEntry.from_dict(data)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise StorageValidationError("view import entry is invalid") from exc
+    if entry.to_dict() != data:
+        raise StorageValidationError("view import entry shape is not canonical")
+    if entry.index_type != view_type or entry.status != "fresh":
+        raise StorageValidationError(
+            "view import entry must be a fresh matching view type"
+        )
+    _bounded_text(entry.path, "view import entry path", allow_empty=False)
+    expected_path = f"views/{view_type}"
+    if entry.path != expected_path:
+        raise StorageValidationError(
+            f"view import entry path must be exactly {expected_path!r}"
+        )
+    _bounded_text(entry.built_at, "view import entry built_at")
+    _epoch(entry.built_at_epoch, "view import entry built_at_epoch")
+    _bounded_text(entry.commit, "view import entry commit")
+    _bounded_text(
+        entry.source_fingerprint,
+        "view import entry source fingerprint",
+        allow_empty=False,
+    )
+    if source_fingerprint_version(entry.source_fingerprint) not in {1, 2}:
+        raise StorageValidationError(
+            "view import entry source fingerprint is unsupported"
+        )
+    return entry
+
+
+def _validate_view_import_intent(intent: ViewImportIntent) -> None:
+    if (
+        type(intent.view_type) is not str
+        or str.__len__(intent.view_type) > _MAX_VIEW_NAME
+        or intent.view_type not in PORTABLE_STORAGE_VIEWS
+    ):
+        raise StorageValidationError("view import intent has an unsupported view type")
+    if type(intent.required) is not bool:
+        raise StorageValidationError("view import intent required flag must be boolean")
+    if type(intent.profile) is not ViewProfile:
+        raise StorageValidationError("view import intent profile is invalid")
+    profile_fields = (
+        intent.profile.view_type,
+        intent.profile.name,
+        intent.profile.config_json,
+    )
+    if any(type(value) is not str for value in profile_fields):
+        raise StorageValidationError("view import intent profile fields must be exact")
+    _bounded_text(
+        intent.profile.view_type,
+        "view import profile view type",
+        max_length=_MAX_VIEW_NAME,
+        allow_empty=False,
+    )
+    _bounded_text(
+        intent.profile.name,
+        "view import profile name",
+        max_length=_MAX_NAME,
+        allow_empty=False,
+    )
+    _canonical_object_json(
+        intent.profile.config_json,
+        label="view import profile config",
+    )
+
+    entry_data = _canonical_object_json(
+        intent.manifest_entry_json,
+        label="view import manifest entry",
+    )
+    _validate_manifest_publication_policy({"entry": entry_data})
+    entry = _intent_entry_from_data(entry_data, view_type=intent.view_type)
+    try:
+        expected_profile = ViewProfile.create(
+            intent.view_type,
+            _profile_config(entry, view_type=intent.view_type),
+            name=REPO_MANIFEST_PROFILE_NAME,
+        )
+        _validate_non_profile_config(entry, view_type=intent.view_type)
+        expected_generation = canonical_json(
+            _generation_record(entry, view_type=intent.view_type)
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise StorageValidationError(
+            "view import intent does not match a complete manifest entry"
+        ) from exc
+    if profile_fields != (
+        expected_profile.view_type,
+        expected_profile.name,
+        expected_profile.config_json,
+    ):
+        raise StorageValidationError(
+            "view import intent profile does not match its manifest entry"
+        )
+    _canonical_object_json(
+        intent.generation_record_json,
+        label="view import generation record",
+    )
+    if intent.generation_record_json != expected_generation:
+        raise StorageValidationError(
+            "view import generation record does not match its manifest entry"
+        )
+
+
+def _canonical_view_names(value: object, *, field: str) -> tuple[str, ...]:
+    if (
+        type(value) is not tuple
+        or tuple.__len__(value) > len(PORTABLE_STORAGE_VIEWS)
+        or any(
+            type(item) is not str
+            or str.__len__(item) > _MAX_VIEW_NAME
+            or item not in PORTABLE_STORAGE_VIEWS
+            for item in value
+        )
+    ):
+        raise StorageValidationError(f"{field} must be a tuple of portable views")
+    if value != tuple(sorted(set(value))):
+        raise StorageValidationError(f"{field} must be sorted and unique")
+    return value
+
+
+def _validate_view_selection(selection: ViewSelection) -> None:
+    required = _canonical_view_names(
+        selection.required_views,
+        field="required views",
+    )
+    optional = _canonical_view_names(
+        selection.optional_views,
+        field="optional views",
+    )
+    selected = _canonical_view_names(
+        selection.selected_views,
+        field="selected views",
+    )
+    if set(required) & set(optional):
+        raise StorageValidationError("required and optional views must be disjoint")
+    if type(selection.skipped_items) is not tuple or tuple.__len__(
+        selection.skipped_items
+    ) > len(PORTABLE_STORAGE_VIEWS):
+        raise StorageValidationError("skipped views must be a canonical tuple")
+    skipped: list[tuple[str, str]] = []
+    for item in selection.skipped_items:
+        if (
+            type(item) is not tuple
+            or len(item) != 2
+            or type(item[0]) is not str
+            or str.__len__(item[0]) > _MAX_VIEW_NAME
+            or item[0] not in PORTABLE_STORAGE_VIEWS
+            or type(item[1]) is not str
+            or str.__len__(item[1]) > _MAX_NAME
+            or item[1] not in _SELECTION_SKIP_REASONS
+        ):
+            raise StorageValidationError("skipped view decision is invalid")
+        skipped.append(item)
+    if tuple(skipped) != tuple(sorted(set(skipped))):
+        raise StorageValidationError("skipped views must be sorted and unique")
+    skipped_names = {view for view, _reason in skipped}
+    if len(skipped_names) != len(skipped):
+        raise StorageValidationError("a view may have only one skip decision")
+    if not skipped_names <= set(optional):
+        raise StorageValidationError("only optional views may be skipped")
+    expected_selected = tuple(sorted(set(required) | (set(optional) - skipped_names)))
+    if not selected or selected != expected_selected:
+        raise StorageValidationError(
+            "selected views do not close required, optional, and skipped views"
+        )
+
+
+def _incomplete_view_reason(entry: IndexEntry, *, view_type: str) -> str | None:
+    try:
+        _profile_config(entry, view_type=view_type)
+    except _IncompleteProfile:
+        return "incomplete_profile"
+    try:
+        _validate_non_profile_config(entry, view_type=view_type)
+        _generation_record(entry, view_type=view_type)
+    except _IncompleteGenerationRecord:
+        return "incomplete_generation_record"
+    return None
+
+
+def _validate_import_plan(plan: RepoManifestImportPlan) -> None:
+    manifest_data = _canonical_object_json(
+        plan.manifest_json,
+        label="import plan manifest",
+    )
+    manifest = _repo_manifest_v11_from_data(manifest_data)
+    _validate_manifest_publication_policy(manifest_data)
+    if not isinstance(plan.source, SourceIntent):
+        raise StorageValidationError("import plan source intent is invalid")
+    if type(plan.source) is not SourceIntent:
+        raise StorageValidationError("import plan source intent must be exact")
+    SourceIntent.__post_init__(plan.source)
+    fingerprint_version = source_fingerprint_version(manifest.source_fingerprint)
+    if fingerprint_version not in {1, 2}:  # pragma: no cover - manifest gate
+        raise StorageValidationError("import plan source fingerprint is unsupported")
+    expected_source = SourceIntent(
+        fingerprint=manifest.source_fingerprint,
+        fingerprint_version=fingerprint_version,
+        file_count=manifest.file_count,
+        display_commit=manifest.commit,
+    )
+    if (
+        plan.source.fingerprint,
+        plan.source.fingerprint_version,
+        plan.source.file_count,
+        plan.source.display_commit,
+    ) != (
+        expected_source.fingerprint,
+        expected_source.fingerprint_version,
+        expected_source.file_count,
+        expected_source.display_commit,
+    ):
+        raise StorageValidationError(
+            "import plan source intent does not match its manifest"
+        )
+    if not isinstance(plan.selection, ViewSelection):
+        raise StorageValidationError("import plan selection is invalid")
+    if type(plan.selection) is not ViewSelection:
+        raise StorageValidationError("import plan selection must be exact")
+    _validate_view_selection(plan.selection)
+    if (
+        type(plan.views) is not tuple
+        or tuple.__len__(plan.views) > len(PORTABLE_STORAGE_VIEWS)
+        or any(type(view) is not ViewImportIntent for view in plan.views)
+    ):
+        raise StorageValidationError("import plan views must be an intent tuple")
+    for view in plan.views:
+        _validate_view_import_intent(view)
+    view_names = tuple(view.view_type for view in plan.views)
+    if len(set(view_names)) != len(view_names):
+        raise StorageValidationError("import plan contains duplicate view intents")
+    if view_names != plan.selection.selected_views:
+        raise StorageValidationError(
+            "import plan views do not match its canonical selection"
+        )
+    for view_type, reason in plan.selection.skipped_items:
+        current, _current_reason = _entry_is_current(manifest, view_type)
+        if reason == "not_current":
+            if current:
+                raise StorageValidationError(
+                    "import plan skip reason conflicts with a current view"
+                )
+            continue
+        if not current:
+            raise StorageValidationError(
+                "import plan incomplete-view skip is not current in its manifest"
+            )
+        observed_reason = _incomplete_view_reason(
+            manifest.indexes[view_type],
+            view_type=view_type,
+        )
+        if observed_reason != reason:
+            raise StorageValidationError(
+                "import plan skip reason does not match its manifest view"
+            )
+    required = set(plan.selection.required_views)
+    for view in plan.views:
+        current, _reason = _entry_is_current(manifest, view.view_type)
+        if not current:
+            raise StorageValidationError(
+                "import plan contains a view not current in its manifest"
+            )
+        if view.required != (view.view_type in required):
+            raise StorageValidationError(
+                "import plan view requirement does not match its selection"
+            )
+        expected_entry = canonical_json(manifest.indexes[view.view_type].to_dict())
+        if view.manifest_entry_json != expected_entry:
+            raise StorageValidationError(
+                "import plan view entry does not match its manifest"
+            )
+
+
+def _validated_manifest_data(
+    value: RepoManifest | Mapping[str, Any],
+    *,
+    max_bytes: int,
+) -> dict[str, Any]:
+    if type(value) is RepoManifest:
+        raw: Any = value
+    elif isinstance(value, Mapping):
+        raw = value
+    else:
+        raise TypeError("manifest must be a RepoManifest or JSON object")
+    try:
+        snapshot, _size = _snapshot_json_value(
+            raw,
+            label="repository manifest",
+            max_bytes=max_bytes,
+        )
+        if not isinstance(snapshot, dict):  # pragma: no cover - Mapping root
+            raise StorageValidationError("repository manifest must be an object")
+        normalized = _strict_json_loads(
+            canonical_json(snapshot),
+            label="repository manifest",
+        )
+    except StorageValidationError:
+        raise
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise StorageValidationError(
+            "repository manifest is not canonical JSON"
+        ) from exc
+    return normalized
+
+
+def plan_repo_manifest_import(
+    manifest: RepoManifest | Mapping[str, Any],
+    *,
+    views: Sequence[str] | None = None,
+    required_views: Sequence[str] | None = None,
+    optional_views: Sequence[str] | None = None,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+) -> RepoManifestImportPlan:
+    """Build a pure import plan from an in-memory manifest value.
+
+    The returned plan is safe to inspect and hash, but it carries no authority
+    to read the repository, execute a native index, write CAS objects, or
+    publish catalog state.
+    """
+
+    limit = _manifest_limit(max_manifest_bytes)
+    data = _validated_manifest_data(manifest, max_bytes=limit)
+    parsed = _repo_manifest_v11_from_data(data)
+    normalized_manifest = parsed.to_dict()
+    _validate_manifest_publication_policy(normalized_manifest)
+    manifest_json = canonical_json(normalized_manifest)
+    if len(manifest_json.encode("ascii")) > limit:
+        raise StorageValidationError(
+            f"repository manifest exceeds the {limit}-byte limit"
+        )
+
+    required, optional, skipped = _initial_selection(
+        parsed,
+        views=views,
+        required_views=required_views,
+        optional_views=optional_views,
+    )
+    intents: list[ViewImportIntent] = []
+    for view_type in sorted(set(required) | set(optional)):
+        is_required = view_type in required
+        try:
+            intent = _view_import_intent(
+                parsed.indexes[view_type],
+                view_type=view_type,
+                required=is_required,
+            )
+        except _IncompleteProfile as exc:
+            if is_required:
+                raise StorageValidationError(
+                    f"required view {view_type!r} has an incomplete profile: {exc}"
+                ) from exc
+            skipped[view_type] = "incomplete_profile"
+            continue
+        except _IncompleteGenerationRecord as exc:
+            if is_required:
+                raise StorageValidationError(
+                    f"required view {view_type!r} has an incomplete generation record: "
+                    f"{exc}"
+                ) from exc
+            skipped[view_type] = "incomplete_generation_record"
+            continue
+        intents.append(intent)
+
+    if not intents:
+        raise StorageValidationError(
+            "manifest storage planning produced no complete portable view intents"
+        )
+    selected = tuple(intent.view_type for intent in intents)
+    selection = ViewSelection(
+        required_views=required,
+        optional_views=tuple(sorted(set(optional) | set(skipped))),
+        selected_views=selected,
+        skipped_items=tuple(sorted(skipped.items())),
+    )
+    fingerprint_version = source_fingerprint_version(parsed.source_fingerprint)
+    assert fingerprint_version in {1, 2}
+    source = SourceIntent(
+        fingerprint=parsed.source_fingerprint,
+        fingerprint_version=fingerprint_version,
+        file_count=parsed.file_count,
+        display_commit=parsed.commit,
+    )
+    return RepoManifestImportPlan(
+        manifest_json=manifest_json,
+        source=source,
+        selection=selection,
+        views=tuple(intents),
+    )
+
+
+def plan_repo_manifest_import_bytes(
+    payload: bytes | bytearray | memoryview | str,
+    *,
+    views: Sequence[str] | None = None,
+    required_views: Sequence[str] | None = None,
+    optional_views: Sequence[str] | None = None,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+) -> RepoManifestImportPlan:
+    """Parse bounded strict JSON bytes and build a pure import plan."""
+
+    limit = _manifest_limit(max_manifest_bytes)
+    if isinstance(payload, str):
+        try:
+            encoded = _encode_bounded_manifest_text(payload, limit=limit)
+        except UnicodeError as exc:
+            raise StorageValidationError(
+                "repository manifest is not valid UTF-8"
+            ) from exc
+        text = encoded.decode("utf-8", errors="strict")
+    elif isinstance(payload, bytes):
+        if bytes.__len__(payload) > limit:
+            raise StorageValidationError(
+                f"repository manifest exceeds the {limit}-byte limit"
+            )
+        encoded = payload if type(payload) is bytes else memoryview(payload).tobytes()
+        try:
+            text = encoded.decode("utf-8", errors="strict")
+        except UnicodeError as exc:
+            raise StorageValidationError(
+                "repository manifest is not valid UTF-8"
+            ) from exc
+    elif isinstance(payload, (bytearray, memoryview)):
+        try:
+            view = memoryview(payload)
+            if view.nbytes > limit:
+                raise StorageValidationError(
+                    f"repository manifest exceeds the {limit}-byte limit"
+                )
+            encoded = view.tobytes()
+        except StorageValidationError:
+            raise
+        except Exception as exc:
+            raise StorageValidationError(
+                "repository manifest buffer is unavailable"
+            ) from exc
+        try:
+            text = encoded.decode("utf-8", errors="strict")
+        except UnicodeError as exc:
+            raise StorageValidationError(
+                "repository manifest is not valid UTF-8"
+            ) from exc
+    else:
+        raise TypeError("manifest payload must be bytes or text")
+    if len(encoded) > limit:
+        raise StorageValidationError(
+            f"repository manifest exceeds the {limit}-byte limit"
+        )
+    if text.startswith("\ufeff"):
+        raise StorageValidationError("repository manifest must not contain a BOM")
+    _preflight_json_bytes(
+        encoded,
+        label="repository manifest",
+        max_bytes=limit,
+    )
+    data = _strict_json_loads(text, label="repository manifest")
+    return plan_repo_manifest_import(
+        data,
+        views=views,
+        required_views=required_views,
+        optional_views=optional_views,
+        max_manifest_bytes=limit,
+    )
+
+
+def _encode_bounded_manifest_text(value: str, *, limit: int) -> bytes:
+    """Encode text without allocating an over-limit UTF-8 copy first."""
+
+    character_count = str.__len__(value)
+    if character_count > limit:
+        raise StorageValidationError(
+            f"repository manifest exceeds the {limit}-byte limit"
+        )
+    encoder = codecs.getincrementalencoder("utf-8")(errors="strict")
+    chunks: list[bytes] = []
+    byte_count = 0
+    for offset in range(0, character_count, 4096):
+        text_chunk = str.__getitem__(value, slice(offset, offset + 4096))
+        encoded_chunk = encoder.encode(text_chunk, final=False)
+        byte_count += len(encoded_chunk)
+        if byte_count > limit:
+            raise StorageValidationError(
+                f"repository manifest exceeds the {limit}-byte limit"
+            )
+        chunks.append(encoded_chunk)
+    final_chunk = encoder.encode("", final=True)
+    byte_count += len(final_chunk)
+    if byte_count > limit:
+        raise StorageValidationError(
+            f"repository manifest exceeds the {limit}-byte limit"
+        )
+    chunks.append(final_chunk)
+    return b"".join(chunks)
+
+
+__all__ = [
+    "BM25_PROFILE_AXES",
+    "DEFAULT_MAX_MANIFEST_BYTES",
+    "PORTABLE_STORAGE_VIEWS",
+    "REPO_MANIFEST_BM25_GENERATION_CONTRACT",
+    "REPO_MANIFEST_IMPORT_PLAN_SCHEMA",
+    "REPO_MANIFEST_PROFILE_CONTRACT",
+    "REPO_MANIFEST_PROFILE_NAME",
+    "REPO_MANIFEST_VECTOR_GENERATION_CONTRACT",
+    "RepoManifestImportPlan",
+    "SourceIntent",
+    "VECTOR_PROFILE_AXES",
+    "ViewImportIntent",
+    "ViewSelection",
+    "plan_repo_manifest_import",
+    "plan_repo_manifest_import_bytes",
+]

--- a/codenib/compiler/manifest_storage.py
+++ b/codenib/compiler/manifest_storage.py
@@ -655,6 +655,8 @@ def _json_string_size(
     """Return the exact ensure-ASCII JSON string size without encoding it."""
 
     size = 2
+    if size > max_bytes:
+        raise StorageValidationError(f"{label} exceeds its byte limit")
     for character in value:
         codepoint = ord(character)
         if 0xD800 <= codepoint <= 0xDFFF:
@@ -689,7 +691,6 @@ def _snapshot_json_value(
             # Retain the original objects, rather than only their ids, so a
             # short-lived projection cannot be freed and have its id reused.
             "seen": {},
-            "max_bytes": max_bytes,
         }
 
     if type(value) is RepoManifest:
@@ -747,6 +748,7 @@ def _snapshot_json_value(
             label=label,
             depth=depth,
             state=state,
+            max_bytes=max_bytes,
         )
 
     if type(value) is IndexEntry:
@@ -785,6 +787,7 @@ def _snapshot_json_value(
             label=label,
             depth=depth,
             state=state,
+            max_bytes=max_bytes,
         )
 
     state["nodes"] += 1
@@ -798,6 +801,8 @@ def _snapshot_json_value(
         )
 
     if isinstance(value, Mapping):
+        if max_bytes < 2:
+            raise StorageValidationError(f"{label} exceeds its byte limit")
         identity = id(value)
         if identity in state["seen"]:
             raise StorageValidationError(
@@ -823,6 +828,17 @@ def _snapshot_json_value(
                     raise StorageValidationError(
                         f"{label} object keys must be exact strings"
                     )
+                separator_size = 1 if result else 0
+                key_budget = max_bytes - size - separator_size - 2
+                key_size = _json_string_size(
+                    key,
+                    label=label,
+                    max_bytes=key_budget,
+                )
+                prefix_size = separator_size + key_size + 1
+                child_budget = max_bytes - size - prefix_size
+                if child_budget < 1:
+                    raise StorageValidationError(f"{label} exceeds its byte limit")
                 if key in result:
                     raise StorageValidationError(
                         f"{label} contains a duplicate object key: {key}"
@@ -832,19 +848,10 @@ def _snapshot_json_value(
                     label=label,
                     depth=depth + 1,
                     state=state,
+                    max_bytes=child_budget,
                 )
-                if result:
-                    size += 1
-                size += (
-                    _json_string_size(
-                        key,
-                        label=label,
-                        max_bytes=state["max_bytes"],
-                    )
-                    + 1
-                    + child_size
-                )
-                if size > state["max_bytes"]:
+                size += prefix_size + child_size
+                if size > max_bytes:
                     raise StorageValidationError(f"{label} exceeds its byte limit")
                 result[key] = child_snapshot
         except StorageValidationError:
@@ -858,6 +865,8 @@ def _snapshot_json_value(
         return result, size
 
     if type(value) in {list, tuple}:
+        if max_bytes < 2:
+            raise StorageValidationError(f"{label} exceeds its byte limit")
         identity = id(value)
         if identity in state["seen"]:
             raise StorageValidationError(
@@ -869,16 +878,19 @@ def _snapshot_json_value(
         size = 2
         try:
             for child in value:
+                separator_size = 1 if result_list else 0
+                child_budget = max_bytes - size - separator_size
+                if child_budget < 1:
+                    raise StorageValidationError(f"{label} exceeds its byte limit")
                 child_snapshot, child_size = _snapshot_json_value(
                     child,
                     label=label,
                     depth=depth + 1,
                     state=state,
+                    max_bytes=child_budget,
                 )
-                if result_list:
-                    size += 1
-                size += child_size
-                if size > state["max_bytes"]:
+                size += separator_size + child_size
+                if size > max_bytes:
                     raise StorageValidationError(f"{label} exceeds its byte limit")
                 result_list.append(child_snapshot)
         finally:
@@ -886,27 +898,39 @@ def _snapshot_json_value(
         return result_list, size
 
     if value is None:
-        return None, 4
+        size = 4
+        if size > max_bytes:
+            raise StorageValidationError(f"{label} exceeds its byte limit")
+        return None, size
     if type(value) is bool:
-        return value, 4 if value else 5
+        size = 4 if value else 5
+        if size > max_bytes:
+            raise StorageValidationError(f"{label} exceeds its byte limit")
+        return value, size
     if type(value) is int:
         if value < -(_INT64_MAX + 1) or value > _INT64_MAX:
             raise StorageValidationError(
                 f"{label} integers must fit signed 64-bit storage"
             )
-        return value, len(str(value))
+        size = len(str(value))
+        if size > max_bytes:
+            raise StorageValidationError(f"{label} exceeds its byte limit")
+        return value, size
     if type(value) is float:
         if not math.isfinite(value):
             raise StorageValidationError(f"{label} numbers must be finite")
         encoded = json.dumps(value, allow_nan=False)
         if len(encoded) > _MAX_JSON_ATOM_BYTES:
             raise StorageValidationError(f"{label} number exceeds its lexical limit")
-        return value, len(encoded)
+        size = len(encoded)
+        if size > max_bytes:
+            raise StorageValidationError(f"{label} exceeds its byte limit")
+        return value, size
     if type(value) is str:
         return value, _json_string_size(
             value,
             label=label,
-            max_bytes=state["max_bytes"],
+            max_bytes=max_bytes,
         )
     raise StorageValidationError(
         f"{label} contains unsupported {type(value).__name__} data"

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -374,6 +374,24 @@ ordinary dataclass is treated as that authority. These gates do not yet plan or
 execute a legacy `RepoManifest` import, upload retained view bytes, or advance a
 ref, so M1 remains in progress.
 
+A pure retained-manifest planning layer now closes the data-only side of that
+boundary for current portable `RepoManifest` v1.1 projections. It accepts only
+bounded, unambiguous, BOM-free UTF-8 JSON; rejects unknown shape, non-finite or
+over-complex values, credential data, diagnostic data, and forged storage or
+filesystem authority claims; and selects only current BM25/vector entries whose
+artifact-relative paths are exactly `views/bm25` or `views/vector`. Required
+views fail closed while optional incompatibilities are recorded explicitly.
+Every current builder compatibility field participates in a versioned
+`ViewProfile`, unknown or missing fields fail closed, and the vector profile
+also records the artifact-safe resolved model revision/trust policy without
+filesystem or ambient-environment discovery. Source-fingerprint v1 remains
+diagnostic and inert; v2 is merely eligible for a later retained-source check,
+and Git commit text remains display provenance rather than source authority.
+Planning performs no source or artifact reads, native parsing, CAS/catalog
+operation, receipt minting, or ref publication. The retained reader adapter,
+object upload, atomic snapshot/ref transaction, and equivalent v1.1 export are
+still outstanding, so M1 and M2 remain in progress.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/test/compiler/test_manifest_storage.py
+++ b/test/compiler/test_manifest_storage.py
@@ -1354,6 +1354,31 @@ def test_mapping_snapshot_rejects_repeated_container_aliases_after_one_read() ->
     assert shared.items_calls == 1
 
 
+def test_parent_json_budget_is_charged_before_consuming_a_child() -> None:
+    reads = 0
+
+    class TrapMapping(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise KeyError(key)
+
+        def __iter__(self) -> Iterator[str]:
+            return iter(())
+
+        def __len__(self) -> int:
+            return 0
+
+        def items(self):
+            nonlocal reads
+            reads += 1
+            return ()
+
+    manifest = _manifest(include_vector=False)
+    manifest.indexes["bm25"].config = {"x" * 4096: TrapMapping()}
+    with pytest.raises(StorageValidationError, match="byte limit"):
+        plan_repo_manifest_import(manifest, max_manifest_bytes=1024)
+    assert reads == 0
+
+
 def test_mapping_snapshot_stops_at_the_node_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/test/compiler/test_manifest_storage.py
+++ b/test/compiler/test_manifest_storage.py
@@ -1,0 +1,1913 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import copy
+import inspect
+import json
+from array import array
+from collections.abc import Iterator, Mapping
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import codenib.compiler as compiler_module
+import codenib.compiler.manifest_storage as manifest_storage_module
+from codenib.compiler.index_builders import BM25IndexBuilder, VectorIndexBuilder
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.compiler.manifest_storage import (
+    BM25_PROFILE_AXES,
+    DEFAULT_MAX_MANIFEST_BYTES,
+    REPO_MANIFEST_BM25_GENERATION_CONTRACT,
+    REPO_MANIFEST_IMPORT_PLAN_SCHEMA,
+    REPO_MANIFEST_PROFILE_CONTRACT,
+    REPO_MANIFEST_PROFILE_NAME,
+    REPO_MANIFEST_VECTOR_GENERATION_CONTRACT,
+    VECTOR_PROFILE_AXES,
+    RepoManifestImportPlan,
+    SourceIntent,
+    ViewImportIntent,
+    ViewSelection,
+    plan_repo_manifest_import,
+    plan_repo_manifest_import_bytes,
+)
+from codenib.index.embedding.model_policy import (
+    DEFAULT_EMBEDDING_MODEL,
+    DEFAULT_EMBEDDING_REVISION,
+)
+from codenib.provider_routes import resolve_inference_route
+from codenib.storage.models import StorageValidationError, ViewProfile, canonical_json
+
+
+def _file_record(seed: str, *, filename: str | None = None) -> dict[str, object]:
+    record: dict[str, object] = {"size": 10, "sha256": seed * 64}
+    if filename is not None:
+        record["file"] = filename
+    return record
+
+
+def _bm25_config() -> dict[str, object]:
+    config = BM25IndexBuilder(
+        languages=["python", "typescript"],
+        max_k=96,
+        max_lines_per_chunk=240,
+    ).artifact_identity()
+    config["artifact_file_fingerprints"] = {
+        "documents.json": _file_record("a"),
+        "bm25_metadata.json": _file_record("b"),
+    }
+    config["chunk_count"] = 11
+    config["source_file_count"] = 3
+    config["file_count"] = 11
+    return config
+
+
+def _vector_config() -> dict[str, object]:
+    config = VectorIndexBuilder(
+        languages=["python", "typescript"],
+        embedding_model="test/model",
+        embedding_dimension=4,
+        build_levels=["l0", "l2"],
+        max_lines_per_chunk=240,
+    ).artifact_identity()
+    config["persistence_config_fingerprint"] = _file_record(
+        "c", filename="config_test__model.json"
+    )
+    config["document_count"] = {"l0": 3, "l2": 8}
+    config["last_commit"] = "c" * 40
+    return config
+
+
+def _set_vector_route(
+    entry: IndexEntry,
+    *,
+    model: str = "test/model",
+    options: dict[str, object] | None = None,
+) -> None:
+    route = resolve_inference_route(
+        operation="embeddings",
+        provider="huggingface",
+        model=model,
+        dimension=4,
+        compatibility_options=options or {},
+        environ={},
+    )
+    _set_entry_fields(
+        entry,
+        {
+            "embedding_model": route.model,
+            "embedding_provider": route.provider,
+            "embedding_dimension": route.dimension,
+            "dimension": route.dimension,
+            "embedding_endpoint": route.endpoint,
+            "embedding_kwargs": route.compatibility_options,
+            "embedding_route": route.public_identity(),
+            "embedding_fingerprint": route.compatibility_fingerprint,
+        },
+    )
+
+
+def _entry(
+    view_type: str,
+    config: dict[str, object],
+    *,
+    fingerprint: str,
+    commit: str,
+    status: str = "fresh",
+) -> IndexEntry:
+    return IndexEntry(
+        index_type=view_type,
+        path=f"views/{view_type}",
+        built_at="2026-08-10T00:00:00+00:00",
+        built_at_epoch=1.0,
+        status=status,
+        config=copy.deepcopy(config),
+        metadata={**copy.deepcopy(config), "build_duration_seconds": 0.25},
+        commit=commit,
+        source_fingerprint=fingerprint,
+    )
+
+
+def _manifest(
+    *,
+    fingerprint_version: int = 2,
+    include_vector: bool = True,
+    commit: str = "c" * 40,
+) -> RepoManifest:
+    prefix = "sha256-v2:" if fingerprint_version == 2 else "sha256:"
+    fingerprint = prefix + "d" * 64
+    indexes = {
+        "bm25": _entry(
+            "bm25",
+            _bm25_config(),
+            fingerprint=fingerprint,
+            commit=commit,
+        )
+    }
+    if include_vector:
+        indexes["vector"] = _entry(
+            "vector",
+            _vector_config(),
+            fingerprint=fingerprint,
+            commit=commit,
+        )
+    return RepoManifest(
+        repo_path="source",
+        commit=commit,
+        last_indexed_commit=commit,
+        source_fingerprint=fingerprint,
+        last_indexed_source_fingerprint=fingerprint,
+        languages=["python", "typescript"],
+        file_count=3,
+        indexes=indexes,
+        capabilities={
+            "sparse_search": True,
+            "dense_search": include_vector,
+            "hybrid_search": include_vector,
+            "symbol_navigation": False,
+        },
+        compiled_at="2026-08-10T00:00:00+00:00",
+        compiled_at_epoch=1.0,
+    )
+
+
+def _add_unselected_view(
+    manifest: RepoManifest, *, status: str = "stale"
+) -> IndexEntry:
+    entry = _entry(
+        "symbol_graph",
+        {},
+        fingerprint=manifest.source_fingerprint,
+        commit=manifest.commit,
+        status=status,
+    )
+    manifest.indexes["symbol_graph"] = entry
+    return entry
+
+
+def _set_entry_field(entry: IndexEntry, field: str, value: object) -> None:
+    entry.config[field] = copy.deepcopy(value)
+    entry.metadata[field] = copy.deepcopy(value)
+
+
+def _set_entry_fields(entry: IndexEntry, values: dict[str, object]) -> None:
+    for field, value in values.items():
+        _set_entry_field(entry, field, value)
+
+
+def _remove_entry_field(entry: IndexEntry, field: str) -> None:
+    entry.config.pop(field, None)
+    entry.metadata.pop(field, None)
+
+
+def _vector_incremental_provenance() -> dict[str, object]:
+    return {
+        "chunks_reembedded": 3,
+        "chunks_from_cache": 2,
+        "cache_hit_rate": 2 / 11,
+        "new_commit": "c" * 40,
+    }
+
+
+def _profile_id(manifest: RepoManifest, view_type: str) -> str:
+    plan = plan_repo_manifest_import(manifest, views=[view_type])
+    return plan.view_map[view_type].profile_id
+
+
+def test_plan_accepts_current_builder_contracts_and_is_canonical() -> None:
+    manifest = _manifest()
+    plan = plan_repo_manifest_import(manifest)
+
+    assert plan.schema == REPO_MANIFEST_IMPORT_PLAN_SCHEMA
+    assert plan.source.disposition == "content-bound"
+    assert plan.source.eligible_for_verification is True
+    assert plan.inert is False
+    assert plan.selection.to_dict() == {
+        "required_views": ["bm25"],
+        "optional_views": ["vector"],
+        "selected_views": ["bm25", "vector"],
+        "skipped_views": {},
+    }
+    assert tuple(plan.view_map) == ("bm25", "vector")
+    assert plan.view_map["bm25"].profile.config == {
+        "contract": REPO_MANIFEST_PROFILE_CONTRACT,
+        "manifest_version": "1.1",
+        "builder_schema": manifest.indexes["bm25"].config["builder_schema"],
+        "compatibility": {
+            axis: manifest.indexes["bm25"].config[axis]
+            for axis in BM25_PROFILE_AXES
+            if axis != "builder_schema"
+        },
+    }
+    assert plan.view_map["bm25"].generation_record["contract"] == (
+        REPO_MANIFEST_BM25_GENERATION_CONTRACT
+    )
+    assert plan.view_map["vector"].generation_record["contract"] == (
+        REPO_MANIFEST_VECTOR_GENERATION_CONTRACT
+    )
+    assert plan.view_map["vector"].profile.config["compatibility"][
+        "embedding_load_policy"
+    ] == {"revision": None, "trust_remote_code": False}
+
+    reordered = json.dumps(
+        manifest.to_dict(),
+        indent=4,
+        sort_keys=False,
+    ).encode()
+    reparsed = plan_repo_manifest_import_bytes(reordered)
+    assert reparsed.canonical_manifest_bytes == plan.canonical_manifest_bytes
+    assert reparsed.manifest_digest == plan.manifest_digest
+    assert reparsed.canonical_bytes == plan.canonical_bytes
+    assert reparsed.plan_digest == plan.plan_digest
+
+
+def test_planner_symbols_are_lazy_compiler_exports() -> None:
+    expected = {
+        "RepoManifestImportPlan",
+        "SourceIntent",
+        "ViewImportIntent",
+        "ViewSelection",
+        "plan_repo_manifest_import",
+        "plan_repo_manifest_import_bytes",
+    }
+
+    assert expected <= set(compiler_module.__all__)
+    assert compiler_module.plan_repo_manifest_import is plan_repo_manifest_import
+    assert list(inspect.signature(plan_repo_manifest_import).parameters) == [
+        "manifest",
+        "views",
+        "required_views",
+        "optional_views",
+        "max_manifest_bytes",
+    ]
+
+
+def test_selected_view_paths_are_exact_artifact_relative_contracts() -> None:
+    required = _manifest(include_vector=False)
+    required.indexes["bm25"].path = "state/bm25"
+    with pytest.raises(StorageValidationError, match="artifact_path_mismatch"):
+        plan_repo_manifest_import(required, views=["bm25"])
+
+    optional = _manifest()
+    optional.indexes["vector"].path = "views/vector/"
+    plan = plan_repo_manifest_import(
+        optional,
+        required_views=["bm25"],
+        optional_views=["vector"],
+    )
+    assert plan.selection.selected_views == ("bm25",)
+    assert plan.selection.skipped_views == {"vector": "not_current"}
+
+
+def test_public_view_intent_rejects_a_rebased_artifact_path() -> None:
+    plan = plan_repo_manifest_import(_manifest(include_vector=False))
+    intent = plan.views[0]
+    entry = intent.manifest_entry
+    entry["path"] = "other/bm25"
+
+    with pytest.raises(StorageValidationError, match="path must be exactly"):
+        replace(intent, manifest_entry_json=canonical_json(entry))
+
+
+def test_plan_is_detached_and_does_not_claim_catalog_or_source_authority() -> None:
+    manifest = _manifest()
+    plan = plan_repo_manifest_import(manifest)
+    before = plan.canonical_bytes
+    manifest.indexes["bm25"].config["max_k"] = 1
+    manifest.source_fingerprint = "sha256-v2:" + "e" * 64
+
+    assert plan.canonical_bytes == before
+    assert plan.manifest.indexes["bm25"].config["max_k"] == 96
+    assert plan.to_dict()["source"]["eligible_for_verification"] is True
+    assert "source_verified" not in plan.canonical_bytes.decode("ascii")
+    assert "repository_id" not in plan.canonical_bytes.decode("ascii")
+    assert "source_revision_id" not in plan.canonical_bytes.decode("ascii")
+    with pytest.raises(TypeError):
+        plan.view_map["extra"] = plan.views[0]  # type: ignore[index]
+    with pytest.raises(TypeError):
+        plan.selection.skipped_views["extra"] = "not_current"  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "claim",
+    [
+        "repository_id",
+        "namespace_id",
+        "source_revision_id",
+        "profile_id",
+        "generation_id",
+        "view_generation_id",
+        "object_id",
+        "object",
+        "storage_key",
+        "snapshot_id",
+        "catalog_snapshot_id",
+        "receipt",
+        "bundle_receipt",
+        "pin_id",
+        "source_verified",
+        "commit_verified",
+        "checkout_verified",
+        "verification_scope",
+        "native_index_authorization",
+        "source_authority",
+        "directory_ownership",
+        "publication_receipt",
+        "verified_source",
+        "durable",
+    ],
+)
+def test_whole_manifest_rejects_authority_claims_in_unselected_views(
+    claim: str,
+) -> None:
+    manifest = _manifest()
+    entry = _add_unselected_view(manifest)
+    entry.metadata["nested"] = {claim: "forged"}
+
+    with pytest.raises(
+        StorageValidationError,
+        match="authority claim|credential field|secret field",
+    ):
+        plan_repo_manifest_import(manifest)
+
+
+@pytest.mark.parametrize("location", ["unselected", "stale-selected"])
+@pytest.mark.parametrize(
+    "claim",
+    [
+        "catalog_id",
+        "receipt_id",
+        "source_verified_at",
+        "is_source_verified",
+        "authority_id",
+        "ownership_id",
+        "directory_fd",
+        "resolved_path",
+        "diagnostics",
+        "stack_trace",
+        "failure_reason",
+        "exception_type",
+    ],
+)
+def test_whole_manifest_rejects_qualified_claim_names(
+    location: str,
+    claim: str,
+) -> None:
+    manifest = _manifest()
+    if location == "unselected":
+        entry = _add_unselected_view(manifest)
+    else:
+        entry = manifest.indexes["vector"]
+        entry.status = "stale"
+    entry.metadata["nested"] = {claim: "forged"}
+
+    with pytest.raises(StorageValidationError, match="authority claim|diagnostic"):
+        plan_repo_manifest_import(manifest)
+
+
+@pytest.mark.parametrize(
+    ("location", "field", "value", "message"),
+    [
+        ("unsupported", "api_key", "secret", "secret field"),
+        ("stale", "error_message", "host traceback", "diagnostic field"),
+        ("unsupported", "note", "Bearer forged", "authorization credentials"),
+        ("stale", "note", "Basic forged", "authorization credentials"),
+        (
+            "repo_path",
+            "path",
+            "https://user:password@example.test/repo",
+            "URL credentials",
+        ),
+        ("entry_path", "path", "Basic forged", "authorization credentials"),
+    ],
+)
+def test_whole_manifest_publication_policy_covers_unselected_and_structural_data(
+    location: str,
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    manifest = _manifest()
+    if location == "unsupported":
+        _add_unselected_view(manifest).metadata[field] = value
+    elif location == "stale":
+        manifest.indexes["vector"].status = "stale"
+        manifest.indexes["vector"].metadata[field] = value
+    elif location == "repo_path":
+        manifest.repo_path = value
+    else:
+        manifest.indexes["bm25"].path = value
+
+    with pytest.raises(StorageValidationError, match=message):
+        plan_repo_manifest_import(manifest)
+
+
+def test_normal_repo_path_and_display_commit_are_not_authority_claim_keys() -> None:
+    manifest = _manifest(commit="display-provenance")
+    manifest.repo_path = "/workspace/repo"
+
+    plan = plan_repo_manifest_import(manifest)
+
+    assert plan.source.display_commit == "display-provenance"
+    assert plan.manifest.repo_path == "/workspace/repo"
+
+
+def test_v1_source_is_diagnostic_and_commit_is_only_display_provenance() -> None:
+    first_manifest = _manifest(fingerprint_version=1, commit="a" * 40)
+    second_manifest = _manifest(fingerprint_version=1, commit="b" * 40)
+    first = plan_repo_manifest_import(first_manifest)
+    second = plan_repo_manifest_import(second_manifest)
+
+    assert first.source.disposition == "legacy-diagnostic"
+    assert first.source.eligible_for_verification is False
+    assert first.inert is True
+    assert first.source.display_commit == "a" * 40
+    assert first.source.identity_digest == second.source.identity_digest
+    assert first.manifest_digest != second.manifest_digest
+    assert first.plan_digest != second.plan_digest
+
+
+@pytest.mark.parametrize("axis", BM25_PROFILE_AXES)
+def test_required_bm25_profile_fails_closed_when_axis_is_missing(axis: str) -> None:
+    manifest = _manifest(include_vector=False)
+    manifest.indexes["bm25"].config.pop(axis)
+    manifest.indexes["bm25"].metadata.pop(axis)
+
+    with pytest.raises(StorageValidationError, match="incomplete profile.*missing"):
+        plan_repo_manifest_import(manifest)
+
+
+@pytest.mark.parametrize("axis", VECTOR_PROFILE_AXES)
+def test_required_vector_profile_fails_closed_when_axis_is_missing(axis: str) -> None:
+    manifest = _manifest()
+    manifest.indexes["vector"].config.pop(axis)
+    manifest.indexes["vector"].metadata.pop(axis)
+
+    with pytest.raises(StorageValidationError, match="incomplete profile.*missing"):
+        plan_repo_manifest_import(manifest, views=["vector"])
+
+
+@pytest.mark.parametrize("view_type", ["bm25", "vector"])
+def test_unknown_builder_schemas_fail_closed(view_type: str) -> None:
+    manifest = _manifest()
+    _set_entry_field(manifest.indexes[view_type], "builder_schema", 999)
+
+    with pytest.raises(StorageValidationError, match="current portable schema"):
+        plan_repo_manifest_import(manifest, views=[view_type])
+
+    optional = plan_repo_manifest_import(
+        manifest,
+        required_views=["bm25" if view_type == "vector" else "vector"],
+        optional_views=[view_type],
+    )
+    assert optional.selection.skipped_views[view_type] == "incomplete_profile"
+
+
+@pytest.mark.parametrize("view_type", ["bm25", "vector"])
+def test_every_profile_axis_participates_in_profile_identity(view_type: str) -> None:
+    plan = plan_repo_manifest_import(_manifest(), views=[view_type])
+    intent = plan.view_map[view_type]
+    axes = BM25_PROFILE_AXES if view_type == "bm25" else VECTOR_PROFILE_AXES
+    baseline = intent.profile.config
+
+    for axis in axes:
+        changed = copy.deepcopy(baseline)
+        if axis == "builder_schema":
+            changed[axis] += 1
+        else:
+            current = changed["compatibility"][axis]
+            changed["compatibility"][axis] = _different_json_value(current)
+        altered = ViewProfile.create(
+            view_type,
+            changed,
+            name=intent.profile.name,
+        )
+        assert altered.profile_id != intent.profile_id, axis
+
+
+def test_vector_profile_binds_resolved_artifact_model_policy() -> None:
+    manifest = _manifest()
+    baseline = _profile_id(manifest, "vector")
+    _set_vector_route(
+        manifest.indexes["vector"],
+        options={
+            "revision": "a" * 40,
+            "model_kwargs": {"trust_remote_code": True},
+        },
+    )
+
+    plan = plan_repo_manifest_import(manifest, views=["vector"])
+    compatibility = plan.view_map["vector"].profile.config["compatibility"]
+
+    assert compatibility["embedding_load_policy"] == {
+        "revision": "a" * 40,
+        "trust_remote_code": True,
+    }
+    assert plan.view_map["vector"].profile_id != baseline
+
+
+def test_vector_profile_materializes_current_default_model_policy() -> None:
+    manifest = _manifest()
+    entry = manifest.indexes["vector"]
+    _set_vector_route(entry, model=DEFAULT_EMBEDDING_MODEL)
+    config_name = f"config_{DEFAULT_EMBEDDING_MODEL.replace('/', '__')}.json"
+    _set_entry_field(
+        entry,
+        "persistence_config_fingerprint",
+        _file_record("c", filename=config_name),
+    )
+
+    plan = plan_repo_manifest_import(manifest, views=["vector"])
+
+    assert plan.view_map["vector"].profile.config["compatibility"][
+        "embedding_load_policy"
+    ] == {
+        "revision": DEFAULT_EMBEDDING_REVISION,
+        "trust_remote_code": True,
+    }
+
+
+def test_vector_profile_rejects_filesystem_shaped_artifact_models() -> None:
+    manifest = _manifest()
+    _set_vector_route(manifest.indexes["vector"], model="/tmp/local-model")
+
+    with pytest.raises(StorageValidationError, match="model policy"):
+        plan_repo_manifest_import(manifest, views=["vector"])
+
+
+def test_vector_profile_rejects_conflicting_model_policy_options() -> None:
+    manifest = _manifest()
+    _set_vector_route(
+        manifest.indexes["vector"],
+        options={
+            "revision": "a" * 40,
+            "model_kwargs": {"revision": "b" * 40},
+        },
+    )
+
+    with pytest.raises(StorageValidationError, match="model policy"):
+        plan_repo_manifest_import(manifest, views=["vector"])
+
+
+def test_planning_uses_no_filesystem_or_ambient_route_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest()
+    real_resolve = manifest_storage_module.resolve_embedding_artifact_route
+    calls: list[object] = []
+
+    def resolve_without_ambient_environment(config, **kwargs):
+        calls.append(kwargs.get("environ"))
+        assert kwargs.get("environ") == {}
+        return real_resolve(config, **kwargs)
+
+    def reject_filesystem_probe(*_args, **_kwargs):
+        pytest.fail("manifest planning probed the filesystem")
+
+    monkeypatch.setattr(
+        manifest_storage_module,
+        "resolve_embedding_artifact_route",
+        resolve_without_ambient_environment,
+    )
+    monkeypatch.setattr(Path, "is_dir", reject_filesystem_probe)
+
+    plan = plan_repo_manifest_import(manifest, views=["vector"])
+
+    assert plan.selection.selected_views == ("vector",)
+    assert calls and all(call == {} for call in calls)
+
+
+def _different_json_value(value: object) -> object:
+    if isinstance(value, bool):
+        return not value
+    if isinstance(value, int):
+        return value + 1
+    if isinstance(value, str):
+        return value + "-different"
+    if value is None:
+        return "explicit"
+    if isinstance(value, list):
+        return [*value, "different"]
+    if isinstance(value, dict):
+        return {**value, "explicit_difference": True}
+    raise AssertionError(f"unhandled test value: {value!r}")
+
+
+def test_generation_fingerprints_do_not_pollute_profile_identity() -> None:
+    manifest = _manifest()
+    original = plan_repo_manifest_import(manifest)
+    changed = copy.deepcopy(manifest)
+    record = changed.indexes["bm25"].config["artifact_file_fingerprints"]
+    record["documents.json"]["sha256"] = "e" * 64
+    changed.indexes["bm25"].metadata["artifact_file_fingerprints"] = copy.deepcopy(
+        record
+    )
+    altered = plan_repo_manifest_import(changed)
+
+    assert altered.view_map["bm25"].profile_id == (original.view_map["bm25"].profile_id)
+    assert altered.view_map["bm25"].generation_record_digest != (
+        original.view_map["bm25"].generation_record_digest
+    )
+    assert altered.plan_digest != original.plan_digest
+
+
+def test_optional_incomplete_profile_is_explicitly_inert() -> None:
+    manifest = _manifest()
+    manifest.indexes["vector"].config.pop("embedding_route")
+    manifest.indexes["vector"].metadata.pop("embedding_route")
+    plan = plan_repo_manifest_import(manifest)
+
+    assert plan.selection.selected_views == ("bm25",)
+    assert plan.selection.optional_views == ("vector",)
+    assert plan.selection.skipped_views == {"vector": "incomplete_profile"}
+    assert tuple(plan.view_map) == ("bm25",)
+
+
+@pytest.mark.parametrize(
+    ("view_type", "record_field"),
+    [
+        ("bm25", "artifact_file_fingerprints"),
+        ("vector", "persistence_config_fingerprint"),
+    ],
+)
+def test_generation_record_is_required_but_not_a_profile_axis(
+    view_type: str, record_field: str
+) -> None:
+    manifest = _manifest()
+    manifest.indexes[view_type].config.pop(record_field)
+    manifest.indexes[view_type].metadata.pop(record_field)
+
+    with pytest.raises(StorageValidationError, match="incomplete generation record"):
+        plan_repo_manifest_import(manifest, views=[view_type])
+
+
+def test_optional_incomplete_generation_record_is_skipped() -> None:
+    manifest = _manifest()
+    manifest.indexes["vector"].config.pop("persistence_config_fingerprint")
+    manifest.indexes["vector"].metadata.pop("persistence_config_fingerprint")
+    plan = plan_repo_manifest_import(manifest)
+
+    assert plan.selection.selected_views == ("bm25",)
+    assert plan.selection.skipped_views == {"vector": "incomplete_generation_record"}
+
+
+def test_optional_malformed_generation_record_is_skipped() -> None:
+    manifest = _manifest()
+    manifest.indexes["vector"].config["persistence_config_fingerprint"] = {
+        "not": "a-record"
+    }
+    manifest.indexes["vector"].metadata["persistence_config_fingerprint"] = {
+        "not": "a-record"
+    }
+
+    plan = plan_repo_manifest_import(manifest)
+
+    assert plan.selection.skipped_views == {"vector": "incomplete_generation_record"}
+
+
+def test_unknown_config_fields_fail_closed_or_skip_when_optional() -> None:
+    required = _manifest(include_vector=False)
+    required.indexes["bm25"].config["new_semantic_axis"] = "unclassified"
+    with pytest.raises(StorageValidationError, match="unclassified config fields"):
+        plan_repo_manifest_import(required)
+
+    optional = _manifest()
+    optional.indexes["vector"].config["new_semantic_axis"] = "unclassified"
+    plan = plan_repo_manifest_import(optional)
+    assert plan.selection.skipped_views == {"vector": "incomplete_profile"}
+
+
+def test_unknown_metadata_fields_cannot_bypass_profile_classification() -> None:
+    required = _manifest(include_vector=False)
+    required.indexes["bm25"].metadata["new_semantic_axis"] = "unclassified"
+    with pytest.raises(StorageValidationError, match="unclassified metadata fields"):
+        plan_repo_manifest_import(required)
+
+    optional = _manifest()
+    optional.indexes["vector"].metadata["new_semantic_axis"] = "unclassified"
+    plan = plan_repo_manifest_import(optional)
+    assert plan.selection.skipped_views == {"vector": "incomplete_profile"}
+
+
+def test_profile_axis_cannot_conflict_with_duplicated_metadata() -> None:
+    manifest = _manifest(include_vector=False)
+    manifest.indexes["bm25"].metadata["max_k"] = 1
+
+    with pytest.raises(StorageValidationError, match="conflicts with metadata"):
+        plan_repo_manifest_import(manifest)
+
+
+def test_selection_is_canonical_and_nonportable_views_are_not_inferred() -> None:
+    manifest = _manifest()
+    manifest.indexes["symbol_graph"] = _entry(
+        "symbol_graph",
+        {},
+        fingerprint=manifest.source_fingerprint,
+        commit=manifest.commit,
+    )
+    plan = plan_repo_manifest_import(
+        manifest,
+        required_views=["vector", "vector"],
+        optional_views=["bm25", "bm25"],
+    )
+
+    assert plan.selection.required_views == ("vector",)
+    assert plan.selection.optional_views == ("bm25",)
+    assert plan.selection.selected_views == ("bm25", "vector")
+    assert set(plan.view_map) == {"bm25", "vector"}
+
+
+def test_noncurrent_optional_view_is_recorded_without_profile_guessing() -> None:
+    manifest = _manifest()
+    manifest.indexes["vector"].status = "stale"
+    plan = plan_repo_manifest_import(
+        manifest,
+        required_views=["bm25"],
+        optional_views=["vector"],
+    )
+
+    assert plan.selection.selected_views == ("bm25",)
+    assert plan.selection.skipped_views == {"vector": "not_current"}
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"views": ["bm25"], "required_views": ["bm25"]},
+        {"required_views": ["bm25"], "optional_views": ["bm25"]},
+        {"views": ["symbol_graph"]},
+        {"views": "bm25"},
+        {"views": [""]},
+        {"views": ["bm25"] * 129},
+    ],
+)
+def test_invalid_selection_is_rejected(kwargs: dict[str, object]) -> None:
+    with pytest.raises(StorageValidationError):
+        plan_repo_manifest_import(_manifest(), **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("drift", ["status", "commit", "fingerprint", "type"])
+def test_required_view_needs_an_exact_manifest_source_binding(drift: str) -> None:
+    manifest = _manifest(include_vector=False)
+    entry = manifest.indexes["bm25"]
+    if drift == "status":
+        entry.status = "stale"
+    elif drift == "commit":
+        entry.commit = "e" * 40
+    elif drift == "fingerprint":
+        entry.source_fingerprint = "sha256-v2:" + "e" * 64
+    else:
+        entry.index_type = "vector"
+
+    with pytest.raises(StorageValidationError, match="not current|does not match"):
+        plan_repo_manifest_import(manifest, views=["bm25"])
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    ["duplicate", "nan", "infinity", "top-level-array"],
+)
+def test_strict_json_rejects_ambiguous_or_nonobject_documents(corruption: str) -> None:
+    manifest = _manifest(include_vector=False)
+    payload = json.dumps(manifest.to_dict())
+    if corruption == "duplicate":
+        payload = payload.replace(
+            '"version": "1.1"', '"version": "1.1", "version": "1.1"'
+        )
+    elif corruption == "nan":
+        payload = payload.replace(
+            '"compiled_at_epoch": 1.0', '"compiled_at_epoch": NaN'
+        )
+    elif corruption == "infinity":
+        payload = payload.replace(
+            '"compiled_at_epoch": 1.0', '"compiled_at_epoch": Infinity'
+        )
+    else:
+        payload = "[]"
+
+    with pytest.raises(StorageValidationError, match="invalid or ambiguous|object"):
+        plan_repo_manifest_import_bytes(payload)
+
+
+@pytest.mark.parametrize(
+    "encoding",
+    ["utf-8-sig", "utf-16", "utf-16-le", "utf-32", "utf-32-le"],
+)
+def test_bytes_api_accepts_only_bomless_strict_utf8(encoding: str) -> None:
+    text = json.dumps(_manifest(include_vector=False).to_dict())
+
+    with pytest.raises(StorageValidationError):
+        plan_repo_manifest_import_bytes(text.encode(encoding))
+
+
+def test_bytes_api_rejects_invalid_utf8_and_string_bom() -> None:
+    with pytest.raises(StorageValidationError, match="UTF-8"):
+        plan_repo_manifest_import_bytes(b'{"version":"\xff"}')
+    with pytest.raises(StorageValidationError, match="BOM"):
+        plan_repo_manifest_import_bytes("\ufeff{}")
+
+
+def test_manifest_json_complexity_fails_before_semantic_planning() -> None:
+    manifest = _manifest(include_vector=False)
+    nested: object = "leaf"
+    for _ in range(70):
+        nested = {"nested": nested}
+    manifest.indexes["bm25"].metadata["note"] = nested
+
+    with pytest.raises(StorageValidationError, match="complexity budget"):
+        plan_repo_manifest_import_bytes(json.dumps(manifest.to_dict()))
+    with pytest.raises(StorageValidationError, match="level depth limit"):
+        plan_repo_manifest_import(manifest)
+
+
+def test_manifest_rejects_lone_unicode_surrogates() -> None:
+    manifest = _manifest(include_vector=False)
+    manifest.compiled_at = "bad-\ud800"
+
+    with pytest.raises(StorageValidationError, match="UTF-8"):
+        plan_repo_manifest_import(manifest)
+    payload = json.dumps(manifest.to_dict()).encode("ascii")
+    with pytest.raises(StorageValidationError, match="UTF-8"):
+        plan_repo_manifest_import_bytes(payload)
+
+
+def test_bytes_api_parses_unicode_text_then_canonicalizes_to_ascii() -> None:
+    manifest = _manifest(include_vector=False)
+    manifest.compiled_at = "build-é"
+    payload = json.dumps(manifest.to_dict(), ensure_ascii=False)
+
+    plan = plan_repo_manifest_import_bytes(payload)
+
+    assert b"build-\\u00e9" in plan.canonical_manifest_bytes
+
+
+@pytest.mark.parametrize(
+    "number",
+    ["9" * 5000, "9" * 400 + ".0", "1e10000"],
+)
+def test_bytes_api_translates_oversized_json_numbers(number: str) -> None:
+    payload = json.dumps(_manifest(include_vector=False).to_dict())
+    payload = payload.replace(
+        '"compiled_at_epoch": 1.0', f'"compiled_at_epoch": {number}'
+    )
+
+    with pytest.raises(StorageValidationError, match="invalid or ambiguous"):
+        plan_repo_manifest_import_bytes(payload)
+
+
+@pytest.mark.parametrize("epoch", [10**400, 1e308, float(2**63)])
+def test_mapping_api_bounds_epoch_before_float_conversion(epoch: object) -> None:
+    manifest = _manifest(include_vector=False)
+    manifest.compiled_at_epoch = epoch  # type: ignore[assignment]
+
+    with pytest.raises(StorageValidationError):
+        plan_repo_manifest_import(manifest)
+
+
+def test_manifest_input_and_canonical_output_are_bounded() -> None:
+    payload = json.dumps(_manifest(include_vector=False).to_dict()).encode()
+    with pytest.raises(StorageValidationError, match="positive integer"):
+        plan_repo_manifest_import_bytes(payload, max_manifest_bytes=0)
+    with pytest.raises(StorageValidationError, match="byte limit"):
+        plan_repo_manifest_import_bytes(payload, max_manifest_bytes=len(payload) - 1)
+    with pytest.raises(StorageValidationError, match="byte limit"):
+        plan_repo_manifest_import(
+            _manifest(include_vector=False),
+            max_manifest_bytes=64,
+        )
+    with pytest.raises(StorageValidationError, match="fixed.*ceiling"):
+        plan_repo_manifest_import_bytes(
+            payload,
+            max_manifest_bytes=DEFAULT_MAX_MANIFEST_BYTES + 1,
+        )
+
+
+def test_manifest_byte_limit_rejects_hostile_integer_subclasses() -> None:
+    class ForgedLimit(int):
+        def __le__(self, other: object) -> bool:
+            return False
+
+        def __gt__(self, other: object) -> bool:
+            return False
+
+    with pytest.raises(StorageValidationError, match="positive integer"):
+        plan_repo_manifest_import(
+            _manifest(include_vector=False),
+            max_manifest_bytes=ForgedLimit(1),
+        )
+
+
+def test_manifest_size_gate_precedes_text_or_buffer_copy() -> None:
+    class TrapText(str):
+        def encode(self, *args, **kwargs):
+            raise AssertionError("text was encoded before its size gate")
+
+    class TrapBytearray(bytearray):
+        def __bytes__(self):
+            raise AssertionError("buffer was copied before its size gate")
+
+    for payload in (TrapText("{}"), TrapBytearray(b"{}")):
+        with pytest.raises(StorageValidationError, match="byte limit"):
+            plan_repo_manifest_import_bytes(payload, max_manifest_bytes=1)
+
+
+def test_manifest_memoryview_size_gate_uses_byte_size() -> None:
+    payload = memoryview(array("I", [0x7B7D7B7D]))
+    assert len(payload) == 1
+    assert payload.nbytes > 1
+
+    with pytest.raises(StorageValidationError, match="byte limit"):
+        plan_repo_manifest_import_bytes(payload, max_manifest_bytes=1)
+
+
+def test_released_manifest_memoryview_is_a_validation_error() -> None:
+    payload = memoryview(b"{}")
+    payload.release()
+
+    with pytest.raises(StorageValidationError, match="buffer is unavailable"):
+        plan_repo_manifest_import_bytes(payload)
+
+
+def test_exact_manifest_is_snapshotted_without_calling_to_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest(include_vector=False)
+    original_to_dict = RepoManifest.to_dict
+
+    def fail_to_dict(self: RepoManifest) -> dict[str, object]:
+        if self is manifest:
+            raise AssertionError(
+                "caller RepoManifest.to_dict must not run before the budget gate"
+            )
+        return original_to_dict(self)
+
+    monkeypatch.setattr(RepoManifest, "to_dict", fail_to_dict)
+    plan = plan_repo_manifest_import(manifest)
+    assert plan.selection.selected_views == ("bm25",)
+
+
+def test_exact_manifest_rejects_hostile_fields_before_consuming_them() -> None:
+    reads = 0
+
+    def languages() -> Iterator[str]:
+        nonlocal reads
+        while True:
+            reads += 1
+            yield "python"
+
+    manifest = _manifest(include_vector=False)
+    manifest.languages = languages()  # type: ignore[assignment]
+    with pytest.raises(StorageValidationError):
+        plan_repo_manifest_import(manifest, max_manifest_bytes=1)
+    assert reads == 0
+
+
+@pytest.mark.parametrize("kind", ["manifest", "entry"])
+def test_exact_manifest_models_with_missing_slots_fail_closed(kind: str) -> None:
+    if kind == "manifest":
+        value = object.__new__(RepoManifest)
+    else:
+        value = _manifest(include_vector=False)
+        value.indexes["bm25"] = object.__new__(IndexEntry)
+
+    with pytest.raises(StorageValidationError, match="missing|invalid"):
+        plan_repo_manifest_import(value)
+
+
+def test_import_plan_revalidates_forged_child_intents() -> None:
+    plan = plan_repo_manifest_import(_manifest(include_vector=False), views=["bm25"])
+    forged = object.__new__(ViewImportIntent)
+    for field in (
+        "view_type",
+        "required",
+        "manifest_entry_json",
+        "profile",
+        "generation_record_json",
+    ):
+        object.__setattr__(forged, field, getattr(plan.views[0], field))
+    object.__setattr__(
+        forged,
+        "generation_record_json",
+        canonical_json({"contract": "forged"}),
+    )
+
+    with pytest.raises(StorageValidationError, match="generation record"):
+        RepoManifestImportPlan(
+            manifest_json=plan.manifest_json,
+            source=plan.source,
+            selection=plan.selection,
+            views=(forged,),
+        )
+
+
+def test_import_plan_rejects_mutable_selection_aliases() -> None:
+    plan = plan_repo_manifest_import(_manifest(include_vector=False), views=["bm25"])
+    forged = object.__new__(ViewSelection)
+    object.__setattr__(forged, "required_views", ["bm25"])
+    object.__setattr__(forged, "optional_views", [])
+    object.__setattr__(forged, "selected_views", ["bm25"])
+    object.__setattr__(forged, "skipped_items", ())
+
+    with pytest.raises(StorageValidationError, match="tuple"):
+        RepoManifestImportPlan(
+            manifest_json=plan.manifest_json,
+            source=plan.source,
+            selection=forged,
+            views=plan.views,
+        )
+
+
+def test_import_plan_rejects_hostile_scalar_and_profile_subclasses() -> None:
+    class ForgedText(str):
+        def __eq__(self, other: object) -> bool:
+            return True
+
+    class ForgedProfile(ViewProfile):
+        def __eq__(self, other: object) -> bool:
+            return True
+
+    plan = plan_repo_manifest_import(_manifest(include_vector=False), views=["bm25"])
+    profile = plan.views[0].profile
+
+    with pytest.raises(StorageValidationError, match="text fields must be exact"):
+        replace(plan.source, fingerprint=ForgedText(plan.source.fingerprint))
+    with pytest.raises(StorageValidationError, match="profile is invalid"):
+        replace(
+            plan.views[0],
+            profile=ForgedProfile(
+                profile.view_type,
+                profile.name,
+                profile.config_json,
+            ),
+        )
+
+
+def test_public_intent_value_objects_reject_subclasses() -> None:
+    plan = plan_repo_manifest_import(_manifest(include_vector=False), views=["bm25"])
+
+    class ForgedSourceIntent(SourceIntent):
+        pass
+
+    class ForgedViewSelection(ViewSelection):
+        pass
+
+    class ForgedViewImportIntent(ViewImportIntent):
+        pass
+
+    with pytest.raises(StorageValidationError, match="exact intent type"):
+        ForgedSourceIntent(
+            plan.source.fingerprint,
+            plan.source.fingerprint_version,
+            plan.source.file_count,
+            plan.source.display_commit,
+        )
+    with pytest.raises(StorageValidationError, match="exact selection type"):
+        ForgedViewSelection(
+            plan.selection.required_views,
+            plan.selection.optional_views,
+            plan.selection.selected_views,
+            plan.selection.skipped_items,
+        )
+    view = plan.views[0]
+    with pytest.raises(StorageValidationError, match="exact intent type"):
+        ForgedViewImportIntent(
+            view.view_type,
+            view.required,
+            view.manifest_entry_json,
+            view.profile,
+            view.generation_record_json,
+        )
+
+    with pytest.raises(StorageValidationError, match="bounded text"):
+        SourceIntent("x" * 129, 2, 1, "display")
+
+
+def test_forged_profile_text_is_bounded_before_plan_comparison() -> None:
+    plan = plan_repo_manifest_import(_manifest(include_vector=False), views=["bm25"])
+    forged_profile = object.__new__(ViewProfile)
+    object.__setattr__(forged_profile, "view_type", "bm25")
+    object.__setattr__(forged_profile, "name", REPO_MANIFEST_PROFILE_NAME)
+    object.__setattr__(
+        forged_profile,
+        "config_json",
+        " " * (DEFAULT_MAX_MANIFEST_BYTES + 1),
+    )
+    with pytest.raises(StorageValidationError, match="byte limit"):
+        replace(plan.views[0], profile=forged_profile)
+
+
+def test_import_plan_rejects_exact_children_forged_without_constructors() -> None:
+    class ForgedText(str):
+        def __eq__(self, other: object) -> bool:
+            return True
+
+    plan = plan_repo_manifest_import(_manifest(include_vector=False), views=["bm25"])
+    forged_source = object.__new__(SourceIntent)
+    for field in ("fingerprint", "fingerprint_version", "file_count", "display_commit"):
+        object.__setattr__(forged_source, field, getattr(plan.source, field))
+    object.__setattr__(
+        forged_source,
+        "fingerprint",
+        ForgedText("sha256-v2:" + "0" * 64),
+    )
+    with pytest.raises(StorageValidationError, match="text fields must be exact"):
+        RepoManifestImportPlan(
+            manifest_json=plan.manifest_json,
+            source=forged_source,
+            selection=plan.selection,
+            views=plan.views,
+        )
+
+    forged_profile = object.__new__(ViewProfile)
+    profile = plan.views[0].profile
+    for field in ("view_type", "name", "config_json"):
+        object.__setattr__(forged_profile, field, getattr(profile, field))
+    object.__setattr__(forged_profile, "view_type", ForgedText("vector"))
+    forged_view = object.__new__(ViewImportIntent)
+    for field in (
+        "view_type",
+        "required",
+        "manifest_entry_json",
+        "profile",
+        "generation_record_json",
+    ):
+        object.__setattr__(forged_view, field, getattr(plan.views[0], field))
+    object.__setattr__(forged_view, "profile", forged_profile)
+    with pytest.raises(StorageValidationError, match="profile fields must be exact"):
+        RepoManifestImportPlan(
+            manifest_json=plan.manifest_json,
+            source=plan.source,
+            selection=plan.selection,
+            views=(forged_view,),
+        )
+
+
+@pytest.mark.parametrize("kind", ["source", "selection", "profile"])
+def test_import_plan_missing_child_slots_are_validation_errors(kind: str) -> None:
+    plan = plan_repo_manifest_import(_manifest(include_vector=False), views=["bm25"])
+    source = plan.source
+    selection = plan.selection
+    views = plan.views
+    if kind == "source":
+        source = object.__new__(SourceIntent)
+    elif kind == "selection":
+        selection = object.__new__(ViewSelection)
+    else:
+        forged_view = object.__new__(ViewImportIntent)
+        for field in (
+            "view_type",
+            "required",
+            "manifest_entry_json",
+            "profile",
+            "generation_record_json",
+        ):
+            object.__setattr__(forged_view, field, getattr(plan.views[0], field))
+        object.__setattr__(forged_view, "profile", object.__new__(ViewProfile))
+        views = (forged_view,)
+
+    with pytest.raises(StorageValidationError, match="invalid"):
+        RepoManifestImportPlan(
+            manifest_json=plan.manifest_json,
+            source=source,
+            selection=selection,
+            views=views,
+        )
+
+
+def test_public_plan_values_are_bounded_before_traversal_or_encoding() -> None:
+    plan = plan_repo_manifest_import(_manifest(include_vector=False), views=["bm25"])
+    oversized_json = " " * (DEFAULT_MAX_MANIFEST_BYTES + 1)
+    with pytest.raises(StorageValidationError, match="byte limit"):
+        replace(plan, manifest_json=oversized_json)
+    with pytest.raises(StorageValidationError, match="byte limit"):
+        replace(plan.views[0], manifest_entry_json=oversized_json)
+    with pytest.raises(StorageValidationError, match="byte limit"):
+        replace(plan.views[0], generation_record_json=oversized_json)
+
+    oversized_names = ("bm25",) * (
+        len(manifest_storage_module.PORTABLE_STORAGE_VIEWS) + 1
+    )
+    with pytest.raises(StorageValidationError, match="tuple of portable views"):
+        ViewSelection(oversized_names, (), ("bm25",), ())
+    oversized_skips = (("vector", "not_current"),) * (
+        len(manifest_storage_module.PORTABLE_STORAGE_VIEWS) + 1
+    )
+    with pytest.raises(StorageValidationError, match="canonical tuple"):
+        ViewSelection(("bm25",), ("vector",), ("bm25",), oversized_skips)
+    with pytest.raises(StorageValidationError, match="intent tuple"):
+        replace(
+            plan,
+            views=plan.views
+            * (len(manifest_storage_module.PORTABLE_STORAGE_VIEWS) + 1),
+        )
+
+
+def test_view_selection_stops_consuming_after_its_fixed_bound() -> None:
+    manifest = _manifest(include_vector=False)
+
+    class LyingSelection:
+        def __init__(self) -> None:
+            self.reads = 0
+
+        def __len__(self) -> int:
+            return 1
+
+        def __getitem__(self, index: int) -> str:
+            self.reads += 1
+            return "bm25"
+
+    requested = LyingSelection()
+    with pytest.raises(StorageValidationError, match="too many"):
+        plan_repo_manifest_import(
+            manifest,
+            views=requested,  # type: ignore[arg-type]
+        )
+    assert requested.reads == manifest_storage_module._MAX_INDEXES + 1
+
+
+@pytest.mark.parametrize("error", [KeyError("selection failed"), OSError("I/O failed")])
+def test_view_selection_normalizes_ordinary_iteration_errors(
+    error: BaseException,
+) -> None:
+    class FailingSelection:
+        def __iter__(self):
+            raise error
+
+    with pytest.raises(StorageValidationError, match="bounded sequence") as caught:
+        plan_repo_manifest_import(
+            _manifest(include_vector=False),
+            views=FailingSelection(),  # type: ignore[arg-type]
+        )
+    assert caught.value.__cause__ is error
+
+
+def test_view_selection_rejects_hostile_or_oversized_string_values() -> None:
+    class HostileText(str):
+        def strip(self, *args, **kwargs):
+            raise AssertionError("overridden strip must not run")
+
+    with pytest.raises(StorageValidationError, match="exact view names"):
+        plan_repo_manifest_import(
+            _manifest(include_vector=False),
+            views=[HostileText("bm25")],
+        )
+    with pytest.raises(StorageValidationError, match="bounded text"):
+        plan_repo_manifest_import(
+            _manifest(include_vector=False),
+            views=[" " * (manifest_storage_module._MAX_VIEW_NAME + 1)],
+        )
+
+
+def test_mapping_input_is_snapshotted_exactly_once() -> None:
+    manifest = _manifest(include_vector=False).to_dict()
+
+    class ChameleonMapping(Mapping[str, object]):
+        def __init__(self) -> None:
+            self.items_calls = 0
+
+        def __getitem__(self, key: str) -> object:
+            return manifest[key]
+
+        def __iter__(self) -> Iterator[str]:
+            return iter(manifest)
+
+        def __len__(self) -> int:
+            return len(manifest)
+
+        def items(self):
+            self.items_calls += 1
+            return () if self.items_calls == 1 else manifest.items()
+
+    value = ChameleonMapping()
+    with pytest.raises(StorageValidationError, match="invalid shape"):
+        plan_repo_manifest_import(value)
+    assert value.items_calls == 1
+
+
+def test_mapping_snapshot_rejects_repeated_container_aliases_after_one_read() -> None:
+    class SharedMapping(Mapping[str, object]):
+        def __init__(self) -> None:
+            self.items_calls = 0
+
+        def __getitem__(self, key: str) -> object:
+            raise KeyError(key)
+
+        def __iter__(self) -> Iterator[str]:
+            return iter(("value",))
+
+        def __len__(self) -> int:
+            return 1
+
+        def items(self):
+            self.items_calls += 1
+            return (("value", self.items_calls),)
+
+    shared = SharedMapping()
+    with pytest.raises(StorageValidationError, match="repeated or cyclic"):
+        manifest_storage_module._snapshot_json_value(
+            {"first": shared, "second": shared},
+            label="aliased mapping",
+        )
+    assert shared.items_calls == 1
+
+
+def test_mapping_snapshot_stops_at_the_node_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reads = 0
+
+    class OversizedMapping(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise KeyError(key)
+
+        def __iter__(self) -> Iterator[str]:
+            return iter(())
+
+        def __len__(self) -> int:
+            return 1
+
+        def items(self):
+            nonlocal reads
+            for index in range(1000):
+                reads += 1
+                yield f"key-{index}", index
+
+    monkeypatch.setattr(manifest_storage_module, "_MAX_JSON_NODES", 4)
+    with pytest.raises(StorageValidationError, match="node limit"):
+        plan_repo_manifest_import(OversizedMapping())
+    assert reads == 4
+
+
+def test_mapping_snapshot_counts_del_using_canonical_json_size() -> None:
+    payload = {"value": "\x7f"}
+    expected = canonical_json(payload).encode("ascii")
+    snapshot, estimated = manifest_storage_module._snapshot_json_value(
+        payload,
+        label="test mapping",
+        max_bytes=len(expected),
+    )
+    assert snapshot == payload
+    assert estimated == len(expected)
+
+    with pytest.raises(StorageValidationError, match="byte limit"):
+        manifest_storage_module._snapshot_json_value(
+            payload,
+            label="test mapping",
+            max_bytes=len(expected) - 1,
+        )
+
+
+@pytest.mark.parametrize("error", [KeyError("mapping failed"), OSError("I/O failed")])
+def test_mapping_snapshot_normalizes_hostile_iteration_errors(
+    error: BaseException,
+) -> None:
+    class FailingMapping(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise KeyError(key)
+
+        def __iter__(self) -> Iterator[str]:
+            return iter(())
+
+        def __len__(self) -> int:
+            return 1
+
+        def items(self):
+            raise error
+
+    with pytest.raises(StorageValidationError, match="snapshotted") as caught:
+        plan_repo_manifest_import(FailingMapping())
+    assert caught.value.__cause__ is error
+
+
+@pytest.mark.parametrize(
+    ("location", "field"),
+    [
+        ("top", "unknown"),
+        ("repo", "unknown"),
+        ("entry", "unknown"),
+    ],
+)
+def test_manifest_shape_rejects_unknown_fields(location: str, field: str) -> None:
+    data = _manifest(include_vector=False).to_dict()
+    if location == "top":
+        data[field] = True
+    elif location == "repo":
+        data["repo"][field] = True
+    else:
+        data["indexes"]["bm25"][field] = True
+
+    with pytest.raises(StorageValidationError, match="invalid shape"):
+        plan_repo_manifest_import(data)
+
+
+@pytest.mark.parametrize(
+    "fingerprint",
+    ["", "sha256-v3:" + "a" * 64, "sha256-v2:" + "A" * 64, "sha256:short"],
+)
+def test_source_fingerprint_must_be_recognized_and_canonical(fingerprint: str) -> None:
+    manifest = _manifest(include_vector=False)
+    manifest.source_fingerprint = fingerprint
+    manifest.last_indexed_source_fingerprint = fingerprint
+    manifest.indexes["bm25"].source_fingerprint = fingerprint
+
+    with pytest.raises(StorageValidationError, match="source fingerprint"):
+        plan_repo_manifest_import(manifest)
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value", "message"),
+    [
+        ("config", "api_key", "secret", "secret field"),
+        ("metadata", "endpoint", "https://u:p@example.test", "URL credentials"),
+        ("metadata", "error_message", "host path", "diagnostic field"),
+    ],
+)
+def test_selected_entry_rejects_secrets_and_diagnostics(
+    section: str, field: str, value: str, message: str
+) -> None:
+    manifest = _manifest(include_vector=False)
+    getattr(manifest.indexes["bm25"], section)[field] = value
+
+    with pytest.raises(StorageValidationError, match=message):
+        plan_repo_manifest_import(manifest)
+
+
+@pytest.mark.parametrize(
+    ("view_type", "mutate", "message"),
+    [
+        (
+            "bm25",
+            lambda record: record["documents.json"].update(sha256="bad"),
+            "SHA-256",
+        ),
+        (
+            "bm25",
+            lambda record: record["documents.json"].update(size=True),
+            "size",
+        ),
+        (
+            "vector",
+            lambda record: record.update(file="config_other.json"),
+            "file name",
+        ),
+        (
+            "vector",
+            lambda record: record.update(size=16 * 1024 * 1024 + 1),
+            "size",
+        ),
+    ],
+)
+def test_generation_fingerprint_records_are_strict(
+    view_type: str, mutate, message: str
+) -> None:
+    manifest = _manifest()
+    field = (
+        "artifact_file_fingerprints"
+        if view_type == "bm25"
+        else "persistence_config_fingerprint"
+    )
+    record = manifest.indexes[view_type].config[field]
+    mutate(record)
+    manifest.indexes[view_type].metadata[field] = copy.deepcopy(record)
+
+    with pytest.raises(StorageValidationError, match=message):
+        plan_repo_manifest_import(manifest, views=[view_type])
+
+
+def test_conflicting_duplicate_generation_records_fail_closed() -> None:
+    manifest = _manifest(include_vector=False)
+    manifest.indexes["bm25"].metadata["artifact_file_fingerprints"]["documents.json"][
+        "sha256"
+    ] = ("e" * 64)
+
+    with pytest.raises(StorageValidationError, match="conflicting"):
+        plan_repo_manifest_import(manifest)
+
+
+@pytest.mark.parametrize(
+    ("view_type", "field", "value"),
+    [
+        ("bm25", "artifact_scope", None),
+        ("bm25", "artifact_scope", "mutable"),
+        ("bm25", "chunk_count", True),
+        ("bm25", "file_count", -1),
+        ("bm25", "portable_document_format", "unknown"),
+        ("bm25", "source_file_count", 100),
+        ("vector", "artifact_scope", "mutable"),
+        ("vector", "document_count", True),
+        ("vector", "document_count", {"l3": 1}),
+        ("vector", "document_count", {"l0": -1}),
+        ("vector", "last_commit", 1),
+        ("vector", "last_commit", "bad\x00commit"),
+        ("vector", "portable_document_format", "unknown"),
+    ],
+)
+def test_non_profile_fields_have_explicit_generation_schemas(
+    view_type: str,
+    field: str,
+    value: object,
+) -> None:
+    manifest = _manifest()
+    _set_entry_field(manifest.indexes[view_type], field, value)
+
+    with pytest.raises(StorageValidationError, match="incomplete generation record"):
+        plan_repo_manifest_import(manifest, views=[view_type])
+
+
+def test_supported_portable_generation_fields_remain_importable() -> None:
+    manifest = _manifest()
+    _set_entry_field(manifest.indexes["bm25"], "artifact_scope", "query-serving")
+    _set_entry_field(
+        manifest.indexes["bm25"],
+        "portable_document_format",
+        "codenib.bm25-documents.v1",
+    )
+    _set_entry_field(manifest.indexes["vector"], "artifact_scope", "query-serving")
+    _set_entry_field(
+        manifest.indexes["vector"],
+        "portable_document_format",
+        "codenib.vector-documents.v1",
+    )
+
+    plan = plan_repo_manifest_import(manifest)
+
+    assert plan.selection.selected_views == ("bm25", "vector")
+
+
+def test_optional_invalid_non_profile_field_is_explicitly_inert() -> None:
+    manifest = _manifest()
+    _set_entry_field(manifest.indexes["vector"], "document_count", True)
+
+    plan = plan_repo_manifest_import(manifest)
+
+    assert plan.selection.selected_views == ("bm25",)
+    assert plan.selection.skipped_views == {"vector": "incomplete_generation_record"}
+
+
+def test_required_vector_document_counts_are_positive_but_may_be_empty() -> None:
+    manifest = _manifest()
+    _set_entry_field(manifest.indexes["vector"], "document_count", {"l0": 0})
+
+    with pytest.raises(StorageValidationError, match="incomplete generation record"):
+        plan_repo_manifest_import(manifest, views=["vector"])
+
+    _set_entry_field(manifest.indexes["vector"], "document_count", {})
+    plan = plan_repo_manifest_import(manifest, views=["vector"])
+
+    assert plan.selection.selected_views == ("vector",)
+
+
+def test_optional_zero_vector_document_count_is_explicitly_inert() -> None:
+    manifest = _manifest()
+    _set_entry_field(manifest.indexes["vector"], "document_count", {"l0": 0})
+
+    plan = plan_repo_manifest_import(manifest)
+
+    assert plan.selection.selected_views == ("bm25",)
+    assert plan.selection.skipped_views == {"vector": "incomplete_generation_record"}
+
+
+@pytest.mark.parametrize("required", [True, False], ids=["required", "optional"])
+@pytest.mark.parametrize(
+    "provenance",
+    ["full-empty", "incremental", "fallback", "fallback-empty"],
+)
+def test_vector_accepts_builder_provenance_without_profile_pollution(
+    required: bool,
+    provenance: str,
+) -> None:
+    manifest = _manifest()
+    requested = ["vector"] if required else None
+    baseline = plan_repo_manifest_import(manifest, views=requested)
+    fields: dict[str, object]
+    if provenance == "full-empty":
+        fields = {"last_commit": ""}
+    elif provenance == "incremental":
+        _remove_entry_field(manifest.indexes["vector"], "last_commit")
+        fields = _vector_incremental_provenance()
+    else:
+        assert provenance in {"fallback", "fallback-empty"}
+        fields = {
+            "update_mode": "full_rebuild",
+            "incremental_fallback_reason": "ValueError",
+        }
+        if provenance == "fallback-empty":
+            fields["last_commit"] = ""
+    _set_entry_fields(manifest.indexes["vector"], fields)
+
+    plan = plan_repo_manifest_import(manifest, views=requested)
+
+    assert "vector" in plan.selection.selected_views
+    assert plan.view_map["vector"].profile_id == baseline.view_map["vector"].profile_id
+    assert plan.view_map["vector"].manifest_entry_digest != (
+        baseline.view_map["vector"].manifest_entry_digest
+    )
+
+
+@pytest.mark.parametrize("required", [True, False], ids=["required", "optional"])
+@pytest.mark.parametrize(
+    "case",
+    [
+        "partial_incremental",
+        "boolean_chunk_count",
+        "negative_chunk_count",
+        "boolean_cache_rate",
+        "negative_cache_rate",
+        "high_cache_rate",
+        "invalid_new_commit",
+        "empty_new_commit",
+        "mismatched_new_commit",
+        "missing_last_commit",
+        "mismatched_last_commit",
+        "last_commit_incremental_hybrid",
+        "unknown_update_mode",
+        "missing_fallback_reason",
+        "fallback_missing_last_commit",
+        "empty_fallback_reason",
+        "nul_fallback_reason",
+        "incremental_fallback_conflict",
+    ],
+)
+def test_malformed_vector_provenance_fails_or_skips(
+    required: bool,
+    case: str,
+) -> None:
+    incremental = _vector_incremental_provenance()
+    fields: dict[str, object]
+    if case == "partial_incremental":
+        fields = {"chunks_reembedded": 1}
+    elif case == "boolean_chunk_count":
+        fields = {**incremental, "chunks_reembedded": True}
+    elif case == "negative_chunk_count":
+        fields = {**incremental, "chunks_from_cache": -1}
+    elif case == "boolean_cache_rate":
+        fields = {**incremental, "cache_hit_rate": True}
+    elif case == "negative_cache_rate":
+        fields = {**incremental, "cache_hit_rate": -0.1}
+    elif case == "high_cache_rate":
+        fields = {**incremental, "cache_hit_rate": 1.1}
+    elif case == "invalid_new_commit":
+        fields = {**incremental, "new_commit": 1}
+    elif case == "empty_new_commit":
+        fields = {**incremental, "new_commit": ""}
+    elif case == "mismatched_new_commit":
+        fields = {**incremental, "new_commit": "f" * 40}
+    elif case == "missing_last_commit":
+        fields = {}
+    elif case == "mismatched_last_commit":
+        fields = {"last_commit": "f" * 40}
+    elif case == "last_commit_incremental_hybrid":
+        fields = incremental
+    elif case == "unknown_update_mode":
+        fields = {
+            "update_mode": "incremental",
+            "incremental_fallback_reason": "ValueError",
+        }
+    elif case == "missing_fallback_reason":
+        fields = {"update_mode": "full_rebuild"}
+    elif case == "fallback_missing_last_commit":
+        fields = {
+            "update_mode": "full_rebuild",
+            "incremental_fallback_reason": "ValueError",
+        }
+    elif case == "empty_fallback_reason":
+        fields = {
+            "update_mode": "full_rebuild",
+            "incremental_fallback_reason": "",
+        }
+    elif case == "nul_fallback_reason":
+        fields = {
+            "update_mode": "full_rebuild",
+            "incremental_fallback_reason": "bad\x00reason",
+        }
+    else:
+        assert case == "incremental_fallback_conflict"
+        fields = {
+            **incremental,
+            "update_mode": "full_rebuild",
+            "incremental_fallback_reason": "ValueError",
+        }
+
+    manifest = _manifest()
+    incremental_fields = set(_vector_incremental_provenance())
+    if (
+        case != "last_commit_incremental_hybrid"
+        and (set(fields) & incremental_fields or case == "missing_last_commit")
+    ) or case == "fallback_missing_last_commit":
+        _remove_entry_field(manifest.indexes["vector"], "last_commit")
+    _set_entry_fields(manifest.indexes["vector"], fields)
+    if required:
+        with pytest.raises(StorageValidationError, match="generation record"):
+            plan_repo_manifest_import(manifest, views=["vector"])
+    else:
+        plan = plan_repo_manifest_import(manifest)
+        assert plan.selection.selected_views == ("bm25",)
+        assert plan.selection.skipped_views == {
+            "vector": "incomplete_generation_record"
+        }
+
+
+def test_vector_route_redundancies_are_checked_without_native_execution() -> None:
+    manifest = _manifest()
+    manifest.indexes["vector"].config["dimension"] = 8
+    manifest.indexes["vector"].metadata["dimension"] = 8
+
+    with pytest.raises(StorageValidationError, match="dimensions must agree"):
+        plan_repo_manifest_import(manifest, views=["vector"])
+
+
+def test_canonical_manifest_digest_commits_full_entry_but_not_object_authority() -> (
+    None
+):
+    plan = plan_repo_manifest_import(_manifest(include_vector=False))
+    manifest_data = json.loads(plan.canonical_manifest_bytes)
+
+    assert canonical_json(manifest_data).encode("ascii") == (
+        plan.canonical_manifest_bytes
+    )
+    assert plan.manifest_digest == plan.to_dict()["manifest"]["digest"]
+    assert plan.view_map["bm25"].manifest_entry["path"] == "views/bm25"
+    assert "object" not in plan.view_map["bm25"].to_dict()
+    assert "receipt" not in plan.view_map["bm25"].to_dict()
+
+
+def test_dataclass_replace_changes_only_display_provenance_identity_layer() -> None:
+    plan = plan_repo_manifest_import(_manifest(include_vector=False))
+    changed_source = replace(plan.source, display_commit="e" * 40)
+
+    assert changed_source.identity_digest == plan.source.identity_digest
+    assert changed_source.to_dict() != plan.source.to_dict()
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"fingerprint_version": True},
+        {"fingerprint_version": 2.0},
+        {"fingerprint_version": 1},
+        {"fingerprint": "sha256-v2:" + "A" * 64},
+        {"file_count": True},
+        {"file_count": -1},
+        {"display_commit": "bad-\ud800"},
+    ],
+)
+def test_public_source_intent_constructor_enforces_canonical_binding(
+    changes: dict[str, object],
+) -> None:
+    values: dict[str, object] = {
+        "fingerprint": "sha256-v2:" + "a" * 64,
+        "fingerprint_version": 2,
+        "file_count": 1,
+        "display_commit": "display",
+    }
+    values.update(changes)
+
+    with pytest.raises(StorageValidationError):
+        SourceIntent(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "required_views": ("bm25", "bm25"),
+            "optional_views": (),
+            "selected_views": ("bm25",),
+            "skipped_items": (),
+        },
+        {
+            "required_views": ("bm25",),
+            "optional_views": ("bm25",),
+            "selected_views": ("bm25",),
+            "skipped_items": (),
+        },
+        {
+            "required_views": ("bm25",),
+            "optional_views": ("vector",),
+            "selected_views": ("bm25",),
+            "skipped_items": (),
+        },
+        {
+            "required_views": ("bm25",),
+            "optional_views": ("vector",),
+            "selected_views": ("bm25",),
+            "skipped_items": (
+                ("vector", "not_current"),
+                ("vector", "incomplete_profile"),
+            ),
+        },
+    ],
+)
+def test_public_selection_constructor_enforces_canonical_closure(
+    kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(StorageValidationError):
+        ViewSelection(**kwargs)  # type: ignore[arg-type]
+
+
+def test_public_view_intent_constructor_binds_canonical_json_and_profile() -> None:
+    plan = plan_repo_manifest_import(_manifest(include_vector=False))
+    intent = plan.views[0]
+    pretty_entry = json.dumps(intent.manifest_entry, indent=2)
+    pretty_generation = json.dumps(intent.generation_record, indent=2)
+    forged_profile = ViewProfile.create(
+        "bm25",
+        {"contract": "forged"},
+        name=REPO_MANIFEST_PROFILE_NAME,
+    )
+
+    with pytest.raises(StorageValidationError, match="canonical JSON"):
+        replace(intent, manifest_entry_json=pretty_entry)
+    with pytest.raises(StorageValidationError, match="profile does not match"):
+        replace(intent, profile=forged_profile)
+    with pytest.raises(StorageValidationError, match="canonical JSON"):
+        replace(intent, generation_record_json=pretty_generation)
+
+
+def test_public_plan_constructor_rejects_duplicate_or_cross_unbound_views() -> None:
+    plan = plan_repo_manifest_import(_manifest())
+    bm25 = plan.view_map["bm25"]
+
+    with pytest.raises(StorageValidationError, match="duplicate view"):
+        replace(plan, views=(bm25, bm25))
+
+    forged_selection = ViewSelection(
+        required_views=("bm25",),
+        optional_views=("vector",),
+        selected_views=("bm25",),
+        skipped_items=(("vector", "not_current"),),
+    )
+    with pytest.raises(StorageValidationError, match="skip reason conflicts"):
+        replace(plan, selection=forged_selection, views=(bm25,))
+
+
+def test_public_plan_constructor_binds_source_and_canonical_manifest() -> None:
+    plan = plan_repo_manifest_import(_manifest(include_vector=False))
+    other_source = replace(plan.source, display_commit="other")
+
+    with pytest.raises(StorageValidationError, match="source intent"):
+        replace(plan, source=other_source)
+    with pytest.raises(StorageValidationError, match="canonical JSON"):
+        RepoManifestImportPlan(
+            manifest_json=json.dumps(json.loads(plan.manifest_json), indent=2),
+            source=plan.source,
+            selection=plan.selection,
+            views=plan.views,
+        )
+
+
+def test_public_view_intent_rejects_view_profile_cross_binding() -> None:
+    plan = plan_repo_manifest_import(_manifest())
+    vector = plan.view_map["vector"]
+
+    with pytest.raises(StorageValidationError):
+        ViewImportIntent(
+            view_type="bm25",
+            required=False,
+            manifest_entry_json=vector.manifest_entry_json,
+            profile=vector.profile,
+            generation_record_json=vector.generation_record_json,
+        )


### PR DESCRIPTION
## Summary
Add a pure, backend-neutral planner that converts bounded `RepoManifest` v1.1 input into immutable retained-import intent. This layer validates and selects portable artifacts, but deliberately does not read artifacts, write CAS objects, mutate the catalog, or publish refs.

## Changes
- Add immutable source, view, selection, and import-plan value types plus mapping and byte-oriented planning entry points.
- Parse manifest JSON under strict UTF-8, ambiguity, size, depth, node, key, atom, integer, and selection bounds.
- Admit only current BM25 schema 8 and vector schema 6 artifacts with complete generation and builder-profile identity; required views fail closed while optional views record explicit skip decisions.
- Treat source fingerprint v2 as eligible input for later authentication and keep v1 plans inert; reject diagnostic and authority claims embedded anywhere in the manifest.
- Charge remaining encoded-byte budgets before reading caller-owned mapping children, and expose the planner through the lazy compiler API.
- Record the pure planning boundary while keeping retained reads, CAS upload, catalog mutation, and ref publication explicitly outstanding.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/compiler/test_manifest_storage.py --tb=short`: 256 passed.
- `pytest -q test/compiler test/storage/test_models.py --tb=short`: 640 passed.
- Local unit tier on the equivalent restacked patch: 5815 passed, 71 skipped, 191 deselected.
- `pre-commit run --from-ref origin/main --to-ref HEAD`: passed.
- `python -m mkdocs build --strict`: passed.
- `git diff --check origin/main...HEAD`: passed.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

#606 is merged and its exact-head and post-merge gates are green. This PR is restacked directly on the resulting `main`. The planner is intentionally authority-free and does not enable a production retained-manifest importer.