### PR TITLE
fix(compiler): set CLOEXEC via fcntl on cache directory descriptor

### DIFF
--- a/codenib/compiler/cache_lock.py
+++ b/codenib/compiler/cache_lock.py
@@ -471,7 +471,11 @@ def _open_posix_cache_directory(cache_dir: str | Path) -> Iterator[tuple[Path, i
         metadata = os.fstat(descriptor)
         if not stat.S_ISDIR(metadata.st_mode) or _is_reparse_point(metadata):
             raise RuntimeError(f"compiler cache path is not a real directory: {cache}")
-        os.set_inheritable(descriptor, False)
+        # Not os.set_inheritable: its FIOCLEX ioctl fast path fails with EBADF
+        # on the execute-only descriptors O_SEARCH yields (e.g. macOS), while
+        # F_SETFD is valid on any descriptor.
+        flags = fcntl.fcntl(descriptor, fcntl.F_GETFD)
+        fcntl.fcntl(descriptor, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
         yield cache, descriptor
     finally:
         os.close(descriptor)


### PR DESCRIPTION
## Summary
Compiler cache locking crashes on macOS: `os.set_inheritable()` fails with `OSError: [Errno 9] Bad file descriptor` on the cache directory descriptor, so every `compile_repo()` (e.g. `scripts/index_repo.py`) dies before acquiring the lock. macOS has no `O_PATH`, so `_directory_open_flags()` opens the directory with `O_SEARCH` (execute-only), and CPython's `set_inheritable` fast path — `ioctl(FIOCLEX)` — is rejected with `EBADF` on execute-only descriptors. This PR sets the flag via `fcntl(F_GETFD/F_SETFD)` instead, which is valid on any descriptor and preserves the same non-inheritance guarantee.

## Changes
- `_open_posix_cache_directory` in `codenib/compiler/cache_lock.py`: replace `os.set_inheritable(descriptor, False)` with an `fcntl`-based `FD_CLOEXEC` re-assertion (the descriptor is already opened `O_CLOEXEC`; this remains a defensive re-assertion, now portable). The other two `set_inheritable` call sites operate on regular read-write descriptors where the ioctl path works, so they are unchanged.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

Verified on macOS 15 (arm64, Python 3.11.14):
- Reproduced the failure in isolation: `os.open(dir, O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC|O_SEARCH)` + `os.set_inheritable(fd, False)` → `EBADF`; `fcntl F_GETFD/F_SETFD` on the same descriptor succeeds.
- `compiler_cache_lock()` now acquires/releases on an APFS cache dir.
- `test/compiler/test_cache_lock.py`: 26 passed, 15 skipped.
- End-to-end: `scripts/index_repo.py` on an external repository completes and writes the manifest (previously crashed at lock acquisition).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published