### PR TITLE
fix(security): bound structured input validation

### DIFF
--- a/codenib/_bounded_json.py
+++ b/codenib/_bounded_json.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from collections.abc import Iterable, Iterator
 from typing import Any, BinaryIO, Protocol
 
@@ -83,7 +84,12 @@ class _ByteStream:
         while self._position >= len(self._block):
             if self._eof:
                 return None
-            self._block = self._source.read(_READ_BYTES)
+            block = self._source.read(_READ_BYTES)
+            if type(block) is not bytes or len(block) > _READ_BYTES:
+                raise ValueError(
+                    "bounded JSON reader returned an invalid or oversized block"
+                )
+            self._block = block
             self._position = 0
             if not self._block:
                 self._eof = True
@@ -108,6 +114,7 @@ class _ByteStream:
 
 _JSON_WHITESPACE = frozenset(b" \t\r\n")
 _ATOM_DELIMITERS = frozenset(b" \t\r\n,]}:")
+_STRING_SPECIAL = re.compile(rb'["\\]')
 
 
 def _next_non_whitespace(stream: _ByteStream) -> int | None:
@@ -123,24 +130,42 @@ def _frame_json_element(
     *,
     label: str,
     max_element_bytes: int,
+    max_nodes: int,
     max_tokens: int,
     max_depth: int,
 ) -> tuple[bytearray, int]:
     """Frame one complete array element before allocating its decoded DOM."""
 
     payload = bytearray()
-    stack: list[int] = []
+    stack: list[list[Any]] = []
     in_string = False
+    string_is_key = False
     escaped = False
     string_bytes = 0
     in_atom = False
     atom_bytes = 0
     token_count = 0
+    node_count = 0
     first_pending = True
 
     def reserve(count: int) -> None:
         if len(payload) + count > max_element_bytes:
             raise ValueError(f"{label} element exceeds {max_element_bytes} bytes")
+
+    def start_value() -> None:
+        nonlocal node_count
+        # Match ``validate_json_complexity``: the element root is level one,
+        # and each containing object/array adds one level for its children.
+        depth = len(stack) + 1
+        if depth > max_depth:
+            raise ValueError(f"{label} exceeds its {max_depth}-level depth limit")
+        node_count += 1
+        if node_count > max_nodes:
+            raise ValueError(f"{label} exceeds its {max_nodes}-node limit")
+
+    def finish_value() -> None:
+        if stack:
+            stack[-1][1] = "comma_or_end"
 
     while True:
         if first_pending:
@@ -165,19 +190,21 @@ def _frame_json_element(
                     string_bytes += 1
                     index += 1
                     continue
-                quote = block.find(b'"', index)
-                slash = block.find(b"\\", index)
-                candidates = tuple(item for item in (quote, slash) if item >= 0)
-                special = min(candidates) if candidates else -1
-                if special < 0:
+                match = _STRING_SPECIAL.search(block, index)
+                if match is None:
                     string_bytes += len(block) - index
                     index = len(block)
                     break
+                special = match.start()
                 string_bytes += special - index + 1
                 if block[special] == ord("\\"):
                     escaped = True
                 else:
                     in_string = False
+                    if string_is_key:
+                        stack[-1][1] = "colon"
+                    else:
+                        finish_value()
                 index = special + 1
                 if string_bytes > max_element_bytes:
                     raise ValueError(
@@ -189,6 +216,7 @@ def _frame_json_element(
                 if current in _ATOM_DELIMITERS:
                     in_atom = False
                     atom_bytes = 0
+                    finish_value()
                 else:
                     atom_bytes += 1
                     if atom_bytes > 1_024:
@@ -211,22 +239,33 @@ def _frame_json_element(
                 token_count += 1
                 in_string = True
                 string_bytes = 0
+                string_is_key = bool(
+                    stack and stack[-1][0] == ord("{") and stack[-1][1] == "key_or_end"
+                )
+                if not string_is_key:
+                    start_value()
             elif current in {ord("{"), ord("[")}:
                 token_count += 1
-                stack.append(current)
-                if len(stack) > max_depth:
-                    raise ValueError(
-                        f"{label} exceeds its {max_depth}-level depth limit"
-                    )
+                start_value()
+                state = "key_or_end" if current == ord("{") else "value_or_end"
+                stack.append([current, state])
             elif current in {ord("}"), ord("]")}:
                 expected = ord("{") if current == ord("}") else ord("[")
-                if not stack or stack[-1] != expected:
+                if not stack or stack[-1][0] != expected:
                     raise ValueError(f"{label} contains mismatched JSON delimiters")
                 stack.pop()
+                finish_value()
             elif current in b"-0123456789tfn":
                 token_count += 1
+                start_value()
                 in_atom = True
                 atom_bytes = 1
+            elif current == ord(":") and stack and stack[-1][0] == ord("{"):
+                stack[-1][1] = "value"
+            elif current == ord(",") and stack:
+                stack[-1][1] = (
+                    "key_or_end" if stack[-1][0] == ord("{") else "value_or_end"
+                )
             if token_count > max_tokens:
                 raise ValueError(f"{label} exceeds its {max_tokens}-token limit")
             index += 1
@@ -297,28 +336,32 @@ def iter_bounded_json_array(
     while True:
         if first is None:
             break
+        if item_count >= max_items:
+            raise ValueError(f"{label} exceeds its {max_items}-item limit")
         element_offset = stream.offset - 1
-        while True:
+        framed, delimiter = _frame_json_element(
+            stream,
+            first,
+            label=label,
+            max_element_bytes=max_element_bytes,
+            max_nodes=max_nodes_per_element,
+            max_tokens=max_lexical_tokens,
+            max_depth=max_depth,
+        )
+        try:
             try:
-                framed, delimiter = _frame_json_element(
-                    stream,
-                    first,
-                    label=label,
-                    max_element_bytes=max_element_bytes,
-                    max_tokens=max_lexical_tokens,
-                    max_depth=max_depth,
-                )
                 text = framed.decode("utf-8", errors="strict")
                 value, end = decoder.raw_decode(text, 0)
                 if end != len(text):
                     raise ValueError(f"{label} element contains trailing data")
-                del text, framed
-                break
-            except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
-                raise ValueError(
-                    f"{label} element {item_count} at byte {element_offset} "
-                    "contains invalid JSON"
-                ) from exc
+            finally:
+                del framed
+        except (RecursionError, ValueError) as exc:
+            raise ValueError(
+                f"{label} element {item_count} at byte {element_offset} "
+                "contains invalid JSON"
+            ) from exc
+        del text
         validate_json_complexity(
             value,
             label=f"{label} element {item_count}",
@@ -327,8 +370,6 @@ def iter_bounded_json_array(
             max_key_bytes=max_key_bytes,
         )
         item_count += 1
-        if item_count > max_items:
-            raise ValueError(f"{label} exceeds its {max_items}-item limit")
         yield value
         if delimiter == ord("]"):
             first = None

--- a/codenib/_secret_fields.py
+++ b/codenib/_secret_fields.py
@@ -79,13 +79,22 @@ def _trim_bounds(value: str) -> tuple[int, int]:
     return start, end
 
 
-def _authority_contains_userinfo(value: str, start: int, end: int) -> bool:
+def _authority_contains_userinfo(
+    value: str,
+    start: int,
+    end: int,
+    *,
+    allow_whitespace: bool,
+) -> bool:
     """Check a URL authority without copying a potentially huge document."""
 
     position = start
     while position < end:
         char = value[position]
-        if char in "/?#" or char.isspace():
+        # urllib.parse treats whitespace inside a standalone URL netloc as
+        # part of the authority. Embedded URLs still stop at prose whitespace
+        # so a later email address is not misclassified as URL userinfo.
+        if char in "/?#" or (not allow_whitespace and char.isspace()):
             break
         if char == "@":
             return True
@@ -93,9 +102,33 @@ def _authority_contains_userinfo(value: str, start: int, end: int) -> bool:
     return False
 
 
+def _urlsplit_start(value: str, start: int, end: int) -> int:
+    """Skip the leading WHATWG C0 controls and space stripped by urlsplit."""
+
+    while start < end and ord(value[start]) <= 0x20:
+        start += 1
+    return start
+
+
+def _is_standalone_url_scheme(value: str, start: int, separator: int) -> bool:
+    """Return whether the first ``://`` follows a scheme at the trim boundary."""
+
+    if separator <= start:
+        return False
+    first = value[start]
+    if not (first.isascii() and first.isalpha()):
+        return False
+    for position in range(start + 1, separator):
+        char = value[position]
+        if not (char.isascii() and (char.isalnum() or char in "+-.")):
+            return False
+    return True
+
+
 def _string_contains_url_credentials(value: str, start: int, end: int) -> bool:
+    url_start = _urlsplit_start(value, start, end)
     if end - start <= 8_192:
-        candidate = value[start:end]
+        candidate = value[url_start:end]
         if "://" not in candidate and not candidate.startswith("//"):
             return False
         try:
@@ -104,15 +137,29 @@ def _string_contains_url_credentials(value: str, start: int, end: int) -> bool:
             raise SecretFieldError("value contains an invalid URL") from exc
         return parsed.username is not None or parsed.password is not None
 
-    if value.startswith("//", start) and _authority_contains_userinfo(
-        value, start + 2, end
+    if value.startswith("//", url_start) and _authority_contains_userinfo(
+        value,
+        url_start + 2,
+        end,
+        allow_whitespace=True,
     ):
         return True
-    search_from = start
-    while (separator := value.find("://", search_from, end)) >= 0:
-        if _authority_contains_userinfo(value, separator + 3, end):
+    separator = value.find("://", url_start, end)
+    standalone_url = separator >= 0 and _is_standalone_url_scheme(
+        value,
+        url_start,
+        separator,
+    )
+    while separator >= 0:
+        if _authority_contains_userinfo(
+            value,
+            separator + 3,
+            end,
+            allow_whitespace=standalone_url,
+        ):
             return True
-        search_from = separator + 3
+        standalone_url = False
+        separator = value.find("://", separator + 3, end)
     return False
 
 

--- a/test/storage/test_models.py
+++ b/test/storage/test_models.py
@@ -64,6 +64,65 @@ def test_shared_secret_classifier_rejects_credential_values(value: str) -> None:
         assert_no_secret_fields({"endpoint": value}, source="profile")
 
 
+def test_shared_secret_classifier_rejects_userinfo_after_authority_whitespace() -> None:
+    value = "http://user pass@host/" + ("x" * 9_000)
+    with pytest.raises(StorageValidationError, match="credentials"):
+        assert_no_secret_fields({"endpoint": value}, source="profile")
+
+
+def test_shared_secret_classifier_stops_embedded_url_at_prose_whitespace() -> None:
+    value = "Visit https://example.test then email user@example.test " + ("x" * 9_000)
+    assert_no_secret_fields({"description": value}, source="profile")
+
+
+@pytest.mark.parametrize("length", [8_192, 8_193])
+@pytest.mark.parametrize("prefix", ["\x00", "\x01", " ", "\t"])
+def test_shared_secret_classifier_matches_urlsplit_leading_c0_boundaries(
+    prefix: str,
+    length: int,
+) -> None:
+    stem = prefix + "http://user pass@host/"
+    value = stem + ("x" * (length - len(stem)))
+    assert len(value) == length
+    with pytest.raises(StorageValidationError, match="credentials"):
+        assert_no_secret_fields({"endpoint": value}, source="profile")
+
+
+@pytest.mark.parametrize("length", [8_192, 8_193])
+@pytest.mark.parametrize("control", ["\x00", "\x01", " ", "\t"])
+def test_shared_secret_classifier_does_not_skip_c0_inside_prose(
+    control: str,
+    length: int,
+) -> None:
+    stem = "Visit " + control + "http://example.test then email user@example.test "
+    value = stem + ("x" * (length - len(stem)))
+    assert len(value) == length
+    assert_no_secret_fields({"description": value}, source="profile")
+
+
+def test_shared_secret_classifier_checks_long_scheme_prefix_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._secret_fields as secret_fields
+
+    real_validator = secret_fields._is_standalone_url_scheme
+    calls = 0
+
+    def track_validator(value: str, start: int, separator: int) -> bool:
+        nonlocal calls
+        calls += 1
+        return real_validator(value, start, separator)
+
+    monkeypatch.setattr(
+        secret_fields,
+        "_is_standalone_url_scheme",
+        track_validator,
+    )
+    value = ("a" * 9_000) + " prose " + ("x://example.test " * 10)
+    assert_no_secret_fields({"description": value}, source="profile")
+    assert calls == 1
+
+
 def test_shared_secret_classifier_does_not_reject_noncredential_token_words() -> None:
     assert_no_secret_fields(
         {

--- a/test/test_bounded_json.py
+++ b/test/test_bounded_json.py
@@ -7,6 +7,11 @@ from __future__ import annotations
 import io
 import json
 import math
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
 
 import pytest
 
@@ -54,6 +59,26 @@ def test_bounded_array_does_not_accept_a_number_prefix_at_a_chunk_end() -> None:
     ) == [123, 4]
 
 
+@pytest.mark.parametrize("block", [bytearray(b"[]"), "[]", None])
+def test_bounded_array_rejects_non_bytes_reader_blocks(block: object) -> None:
+    class InvalidReader:
+        def read(self, _size: int = -1) -> object:
+            return block
+
+    with pytest.raises(ValueError, match="invalid or oversized block"):
+        list(iter_bounded_json_array(InvalidReader(), label="documents"))
+
+
+def test_bounded_array_rejects_oversized_reader_blocks() -> None:
+    class OversizedReader:
+        def read(self, size: int = -1) -> bytes:
+            assert size > 0
+            return b" " * (size + 1)
+
+    with pytest.raises(ValueError, match="invalid or oversized block"):
+        list(iter_bounded_json_array(OversizedReader(), label="documents"))
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -97,6 +122,121 @@ def test_bounded_array_enforces_complexity_before_decode(
     assert decode_called is False
 
 
+@pytest.mark.parametrize(
+    ("payload", "limits", "message"),
+    [
+        (b"[[0,1,2]]", {"max_nodes_per_element": 3}, "node limit"),
+        (b"[[[[0]]]]", {"max_depth": 2}, "depth limit"),
+    ],
+)
+def test_node_and_depth_budgets_reject_before_dom_allocation(
+    payload: bytes,
+    limits: dict[str, int],
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._bounded_json as bounded_json
+
+    decode_called = False
+
+    class _ForbiddenDecoder:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def raw_decode(self, _value: str, _offset: int):
+            nonlocal decode_called
+            decode_called = True
+            raise AssertionError("structural budget must reject before decoding")
+
+    monkeypatch.setattr(bounded_json.json, "JSONDecoder", _ForbiddenDecoder)
+    with pytest.raises(ValueError, match=message):
+        list(
+            bounded_json.iter_bounded_json_array(
+                io.BytesIO(payload),
+                label="documents",
+                **limits,
+            )
+        )
+    assert decode_called is False
+
+
+def test_depth_budget_uses_the_same_one_based_levels_before_and_after_decode() -> None:
+    assert list(
+        iter_bounded_json_array(
+            io.BytesIO(b"[[[0]]]"),
+            label="documents",
+            max_depth=3,
+        )
+    ) == [[[0]]]
+
+
+def test_item_budget_rejects_the_next_element_before_decoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._bounded_json as bounded_json
+
+    real_decoder = json.JSONDecoder
+    decode_calls = 0
+
+    class _TrackingDecoder:
+        def __init__(self, **kwargs) -> None:
+            self._decoder = real_decoder(**kwargs)
+
+        def raw_decode(self, value: str, offset: int):
+            nonlocal decode_calls
+            decode_calls += 1
+            return self._decoder.raw_decode(value, offset)
+
+    monkeypatch.setattr(bounded_json.json, "JSONDecoder", _TrackingDecoder)
+    with pytest.raises(ValueError, match="1-item limit"):
+        list(
+            bounded_json.iter_bounded_json_array(
+                io.BytesIO(b"[0,1]"),
+                label="documents",
+                max_items=1,
+            )
+        )
+    assert decode_calls == 1
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"\xef\xbb\xbf[]",
+        b"[0,]",
+        b"[0,,1]",
+        b"[{]",
+        b"[[)]",
+        b'["\\x"]',
+        b'["\x01"]',
+        b"[0] trailing",
+    ],
+)
+def test_bounded_array_rejects_malformed_framing(payload: bytes) -> None:
+    with pytest.raises(ValueError):
+        list(iter_bounded_json_array(io.BytesIO(payload), label="documents"))
+
+
+def test_escape_dense_string_scanning_scales_linearly() -> None:
+    def elapsed(pairs: int) -> float:
+        payload = b'["' + (b"\\\\" * pairs) + b'"]'
+        started = time.perf_counter()
+        assert list(
+            iter_bounded_json_array(
+                io.BytesIO(payload),
+                label="escape-dense documents",
+                max_element_bytes=len(payload),
+            )
+        ) == ["\\" * pairs]
+        return time.perf_counter() - started
+
+    # Use the best of two runs to reduce scheduler noise. The larger input is
+    # four times the size; the old repeated-find loop grew quadratically.
+    small = min(elapsed(100_000) for _ in range(2))
+    large = min(elapsed(400_000) for _ in range(2))
+    assert large < max(0.25, small * 8)
+
+
 def test_canonical_array_chunks_match_the_existing_json_contract() -> None:
     values = [
         {},
@@ -118,3 +258,106 @@ def test_canonical_array_chunks_match_the_existing_json_contract() -> None:
     ).encode("ascii")
 
     assert observed == expected
+
+
+def _pipeline_rss(path: Path) -> dict[str, int]:
+    script = textwrap.dedent(
+        """
+        import hashlib
+        import json
+        import os
+        import sys
+
+        from codenib._bounded_json import (
+            canonical_json_array_chunks,
+            iter_bounded_json_array,
+        )
+
+        def vm_hwm_kib():
+            with open("/proc/self/status", encoding="ascii") as handle:
+                for line in handle:
+                    if line.startswith("VmHWM:"):
+                        return int(line.split()[1])
+            raise RuntimeError("VmHWM is unavailable")
+
+        before = vm_hwm_kib()
+        count = 0
+        largest_chunk = 0
+        digest = hashlib.sha256()
+
+        def values():
+            global count
+            with open(sys.argv[1], "rb") as source:
+                for value in iter_bounded_json_array(
+                    source,
+                    label="documents",
+                ):
+                    count += 1
+                    yield value
+
+        for chunk in canonical_json_array_chunks(values()):
+            largest_chunk = max(largest_chunk, len(chunk))
+            digest.update(chunk)
+        print(
+            json.dumps(
+                {
+                    "before_kib": before,
+                    "after_kib": vm_hwm_kib(),
+                    "count": count,
+                    "largest_chunk": largest_chunk,
+                    "input_bytes": os.path.getsize(sys.argv[1]),
+                }
+            )
+        )
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="the isolated RSS evidence reads Linux VmHWM",
+)
+def test_streaming_pipeline_peak_rss_is_bounded_by_one_element(
+    tmp_path: Path,
+) -> None:
+    many = tmp_path / "many.json"
+    item = b'{"metadata":{},"page_content":"' + (b"x" * 8_160) + b'"}'
+    target_bytes = 32 * 1024 * 1024
+    with many.open("wb") as handle:
+        handle.write(b"[")
+        size = 1
+        count = 0
+        while size + len(item) + 2 < target_bytes:
+            if count:
+                handle.write(b",")
+                size += 1
+            handle.write(item)
+            size += len(item)
+            count += 1
+        handle.write(b"]")
+
+    many_stats = _pipeline_rss(many)
+    assert many_stats["count"] == count
+    assert many_stats["after_kib"] - many_stats["before_kib"] < 64 * 1024
+    assert many_stats["largest_chunk"] <= 1024 * 1024
+
+    near_limit = tmp_path / "near-limit.json"
+    with near_limit.open("wb") as handle:
+        handle.write(b'["')
+        block = b"x" * (1024 * 1024)
+        for _ in range(60):
+            handle.write(block)
+        handle.write(b'"]')
+
+    element_stats = _pipeline_rss(near_limit)
+    assert element_stats["count"] == 1
+    assert element_stats["after_kib"] - element_stats["before_kib"] < 256 * 1024
+    assert element_stats["largest_chunk"] <= 1024 * 1024


### PR DESCRIPTION
## Summary

Bound structured input validation before large allocations and reject credential-bearing URL authorities without introducing input-size-dependent parser gaps.

These two self-contained hardening commits were extracted from the later #590 storage stack because they do not depend on #586–#588.

## Changes

- validate JSON reader block type and size before buffering
- enforce lexical node, depth, token, item, and element budgets before DOM decoding
- use linear escape-dense string scanning and retain post-decode complexity validation
- reject URL userinfo after authority whitespace for standalone and protocol-relative URLs
- keep embedded prose URLs bounded at whitespace so later email addresses are not misclassified
- align the short and long URL paths with `urlsplit` leading WHATWG C0 handling
- validate the standalone scheme prefix once so repeated embedded separators remain linear
- add malformed-input, boundary, bounded-memory, scaling, and credential regressions

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/test_bounded_json.py test/storage/test_models.py --tb=short`: 77 passed
- independent secret-classifier audit: 50 passed
- Python 3.10/3.11/3.12 checks across the 8,192/8,193 boundary and leading U+0000..U+0020
- randomized malformed/valid differential checks and 100k/200k/400k linearity probes
- `pre-commit run --files codenib/_bounded_json.py codenib/_secret_fields.py test/test_bounded_json.py test/storage/test_models.py`: passed
- `git diff --check origin/main...HEAD`: passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of the code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] The changes generate no new warnings
- [x] Any dependent changes have been merged and published