### PR TITLE
fix(profiling): retain repository batch rejection receipt

### DIFF
--- a/codenib/code_chunking/README.md
+++ b/codenib/code_chunking/README.md
@@ -261,9 +261,10 @@ cache is uncontrolled. The stopwatch starts
 before cold adapter or chunker construction and includes discovery and
 filtering, minified-source inspection, reads, parser/worker setup, the native
 binding and ordered merge, buffer decode, complete `CodeChunk` construction,
-and node materialization. Contract and receipt checks happen before timing;
-parity, backend checks, stage aggregation, and report serialization happen
-after timing.
+and node materialization. Controller-side identity, artifact, contract, and
+receipt checks happen before timing; the candidate's runtime contract safety
+check remains inside its stopwatch. Parity, backend checks, stage aggregation,
+and report serialization happen after timing.
 
 Every warmup and measured pair must preserve the complete ordered seven-field
 `CodeChunk` sequence, including content and node IDs. Because

--- a/codenib/code_chunking/README.md
+++ b/codenib/code_chunking/README.md
@@ -230,13 +230,14 @@ instead of another per-file language-boundary crossing.
 
 [#599](https://github.com/sysevol-ai/CodeNib/issues/599) defines the rejection
 gate for one repository-level successor without adding that successor. It does
-not reuse or retune the #558 per-file candidate, add C++ code, or change a
-production chunking route. The candidate is the fixed private #600 adapter
+not reuse or retune the #558 per-file candidate or change a production
+chunking route. [#600](https://github.com/sysevol-ai/CodeNib/issues/600)
+temporarily supplied the fixed private adapter
 `codenib.code_chunking.python_repository_batch_poc.run_python_repository_batch`
-with `CODENIB_NATIVE_PYTHON_CHUNK_BATCH=required`. Until that adapter exists,
-the controller validates the complete benchmark contract, writes its report
-atomically, and exits nonzero instead of comparing the established arm with
-itself.
+and measured it with `CODENIB_NATIVE_PYTHON_CHUNK_BATCH=required`. The
+canonical gate rejected every global worker variant, so the adapter, C++
+batch implementation, bindings, build option, and runtime environment switch
+were removed rather than retained as dead experimental code.
 
 The versioned manifest fixes clean detached checkouts of CodeNib
 `a33bb13118e3a04f8d3d76eabcfb2602f785477a` and HTTPie
@@ -285,12 +286,27 @@ make python-repository-chunk-gate \
   CODENIB_CHUNK_GATE_HTTPIE_ROOT=/path/to/httpie
 ```
 
-The default report is
-`/tmp/codenib-python-repository-chunk-gate.json`. Before #600 supplies the
-adapter, the expected result is a complete fail-closed report and a nonzero
-exit. After #600 connects it, the unchanged command becomes the formal
-four-cell performance gate. Raw machine reports remain local; only their hash
-and durable decision belong in the issue and roadmap.
+The August 12, 2026 formal run used 576 unique sample processes and preserved
+the ordered seven-field chunk sequence plus the canonical sorted-unique node
+set in all 288 pairs. Every candidate sample used one native batch call and
+zero fallbacks. Peak RSS used each Linux worker's process-scoped `VmHWM` from
+`/proc/self/status`; a missing or malformed value fails the canonical gate.
+Worker 1 regressed all four cells. Worker 2 cleared both time
+cutoffs for the two CodeNib cells but exceeded the RSS limit and missed both
+time cutoffs on HTTPie. Worker 4 cleared both CodeNib time cutoffs but exceeded
+their RSS limit; on HTTPie it passed only the continuity cell, while BM25
+improved by 17.115% at p50 and 12.761% at p95. No one worker count passed all
+four cells, so no successor was promoted and production chunking is unchanged.
+
+The authoritative local report has SHA-256
+`e580b29b5eb3e5c5373eb5b90bd107c7e5f7b6dfbaf326b64f941952ed9f01a4`;
+the complete receipt and all twelve cell results are retained in the
+[multi-language roadmap](../../docs/scip_multilanguage_roadmap.md). Raw
+machine JSON is not versioned. With the rejected adapter absent, the command
+above again performs the full subject/configuration preflight, writes an
+atomic diagnostic report to
+`/tmp/codenib-python-repository-chunk-gate.json`, and exits nonzero. It must
+not substitute legacy for the missing candidate.
 
 ## File Extension Mapping
 

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -533,8 +533,8 @@ candidate samples reported the required backend, one batch call, and zero
 fallbacks. The report completed normally as `rejected` with no measurement
 failure and has SHA-256
 `e580b29b5eb3e5c5373eb5b90bd107c7e5f7b6dfbaf326b64f941952ed9f01a4`.
-The exact twelve-cell results and artifact receipts are in the
-[multi-language roadmap](scip_multilanguage_roadmap.md).
+The exact twelve-cell results and artifact receipts are in
+`docs/scip_multilanguage_roadmap.md`.
 
 The retained controller still expects the now-absent fixed adapter and fails
 closed after full preflight. Its default report path is

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -452,17 +452,25 @@ Python tree-sitter already performs parsing in native code, so the next
 experiment should amortize work through incremental parse-tree reuse or
 repository-level batching rather than repeat the same per-file boundary.
 
-## Python Repository-Batch Rejection Gate
+## Python Repository-Batch Gate And Outcome
 
 [#599](https://github.com/sysevol-ai/CodeNib/issues/599) adds only the
-repository-successor controller and fail-closed contract. It adds no C++
-successor, does not reuse the #558 per-file span route, and does not expose a
-standard or production API. The only accepted candidate is the private #600
-adapter
-`codenib.code_chunking.python_repository_batch_poc.run_python_repository_batch`
-under `CODENIB_NATIVE_PYTHON_CHUNK_BATCH=required`. If that adapter or its
-contract is absent, the controller still writes an atomic diagnostic report
-and exits nonzero; legacy-versus-legacy substitution is forbidden.
+repository-successor controller and fail-closed contract. It does not reuse
+the #558 per-file span route and exposes no standard or production API.
+[#600](https://github.com/sysevol-ai/CodeNib/issues/600) tested exactly one
+private candidate: one repository call, a bounded worker set of 1, 2, or 4,
+and one flat result ordered by input file and span. The experimental binding
+released the GIL once, gave each worker private parser/tree and result state,
+and left repository discovery, source decoding, final chunk splitting, header
+and epilogue materialization, and node construction in Python.
+
+The candidate passed its ABI, bounds, malformed-payload, atomic fallback,
+thread-safety, deterministic ordering, and complete consumer-parity tests. The
+formal gate nevertheless rejected it. No global worker count passed every
+CodeNib/HTTPie x continuity/BM25 cell at the simultaneous 20% p50, 20% p95,
+and 1.25x peak-RSS cutoffs. The private adapter, C++ source, pybind APIs,
+CMake option, build targets, and environment switch were therefore removed.
+Normal builds and production routing contain no repository-batch POC surface.
 
 The manifest pins CodeNib
 `a33bb13118e3a04f8d3d76eabcfb2602f785477a` and HTTPie
@@ -480,9 +488,11 @@ paired order alternates AB/BA. The clock covers the entire cold repository
 consumer boundary: adapter/chunker construction, discovery and filtering,
 minified inspection, reads, parser/worker setup, binding, native batch work,
 ordered merge, buffer decode, Python chunk materialization, and node
-materialization. Identity checks occur before timing, while parity, receipt
-observation, backend verification, telemetry aggregation, and report writing
-occur afterward. Filesystem page cache is intentionally uncontrolled.
+materialization. Controller artifact, contract, and subject-receipt checks
+occur before timing. The candidate repeats its runtime contract safety check
+inside its stopwatch. Parity, receipt observation, backend verification,
+telemetry aggregation, and report writing occur afterward. Filesystem page
+cache is intentionally uncontrolled.
 
 The controller requires the complete ordered seven-field `CodeChunk` sequence
 to match for every warmup and measured pair. Canonical node parity compares
@@ -515,11 +525,22 @@ make python-repository-chunk-gate \
   CODENIB_CHUNK_GATE_HTTPIE_ROOT=/path/to/httpie
 ```
 
-The default report path is
-`/tmp/codenib-python-repository-chunk-gate.json`. A missing #600 adapter is an
-expected negative pre-implementation result, not candidate performance
-evidence. No p50, p95, RSS, or promotion claim is published until the fixed
-adapter completes the canonical four-cell gate.
+The authoritative August 12, 2026 run used benchmark implementation commit
+`8e922a3d9ae2132787f402e81aeafe930d84135c`, 576 unique sample processes,
+and Linux process-scoped `VmHWM` peak RSS. All 288 pairs preserved the complete
+ordered seven-field chunk digest and canonical sorted-unique node digest; all
+candidate samples reported the required backend, one batch call, and zero
+fallbacks. The report completed normally as `rejected` with no measurement
+failure and has SHA-256
+`e580b29b5eb3e5c5373eb5b90bd107c7e5f7b6dfbaf326b64f941952ed9f01a4`.
+The exact twelve-cell results and artifact receipts are in the
+[multi-language roadmap](scip_multilanguage_roadmap.md).
+
+The retained controller still expects the now-absent fixed adapter and fails
+closed after full preflight. Its default report path is
+`/tmp/codenib-python-repository-chunk-gate.json`; legacy-versus-legacy
+substitution is forbidden. A future hypothesis must use a new focused issue
+and candidate contract rather than silently reviving this rejected ABI.
 
 ## Verify
 

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -1110,19 +1110,19 @@ material fraction of cold-start graph build time.
 Milestone 3 and [#601](https://github.com/sysevol-ai/CodeNib/issues/601) track a
 new, ordered program rather than extending the archived Phase 0--6 queue:
 
-1. [#597](https://github.com/sysevol-ai/CodeNib/issues/597) must produce a
+1. [#597](https://github.com/sysevol-ai/CodeNib/issues/597) produced a
    graph-free SCIP FactQueryIndex import path, complete source/filter receipt,
    and exact filtered-graph parity proof.
-2. [#598](https://github.com/sysevol-ai/CodeNib/issues/598) then compares that
+2. [#598](https://github.com/sysevol-ai/CodeNib/issues/598) compared that
    candidate with the real MCP baseline of loading the existing `graph.pkl`.
    The earlier Python/Rust query-ready gains are API evidence, not yet a
    user-visible consumer claim.
-3. [#599](https://github.com/sysevol-ai/CodeNib/issues/599) defines exact
+3. [#599](https://github.com/sysevol-ai/CodeNib/issues/599) defined exact
    repository-level chunk parity and 20% p50/p95 gates before another native
    implementation is added.
-4. [#600](https://github.com/sysevol-ai/CodeNib/issues/600) timeboxes one
+4. [#600](https://github.com/sysevol-ai/CodeNib/issues/600) timeboxed one
    repository call with bounded native workers and an ordered flat buffer. A
-   failed gate removes the POC implementation and retains only the receipt.
+   failed gate removed the POC implementation and retained only the receipt.
 
 M1 implementation status ([#597](https://github.com/sysevol-ai/CodeNib/issues/597)):
 the candidate boundary is deliberately split into two proofs. C++ records the
@@ -1209,17 +1209,18 @@ Python and Rust are decided independently, but neither qualified. The
 consumer-promoted set therefore remains empty, production `ServerContext`, MCP,
 and agent routing for these Python/Rust SCIP paths stay on persisted
 `CodeGraph`, and #598 is a measured negative promotion decision rather than
-unfinished integration work. The ordered next issue is
-[#599](https://github.com/sysevol-ai/CodeNib/issues/599), which defines the
-repository-level chunk successor gate without adding a C++ batch implementation
-or production route. #600 remains the bounded repository-native implementation
-experiment. Storage RFC #199 and Guardian #309 remain independent programs.
+unfinished integration work. At that M2 decision, the ordered next issue was
+[#599](https://github.com/sysevol-ai/CodeNib/issues/599), which defined the
+repository-level chunk successor gate without adding a C++ batch
+implementation or production route; #600 was the subsequent bounded
+repository-native implementation experiment. Storage RFC #199 and Guardian
+#309 remain independent programs.
 
 M3 gate implementation status
 ([#599](https://github.com/sysevol-ai/CodeNib/issues/599)): this issue is the
 fail-closed controller and benchmark contract only. It contains no C++
 successor, does not reuse or retune the negative #558 per-file route, and
-cannot publish candidate performance before #600 supplies the fixed private
+could not publish candidate performance until #600 supplied the fixed private
 `run_python_repository_batch` adapter. In that pre-adapter state, the command
 validates both pinned subjects and configurations, exercises the complete
 controller through deterministic fake adapters in unit tests, writes an atomic
@@ -1241,9 +1242,10 @@ order, with symmetric GC treatment and uncontrolled filesystem page cache.
 The clock spans cold construction, repository discovery/filtering and
 minified-source inspection, reads, parser/worker setup, binding and native
 batch work, ordered merge, decode, complete chunk construction, and node
-materialization. Identity validation is outside the front of the stopwatch;
-parity, backend checks, stage aggregation, receipt observation, and report
-serialization are outside its end.
+materialization. Controller artifact, contract, and subject-receipt checks are
+outside the front of the stopwatch; the candidate's runtime contract safety
+check remains inside. Parity, backend checks, stage aggregation, receipt
+observation, and report serialization are outside its end.
 
 Every warmup and measured pair requires exact ordered parity for all seven
 `CodeChunk` fields. Canonical node parity compares sorted unique symbolic IDs
@@ -1265,10 +1267,99 @@ make python-repository-chunk-gate \
 ```
 
 The raw JSON remains local at
-`/tmp/codenib-python-repository-chunk-gate.json`. Once #600 supplies the fixed
-adapter, the same command and frozen contract become the formal four-cell gate.
-No repository-batch speed, tail-latency, RSS, or promotion result has been
-recorded yet.
+`/tmp/codenib-python-repository-chunk-gate.json`. #600 supplied the fixed
+adapter only long enough to run the unchanged command and frozen contract as
+the formal four-cell gate. The measured outcome follows.
+
+M4 implementation and gate outcome
+([#600](https://github.com/sysevol-ai/CodeNib/issues/600)): the private
+candidate accepted one ordered repository source sequence, released the GIL
+around one bounded native batch, used worker-private parser/tree/result state,
+and merged file/span buffers by original input ordinal. Python retained
+repository filtering, UTF-8-with-replacement decoding, strict/skip behavior,
+final `CodeChunk` construction, headers/epilogues, splitting, and node IDs.
+The ABI, overflow/resource caps, malformed buffers, deterministic concurrency,
+whole-repository fallback, `MemoryError`, and worker 1/2/4 exact parity tests
+all passed before the formal run.
+
+The authoritative `python_repository_chunk_successor_gate_v1` run on August
+12, 2026 used experimental implementation commit
+`8e922a3d9ae2132787f402e81aeafe930d84135c`. Each arm received four warmups
+and 20 measured fresh-process samples for every worker/subject/configuration
+cell: 576 samples and 576 unique PIDs in total, with 144 AB and 144 BA pairs.
+The stopwatch and two configurations remained exactly as frozen by #599.
+Linux peak RSS came from the process-scoped `/proc/self/status` `VmHWM` value;
+an earlier run using inherited `getrusage()` high-water state was superseded
+and is not promotion evidence. Filesystem page cache remained uncontrolled.
+
+| Workers | Subject | Configuration | Legacy p50 / p95 | Candidate p50 / p95 | p50 / p95 improvement | RSS p95 legacy / candidate (ratio) | Cell |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | --- |
+| 1 | CodeNib | BM25 | 0.814943s / 0.882297s | 0.970822s / 1.010272s | -19.128% / -14.505% | 51.000 / 64.270 MiB (1.2602x) | reject |
+| 1 | CodeNib | continuity | 0.697553s / 0.712019s | 0.801416s / 0.822192s | -14.890% / -15.473% | 50.000 / 63.273 MiB (1.2655x) | reject |
+| 1 | HTTPie | BM25 | 0.087597s / 0.110658s | 0.108079s / 0.144070s | -23.381% / -30.193% | 36.500 / 39.500 MiB (1.0822x) | reject |
+| 1 | HTTPie | continuity | 0.088109s / 0.151746s | 0.104742s / 0.165491s | -18.878% / -9.058% | 36.000 / 39.500 MiB (1.0972x) | reject |
+| 2 | CodeNib | BM25 | 0.702405s / 0.787032s | 0.473816s / 0.591675s | +32.544% / +24.822% | 51.000 / 66.438 MiB (1.3027x) | reject |
+| 2 | CodeNib | continuity | 0.860423s / 0.872750s | 0.565708s / 0.608869s | +34.252% / +30.236% | 50.000 / 65.840 MiB (1.3168x) | reject |
+| 2 | HTTPie | BM25 | 0.081361s / 0.084126s | 0.075882s / 0.082794s | +6.735% / +1.583% | 36.500 / 40.000 MiB (1.0959x) | reject |
+| 2 | HTTPie | continuity | 0.080706s / 0.088504s | 0.078726s / 0.079568s | +2.453% / +10.097% | 36.000 / 39.500 MiB (1.0972x) | reject |
+| 4 | CodeNib | BM25 | 0.703526s / 1.601690s | 0.330657s / 0.675341s | +53.000% / +57.836% | 51.000 / 69.457 MiB (1.3619x) | reject |
+| 4 | CodeNib | continuity | 1.199357s / 1.598776s | 0.448330s / 0.670158s | +62.619% / +58.083% | 50.000 / 68.973 MiB (1.3795x) | reject |
+| 4 | HTTPie | BM25 | 0.081310s / 0.081943s | 0.067394s / 0.071486s | +17.115% / +12.761% | 36.500 / 39.500 MiB (1.0822x) | reject |
+| 4 | HTTPie | continuity | 0.157862s / 0.159411s | 0.114359s / 0.117342s | +27.557% / +26.390% | 36.000 / 39.500 MiB (1.0972x) | pass |
+
+Negative improvement denotes a regression. All 288 pairs preserved the
+complete ordered seven-field `CodeChunk` digest and the canonical
+sorted-unique symbolic-node digest. All 288 candidate samples used backend
+`native-repository-batch-poc`, one batch call, zero fallbacks, the requested
+worker count, and valid contract/counter/stage telemetry. Subject, source,
+benchmark, harness, adapter, binary, and contract receipts were clean, stable,
+and unchanged. The gate completed as `status=rejected` with `failure=null`; it
+was not a harness failure.
+
+The durable identities are:
+
+- benchmark commit
+  `8e922a3d9ae2132787f402e81aeafe930d84135c`; harness SHA-256
+  `fd4d083ccb7aefd3ecef12d0db5220d4f95c9c803128f441d95d63e94269ecd7`;
+  subject-manifest SHA-256
+  `d40a35aedc1afcc9980cf414f20a9d1b196e2be615bd44f665020ad6333e16a6`;
+- candidate adapter SHA-256
+  `795867839a0d3ad9927a68dead728c4b140b3f9d2e3aa564336262b28a460be5`;
+  native binary SHA-256
+  `6a0d14f8366a426ebc39b316849b7f1deb6c7d000befe09663a8559bf8405cd9`;
+  contract SHA-256
+  `7e46684ba7b0733bfdb164d44bc664a68c06befc45684641e7ea35103c198849`;
+- CodeNib `a33bb13118e3a04f8d3d76eabcfb2602f785477a`: 520 selected
+  files / 6,630,346 bytes; continuity source SHA-256
+  `65e2ba3a8106cff5ba39a568d3bcad5f279f54f4aaabcf5cba5167d69cc21b09`;
+  BM25 source SHA-256
+  `2b3e1d607d9627d928b51b09af93d1cd5a02b224fca10ffd4840ba64f3bf7e29`;
+  5,620 / 6,403 chunks and 5,619 canonical nodes;
+- HTTPie `2105caa49bae87c5809c274e407619a0de2639d1`: 89 selected
+  files / 338,976 bytes; continuity source SHA-256
+  `d5feafe737d7d3bdfdb54b92883168fe32a255886fbb8fccbc140f6a43aa12a9`;
+  BM25 source SHA-256
+  `645911e349ec6bda45cb8a34688de74e0b3833a216a7dc29f09ed4a358840192`;
+  498 / 595 chunks and 494 canonical nodes;
+- final 8,596,802-byte raw report SHA-256
+  `e580b29b5eb3e5c5373eb5b90bd107c7e5f7b6dfbaf326b64f941952ed9f01a4`.
+
+Only worker 4's HTTPie continuity cell passed all three numeric gates. Worker
+2 cleared both time gates for CodeNib but exceeded the 1.25x RSS limit; worker
+4 cleared both CodeNib time gates but also exceeded that RSS limit, while its
+HTTPie BM25 improvements remained below 20%. The global selection therefore
+returned `qualifying_worker_counts=[]` and `selected_worker_count=null`.
+Per-cell selection and averaging are forbidden, so no successor qualifies.
+
+In accordance with #600's outcome rule, the private Python adapter, C++
+implementation and tests, pybind entry points, CMake option, Make targets, CI
+configuration, and runtime environment switch were removed from the merge
+surface. The #599 fail-closed controller and manifest remain, together with
+the process-scoped RSS and failure-status hardening discovered during the
+measurement. Production chunking remains unchanged and no integration issue
+was opened. Milestone 3 completed with no consumer-boundary backend promoted;
+future warm-session or incremental-reuse hypotheses require a new focused
+issue and gate rather than reopening either rejected native design.
 
 ## PR And Issue Flow
 
@@ -1288,7 +1379,7 @@ Issue triage rules:
 - If a PR changes graph schema or decoder semantics, run parity checks and
   inspect whether `_SCHEMA_VERSION` must change.
 
-Current issue triage notes through August 11, 2026:
+Current issue triage notes through August 12, 2026:
 
 - PR #248 is merged (June 25, 2026). It was an agent-compile/Qwen local-backend
   PR outside this SCIP roadmap and landed as agent-compile work, not as a
@@ -1306,11 +1397,15 @@ Current issue triage notes through August 11, 2026:
 - #558 is closed with exact parity but a negative per-file native chunking
   result; repository batching is tracked separately by #599/#600.
 - #598 is resolved with exact parity and safety but negative Python and Rust
-  consumer performance gates. No language is promoted; #599 is next.
-- #599 is the active fail-closed repository-successor gate. Its harness does
-  not contain a C++ candidate; formal performance waits for the fixed #600
-  adapter.
-- #601 is the open tracker for consumer-boundary acceleration follow-up work.
+  consumer performance gates. No language was promoted; the subsequent #599
+  and #600 repository-chunk gates are now also decided.
+- #599 is closed with its fail-closed repository-successor harness retained.
+- #600 completed as a measured negative result. Its private batch POC was
+  removed after no global worker count passed every fixed cell; no production
+  integration follow-up was opened.
+- #601 completes when this recorded negative outcome is merged and the exact
+  main verification chain is green. The ordered consumer-boundary program then
+  has zero promoted backends.
 - #133 is closed. Its query-time skill-selection runtime landed through #149
   and the subsequent agent-runtime refactor; the original fitted A0--A6 table
   plan was retired in favor of the design-space cost study. Any new adaptive

--- a/scripts/profiling/profile_python_repository_chunk_gate.py
+++ b/scripts/profiling/profile_python_repository_chunk_gate.py
@@ -49,6 +49,7 @@ DEFAULT_PROMOTION_THRESHOLD = 0.20
 DEFAULT_RSS_RATIO_LIMIT = 1.25
 DEFAULT_WORKER_COUNTS = (1, 2, 4)
 DEFAULT_WORKER_TIMEOUT_SECONDS = 900.0
+CANONICAL_PEAK_RSS_SOURCE = "proc-self-status-vmhwm-kib-v1"
 REPOSITORY_FILTER_POLICY = 3
 REPORT_SCHEMA_VERSION = 1
 _DEFAULT_OUTPUT = (
@@ -691,7 +692,45 @@ def _benchmark_identity(manifest_path: Path) -> dict[str, Any]:
     }
 
 
+def _linux_peak_rss_bytes(
+    status_path: Path | None = None,
+) -> int | None:
+    if status_path is None:
+        status_path = Path("/proc/self/status")
+    try:
+        lines = status_path.read_text(encoding="ascii").splitlines()
+    except (OSError, UnicodeError):
+        return None
+    for line in lines:
+        if not line.startswith("VmHWM:"):
+            continue
+        fields = line.split()
+        if len(fields) != 3 or fields[0] != "VmHWM:" or fields[2] != "kB":
+            return None
+        try:
+            kibibytes = int(fields[1], 10)
+        except ValueError:
+            return None
+        if kibibytes <= 0:
+            return None
+        return kibibytes * 1024
+    return None
+
+
+def _peak_rss_source() -> str:
+    if sys.platform.startswith("linux"):
+        return "proc-self-status-vmhwm-kib-v1"
+    if sys.platform == "darwin":
+        return "getrusage-self-ru-maxrss-bytes-v1"
+    return "getrusage-self-ru-maxrss-kib-v1"
+
+
 def _peak_rss_bytes() -> int | None:
+    # Linux carries ru_maxrss across fork+exec, so it can report the
+    # controller's historical high-water mark instead of this fresh worker's
+    # peak. /proc/self/status VmHWM is scoped to the current executable image.
+    if sys.platform.startswith("linux"):
+        return _linux_peak_rss_bytes()
     try:
         import resource
 
@@ -1553,6 +1592,7 @@ def _canonical_protocol(
         "fresh_process_per_sample": True,
         "paired_arm_order": "alternating-ab-ba",
         "filesystem_page_cache": "uncontrolled",
+        "peak_rss_source": CANONICAL_PEAK_RSS_SOURCE,
     }
     observed = {
         "iterations_per_arm": iterations,
@@ -1566,6 +1606,7 @@ def _canonical_protocol(
         "fresh_process_per_sample": True,
         "paired_arm_order": "alternating-ab-ba",
         "filesystem_page_cache": "uncontrolled",
+        "peak_rss_source": _peak_rss_source(),
     }
     return {"expected": expected, "observed": observed, "passed": observed == expected}
 
@@ -1615,6 +1656,7 @@ def _base_report(
             "arm_order": "alternating paired AB/BA rounds",
             "fresh_process_per_sample": True,
             "gc_policy": "collect-then-disabled-during-stopwatch-v1",
+            "peak_rss_source": _peak_rss_source(),
             "filesystem_page_cache": "uncontrolled",
             "stopwatch_boundary": (
                 "cold construction through repository discovery/filtering, "

--- a/scripts/profiling/profile_python_repository_chunk_gate.py
+++ b/scripts/profiling/profile_python_repository_chunk_gate.py
@@ -1621,7 +1621,15 @@ def _base_report(
                 "minified inspection, reads, parser/worker setup, native binding, "
                 "ordered merge, decode, CodeChunk and node materialization"
             ),
-            "verification_outside_stopwatch": True,
+            "verification_boundary": {
+                "controller_artifact_contract_and_subject_receipts": (
+                    "outside-stopwatch"
+                ),
+                "candidate_runtime_contract_safety_check": (
+                    "inside-candidate-stopwatch"
+                ),
+                "parity_backend_stage_and_report_checks": "outside-stopwatch",
+            },
             "manifest": _json_safe_observed(manifest_path),
             "candidate_build_dir": _json_safe_observed(build_dir),
             "candidate_adapter": f"{_ADAPTER_MODULE}.{_ADAPTER_FUNCTION}",
@@ -1892,7 +1900,8 @@ def profile_python_repository_chunk_gate(
     # performance, RSS, identity, and isolation gate to pass.
     report["promotion_eligible"] = passed
     report["passed"] = passed
-    report["status"] = "passed" if passed else "rejected"
+    if report["failure"] is None:
+        report["status"] = "passed" if passed else "rejected"
     return report
 
 

--- a/scripts/profiling/profile_python_repository_chunk_gate.py
+++ b/scripts/profiling/profile_python_repository_chunk_gate.py
@@ -1681,6 +1681,8 @@ def _base_report(
         "canonical_protocol": None,
         "process_isolation": {
             "sample_count": 0,
+            "expected_sample_count": None,
+            "sample_set_complete": False,
             "unique_process_count": 0,
             "duplicate_process_ids": [],
             "passed": False,
@@ -1897,9 +1899,21 @@ def profile_python_repository_chunk_gate(
     duplicate_process_ids = sorted(
         process_id for process_id, count in pid_counts.items() if count > 1
     )
-    global_process_isolation = bool(all_process_ids and not duplicate_process_ids)
+    expected_sample_count = (
+        len(worker_counts)
+        * len(prepared["subjects"])
+        * len(CONFIGURATIONS)
+        * (iterations + warmups)
+        * len(_ARMS)
+    )
+    sample_set_complete = len(all_process_ids) == expected_sample_count
+    global_process_isolation = bool(
+        expected_sample_count > 0 and sample_set_complete and not duplicate_process_ids
+    )
     report["process_isolation"] = {
         "sample_count": len(all_process_ids),
+        "expected_sample_count": expected_sample_count,
+        "sample_set_complete": sample_set_complete,
         "unique_process_count": len(pid_counts),
         "duplicate_process_ids": duplicate_process_ids,
         "passed": global_process_isolation,
@@ -1918,11 +1932,13 @@ def profile_python_repository_chunk_gate(
             cell["decision"]["passed"] for cell in worker["cells"].values()
         )
 
-    qualifying = [
-        int(worker_count)
-        for worker_count, result in report["workers"].items()
-        if result["passed_all_four_cells"]
-    ]
+    qualifying = []
+    if report["failure"] is None:
+        qualifying = [
+            int(worker_count)
+            for worker_count, result in report["workers"].items()
+            if result["passed_all_four_cells"]
+        ]
     qualifying.sort()
     selected = qualifying[0] if qualifying else None
     passed = bool(

--- a/test/scripts/test_profile_python_repository_chunk_gate.py
+++ b/test/scripts/test_profile_python_repository_chunk_gate.py
@@ -589,6 +589,36 @@ def test_missing_adapter_fails_after_complete_preflight(tmp_path: Path) -> None:
     assert report["workers"] == {}
 
 
+def test_measurement_exception_remains_failed_not_performance_rejected(
+    tmp_path: Path,
+) -> None:
+    manifest, roots = _write_manifest(tmp_path)
+
+    def broken_sample(_config: dict[str, Any]) -> dict[str, Any]:
+        raise TimeoutError("synthetic worker timeout")
+
+    report = profiler.profile_python_repository_chunk_gate(
+        subject_roots=roots,
+        manifest_path=manifest,
+        iterations=1,
+        warmups=0,
+        worker_counts=(1,),
+        _sample_runner=broken_sample,
+        _candidate_observer=_candidate_receipt,
+        _benchmark_observer=_benchmark_receipt,
+    )
+
+    assert report["status"] == "failed"
+    assert report["failure"] == {
+        "stage": "measurement",
+        "error_type": "TimeoutError",
+        "message": "synthetic worker timeout",
+    }
+    assert report["passed"] is False
+    assert report["promotion_eligible"] is False
+    assert report["decision"]["selected_worker_count"] is None
+
+
 def test_selector_drift_fails_closed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/test/scripts/test_profile_python_repository_chunk_gate.py
+++ b/test/scripts/test_profile_python_repository_chunk_gate.py
@@ -691,6 +691,52 @@ def test_measurement_exception_remains_failed_not_performance_rejected(
     assert report["decision"]["selected_worker_count"] is None
 
 
+def test_late_measurement_failure_clears_partial_worker_qualification(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest, roots = _write_manifest(tmp_path)
+    monkeypatch.setattr(
+        profiler,
+        "_peak_rss_source",
+        lambda: profiler.CANONICAL_PEAK_RSS_SOURCE,
+    )
+    green_sample = _fake_sample_runner()
+    call_count = 0
+
+    def fail_after_first_worker(config: dict[str, Any]) -> dict[str, Any]:
+        nonlocal call_count
+        call_count += 1
+        if call_count > 192:
+            raise TimeoutError("synthetic late worker timeout")
+        return green_sample(config)
+
+    report = profiler.profile_python_repository_chunk_gate(
+        subject_roots=roots,
+        manifest_path=manifest,
+        _sample_runner=fail_after_first_worker,
+        _candidate_observer=_candidate_receipt,
+        _benchmark_observer=_benchmark_receipt,
+    )
+
+    assert report["status"] == "failed"
+    assert report["failure"]["stage"] == "measurement"
+    assert report["process_isolation"] == {
+        "sample_count": 192,
+        "expected_sample_count": 576,
+        "sample_set_complete": False,
+        "unique_process_count": 192,
+        "duplicate_process_ids": [],
+        "passed": False,
+    }
+    assert report["decision"]["qualifying_worker_counts"] == []
+    assert report["decision"]["selected_worker_count"] is None
+    assert report["workers"]["1"]["passed_all_four_cells"] is False
+    assert all(
+        not cell["decision"]["gates"]["process_ids_unique"]
+        for cell in report["workers"]["1"]["cells"].values()
+    )
+
+
 def test_selector_drift_fails_closed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/test/scripts/test_profile_python_repository_chunk_gate.py
+++ b/test/scripts/test_profile_python_repository_chunk_gate.py
@@ -130,6 +130,66 @@ def _candidate_receipt() -> dict[str, Any]:
     }
 
 
+@pytest.mark.parametrize(
+    ("contents", "expected"),
+    [
+        ("Name:\tpython\nVmHWM:\t123 kB\n", 123 * 1024),
+        ("VmHWM:\t0 kB\n", None),
+        ("VmHWM:\t-1 kB\n", None),
+        ("VmHWM:\tnot-an-int kB\n", None),
+        ("VmHWM:\t123 bytes\n", None),
+        ("VmHWM:\t123 kB extra\n", None),
+        ("VmRSS:\t123 kB\n", None),
+    ],
+)
+def test_linux_peak_rss_reads_current_process_vmhwm(
+    tmp_path: Path, contents: str, expected: int | None
+) -> None:
+    status = tmp_path / "status"
+    status.write_text(contents, encoding="ascii")
+
+    assert profiler._linux_peak_rss_bytes(status) == expected
+
+
+def test_linux_peak_rss_does_not_fall_back_to_inherited_getrusage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(profiler.sys, "platform", "linux")
+    monkeypatch.setattr(profiler, "_linux_peak_rss_bytes", lambda: None)
+
+    assert profiler._peak_rss_bytes() is None
+    assert profiler._peak_rss_source() == "proc-self-status-vmhwm-kib-v1"
+
+
+def test_canonical_protocol_requires_process_scoped_linux_peak_rss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared = {
+        "manifest": {"repository_filter_policy": 3},
+        "subjects": [{"id": "codenib"}, {"id": "httpie"}],
+    }
+    monkeypatch.setattr(
+        profiler,
+        "_peak_rss_source",
+        lambda: "getrusage-self-ru-maxrss-kib-v1",
+    )
+
+    protocol = profiler._canonical_protocol(
+        prepared,
+        iterations=profiler.DEFAULT_ITERATIONS,
+        warmups=profiler.DEFAULT_WARMUPS,
+        threshold=profiler.DEFAULT_PROMOTION_THRESHOLD,
+        rss_ratio_limit=profiler.DEFAULT_RSS_RATIO_LIMIT,
+        worker_counts=profiler.DEFAULT_WORKER_COUNTS,
+    )
+
+    assert protocol["passed"] is False
+    assert protocol["expected"]["peak_rss_source"] == ("proc-self-status-vmhwm-kib-v1")
+    assert protocol["observed"]["peak_rss_source"] == (
+        "getrusage-self-ru-maxrss-kib-v1"
+    )
+
+
 def _fake_sample_runner(
     *,
     candidate_ratio: float = 0.75,
@@ -380,9 +440,14 @@ def test_arm_order_is_one_pair_per_round_and_alternates() -> None:
 
 
 def test_complete_four_cell_matrix_selects_smallest_global_worker(
-    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     manifest, roots = _write_manifest(tmp_path)
+    monkeypatch.setattr(
+        profiler,
+        "_peak_rss_source",
+        lambda: profiler.CANONICAL_PEAK_RSS_SOURCE,
+    )
 
     report = profiler.profile_python_repository_chunk_gate(
         subject_roots=roots,
@@ -457,8 +522,15 @@ def test_noncanonical_green_matrix_is_never_promotion_eligible(
         assert cell["decision"]["gates"]["canonical_protocol"] is False
 
 
-def test_canonical_slow_matrix_is_not_promotion_eligible(tmp_path: Path) -> None:
+def test_canonical_slow_matrix_is_not_promotion_eligible(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     manifest, roots = _write_manifest(tmp_path)
+    monkeypatch.setattr(
+        profiler,
+        "_peak_rss_source",
+        lambda: profiler.CANONICAL_PEAK_RSS_SOURCE,
+    )
 
     report = profiler.profile_python_repository_chunk_gate(
         subject_roots=roots,


### PR DESCRIPTION
## Summary

Complete #600 with a reproducible negative promotion decision for bounded native repository extraction. The canonical consumer gate preserved exact chunk and canonical-node behavior, but no single worker count passed every fixed CodeNib/HTTPie continuity/BM25 cell at the simultaneous 20% p50, 20% p95, and 1.25x peak-RSS limits.

The private C++/pybind/Python POC is intentionally absent from this merge surface. Production chunking remains unchanged and no integration follow-up is opened.

Closes #600

## Changes

- Harden the retained #599 controller so measurement failures remain `failed`, incomplete sample matrices cannot retain partial worker qualification, and controller/runtime verification boundaries are explicit.
- Measure Linux worker peak RSS from process-scoped `/proc/self/status` `VmHWM` instead of inherited `getrusage()` high-water state, with a fail-closed canonical source contract.
- Record the canonical 576-process result, all twelve cell summaries, immutable receipts, and `qualifying_worker_counts=[]` in the durable roadmap.
- Document removal of the rejected adapter, native implementation, bindings, build option, and runtime switch.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/scripts/test_profile_python_repository_chunk_gate.py --tb=short` — 73 passed
- `make core-test` — 217 passed, 2 skipped
- `make core-chunk-poc-test` — 92 passed
- `pytest -q test/test_ci_policy.py --tb=short` — 21 passed
- Relevant pre-commit hooks — passed
- `python -m mkdocs build --strict` — passed
- Canonical report SHA-256: `e580b29b5eb3e5c5373eb5b90bd107c7e5f7b6dfbaf326b64f941952ed9f01a4`
- Full local unit tier encountered the existing timing-sensitive `test_reader_callbacks_survive_reversible_root_swap[stage]` failure; the same `origin/main` case failed in 15 of 20 isolated runs.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand behavior where needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
