### PR TITLE
feat(serving): resolve target auto-class from a verified registry

### DIFF
--- a/codenib/serving/server/real_model.py
+++ b/codenib/serving/server/real_model.py
@@ -39,12 +39,14 @@ also deferred.
 ``Qwen3_5ForConditionalGeneration`` with a ``vision_config`` — maps cleanly:
 ``transformers`` (>= 5.2) registers ``Qwen3_5ForCausalLM`` in the causal-LM
 auto-mapping, so ``AutoModelForCausalLM.from_pretrained`` returns the text model
-directly (verified on transformers 5.12). A model outside that mapping loads
-only if its ``model_type`` is in :data:`VERIFIED_NON_CAUSAL_MODEL_TYPES` — an
-allowlist of architectures whose ``input_ids``-only forward is known to emit
-causal-LM ``.logits`` — and each registry load is validated with a one-token
-text forward before serving. Anything else fails loudly; the ``model_class``
-parameter remains as the explicit escape hatch (and is how tests inject stubs).
+directly. The serving extra requires ``transformers>=5.15.0``, the first release
+whose built-in config and image-text auto-model metadata include Muse Glimmer. A
+model outside the causal mapping loads only if its ``model_type`` is in
+:data:`VERIFIED_NON_CAUSAL_MODEL_TYPES` — an allowlist of architectures whose
+``input_ids``-only forward is known to emit causal-LM ``.logits`` — and each
+registry load is validated with a one-token text forward before serving.
+Anything else fails loudly; the ``model_class`` parameter remains as the
+explicit escape hatch (and is how tests inject stubs).
 
 torch/transformers are imported lazily so this module (and ``best_linear_path``)
 stay importable without the ``bench`` extra installed.
@@ -69,6 +71,25 @@ VERIFIED_NON_CAUSAL_MODEL_TYPES = {
     "muse_glimmer": "AutoModelForImageTextToText",
 }
 
+# Arguments that affect which config bytes/classes ``from_pretrained`` resolves.
+# They must be applied to both our preflight config lookup and the subsequent
+# model load. In particular, never let the lookup reach the network when the
+# caller requested ``local_files_only=True`` or resolve a different revision.
+_CONFIG_RESOLUTION_KWARGS = frozenset(
+    {
+        "_commit_hash",
+        "cache_dir",
+        "code_revision",
+        "force_download",
+        "local_files_only",
+        "proxies",
+        "revision",
+        "subfolder",
+        "token",
+        "trust_remote_code",
+    }
+)
+
 
 def best_linear_path(tree: DraftTree) -> List[TokenId]:
     """Flatten a draft tree to one linear branch for single-path verification.
@@ -86,7 +107,12 @@ def best_linear_path(tree: DraftTree) -> List[TokenId]:
     return path
 
 
-def _resolve_model_class(model_name: str):
+def _resolve_model_class(
+    model_name: str,
+    *,
+    config: object = None,
+    **from_pretrained_kwargs,
+):
     """Pick the auto-class for ``model_name`` from its config ``model_type``.
 
     Resolution is fail-closed, mirroring how the compiler picks index builders
@@ -97,19 +123,32 @@ def _resolve_model_class(model_name: str):
     rather than guessing — a class that merely *loads* can still verify
     speculation against the wrong logits.
 
+    A caller-supplied ``config`` is authoritative. Otherwise the config lookup
+    receives the same Hub/security arguments as the model load (revision,
+    token, cache, offline mode, and remote-code policy), and the resolved object
+    is returned so the model loader does not resolve it a second time.
+
     Returns:
-        ``(auto_class, needs_validation)``.
+        ``(auto_class, needs_validation, config)``.
     """
     import transformers
     from transformers import AutoConfig, AutoModelForCausalLM
     from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 
-    model_type = getattr(AutoConfig.from_pretrained(model_name), "model_type", None)
+    if config is None:
+        config_kwargs = {
+            name: value
+            for name, value in from_pretrained_kwargs.items()
+            if name in _CONFIG_RESOLUTION_KWARGS
+        }
+        config = AutoConfig.from_pretrained(model_name, **config_kwargs)
+
+    model_type = getattr(config, "model_type", None)
     if model_type in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
-        return AutoModelForCausalLM, False
+        return AutoModelForCausalLM, False, config
     registered = VERIFIED_NON_CAUSAL_MODEL_TYPES.get(model_type)
     if registered is not None:
-        return getattr(transformers, registered), True
+        return getattr(transformers, registered), True, config
     raise RuntimeError(
         f"model_type {model_type!r} of {model_name!r} is neither in the "
         "transformers causal-LM auto-mapping nor in "
@@ -172,10 +211,15 @@ def _load_lm(
     if model_class is not None:
         cls, needs_validation = model_class, False
     else:
-        cls, needs_validation = _resolve_model_class(model_name)
-    # ``torch_dtype`` is supported by the oldest transformers version in the
-    # serving extra (4.44).  The shorter ``dtype`` spelling was added later and
-    # is forwarded to model constructors by older releases, where it fails.
+        cls, needs_validation, config = _resolve_model_class(
+            model_name,
+            **from_pretrained_kwargs,
+        )
+        # Passing the exact object makes config resolution single-shot and pins
+        # class selection and weight loading to the same metadata.
+        from_pretrained_kwargs["config"] = config
+    # Keep ``torch_dtype`` rather than the newer short spelling for explicit
+    # model-class overrides that still implement the established HF argument.
     model = cls.from_pretrained(
         model_name,
         torch_dtype=dtype,

--- a/codenib/serving/server/real_model.py
+++ b/codenib/serving/server/real_model.py
@@ -39,10 +39,12 @@ also deferred.
 ``Qwen3_5ForConditionalGeneration`` with a ``vision_config`` — maps cleanly:
 ``transformers`` (>= 5.2) registers ``Qwen3_5ForCausalLM`` in the causal-LM
 auto-mapping, so ``AutoModelForCausalLM.from_pretrained`` returns the text model
-directly (verified on transformers 5.12). For any model the causal-LM mapping
-genuinely rejects, pass an explicit ``model_class`` (e.g.
-``AutoModelForImageTextToText``, whose ``input_ids``-only forward also emits
-next-token text ``.logits``); ``RealModelVerifier`` forwards it to :func:`_load_lm`.
+directly (verified on transformers 5.12). A model outside that mapping loads
+only if its ``model_type`` is in :data:`VERIFIED_NON_CAUSAL_MODEL_TYPES` — an
+allowlist of architectures whose ``input_ids``-only forward is known to emit
+causal-LM ``.logits`` — and each registry load is validated with a one-token
+text forward before serving. Anything else fails loudly; the ``model_class``
+parameter remains as the explicit escape hatch (and is how tests inject stubs).
 
 torch/transformers are imported lazily so this module (and ``best_linear_path``)
 stay importable without the ``bench`` extra installed.
@@ -73,6 +75,80 @@ def best_linear_path(tree: DraftTree) -> List[TokenId]:
     return path
 
 
+#: ``model_type`` values that live outside the transformers causal-LM
+#: auto-mapping but whose ``input_ids``-only forward is verified to emit
+#: causal-LM ``.logits``. Values name the auto-class attribute on
+#: ``transformers`` (resolved lazily, so this module imports without the
+#: serving extra). Add a type here only after checking its text-only forward;
+#: every registry load is additionally validated by
+#: :func:`_validate_text_logits` at startup.
+VERIFIED_NON_CAUSAL_MODEL_TYPES = {
+    "muse_glimmer": "AutoModelForImageTextToText",
+}
+
+
+def _resolve_model_class(model_name: str):
+    """Pick the auto-class for ``model_name`` from its config ``model_type``.
+
+    Resolution is fail-closed, mirroring how the compiler picks index builders
+    from :class:`~codenib.compiler.index_builders.IndexBuilderRegistry`: the
+    causal-LM auto-mapping wins, then the
+    :data:`VERIFIED_NON_CAUSAL_MODEL_TYPES` allowlist (the returned marker makes
+    the caller run the one-token forward validation), and an unknown type raises
+    rather than guessing — a class that merely *loads* can still verify
+    speculation against the wrong logits.
+
+    Returns:
+        ``(auto_class, needs_validation)``.
+    """
+    import transformers
+    from transformers import AutoConfig, AutoModelForCausalLM
+    from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+
+    model_type = getattr(AutoConfig.from_pretrained(model_name), "model_type", None)
+    if model_type in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
+        return AutoModelForCausalLM, False
+    registered = VERIFIED_NON_CAUSAL_MODEL_TYPES.get(model_type)
+    if registered is not None:
+        return getattr(transformers, registered), True
+    raise RuntimeError(
+        f"model_type {model_type!r} of {model_name!r} is neither in the "
+        "transformers causal-LM auto-mapping nor in "
+        "VERIFIED_NON_CAUSAL_MODEL_TYPES; verify its text-only forward emits "
+        "causal-LM logits, then add it to the registry (or pass an explicit "
+        "model_class)"
+    )
+
+
+def _validate_text_logits(model, model_name: str) -> None:
+    """Assert ``model`` emits ``[batch, seq, vocab]`` logits from a text forward.
+
+    Turns the registry's behavioral assumption into a startup invariant: a
+    registry-listed class that needs pixel inputs, or that routes text through a
+    head with different logits semantics, fails here — before the server binds a
+    port — instead of silently corrupting speculation verification. One token on
+    the load-time device; for large models this is a one-off startup cost.
+    """
+    import torch
+
+    token = getattr(model.config, "bos_token_id", None) or 0
+    try:
+        with torch.no_grad():
+            out = model(input_ids=torch.tensor([[token]], dtype=torch.long))
+    except Exception as exc:
+        raise RuntimeError(
+            f"{model_name!r} rejected a text-only forward; its registry entry "
+            "in VERIFIED_NON_CAUSAL_MODEL_TYPES is wrong for this checkpoint"
+        ) from exc
+    logits = getattr(out, "logits", None)
+    if logits is None or getattr(logits, "ndim", None) != 3:
+        raise RuntimeError(
+            f"text-only forward of {model_name!r} did not return "
+            "[batch, seq, vocab] logits; the model cannot back greedy "
+            "speculation verification"
+        )
+
+
 def _load_lm(
     model_name: str,
     *,
@@ -82,29 +158,33 @@ def _load_lm(
 ):
     """Load a model that exposes causal-LM ``.logits`` from a text-only forward.
 
-    Uses ``AutoModelForCausalLM`` by default (covers every target we run,
-    including ``Qwen/Qwen3.5-4B`` — its ``Qwen3_5ForCausalLM`` is in the causal-LM
-    auto-mapping on transformers >= 5.2). For a model that mapping genuinely
-    rejects, pass an explicit ``model_class`` (e.g. ``AutoModelForImageTextToText``,
-    whose ``input_ids``-only forward also emits next-token text logits) — it wins
-    over the default. Either way the result returns ``.logits`` from a text-only
-    forward, which is all :meth:`RealModelVerifier.verify` needs.
+    The auto-class comes from :func:`_resolve_model_class`: the causal-LM
+    auto-mapping (covers every target we run, including ``Qwen/Qwen3.5-4B`` —
+    its ``Qwen3_5ForCausalLM`` is in that mapping on transformers >= 5.2), then
+    the :data:`VERIFIED_NON_CAUSAL_MODEL_TYPES` allowlist, whose loads are
+    validated with a one-token text forward. An explicit ``model_class`` skips
+    both resolution and validation — the caller asserts the class is right
+    (tests use this to inject stubs).
 
     Extra ``from_pretrained_kwargs`` are forwarded verbatim, so callers with
     stricter loading needs can pass them through — e.g. the tree engine loads
     with ``attn_implementation="eager"`` (see :meth:`HFTreeEngine.from_pretrained`).
     """
-    from transformers import AutoModelForCausalLM
-
-    cls = model_class if model_class is not None else AutoModelForCausalLM
+    if model_class is not None:
+        cls, needs_validation = model_class, False
+    else:
+        cls, needs_validation = _resolve_model_class(model_name)
     # ``torch_dtype`` is supported by the oldest transformers version in the
     # serving extra (4.44).  The shorter ``dtype`` spelling was added later and
     # is forwarded to model constructors by older releases, where it fails.
-    return cls.from_pretrained(
+    model = cls.from_pretrained(
         model_name,
         torch_dtype=dtype,
         **from_pretrained_kwargs,
     )
+    if needs_validation:
+        _validate_text_logits(model, model_name)
+    return model
 
 
 class RealModelVerifier(Verifier):

--- a/codenib/serving/server/real_model.py
+++ b/codenib/serving/server/real_model.py
@@ -58,6 +58,17 @@ from codenib.serving.server.sglang import _normalize_eos_token_ids
 from codenib.serving.server.worker import Verifier, VerifyResult
 from codenib.serving.types import DraftTree, TokenId
 
+#: ``model_type`` values that live outside the transformers causal-LM
+#: auto-mapping but whose ``input_ids``-only forward is verified to emit
+#: causal-LM ``.logits``. Values name the auto-class attribute on
+#: ``transformers`` (resolved lazily, so this module imports without the
+#: serving extra). Add a type here only after checking its text-only forward;
+#: every registry load is additionally validated by
+#: :func:`_validate_text_logits` at startup.
+VERIFIED_NON_CAUSAL_MODEL_TYPES = {
+    "muse_glimmer": "AutoModelForImageTextToText",
+}
+
 
 def best_linear_path(tree: DraftTree) -> List[TokenId]:
     """Flatten a draft tree to one linear branch for single-path verification.
@@ -73,18 +84,6 @@ def best_linear_path(tree: DraftTree) -> List[TokenId]:
         node = max(node.children, key=lambda c: c.score)
         path.append(node.token)
     return path
-
-
-#: ``model_type`` values that live outside the transformers causal-LM
-#: auto-mapping but whose ``input_ids``-only forward is verified to emit
-#: causal-LM ``.logits``. Values name the auto-class attribute on
-#: ``transformers`` (resolved lazily, so this module imports without the
-#: serving extra). Add a type here only after checking its text-only forward;
-#: every registry load is additionally validated by
-#: :func:`_validate_text_logits` at startup.
-VERIFIED_NON_CAUSAL_MODEL_TYPES = {
-    "muse_glimmer": "AutoModelForImageTextToText",
-}
 
 
 def _resolve_model_class(model_name: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ serving = [
     "numpy>=1.24.0",
     "sse-starlette>=2.0.0",
     "torch>=2.2.0",
-    "transformers>=4.44.0",
+    "transformers>=5.15.0",
 ]
 # Vertex AI backends (``vertex_ai/...`` model strings, via gcloud ADC).
 # Keep the provider SDK coupled to LiteLLM's own compatibility constraint

--- a/test/serving/test_real_model.py
+++ b/test/serving/test_real_model.py
@@ -45,58 +45,106 @@ def test_best_linear_path_picks_highest_scored_branch():
     assert best_linear_path(tree) == [9, 8]
 
 
-def _fake_transformers(*, causal_raises: bool):
-    """A stand-in ``transformers`` module recording which auto-class was used.
+class _CallableModelStub:
+    """Model stand-in: records nothing, answers a text forward with logits."""
 
-    ``AutoModelForCausalLM`` raises ``ValueError`` (mimicking an unmapped
-    architecture) when ``causal_raises``, else returns a sentinel string tagging
-    the class that loaded.
+    def __init__(self, logits_ndim=3):
+        self.config = types.SimpleNamespace(bos_token_id=1)
+        self._ndim = logits_ndim
+
+    def __call__(self, **kwargs):
+        return types.SimpleNamespace(logits=types.SimpleNamespace(ndim=self._ndim))
+
+
+def _fake_transformers(monkeypatch, *, model_type, vlm_result=None):
+    """Install stand-in ``transformers`` modules for auto-class resolution.
+
+    ``AutoConfig`` reports ``model_type`` for every model name; the causal-LM
+    mapping contains only ``"mapped_causal"``. ``AutoModelForImageTextToText``
+    returns ``vlm_result`` (default: a validation-passing model stub).
     """
     mod = types.ModuleType("transformers")
 
     class _CausalLM:
         @staticmethod
-        def from_pretrained(name, torch_dtype=None):
-            if causal_raises:
-                raise ValueError("architecture not mapped for causal LM")
+        def from_pretrained(name, torch_dtype=None, **kwargs):
             return f"causal:{name}:{torch_dtype}"
 
+    class _AutoConfig:
+        @staticmethod
+        def from_pretrained(name, **kwargs):
+            return types.SimpleNamespace(model_type=model_type)
+
+    class _ImageTextToText:
+        @staticmethod
+        def from_pretrained(name, torch_dtype=None, **kwargs):
+            return vlm_result if vlm_result is not None else _CallableModelStub()
+
     mod.AutoModelForCausalLM = _CausalLM
+    mod.AutoConfig = _AutoConfig
+    mod.AutoModelForImageTextToText = _ImageTextToText
+
+    auto_mod = types.ModuleType("transformers.models.auto.modeling_auto")
+    auto_mod.MODEL_FOR_CAUSAL_LM_MAPPING_NAMES = {"mapped_causal": "FakeForCausalLM"}
+    monkeypatch.setitem(sys.modules, "transformers", mod)
+    monkeypatch.setitem(sys.modules, "transformers.models.auto.modeling_auto", auto_mod)
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.long = object()
+    fake_torch.tensor = lambda *args, **kwargs: object()
+    fake_torch.no_grad = nullcontext
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
     return mod
 
 
-def test_load_lm_uses_causal_lm_by_default(monkeypatch):
+def test_load_lm_uses_causal_lm_for_mapped_model_type(monkeypatch):
     # Every target we run — including Qwen3.5-4B, whose Qwen3_5ForCausalLM is in
-    # the causal-LM auto-mapping on transformers >= 5.2 — loads this way.
-    monkeypatch.setitem(
-        sys.modules, "transformers", _fake_transformers(causal_raises=False)
-    )
+    # the causal-LM auto-mapping on transformers >= 5.2 — resolves this way, with
+    # no validation forward.
+    _fake_transformers(monkeypatch, model_type="mapped_causal")
     assert (
         _load_lm("some/causal-model", dtype="bf16") == "causal:some/causal-model:bf16"
     )
 
 
-def test_load_lm_does_not_silently_fall_back(monkeypatch):
-    # If the causal-LM mapping genuinely rejects a model, the error propagates —
-    # there is no automatic multimodal fallback; callers pass an explicit
-    # model_class instead (see test below).
-    monkeypatch.setitem(
-        sys.modules, "transformers", _fake_transformers(causal_raises=True)
+def test_load_lm_resolves_registry_model_type_and_validates(monkeypatch):
+    # muse_glimmer is outside the causal-LM mapping but allowlisted in
+    # VERIFIED_NON_CAUSAL_MODEL_TYPES; it loads via AutoModelForImageTextToText
+    # and must pass the one-token text-forward validation.
+    _fake_transformers(monkeypatch, model_type="muse_glimmer")
+    model = _load_lm("meta-models/Muse-Glimmer-30B", dtype=None)
+    assert isinstance(model, _CallableModelStub)
+
+
+def test_load_lm_registry_load_failing_validation_raises(monkeypatch):
+    # A registry entry whose checkpoint does not emit [batch, seq, vocab] logits
+    # from a text-only forward is rejected at load time, not at verify time.
+    _fake_transformers(
+        monkeypatch,
+        model_type="muse_glimmer",
+        vlm_result=_CallableModelStub(logits_ndim=2),
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError, match="logits"):
+        _load_lm("meta-models/Muse-Glimmer-30B", dtype=None)
+
+
+def test_load_lm_unknown_model_type_fails_closed(monkeypatch):
+    # No blind fallback: a model_type outside both the causal-LM mapping and the
+    # registry raises with the remediation named, instead of guessing a class
+    # that might load but verify against the wrong logits.
+    _fake_transformers(monkeypatch, model_type="novel_arch")
+    with pytest.raises(RuntimeError, match="VERIFIED_NON_CAUSAL_MODEL_TYPES"):
         _load_lm("x/y", dtype=None)
 
 
 def test_load_lm_honours_explicit_model_class(monkeypatch):
-    # Explicit override wins over the causal-LM default and is used even when the
-    # causal-LM mapping would have rejected the model.
-    monkeypatch.setitem(
-        sys.modules, "transformers", _fake_transformers(causal_raises=True)
-    )
+    # Explicit override wins without touching resolution or validation — the
+    # caller asserts the class is right (this is also how tests inject stubs).
+    _fake_transformers(monkeypatch, model_type="novel_arch")
 
     class _Forced:
         @staticmethod
-        def from_pretrained(name, torch_dtype=None):
+        def from_pretrained(name, torch_dtype=None, **kwargs):
             return f"forced:{name}:{torch_dtype}"
 
     assert _load_lm("x/y", dtype="fp32", model_class=_Forced) == "forced:x/y:fp32"

--- a/test/serving/test_real_model.py
+++ b/test/serving/test_real_model.py
@@ -13,12 +13,19 @@ import os
 import sys
 import types
 from contextlib import nullcontext
+from pathlib import Path
 
 import pytest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
 
 from codenib.serving.server.real_model import (
     RealModelVerifier,
     _load_lm,
+    _resolve_model_class,
     best_linear_path,
 )
 from codenib.serving.types import DraftNode, DraftTree
@@ -56,7 +63,14 @@ class _CallableModelStub:
         return types.SimpleNamespace(logits=types.SimpleNamespace(ndim=self._ndim))
 
 
-def _fake_transformers(monkeypatch, *, model_type, vlm_result=None):
+def _fake_transformers(
+    monkeypatch,
+    *,
+    model_type,
+    vlm_result=None,
+    resolved_config=None,
+    seen=None,
+):
     """Install stand-in ``transformers`` modules for auto-class resolution.
 
     ``AutoConfig`` reports ``model_type`` for every model name; the causal-LM
@@ -64,20 +78,27 @@ def _fake_transformers(monkeypatch, *, model_type, vlm_result=None):
     returns ``vlm_result`` (default: a validation-passing model stub).
     """
     mod = types.ModuleType("transformers")
+    if resolved_config is None:
+        resolved_config = types.SimpleNamespace(model_type=model_type)
+    seen = seen if seen is not None else {}
+    seen["resolved_config"] = resolved_config
 
     class _CausalLM:
         @staticmethod
         def from_pretrained(name, torch_dtype=None, **kwargs):
+            seen["causal_load"] = (name, torch_dtype, kwargs)
             return f"causal:{name}:{torch_dtype}"
 
     class _AutoConfig:
         @staticmethod
         def from_pretrained(name, **kwargs):
-            return types.SimpleNamespace(model_type=model_type)
+            seen["config_load"] = (name, kwargs)
+            return resolved_config
 
     class _ImageTextToText:
         @staticmethod
         def from_pretrained(name, torch_dtype=None, **kwargs):
+            seen["image_text_load"] = (name, torch_dtype, kwargs)
             return vlm_result if vlm_result is not None else _CallableModelStub()
 
     mod.AutoModelForCausalLM = _CausalLM
@@ -105,6 +126,70 @@ def test_load_lm_uses_causal_lm_for_mapped_model_type(monkeypatch):
     assert (
         _load_lm("some/causal-model", dtype="bf16") == "causal:some/causal-model:bf16"
     )
+
+
+def test_load_lm_resolves_and_loads_with_identical_hub_policy(monkeypatch):
+    seen = {}
+    token = object()
+    cache_dir = object()
+    _fake_transformers(
+        monkeypatch,
+        model_type="mapped_causal",
+        seen=seen,
+    )
+
+    _load_lm(
+        "private/revisioned-model",
+        dtype="bf16",
+        revision="pinned-sha",
+        token=token,
+        cache_dir=cache_dir,
+        local_files_only=True,
+        trust_remote_code=False,
+        attn_implementation="eager",
+    )
+
+    config_name, config_kwargs = seen["config_load"]
+    model_name, model_dtype, model_kwargs = seen["causal_load"]
+    assert config_name == model_name == "private/revisioned-model"
+    assert model_dtype == "bf16"
+    for name, value in {
+        "revision": "pinned-sha",
+        "token": token,
+        "cache_dir": cache_dir,
+        "local_files_only": True,
+        "trust_remote_code": False,
+    }.items():
+        assert config_kwargs[name] is value
+        assert model_kwargs[name] is value
+    assert "attn_implementation" not in config_kwargs
+    assert model_kwargs["attn_implementation"] == "eager"
+    assert model_kwargs["config"] is seen["resolved_config"]
+
+
+def test_load_lm_uses_supplied_config_without_resolving_again(monkeypatch):
+    seen = {}
+    config = types.SimpleNamespace(model_type="muse_glimmer")
+    _fake_transformers(
+        monkeypatch,
+        model_type="ignored",
+        resolved_config=types.SimpleNamespace(model_type="novel_arch"),
+        seen=seen,
+    )
+
+    _load_lm(
+        "meta-models/Muse-Glimmer-30B",
+        dtype=None,
+        config=config,
+        revision="pinned-sha",
+        local_files_only=True,
+    )
+
+    assert "config_load" not in seen
+    _, _, model_kwargs = seen["image_text_load"]
+    assert model_kwargs["config"] is config
+    assert model_kwargs["revision"] == "pinned-sha"
+    assert model_kwargs["local_files_only"] is True
 
 
 def test_load_lm_resolves_registry_model_type_and_validates(monkeypatch):
@@ -148,6 +233,46 @@ def test_load_lm_honours_explicit_model_class(monkeypatch):
             return f"forced:{name}:{torch_dtype}"
 
     assert _load_lm("x/y", dtype="fp32", model_class=_Forced) == "forced:x/y:fp32"
+
+
+def test_serving_extra_requires_muse_glimmer_capable_transformers():
+    project_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    with project_path.open("rb") as handle:
+        serving = tomllib.load(handle)["project"]["optional-dependencies"]["serving"]
+
+    assert "transformers>=5.15.0" in serving
+
+
+def test_real_transformers_metadata_registers_muse_glimmer():
+    transformers = pytest.importorskip("transformers")
+    from packaging.version import Version
+
+    if Version(transformers.__version__) < Version("5.15.0"):
+        pytest.skip("the optional serving runtime requires transformers>=5.15.0")
+
+    from transformers import AutoConfig
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+    from transformers.models.auto.modeling_auto import (
+        MODEL_FOR_CAUSAL_LM_MAPPING_NAMES,
+        MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
+    )
+
+    assert CONFIG_MAPPING_NAMES["muse_glimmer"] == "MuseGlimmerConfig"
+    assert "muse_glimmer" not in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+    assert (
+        MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES["muse_glimmer"]
+        == "MuseGlimmerForConditionalGeneration"
+    )
+
+    config = AutoConfig.for_model("muse_glimmer")
+    cls, needs_validation, resolved_config = _resolve_model_class(
+        "metadata-only/no-download",
+        config=config,
+        local_files_only=True,
+    )
+    assert cls is transformers.AutoModelForImageTextToText
+    assert needs_validation is True
+    assert resolved_config is config
 
 
 def test_real_model_verifier_stops_before_drafted_eos(monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ requires-dist = [
     { name = "sse-starlette", marker = "extra == 'test'", specifier = ">=2.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'test'", specifier = ">=1.1.0" },
     { name = "torch", marker = "extra == 'serving'", specifier = ">=2.2.0" },
-    { name = "transformers", marker = "extra == 'serving'", specifier = ">=4.44.0" },
+    { name = "transformers", marker = "extra == 'serving'", specifier = ">=5.15.0" },
     { name = "tree-sitter", specifier = ">=0.25.2" },
     { name = "tree-sitter-language-pack", specifier = ">=1.8.1,<1.9.0" },
     { name = "uvicorn", specifier = ">=0.20.0" },
@@ -792,7 +792,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -876,7 +876,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -1119,7 +1119,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -1154,43 +1154,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -1271,7 +1271,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2634,15 +2634,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "cycler", marker = "python_full_version < '3.11'" },
+    { name = "fonttools", marker = "python_full_version < '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pillow", marker = "python_full_version < '3.11'" },
+    { name = "pyparsing", marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -2724,16 +2724,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cycler", marker = "python_full_version >= '3.11'" },
+    { name = "fonttools", marker = "python_full_version >= '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pillow", marker = "python_full_version >= '3.11'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [
@@ -3483,7 +3483,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -3522,7 +3522,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -3534,7 +3534,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3564,9 +3564,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3578,7 +3578,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3687,10 +3687,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -3765,10 +3765,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
 wheels = [
@@ -5088,10 +5088,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -5149,13 +5149,13 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "narwhals" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "narwhals", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "threadpoolctl" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -5199,7 +5199,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -5260,7 +5260,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -5345,7 +5345,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -5723,7 +5723,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.14.1"
+version = "5.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -5738,9 +5738,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/fb/2a2ba88f325e68a921d8b69ff63b477830b2e73ade9a3c8c8cab2f06d741/transformers-5.14.1.tar.gz", hash = "sha256:60d196c27781eacf8637e2b533f517582907ad6f9ae142046d6b69431a5b2173", size = 9295927, upload-time = "2026-07-16T09:41:57.773Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/3f/d89353267d511e18f137dfd7769d07837350c11b88408ce1dfe2e93e56c7/transformers-5.15.0.tar.gz", hash = "sha256:bbf98f57b2ddd7c4ecbccfa2c0069017aa6fd01cc204bd50cbc0eeadcf2a13b8", size = 9377983, upload-time = "2026-08-10T10:27:23.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/67/8d85ca2323233ae3c0365a659c4e52ee1f587b440e4bc577e7d8e4416d0f/transformers-5.14.1-py3-none-any.whl", hash = "sha256:9db974c4079ede2d1a3ea7ca5a240df33f2cc26fc2b36ba64c5f2a4f43b6e725", size = 11625234, upload-time = "2026-07-16T09:41:54.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/43/81355710a4c84e9420e11a86d41a5364deb561f2ef36dfdf254a07371bbb/transformers-5.15.0-py3-none-any.whl", hash = "sha256:d7f007736f67749ae9490c4f8cb5d30b452ae2d68c8675e50ba8d63ea7feb107", size = 11749280, upload-time = "2026-08-10T10:27:20.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`codenib-serve` previously loaded every target as `AutoModelForCausalLM`, so a model outside that auto-mapping could not be served from the CLI. Muse Glimmer (`model_type: muse_glimmer`) is registered under `AutoModelForImageTextToText` in Transformers 5.15.

This PR resolves the auto-class from one pinned model config, follows a small verified registry for non-causal mappings, validates their text-only logits contract before serving, and fails closed for unknown architectures. The Python-level `model_class` override remains available for explicit callers and test stubs.

## Changes

- Add `VERIFIED_NON_CAUSAL_MODEL_TYPES`, seeded with `muse_glimmer -> AutoModelForImageTextToText`.
- Resolve one config under the same revision, token, cache, offline, subfolder, and remote-code policy used by the model load, then pass that exact config object to the selected auto-class.
- Add a one-token text-only validation for registry-selected models and reject unknown or incompatible architectures before serving.
- Require `transformers>=5.15.0` in the serving extra and update `uv.lock` to the first built-in Muse Glimmer release.
- Keep the explicit `model_class` escape hatch unchanged.
- Cover mapped, registry, unknown, explicit, offline/private-revision, lock-version, and real Transformers metadata contracts without downloading model weights.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/serving test/test_release_metadata.py --tb=short`: **170 passed, 2 skipped**
- The real metadata contract was also run with `transformers==5.15.0`; it verifies the built-in Muse Glimmer config and image-text mapping without weights or network access.
- `uv lock --check`
- Repository-pinned Black, isort, flake8, namespace checks, and `git diff --check`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of the code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
