### PR TITLE
feat(storage): add retained artifact authorities

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -17,7 +17,9 @@ from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from functools import partial
+from itertools import pairwise
 from pathlib import Path, PurePosixPath
+from threading import RLock
 from typing import (
     Callable,
     ContextManager,
@@ -152,6 +154,8 @@ class PublicationAuthenticatedFile:
         "_digest",
         "_record",
         "_closed",
+        "_pid",
+        "_lifetime",
     )
 
     def __init__(
@@ -172,6 +176,13 @@ class PublicationAuthenticatedFile:
         self._digest = hashlib.sha256()
         self._record: TreeFileRecord | None = None
         self._closed = False
+        self._pid = os.getpid()
+        self._lifetime: _PublicationReaderLifetime | None = None
+
+    def _bind_lifetime(self, lifetime: _PublicationReaderLifetime) -> None:
+        if self._lifetime is not None and self._lifetime is not lifetime:
+            raise RuntimeError("publication authenticated file lifetime changed")
+        self._lifetime = lifetime
 
     @property
     def record(self) -> TreeFileRecord:
@@ -182,6 +193,17 @@ class PublicationAuthenticatedFile:
         return self._record
 
     def read(self, size: int = -1) -> bytes:
+        if os.getpid() != self._pid:
+            self._closed = True
+            raise RuntimeError(
+                "publication authenticated file cannot cross a process boundary"
+            )
+        lifetime = self._lifetime
+        if lifetime is not None and (
+            not lifetime.active or lifetime.pid != os.getpid()
+        ):
+            self._closed = True
+            raise ValueError("publication authenticated file is closed")
         if self._closed:
             raise ValueError("publication authenticated file is closed")
         if isinstance(size, bool) or not isinstance(size, int):
@@ -238,6 +260,190 @@ class PublicationAuthenticatedFile:
         finally:
             self._closed = True
 
+    def _abort(self) -> None:
+        """Terminate a failed consumer stream without reading more source bytes."""
+
+        self._closed = True
+
+
+class _PublicationReaderLifetime:
+    """Process-local lifetime shared by one reader and every subtree facade."""
+
+    __slots__ = ("pid", "active", "authentication_failed", "open_files")
+
+    def __init__(self) -> None:
+        self.pid = os.getpid()
+        self.active = True
+        self.authentication_failed = False
+        self.open_files: list[_PublicationAuthenticatedFileContext] = []
+
+
+class _PublicationAuthenticatedFileContext:
+    """Own one callback-scoped file context until it is verified or aborted."""
+
+    __slots__ = (
+        "_reader",
+        "_relative",
+        "_authority_relative",
+        "_max_bytes",
+        "_expected",
+        "_authority_expected",
+        "_backend_context",
+        "_authenticated",
+        "_entered",
+        "_finished",
+    )
+
+    def __init__(
+        self,
+        reader: PublicationDirectoryReader,
+        *,
+        relative: PurePosixPath,
+        authority_relative: PurePosixPath,
+        max_bytes: int,
+        expected: _ExpectedPublicationFile,
+        authority_expected: _ExpectedPublicationFile,
+    ) -> None:
+        self._reader = reader
+        self._relative = relative
+        self._authority_relative = authority_relative
+        self._max_bytes = max_bytes
+        self._expected = expected
+        self._authority_expected = authority_expected
+        self._backend_context: ContextManager[PublicationAuthenticatedFile] | None = (
+            None
+        )
+        self._authenticated: PublicationAuthenticatedFile | None = None
+        self._entered = False
+        self._finished = False
+
+    def __enter__(self) -> PublicationAuthenticatedFile:
+        if self._entered:
+            raise RuntimeError("publication authenticated file context is single-use")
+        self._reader._require_active()
+        self._entered = True
+        self._reader._register_open_file(self)
+        context: ContextManager[PublicationAuthenticatedFile] | None = None
+        try:
+            context = self._reader._open_file(
+                self._authority_relative,
+                self._max_bytes,
+                self._authority_expected,
+            )
+            self._backend_context = context
+            authenticated = context.__enter__()
+            self._authenticated = authenticated
+            authenticated._bind_lifetime(self._reader._lifetime)
+            if (
+                authenticated.path,
+                authenticated.mode,
+                authenticated.size,
+            ) != (
+                self._authority_expected.record.path,
+                self._authority_expected.record.mode,
+                self._authority_expected.record.size,
+            ):
+                raise RuntimeError(
+                    "publication file metadata differs from captured ownership"
+                )
+            # The backend authenticates the authority-root-relative path.  A
+            # subtree facade presents only its own relative namespace.
+            authenticated.path = self._relative.as_posix()
+            return authenticated
+        except BaseException as primary_error:
+            self._reader._mark_authentication_failed()
+            if context is not None:
+                authenticated = self._authenticated
+                if authenticated is not None:
+                    authenticated._abort()
+                try:
+                    context.__exit__(
+                        type(primary_error),
+                        primary_error,
+                        primary_error.__traceback__,
+                    )
+                except BaseException as cleanup_error:  # noqa: B036
+                    if cleanup_error is not primary_error:
+                        _annotate_secondary_error(
+                            primary_error,
+                            "publication authenticated file entry cleanup also failed",
+                            cleanup_error,
+                        )
+            self._finished = True
+            self._reader._forget_open_file(self)
+            raise
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object,
+    ) -> Literal[False]:
+        self._finish(exc, exc_type=exc_type, traceback=traceback)
+        return False
+
+    def _finish(
+        self,
+        primary_error: BaseException | None,
+        *,
+        exc_type: type[BaseException] | None = None,
+        traceback: object = None,
+    ) -> None:
+        if self._finished:
+            return
+        if not self._entered:
+            self._finished = True
+            return
+        context = self._backend_context
+        authenticated = self._authenticated
+        if context is None:
+            self._finished = True
+            self._reader._forget_open_file(self)
+            return
+        if primary_error is not None:
+            self._reader._mark_authentication_failed()
+            if authenticated is not None:
+                authenticated._abort()
+            if exc_type is None:
+                exc_type = type(primary_error)
+            if traceback is None:
+                traceback = primary_error.__traceback__
+        try:
+            context.__exit__(exc_type, primary_error, traceback)
+            if primary_error is None:
+                if (
+                    authenticated is None
+                    or authenticated.record != self._expected.record
+                ):
+                    raise RuntimeError(
+                        "publication file bytes differ from captured ownership"
+                    )
+        except BaseException:
+            self._reader._mark_authentication_failed()
+            raise
+        finally:
+            self._finished = True
+            self._reader._forget_open_file(self)
+
+    def _abort_and_close(self) -> None:
+        """Abort an escaped stream and close it without authenticating more bytes."""
+
+        if self._finished:
+            return
+        authenticated = self._authenticated
+        context = self._backend_context
+        if authenticated is not None:
+            authenticated._abort()
+        try:
+            if context is not None:
+                context.__exit__(None, None, None)
+        except BaseException:
+            self._reader._mark_authentication_failed()
+            raise
+        finally:
+            self._finished = True
+            self._reader._forget_open_file(self)
+
 
 class PublicationDirectoryReader:
     """A child tree that is usable only during an authority-owned callback."""
@@ -250,8 +456,11 @@ class PublicationDirectoryReader:
         "_expected_ownership",
         "_records_by_path",
         "_entries_by_path",
-        "_authentication_failed",
-        "_active",
+        "_authority_records_by_path",
+        "_authority_entries_by_path",
+        "_authority_expected_ownership",
+        "_path_prefix",
+        "_lifetime",
     )
 
     def __init__(
@@ -266,12 +475,25 @@ class PublicationDirectoryReader:
             ContextManager[PublicationAuthenticatedFile],
         ],
         expected_ownership: _TreeOwnership | None,
+        *,
+        _authority_expected_ownership: _TreeOwnership | None = None,
+        _path_prefix: PurePosixPath | None = None,
+        _lifetime: _PublicationReaderLifetime | None = None,
     ) -> None:
         self._diagnostic_path = display_path
         self.root_identity = root_identity
         self._capture = capture
         self._open_file = open_file
         self._expected_ownership = expected_ownership
+        self._authority_expected_ownership = (
+            expected_ownership
+            if _authority_expected_ownership is None
+            else _authority_expected_ownership
+        )
+        self._path_prefix = _path_prefix
+        self._lifetime = (
+            _PublicationReaderLifetime() if _lifetime is None else _lifetime
+        )
         self._records_by_path = (
             {}
             if expected_ownership is None
@@ -285,16 +507,111 @@ class PublicationDirectoryReader:
                 for path, kind, identity in expected_ownership.entry_identities
             }
         )
-        self._authentication_failed = False
-        self._active = True
+        authority_ownership = self._authority_expected_ownership
+        self._authority_records_by_path = (
+            {}
+            if authority_ownership is None
+            else {record.path: record for record in authority_ownership.file_records}
+        )
+        self._authority_entries_by_path = (
+            {}
+            if authority_ownership is None
+            else {
+                path: (kind, identity)
+                for path, kind, identity in authority_ownership.entry_identities
+            }
+        )
         if (
             expected_ownership is not None
             and root_identity != expected_ownership.root_identity
         ):
-            self._authentication_failed = True
+            self._mark_authentication_failed()
             raise RuntimeError(
                 "publication callback root differs from captured ownership"
             )
+
+    @property
+    def _authentication_failed(self) -> bool:
+        return self._lifetime.authentication_failed
+
+    @_authentication_failed.setter
+    def _authentication_failed(self, value: bool) -> None:
+        self._lifetime.authentication_failed = value
+
+    @property
+    def _active(self) -> bool:
+        return self._lifetime.active and self._lifetime.pid == os.getpid()
+
+    @_active.setter
+    def _active(self, value: bool) -> None:
+        self._lifetime.active = value
+
+    def _require_active(self) -> None:
+        if self._lifetime.pid != os.getpid():
+            self._lifetime.active = False
+            raise RuntimeError(
+                "publication tree reader cannot cross a process boundary"
+            )
+        if not self._lifetime.active:
+            raise RuntimeError("publication tree reader is no longer active")
+
+    def _mark_authentication_failed(self) -> None:
+        self._lifetime.authentication_failed = True
+
+    def _register_open_file(
+        self,
+        context: _PublicationAuthenticatedFileContext,
+    ) -> None:
+        self._require_active()
+        self._lifetime.open_files.append(context)
+
+    def _forget_open_file(
+        self,
+        context: _PublicationAuthenticatedFileContext,
+    ) -> None:
+        self._lifetime.open_files[:] = [
+            candidate
+            for candidate in self._lifetime.open_files
+            if candidate is not context
+        ]
+
+    def _close_open_files(self, primary_error: BaseException | None) -> None:
+        actions = tuple(
+            (
+                "publication escaped authenticated file cleanup also failed",
+                lambda context=context: context._finish(primary_error),
+            )
+            for context in reversed(tuple(self._lifetime.open_files))
+        )
+        failures = _OrderedActionState(
+            actions=actions,
+            iteration_failure_label=(
+                "publication escaped file cleanup iteration also failed"
+            ),
+            primary_error=None,
+        )
+        _run_ordered_actions(failures)
+        if failures.primary_error is not None:
+            raise failures.primary_error
+
+    def _abort_open_files(self) -> None:
+        actions = tuple(
+            (
+                "publication escaped authenticated file abort also failed",
+                context._abort_and_close,
+            )
+            for context in reversed(tuple(self._lifetime.open_files))
+        )
+        failures = _OrderedActionState(
+            actions=actions,
+            iteration_failure_label=(
+                "publication escaped file abort iteration also failed"
+            ),
+            primary_error=None,
+        )
+        _run_ordered_actions(failures)
+        if failures.primary_error is not None:
+            raise failures.primary_error
 
     def capture_ownership(
         self,
@@ -305,9 +622,14 @@ class PublicationDirectoryReader:
     ) -> _TreeOwnership:
         """Capture through the already-open directory authority."""
 
-        if not self._active:
-            raise RuntimeError("publication tree reader is no longer active")
+        self._require_active()
         try:
+            if self._path_prefix is not None:
+                return self._projected_capture(
+                    required_root_file=required_root_file,
+                    allow_empty_root=allow_empty_root,
+                    entry_policy=entry_policy,
+                )
             observed = self._capture(
                 required_root_file,
                 allow_empty_root,
@@ -322,19 +644,92 @@ class PublicationDirectoryReader:
                 )
             return observed
         except BaseException:
-            self._authentication_failed = True
+            self._mark_authentication_failed()
             raise
 
+    def _projected_capture(
+        self,
+        *,
+        required_root_file: str | None,
+        allow_empty_root: bool,
+        entry_policy: DirectoryEntryPolicy | None,
+    ) -> _TreeOwnership:
+        ownership = self._expected_ownership
+        if ownership is None:
+            raise RuntimeError("publication subtree requires captured ownership")
+        marker = _required_root_file_bytes(required_root_file)
+        if marker is not None:
+            marker_name = os.fsdecode(marker)
+            roots = {
+                path: kind for path, kind in ownership.inventory if "/" not in path
+            }
+            if (
+                not (allow_empty_root and not roots)
+                and roots.get(marker_name) != "file"
+            ):
+                raise RuntimeError(
+                    "directory ownership root is missing its required marker"
+                )
+        if entry_policy is not None:
+            records = {record.path: record for record in ownership.file_records}
+            identities = {
+                path: identity for path, _kind, identity in ownership.entry_identities
+            }
+            for path, kind in ownership.inventory:
+                if kind == "file":
+                    record = records[path]
+                    entry_policy(path, "file", record.mode, record.size)
+                else:
+                    entry_policy(
+                        path,
+                        "directory",
+                        stat.S_IMODE(identities[path][2]),
+                        0,
+                    )
+        return ownership
+
+    def subtree(
+        self,
+        prefix: str | PurePosixPath,
+    ) -> PublicationDirectoryReader:
+        """Return an authority-scoped, prefix-relative view of an owned subtree."""
+
+        self._require_active()
+        ownership = self._expected_ownership
+        if ownership is None:
+            self._mark_authentication_failed()
+            raise RuntimeError("publication subtree requires captured ownership")
+        try:
+            normalized = PurePosixPath(_ownership_subtree_prefix(prefix))
+            projected = project_directory_ownership_subtree(
+                ownership,
+                normalized,
+            )
+        except BaseException:
+            self._mark_authentication_failed()
+            raise
+        authority_prefix = (
+            normalized if self._path_prefix is None else self._path_prefix / normalized
+        )
+        return PublicationDirectoryReader(
+            self._diagnostic_path.joinpath(*normalized.parts),
+            projected.root_identity,
+            self._capture,
+            self._open_file,
+            projected,
+            _authority_expected_ownership=self._authority_expected_ownership,
+            _path_prefix=authority_prefix,
+            _lifetime=self._lifetime,
+        )
+
     def inventory(self) -> tuple[tuple[str, str], ...]:
-        if not self._active:
-            raise RuntimeError("publication tree reader is no longer active")
+        self._require_active()
         if self._expected_ownership is not None:
             return self._expected_ownership.inventory
         return self.capture_ownership().inventory
 
     def file_records(self) -> tuple[TreeFileRecord, ...]:
-        if not self._active:
-            raise RuntimeError("publication tree reader is no longer active")
+        self._require_active()
         if self._expected_ownership is not None:
             return self._expected_ownership.file_records
         return self.capture_ownership().file_records
@@ -345,8 +740,7 @@ class PublicationDirectoryReader:
         *,
         max_bytes: int,
     ) -> PublicationFileSnapshot:
-        if not self._active:
-            raise RuntimeError("publication tree reader is no longer active")
+        self._require_active()
         if isinstance(max_bytes, bool) or not isinstance(max_bytes, int):
             raise TypeError("publication snapshot limit must be an integer")
         if max_bytes < 0 or max_bytes > _MAX_PUBLICATION_SNAPSHOT_BYTES:
@@ -374,15 +768,13 @@ class PublicationDirectoryReader:
             max_bytes=max_bytes,
         ).read_bytes()
 
-    @contextmanager
     def open_authenticated_file(
         self,
         relative: str | PurePosixPath,
         *,
         max_bytes: int,
-    ) -> Iterator[PublicationAuthenticatedFile]:
-        if not self._active:
-            raise RuntimeError("publication tree reader is no longer active")
+    ) -> ContextManager[PublicationAuthenticatedFile]:
+        self._require_active()
         if isinstance(max_bytes, bool) or not isinstance(max_bytes, int):
             raise TypeError("publication stream limit must be an integer")
         if max_bytes < 0 or max_bytes > _MAX_OWNERSHIP_BYTES:
@@ -390,26 +782,25 @@ class PublicationDirectoryReader:
         normalized = _publication_relative_path(relative)
         expected = self._expected_file(normalized)
         try:
-            with self._open_file(normalized, max_bytes, expected) as authenticated:
-                if (
-                    authenticated.path,
-                    authenticated.mode,
-                    authenticated.size,
-                ) != (
-                    expected.record.path,
-                    expected.record.mode,
-                    expected.record.size,
-                ):
-                    raise RuntimeError(
-                        "publication file metadata differs from captured ownership"
-                    )
-                yield authenticated
-            if authenticated.record != expected.record:
-                raise RuntimeError(
-                    "publication file bytes differ from captured ownership"
-                )
+            authority_relative = (
+                normalized
+                if self._path_prefix is None
+                else self._path_prefix / normalized
+            )
+            authority_expected = self._expected_file(
+                authority_relative,
+                authority=True,
+            )
+            return _PublicationAuthenticatedFileContext(
+                self,
+                relative=normalized,
+                authority_relative=authority_relative,
+                max_bytes=max_bytes,
+                expected=expected,
+                authority_expected=authority_expected,
+            )
         except BaseException:
-            self._authentication_failed = True
+            self._mark_authentication_failed()
             raise
 
     @contextmanager
@@ -429,37 +820,49 @@ class PublicationDirectoryReader:
     def _expected_file(
         self,
         relative: PurePosixPath,
+        *,
+        authority: bool = False,
     ) -> _ExpectedPublicationFile:
-        ownership = self._expected_ownership
+        ownership = (
+            self._authority_expected_ownership
+            if authority
+            else self._expected_ownership
+        )
         if ownership is None:
-            self._authentication_failed = True
+            self._mark_authentication_failed()
             raise RuntimeError(
                 "publication file reads require captured callback ownership"
             )
         normalized = relative.as_posix()
+        records_by_path = (
+            self._authority_records_by_path if authority else self._records_by_path
+        )
+        entries_by_path = (
+            self._authority_entries_by_path if authority else self._entries_by_path
+        )
         try:
-            record = self._records_by_path[normalized]
-            kind, file_identity = self._entries_by_path[normalized]
+            record = records_by_path[normalized]
+            kind, file_identity = entries_by_path[normalized]
         except KeyError as exc:
-            self._authentication_failed = True
+            self._mark_authentication_failed()
             raise ValueError(
                 f"publication file is absent from captured ownership: {normalized}"
             ) from exc
         if kind != "file":
-            self._authentication_failed = True
+            self._mark_authentication_failed()
             raise ValueError(f"publication path is not a captured file: {normalized}")
         directories: list[tuple[str, tuple[int, ...]]] = []
         for depth in range(1, len(relative.parts)):
             directory = "/".join(relative.parts[:depth])
             try:
-                directory_kind, identity = self._entries_by_path[directory]
+                directory_kind, identity = entries_by_path[directory]
             except KeyError as exc:
-                self._authentication_failed = True
+                self._mark_authentication_failed()
                 raise RuntimeError(
                     f"publication directory is absent from ownership: {directory}"
                 ) from exc
             if directory_kind != "directory":
-                self._authentication_failed = True
+                self._mark_authentication_failed()
                 raise RuntimeError(
                     f"publication ancestor is not a directory: {directory}"
                 )
@@ -475,10 +878,58 @@ class PublicationDirectoryReader:
             raise RuntimeError("publication callback suppressed authentication failure")
 
     def _deactivate(self) -> None:
-        self._active = False
+        failures = _OrderedActionState(
+            actions=(),
+            iteration_failure_label=(
+                "publication reader deactivation iteration also failed"
+            ),
+            primary_error=None,
+        )
+        try:
+            _force_publication_reader_inactive(self._lifetime, failures)
+        except BaseException as deactivation_error:  # noqa: B036 - cleanup-all
+            failures.retain(
+                "publication reader deactivation also failed",
+                deactivation_error,
+            )
+        if self._lifetime.open_files:
+            self._mark_authentication_failed()
+        failures.actions = (
+            (
+                "publication reader escaped stream abort also failed",
+                self._abort_open_files,
+            ),
+        )
+        _run_ordered_actions(failures)
+        if failures.primary_error is not None:
+            raise failures.primary_error
 
 
 _PublicationTreeReader = PublicationDirectoryReader
+
+
+def _force_publication_reader_inactive(
+    lifetime: _PublicationReaderLifetime,
+    failures: _OrderedActionState,
+) -> None:
+    """Finish the idempotent inactive transition after an injected interruption."""
+
+    try:
+        while lifetime.active:
+            try:
+                lifetime.active = False
+            except BaseException as transition_error:  # noqa: B036 - retry state
+                failures.retain(
+                    "publication reader inactive transition also failed",
+                    transition_error,
+                )
+    except BaseException as iteration_error:  # noqa: B036 - retry transition
+        failures.retain(
+            "publication reader inactive transition iteration also failed",
+            iteration_error,
+        )
+        if lifetime.active:
+            _force_publication_reader_inactive(lifetime, failures)
 
 
 def _annotate_secondary_error(
@@ -1060,21 +1511,47 @@ def _run_publication_reader_callback(
     callback: Callable[[PublicationDirectoryReader], _T],
     validate_child_binding: Callable[[], None],
 ) -> _T:
-    """Run a reader callback and always recheck validity plus child binding."""
+    """Run a reader callback, close escaped streams, and recheck its authority."""
 
-    return _run_callback_with_post_validations(
-        lambda: callback(reader),
-        (
-            (
-                "publication reader validity validation also failed",
-                reader._require_valid,
+    ambient_error = sys.exc_info()[1]
+    callback_error: BaseException | None = None
+    try:
+        result = callback(reader)
+        return result
+    except BaseException as error:  # noqa: B036 - preserve exact callback primary
+        callback_error = error
+        raise
+    finally:
+        active_error = sys.exc_info()[1]
+        locally_unwinding = callback_error is not None or (
+            active_error is not None and active_error is not ambient_error
+        )
+        primary_error = callback_error
+        if primary_error is None and locally_unwinding:
+            primary_error = active_error
+        failures = _OrderedActionState(
+            actions=(
+                (
+                    "publication reader escaped file cleanup also failed",
+                    lambda: reader._close_open_files(primary_error),
+                ),
+                (
+                    "publication reader validity validation also failed",
+                    reader._require_valid,
+                ),
+                (
+                    "publication reader child namespace validation also failed",
+                    validate_child_binding,
+                ),
             ),
-            (
-                "publication reader child namespace validation also failed",
-                validate_child_binding,
+            iteration_failure_label=(
+                "publication reader post-validation iteration also failed"
             ),
-        ),
-    )
+            primary_error=primary_error,
+        )
+        _run_ordered_actions(failures)
+        if not locally_unwinding and failures.primary_error is not None:
+            raise failures.primary_error
 
 
 @dataclass(slots=True)
@@ -1817,10 +2294,16 @@ class _WindowsLexicalAuthorityOwner:
 class _PublicationAuthorityOwner:
     """Pre-existing slot for cancellation-safe authority handoff."""
 
-    __slots__ = ("_authority",)
+    __slots__ = ("_authority", "_pid")
 
     def __init__(self) -> None:
         self._authority: _PublicationAuthority | None = None
+        self._pid = os.getpid()
+        # Registration precedes acquisition of any authority resource.  Once
+        # install succeeds, an interrupted or persistently failing close stays
+        # reachable for an explicit retry instead of becoming an fd/HANDLE
+        # leak hidden in a dead stack frame.
+        _register_publication_authority_owner(self)
 
     @property
     def authority(self) -> _PublicationAuthority | None:
@@ -1834,33 +2317,50 @@ class _PublicationAuthorityOwner:
     def install(self, authority: _PublicationAuthority) -> None:
         if self._authority is not None:
             raise RuntimeError("publication authority owner is already active")
+        _register_publication_authority_owner(self)
         self._authority = authority
 
     def close(self) -> None:
-        authority = self._authority
-        if authority is None:
-            return
-        primary_error: BaseException | None = None
-        try:
-            authority.close()
-        except BaseException as close_error:  # noqa: B036 - reconcile owner state
-            primary_error = close_error
-        try:
-            close_complete = authority._closed
-        except BaseException as reconciliation_error:  # noqa: B036
-            if primary_error is None:
-                raise
-            _annotate_secondary_error(
-                primary_error,
-                "publication authority owner reconciliation also failed",
-                reconciliation_error,
-            )
-        else:
-            if close_complete:
-                self._authority = None
-        if primary_error is not None:
-            _attach_publication_cleanup_owner(primary_error, self)
-            raise primary_error
+        _synchronize_retained_publication_process()
+        with _RETAINED_PUBLICATION_AUTHORITY_LOCK:
+            authority = self._authority
+            if authority is None:
+                _forget_publication_authority_owner(self)
+                return
+            primary_error: BaseException | None = None
+            try:
+                authority.close()
+            except BaseException as close_error:  # noqa: B036 - reconcile owner state
+                primary_error = close_error
+            try:
+                close_complete = authority._closed
+            except BaseException as reconciliation_error:  # noqa: B036
+                if primary_error is None:
+                    primary_error = reconciliation_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "publication authority owner reconciliation also failed",
+                        reconciliation_error,
+                    )
+            else:
+                if close_complete:
+                    self._authority = None
+            if self._authority is None:
+                try:
+                    _forget_publication_authority_owner(self)
+                except BaseException as retention_error:  # noqa: B036
+                    if primary_error is None:
+                        primary_error = retention_error
+                    else:
+                        _annotate_secondary_error(
+                            primary_error,
+                            "publication authority retry release also failed",
+                            retention_error,
+                        )
+            if primary_error is not None:
+                _attach_publication_cleanup_owner(primary_error, self)
+                raise primary_error
 
     def close_after_error(self, primary_error: BaseException) -> None:
         try:
@@ -1888,6 +2388,78 @@ class _PublicationAuthorityOwner:
             self.close_after_error(exc)
 
 
+_RETAINED_PUBLICATION_AUTHORITY_OWNERS: list[_PublicationAuthorityOwner] = []
+_RETAINED_PUBLICATION_AUTHORITY_LOCK = RLock()
+_RETAINED_PUBLICATION_AUTHORITY_PID = os.getpid()
+
+
+def _synchronize_retained_publication_process() -> None:
+    """Re-home inherited retry state after a real or simulated process fork."""
+
+    global _RETAINED_PUBLICATION_AUTHORITY_LOCK
+    global _RETAINED_PUBLICATION_AUTHORITY_PID
+    pid = os.getpid()
+    if pid == _RETAINED_PUBLICATION_AUTHORITY_PID:
+        return
+    # A lock held by a vanished thread cannot be reused safely in the child.
+    _RETAINED_PUBLICATION_AUTHORITY_LOCK = RLock()
+    _RETAINED_PUBLICATION_AUTHORITY_PID = pid
+    for owner in _RETAINED_PUBLICATION_AUTHORITY_OWNERS:
+        owner._pid = pid
+
+
+def _register_publication_authority_owner(
+    owner: _PublicationAuthorityOwner,
+) -> None:
+    _synchronize_retained_publication_process()
+    with _RETAINED_PUBLICATION_AUTHORITY_LOCK:
+        owner._pid = os.getpid()
+        if any(
+            retained is owner for retained in _RETAINED_PUBLICATION_AUTHORITY_OWNERS
+        ):
+            return
+        _RETAINED_PUBLICATION_AUTHORITY_OWNERS.append(owner)
+
+
+def _forget_publication_authority_owner(
+    owner: _PublicationAuthorityOwner,
+) -> None:
+    _synchronize_retained_publication_process()
+    with _RETAINED_PUBLICATION_AUTHORITY_LOCK:
+        _RETAINED_PUBLICATION_AUTHORITY_OWNERS[:] = [
+            retained
+            for retained in _RETAINED_PUBLICATION_AUTHORITY_OWNERS
+            if retained is not owner
+        ]
+
+
+def retry_retained_publication_cleanup() -> None:
+    """Retry every retained authority close after publication work is quiescent."""
+
+    _synchronize_retained_publication_process()
+    with _RETAINED_PUBLICATION_AUTHORITY_LOCK:
+        failures = _OrderedActionState(
+            actions=tuple(
+                (
+                    "additional retained publication authority cleanup failed",
+                    owner.close,
+                )
+                for owner in tuple(_RETAINED_PUBLICATION_AUTHORITY_OWNERS)
+            ),
+            iteration_failure_label=(
+                "retained publication cleanup iteration also failed"
+            ),
+            primary_error=None,
+        )
+        _run_ordered_actions(failures)
+    if failures.primary_error is not None:
+        raise failures.primary_error
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_synchronize_retained_publication_process)
+
+
 class _PublicationAuthority:
     """One pinned parent namespace and its platform-specific operations.
 
@@ -1908,6 +2480,7 @@ class _PublicationAuthority:
         "_verify_callback",
         "_close_complete_callback",
         "_close_state",
+        "_pid",
     )
 
     def __init__(
@@ -1944,6 +2517,11 @@ class _PublicationAuthority:
         self._verify_callback = verify_callback
         self._close_complete_callback = close_complete_callback
         self._close_state = False
+        self._pid = os.getpid()
+
+    def _require_process(self) -> None:
+        if self._pid != os.getpid():
+            raise RuntimeError("publication authority cannot cross a process boundary")
 
     @property
     def _closed(self) -> bool:
@@ -1960,6 +2538,7 @@ class _PublicationAuthority:
 
     @property
     def resource(self) -> int:
+        self._require_process()
         if self._closed:
             raise RuntimeError("publication authority is closed")
         return self._resource
@@ -1971,6 +2550,7 @@ class _PublicationAuthority:
         path: Path,
         label: str,
     ) -> object | None:
+        self._require_process()
         if self._closed:
             raise RuntimeError("publication authority is closed")
         child_name = _simple_child_name(name, label=label)
@@ -1985,6 +2565,7 @@ class _PublicationAuthority:
         expected_ownership: _TreeOwnership | None = None,
         callback: Callable[[_PublicationTreeReader], _T],
     ) -> _T:
+        self._require_process()
         if self._closed:
             raise RuntimeError("publication authority is closed")
         child_name = _simple_child_name(name, label=label)
@@ -2019,6 +2600,7 @@ class _PublicationAuthority:
         )
 
     def rename_noreplace(self, source: str, destination: str) -> None:
+        self._require_process()
         if self._closed:
             raise RuntimeError("publication authority is closed")
         self._rename_callback(
@@ -2027,6 +2609,7 @@ class _PublicationAuthority:
         )
 
     def verify_path_binding(self) -> None:
+        self._require_process()
         if self._closed:
             raise RuntimeError("publication authority is closed")
         self._verify_callback()
@@ -2321,9 +2904,28 @@ def _open_posix_publication_authority(
                 flags,
                 dir_fd=owned_descriptor,
             )
+            child_record = resources.record_for_cleanup(child_descriptor)
+            child_owner = resources._exact_record_cleanup_owner(child_record)
             reader: _PublicationTreeReader | None = None
-            primary_error: BaseException | None = None
-            try:
+
+            def deactivate_reader() -> None:
+                if reader is not None:
+                    reader._deactivate()
+
+            cleanup_actions = (
+                (
+                    "publication reader deactivation also failed",
+                    deactivate_reader,
+                ),
+                _OrderedAction(
+                    label="publication child descriptor cleanup also failed",
+                    action=child_owner.close,
+                    complete=lambda owner=child_owner: owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=child_owner,
+                ),
+            )
+            with _run_context_with_cleanup_actions(cleanup_actions):
                 opened_child = os.fstat(child_descriptor)
                 if (
                     _is_link_or_reparse(opened_child)
@@ -2340,6 +2942,7 @@ def _open_posix_publication_authority(
                         _capture_posix_directory_descriptor(
                             child_descriptor,
                             display_path,
+                            resources=resources,
                             required_root_file=required_root_file,
                             allow_empty_root=allow_empty_root,
                             entry_policy=entry_policy,
@@ -2349,6 +2952,7 @@ def _open_posix_publication_authority(
                         child_descriptor,
                         display_path,
                         relative,
+                        resources=resources,
                         max_bytes=max_bytes,
                         expected=expected,
                     ),
@@ -2369,22 +2973,6 @@ def _open_posix_publication_authority(
                     callback,
                     validate_child_binding,
                 )
-            except BaseException as exc:
-                primary_error = exc
-                raise
-            finally:
-                if reader is not None:
-                    reader._deactivate()
-                try:
-                    resources.close_descriptor(child_descriptor)
-                except BaseException as close_error:  # noqa: B036
-                    if primary_error is None:
-                        raise
-                    _annotate_secondary_error(
-                        primary_error,
-                        "publication child descriptor cleanup also failed",
-                        close_error,
-                    )
 
         def rename_callback(source: str, destination: str) -> None:
             _rename_noreplace_at(
@@ -2977,11 +3565,16 @@ def _open_windows_authenticated_file(
     root_path: Path,
     relative: PurePosixPath,
     *,
+    resources: _WindowsResourceOwner | None = None,
     max_bytes: int,
     expected: _ExpectedPublicationFile,
 ) -> Iterator[PublicationAuthenticatedFile]:
-    resources = _WindowsResourceOwner(api)
+    owns_resources = resources is None
+    selected_resources = _WindowsResourceOwner(api) if resources is None else resources
+    root_before = api.metadata(root_handle)
     parent_handle = root_handle
+    opened_directories: list[int] = []
+    exact_owners: list[_ExactResourceCleanupOwner] = []
     bindings: list[tuple[int, str, int, int, tuple[int, ...]]] = []
     file_handle = 0
     authenticated: PublicationAuthenticatedFile | None = None
@@ -2995,7 +3588,28 @@ def _open_windows_authenticated_file(
 
     def close_resources() -> None:
         nonlocal cleanup_complete
-        resources.close_all()
+        if owns_resources:
+            selected_resources.close_all()
+        else:
+            failures = _OrderedActionState(
+                actions=tuple(
+                    _OrderedAction(
+                        label="publication authenticated HANDLE cleanup also failed",
+                        action=owner.close,
+                        complete=lambda owner=owner: owner.closed,
+                        retry_incomplete="cancellation",
+                        incomplete_owner=owner,
+                    )
+                    for owner in reversed(exact_owners)
+                ),
+                iteration_failure_label=(
+                    "publication authenticated HANDLE cleanup iteration also failed"
+                ),
+                primary_error=None,
+            )
+            _run_ordered_actions(failures)
+            if failures.primary_error is not None:
+                raise failures.primary_error
         cleanup_complete = True
 
     cleanup_actions: tuple[_OrderedActionInput, ...] = (
@@ -3011,7 +3625,7 @@ def _open_windows_authenticated_file(
             action=close_resources,
             complete=lambda: cleanup_complete,
             retry_incomplete="cancellation",
-            incomplete_owner=resources,
+            incomplete_owner=selected_resources,
         ),
     )
 
@@ -3031,8 +3645,14 @@ def _open_windows_authenticated_file(
                 | _WINDOWS_FILE_READ_ATTRIBUTES
                 | _WINDOWS_SYNCHRONIZE,
                 expected_directory=True,
-                resource_owner=resources,
+                resource_owner=selected_resources,
             )
+            if not owns_resources:
+                child_record = selected_resources.record_for_cleanup(child_handle)
+                exact_owners.append(
+                    selected_resources._exact_record_cleanup_owner(child_record)
+                )
+            opened_directories.append(child_handle)
             if opened.st_dev != root_before.st_dev:
                 raise RuntimeError("publication stream crosses a volume")
             if expected_directories.get(
@@ -3063,8 +3683,13 @@ def _open_windows_authenticated_file(
             | _WINDOWS_FILE_READ_ATTRIBUTES
             | _WINDOWS_SYNCHRONIZE,
             expected_directory=False,
-            resource_owner=resources,
+            resource_owner=selected_resources,
         )
+        if not owns_resources:
+            file_record = selected_resources.record_for_cleanup(file_handle)
+            exact_owners.append(
+                selected_resources._exact_record_cleanup_owner(file_record)
+            )
         if opened_file.st_dev != root_before.st_dev:
             raise RuntimeError("publication stream crosses a volume")
         if _ownership_version_identity(opened_file) != expected.file_identity:
@@ -3104,7 +3729,11 @@ def _open_windows_authenticated_file(
             read_callback=lambda size: api.read(file_handle, size),
             verify_callback=verify,
         )
-        yield authenticated
+        try:
+            yield authenticated
+        except BaseException:
+            authenticated._abort()
+            raise
 
 
 def _scan_windows_owned_directory(
@@ -3277,71 +3906,52 @@ def _capture_windows_directory_handle(
     handle: int,
     path: Path,
     *,
+    resources: _WindowsResourceOwner | None = None,
     required_root_file: str | None,
     allow_empty_root: bool,
     entry_policy: DirectoryEntryPolicy | None,
 ) -> _TreeOwnership:
+    selected_resources = _WindowsResourceOwner(api) if resources is None else resources
     _required_root_file_bytes(required_root_file)
-    resources = _WindowsResourceOwner(api)
-    cleanup_complete = False
-
-    def close_resources() -> None:
-        nonlocal cleanup_complete
-        resources.close_all()
-        cleanup_complete = True
-
-    with _run_context_with_cleanup_actions(
-        (
-            _OrderedAction(
-                label="Windows ownership scan HANDLE cleanup also failed",
-                action=close_resources,
-                complete=lambda: cleanup_complete,
-                retry_incomplete="cancellation",
-                incomplete_owner=resources,
-            ),
-        )
-    ):
-        opened = api.metadata(handle)
-        if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
-            raise RuntimeError(f"directory ownership root changed: {path}")
-        if not opened.st_dev or not opened.st_ino:
-            raise RuntimeError(
-                "directory ownership root has no reliable FILE_ID identity"
-            )
-        budget = _OwnershipBudget()
-        inventory: list[tuple[str, str]] = []
-        file_records: list[TreeFileRecord] = []
-        entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
-        digest = _scan_windows_owned_directory(
-            api,
-            handle,
-            path,
-            (),
-            root_device=opened.st_dev,
-            budget=budget,
-            inventory=inventory,
-            file_records=file_records,
-            entry_identities=entry_identities,
-            entry_policy=entry_policy,
-            depth=0,
-            required_root_file=required_root_file,
-            allow_empty_root=allow_empty_root,
-            resource_owner=resources,
-        )
-        after = api.metadata(handle)
-        if _ownership_version_identity(after) != _ownership_version_identity(opened):
-            raise RuntimeError(f"directory ownership root changed: {path}")
-        return _TreeOwnership(
-            root_identity=_directory_inode_identity(opened),
-            root_version_identity=_ownership_version_identity(opened),
-            digest=digest.hex(),
-            entries=budget.entries,
-            byte_count=budget.byte_count,
-            metadata_bytes=budget.metadata_bytes,
-            inventory=tuple(sorted(inventory)),
-            file_records=tuple(sorted(file_records, key=lambda record: record.path)),
-            entry_identities=tuple(sorted(entry_identities)),
-        )
+    opened = api.metadata(handle)
+    if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    if not opened.st_dev or not opened.st_ino:
+        raise RuntimeError("directory ownership root has no reliable FILE_ID identity")
+    budget = _OwnershipBudget()
+    inventory: list[tuple[str, str]] = []
+    file_records: list[TreeFileRecord] = []
+    entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
+    digest = _scan_windows_owned_directory(
+        api,
+        handle,
+        path,
+        (),
+        root_device=opened.st_dev,
+        budget=budget,
+        inventory=inventory,
+        file_records=file_records,
+        entry_identities=entry_identities,
+        entry_policy=entry_policy,
+        depth=0,
+        required_root_file=required_root_file,
+        allow_empty_root=allow_empty_root,
+        resource_owner=selected_resources,
+    )
+    after = api.metadata(handle)
+    if _ownership_version_identity(after) != _ownership_version_identity(opened):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    return _TreeOwnership(
+        root_identity=_directory_inode_identity(opened),
+        root_version_identity=_ownership_version_identity(opened),
+        digest=digest.hex(),
+        entries=budget.entries,
+        byte_count=budget.byte_count,
+        metadata_bytes=budget.metadata_bytes,
+        inventory=tuple(sorted(inventory)),
+        file_records=tuple(sorted(file_records, key=lambda record: record.path)),
+        entry_identities=tuple(sorted(entry_identities)),
+    )
 
 
 def _open_windows_publication_authority(
@@ -3492,9 +4102,28 @@ def _open_windows_publication_authority(
             if metadata.st_dev != opened.st_dev:
                 resources.close_handle(handle)
                 raise RuntimeError("publication child crosses a volume")
+            handle_record = resources.record_for_cleanup(handle)
+            handle_owner = resources._exact_record_cleanup_owner(handle_record)
             reader: _PublicationTreeReader | None = None
-            primary_error: BaseException | None = None
-            try:
+
+            def deactivate_reader() -> None:
+                if reader is not None:
+                    reader._deactivate()
+
+            cleanup_actions = (
+                (
+                    "Windows publication reader deactivation also failed",
+                    deactivate_reader,
+                ),
+                _OrderedAction(
+                    label="Windows reader HANDLE cleanup also failed",
+                    action=handle_owner.close,
+                    complete=lambda: handle_owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=handle_owner,
+                ),
+            )
+            with _run_context_with_cleanup_actions(cleanup_actions):
                 reader = _PublicationTreeReader(
                     display_path,
                     _directory_inode_identity(metadata),
@@ -3503,6 +4132,7 @@ def _open_windows_publication_authority(
                             api,
                             handle,
                             display_path,
+                            resources=resources,
                             required_root_file=required_root_file,
                             allow_empty_root=allow_empty_root,
                             entry_policy=entry_policy,
@@ -3514,6 +4144,7 @@ def _open_windows_publication_authority(
                             handle,
                             display_path,
                             relative,
+                            resources=resources,
                             max_bytes=max_bytes,
                             expected=expected,
                         )
@@ -3531,22 +4162,6 @@ def _open_windows_publication_authority(
                     callback,
                     validate_child_binding,
                 )
-            except BaseException as exc:
-                primary_error = exc
-                raise
-            finally:
-                if reader is not None:
-                    reader._deactivate()
-                try:
-                    resources.close_handle(handle)
-                except BaseException as close_error:  # noqa: B036
-                    if primary_error is None:
-                        raise
-                    _annotate_secondary_error(
-                        primary_error,
-                        "Windows reader HANDLE cleanup also failed",
-                        close_error,
-                    )
 
         def rename_callback(source: str, destination: str) -> None:
             opened_source = open_child(
@@ -3749,14 +4364,17 @@ def _open_posix_authenticated_file(
     root_path: Path,
     relative: PurePosixPath,
     *,
+    resources: _PosixResourceOwner | None = None,
     max_bytes: int,
     expected: _ExpectedPublicationFile,
 ) -> Iterator[PublicationAuthenticatedFile]:
-    resources = _PosixResourceOwner()
+    owns_resources = resources is None
+    selected_resources = _PosixResourceOwner() if resources is None else resources
     flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
     directory_flags = flags | os.O_DIRECTORY | getattr(os, "O_NONBLOCK", 0)
     file_flags = flags | getattr(os, "O_NONBLOCK", 0)
     descriptors: list[int] = []
+    exact_owners: list[_ExactResourceCleanupOwner] = []
     bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
     file_descriptor = -1
     authenticated: PublicationAuthenticatedFile | None = None
@@ -3770,7 +4388,31 @@ def _open_posix_authenticated_file(
 
     def close_resources() -> None:
         nonlocal cleanup_complete
-        resources.close_all()
+        if owns_resources:
+            selected_resources.close_all()
+        else:
+            failures = _OrderedActionState(
+                actions=tuple(
+                    _OrderedAction(
+                        label=(
+                            "publication authenticated descriptor cleanup also failed"
+                        ),
+                        action=owner.close,
+                        complete=lambda owner=owner: owner.closed,
+                        retry_incomplete="cancellation",
+                        incomplete_owner=owner,
+                    )
+                    for owner in reversed(exact_owners)
+                ),
+                iteration_failure_label=(
+                    "publication authenticated descriptor cleanup iteration also "
+                    "failed"
+                ),
+                primary_error=None,
+            )
+            _run_ordered_actions(failures)
+            if failures.primary_error is not None:
+                raise failures.primary_error
         cleanup_complete = True
 
     cleanup_actions: tuple[_OrderedActionInput, ...] = (
@@ -3786,14 +4428,20 @@ def _open_posix_authenticated_file(
             action=close_resources,
             complete=lambda: cleanup_complete,
             retry_incomplete="cancellation",
-            incomplete_owner=resources,
+            incomplete_owner=selected_resources,
         ),
     )
 
     with _run_context_with_cleanup_actions(cleanup_actions):
         root_before = os.fstat(root_descriptor)
         root_device = root_before.st_dev
-        descriptors.append(resources.duplicate(root_descriptor))
+        root_copy = selected_resources.duplicate(root_descriptor)
+        descriptors.append(root_copy)
+        if not owns_resources:
+            root_record = selected_resources.record_for_cleanup(root_copy)
+            exact_owners.append(
+                selected_resources._exact_record_cleanup_owner(root_record)
+            )
         for part in relative.parts[:-1]:
             traversed.append(part)
             relative_directory = "/".join(traversed)
@@ -3807,8 +4455,13 @@ def _open_posix_authenticated_file(
                 raise RuntimeError(
                     f"publication stream refuses directory: {root_path / relative}"
                 )
-            child = resources.open(part, directory_flags, dir_fd=parent)
+            child = selected_resources.open(part, directory_flags, dir_fd=parent)
             descriptors.append(child)
+            if not owns_resources:
+                child_record = selected_resources.record_for_cleanup(child)
+                exact_owners.append(
+                    selected_resources._exact_record_cleanup_owner(child_record)
+                )
             opened = os.fstat(child)
             if _ownership_binding_identity(opened) != _ownership_binding_identity(
                 metadata
@@ -3833,7 +4486,12 @@ def _open_posix_authenticated_file(
             raise RuntimeError(
                 f"publication stream refuses non-file: {root_path / relative}"
             )
-        file_descriptor = resources.open(name, file_flags, dir_fd=parent)
+        file_descriptor = selected_resources.open(name, file_flags, dir_fd=parent)
+        if not owns_resources:
+            file_record = selected_resources.record_for_cleanup(file_descriptor)
+            exact_owners.append(
+                selected_resources._exact_record_cleanup_owner(file_record)
+            )
         opened_file = os.fstat(file_descriptor)
         if _ownership_binding_identity(opened_file) != _ownership_binding_identity(
             metadata
@@ -3887,7 +4545,11 @@ def _open_posix_authenticated_file(
             read_callback=lambda size: os.read(file_descriptor, size),
             verify_callback=verify,
         )
-        yield authenticated
+        try:
+            yield authenticated
+        except BaseException:
+            authenticated._abort()
+            raise
 
 
 def _ownership_hash_field(hasher, value: bytes) -> None:
@@ -3933,6 +4595,7 @@ def _hash_owned_regular_file(
     path: Path,
     metadata: os.stat_result,
     *,
+    resources: _PosixResourceOwner,
     root_device: int,
     budget: _OwnershipBudget,
     relative: str,
@@ -3941,8 +4604,20 @@ def _hash_owned_regular_file(
     flags = os.O_RDONLY | os.O_NOFOLLOW
     flags |= getattr(os, "O_CLOEXEC", 0)
     flags |= getattr(os, "O_NONBLOCK", 0)
-    descriptor = os.open(name, flags, dir_fd=parent_descriptor)
-    try:
+    descriptor = resources.open(name, flags, dir_fd=parent_descriptor)
+    descriptor_record = resources.record_for_cleanup(descriptor)
+    exact_owner = resources._exact_record_cleanup_owner(descriptor_record)
+    with _run_context_with_cleanup_actions(
+        (
+            _OrderedAction(
+                label="directory ownership file descriptor cleanup also failed",
+                action=exact_owner.close,
+                complete=lambda: exact_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=exact_owner,
+            ),
+        )
+    ):
         opened = os.fstat(descriptor)
         if (
             not stat.S_ISREG(opened.st_mode)
@@ -3980,8 +4655,6 @@ def _hash_owned_regular_file(
             opened
         ):
             raise RuntimeError(f"directory ownership file changed: {path}")
-    finally:
-        os.close(descriptor)
     budget.byte_count += size
     return size, digest.hexdigest(), _ownership_version_identity(after)
 
@@ -3991,6 +4664,7 @@ def _scan_owned_directory(
     path: Path,
     parts: tuple[bytes, ...],
     *,
+    resources: _PosixResourceOwner,
     root_device: int,
     mount_points: frozenset[str],
     budget: _OwnershipBudget,
@@ -4015,9 +4689,21 @@ def _scan_owned_directory(
 
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     flags |= getattr(os, "O_CLOEXEC", 0)
-    scan_descriptor = os.open(".", flags, dir_fd=descriptor)
+    scan_descriptor = resources.open(".", flags, dir_fd=descriptor)
+    scan_record = resources.record_for_cleanup(scan_descriptor)
+    scan_owner = resources._exact_record_cleanup_owner(scan_record)
     names: list[tuple[bytes, str]] = []
-    try:
+    with _run_context_with_cleanup_actions(
+        (
+            _OrderedAction(
+                label="directory ownership scan descriptor cleanup also failed",
+                action=scan_owner.close,
+                complete=lambda: scan_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=scan_owner,
+            ),
+        )
+    ):
         with os.scandir(scan_descriptor) as entries:
             for entry in entries:
                 raw_name = os.fsencode(entry.name)
@@ -4028,8 +4714,6 @@ def _scan_owned_directory(
                 relative = _ownership_relative_path(parts + (raw_name,))
                 _reserve_ownership_record(budget, relative=relative)
                 names.append((raw_name, entry.name))
-    finally:
-        os.close(scan_descriptor)
     names.sort(key=lambda item: item[0])
     if (
         required_root_file is not None
@@ -4071,8 +4755,19 @@ def _scan_owned_directory(
                     stat.S_IMODE(metadata.st_mode),
                     0,
                 )
-            child_descriptor = os.open(name, flags, dir_fd=descriptor)
-            try:
+            child_descriptor = resources.open(name, flags, dir_fd=descriptor)
+            child_record = resources.record_for_cleanup(child_descriptor)
+            child_owner = resources._exact_record_cleanup_owner(child_record)
+            child_cleanup: tuple[_OrderedActionInput, ...] = (
+                _OrderedAction(
+                    label="directory ownership child descriptor cleanup also failed",
+                    action=child_owner.close,
+                    complete=lambda owner=child_owner: owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=child_owner,
+                ),
+            )
+            with _run_context_with_cleanup_actions(child_cleanup):
                 opened = os.fstat(child_descriptor)
                 if _ownership_binding_identity(opened) != _ownership_binding_identity(
                     metadata
@@ -4084,6 +4779,7 @@ def _scan_owned_directory(
                     child_descriptor,
                     child_path,
                     child_parts,
+                    resources=resources,
                     root_device=root_device,
                     mount_points=mount_points,
                     budget=budget,
@@ -4100,8 +4796,6 @@ def _scan_owned_directory(
                     raise RuntimeError(
                         f"directory ownership directory changed: {child_path}"
                     )
-            finally:
-                os.close(child_descriptor)
             path_after = os.stat(
                 name,
                 dir_fd=descriptor,
@@ -4131,6 +4825,7 @@ def _scan_owned_directory(
                 name,
                 child_path,
                 metadata,
+                resources=resources,
                 root_device=root_device,
                 budget=budget,
                 relative=os.fsdecode(relative),
@@ -4186,6 +4881,7 @@ def _capture_posix_directory_descriptor(
     descriptor: int,
     path: Path,
     *,
+    resources: _PosixResourceOwner | None = None,
     required_root_file: str | None,
     allow_empty_root: bool,
     entry_policy: DirectoryEntryPolicy | None,
@@ -4193,6 +4889,7 @@ def _capture_posix_directory_descriptor(
     """Capture one already-open POSIX directory without reacquiring its path."""
 
     required_root_file_bytes = _required_root_file_bytes(required_root_file)
+    selected_resources = _PosixResourceOwner() if resources is None else resources
     opened = os.fstat(descriptor)
     if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
         raise RuntimeError(f"directory ownership root changed: {path}")
@@ -4208,6 +4905,7 @@ def _capture_posix_directory_descriptor(
         descriptor,
         path,
         (),
+        resources=selected_resources,
         root_device=opened.st_dev,
         mount_points=_linux_mount_points(),
         budget=budget,
@@ -4330,6 +5028,391 @@ def capture_directory_ownership_if_exists(
             raise RuntimeError("directory ownership root changed while it was captured")
         authority.verify_path_binding()
         return ownership
+
+
+def _ownership_token_path_bytes(value: object) -> bytes:
+    """Return the exact path bytes represented by one captured token entry."""
+
+    if not isinstance(value, str) or not value or value in {".", ".."}:
+        raise RuntimeError("directory ownership token contains an invalid path")
+    if "\x00" in value:
+        raise RuntimeError("directory ownership token contains an invalid path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or path.as_posix() != value:
+        raise RuntimeError("directory ownership token contains a non-canonical path")
+    if len(path.parts) > _MAX_SAFE_REMOVAL_DEPTH:
+        raise RuntimeError("directory ownership token path exceeds its depth limit")
+    try:
+        encoded_parts = tuple(os.fsencode(part) for part in path.parts)
+    except UnicodeEncodeError as exc:
+        raise RuntimeError(
+            "directory ownership token path cannot be represented"
+        ) from exc
+    if any(not part or part in {b".", b".."} for part in encoded_parts):
+        raise RuntimeError("directory ownership token contains an invalid path")
+    if any(len(part) > _MAX_OWNERSHIP_COMPONENT_BYTES for part in encoded_parts):
+        raise RuntimeError("directory ownership token component exceeds its byte limit")
+    return _ownership_relative_path(encoded_parts)
+
+
+def _ownership_subtree_prefix(value: object) -> str:
+    raw = value.as_posix() if isinstance(value, PurePosixPath) else value
+    try:
+        _ownership_token_path_bytes(raw)
+    except RuntimeError as exc:
+        raise ValueError(
+            "directory ownership subtree prefix must be canonical and non-root"
+        ) from exc
+    if not isinstance(raw, str):
+        raise ValueError(
+            "directory ownership subtree prefix must be canonical and non-root"
+        )
+    return raw
+
+
+def _validated_ownership_version_identity(
+    value: object,
+    *,
+    kind: Literal["directory", "file"],
+    root_device: int | None = None,
+) -> tuple[int, ...]:
+    if (
+        not isinstance(value, tuple)
+        or len(value) != 8
+        or any(isinstance(part, bool) or not isinstance(part, int) for part in value)
+    ):
+        raise RuntimeError("directory ownership token contains an invalid identity")
+    identity = value
+    device, inode, mode, size, attributes, _mtime, _ctime, link_count = identity
+    expected_type = stat.S_IFDIR if kind == "directory" else stat.S_IFREG
+    if (
+        device <= 0
+        or inode <= 0
+        or not 0 <= mode < 1 << 32
+        or stat.S_IFMT(mode) != expected_type
+        or size < 0
+        or attributes < 0
+        or attributes & _FILE_ATTRIBUTE_REPARSE_POINT
+        or link_count <= 0
+        or (kind == "directory" and size != 0)
+        or (root_device is not None and device != root_device)
+    ):
+        raise RuntimeError("directory ownership token contains an invalid identity")
+    return identity
+
+
+def _validated_ownership_kind(
+    value: object,
+) -> Literal["directory", "file"]:
+    if value == "directory":
+        return "directory"
+    if value == "file":
+        return "file"
+    raise RuntimeError("directory ownership token contains an invalid entry kind")
+
+
+def _ownership_root_identity_from_version(
+    identity: tuple[int, ...],
+) -> tuple[int, ...]:
+    return (identity[0], identity[1], stat.S_IFMT(identity[2]), identity[4])
+
+
+def _rebuild_ownership_digest(
+    root_version_identity: tuple[int, ...],
+    entries: dict[str, tuple[Literal["directory", "file"], tuple[int, ...]]],
+    records: dict[str, TreeFileRecord],
+) -> str:
+    children: dict[str, list[str]] = {"": []}
+    for path, (kind, _identity) in entries.items():
+        parts = PurePosixPath(path).parts
+        parent = "/".join(parts[:-1])
+        if parent:
+            parent_entry = entries.get(parent)
+            if parent_entry is None or parent_entry[0] != "directory":
+                raise RuntimeError(
+                    "directory ownership token is missing a directory ancestor"
+                )
+        children.setdefault(parent, []).append(path)
+        if kind == "directory":
+            children.setdefault(path, [])
+
+    def raw_byte_order(paths: list[str]) -> Iterator[str]:
+        terminal = -1
+        trie: dict[int, object] = {}
+        for candidate in paths:
+            node = trie
+            for octet in os.fsencode(PurePosixPath(candidate).name):
+                child = node.get(octet)
+                if child is None:
+                    child = {}
+                    node[octet] = child
+                if not isinstance(child, dict):
+                    raise RuntimeError(
+                        "directory ownership token contains a duplicate raw name"
+                    )
+                node = child
+            if terminal in node:
+                raise RuntimeError(
+                    "directory ownership token contains a duplicate raw name"
+                )
+            node[terminal] = candidate
+
+        def visit(node: dict[int, object]) -> Iterator[str]:
+            candidate = node.get(terminal)
+            if candidate is not None:
+                if not isinstance(candidate, str):
+                    raise RuntimeError("directory ownership token trie is invalid")
+                yield candidate
+            keys = 0
+            for octet in node:
+                if octet >= 0:
+                    keys |= 1 << octet
+            while keys:
+                lowest = keys & -keys
+                octet = lowest.bit_length() - 1
+                child = node[octet]
+                if not isinstance(child, dict):
+                    raise RuntimeError("directory ownership token trie is invalid")
+                yield from visit(child)
+                keys ^= lowest
+
+        yield from visit(trie)
+
+    def hash_directory(path: str, identity: tuple[int, ...]) -> bytes:
+        hasher = hashlib.sha256()
+        hasher.update(b"codenib.atomic-directory.v1\x00")
+        hasher.update(stat.S_IMODE(identity[2]).to_bytes(4, "big"))
+        for child in raw_byte_order(children.get(path, [])):
+            kind, child_identity = entries[child]
+            relative = _ownership_token_path_bytes(child)
+            entry_hasher = hashlib.sha256()
+            if kind == "directory":
+                entry_hasher.update(b"D")
+                _ownership_hash_field(entry_hasher, relative)
+                entry_hasher.update(stat.S_IMODE(child_identity[2]).to_bytes(4, "big"))
+                entry_hasher.update(hash_directory(child, child_identity))
+            else:
+                record = records[child]
+                entry_hasher.update(b"F")
+                _ownership_hash_field(entry_hasher, relative)
+                entry_hasher.update(record.mode.to_bytes(4, "big"))
+                entry_hasher.update(record.size.to_bytes(8, "big"))
+                entry_hasher.update(bytes.fromhex(record.sha256))
+            hasher.update(entry_hasher.digest())
+        return hasher.digest()
+
+    return hash_directory("", root_version_identity).hex()
+
+
+def _validate_directory_ownership_token(
+    ownership: _TreeOwnership,
+) -> dict[str, tuple[Literal["directory", "file"], tuple[int, ...]]]:
+    """Validate canonical structure and every redundant ownership-token field."""
+
+    if not isinstance(ownership, _TreeOwnership):
+        raise TypeError("ownership must be a captured directory ownership token")
+    root_version = _validated_ownership_version_identity(
+        ownership.root_version_identity,
+        kind="directory",
+    )
+    if ownership.root_identity != _ownership_root_identity_from_version(root_version):
+        raise RuntimeError("directory ownership token root identity is inconsistent")
+    for value, limit, label in (
+        (ownership.entries, _MAX_OWNERSHIP_ENTRIES, "entry"),
+        (ownership.byte_count, _MAX_OWNERSHIP_BYTES, "byte"),
+        (ownership.metadata_bytes, _MAX_OWNERSHIP_METADATA_BYTES, "metadata"),
+    ):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or not 0 <= value <= limit
+        ):
+            raise RuntimeError(
+                f"directory ownership token contains an invalid {label} count"
+            )
+    if (
+        not isinstance(ownership.digest, str)
+        or len(ownership.digest) != 64
+        or ownership.digest != ownership.digest.lower()
+    ):
+        raise RuntimeError("directory ownership token contains an invalid digest")
+    try:
+        digest_bytes = bytes.fromhex(ownership.digest)
+    except ValueError as exc:
+        raise RuntimeError(
+            "directory ownership token contains an invalid digest"
+        ) from exc
+    if len(digest_bytes) != hashlib.sha256().digest_size or any(
+        character not in "0123456789abcdef" for character in ownership.digest
+    ):
+        raise RuntimeError("directory ownership token contains an invalid digest")
+    if not all(
+        isinstance(collection, tuple)
+        for collection in (
+            ownership.inventory,
+            ownership.file_records,
+            ownership.entry_identities,
+        )
+    ):
+        raise RuntimeError("directory ownership token collections are not canonical")
+
+    entries: dict[str, tuple[Literal["directory", "file"], tuple[int, ...]]] = {}
+    inventory_kinds: dict[str, Literal["directory", "file"]] = {}
+    inventory: list[tuple[str, str]] = []
+    for inventory_item in ownership.inventory:
+        if (
+            not isinstance(inventory_item, tuple)
+            or len(inventory_item) != 2
+            or inventory_item[1] not in {"directory", "file"}
+        ):
+            raise RuntimeError("directory ownership token inventory is invalid")
+        path, raw_kind = inventory_item
+        kind = _validated_ownership_kind(raw_kind)
+        _ownership_token_path_bytes(path)
+        if path in inventory_kinds:
+            raise RuntimeError("directory ownership token contains a duplicate path")
+        inventory_kinds[path] = kind
+        inventory.append((path, kind))
+    if any(previous >= current for previous, current in pairwise(inventory)):
+        raise RuntimeError("directory ownership token inventory is not canonical")
+    if ownership.entries != len(inventory):
+        raise RuntimeError("directory ownership token entry count is inconsistent")
+
+    identities: list[tuple[str, str, tuple[int, ...]]] = []
+    seen_identities: set[str] = set()
+    for identity_item in ownership.entry_identities:
+        if not isinstance(identity_item, tuple) or len(identity_item) != 3:
+            raise RuntimeError("directory ownership token identities are invalid")
+        path, raw_kind, raw_identity = identity_item
+        kind = _validated_ownership_kind(raw_kind)
+        if path in seen_identities or inventory_kinds.get(path) != kind:
+            raise RuntimeError("directory ownership token identities are inconsistent")
+        identity = _validated_ownership_version_identity(
+            raw_identity,
+            kind=kind,
+            root_device=root_version[0],
+        )
+        entries[path] = (kind, identity)
+        seen_identities.add(path)
+        identities.append((path, kind, identity))
+    if any(
+        previous >= current for previous, current in pairwise(identities)
+    ) or seen_identities != set(inventory_kinds):
+        raise RuntimeError("directory ownership token identities are not canonical")
+
+    records: dict[str, TreeFileRecord] = {}
+    canonical_records: list[TreeFileRecord] = []
+    for record in ownership.file_records:
+        if not isinstance(record, TreeFileRecord):
+            raise RuntimeError("directory ownership token file records are invalid")
+        entry = entries.get(record.path)
+        if entry is None or entry[0] != "file" or record.path in records:
+            raise RuntimeError(
+                "directory ownership token file records are inconsistent"
+            )
+        if (
+            isinstance(record.mode, bool)
+            or not isinstance(record.mode, int)
+            or not 0 <= record.mode <= 0o7777
+            or isinstance(record.size, bool)
+            or not isinstance(record.size, int)
+            or record.size < 0
+            or record.size != entry[1][3]
+            or record.mode != stat.S_IMODE(entry[1][2])
+            or not isinstance(record.sha256, str)
+            or len(record.sha256) != 64
+            or record.sha256 != record.sha256.lower()
+        ):
+            raise RuntimeError("directory ownership token file record is invalid")
+        try:
+            record_digest = bytes.fromhex(record.sha256)
+        except ValueError as exc:
+            raise RuntimeError(
+                "directory ownership token file record is invalid"
+            ) from exc
+        if len(record_digest) != hashlib.sha256().digest_size or any(
+            character not in "0123456789abcdef" for character in record.sha256
+        ):
+            raise RuntimeError("directory ownership token file record is invalid")
+        records[record.path] = record
+        canonical_records.append(record)
+    expected_files = {
+        path for path, (kind, _identity) in entries.items() if kind == "file"
+    }
+    if set(records) != expected_files or any(
+        previous.path >= current.path
+        for previous, current in pairwise(canonical_records)
+    ):
+        raise RuntimeError("directory ownership token file records are not canonical")
+
+    byte_count = sum(record.size for record in records.values())
+    metadata_bytes = sum(
+        8 + len(_ownership_token_path_bytes(path)) + 1 + 4 + 8 + 32 for path in entries
+    )
+    if byte_count != ownership.byte_count or metadata_bytes != ownership.metadata_bytes:
+        raise RuntimeError("directory ownership token accounting is inconsistent")
+    if _rebuild_ownership_digest(root_version, entries, records) != ownership.digest:
+        raise RuntimeError("directory ownership token digest is inconsistent")
+    return entries
+
+
+def project_directory_ownership_subtree(
+    outer: _TreeOwnership,
+    prefix: str | PurePosixPath,
+) -> _TreeOwnership:
+    """Derive an exact subtree token without reopening filesystem paths.
+
+    The returned token describes data only.  It does not grant read authority;
+    callers need an active ``PublicationDirectoryReader.subtree`` facade to
+    consume the corresponding bytes.
+    """
+
+    entries = _validate_directory_ownership_token(outer)
+    normalized = _ownership_subtree_prefix(prefix)
+    selected = entries.get(normalized)
+    if selected is None:
+        raise ValueError("directory ownership subtree prefix is absent")
+    if selected[0] != "directory":
+        raise ValueError("directory ownership subtree prefix is not a directory")
+    root_version = selected[1]
+    descendant_prefix = f"{normalized}/"
+
+    projected_inventory = tuple(
+        (path[len(descendant_prefix) :], kind)
+        for path, kind in outer.inventory
+        if path.startswith(descendant_prefix)
+    )
+    projected_records = tuple(
+        replace(record, path=record.path[len(descendant_prefix) :])
+        for record in outer.file_records
+        if record.path.startswith(descendant_prefix)
+    )
+    projected_identities = tuple(
+        (path[len(descendant_prefix) :], kind, identity)
+        for path, kind, identity in outer.entry_identities
+        if path.startswith(descendant_prefix)
+    )
+    projected_entries = {
+        path: (_validated_ownership_kind(kind), identity)
+        for path, kind, identity in projected_identities
+    }
+    records = {record.path: record for record in projected_records}
+    projected = _TreeOwnership(
+        root_identity=_ownership_root_identity_from_version(root_version),
+        root_version_identity=root_version,
+        digest=_rebuild_ownership_digest(root_version, projected_entries, records),
+        entries=len(projected_inventory),
+        byte_count=sum(record.size for record in projected_records),
+        metadata_bytes=sum(
+            8 + len(_ownership_token_path_bytes(path)) + 1 + 4 + 8 + 32
+            for path, _kind in projected_inventory
+        ),
+        inventory=projected_inventory,
+        file_records=projected_records,
+        entry_identities=projected_identities,
+    )
+    _validate_directory_ownership_token(projected)
+    return projected
 
 
 def directory_ownership_inventory(
@@ -5284,7 +6367,9 @@ __all__ = [
     "discard_owned_directory",
     "lexical_directory_path",
     "publication_parent_identity",
+    "project_directory_ownership_subtree",
     "publish_staged_directory",
     "reopen_authenticated_directory",
     "require_publishable_directory_ownership",
+    "retry_retained_publication_cleanup",
 ]

--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -154,6 +154,7 @@ class PublicationAuthenticatedFile:
         "_digest",
         "_record",
         "_closed",
+        "_finalized",
         "_pid",
         "_lifetime",
     )
@@ -176,6 +177,7 @@ class PublicationAuthenticatedFile:
         self._digest = hashlib.sha256()
         self._record: TreeFileRecord | None = None
         self._closed = False
+        self._finalized = False
         self._pid = os.getpid()
         self._lifetime: _PublicationReaderLifetime | None = None
 
@@ -242,9 +244,11 @@ class PublicationAuthenticatedFile:
             yield self.read(min(chunk_size, self._remaining))
 
     def _finalize(self) -> None:
-        if self._closed:
+        if self._finalized:
             return
         try:
+            if self._closed:
+                return
             while self._remaining:
                 self.read(min(_OWNERSHIP_COPY_BYTES, self._remaining))
             extra = self._read_callback(1)
@@ -257,8 +261,12 @@ class PublicationAuthenticatedFile:
                 size=self.size,
                 sha256=self._digest.hexdigest(),
             )
-        finally:
+        except BaseException:
             self._closed = True
+            raise
+        else:
+            self._closed = True
+            self._finalized = True
 
     def _abort(self) -> None:
         """Terminate a failed consumer stream without reading more source bytes."""
@@ -276,6 +284,43 @@ class _PublicationReaderLifetime:
         self.active = True
         self.authentication_failed = False
         self.open_files: list[_PublicationAuthenticatedFileContext] = []
+
+
+class _PublicationAuthenticatedFileBackendContext:
+    """Expose the at-most-once handoff into one backend context exit.
+
+    ``exit_handed_off`` records delegation, not backend completion.  Production
+    backends register their descriptors or HANDLEs with the retained
+    publication authority before yielding, so an interruption at the nested
+    ``__exit__`` call can safely defer physical cleanup to that owner.  A
+    directly supplied custom context remains responsible for its own resources
+    after the handoff; this adapter cannot manufacture ownership for it.
+    """
+
+    __slots__ = ("_context", "exit_handed_off")
+
+    def __init__(
+        self,
+        context: ContextManager[PublicationAuthenticatedFile],
+    ) -> None:
+        self._context = context
+        self.exit_handed_off = False
+
+    def __enter__(self) -> PublicationAuthenticatedFile:
+        return self._context.__enter__()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object,
+    ) -> bool | None:
+        # Mark the at-most-once handoff before the nested CALL.  An interruption
+        # at that CALL is indistinguishable in pure Python from one just inside
+        # an arbitrary context's ``__exit__``.  Authority-backed production
+        # contexts remain physically owned even when this call never begins.
+        self.exit_handed_off = True
+        return self._context.__exit__(exc_type, exc, traceback)
 
 
 class _PublicationAuthenticatedFileContext:
@@ -310,9 +355,7 @@ class _PublicationAuthenticatedFileContext:
         self._max_bytes = max_bytes
         self._expected = expected
         self._authority_expected = authority_expected
-        self._backend_context: ContextManager[PublicationAuthenticatedFile] | None = (
-            None
-        )
+        self._backend_context: _PublicationAuthenticatedFileBackendContext | None = None
         self._authenticated: PublicationAuthenticatedFile | None = None
         self._entered = False
         self._finished = False
@@ -323,12 +366,14 @@ class _PublicationAuthenticatedFileContext:
         self._reader._require_active()
         self._entered = True
         self._reader._register_open_file(self)
-        context: ContextManager[PublicationAuthenticatedFile] | None = None
+        context: _PublicationAuthenticatedFileBackendContext | None = None
         try:
-            context = self._reader._open_file(
-                self._authority_relative,
-                self._max_bytes,
-                self._authority_expected,
+            context = _PublicationAuthenticatedFileBackendContext(
+                self._reader._open_file(
+                    self._authority_relative,
+                    self._max_bytes,
+                    self._authority_expected,
+                )
             )
             self._backend_context = context
             authenticated = context.__enter__()
@@ -369,8 +414,9 @@ class _PublicationAuthenticatedFileContext:
                             "publication authenticated file entry cleanup also failed",
                             cleanup_error,
                         )
-            self._finished = True
-            self._reader._forget_open_file(self)
+            if context is None or context.exit_handed_off:
+                self._reader._forget_open_file(self)
+                self._finished = True
             raise
 
     def __exit__(
@@ -379,7 +425,17 @@ class _PublicationAuthenticatedFileContext:
         exc: BaseException | None,
         traceback: object,
     ) -> Literal[False]:
-        self._finish(exc, exc_type=exc_type, traceback=traceback)
+        try:
+            self._finish(exc, exc_type=exc_type, traceback=traceback)
+        except BaseException as cleanup_error:  # noqa: B036 - keep body primary
+            if exc is None:
+                raise
+            if cleanup_error is not exc:
+                _annotate_secondary_error(
+                    exc,
+                    "publication authenticated file exit also failed",
+                    cleanup_error,
+                )
         return False
 
     def _finish(
@@ -397,8 +453,12 @@ class _PublicationAuthenticatedFileContext:
         context = self._backend_context
         authenticated = self._authenticated
         if context is None:
-            self._finished = True
             self._reader._forget_open_file(self)
+            self._finished = True
+            return
+        if context.exit_handed_off:
+            self._reader._forget_open_file(self)
+            self._finished = True
             return
         if primary_error is not None:
             self._reader._mark_authentication_failed()
@@ -422,8 +482,9 @@ class _PublicationAuthenticatedFileContext:
             self._reader._mark_authentication_failed()
             raise
         finally:
-            self._finished = True
-            self._reader._forget_open_file(self)
+            if context.exit_handed_off:
+                self._reader._forget_open_file(self)
+                self._finished = True
 
     def _abort_and_close(self) -> None:
         """Abort an escaped stream and close it without authenticating more bytes."""
@@ -432,6 +493,10 @@ class _PublicationAuthenticatedFileContext:
             return
         authenticated = self._authenticated
         context = self._backend_context
+        if context is not None and context.exit_handed_off:
+            self._reader._forget_open_file(self)
+            self._finished = True
+            return
         if authenticated is not None:
             authenticated._abort()
         try:
@@ -441,12 +506,19 @@ class _PublicationAuthenticatedFileContext:
             self._reader._mark_authentication_failed()
             raise
         finally:
-            self._finished = True
-            self._reader._forget_open_file(self)
+            if context is None or context.exit_handed_off:
+                self._reader._forget_open_file(self)
+                self._finished = True
 
 
 class PublicationDirectoryReader:
-    """A child tree that is usable only during an authority-owned callback."""
+    """A child tree that is usable only during an authority-owned callback.
+
+    Direct construction with a custom ``open_file`` context is a testing and
+    integration seam.  Such a provider owns its resources independently: if
+    exit delegation is interrupted, it must retain and eventually release
+    them just as the built-in publication-authority backends do.
+    """
 
     __slots__ = (
         "_diagnostic_path",
@@ -577,9 +649,11 @@ class PublicationDirectoryReader:
 
     def _close_open_files(self, primary_error: BaseException | None) -> None:
         actions = tuple(
-            (
-                "publication escaped authenticated file cleanup also failed",
-                lambda context=context: context._finish(primary_error),
+            _OrderedAction(
+                label=("publication escaped authenticated file cleanup also failed"),
+                action=lambda context=context: context._finish(primary_error),
+                complete=lambda context=context: context._finished,
+                retry_incomplete="cancellation",
             )
             for context in reversed(tuple(self._lifetime.open_files))
         )
@@ -596,9 +670,11 @@ class PublicationDirectoryReader:
 
     def _abort_open_files(self) -> None:
         actions = tuple(
-            (
-                "publication escaped authenticated file abort also failed",
-                context._abort_and_close,
+            _OrderedAction(
+                label="publication escaped authenticated file abort also failed",
+                action=context._abort_and_close,
+                complete=lambda context=context: context._finished,
+                retry_incomplete="cancellation",
             )
             for context in reversed(tuple(self._lifetime.open_files))
         )
@@ -895,9 +971,13 @@ class PublicationDirectoryReader:
         if self._lifetime.open_files:
             self._mark_authentication_failed()
         failures.actions = (
-            (
-                "publication reader escaped stream abort also failed",
-                self._abort_open_files,
+            _OrderedAction(
+                label="publication reader escaped stream abort also failed",
+                action=self._abort_open_files,
+                complete=lambda: all(
+                    context._finished for context in self._lifetime.open_files
+                ),
+                retry_incomplete="cancellation",
             ),
         )
         _run_ordered_actions(failures)
@@ -1531,9 +1611,13 @@ def _run_publication_reader_callback(
             primary_error = active_error
         failures = _OrderedActionState(
             actions=(
-                (
-                    "publication reader escaped file cleanup also failed",
-                    lambda: reader._close_open_files(primary_error),
+                _OrderedAction(
+                    label="publication reader escaped file cleanup also failed",
+                    action=lambda: reader._close_open_files(primary_error),
+                    complete=lambda: all(
+                        context._finished for context in reader._lifetime.open_files
+                    ),
+                    retry_incomplete="cancellation",
                 ),
                 (
                     "publication reader validity validation also failed",
@@ -2320,7 +2404,13 @@ class _PublicationAuthorityOwner:
         _register_publication_authority_owner(self)
         self._authority = authority
 
-    def close(self) -> None:
+    def close(
+        self,
+        *,
+        _attempt_started: Callable[[], None] | None = None,
+    ) -> None:
+        if _attempt_started is not None:
+            _attempt_started()
         _synchronize_retained_publication_process()
         with _RETAINED_PUBLICATION_AUTHORITY_LOCK:
             authority = self._authority
@@ -2433,18 +2523,59 @@ def _forget_publication_authority_owner(
         ]
 
 
+def _publication_authority_owner_released(
+    owner: _PublicationAuthorityOwner,
+) -> bool:
+    return owner.authority is None and not any(
+        retained is owner for retained in _RETAINED_PUBLICATION_AUTHORITY_OWNERS
+    )
+
+
+@dataclass(slots=True)
+class _RetainedAuthorityCloseAttempt:
+    """Expose whether a retained owner accepted one close attempt."""
+
+    owner: _PublicationAuthorityOwner
+    entered: bool = False
+
+    def _mark_entered(self) -> None:
+        self.entered = True
+
+    def __call__(self) -> None:
+        self.owner.close(_attempt_started=self._mark_entered)
+
+    def retry_incomplete(self, error: BaseException | None) -> bool:
+        """Retry pre-handoff cancellation and interrupted registry release."""
+
+        if error is None or isinstance(error, Exception):
+            return False
+        if not self.entered:
+            return True
+        return self.owner.authority is None and not (
+            _publication_authority_owner_released(self.owner)
+        )
+
+
 def retry_retained_publication_cleanup() -> None:
     """Retry every retained authority close after publication work is quiescent."""
 
     _synchronize_retained_publication_process()
     with _RETAINED_PUBLICATION_AUTHORITY_LOCK:
+        attempts = tuple(
+            _RetainedAuthorityCloseAttempt(owner)
+            for owner in tuple(_RETAINED_PUBLICATION_AUTHORITY_OWNERS)
+        )
         failures = _OrderedActionState(
             actions=tuple(
-                (
-                    "additional retained publication authority cleanup failed",
-                    owner.close,
+                _OrderedAction(
+                    label=("additional retained publication authority cleanup failed"),
+                    action=attempt,
+                    complete=lambda attempt=attempt: (
+                        _publication_authority_owner_released(attempt.owner)
+                    ),
+                    retry_incomplete=attempt.retry_incomplete,
                 )
-                for owner in tuple(_RETAINED_PUBLICATION_AUTHORITY_OWNERS)
+                for attempt in attempts
             ),
             iteration_failure_label=(
                 "retained publication cleanup iteration also failed"
@@ -2913,9 +3044,11 @@ def _open_posix_publication_authority(
                     reader._deactivate()
 
             cleanup_actions = (
-                (
-                    "publication reader deactivation also failed",
-                    deactivate_reader,
+                _OrderedAction(
+                    label="publication reader deactivation also failed",
+                    action=deactivate_reader,
+                    complete=lambda: reader is None or not reader._lifetime.active,
+                    retry_incomplete="cancellation",
                 ),
                 _OrderedAction(
                     label="publication child descriptor cleanup also failed",
@@ -4059,6 +4192,7 @@ def _open_windows_publication_authority(
             if opened_child is None:
                 return None
             handle, metadata = opened_child
+            child_record = resources.record_for_cleanup(handle)
             primary_error: BaseException | None = None
             try:
                 if metadata.st_dev != opened.st_dev:
@@ -4073,7 +4207,7 @@ def _open_windows_publication_authority(
                 raise
             finally:
                 try:
-                    resources.close_handle(handle)
+                    resources.close_record(child_record)
                 except BaseException as close_error:  # noqa: B036
                     if primary_error is None:
                         raise
@@ -4099,8 +4233,9 @@ def _open_windows_publication_authority(
             if opened_child is None:
                 raise RuntimeError(f"{label} disappeared: {display_path}")
             handle, metadata = opened_child
+            child_record = resources.record_for_cleanup(handle)
             if metadata.st_dev != opened.st_dev:
-                resources.close_handle(handle)
+                resources.close_record(child_record)
                 raise RuntimeError("publication child crosses a volume")
             handle_record = resources.record_for_cleanup(handle)
             handle_owner = resources._exact_record_cleanup_owner(handle_record)
@@ -4111,9 +4246,11 @@ def _open_windows_publication_authority(
                     reader._deactivate()
 
             cleanup_actions = (
-                (
-                    "Windows publication reader deactivation also failed",
-                    deactivate_reader,
+                _OrderedAction(
+                    label="Windows publication reader deactivation also failed",
+                    action=deactivate_reader,
+                    complete=lambda: reader is None or not reader._lifetime.active,
+                    retry_incomplete="cancellation",
                 ),
                 _OrderedAction(
                     label="Windows reader HANDLE cleanup also failed",
@@ -4173,6 +4310,7 @@ def _open_windows_publication_authority(
             if opened_source is None:
                 raise FileNotFoundError(source)
             source_handle, _metadata = opened_source
+            source_record = resources.record_for_cleanup(source_handle)
             primary_error: BaseException | None = None
             try:
                 api.rename_noreplace(
@@ -4185,7 +4323,7 @@ def _open_windows_publication_authority(
                 raise
             finally:
                 try:
-                    resources.close_handle(source_handle)
+                    resources.close_record(source_record)
                 except BaseException as close_error:  # noqa: B036
                     if primary_error is None:
                         raise
@@ -4204,6 +4342,7 @@ def _open_windows_publication_authority(
             rebound_handle = resources.acquire(
                 lambda: api.create_directory_handle(path)
             )
+            rebound_record = resources.record_for_cleanup(rebound_handle)
             primary_error: BaseException | None = None
             try:
                 if _directory_inode_identity(api.metadata(rebound_handle)) != identity:
@@ -4213,7 +4352,7 @@ def _open_windows_publication_authority(
                 raise
             finally:
                 try:
-                    resources.close_handle(rebound_handle)
+                    resources.close_record(rebound_record)
                 except BaseException as close_error:  # noqa: B036
                     if primary_error is None:
                         raise

--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -988,6 +988,14 @@ class PublicationDirectoryReader:
 _PublicationTreeReader = PublicationDirectoryReader
 
 
+def _set_publication_reader_inactive(
+    lifetime: _PublicationReaderLifetime,
+) -> None:
+    """Apply the reader lifetime transition through a stable fault seam."""
+
+    lifetime.active = False
+
+
 def _force_publication_reader_inactive(
     lifetime: _PublicationReaderLifetime,
     failures: _OrderedActionState,
@@ -997,7 +1005,7 @@ def _force_publication_reader_inactive(
     try:
         while lifetime.active:
             try:
-                lifetime.active = False
+                _set_publication_reader_inactive(lifetime)
             except BaseException as transition_error:  # noqa: B036 - retry state
                 failures.retain(
                     "publication reader inactive transition also failed",

--- a/codenib/storage/__init__.py
+++ b/codenib/storage/__init__.py
@@ -7,6 +7,7 @@
 from .cas import BlobInfo, LocalCAS
 from .models import (
     INDEX_JOB_REQUEST_CONTRACT,
+    VIEW_GENERATION_MEMBERS_METADATA_KEY,
     ArtifactMember,
     IndexJobCompletion,
     IndexJobRecord,
@@ -28,12 +29,15 @@ from .models import (
     StorageValidationError,
     ViewGeneration,
     ViewProfile,
+    normalize_view_generation_metadata,
+    view_generation_member_digests,
 )
 from .protocols import (
     IndexCatalog,
     JobCatalog,
     ObjectStore,
     ReceiptVerifyingObjectStore,
+    StreamingObjectStore,
 )
 from .sqlite_catalog import (
     DEFAULT_NAMESPACE_ID,
@@ -96,6 +100,8 @@ __all__ = [
     "StorageIntegrityError",
     "StorageNotFound",
     "StorageValidationError",
+    "StreamingObjectStore",
+    "VIEW_GENERATION_MEMBERS_METADATA_KEY",
     "VIEW_BUNDLE_MANIFEST",
     "VIEW_BUNDLE_MEDIA_TYPE",
     "VIEW_BUNDLE_PAYLOAD",
@@ -105,6 +111,8 @@ __all__ = [
     "ViewProfile",
     "build_view_bundle",
     "materialize_view_bundle",
+    "normalize_view_generation_metadata",
+    "view_generation_member_digests",
     "validate_view_bundle_physical_size",
     "verify_view_bundle",
 ]

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -1500,11 +1500,50 @@ class _ValidatedObjectChunks(Iterator[bytes]):
         return block
 
     def close(self) -> None:
-        """Close the acquired iterator at most once on every terminal path."""
+        """Terminally stop iteration and close its producer at most once.
 
-        if self._closed:
-            return
-        self._closed = True
+        ``_closed`` is only the iteration-terminal marker.  The retained
+        ``_iterator`` is the close authority: an interruption after the marker
+        changes must not make a later cleanup attempt believe that the producer
+        was already handled.  Converge the marker first, retaining its first
+        interruption, and then hand off the producer exactly once.
+
+        Detaching ``_iterator`` is the arbitrary-callback boundary.  Dynamic
+        ``close`` lookup and invocation can run producer code which commits a
+        side effect before raising, so neither operation may be replayed after
+        that handoff.
+        """
+
+        transition_error: BaseException | None = None
+        while not self._closed:
+            try:
+                self._closed = True
+            except BaseException as error:  # noqa: B036 - finish transition
+                if transition_error is None:
+                    transition_error = error
+                else:
+                    _atomic._annotate_secondary_error(
+                        transition_error,
+                        "CAS chunk iterator terminal transition also failed",
+                        error,
+                    )
+
+        try:
+            self._close_producer_once()
+        except BaseException as close_error:  # noqa: B036 - keep first error
+            if transition_error is None:
+                raise
+            _atomic._annotate_secondary_error(
+                transition_error,
+                "CAS chunk producer cleanup also failed",
+                close_error,
+            )
+        if transition_error is not None:
+            raise transition_error
+
+    def _close_producer_once(self) -> None:
+        """Consume retained producer-close authority without replaying it."""
+
         iterator = self._iterator
         self._iterator = None
         self._chunks = None

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -31,6 +31,7 @@ from .models import StorageIntegrityError, StorageValidationError
 
 _DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
 _COPY_BUFFER_SIZE = 1024 * 1024
+_MAX_OBJECT_BYTES = 64 << 30
 _SAFE_DIRECTORY_FDS = (
     hasattr(os, "O_DIRECTORY")
     and hasattr(os, "O_NOFOLLOW")
@@ -498,6 +499,38 @@ class LocalCAS:
 
         return self._run_strict_operation(put)
 
+    def put_chunks(
+        self,
+        chunks: Iterable[bytes],
+        expected_digest: str,
+        expected_size: int,
+    ) -> BlobInfo:
+        """Stream one expected-identity object into the CAS.
+
+        Platform support, the expected identity, and any existing canonical
+        object are checked before the producer is iterated.  Reuse therefore
+        performs no producer reads.  New bytes are bounded and authenticated
+        while the owned publication stage is written, before its final name
+        can be installed.
+        """
+
+        if type(expected_digest) is not str:
+            raise StorageValidationError(
+                "digest must be 64 lowercase hexadecimal characters"
+            )
+        digest = _validate_digest(expected_digest)
+        byte_size = _validate_expected_object_size(expected_size)
+        _require_local_cas_support()
+        reused = self._reuse_expected_object(digest, byte_size)
+        if reused is not None:
+            return reused
+        validated_chunks = _ValidatedObjectChunks(
+            chunks,
+            expected_digest=digest,
+            expected_size=byte_size,
+        )
+        return self._publish_object(digest, byte_size, validated_chunks)
+
     def has(self, digest: str) -> bool:
         """Return whether a regular object exists for *digest*.
 
@@ -946,6 +979,102 @@ class LocalCAS:
                 shard_path / destination_name,
             )
 
+    def _reuse_expected_object(
+        self,
+        digest: str,
+        byte_size: int,
+    ) -> BlobInfo | None:
+        """Authenticate and durably rebind an existing canonical object."""
+
+        shard_opened = False
+        try:
+            with self._open_shard(digest) as (shard_descriptor, shard_path):
+                shard_opened = True
+                if shard_descriptor is None:
+                    raise RuntimeError(
+                        "strict CAS reuse requires an anchored shard descriptor"
+                    )
+                name = digest[2:]
+                destination = shard_path / name
+                try:
+                    before = os.stat(
+                        name,
+                        dir_fd=shard_descriptor,
+                        follow_symlinks=False,
+                    )
+                except FileNotFoundError:
+                    return None
+                if not _is_canonical_object(before, expected_size=byte_size):
+                    raise _existing_object_conflict(destination)
+
+                try:
+                    handle = _open_regular_at(
+                        shard_descriptor,
+                        shard_path,
+                        name,
+                        label="CAS object",
+                    )
+                except FileNotFoundError as exc:
+                    raise _existing_object_conflict(destination) from exc
+                with _close_binary_handle(handle):
+                    opened = os.fstat(handle.fileno())
+                    signature = _canonical_object_signature(opened)
+                    if signature != _canonical_object_signature(before):
+                        raise _existing_object_conflict(destination)
+
+                    observed = hashlib.sha256()
+                    remaining = byte_size
+                    while remaining:
+                        block = handle.read(min(_COPY_BUFFER_SIZE, remaining))
+                        if not block or len(block) > remaining:
+                            raise _existing_object_conflict(destination)
+                        observed.update(block)
+                        remaining -= len(block)
+                    if handle.read(1):
+                        raise _existing_object_conflict(destination)
+                    if observed.hexdigest() != digest:
+                        raise _existing_object_conflict(destination)
+                    if (
+                        _canonical_object_signature(os.fstat(handle.fileno()))
+                        != signature
+                    ):
+                        raise _existing_object_conflict(destination)
+
+                    # A prior publication may have committed before reporting
+                    # an fsync failure. Replay both the object and directory
+                    # durability boundaries before issuing a reuse receipt.
+                    os.fsync(handle.fileno())
+                    if (
+                        _canonical_object_signature(os.fstat(handle.fileno()))
+                        != signature
+                    ):
+                        raise _existing_object_conflict(destination)
+                    rebound = os.stat(
+                        name,
+                        dir_fd=shard_descriptor,
+                        follow_symlinks=False,
+                    )
+                    if _canonical_object_signature(rebound) != signature:
+                        raise _existing_object_conflict(destination)
+                    os.fsync(shard_descriptor)
+                    if (
+                        _canonical_object_signature(os.fstat(handle.fileno()))
+                        != signature
+                    ):
+                        raise _existing_object_conflict(destination)
+                    durable_rebound = os.stat(
+                        name,
+                        dir_fd=shard_descriptor,
+                        follow_symlinks=False,
+                    )
+                    if _canonical_object_signature(durable_rebound) != signature:
+                        raise _existing_object_conflict(destination)
+        except FileNotFoundError:
+            if shard_opened:
+                raise
+            return None
+        return self._blob_info(digest, byte_size)
+
     def _consume_object(
         self,
         digest: str,
@@ -1259,7 +1388,7 @@ def _open_regular_at(
             f"{label} is not a regular file: {directory_path / name}"
         )
 
-    flags = os.O_RDONLY | os.O_NOFOLLOW
+    flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
     if hasattr(os, "O_BINARY"):
         flags |= os.O_BINARY
     if hasattr(os, "O_CLOEXEC"):
@@ -1300,12 +1429,193 @@ def _unlink_portable(directory_path: Path, name: str) -> None:
         pass
 
 
+class _ValidatedObjectChunks(Iterator[bytes]):
+    """One-shot producer adapter with exact terminal identity validation."""
+
+    __slots__ = (
+        "_byte_size",
+        "_chunks",
+        "_closed",
+        "_expected_digest",
+        "_expected_size",
+        "_iterator",
+        "_observed",
+    )
+
+    def __init__(
+        self,
+        chunks: Iterable[bytes],
+        *,
+        expected_digest: str,
+        expected_size: int,
+    ) -> None:
+        self._chunks: Iterable[bytes] | None = chunks
+        self._iterator: Iterator[bytes] | None = None
+        self._expected_digest = expected_digest
+        self._expected_size = expected_size
+        self._observed = hashlib.sha256()
+        self._byte_size = 0
+        self._closed = False
+
+    def __iter__(self) -> _ValidatedObjectChunks:
+        return self
+
+    def __next__(self) -> bytes:
+        if self._closed:
+            raise StopIteration
+        try:
+            iterator = self._start()
+        except BaseException as primary_error:  # noqa: B036 - acquisition failed
+            self._close_preserving(primary_error)
+            if isinstance(primary_error, StopIteration):
+                raise RuntimeError(
+                    "CAS chunk iterator acquisition raised StopIteration"
+                ) from primary_error
+            raise
+        try:
+            block = next(iterator)
+        except StopIteration:
+            completion_error = self._completion_error()
+            if completion_error is not None:
+                self._close_preserving(completion_error)
+                raise completion_error
+            self.close()
+            raise
+        except BaseException as primary_error:  # noqa: B036 - close producer
+            self._close_preserving(primary_error)
+            raise
+
+        try:
+            if type(block) is not bytes:
+                raise TypeError("CAS chunk producer must yield bytes")
+            if len(block) > self._expected_size - self._byte_size:
+                raise StorageIntegrityError(
+                    "CAS chunk producer exceeds its expected object size"
+                )
+            self._observed.update(block)
+            self._byte_size += len(block)
+        except BaseException as primary_error:  # noqa: B036 - close producer
+            self._close_preserving(primary_error)
+            raise
+        return block
+
+    def close(self) -> None:
+        """Close the acquired iterator at most once on every terminal path."""
+
+        if self._closed:
+            return
+        self._closed = True
+        iterator = self._iterator
+        self._iterator = None
+        self._chunks = None
+        if iterator is None:
+            return
+        try:
+            close = getattr(iterator, "close", None)
+            if callable(close):
+                close()
+        except StopIteration as exc:
+            raise RuntimeError(
+                "CAS chunk iterator cleanup raised StopIteration"
+            ) from exc
+
+    def _start(self) -> Iterator[bytes]:
+        iterator = self._iterator
+        if iterator is not None:
+            return iterator
+        chunks = self._chunks
+        if chunks is None:
+            self._closed = True
+            raise RuntimeError("CAS chunk producer is no longer available")
+        try:
+            iterator = iter(chunks)
+        except BaseException:  # noqa: B036 - make iterator acquisition terminal
+            self._closed = True
+            self._chunks = None
+            raise
+        self._iterator = iterator
+        self._chunks = None
+        return iterator
+
+    def _completion_error(self) -> StorageIntegrityError | None:
+        if self._byte_size != self._expected_size:
+            return StorageIntegrityError(
+                "CAS chunk producer size does not match its expected object size"
+            )
+        if self._observed.hexdigest() != self._expected_digest:
+            return StorageIntegrityError(
+                "CAS chunk producer digest does not match its expected digest"
+            )
+        return None
+
+    def _close_preserving(self, primary_error: BaseException) -> None:
+        try:
+            self.close()
+        except BaseException as close_error:  # noqa: B036 - keep first primary
+            _atomic._annotate_secondary_error(
+                primary_error,
+                "CAS chunk iterator cleanup also failed",
+                close_error,
+            )
+
+
+@contextmanager
+def _close_binary_handle(handle: BinaryIO) -> Iterator[None]:
+    """Close one opened object while retaining an earlier verification error."""
+
+    try:
+        yield
+    except BaseException as primary_error:  # noqa: B036 - retain first primary
+        try:
+            handle.close()
+        except BaseException as close_error:  # noqa: B036 - diagnostic only
+            _atomic._annotate_secondary_error(
+                primary_error,
+                "CAS object handle cleanup also failed",
+                close_error,
+            )
+        raise
+    else:
+        handle.close()
+
+
 def _validate_digest(digest: str) -> str:
     if not isinstance(digest, str) or _DIGEST_RE.fullmatch(digest) is None:
         raise StorageValidationError(
             "digest must be 64 lowercase hexadecimal characters"
         )
     return digest
+
+
+def _validate_expected_object_size(value: object) -> int:
+    if type(value) is not int or value < 0:
+        raise StorageValidationError(
+            "expected object size must be a nonnegative integer"
+        )
+    if value > _MAX_OBJECT_BYTES:
+        raise StorageValidationError(
+            f"expected object size exceeds the {_MAX_OBJECT_BYTES}-byte limit"
+        )
+    return value
+
+
+def _is_canonical_object(
+    metadata: os.stat_result,
+    *,
+    expected_size: int,
+) -> bool:
+    return (
+        stat.S_ISREG(metadata.st_mode)
+        and metadata.st_nlink == 1
+        and stat.S_IMODE(metadata.st_mode) == _CAS_OBJECT_MODE
+        and metadata.st_size == expected_size
+    )
+
+
+def _existing_object_conflict(destination: Path) -> StorageIntegrityError:
+    return StorageIntegrityError(
+        f"existing CAS object failed integrity validation: {destination}"
+    )
 
 
 def _require_local_cas_support() -> None:
@@ -1379,7 +1689,7 @@ def _open_regular_file(path: Path, *, label: str) -> BinaryIO:
     if not stat.S_ISREG(metadata.st_mode):
         raise StorageIntegrityError(f"{label} is not a regular file: {path}")
 
-    flags = os.O_RDONLY
+    flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     if hasattr(os, "O_BINARY"):
         flags |= os.O_BINARY
     if hasattr(os, "O_NOFOLLOW"):
@@ -1467,6 +1777,20 @@ def _object_signature(metadata: os.stat_result) -> tuple[int, ...]:
         metadata.st_mode,
         metadata.st_size,
         metadata.st_mtime_ns,
+    )
+
+
+def _canonical_object_signature(metadata: os.stat_result) -> tuple[int, ...]:
+    """Exact metadata required throughout canonical-object reuse."""
+
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
     )
 
 

--- a/codenib/storage/models.py
+++ b/codenib/storage/models.py
@@ -13,7 +13,7 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from .._secret_fields import SecretFieldError
 from .._secret_fields import assert_no_secret_fields as _assert_no_secret_fields
@@ -21,6 +21,7 @@ from .._secret_fields import assert_no_secret_fields as _assert_no_secret_fields
 _DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
 _CATALOG_INT64_MAX = 9_223_372_036_854_775_807
 INDEX_JOB_REQUEST_CONTRACT = "codenib.index-job-request.v1"
+VIEW_GENERATION_MEMBERS_METADATA_KEY = "_codenib_member_object_digests"
 
 
 class StorageError(RuntimeError):
@@ -102,6 +103,84 @@ def normalize_digest(value: str) -> str:
     if _DIGEST_RE.fullmatch(normalized) is None:
         raise StorageValidationError(
             "digest must be 64 lowercase hexadecimal characters"
+        )
+    return normalized
+
+
+def normalize_view_generation_metadata(
+    object_digest: str,
+    metadata: Mapping[str, Any] | None = None,
+    *,
+    member_object_digests: Sequence[str] = (),
+) -> tuple[dict[str, Any], tuple[str, ...]]:
+    """Return canonical metadata and reachability members for one generation.
+
+    The reserved member list is identity-bearing catalog metadata.  Keeping
+    this normalization beside :class:`ViewGeneration` lets planners compute
+    the exact schema-v4 generation ID without reproducing SQLite-private
+    behavior.
+    """
+
+    primary = normalize_digest(object_digest)
+    if isinstance(member_object_digests, (str, bytes)):
+        raise StorageValidationError("member object digests must be a sequence")
+    normalized_members_list: list[str] = []
+    for value in member_object_digests:
+        if type(value) is not str:
+            raise StorageValidationError("member object digests must be exact strings")
+        normalized_members_list.append(normalize_digest(value))
+    normalized_members = tuple(sorted(normalized_members_list))
+    if len(normalized_members) != len(set(normalized_members)):
+        raise StorageValidationError("duplicate member object digests")
+    if primary in normalized_members:
+        raise StorageValidationError(
+            "the primary object must not also be a member object"
+        )
+    if metadata is not None and not isinstance(metadata, Mapping):
+        raise StorageValidationError("view generation metadata must be a mapping")
+    normalized_metadata = dict(metadata or {})
+    if VIEW_GENERATION_MEMBERS_METADATA_KEY in normalized_metadata:
+        raise StorageValidationError(
+            f"{VIEW_GENERATION_MEMBERS_METADATA_KEY} is reserved catalog metadata"
+        )
+    if normalized_members:
+        normalized_metadata[VIEW_GENERATION_MEMBERS_METADATA_KEY] = list(
+            normalized_members
+        )
+    # Round-trip through the shared canonicalizer so callers receive detached,
+    # JSON-compatible values rather than references to mutable input objects.
+    return json.loads(canonical_json(normalized_metadata)), normalized_members
+
+
+def view_generation_member_digests(
+    object_digest: str,
+    metadata: Mapping[str, Any],
+) -> tuple[str, ...]:
+    if not isinstance(metadata, Mapping):
+        raise StorageValidationError("view generation metadata must be a mapping")
+    if VIEW_GENERATION_MEMBERS_METADATA_KEY not in metadata:
+        return ()
+    raw_members = metadata[VIEW_GENERATION_MEMBERS_METADATA_KEY]
+    if not isinstance(raw_members, list) or not raw_members:
+        raise StorageValidationError(
+            "view generation member metadata must be a nonempty digest list"
+        )
+    if any(type(value) is not str for value in raw_members):
+        raise StorageValidationError(
+            "view generation member metadata must contain exact digest strings"
+        )
+    normalized = tuple(normalize_digest(value) for value in raw_members)
+    if tuple(raw_members) != normalized:
+        raise StorageValidationError(
+            "view generation member metadata must use canonical bare digests"
+        )
+    if normalized != tuple(sorted(set(normalized))):
+        raise StorageValidationError(
+            "view generation member metadata must be sorted and unique"
+        )
+    if normalize_digest(object_digest) in normalized:
+        raise StorageValidationError(
+            "the primary object must not also be a member object"
         )
     return normalized
 
@@ -461,6 +540,7 @@ class ViewGeneration:
             raise StorageValidationError("view metadata must be valid JSON") from exc
         if not isinstance(metadata, dict):
             raise StorageValidationError("view metadata must be a JSON object")
+        view_generation_member_digests(self.object_digest, metadata)
         object.__setattr__(self, "metadata_json", canonical_json(metadata))
 
     @classmethod
@@ -472,14 +552,20 @@ class ViewGeneration:
         *,
         schema_version: str,
         metadata: Mapping[str, Any] | None = None,
+        member_object_digests: Sequence[str] = (),
     ) -> ViewGeneration:
+        normalized_metadata, _members = normalize_view_generation_metadata(
+            object_record.digest,
+            metadata,
+            member_object_digests=member_object_digests,
+        )
         return cls(
             repository_id=source.repository_id,
             source_revision_id=source.source_revision_id,
             profile=profile,
             object_digest=object_record.digest,
             schema_version=schema_version,
-            metadata_json=canonical_json(metadata or {}),
+            metadata_json=canonical_json(normalized_metadata),
         )
 
     @property
@@ -489,6 +575,13 @@ class ViewGeneration:
     @property
     def view_type(self) -> str:
         return self.profile.view_type
+
+    @property
+    def member_object_digests(self) -> tuple[str, ...]:
+        return view_generation_member_digests(
+            self.object_digest,
+            json.loads(self.metadata_json),
+        )
 
     @property
     def view_generation_id(self) -> str:
@@ -998,10 +1091,13 @@ __all__ = [
     "StorageIntegrityError",
     "StorageNotFound",
     "StorageValidationError",
+    "VIEW_GENERATION_MEMBERS_METADATA_KEY",
     "ViewGeneration",
     "ViewProfile",
     "assert_no_secret_fields",
     "canonical_json",
     "content_id",
     "normalize_digest",
+    "normalize_view_generation_metadata",
+    "view_generation_member_digests",
 ]

--- a/codenib/storage/protocols.py
+++ b/codenib/storage/protocols.py
@@ -7,7 +7,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, BinaryIO, Mapping, Protocol, Sequence, runtime_checkable
+from typing import (
+    Any,
+    BinaryIO,
+    Iterable,
+    Mapping,
+    Protocol,
+    Sequence,
+    runtime_checkable,
+)
 
 from .cas import BlobInfo
 from .models import IndexJobCompletion, IndexJobRecord, IndexJobViewRecord, RefJobLease
@@ -57,6 +65,27 @@ class ReceiptVerifyingObjectStore(ObjectStore, Protocol):
 
     def verify_receipt(self, expected: BlobInfo) -> BlobInfo:
         """Revalidate one exact digest/size/storage-key receipt."""
+
+        ...
+
+
+@runtime_checkable
+class StreamingObjectStore(ObjectStore, Protocol):
+    """Additive capability for bounded, expected-identity object ingestion.
+
+    The producer is not part of the baseline :class:`ObjectStore` contract so
+    existing backends remain structurally compatible.  Implementations must
+    validate the expected identity and any reusable object before asking the
+    producer for its first chunk.
+    """
+
+    def put_chunks(
+        self,
+        chunks: Iterable[bytes],
+        expected_digest: str,
+        expected_size: int,
+    ) -> BlobInfo:
+        """Stream bytes that must match the exact expected identity."""
 
         ...
 
@@ -206,4 +235,5 @@ __all__ = [
     "JobCatalog",
     "ObjectStore",
     "ReceiptVerifyingObjectStore",
+    "StreamingObjectStore",
 ]

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -40,13 +40,13 @@ from .models import (
     canonical_json,
     content_id,
     normalize_digest,
+    normalize_view_generation_metadata,
+    view_generation_member_digests,
 )
 
 LATEST_SCHEMA_VERSION = 4
 DEFAULT_NAMESPACE_ID = "ns_default"
 DEFAULT_NAMESPACE_NAME = "default"
-
-_GENERATION_MEMBERS_METADATA_KEY = "_codenib_member_object_digests"
 
 CatalogError = StorageError
 CatalogConflictError = PublishConflict
@@ -1113,14 +1113,12 @@ class SQLiteCatalog:
 
     def _migrate(self) -> None:
         with self._transaction():
-            self._connection.execute(
-                """
+            self._connection.execute("""
                 CREATE TABLE IF NOT EXISTS schema_migrations (
                     version INTEGER PRIMARY KEY,
                     applied_at TEXT NOT NULL
                 )
-                """
-            )
+                """)
             rows = self._connection.execute(
                 "SELECT version FROM schema_migrations ORDER BY version"
             ).fetchall()
@@ -2161,27 +2159,14 @@ class SQLiteCatalog:
         normalized_schema_version = _required_text(
             schema_version, "view schema version"
         )
-        if isinstance(member_object_digests, (str, bytes)):
-            raise CatalogValidationError("member object digests must be a sequence")
-        normalized_members = [
-            normalize_digest(value) for value in member_object_digests
-        ]
-        if len(normalized_members) != len(set(normalized_members)):
-            raise CatalogValidationError("duplicate member object digests")
-        normalized_members.sort()
-        if digest in normalized_members:
-            raise CatalogValidationError(
-                "the primary object must not also be a member object"
+        normalized_metadata, normalized_member_tuple = (
+            normalize_view_generation_metadata(
+                digest,
+                metadata,
+                member_object_digests=member_object_digests,
             )
-        if metadata is not None and not isinstance(metadata, Mapping):
-            raise CatalogValidationError("view generation metadata must be a mapping")
-        normalized_metadata = dict(metadata or {})
-        if _GENERATION_MEMBERS_METADATA_KEY in normalized_metadata:
-            raise CatalogValidationError(
-                f"{_GENERATION_MEMBERS_METADATA_KEY} is reserved catalog metadata"
-            )
-        if normalized_members:
-            normalized_metadata[_GENERATION_MEMBERS_METADATA_KEY] = normalized_members
+        )
+        normalized_members = list(normalized_member_tuple)
         metadata_json = canonical_json(normalized_metadata)
         identity = {
             "repository_id": repository,
@@ -2669,25 +2654,9 @@ class SQLiteCatalog:
                     "view generation metadata must be a JSON object"
                 )
             canonical_metadata = canonical_json(metadata)
-            encoded_members = metadata.get(_GENERATION_MEMBERS_METADATA_KEY)
-            if encoded_members is None:
-                expected_member_digests: list[str] = []
-            else:
-                if not isinstance(encoded_members, list) or not encoded_members:
-                    raise CatalogValidationError(
-                        "view generation member metadata must be a non-empty list"
-                    )
-                expected_member_digests = [
-                    normalize_digest(value) for value in encoded_members
-                ]
-                if (
-                    expected_member_digests != sorted(expected_member_digests)
-                    or len(expected_member_digests) != len(set(expected_member_digests))
-                    or row["object_digest"] in expected_member_digests
-                ):
-                    raise CatalogValidationError(
-                        "view generation member metadata is not canonical"
-                    )
+            expected_member_digests = list(
+                view_generation_member_digests(row["object_digest"], metadata)
+            )
         except (TypeError, json.JSONDecodeError, CatalogValidationError) as exc:
             raise CatalogConflictError("view generation identity conflicts") from exc
         member_objects = self._generation_member_objects(row["view_generation_id"])
@@ -2746,14 +2715,27 @@ class SQLiteCatalog:
                     raise CatalogValidationError(
                         "view generation member object join is inconsistent"
                     )
-                records.append(
-                    ObjectRecord(
-                        digest=joined["digest"],
-                        storage_key=joined["storage_key"],
-                        byte_size=joined["byte_size"],
-                        media_type=joined["media_type"],
-                    )
+                record = ObjectRecord(
+                    digest=joined["digest"],
+                    storage_key=joined["storage_key"],
+                    byte_size=joined["byte_size"],
+                    media_type=joined["media_type"],
                 )
+                if (
+                    record.digest,
+                    record.storage_key,
+                    record.byte_size,
+                    record.media_type,
+                ) != (
+                    joined["digest"],
+                    joined["storage_key"],
+                    joined["byte_size"],
+                    joined["media_type"],
+                ):
+                    raise CatalogValidationError(
+                        "view generation member object metadata is not canonical"
+                    )
+                records.append(record)
         except CatalogValidationError as exc:
             raise CatalogConflictError(
                 "view generation member object metadata conflicts"

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -1113,12 +1113,14 @@ class SQLiteCatalog:
 
     def _migrate(self) -> None:
         with self._transaction():
-            self._connection.execute("""
+            self._connection.execute(
+                """
                 CREATE TABLE IF NOT EXISTS schema_migrations (
                     version INTEGER PRIMARY KEY,
                     applied_at TEXT NOT NULL
                 )
-                """)
+                """
+            )
             rows = self._connection.execute(
                 "SELECT version FROM schema_migrations ORDER BY version"
             ).fetchall()

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -392,6 +392,22 @@ operation, receipt minting, or ref publication. The retained reader adapter,
 object upload, atomic snapshot/ref transaction, and equivalent v1.1 export are
 still outstanding, so M1 and M2 remain in progress.
 
+The retained-import foundation now also exposes schema-v4 compound-generation
+identity as one backend-neutral model rule, including the canonical member
+object set that participates in both the generation ID and catalog
+reachability. `StreamingObjectStore` is an additive capability, so existing
+object-store implementations remain compatible while `LocalCAS` can accept a
+bounded expected-digest stream, authenticate it before publication, and reuse
+an already durable exact object without consuming the producer. Publication
+readers can project an authenticated child subtree without filesystem I/O and
+share one process-bound lifetime across every facade and opened stream. Streams
+that escape a callback are drained and authenticated on success, aborted
+without further source reads on failure or cancellation, and retained for
+explicit cleanup retry if a descriptor or HANDLE cannot close. These are
+authority and transport prerequisites only: no view-bundle replay plan,
+manifest import transaction, materialized export owner, or ref update is added
+here, so M1 remains in progress.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -44,6 +44,37 @@ def _exception_notes(error: BaseException) -> tuple[str, ...]:
     )
 
 
+def _call_with_interrupt_after_validated_close_store(
+    callback: object,
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    error: BaseException,
+) -> None:
+    """Interrupt after ``_closed`` is stored but before producer handoff."""
+
+    assert callable(callback)
+    chunks_type = cas_module._ValidatedObjectChunks
+    real_setattr = chunks_type.__setattr__
+    injected = False
+
+    def interrupt_after_setattr(
+        chunks: object,
+        name: str,
+        value: object,
+    ) -> None:
+        nonlocal injected
+        real_setattr(chunks, name, value)
+        if not injected and name == "_closed" and value is True:
+            injected = True
+            raise error
+
+    monkeypatch.setattr(chunks_type, "__setattr__", interrupt_after_setattr)
+    try:
+        callback()
+    finally:
+        assert injected, "failed to interrupt after _closed STORE_ATTR"
+
+
 class _UnconsumableChunks:
     def __init__(self) -> None:
         self.iter_calls = 0
@@ -621,6 +652,65 @@ def test_validated_chunks_never_reads_again_after_iterator_failure() -> None:
     assert producer.close_calls == 1
 
 
+@pytest.mark.parametrize(
+    "exception_type",
+    [KeyboardInterrupt, SystemExit, GeneratorExit],
+)
+def test_put_chunks_close_store_interruption_still_closes_producer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"terminal close transition"
+    digest = hashlib.sha256(payload).hexdigest()
+    producer = _ClosableChunks([payload])
+    interruption = exception_type("after validated close marker store")
+
+    with pytest.raises(exception_type) as caught:
+        _call_with_interrupt_after_validated_close_store(
+            lambda: store.put_chunks(producer, digest, len(payload)),
+            monkeypatch=monkeypatch,
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert producer.close_calls == 1
+    assert not store._object_path(digest).exists()
+
+
+@pytest.mark.parametrize(
+    "exception_type",
+    [KeyboardInterrupt, SystemExit, GeneratorExit],
+)
+def test_put_chunks_close_store_interruption_keeps_iteration_primary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[BaseException],
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"unproduced payload"
+    digest = hashlib.sha256(payload).hexdigest()
+    primary = OSError(errno.EIO, "producer read failed")
+    interruption = exception_type("after validated close marker store")
+    producer = _ClosableChunks([], iteration_error=primary)
+
+    with pytest.raises(OSError) as caught:
+        _call_with_interrupt_after_validated_close_store(
+            lambda: store.put_chunks(producer, digest, len(payload)),
+            monkeypatch=monkeypatch,
+            error=interruption,
+        )
+
+    assert caught.value is primary
+    assert producer.close_calls == 1
+    assert any(
+        "after validated close marker store" in note
+        for note in _exception_notes(primary)
+    )
+    assert not store._object_path(digest).exists()
+
+
 def test_put_chunks_identity_failure_keeps_primary_over_close_property_fault(
     tmp_path: Path,
 ) -> None:
@@ -629,6 +719,7 @@ def test_put_chunks_identity_failure_keeps_primary_over_close_property_fault(
     class ClosePropertyFault:
         def __init__(self) -> None:
             self._blocks = iter([b"short"])
+            self.close_get_calls = 0
 
         def __iter__(self) -> ClosePropertyFault:
             return self
@@ -638,17 +729,20 @@ def test_put_chunks_identity_failure_keeps_primary_over_close_property_fault(
 
         @property
         def close(self):
+            self.close_get_calls += 1
             raise secondary
 
     store = LocalCAS(tmp_path / "objects")
     digest = hashlib.sha256(b"short plus more").hexdigest()
 
+    producer = ClosePropertyFault()
     with pytest.raises(StorageIntegrityError, match="size does not match") as caught:
-        store.put_chunks(ClosePropertyFault(), digest, len(b"short plus more"))
+        store.put_chunks(producer, digest, len(b"short plus more"))
 
     assert any(
         "close property interrupted" in note for note in _exception_notes(caught.value)
     )
+    assert producer.close_get_calls == 1
     assert not store._object_path(digest).exists()
 
 
@@ -657,6 +751,9 @@ def test_put_chunks_identity_failure_keeps_primary_over_close_property_fault(
     [
         OSError(errno.EIO, "iterator close failed"),
         StopIteration("iterator close stopped"),
+        KeyboardInterrupt("iterator close interrupted"),
+        SystemExit("iterator close exited"),
+        GeneratorExit("iterator close terminated"),
     ],
 )
 def test_put_chunks_close_failure_prevents_final_publication(
@@ -668,7 +765,9 @@ def test_put_chunks_close_failure_prevents_final_publication(
     digest = hashlib.sha256(payload).hexdigest()
     producer = _ClosableChunks([payload], close_error=close_error)
 
-    expected_type = RuntimeError if isinstance(close_error, StopIteration) else OSError
+    expected_type = (
+        RuntimeError if isinstance(close_error, StopIteration) else type(close_error)
+    )
     with pytest.raises(expected_type) as caught:
         store.put_chunks(producer, digest, len(payload))
 

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -13,6 +13,7 @@ import stat
 import threading
 from pathlib import Path
 from queue import Empty
+from typing import Iterator
 
 import pytest
 
@@ -41,6 +42,50 @@ def _exception_notes(error: BaseException) -> tuple[str, ...]:
         *tuple(getattr(error, "__notes__", ())),
         *tuple(getattr(error, "_codenib_cleanup_notes", ())),
     )
+
+
+class _UnconsumableChunks:
+    def __init__(self) -> None:
+        self.iter_calls = 0
+
+    def __iter__(self) -> Iterator[bytes]:
+        self.iter_calls += 1
+        raise AssertionError("chunk producer must not be consumed")
+
+
+class _ClosableChunks:
+    def __init__(
+        self,
+        blocks: list[bytes],
+        *,
+        iteration_error: BaseException | None = None,
+        close_error: BaseException | None = None,
+    ) -> None:
+        self._blocks = iter(blocks)
+        self._iteration_error = iteration_error
+        self._close_error = close_error
+        self.next_calls = 0
+        self.close_calls = 0
+
+    def __iter__(self) -> _ClosableChunks:
+        return self
+
+    def __next__(self) -> bytes:
+        self.next_calls += 1
+        try:
+            block = next(self._blocks)
+        except StopIteration:
+            pass
+        else:
+            return block
+        if self._iteration_error is not None:
+            raise self._iteration_error
+        raise StopIteration
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self._close_error is not None:
+            raise self._close_error
 
 
 def _put_bytes_in_process(
@@ -92,6 +137,573 @@ def test_put_file_stores_regular_file(tmp_path: Path) -> None:
 
     assert info.byte_size == source.stat().st_size
     assert store.read_bytes(info.digest) == source.read_bytes()
+
+
+@pytest.mark.parametrize(
+    "blocks",
+    [
+        [b"reader-", b"native", b"", b" CAS"],
+        [],
+    ],
+)
+def test_put_chunks_streams_exact_identity_and_closes_iterator(
+    tmp_path: Path,
+    blocks: list[bytes],
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"".join(blocks)
+    digest = hashlib.sha256(payload).hexdigest()
+    producer = _ClosableChunks(blocks)
+
+    info = store.put_chunks(producer, digest, len(payload))
+
+    assert info.digest == digest
+    assert info.byte_size == len(payload)
+    assert info.storage_key == f"sha256/{digest[:2]}/{digest[2:]}"
+    assert store.read_bytes(digest) == payload
+    assert producer.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("expected_digest", "expected_size", "message"),
+    [
+        ("not-a-digest", 0, "64 lowercase hexadecimal"),
+        (hashlib.sha256(b"").hexdigest(), True, "nonnegative integer"),
+        (hashlib.sha256(b"").hexdigest(), -1, "nonnegative integer"),
+        (
+            hashlib.sha256(b"").hexdigest(),
+            cas_module._MAX_OBJECT_BYTES + 1,
+            "byte limit",
+        ),
+    ],
+)
+def test_put_chunks_validates_expected_identity_before_producer_use(
+    tmp_path: Path,
+    expected_digest: str,
+    expected_size: int,
+    message: str,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    producer = _UnconsumableChunks()
+
+    with pytest.raises(StorageValidationError, match=message):
+        store.put_chunks(producer, expected_digest, expected_size)
+
+    assert producer.iter_calls == 0
+
+
+def test_put_chunks_iterator_acquisition_stopiteration_never_publishes(
+    tmp_path: Path,
+) -> None:
+    class StoppedBeforeIteration:
+        def __init__(self) -> None:
+            self.iter_calls = 0
+
+        def __iter__(self):
+            self.iter_calls += 1
+            raise StopIteration("iterator acquisition stopped")
+
+    store = LocalCAS(tmp_path / "objects")
+    digest = hashlib.sha256(b"").hexdigest()
+    producer = StoppedBeforeIteration()
+
+    with pytest.raises(RuntimeError, match="acquisition") as caught:
+        store.put_chunks(producer, digest, 0)
+
+    assert isinstance(caught.value.__cause__, StopIteration)
+    assert producer.iter_calls == 1
+    assert not store._object_path(digest).exists()
+
+
+def test_put_chunks_rejects_identity_subclasses_before_producer_use(
+    tmp_path: Path,
+) -> None:
+    class ForgedDigest(str):
+        pass
+
+    class ForgedSize(int):
+        pass
+
+    store = LocalCAS(tmp_path / "objects")
+    digest = hashlib.sha256(b"").hexdigest()
+
+    for expected_digest, expected_size, message in (
+        (ForgedDigest(digest), 0, "64 lowercase hexadecimal"),
+        (digest, ForgedSize(0), "nonnegative integer"),
+    ):
+        producer = _UnconsumableChunks()
+        with pytest.raises(StorageValidationError, match=message):
+            store.put_chunks(producer, expected_digest, expected_size)
+        assert producer.iter_calls == 0
+
+
+def test_put_chunks_accepts_the_64_gib_identity_boundary(tmp_path: Path) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    digest = hashlib.sha256(b"").hexdigest()
+    producer = _UnconsumableChunks()
+
+    with pytest.raises(AssertionError, match="must not be consumed"):
+        store.put_chunks(producer, digest, cas_module._MAX_OBJECT_BYTES)
+
+    assert producer.iter_calls == 1
+    assert not store._object_path(digest).exists()
+
+
+def test_put_chunks_support_gate_precedes_producer_use(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"unsupported producer"
+    digest = hashlib.sha256(payload).hexdigest()
+    producer = _UnconsumableChunks()
+    destination = store._object_path(digest)
+    monkeypatch.setattr(cas_module, "_SAFE_DIRECTORY_FDS", False)
+
+    with pytest.raises(RuntimeError, match="directory-fd support"):
+        store.put_chunks(producer, digest, len(payload))
+
+    assert producer.iter_calls == 0
+    assert not destination.exists()
+
+
+def test_put_chunks_strict_identity_gate_precedes_producer_use(
+    tmp_path: Path,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"strict generation"
+    digest = hashlib.sha256(payload).hexdigest()
+    shard = store.root / "sha256" / digest[:2]
+    previous = shard.with_name(f"{shard.name}-previous")
+    shard.rename(previous)
+    shard.mkdir()
+    producer = _UnconsumableChunks()
+
+    with pytest.raises(StorageIntegrityError, match="generation changed"):
+        store.put_chunks(producer, digest, len(payload))
+
+    assert producer.iter_calls == 0
+    assert list(shard.iterdir()) == []
+
+
+@pytest.mark.parametrize("conflict", [False, True], ids=["reuse", "conflict"])
+def test_put_chunks_reuse_or_conflict_precedes_producer_use(
+    tmp_path: Path,
+    conflict: bool,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"existing canonical object"
+    expected = store.put_bytes(payload)
+    destination = store.root / expected.storage_key
+    if conflict:
+        destination.write_bytes(b"x" * len(payload))
+    producer = _UnconsumableChunks()
+
+    if conflict:
+        with pytest.raises(StorageIntegrityError, match="failed integrity"):
+            store.put_chunks(producer, expected.digest, expected.byte_size)
+    else:
+        assert (
+            store.put_chunks(producer, expected.digest, expected.byte_size) == expected
+        )
+
+    assert producer.iter_calls == 0
+    assert list(destination.parent.glob(".codenib-file-*")) == []
+
+
+def test_put_chunks_observed_object_disappearing_before_open_is_a_conflict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"observed before open"
+    expected = store.put_bytes(payload)
+    destination = store.root / expected.storage_key
+    producer = _UnconsumableChunks()
+    real_open = cas_module._open_regular_at
+    removed = False
+
+    def remove_then_open(*args, **kwargs):
+        nonlocal removed
+        if not removed and kwargs.get("label") == "CAS object":
+            removed = True
+            destination.unlink()
+        return real_open(*args, **kwargs)
+
+    monkeypatch.setattr(cas_module, "_open_regular_at", remove_then_open)
+
+    with pytest.raises(StorageIntegrityError, match="failed integrity"):
+        store.put_chunks(producer, expected.digest, expected.byte_size)
+
+    assert removed
+    assert producer.iter_calls == 0
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NONBLOCK"), reason="POSIX open flag")
+def test_cas_regular_file_opens_are_nonblocking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    payload = root / "payload"
+    payload.write_bytes(b"payload")
+    directory_descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    real_open = cas_module.os.open
+    observed: list[int] = []
+
+    def record_open(path, flags, *args, **kwargs):
+        if path == "payload" or path == payload:
+            observed.append(flags)
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(cas_module.os, "open", record_open)
+    try:
+        with cas_module._open_regular_at(
+            directory_descriptor,
+            root,
+            "payload",
+            label="test object",
+        ) as source:
+            assert source.read() == b"payload"
+        with cas_module._open_regular_file(payload, label="test source") as source:
+            assert source.read() == b"payload"
+    finally:
+        os.close(directory_descriptor)
+
+    assert len(observed) == 2
+    assert all(flags & os.O_NONBLOCK for flags in observed)
+
+
+def test_put_chunks_reuse_fsyncs_object_then_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = b"durably reusable object"
+    expected = store.put_bytes(payload)
+    destination = store.root / expected.storage_key
+    object_metadata = destination.stat()
+    shard_metadata = destination.parent.stat()
+    identities = {
+        (object_metadata.st_dev, object_metadata.st_ino): "object",
+        (shard_metadata.st_dev, shard_metadata.st_ino): "shard",
+    }
+    real_fsync = cas_module.os.fsync
+    events: list[str] = []
+
+    def record_fsync(descriptor: int) -> None:
+        metadata = os.fstat(descriptor)
+        label = identities.get((metadata.st_dev, metadata.st_ino))
+        if label is not None:
+            events.append(label)
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(cas_module.os, "fsync", record_fsync)
+    producer = _UnconsumableChunks()
+
+    assert store.put_chunks(producer, expected.digest, expected.byte_size) == expected
+    assert events == ["object", "shard"]
+    assert producer.iter_calls == 0
+
+
+@pytest.mark.parametrize("layer", ["object", "shard"])
+@pytest.mark.parametrize("exception_type", [OSError, KeyboardInterrupt, SystemExit])
+def test_put_chunks_reuse_fsync_cancellation_returns_no_receipt_and_replays(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    layer: str,
+    exception_type: type[BaseException],
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = f"reuse-{layer}-{exception_type.__name__}".encode()
+    expected = store.put_bytes(payload)
+    destination = store.root / expected.storage_key
+    object_metadata = destination.stat()
+    shard_metadata = destination.parent.stat()
+    identities = {
+        "object": (object_metadata.st_dev, object_metadata.st_ino),
+        "shard": (shard_metadata.st_dev, shard_metadata.st_ino),
+    }
+    real_fsync = cas_module.os.fsync
+    error = (
+        OSError(errno.EIO, f"{layer} fsync failure")
+        if exception_type is OSError
+        else exception_type(f"{layer} fsync cancellation")
+    )
+    interrupted = False
+
+    def interrupt_fsync(descriptor: int) -> None:
+        nonlocal interrupted
+        metadata = os.fstat(descriptor)
+        if not interrupted and (metadata.st_dev, metadata.st_ino) == identities[layer]:
+            interrupted = True
+            real_fsync(descriptor)
+            raise error
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(cas_module.os, "fsync", interrupt_fsync)
+    producer = _UnconsumableChunks()
+    with pytest.raises(exception_type) as caught:
+        store.put_chunks(producer, expected.digest, expected.byte_size)
+
+    assert caught.value is error
+    assert interrupted
+    assert producer.iter_calls == 0
+
+    events: list[str] = []
+
+    def record_retry(descriptor: int) -> None:
+        metadata = os.fstat(descriptor)
+        identity = (metadata.st_dev, metadata.st_ino)
+        for label, expected_identity in identities.items():
+            if identity == expected_identity:
+                events.append(label)
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(cas_module.os, "fsync", record_retry)
+    assert store.put_chunks(producer, expected.digest, expected.byte_size) == expected
+    assert events == ["object", "shard"]
+    assert producer.iter_calls == 0
+
+
+@pytest.mark.parametrize("layer", ["object", "shard"])
+def test_put_chunks_reuse_rejects_rebinding_across_durability_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    layer: str,
+) -> None:
+    store = LocalCAS.provision(tmp_path / "objects")
+    payload = f"replace-after-{layer}-fsync".encode()
+    expected = store.put_bytes(payload)
+    destination = store.root / expected.storage_key
+    object_metadata = destination.stat()
+    shard_metadata = destination.parent.stat()
+    target_identity = (
+        (object_metadata.st_dev, object_metadata.st_ino)
+        if layer == "object"
+        else (shard_metadata.st_dev, shard_metadata.st_ino)
+    )
+    real_fsync = cas_module.os.fsync
+    replaced = False
+
+    def replace_after_fsync(descriptor: int) -> None:
+        nonlocal replaced
+        real_fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        if not replaced and (metadata.st_dev, metadata.st_ino) == target_identity:
+            replaced = True
+            destination.unlink()
+            destination.write_bytes(payload)
+            destination.chmod(0o600)
+
+    monkeypatch.setattr(cas_module.os, "fsync", replace_after_fsync)
+    producer = _UnconsumableChunks()
+
+    with pytest.raises(StorageIntegrityError, match="failed integrity"):
+        store.put_chunks(producer, expected.digest, expected.byte_size)
+
+    assert replaced
+    assert producer.iter_calls == 0
+
+
+@pytest.mark.parametrize("mismatch", ["digest", "short", "long"])
+def test_put_chunks_identity_mismatch_never_publishes_final_object(
+    tmp_path: Path,
+    mismatch: str,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"identity-bound stream"
+    digest = hashlib.sha256(payload).hexdigest()
+    expected_digest = hashlib.sha256(b"different bytes").hexdigest()
+    expected_size = len(payload)
+    if mismatch == "short":
+        expected_digest = digest
+        expected_size -= 1
+    elif mismatch == "long":
+        expected_digest = digest
+        expected_size += 1
+    destination = store._object_path(expected_digest)
+
+    with pytest.raises(StorageIntegrityError, match="chunk producer"):
+        store.put_chunks([payload], expected_digest, expected_size)
+
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize(
+    "invalid_chunk",
+    [bytearray(b"suffix"), memoryview(b"suffix"), "suffix", 1],
+)
+def test_put_chunks_rejects_non_bytes_without_publishing(
+    tmp_path: Path,
+    invalid_chunk: object,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    expected = b"prefix-suffix"
+    digest = hashlib.sha256(expected).hexdigest()
+    destination = store._object_path(digest)
+
+    with pytest.raises(TypeError, match="must yield bytes"):
+        store.put_chunks(
+            [b"prefix-", invalid_chunk],  # type: ignore[list-item]
+            digest,
+            len(expected),
+        )
+
+    assert not destination.exists()
+
+
+def test_put_chunks_rejects_bytes_subclass_length_forgery(tmp_path: Path) -> None:
+    class ForgedBytes(bytes):
+        def __len__(self) -> int:
+            return 0
+
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"forged-length"
+    digest = hashlib.sha256(payload).hexdigest()
+
+    with pytest.raises(TypeError, match="must yield bytes"):
+        store.put_chunks([ForgedBytes(payload)], digest, 0)
+
+    assert not store._object_path(digest).exists()
+
+
+@pytest.mark.parametrize(
+    "primary",
+    [
+        OSError(errno.EIO, "iterator failed"),
+        KeyboardInterrupt("iterator cancelled"),
+        SystemExit("iterator exited"),
+        GeneratorExit("iterator closed"),
+    ],
+)
+def test_put_chunks_iterator_failure_is_terminal_and_keeps_first_primary(
+    tmp_path: Path,
+    primary: BaseException,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    secondary = RuntimeError("iterator close failed")
+    producer = _ClosableChunks(
+        [],
+        iteration_error=primary,
+        close_error=secondary,
+    )
+    digest = hashlib.sha256(b"expected bytes").hexdigest()
+
+    with pytest.raises(type(primary)) as caught:
+        store.put_chunks(producer, digest, len(b"expected bytes"))
+
+    assert caught.value is primary
+    assert producer.next_calls == 1
+    assert producer.close_calls == 1
+    assert any("iterator close failed" in note for note in _exception_notes(primary))
+    assert not store._object_path(digest).exists()
+
+
+def test_validated_chunks_never_reads_again_after_iterator_failure() -> None:
+    primary = OSError(errno.EIO, "producer read failed")
+    producer = _ClosableChunks([], iteration_error=primary)
+    chunks = cas_module._ValidatedObjectChunks(
+        producer,
+        expected_digest=hashlib.sha256(b"expected").hexdigest(),
+        expected_size=len(b"expected"),
+    )
+
+    with pytest.raises(OSError) as caught:
+        next(chunks)
+    assert caught.value is primary
+    assert producer.next_calls == 1
+
+    with pytest.raises(StopIteration):
+        next(chunks)
+    assert producer.next_calls == 1
+    assert producer.close_calls == 1
+
+
+def test_put_chunks_identity_failure_keeps_primary_over_close_property_fault(
+    tmp_path: Path,
+) -> None:
+    secondary = SystemExit("close property interrupted")
+
+    class ClosePropertyFault:
+        def __init__(self) -> None:
+            self._blocks = iter([b"short"])
+
+        def __iter__(self) -> ClosePropertyFault:
+            return self
+
+        def __next__(self) -> bytes:
+            return next(self._blocks)
+
+        @property
+        def close(self):
+            raise secondary
+
+    store = LocalCAS(tmp_path / "objects")
+    digest = hashlib.sha256(b"short plus more").hexdigest()
+
+    with pytest.raises(StorageIntegrityError, match="size does not match") as caught:
+        store.put_chunks(ClosePropertyFault(), digest, len(b"short plus more"))
+
+    assert any(
+        "close property interrupted" in note for note in _exception_notes(caught.value)
+    )
+    assert not store._object_path(digest).exists()
+
+
+@pytest.mark.parametrize(
+    "close_error",
+    [
+        OSError(errno.EIO, "iterator close failed"),
+        StopIteration("iterator close stopped"),
+    ],
+)
+def test_put_chunks_close_failure_prevents_final_publication(
+    tmp_path: Path,
+    close_error: BaseException,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"complete before close"
+    digest = hashlib.sha256(payload).hexdigest()
+    producer = _ClosableChunks([payload], close_error=close_error)
+
+    expected_type = RuntimeError if isinstance(close_error, StopIteration) else OSError
+    with pytest.raises(expected_type) as caught:
+        store.put_chunks(producer, digest, len(payload))
+
+    if isinstance(close_error, StopIteration):
+        assert caught.value.__cause__ is close_error
+    else:
+        assert caught.value is close_error
+    assert producer.close_calls == 1
+    assert not store._object_path(digest).exists()
+
+
+def test_put_chunks_publication_cancellation_closes_and_keeps_primary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"cancel while writing"
+    digest = hashlib.sha256(payload).hexdigest()
+    primary = KeyboardInterrupt("publication write cancelled")
+    secondary = SystemExit("producer close cancelled")
+    producer = _ClosableChunks([payload], close_error=secondary)
+
+    def interrupt_write(_descriptor: int, _data: object) -> int:
+        raise primary
+
+    monkeypatch.setattr(owned_file_module.os, "write", interrupt_write)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        store.put_chunks(producer, digest, len(payload))
+
+    assert caught.value is primary
+    assert producer.next_calls == 1
+    assert producer.close_calls == 1
+    assert any("producer close cancelled" in note for note in _exception_notes(primary))
+    assert not store._object_path(digest).exists()
 
 
 def test_existing_corrupt_object_is_rejected_instead_of_replaced(

--- a/test/storage/test_contracts.py
+++ b/test/storage/test_contracts.py
@@ -4,8 +4,11 @@
 
 from __future__ import annotations
 
+import hashlib
+
 import pytest
 
+from codenib.storage import StreamingObjectStore
 from codenib.storage.cas import BlobInfo, LocalCAS
 from codenib.storage.models import (
     ObjectRecord,
@@ -33,6 +36,7 @@ def test_embedded_backends_implement_storage_protocols(tmp_path) -> None:
     try:
         assert isinstance(object_store, ObjectStore)
         assert isinstance(object_store, ReceiptVerifyingObjectStore)
+        assert isinstance(object_store, StreamingObjectStore)
         assert isinstance(catalog, IndexCatalog)
         assert isinstance(catalog, JobCatalog)
     finally:
@@ -66,6 +70,57 @@ def test_receipt_verification_is_an_additive_object_store_capability() -> None:
 
     assert isinstance(legacy, ObjectStore)
     assert not isinstance(legacy, ReceiptVerifyingObjectStore)
+    assert not isinstance(legacy, StreamingObjectStore)
+
+
+def test_streaming_is_additive_to_receipt_verifying_object_store() -> None:
+    class ReceiptOnlyObjectStore:
+        def put_bytes(self, data):
+            raise NotImplementedError
+
+        def put_file(self, source):
+            raise NotImplementedError
+
+        def has(self, digest):
+            raise NotImplementedError
+
+        def open(self, digest):
+            raise NotImplementedError
+
+        def read_bytes(self, digest):
+            raise NotImplementedError
+
+        def verify(self, digest):
+            raise NotImplementedError
+
+        def materialize(self, digest, destination):
+            raise NotImplementedError
+
+        def verify_receipt(self, expected):
+            raise NotImplementedError
+
+    receipt_only = ReceiptOnlyObjectStore()
+
+    assert isinstance(receipt_only, ObjectStore)
+    assert isinstance(receipt_only, ReceiptVerifyingObjectStore)
+    assert not isinstance(receipt_only, StreamingObjectStore)
+
+
+def test_streaming_object_store_protocol_executes_expected_identity_put(
+    tmp_path,
+) -> None:
+    object_store: StreamingObjectStore = LocalCAS(tmp_path / "objects")
+    payload = b"protocol streamed object"
+    digest = hashlib.sha256(payload).hexdigest()
+
+    receipt = object_store.put_chunks(
+        iter((payload[:8], payload[8:])),
+        digest,
+        len(payload),
+    )
+
+    assert receipt.digest == digest
+    assert object_store.read_bytes(digest) == payload
 
 
 def test_object_receipt_revalidation_is_executable_and_does_not_pin_lifetime(

--- a/test/storage/test_models.py
+++ b/test/storage/test_models.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import FrozenInstanceError
 
 import pytest
 
 from codenib.storage.models import (
+    VIEW_GENERATION_MEMBERS_METADATA_KEY,
     ArtifactMember,
     ObjectRecord,
     PublishedSnapshot,
@@ -20,6 +22,7 @@ from codenib.storage.models import (
     ViewProfile,
     assert_no_secret_fields,
     canonical_json,
+    normalize_view_generation_metadata,
 )
 
 
@@ -347,3 +350,91 @@ def test_generation_derives_view_identity_from_profile() -> None:
             "a" * 64,
             "1",
         )
+
+
+def test_compound_generation_members_are_publicly_identity_bound() -> None:
+    repository_id = RepositoryIdentity("default", "owner/repo").repository_id
+    source = SourceRevision.clean(
+        repository_id,
+        commit_sha="a" * 40,
+        tree_sha="b" * 64,
+    )
+    profile = ViewProfile.create("portable_context", {})
+    primary = _object("a")
+    first = ViewGeneration.create(
+        source,
+        profile,
+        primary,
+        schema_version="1",
+        metadata={"view_count": 2},
+        member_object_digests=("c" * 64, "b" * 64),
+    )
+    second = ViewGeneration.create(
+        source,
+        profile,
+        primary,
+        schema_version="1",
+        metadata={"view_count": 2},
+        member_object_digests=("b" * 64, "c" * 64),
+    )
+
+    assert first.view_generation_id == second.view_generation_id
+    assert json.loads(first.metadata_json) == {
+        VIEW_GENERATION_MEMBERS_METADATA_KEY: ["b" * 64, "c" * 64],
+        "view_count": 2,
+    }
+    assert first.member_object_digests == ("b" * 64, "c" * 64)
+    legacy = ViewGeneration.create(
+        source,
+        profile,
+        primary,
+        schema_version="1",
+        metadata={"view_count": 2},
+    )
+    assert legacy.view_generation_id != first.view_generation_id
+    assert legacy.member_object_digests == ()
+
+
+@pytest.mark.parametrize(
+    ("members", "match"),
+    [
+        (("b" * 64, "b" * 64), "duplicate"),
+        (("a" * 64,), "primary object"),
+        ("b" * 64, "must be a sequence"),
+    ],
+)
+def test_compound_generation_member_normalization_rejects_ambiguous_inputs(
+    members: object,
+    match: str,
+) -> None:
+    with pytest.raises(StorageValidationError, match=match):
+        normalize_view_generation_metadata(
+            "a" * 64,
+            member_object_digests=members,  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(StorageValidationError, match="reserved"):
+        normalize_view_generation_metadata(
+            "a" * 64,
+            {VIEW_GENERATION_MEMBERS_METADATA_KEY: []},
+        )
+
+    for raw in (
+        None,
+        [],
+        ["b" * 64, "b" * 64],
+        ["c" * 64, "b" * 64],
+        ["B" * 64],
+        ["sha256:" + "b" * 64],
+    ):
+        with pytest.raises(StorageValidationError, match="member metadata"):
+            ViewGeneration(
+                repository_id="repo_id",
+                source_revision_id="source_id",
+                profile=ViewProfile.create("portable_context", {}),
+                object_digest="a" * 64,
+                schema_version="1",
+                metadata_json=canonical_json(
+                    {VIEW_GENERATION_MEMBERS_METADATA_KEY: raw}
+                ),
+            )

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -194,13 +194,11 @@ def test_commit_failure_rolls_back_and_leaves_connection_reusable(tmp_path):
 
         with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
             with catalog._transaction():
-                catalog._connection.execute(
-                    """
+                catalog._connection.execute("""
                     INSERT INTO repositories(
                         repository_id, namespace_id, repository_key, created_at
                     ) VALUES ('invalid-repo', 'missing-namespace', 'invalid', 'now')
-                    """
-                )
+                    """)
 
         assert catalog._connection.in_transaction is False
         assert (
@@ -415,6 +413,28 @@ def test_compound_generation_members_are_identity_bound_and_immutable(tmp_path):
             metadata={"unit_count": 2},
             member_object_digests=(member_two, member_one),
         )
+        source = SourceRevision.clean(
+            repository_id,
+            commit_sha="a" * 40,
+            tree_sha="a" * 64,
+        )
+        profile = ViewProfile.create("semantic_facts", {})
+        primary_record = ObjectRecord(
+            digest=primary,
+            byte_size=12,
+            storage_key=f"sha256/{primary[:2]}/{primary[2:]}",
+        )
+        assert (
+            ViewGeneration.create(
+                source,
+                profile,
+                primary_record,
+                schema_version="1",
+                metadata={"unit_count": 2},
+                member_object_digests=(member_two, member_one),
+            ).view_generation_id
+            == view_id
+        )
         assert (
             catalog.stage_view_generation(
                 repository_id,
@@ -469,6 +489,81 @@ def test_compound_generation_members_are_identity_bound_and_immutable(tmp_path):
                 WHERE view_generation_id = ? AND object_digest = ?
                 """,
                 (view_id, member_one),
+            )
+
+
+@pytest.mark.parametrize(
+    ("column", "corrupt"),
+    [
+        ("digest", lambda value: value.upper()),
+        ("storage_key", lambda value: f" {value} "),
+        ("media_type", lambda value: f" {value} "),
+    ],
+)
+def test_publish_rejects_noncanonical_compound_member_object_metadata(
+    tmp_path,
+    column,
+    corrupt,
+):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id = catalog.create_repository("owner/corrupt-compound")
+        source_revision_id = _source(catalog, repository_id)
+        profile_id = catalog.create_view_profile("semantic_facts", {})
+        primary = _object(catalog, "a")
+        member = _object(catalog, "b")
+        view_id = catalog.stage_view_generation(
+            repository_id,
+            source_revision_id,
+            profile_id,
+            "semantic_facts",
+            primary,
+            schema_version="1",
+            member_object_digests=(member,),
+        )
+        original = catalog._connection.execute(
+            "SELECT * FROM objects WHERE digest = ?",
+            (member,),
+        ).fetchone()
+        assert original is not None
+        catalog._connection.execute("DROP TRIGGER objects_are_immutable")
+        if column == "digest":
+            catalog._connection.execute(
+                "DROP TRIGGER view_generation_objects_are_immutable"
+            )
+            catalog._connection.execute(
+                """
+                INSERT INTO objects(
+                    digest, storage_key, byte_size, media_type, created_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    corrupt(original["digest"]),
+                    "corrupt/member-object",
+                    original["byte_size"],
+                    original["media_type"],
+                    original["created_at"],
+                ),
+            )
+            catalog._connection.execute(
+                """
+                UPDATE view_generation_objects SET object_digest = ?
+                WHERE view_generation_id = ? AND object_digest = ?
+                """,
+                (corrupt(member), view_id, member),
+            )
+        else:
+            catalog._connection.execute(
+                f"UPDATE objects SET {column} = ? WHERE digest = ?",
+                (corrupt(original[column]), member),
+            )
+        catalog._connection.commit()
+
+        with pytest.raises(CatalogConflictError, match="member object metadata"):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                (view_id,),
+                expected_generation=0,
             )
 
 
@@ -1858,12 +1953,10 @@ def test_direct_sql_cannot_seal_invalid_or_expose_building_snapshots(tmp_path):
             (ready_view,),
         )
         with pytest.raises(sqlite3.IntegrityError, match="snapshot seal"):
-            catalog._connection.execute(
-                """
+            catalog._connection.execute("""
                 UPDATE snapshots SET status = 'ready', published_at = 'now'
                 WHERE snapshot_id = 'cross-source'
-                """
-            )
+                """)
 
         catalog._connection.execute(
             """
@@ -1882,12 +1975,10 @@ def test_direct_sql_cannot_seal_invalid_or_expose_building_snapshots(tmp_path):
             (staged_view,),
         )
         with pytest.raises(sqlite3.IntegrityError, match="snapshot seal"):
-            catalog._connection.execute(
-                """
+            catalog._connection.execute("""
                 UPDATE snapshots SET status = 'ready', published_at = 'now'
                 WHERE snapshot_id = 'staged-view'
-                """
-            )
+                """)
 
         catalog._connection.execute(
             """
@@ -1899,12 +1990,10 @@ def test_direct_sql_cannot_seal_invalid_or_expose_building_snapshots(tmp_path):
             (repository_two, source_two),
         )
         with pytest.raises(sqlite3.IntegrityError, match="snapshot seal"):
-            catalog._connection.execute(
-                """
+            catalog._connection.execute("""
                 UPDATE snapshots SET status = 'ready', published_at = 'now'
                 WHERE snapshot_id = 'empty'
-                """
-            )
+                """)
         with pytest.raises(CatalogValidationError, match="not ready"):
             catalog.get_manifest_summary("empty")
 
@@ -1951,15 +2040,13 @@ def test_late_ref_failure_rolls_back_building_snapshot_and_view_seal(tmp_path):
             profile_id,
             _object(catalog, "a"),
         )
-        catalog._connection.execute(
-            """
+        catalog._connection.execute("""
             CREATE TRIGGER fail_ref_publication
             BEFORE INSERT ON refs
             BEGIN
                 SELECT RAISE(ABORT, 'simulated ref failure');
             END
-            """
-        )
+            """)
 
         with pytest.raises(sqlite3.IntegrityError, match="simulated ref failure"):
             catalog.publish_snapshot(

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -194,11 +194,13 @@ def test_commit_failure_rolls_back_and_leaves_connection_reusable(tmp_path):
 
         with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
             with catalog._transaction():
-                catalog._connection.execute("""
+                catalog._connection.execute(
+                    """
                     INSERT INTO repositories(
                         repository_id, namespace_id, repository_key, created_at
                     ) VALUES ('invalid-repo', 'missing-namespace', 'invalid', 'now')
-                    """)
+                    """
+                )
 
         assert catalog._connection.in_transaction is False
         assert (
@@ -1953,10 +1955,12 @@ def test_direct_sql_cannot_seal_invalid_or_expose_building_snapshots(tmp_path):
             (ready_view,),
         )
         with pytest.raises(sqlite3.IntegrityError, match="snapshot seal"):
-            catalog._connection.execute("""
+            catalog._connection.execute(
+                """
                 UPDATE snapshots SET status = 'ready', published_at = 'now'
                 WHERE snapshot_id = 'cross-source'
-                """)
+                """
+            )
 
         catalog._connection.execute(
             """
@@ -1975,10 +1979,12 @@ def test_direct_sql_cannot_seal_invalid_or_expose_building_snapshots(tmp_path):
             (staged_view,),
         )
         with pytest.raises(sqlite3.IntegrityError, match="snapshot seal"):
-            catalog._connection.execute("""
+            catalog._connection.execute(
+                """
                 UPDATE snapshots SET status = 'ready', published_at = 'now'
                 WHERE snapshot_id = 'staged-view'
-                """)
+                """
+            )
 
         catalog._connection.execute(
             """
@@ -1990,10 +1996,12 @@ def test_direct_sql_cannot_seal_invalid_or_expose_building_snapshots(tmp_path):
             (repository_two, source_two),
         )
         with pytest.raises(sqlite3.IntegrityError, match="snapshot seal"):
-            catalog._connection.execute("""
+            catalog._connection.execute(
+                """
                 UPDATE snapshots SET status = 'ready', published_at = 'now'
                 WHERE snapshot_id = 'empty'
-                """)
+                """
+            )
         with pytest.raises(CatalogValidationError, match="not ready"):
             catalog.get_manifest_summary("empty")
 
@@ -2040,13 +2048,15 @@ def test_late_ref_failure_rolls_back_building_snapshot_and_view_seal(tmp_path):
             profile_id,
             _object(catalog, "a"),
         )
-        catalog._connection.execute("""
+        catalog._connection.execute(
+            """
             CREATE TRIGGER fail_ref_publication
             BEFORE INSERT ON refs
             BEGIN
                 SELECT RAISE(ABORT, 'simulated ref failure');
             END
-            """)
+            """
+        )
 
         with pytest.raises(sqlite3.IntegrityError, match="simulated ref failure"):
             catalog.publish_snapshot(

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -230,6 +230,7 @@ def _install_fake_windows_api(
 
     monkeypatch.setattr(atomic_module.sys, "platform", "win32")
     monkeypatch.setattr(atomic_module, "_windows_kernel_api", lambda: api)
+    monkeypatch.setattr(atomic_module, "_windows_require_publication_api", lambda: None)
     monkeypatch.setattr(
         atomic_module._windows_fs,
         "open_lexical_directory_authority",
@@ -7910,6 +7911,9 @@ def test_publication_authority_close_preserves_close_error_over_state_probe() ->
     assert any("secondary close-state interruption" in note for note in notes)
     assert not authority._close_state
     assert authority_owner.authority is authority
+    authority._close_callback = lambda _resource: None
+    authority._close_complete_callback = lambda: True
+    authority_owner.close()
 
 
 @pytest.mark.skipif(
@@ -8497,3 +8501,1289 @@ def test_resource_owner_documents_native_p2_boundary() -> None:
     assert "raw" in posix_source and "native owning object" in posix_source
     assert "raw HANDLE" in windows_source and "native owning object" in windows_source
     assert "exact dup2 ABA" in reconciliation_source
+
+
+def test_project_directory_ownership_subtree_matches_capture_without_io(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outer = tmp_path / "outer"
+    selected = outer / "selected"
+    nested = selected / "nested"
+    empty = selected / "empty"
+    nested.mkdir(parents=True)
+    empty.mkdir()
+    (outer / "outside.txt").write_bytes(b"outside")
+    (selected / "root.txt").write_bytes(b"root")
+    (nested / "payload.bin").write_bytes(b"payload")
+    outer_ownership = capture_directory_ownership(outer)
+    selected_ownership = capture_directory_ownership(selected)
+    nested_ownership = capture_directory_ownership(nested)
+
+    def unexpected_io(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("subtree ownership projection performed I/O")
+
+    for name in ("open", "read", "stat", "fstat", "scandir"):
+        monkeypatch.setattr(atomic_module.os, name, unexpected_io)
+
+    assert (
+        atomic_module.project_directory_ownership_subtree(
+            outer_ownership,
+            "selected",
+        )
+        == selected_ownership
+    )
+    assert (
+        atomic_module.project_directory_ownership_subtree(
+            outer_ownership,
+            PurePosixPath("selected/nested"),
+        )
+        == nested_ownership
+    )
+    assert (
+        atomic_module.project_directory_ownership_subtree(
+            outer_ownership,
+            "selected/empty",
+        ).inventory
+        == ()
+    )
+    assert "project_directory_ownership_subtree" in atomic_module.__all__
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    ["", ".", "..", "/selected", "selected/", "selected//nested", "x/../y"],
+)
+def test_project_directory_ownership_subtree_rejects_noncanonical_prefix(
+    tmp_path: Path,
+    prefix: str,
+) -> None:
+    outer = tmp_path / "outer"
+    (outer / "selected").mkdir(parents=True)
+    ownership = capture_directory_ownership(outer)
+
+    with pytest.raises(ValueError, match="subtree prefix"):
+        atomic_module.project_directory_ownership_subtree(ownership, prefix)
+
+
+def test_project_directory_ownership_subtree_rejects_forged_token(
+    tmp_path: Path,
+) -> None:
+    outer = tmp_path / "outer"
+    selected = outer / "selected"
+    selected.mkdir(parents=True)
+    (selected / "payload.bin").write_bytes(b"payload")
+    ownership = capture_directory_ownership(outer)
+    record = ownership.file_records[0]
+    forged = (
+        replace(ownership, digest="0" * 64),
+        replace(ownership, entries=ownership.entries + 1),
+        replace(ownership, byte_count=ownership.byte_count + 1),
+        replace(ownership, inventory=tuple(reversed(ownership.inventory))),
+        replace(
+            ownership,
+            file_records=(replace(record, sha256=" " * 64),),
+        ),
+    )
+
+    for token in forged:
+        with pytest.raises(RuntimeError, match="directory ownership token"):
+            atomic_module.project_directory_ownership_subtree(token, "selected")
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX raw path names")
+def test_project_directory_ownership_subtree_preserves_raw_posix_names(
+    tmp_path: Path,
+) -> None:
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    outer_descriptor = os.open(outer, os.O_RDONLY | os.O_DIRECTORY)
+    raw_name = b"raw\xff"
+    try:
+        os.mkdir(raw_name, dir_fd=outer_descriptor)
+        child_descriptor = os.open(
+            raw_name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            dir_fd=outer_descriptor,
+        )
+        try:
+            payload = os.open(
+                b"payload\xfe.bin",
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=child_descriptor,
+            )
+            try:
+                os.write(payload, b"payload")
+            finally:
+                os.close(payload)
+            expected = atomic_module._capture_posix_directory_descriptor(
+                child_descriptor,
+                outer / os.fsdecode(raw_name),
+                required_root_file=None,
+                allow_empty_root=False,
+                entry_policy=None,
+            )
+        finally:
+            os.close(child_descriptor)
+    finally:
+        os.close(outer_descriptor)
+
+    outer_ownership = capture_directory_ownership(outer)
+    assert (
+        atomic_module.project_directory_ownership_subtree(
+            outer_ownership,
+            os.fsdecode(raw_name),
+        )
+        == expected
+    )
+
+
+def test_authenticated_reader_subtree_is_prefix_relative_and_lifetime_bound(
+    tmp_path: Path,
+) -> None:
+    outer = tmp_path / "outer"
+    nested = outer / "selected" / "nested"
+    nested.mkdir(parents=True)
+    (outer / "outside.bin").write_bytes(b"outside")
+    (outer / "selected" / "root.bin").write_bytes(b"root")
+    (nested / "payload.bin").write_bytes(b"payload")
+    ownership = capture_directory_ownership(outer)
+    saved: list[atomic_module.PublicationDirectoryReader] = []
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> bytes:
+        selected = reader.subtree("selected")
+        nested_reader = selected.subtree("nested")
+        saved.extend((selected, nested_reader))
+        assert selected.inventory() == (
+            ("nested", "directory"),
+            ("nested/payload.bin", "file"),
+            ("root.bin", "file"),
+        )
+        assert tuple(record.path for record in selected.file_records()) == (
+            "nested/payload.bin",
+            "root.bin",
+        )
+        assert selected.capture_ownership() == (
+            atomic_module.project_directory_ownership_subtree(ownership, "selected")
+        )
+        for escaped in ("../outside.bin", "/outside.bin", "nested/../../outside.bin"):
+            with pytest.raises(ValueError, match="publication reader"):
+                selected.read_bytes(escaped, max_bytes=64)
+        snapshot = nested_reader.authenticated_snapshot(
+            "payload.bin",
+            max_bytes=64,
+        )
+        assert snapshot.record.path == "payload.bin"
+        return snapshot.read_bytes()
+
+    assert (
+        atomic_module.reopen_authenticated_directory(
+            outer,
+            ownership,
+            consume,
+        )
+        == b"payload"
+    )
+    for reader in saved:
+        with pytest.raises(RuntimeError, match="no longer active"):
+            reader.inventory()
+
+
+def test_fake_windows_reader_subtree_keeps_prefix_relative_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    owned_id = api.add_directory(api.root_id, "owned")
+    selected_id = api.add_directory(owned_id, "sélected")
+    nested_id = api.add_directory(selected_id, "子")
+    api.add_file(owned_id, "outside.bin", b"outside")
+    api.add_file(selected_id, "root.bin", b"root")
+    api.add_file(nested_id, "payload.bin", b"payload")
+    owned_handle = api._new_handle(owned_id)
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            owned_handle,
+            Path("C:/authority/owned"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+    finally:
+        api.close(owned_handle)
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> bytes:
+        selected = reader.subtree("sélected")
+        assert tuple(record.path for record in selected.file_records()) == (
+            "root.bin",
+            "子/payload.bin",
+        )
+        with pytest.raises(ValueError, match="publication reader"):
+            selected.read_bytes("../outside.bin", max_bytes=64)
+        return selected.subtree("子").read_bytes("payload.bin", max_bytes=64)
+
+    _install_fake_windows_api(monkeypatch, api)
+
+    assert (
+        atomic_module.reopen_authenticated_directory(
+            Path("C:/authority/owned"),
+            ownership,
+            consume,
+        )
+        == b"payload"
+    )
+    assert api.handles == {}
+
+
+def test_reopen_closes_manual_file_and_hidden_iterator_escapes(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "payload.bin").write_bytes(b"payload-data")
+    ownership = capture_directory_ownership(directory)
+    escaped_files: list[atomic_module.PublicationAuthenticatedFile] = []
+    escaped_contexts: list[object] = []
+    escaped_iterators: list[object] = []
+    hidden_readers: list[object] = []
+
+    def consume(
+        reader: atomic_module.PublicationDirectoryReader,
+    ) -> atomic_module.PublicationAuthenticatedFile:
+        file_context = reader.open_authenticated_file(
+            "payload.bin",
+            max_bytes=64,
+        )
+        authenticated = file_context.__enter__()
+        assert authenticated.read(2) == b"pa"
+        chunk_context = reader.iter_authenticated_chunks(
+            "payload.bin",
+            max_bytes=64,
+            chunk_size=3,
+        )
+        chunks = chunk_context.__enter__()
+        assert next(chunks) == b"pay"
+        escaped_files.extend((authenticated,))
+        escaped_contexts.extend((file_context, chunk_context))
+        escaped_iterators.append(chunks)
+        hidden_readers.append(lambda: authenticated.read(1))
+        return authenticated
+
+    returned = atomic_module.reopen_authenticated_directory(
+        directory,
+        ownership,
+        consume,
+    )
+
+    assert returned is escaped_files[0]
+    assert returned.record.sha256 == hashlib.sha256(b"payload-data").hexdigest()
+    with pytest.raises(ValueError, match="closed"):
+        returned.read(1)
+    with pytest.raises(ValueError, match="closed"):
+        hidden_readers[0]()
+    with pytest.raises(StopIteration):
+        next(escaped_iterators[0])
+    assert escaped_contexts[0].__exit__(None, None, None) is False
+    assert escaped_contexts[1].__exit__(None, None, None) is False
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+@pytest.mark.parametrize("primary_type", [KeyboardInterrupt, SystemExit, GeneratorExit])
+def test_posix_manual_stream_escape_aborts_without_drain_on_callback_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    primary_type: type[BaseException],
+) -> None:
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    payload = b"prefix-" + (b"x" * (2 << 20))
+    (directory / "payload.bin").write_bytes(payload)
+    ownership = capture_directory_ownership(directory)
+    real_read = atomic_module.os.read
+    target = -1
+    target_reads: list[bytes] = []
+    escaped: list[atomic_module.PublicationAuthenticatedFile] = []
+    primary = primary_type("callback primary")
+
+    def track_read(descriptor: int, size: int) -> bytes:
+        block = real_read(descriptor, size)
+        if descriptor == target and escaped and not escaped[0]._closed:
+            target_reads.append(block)
+        return block
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> None:
+        nonlocal target
+        context = reader.open_authenticated_file(
+            "payload.bin",
+            max_bytes=len(payload),
+        )
+        authenticated = context.__enter__()
+        escaped.append(authenticated)
+        target = next(
+            cell.cell_contents
+            for cell in (authenticated._read_callback.__closure__ or ())
+            if isinstance(cell.cell_contents, int)
+        )
+        assert authenticated.read(7) == b"prefix-"
+        raise primary
+
+    monkeypatch.setattr(atomic_module.os, "read", track_read)
+    with pytest.raises(primary_type) as caught:
+        atomic_module.reopen_authenticated_directory(directory, ownership, consume)
+
+    assert caught.value is primary
+    assert target_reads == [b"prefix-"]
+    with pytest.raises(ValueError, match="closed"):
+        escaped[0].read(1)
+    with pytest.raises(RuntimeError, match="after context verification"):
+        _ = escaped[0].record
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_manual_stream_aborts_on_callback_result_return_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    payload = b"prefix-" + (b"x" * (2 << 20))
+    (directory / "payload.bin").write_bytes(payload)
+    ownership = capture_directory_ownership(directory)
+    real_read = atomic_module.os.read
+    target = -1
+    target_reads: list[bytes] = []
+    escaped: list[atomic_module.PublicationAuthenticatedFile] = []
+    interruption = KeyboardInterrupt("callback return cancellation")
+
+    def track_read(descriptor: int, size: int) -> bytes:
+        block = real_read(descriptor, size)
+        if descriptor == target and escaped and not escaped[0]._closed:
+            target_reads.append(block)
+        return block
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> int:
+        nonlocal target
+        context = reader.open_authenticated_file(
+            "payload.bin",
+            max_bytes=len(payload),
+        )
+        authenticated = context.__enter__()
+        escaped.append(authenticated)
+        target = next(
+            cell.cell_contents
+            for cell in (authenticated._read_callback.__closure__ or ())
+            if isinstance(cell.cell_contents, int)
+        )
+        assert authenticated.read(7) == b"prefix-"
+        return 7
+
+    monkeypatch.setattr(atomic_module.os, "read", track_read)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _call_with_interrupt_after_store(
+            atomic_module._run_publication_reader_callback,
+            "result",
+            lambda: atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                consume,
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert target_reads == [b"prefix-"]
+    with pytest.raises(ValueError, match="closed"):
+        escaped[0].read(1)
+
+
+@pytest.mark.parametrize("primary_type", [KeyboardInterrupt, SystemExit, GeneratorExit])
+def test_fake_windows_manual_stream_aborts_without_drain_on_callback_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    primary_type: type[BaseException],
+) -> None:
+    api = _FakeWindowsApi()
+    child_id = api.add_directory(api.root_id, "owned")
+    payload = b"prefix-" + (b"x" * (2 << 20))
+    api.add_file(child_id, "payload.bin", payload)
+    child_handle = api._new_handle(child_id)
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            child_handle,
+            Path("C:/authority/owned"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+    finally:
+        api.close(child_handle)
+    real_read = api.read
+    target = 0
+    target_reads: list[bytes] = []
+    escaped: list[atomic_module.PublicationAuthenticatedFile] = []
+    primary = primary_type("callback primary")
+
+    def track_read(handle: int, size: int) -> bytes:
+        block = real_read(handle, size)
+        if handle == target and escaped and not escaped[0]._closed:
+            target_reads.append(block)
+        return block
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> None:
+        nonlocal target
+        context = reader.open_authenticated_file(
+            "payload.bin",
+            max_bytes=len(payload),
+        )
+        authenticated = context.__enter__()
+        escaped.append(authenticated)
+        target = next(
+            cell.cell_contents
+            for cell in (authenticated._read_callback.__closure__ or ())
+            if isinstance(cell.cell_contents, int)
+        )
+        assert authenticated.read(7) == b"prefix-"
+        raise primary
+
+    _install_fake_windows_api(monkeypatch, api)
+    monkeypatch.setattr(api, "read", track_read)
+    with pytest.raises(primary_type) as caught:
+        atomic_module.reopen_authenticated_directory(
+            Path("C:/authority/owned"),
+            ownership,
+            consume,
+        )
+
+    assert caught.value is primary
+    assert target_reads == [b"prefix-"]
+    with pytest.raises(ValueError, match="closed"):
+        escaped[0].read(1)
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_public_reopen_retains_posix_stream_close_for_explicit_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "payload.bin").write_bytes(b"payload")
+    ownership = capture_directory_ownership(directory)
+    real_close = atomic_module.os.close
+    close_error = OSError(errno.EIO, "persistent authenticated close failure")
+    target = -1
+
+    def fail_stream_close(descriptor: int) -> None:
+        nonlocal target
+        if target < 0 and stat.S_ISREG(os.fstat(descriptor).st_mode):
+            target = descriptor
+        if descriptor == target:
+            raise close_error
+        real_close(descriptor)
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> None:
+        monkeypatch.setattr(atomic_module.os, "close", fail_stream_close)
+        with reader.open_authenticated_file(
+            "payload.bin",
+            max_bytes=64,
+        ) as authenticated:
+            assert authenticated.read(2) == b"pa"
+
+    try:
+        with pytest.raises(OSError) as caught:
+            atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                consume,
+            )
+        assert caught.value is close_error
+        assert target >= 0
+        os.fstat(target)
+        assert len(atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS) == 1
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        atomic_module.retry_retained_publication_cleanup()
+
+    assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+    _assert_descriptor_closed(target)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_escaped_stream_cleanup_preserves_primary_and_attempts_every_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "first.bin").write_bytes(b"first")
+    (directory / "second.bin").write_bytes(b"second")
+    ownership = capture_directory_ownership(directory)
+    real_close = atomic_module.os.close
+    primary = KeyboardInterrupt("callback primary")
+    targets: list[int] = []
+    close_calls: dict[int, int] = {}
+    close_errors: dict[int, OSError] = {}
+
+    def fail_stream_closes(descriptor: int) -> None:
+        if descriptor in targets:
+            close_calls[descriptor] = close_calls.get(descriptor, 0) + 1
+            error = close_errors.setdefault(
+                descriptor,
+                OSError(errno.EIO, f"persistent close failure {descriptor}"),
+            )
+            raise error
+        real_close(descriptor)
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> None:
+        for path in ("first.bin", "second.bin"):
+            context = reader.open_authenticated_file(path, max_bytes=64)
+            authenticated = context.__enter__()
+            authenticated.read(1)
+            descriptor = next(
+                cell.cell_contents
+                for cell in (authenticated._read_callback.__closure__ or ())
+                if isinstance(cell.cell_contents, int)
+            )
+            targets.append(descriptor)
+        monkeypatch.setattr(atomic_module.os, "close", fail_stream_closes)
+        raise primary
+
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                consume,
+            )
+        assert caught.value is primary
+        assert len(set(targets)) == 2
+        assert all(close_calls[target] >= 2 for target in targets)
+        notes = _exception_notes(primary)
+        for error in close_errors.values():
+            assert any(repr(error) in note for note in notes)
+        assert len(atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS) == 1
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        atomic_module.retry_retained_publication_cleanup()
+
+    for target in targets:
+        _assert_descriptor_closed(target)
+
+
+def test_public_reopen_retains_fake_windows_stream_close_for_explicit_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    api = _FakeWindowsApi()
+    child_id = api.add_directory(api.root_id, "owned")
+    api.add_file(child_id, "payload.bin", b"payload")
+    child_handle = api._new_handle(child_id)
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            child_handle,
+            Path("C:/authority/owned"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+    finally:
+        api.close(child_handle)
+    real_close = api.close
+    close_error = OSError(errno.EIO, "persistent authenticated HANDLE failure")
+    target = 0
+
+    def fail_stream_close(handle: int) -> None:
+        nonlocal target
+        if not target and stat.S_ISREG(api.metadata(handle).st_mode):
+            target = handle
+        if handle == target:
+            raise close_error
+        real_close(handle)
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> None:
+        monkeypatch.setattr(api, "close", fail_stream_close)
+        with reader.open_authenticated_file(
+            "payload.bin",
+            max_bytes=64,
+        ) as authenticated:
+            assert authenticated.read(2) == b"pa"
+
+    _install_fake_windows_api(monkeypatch, api)
+    try:
+        with pytest.raises(OSError) as caught:
+            atomic_module.reopen_authenticated_directory(
+                Path("C:/authority/owned"),
+                ownership,
+                consume,
+            )
+        assert caught.value is close_error
+        assert target in api.handles
+        assert len(atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS) == 1
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        atomic_module.retry_retained_publication_cleanup()
+
+    assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+    assert api.handles == {}
+
+
+def test_retry_retained_cleanup_preserves_first_and_attempts_every_owner() -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    first = KeyboardInterrupt("first retained cleanup failure")
+    second = SystemExit("second retained cleanup failure")
+    failures: list[BaseException | None] = [first, second]
+    calls = [0, 0]
+    closed = [False, False]
+    owners: list[atomic_module._PublicationAuthorityOwner] = []
+
+    for index in range(2):
+
+        def close_resource(_resource: int, *, selected: int = index) -> None:
+            calls[selected] += 1
+            failure = failures[selected]
+            if failure is not None:
+                raise failure
+            closed[selected] = True
+
+        authority = atomic_module._PublicationAuthority(
+            display_parent=Path("/authority"),
+            identity=(1, index + 1),
+            backend_tag="test",
+            resource=index + 1,
+            close_callback=close_resource,
+            metadata_callback=lambda _name, _path, _label: None,
+            reader_callback=lambda *_args: None,
+            rename_callback=lambda _source, _destination: None,
+            verify_callback=lambda: None,
+            close_complete_callback=lambda selected=index: closed[selected],
+        )
+        owner = atomic_module._PublicationAuthorityOwner()
+        owner.install(authority)
+        owners.append(owner)
+
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            atomic_module.retry_retained_publication_cleanup()
+        assert caught.value is first
+        assert calls == [1, 1]
+        assert any(repr(second) in note for note in _exception_notes(first))
+        assert all(owner.authority is not None for owner in owners)
+    finally:
+        failures[:] = [None, None]
+        atomic_module.retry_retained_publication_cleanup()
+
+    assert closed == [True, True]
+    assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or not hasattr(os, "fork"),
+    reason="requires real POSIX fork semantics",
+)
+def test_retained_authority_registry_rehomes_and_closes_in_real_child(
+    tmp_path: Path,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    owner = atomic_module._PublicationAuthorityOwner()
+    authority = atomic_module._open_posix_publication_authority(
+        tmp_path,
+        parent_resource=None,
+        expected_parent_identity=None,
+        authority_owner=owner,
+    )
+    resources = _posix_authority_resources(authority)
+    inherited = tuple(
+        record.descriptor for record in resources._records if record.descriptor >= 0
+    )
+    child = os.fork()
+    if child == 0:
+        try:
+            try:
+                authority.verify_path_binding()
+            except RuntimeError as error:
+                if "process boundary" not in str(error):
+                    os._exit(11)
+            else:
+                os._exit(12)
+            atomic_module.retry_retained_publication_cleanup()
+            if atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS:
+                os._exit(13)
+            for descriptor in inherited:
+                try:
+                    os.fstat(descriptor)
+                except OSError as error:
+                    if error.errno != errno.EBADF:
+                        os._exit(14)
+                else:
+                    os._exit(15)
+            os._exit(0)
+        except BaseException:  # noqa: B036 - child reports failure by exit status
+            os._exit(16)
+
+    waited, status = os.waitpid(child, 0)
+    assert waited == child
+    assert os.waitstatus_to_exitcode(status) == 0
+    authority.verify_path_binding()
+    for descriptor in inherited:
+        os.fstat(descriptor)
+    owner.close()
+    assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or not hasattr(os, "fork"),
+    reason="requires real POSIX fork semantics",
+)
+def test_reader_and_authenticated_file_reject_real_fork_escape(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "payload.bin").write_bytes(b"payload")
+    ownership = capture_directory_ownership(directory)
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> None:
+        with reader.open_authenticated_file(
+            "payload.bin",
+            max_bytes=64,
+        ) as authenticated:
+            child = os.fork()
+            if child == 0:
+                try:
+                    for callback in (
+                        reader.inventory,
+                        lambda: authenticated.read(1),
+                    ):
+                        try:
+                            callback()
+                        except RuntimeError as error:
+                            if "process boundary" not in str(error):
+                                os._exit(21)
+                        else:
+                            os._exit(22)
+                    os._exit(0)
+                except BaseException:  # noqa: B036 - child reports by exit status
+                    os._exit(23)
+            waited, status = os.waitpid(child, 0)
+            assert waited == child
+            assert os.waitstatus_to_exitcode(status) == 0
+            assert authenticated.read() == b"payload"
+
+    atomic_module.reopen_authenticated_directory(directory, ownership, consume)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_capture_retains_posix_regular_file_close_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "payload.bin").write_bytes(b"payload")
+    real_close = atomic_module.os.close
+    close_error = OSError(errno.EIO, "persistent ownership file close failure")
+    target = -1
+
+    def fail_regular_file_close(descriptor: int) -> None:
+        nonlocal target
+        if target < 0 and stat.S_ISREG(os.fstat(descriptor).st_mode):
+            target = descriptor
+        if descriptor == target:
+            raise close_error
+        real_close(descriptor)
+
+    try:
+        monkeypatch.setattr(atomic_module.os, "close", fail_regular_file_close)
+        with pytest.raises(OSError) as caught:
+            atomic_module.capture_directory_ownership(directory)
+        assert caught.value is close_error
+        assert target >= 0
+        os.fstat(target)
+        assert len(atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS) == 1
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        atomic_module.retry_retained_publication_cleanup()
+
+    assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+    _assert_descriptor_closed(target)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or not hasattr(os, "fork"),
+    reason="requires real POSIX fork semantics",
+)
+def test_capture_retained_regular_file_cleanup_rehomes_across_fork(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "payload.bin").write_bytes(b"payload")
+    real_close = atomic_module.os.close
+    close_error = OSError(errno.EIO, "persistent ownership file close failure")
+    target = -1
+
+    def fail_regular_file_close(descriptor: int) -> None:
+        nonlocal target
+        if target < 0 and stat.S_ISREG(os.fstat(descriptor).st_mode):
+            target = descriptor
+        if descriptor == target:
+            raise close_error
+        real_close(descriptor)
+
+    monkeypatch.setattr(atomic_module.os, "close", fail_regular_file_close)
+    with pytest.raises(OSError) as caught:
+        atomic_module.capture_directory_ownership(directory)
+    assert caught.value is close_error
+    assert target >= 0
+    assert len(atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS) == 1
+    monkeypatch.setattr(atomic_module.os, "close", real_close)
+
+    child = os.fork()
+    if child == 0:
+        try:
+            atomic_module.retry_retained_publication_cleanup()
+            if atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS:
+                os._exit(31)
+            try:
+                os.fstat(target)
+            except OSError as error:
+                if error.errno != errno.EBADF:
+                    os._exit(32)
+            else:
+                os._exit(33)
+            os._exit(0)
+        except BaseException:  # noqa: B036 - child reports by exit status
+            os._exit(34)
+
+    waited, status = os.waitpid(child, 0)
+    assert waited == child
+    assert os.waitstatus_to_exitcode(status) == 0
+    os.fstat(target)
+    atomic_module.retry_retained_publication_cleanup()
+    assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+    _assert_descriptor_closed(target)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor semantics",
+)
+def test_post_callback_capture_close_failure_keeps_callback_primary_and_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "payload.bin").write_bytes(b"payload")
+    ownership = capture_directory_ownership(directory)
+    real_close = atomic_module.os.close
+    callback_error = ValueError("callback primary")
+    close_error = OSError(errno.EIO, "post-callback ownership close failure")
+    target = -1
+
+    def fail_regular_file_close(descriptor: int) -> None:
+        nonlocal target
+        if target < 0 and stat.S_ISREG(os.fstat(descriptor).st_mode):
+            target = descriptor
+        if descriptor == target:
+            raise close_error
+        real_close(descriptor)
+
+    def consume(_reader: atomic_module.PublicationDirectoryReader) -> None:
+        monkeypatch.setattr(atomic_module.os, "close", fail_regular_file_close)
+        raise callback_error
+
+    try:
+        with pytest.raises(ValueError) as caught:
+            atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                consume,
+            )
+        assert caught.value is callback_error
+        assert target >= 0
+        os.fstat(target)
+        assert any(
+            repr(close_error) in note for note in _exception_notes(callback_error)
+        )
+        assert len(atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS) == 1
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        atomic_module.retry_retained_publication_cleanup()
+
+    assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+    _assert_descriptor_closed(target)
+
+
+def test_capture_retains_fake_windows_regular_file_close_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    api = _FakeWindowsApi()
+    owned_id = api.add_directory(api.root_id, "owned")
+    api.add_file(owned_id, "payload.bin", b"payload")
+    owned_handle = api._new_handle(owned_id)
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            owned_handle,
+            Path("C:/authority/owned"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+    finally:
+        api.close(owned_handle)
+    real_close = api.close
+    close_error = OSError(errno.EIO, "persistent ownership HANDLE close failure")
+    target = 0
+
+    def fail_regular_file_close(handle: int) -> None:
+        nonlocal target
+        if not target and stat.S_ISREG(api.metadata(handle).st_mode):
+            target = handle
+        if handle == target:
+            raise close_error
+        real_close(handle)
+
+    _install_fake_windows_api(monkeypatch, api)
+    try:
+        monkeypatch.setattr(api, "close", fail_regular_file_close)
+        with pytest.raises(OSError) as caught:
+            atomic_module.reopen_authenticated_directory(
+                Path("C:/authority/owned"),
+                ownership,
+                lambda _reader: None,
+            )
+        assert caught.value is close_error
+        assert target in api.handles
+        assert len(atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS) == 1
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        atomic_module.retry_retained_publication_cleanup()
+
+    assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+    assert api.handles == {}
+
+
+def _call_with_interrupt_before_reader_inactive_store(
+    callback: object,
+    *,
+    error: BaseException,
+    event_mode: str,
+) -> None:
+    assert callable(callback)
+    assert event_mode in {"opcode", "line"}
+    code = atomic_module._force_publication_reader_inactive.__code__
+    store_offsets = {
+        instruction.offset
+        for instruction in dis.get_instructions(
+            atomic_module._force_publication_reader_inactive
+        )
+        if instruction.opname == "STORE_ATTR" and instruction.argval == "active"
+    }
+    assert store_offsets
+    source, first_line = inspect.getsourcelines(
+        atomic_module._force_publication_reader_inactive
+    )
+    assignment_lines = {
+        first_line + offset
+        for offset, line in enumerate(source)
+        if "lifetime.active = False" in line
+    }
+    assert len(assignment_lines) == 1
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is code
+            and (
+                (
+                    event_mode == "opcode"
+                    and event == "opcode"
+                    and frame.f_lasti in store_offsets
+                )
+                or (
+                    event_mode == "line"
+                    and event == "line"
+                    and frame.f_lineno in assignment_lines
+                )
+            )
+            and frame.f_locals["lifetime"].active
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, "failed to inject before reader inactive STORE_ATTR"
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor reuse semantics",
+)
+def test_posix_reader_deactivation_interrupt_closes_child_and_rejects_aba(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "payload.bin").write_bytes(b"payload")
+    ownership = capture_directory_ownership(directory)
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    foreign_source = os.open(
+        foreign,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    foreign_identity = atomic_module._resource_owner_identity(os.fstat(foreign_source))
+    real_close = atomic_module.os.close
+    deactivation_error = KeyboardInterrupt("reader deactivation interruption")
+    close_error = SystemExit("child close ABA interruption")
+    target = -1
+    reused = False
+    saved: list[atomic_module.PublicationDirectoryReader] = []
+
+    def close_then_reuse(descriptor: int) -> None:
+        nonlocal reused
+        real_close(descriptor)
+        if descriptor == target and not reused:
+            os.dup2(foreign_source, descriptor)
+            reused = True
+            raise close_error
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> int:
+        nonlocal target
+        saved.append(reader)
+        target = next(
+            cell.cell_contents
+            for cell in (reader._capture.__closure__ or ())
+            if isinstance(cell.cell_contents, int)
+        )
+        monkeypatch.setattr(atomic_module.os, "close", close_then_reuse)
+        return 7
+
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            _call_with_interrupt_before_reader_inactive_store(
+                lambda: atomic_module.reopen_authenticated_directory(
+                    directory,
+                    ownership,
+                    consume,
+                ),
+                error=deactivation_error,
+                event_mode="opcode",
+            )
+        assert caught.value is deactivation_error
+        assert reused
+        assert any(repr(close_error) in note for note in _exception_notes(caught.value))
+        assert atomic_module._resource_owner_identity(os.fstat(target)) == (
+            foreign_identity
+        )
+        with pytest.raises(RuntimeError, match="no longer active"):
+            saved[0].read_bytes("payload.bin", max_bytes=64)
+        assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        if target >= 0:
+            try:
+                real_close(target)
+            except OSError as error:
+                if error.errno != errno.EBADF:
+                    raise
+        real_close(foreign_source)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor reuse semantics",
+)
+def test_reader_deactivation_and_child_cleanup_keep_callback_primary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "payload.bin").write_bytes(b"payload")
+    ownership = capture_directory_ownership(directory)
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    foreign_source = os.open(
+        foreign,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    real_close = atomic_module.os.close
+    callback_error = ValueError("callback primary")
+    deactivation_error = KeyboardInterrupt("reader deactivation interruption")
+    close_error = SystemExit("child close ABA interruption")
+    target = -1
+    reused = False
+    saved: list[atomic_module.PublicationDirectoryReader] = []
+
+    def close_then_reuse(descriptor: int) -> None:
+        nonlocal reused
+        real_close(descriptor)
+        if descriptor == target and not reused:
+            os.dup2(foreign_source, descriptor)
+            reused = True
+            raise close_error
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> None:
+        nonlocal target
+        saved.append(reader)
+        target = next(
+            cell.cell_contents
+            for cell in (reader._capture.__closure__ or ())
+            if isinstance(cell.cell_contents, int)
+        )
+        monkeypatch.setattr(atomic_module.os, "close", close_then_reuse)
+        raise callback_error
+
+    try:
+        with pytest.raises(ValueError) as caught:
+            _call_with_interrupt_before_reader_inactive_store(
+                lambda: atomic_module.reopen_authenticated_directory(
+                    directory,
+                    ownership,
+                    consume,
+                ),
+                error=deactivation_error,
+                event_mode="line",
+            )
+        assert caught.value is callback_error
+        assert reused
+        notes = _exception_notes(callback_error)
+        deactivation_note = next(
+            index
+            for index, note in enumerate(notes)
+            if repr(deactivation_error) in note
+        )
+        child_note = next(
+            index for index, note in enumerate(notes) if repr(close_error) in note
+        )
+        assert deactivation_note < child_note
+        with pytest.raises(RuntimeError, match="no longer active"):
+            saved[0].inventory()
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        if target >= 0:
+            try:
+                real_close(target)
+            except OSError as error:
+                if error.errno != errno.EBADF:
+                    raise
+        real_close(foreign_source)
+
+
+def test_fake_windows_reader_deactivation_interrupt_rejects_handle_aba(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    api = _FakeWindowsApi()
+    owned_id = api.add_directory(api.root_id, "owned")
+    api.add_file(owned_id, "payload.bin", b"payload")
+    foreign_id = api.add_directory()
+    owned_handle = api._new_handle(owned_id)
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            owned_handle,
+            Path("C:/authority/owned"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+    finally:
+        api.close(owned_handle)
+    real_close = api.close
+    deactivation_error = KeyboardInterrupt("reader deactivation interruption")
+    close_error = SystemExit("child HANDLE ABA interruption")
+    target = 0
+    reused = False
+    saved: list[atomic_module.PublicationDirectoryReader] = []
+
+    def close_then_reuse(handle: int) -> None:
+        nonlocal reused
+        real_close(handle)
+        if handle == target and not reused:
+            api.handles[handle] = foreign_id
+            api.offsets[handle] = 0
+            reused = True
+            raise close_error
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> int:
+        nonlocal target
+        saved.append(reader)
+        target = next(
+            cell.cell_contents
+            for cell in (reader._capture.__closure__ or ())
+            if isinstance(cell.cell_contents, int)
+        )
+        monkeypatch.setattr(api, "close", close_then_reuse)
+        return 7
+
+    _install_fake_windows_api(monkeypatch, api)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            _call_with_interrupt_before_reader_inactive_store(
+                lambda: atomic_module.reopen_authenticated_directory(
+                    Path("C:/authority/owned"),
+                    ownership,
+                    consume,
+                ),
+                error=deactivation_error,
+                event_mode="line",
+            )
+        assert caught.value is deactivation_error
+        assert reused
+        assert any(repr(close_error) in note for note in _exception_notes(caught.value))
+        assert api.handles[target] == foreign_id
+        with pytest.raises(RuntimeError, match="no longer active"):
+            saved[0].read_bytes("payload.bin", max_bytes=64)
+        assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        if target in api.handles:
+            real_close(target)
+
+    assert api.handles == {}

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -9491,69 +9491,33 @@ def test_capture_retains_fake_windows_regular_file_close_for_retry(
     assert api.handles == {}
 
 
-def _call_with_interrupt_before_reader_inactive_store(
+def _call_with_interrupt_before_reader_inactive_transition(
     callback: object,
     *,
+    monkeypatch: pytest.MonkeyPatch,
     error: BaseException,
-    event_mode: str,
 ) -> None:
     assert callable(callback)
-    assert event_mode in {"opcode", "line"}
-    code = atomic_module._force_publication_reader_inactive.__code__
-    store_offsets = {
-        instruction.offset
-        for instruction in dis.get_instructions(
-            atomic_module._force_publication_reader_inactive
-        )
-        if instruction.opname == "STORE_ATTR" and instruction.argval == "active"
-    }
-    assert store_offsets
-    source, first_line = inspect.getsourcelines(
-        atomic_module._force_publication_reader_inactive
-    )
-    assignment_lines = {
-        first_line + offset
-        for offset, line in enumerate(source)
-        if "lifetime.active = False" in line
-    }
-    assert len(assignment_lines) == 1
-    previous_trace = sys.gettrace()
+    real_transition = atomic_module._set_publication_reader_inactive
     injected = False
 
-    def trace(frame: object, event: str, _arg: object) -> object:
+    def interrupt_once(
+        lifetime: atomic_module._PublicationReaderLifetime,
+    ) -> None:
         nonlocal injected
-        if event == "call" and frame.f_code is code:
-            frame.f_trace_opcodes = True
-            frame.f_trace_lines = True
-            return trace
-        if (
-            not injected
-            and frame.f_code is code
-            and (
-                (
-                    event_mode == "opcode"
-                    and event == "opcode"
-                    and frame.f_lasti in store_offsets
-                )
-                or (
-                    event_mode == "line"
-                    and event == "line"
-                    and frame.f_lineno in assignment_lines
-                )
-            )
-            and frame.f_locals["lifetime"].active
-        ):
+        if not injected and lifetime.active:
             injected = True
-            sys.settrace(None)
             raise error
-        return trace
+        real_transition(lifetime)
 
-    sys.settrace(trace)
-    try:
+    with monkeypatch.context() as fault:
+        fault.setattr(
+            atomic_module,
+            "_set_publication_reader_inactive",
+            interrupt_once,
+        )
         callback()
-    finally:
-        sys.settrace(previous_trace)
-        assert injected, "failed to inject before reader inactive STORE_ATTR"
+    assert injected, "failed to inject before reader inactive transition"
 
 
 @pytest.mark.skipif(
@@ -9604,14 +9568,14 @@ def test_posix_reader_deactivation_interrupt_closes_child_and_rejects_aba(
 
     try:
         with pytest.raises(KeyboardInterrupt) as caught:
-            _call_with_interrupt_before_reader_inactive_store(
+            _call_with_interrupt_before_reader_inactive_transition(
                 lambda: atomic_module.reopen_authenticated_directory(
                     directory,
                     ownership,
                     consume,
                 ),
+                monkeypatch=monkeypatch,
                 error=deactivation_error,
-                event_mode="opcode",
             )
         assert caught.value is deactivation_error
         assert reused
@@ -9681,14 +9645,14 @@ def test_reader_deactivation_and_child_cleanup_keep_callback_primary(
 
     try:
         with pytest.raises(ValueError) as caught:
-            _call_with_interrupt_before_reader_inactive_store(
+            _call_with_interrupt_before_reader_inactive_transition(
                 lambda: atomic_module.reopen_authenticated_directory(
                     directory,
                     ownership,
                     consume,
                 ),
+                monkeypatch=monkeypatch,
                 error=deactivation_error,
-                event_mode="line",
             )
         assert caught.value is callback_error
         assert reused
@@ -9765,14 +9729,14 @@ def test_fake_windows_reader_deactivation_interrupt_rejects_handle_aba(
     _install_fake_windows_api(monkeypatch, api)
     try:
         with pytest.raises(KeyboardInterrupt) as caught:
-            _call_with_interrupt_before_reader_inactive_store(
+            _call_with_interrupt_before_reader_inactive_transition(
                 lambda: atomic_module.reopen_authenticated_directory(
                     Path("C:/authority/owned"),
                     ownership,
                     consume,
                 ),
+                monkeypatch=monkeypatch,
                 error=deactivation_error,
-                event_mode="line",
             )
         assert caught.value is deactivation_error
         assert reused

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -9787,3 +9787,546 @@ def test_fake_windows_reader_deactivation_interrupt_rejects_handle_aba(
             real_close(target)
 
     assert api.handles == {}
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux publication authority",
+)
+def test_posix_reader_deactivation_retries_repeated_pre_call_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "payload.bin").write_bytes(b"payload")
+    ownership = capture_directory_ownership(directory)
+    saved: list[atomic_module.PublicationDirectoryReader] = []
+    first = KeyboardInterrupt("first reader cancellation")
+    events = _interrupt_ordered_action_before_call(
+        monkeypatch,
+        label="publication reader deactivation also failed",
+        errors=(first, SystemExit("second reader cancellation")),
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            lambda reader: saved.append(reader),
+        )
+
+    assert caught.value is first
+    assert events == ["KeyboardInterrupt", "SystemExit"]
+    assert saved and not saved[0]._lifetime.active
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved[0].inventory()
+
+
+def test_fake_windows_reader_deactivation_retries_repeated_pre_call_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    owned_id = api.add_directory(api.root_id, "owned")
+    api.add_file(owned_id, "payload.bin", b"payload")
+    handle = api._new_handle(owned_id)
+    try:
+        ownership = atomic_module._capture_windows_directory_handle(
+            api,
+            handle,
+            Path("C:/authority/owned"),
+            required_root_file=None,
+            allow_empty_root=False,
+            entry_policy=None,
+        )
+    finally:
+        api.close(handle)
+    saved: list[atomic_module.PublicationDirectoryReader] = []
+    first = KeyboardInterrupt("first Windows reader cancellation")
+    events = _interrupt_ordered_action_before_call(
+        monkeypatch,
+        label="Windows publication reader deactivation also failed",
+        errors=(first, SystemExit("second Windows reader cancellation")),
+    )
+    _install_fake_windows_api(monkeypatch, api)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        atomic_module.reopen_authenticated_directory(
+            Path("C:/authority/owned"),
+            ownership,
+            lambda reader: saved.append(reader),
+        )
+
+    assert caught.value is first
+    assert events == ["KeyboardInterrupt", "SystemExit"]
+    assert saved and not saved[0]._lifetime.active
+    assert api.handles == {}
+
+
+def test_retained_cleanup_retries_registry_release_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    closed = False
+
+    def close_resource(_resource: int) -> None:
+        nonlocal closed
+        closed = True
+
+    authority = atomic_module._PublicationAuthority(
+        display_parent=Path("/authority"),
+        identity=(1, 2),
+        backend_tag="test",
+        resource=7,
+        close_callback=close_resource,
+        metadata_callback=lambda *_args: None,
+        reader_callback=lambda *_args: None,
+        rename_callback=lambda *_args: None,
+        verify_callback=lambda: None,
+        close_complete_callback=lambda: closed,
+    )
+    owner = atomic_module._PublicationAuthorityOwner()
+    owner.install(authority)
+    real_forget = atomic_module._forget_publication_authority_owner
+    errors = [
+        KeyboardInterrupt("first registry release"),
+        SystemExit("second registry release"),
+    ]
+
+    def interrupt_forget(candidate: object) -> None:
+        if candidate is owner and errors:
+            raise errors.pop(0)
+        real_forget(candidate)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_forget_publication_authority_owner",
+        interrupt_forget,
+    )
+    with pytest.raises(KeyboardInterrupt):
+        atomic_module.retry_retained_publication_cleanup()
+
+    assert closed
+    assert errors == []
+    assert owner.authority is None
+    assert all(
+        retained is not owner
+        for retained in atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS
+    )
+
+
+def _interrupt_retained_owner_close_call(
+    callback: object,
+    *,
+    error: BaseException,
+) -> None:
+    assert callable(callback)
+    function = atomic_module._RetainedAuthorityCloseAttempt.__call__
+    code = function.__code__
+    source, first_line = inspect.getsourcelines(function)
+    call_lines = {
+        first_line + offset
+        for offset, line in enumerate(source)
+        if "self.owner.close(" in line
+    }
+    assert len(call_lines) == 1
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is code
+            and event == "line"
+            and frame.f_lineno in call_lines
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, "failed to inject before retained owner close call"
+
+
+def test_retained_cleanup_retries_owner_close_call_cancellation() -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    closed = False
+    cancellation = KeyboardInterrupt("owner close cancellation")
+
+    def close_resource(_resource: int) -> None:
+        nonlocal closed
+        closed = True
+
+    authority = atomic_module._PublicationAuthority(
+        display_parent=Path("/authority"),
+        identity=(1, 2),
+        backend_tag="test",
+        resource=7,
+        close_callback=close_resource,
+        metadata_callback=lambda *_args: None,
+        reader_callback=lambda *_args: None,
+        rename_callback=lambda *_args: None,
+        verify_callback=lambda: None,
+        close_complete_callback=lambda: closed,
+    )
+    owner = atomic_module._PublicationAuthorityOwner()
+    owner.install(authority)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_retained_owner_close_call(
+            atomic_module.retry_retained_publication_cleanup,
+            error=cancellation,
+        )
+
+    assert caught.value is cancellation
+    assert closed
+    assert owner.authority is None
+    assert all(
+        retained is not owner
+        for retained in atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS
+    )
+
+
+def test_retained_cleanup_does_not_spin_on_persistent_close_cancellation() -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    cancellation = KeyboardInterrupt("persistent retained close cancellation")
+    calls = 0
+
+    def fail_close(_resource: int) -> None:
+        nonlocal calls
+        calls += 1
+        raise cancellation
+
+    authority = atomic_module._PublicationAuthority(
+        display_parent=Path("/authority"),
+        identity=(1, 2),
+        backend_tag="test",
+        resource=7,
+        close_callback=fail_close,
+        metadata_callback=lambda *_args: None,
+        reader_callback=lambda *_args: None,
+        rename_callback=lambda *_args: None,
+        verify_callback=lambda: None,
+        close_complete_callback=lambda: False,
+    )
+    owner = atomic_module._PublicationAuthorityOwner()
+    owner.install(authority)
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            atomic_module.retry_retained_publication_cleanup()
+
+        assert caught.value is cancellation
+        assert calls == 1
+        assert owner.authority is authority
+        assert any(
+            retained is owner
+            for retained in atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS
+        )
+    finally:
+        authority._close_callback = lambda _resource: None
+        authority._close_complete_callback = lambda: True
+        atomic_module.retry_retained_publication_cleanup()
+
+
+def _call_with_interrupt_at_context_boundary(
+    function: object,
+    callback: object,
+    *,
+    source_fragment: str,
+    select_last: bool = False,
+    error: BaseException,
+) -> None:
+    """Inject at an exact source-line boundary in a context cleanup method."""
+
+    assert callable(function)
+    assert callable(callback)
+    code = function.__code__
+    source, first_line = inspect.getsourcelines(function)
+    matching_lines = sorted(
+        first_line + offset
+        for offset, line in enumerate(source)
+        if source_fragment in line
+    )
+    if select_last:
+        assert matching_lines
+        target_line = matching_lines[-1]
+    else:
+        assert len(matching_lines) == 1
+        target_line = matching_lines[0]
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is code
+            and event == "line"
+            and frame.f_lineno == target_line
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, "failed to inject at the context cleanup boundary"
+
+
+@pytest.mark.parametrize("boundary", ["wrapper-exit-call", "forget"])
+@pytest.mark.parametrize("operation", ["finish", "abort"])
+def test_authenticated_file_outer_exit_retries_real_boundary_cancellation(
+    operation: str,
+    boundary: str,
+) -> None:
+    record = atomic_module.TreeFileRecord(
+        path="payload.bin",
+        mode=0o644,
+        size=0,
+        sha256=hashlib.sha256(b"").hexdigest(),
+    )
+    ownership = atomic_module._TreeOwnership(
+        root_identity=(1, 2),
+        root_version_identity=(1, 2, 3),
+        digest="test",
+        entries=1,
+        byte_count=0,
+        metadata_bytes=0,
+        inventory=(("payload.bin", "file"),),
+        file_records=(record,),
+        entry_identities=(("payload.bin", "file", (3, 4)),),
+    )
+    authenticated = atomic_module.PublicationAuthenticatedFile(
+        path=record.path,
+        mode=record.mode,
+        size=record.size,
+        read_callback=lambda _size: b"",
+        verify_callback=lambda: None,
+    )
+    backend_error = (
+        SystemExit(f"persistent {operation} backend exit")
+        if boundary == "wrapper-exit-call"
+        else None
+    )
+
+    class BackendContext:
+        def __init__(self) -> None:
+            self.exit_calls = 0
+
+        def __enter__(self) -> atomic_module.PublicationAuthenticatedFile:
+            return authenticated
+
+        def __exit__(
+            self,
+            _exc_type: type[BaseException] | None,
+            _exc: BaseException | None,
+            _traceback: object,
+        ) -> bool:
+            self.exit_calls += 1
+            authenticated._record = record
+            authenticated._closed = True
+            authenticated._finalized = True
+            if backend_error is not None:
+                raise backend_error
+            return False
+
+    backend = BackendContext()
+    reader = atomic_module.PublicationDirectoryReader(
+        Path("/authority/owned"),
+        ownership.root_identity,
+        lambda *_args: ownership,
+        lambda *_args: backend,
+        ownership,
+    )
+    context = reader.open_authenticated_file("payload.bin", max_bytes=0)
+    assert context.__enter__() is authenticated
+    cancellation = KeyboardInterrupt(f"pre-{operation} backend exit")
+
+    def finish() -> None:
+        reader._close_open_files(None)
+
+    if operation == "finish":
+        function = atomic_module._PublicationAuthenticatedFileContext._finish
+        callback = finish
+    else:
+        function = atomic_module._PublicationAuthenticatedFileContext._abort_and_close
+        callback = reader._abort_open_files
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _call_with_interrupt_at_context_boundary(
+            function,
+            callback,
+            source_fragment=(
+                "context.__exit__("
+                if boundary == "wrapper-exit-call"
+                else "self._reader._forget_open_file(self)"
+            ),
+            select_last=boundary == "forget",
+            error=cancellation,
+        )
+
+    assert caught.value is cancellation
+    assert backend.exit_calls == 1
+    assert context._finished
+    assert reader._lifetime.open_files == []
+    notes = _exception_notes(cancellation)
+    if backend_error is not None:
+        # A cancellation at the nested Python call boundary can replace an
+        # exception raised by the delegated context before its caller can
+        # observe that value. The handoff remains at-most-once and the retained
+        # authority still owns the physical resource.
+        assert not any(repr(backend_error) in note for note in notes)
+
+
+def test_authenticated_file_nested_exit_handoff_keeps_body_primary() -> None:
+    record = atomic_module.TreeFileRecord(
+        path="payload.bin",
+        mode=0o644,
+        size=0,
+        sha256=hashlib.sha256(b"").hexdigest(),
+    )
+    ownership = atomic_module._TreeOwnership(
+        root_identity=(1, 2),
+        root_version_identity=(1, 2, 3),
+        digest="test",
+        entries=1,
+        byte_count=0,
+        metadata_bytes=0,
+        inventory=(("payload.bin", "file"),),
+        file_records=(record,),
+        entry_identities=(("payload.bin", "file", (3, 4)),),
+    )
+    authenticated = atomic_module.PublicationAuthenticatedFile(
+        path=record.path,
+        mode=record.mode,
+        size=record.size,
+        read_callback=lambda _size: b"",
+        verify_callback=lambda: None,
+    )
+
+    class BackendContext:
+        def __init__(self) -> None:
+            self.exit_calls = 0
+
+        def __enter__(self) -> atomic_module.PublicationAuthenticatedFile:
+            return authenticated
+
+        def __exit__(self, *_exc: object) -> bool:
+            self.exit_calls += 1
+            raise AssertionError("nested backend exit must remain at-most-once")
+
+    backend = BackendContext()
+    reader = atomic_module.PublicationDirectoryReader(
+        Path("/authority/owned"),
+        ownership.root_identity,
+        lambda *_args: ownership,
+        lambda *_args: backend,
+        ownership,
+    )
+    context = reader.open_authenticated_file("payload.bin", max_bytes=0)
+    assert context.__enter__() is authenticated
+    body_error = ValueError("body primary")
+    cancellation = KeyboardInterrupt("nested backend exit handoff")
+    results: list[bool] = []
+
+    _call_with_interrupt_at_context_boundary(
+        atomic_module._PublicationAuthenticatedFileBackendContext.__exit__,
+        lambda: results.append(
+            context.__exit__(type(body_error), body_error, body_error.__traceback__)
+        ),
+        source_fragment="return self._context.__exit__",
+        error=cancellation,
+    )
+
+    assert results == [False]
+    assert backend.exit_calls == 0
+    assert context._backend_context is not None
+    assert context._backend_context.exit_handed_off
+    assert context._finished
+    assert reader._authentication_failed
+    assert reader._lifetime.open_files == []
+    assert any(repr(cancellation) in note for note in _exception_notes(body_error))
+
+    # The handoff is deliberately at-most-once.  A later public exit cannot
+    # guess that the arbitrary custom backend never entered its delegate.
+    assert context.__exit__(type(body_error), body_error, None) is False
+    assert backend.exit_calls == 0
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX directory descriptors",
+)
+def test_posix_nested_exit_handoff_defers_cleanup_to_authority(
+    tmp_path: Path,
+) -> None:
+    atomic_module.retry_retained_publication_cleanup()
+    directory = tmp_path / "owned"
+    directory.mkdir()
+    (directory / "payload.bin").write_bytes(b"payload")
+    ownership = capture_directory_ownership(directory)
+    body_error = ValueError("body primary")
+    cancellation = KeyboardInterrupt("nested POSIX backend exit handoff")
+    owners: list[atomic_module._PosixResourceOwner] = []
+    authority_owners: list[atomic_module._PublicationAuthorityOwner] = []
+    file_records: list[atomic_module._PosixDescriptorRecord] = []
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> None:
+        matches = [
+            cell.cell_contents
+            for cell in (reader._open_file.__closure__ or ())
+            if isinstance(cell.cell_contents, atomic_module._PosixResourceOwner)
+        ]
+        assert len(matches) == 1
+        owner = matches[0]
+        owners.append(owner)
+        retained = tuple(atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS)
+        assert len(retained) == 1
+        assert retained[0].authority is not None
+        assert _posix_authority_resources(retained[0].authority) is owner
+        authority_owners.append(retained[0])
+        with reader.open_authenticated_file(
+            "payload.bin",
+            max_bytes=64,
+        ) as authenticated:
+            assert authenticated.read(1) == b"p"
+            file_record = owner._records[-1]
+            assert file_record.descriptor >= 0
+            file_records.append(file_record)
+            raise body_error
+
+    with pytest.raises(ValueError) as caught:
+        _call_with_interrupt_at_context_boundary(
+            atomic_module._PublicationAuthenticatedFileBackendContext.__exit__,
+            lambda: atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                consume,
+            ),
+            source_fragment="return self._context.__exit__",
+            error=cancellation,
+        )
+
+    assert caught.value is body_error
+    assert any(repr(cancellation) in note for note in _exception_notes(body_error))
+    assert len(owners) == len(authority_owners) == len(file_records) == 1
+    assert file_records[0].descriptor < 0
+    assert owners[0].closed
+    assert authority_owners[0].authority is None
+    assert atomic_module._RETAINED_PUBLICATION_AUTHORITY_OWNERS == []


### PR DESCRIPTION
## Summary

Add the retained authority and streaming prerequisites needed to execute the manifest import plans introduced by #609. This is a stacked Draft PR and does not publish snapshots or refs.

Stacked directly on #609. Keep this PR in Draft until #609 and its transitive dependency chain are merged, or the stack is explicitly restacked and reverified.

## Changes

- Add authenticated child-subtree reader projection with process-bound lifetimes, tracked stream cleanup, retained retry ownership, and exact descriptor/HANDLE reconciliation.
- Preserve callback and context-body primary failures across cancellation, including honest at-most-once backend-exit and CAS producer-close handoffs.
- Add the additive `StreamingObjectStore` capability and bounded `LocalCAS.put_chunks` publication with exact receipt verification and zero-consumption reuse/conflict gates.
- Expose canonical schema-v4 compound generation member identity and validate catalog member reachability without changing legacy object-store protocol compatibility.
- Close manifest summary namespace/repository identity and physical bundle validation gates.
- Record that these are authority and transport prerequisites only; manifest execution, materialized export ownership, and ref publication remain pending.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validated with:

- Python 3.10 and 3.12: `225 passed, 10 skipped` in `test/test_atomic_directory.py`
- Storage suite: `342 passed`
- Direct retained-reader consumers: `366 passed`
- Manifest planner regression suite: `256 passed`
- Repository-pinned Black 24.8.0, isort 5.13.2, flake8 7.1.1 plus bugbear, py_compile, and `git diff --check`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
