### PR TITLE
fix(storage): harden callback cleanup boundaries

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -13,8 +13,10 @@ import os
 import secrets
 import stat
 import sys
+from collections import deque
 from contextlib import contextmanager
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
+from functools import partial
 from pathlib import Path, PurePosixPath
 from typing import (
     Callable,
@@ -59,6 +61,7 @@ _MAX_PUBLICATION_STREAM_READ_BYTES = 8 << 20
 _RENAME_NOREPLACE = 1
 _RENAME_EXCL = 0x4
 _MAX_ORPHAN_NAME_ATTEMPTS = 128
+_MAX_ORDERED_ACTION_CANCELLATION_RETRIES = 8
 _DURABLE_PUBLICATION_FSYNC_BACKENDS = frozenset({"linux-renameat2"})
 _WINDOWS_RESERVED_BASENAMES = frozenset(
     {"CON", "PRN", "AUX", "NUL"}
@@ -483,15 +486,119 @@ def _annotate_secondary_error(
     label: str,
     secondary_error: BaseException,
 ) -> None:
-    message = f"{label}: {secondary_error!r}"
-    if hasattr(primary_error, "add_note"):
-        primary_error.add_note(message)
+    """Best-effort diagnostics that can never replace the primary error."""
+
+    if primary_error is secondary_error:
         return
-    notes = list(getattr(primary_error, "_codenib_cleanup_notes", ()))
-    notes.append(message)
-    primary_error._codenib_cleanup_notes = tuple(notes)  # type: ignore[attr-defined]
-    if primary_error.__cause__ is None:
-        primary_error.__cause__ = secondary_error
+    try:
+        message = f"{label}: {secondary_error!r}"
+        add_note = getattr(BaseException, "add_note", None)
+        if add_note is not None:
+            # Bypass a hostile BaseException subclass override.  Diagnostics
+            # must not execute code supplied by the exception being preserved.
+            add_note(primary_error, message)
+            return
+
+        try:
+            notes = BaseException.__getattribute__(
+                primary_error,
+                "_codenib_cleanup_notes",
+            )
+        except AttributeError:
+            notes = ()
+        if not isinstance(notes, tuple):
+            notes = ()
+        BaseException.__setattr__(
+            primary_error,
+            "_codenib_cleanup_notes",
+            (*notes, message),
+        )
+        if BaseException.__getattribute__(primary_error, "__cause__") is None:
+            BaseException.__setattr__(
+                primary_error,
+                "__cause__",
+                secondary_error,
+            )
+    except BaseException:  # noqa: B036 - diagnostics are strictly non-primary
+        return
+
+
+def _publication_cleanup_owner_is_closed(owner: object) -> bool:
+    """Best-effort completion probe for an exception-retained cleanup owner."""
+
+    try:
+        return bool(owner.closed)  # type: ignore[attr-defined]
+    except BaseException:  # noqa: B036 - uncertain ownership stays reachable
+        return False
+
+
+def _attach_publication_cleanup_owner(
+    failure: BaseException,
+    owner: object | None,
+) -> None:
+    """Keep an incomplete idempotent cleanup owner reachable from ``failure``."""
+
+    if owner is None or _publication_cleanup_owner_is_closed(owner):
+        return
+    try:
+        close = owner.close  # type: ignore[attr-defined]
+        if not callable(close):
+            return
+        try:
+            existing = BaseException.__getattribute__(
+                failure,
+                "publication_cleanup_owners",
+            )
+        except AttributeError:
+            existing = ()
+        # A callback-controlled exception may expose a tuple subclass whose
+        # iteration executes hostile code.  Retain only the inert built-in
+        # representation; any other value is not a trustworthy owner list.
+        if type(existing) is not tuple:
+            existing = ()
+        retained = tuple(
+            candidate
+            for candidate in existing
+            if not _publication_cleanup_owner_is_closed(candidate)
+        )
+        if any(candidate is owner for candidate in retained):
+            return
+        BaseException.__setattr__(
+            failure,
+            "publication_cleanup_owners",
+            (*retained, owner),
+        )
+    except BaseException:  # noqa: B036 - local ownership remains authoritative
+        return
+
+
+def _prune_publication_cleanup_owners(failure: BaseException | None) -> None:
+    """Drop completed owners after an eagerly protected cleanup finishes."""
+
+    if failure is None:
+        return
+    try:
+        try:
+            existing = BaseException.__getattribute__(
+                failure,
+                "publication_cleanup_owners",
+            )
+        except AttributeError:
+            return
+        if type(existing) is not tuple:
+            return
+        retained = tuple(
+            candidate
+            for candidate in existing
+            if not _publication_cleanup_owner_is_closed(candidate)
+        )
+        BaseException.__setattr__(
+            failure,
+            "publication_cleanup_owners",
+            retained,
+        )
+    except BaseException:  # noqa: B036 - diagnostics are strictly best-effort
+        return
 
 
 def _retain_first_error(
@@ -503,6 +610,461 @@ def _retain_first_error(
         return secondary_error
     _annotate_secondary_error(primary_error, label, secondary_error)
     return primary_error
+
+
+@dataclass(slots=True)
+class _OrderedAction:
+    """One cleanup step with an optional observable completion boundary."""
+
+    label: str
+    action: Callable[[], None]
+    complete: Callable[[], bool] | None = None
+    retry_incomplete: (
+        Literal["never", "cancellation"] | Callable[[BaseException | None], bool]
+    ) = "never"
+    incomplete_owner: object | None = None
+
+
+_OrderedActionInput = _OrderedAction | tuple[str, Callable[[], None]]
+
+
+@dataclass(slots=True)
+class _OrderedActionState:
+    actions: tuple[_OrderedActionInput, ...]
+    iteration_failure_label: str
+    primary_error: BaseException | None
+    next_index: int = 0
+    cancellation_retries: int = 0
+    retry_error_retained: bool = False
+    retained_diagnostics: set[tuple[int, str]] = field(default_factory=set)
+
+    def retain(self, label: str, error: BaseException) -> None:
+        if self.primary_error is None:
+            self.primary_error = error
+            return
+        _annotate_secondary_error(self.primary_error, label, error)
+
+    def retain_once(
+        self,
+        marker: str,
+        label: str,
+        error: BaseException,
+    ) -> None:
+        key = (self.next_index, marker)
+        if key in self.retained_diagnostics:
+            return
+        self.retained_diagnostics.add(key)
+        self.retain(label, error)
+
+    def retain_retry_error(self, label: str, error: BaseException) -> None:
+        if self.retry_error_retained:
+            return
+        self.retry_error_retained = True
+        self.retain(label, error)
+
+    def reset_retry_state(self) -> None:
+        self.cancellation_retries = 0
+        self.retry_error_retained = False
+
+    def protect_pending_owners(self) -> None:
+        """Make every not-yet-run cleanup owner retryable from the primary."""
+
+        if self.primary_error is None:
+            return
+        for action in self.actions[self.next_index :]:
+            if isinstance(action, _OrderedAction):
+                _attach_publication_cleanup_owner(
+                    self.primary_error,
+                    action.incomplete_owner,
+                )
+
+
+def _coerce_ordered_action(value: _OrderedActionInput) -> _OrderedAction:
+    if isinstance(value, _OrderedAction):
+        return value
+    label, action = value
+    return _OrderedAction(label=label, action=action)
+
+
+def _ordered_action_complete(
+    state: _OrderedActionState,
+    ordered: _OrderedAction,
+) -> bool:
+    complete = ordered.complete
+    if complete is None:
+        return False
+    try:
+        return complete() is True
+    except BaseException as completion_error:  # noqa: B036 - keep first
+        state.retain_once(
+            "completion-observation",
+            f"{ordered.label} completion observation also failed",
+            completion_error,
+        )
+        return False
+
+
+def _attempt_ordered_action(
+    state: _OrderedActionState,
+    ordered: _OrderedAction,
+) -> BaseException | None:
+    """Attempt an action inside the region that catches pre-call cancellation."""
+
+    try:
+        ordered.action()
+    except BaseException as action_error:  # noqa: B036 - keep first
+        return action_error
+    return None
+
+
+def _advance_ordered_action(state: _OrderedActionState) -> None:
+    """Advance only after completion, keeping the cursor restartable."""
+
+    state.next_index += 1
+    state.reset_retry_state()
+
+
+def _retain_incomplete_ordered_action(
+    state: _OrderedActionState,
+    ordered: _OrderedAction,
+) -> None:
+    state.retain_once(
+        "incomplete",
+        f"{ordered.label} did not reach completion",
+        RuntimeError("ordered cleanup action did not complete"),
+    )
+    if state.primary_error is not None:
+        _attach_publication_cleanup_owner(
+            state.primary_error,
+            ordered.incomplete_owner,
+        )
+
+
+def _exhaust_ordered_action_retries(
+    state: _OrderedActionState,
+    ordered: _OrderedAction | None,
+    *,
+    label: str,
+) -> None:
+    """Stop one non-progressing action and leave later actions runnable."""
+
+    state.retain_once(
+        "cancellation-retry-exhausted",
+        f"{label} cancellation retry limit also exhausted",
+        RuntimeError(
+            "ordered cleanup progress remained interrupted after "
+            f"{_MAX_ORDERED_ACTION_CANCELLATION_RETRIES} cancellation retries"
+        ),
+    )
+    if ordered is not None and _ordered_action_complete(state, ordered):
+        state.next_index += 1
+        state.reset_retry_state()
+        return
+    if state.primary_error is not None and ordered is not None:
+        _attach_publication_cleanup_owner(
+            state.primary_error,
+            ordered.incomplete_owner,
+        )
+    # Do not call the separately patchable advance seam here.  Its persistent
+    # interruption is one of the no-progress cases this boundary must contain.
+    state.next_index += 1
+    state.reset_retry_state()
+
+
+def _retry_ordered_action(
+    state: _OrderedActionState,
+    ordered: _OrderedAction | None,
+    error: BaseException,
+    *,
+    label: str,
+) -> bool:
+    """Retain one cancellation and grant only a bounded number of retries."""
+
+    state.retain_retry_error(label, error)
+    if state.cancellation_retries >= _MAX_ORDERED_ACTION_CANCELLATION_RETRIES:
+        _exhaust_ordered_action_retries(
+            state,
+            ordered,
+            label=label,
+        )
+        return False
+    state.cancellation_retries += 1
+    return True
+
+
+def _run_plain_ordered_action(
+    state: _OrderedActionState,
+    ordered: _OrderedAction,
+) -> None:
+    """Keep validation actions at-most-once across result/loop cancellation."""
+
+    state.next_index += 1
+    try:
+        ordered.action()
+    except BaseException as action_error:  # noqa: B036 - keep first
+        state.retain(ordered.label, action_error)
+
+
+def _run_ordered_actions_pass(state: _OrderedActionState) -> bool:
+    """Run until completion or one cancellation-sensitive seam interrupts."""
+
+    active_index: int | None = None
+    ordered: _OrderedAction | None = None
+    try:
+        while state.next_index < len(state.actions):
+            active_index = state.next_index
+            ordered = None
+            action_input = state.actions[state.next_index]
+            if isinstance(action_input, _OrderedAction):
+                ordered = action_input
+            ordered = _coerce_ordered_action(action_input)
+            if ordered.complete is None:
+                _run_plain_ordered_action(state, ordered)
+                continue
+            if _ordered_action_complete(state, ordered):
+                _advance_ordered_action(state)
+                continue
+            action_error = _attempt_ordered_action(state, ordered)
+            completed = _ordered_action_complete(state, ordered)
+            retry_policy = ordered.retry_incomplete
+            if callable(retry_policy):
+                retry_incomplete = retry_policy(action_error)
+            else:
+                retry_incomplete = (
+                    retry_policy == "cancellation"
+                    and action_error is not None
+                    and not isinstance(action_error, Exception)
+                )
+            if completed:
+                if action_error is not None:
+                    state.retain_retry_error(ordered.label, action_error)
+                _advance_ordered_action(state)
+                continue
+            if retry_incomplete:
+                retry_error = action_error or RuntimeError(
+                    "ordered cleanup action requested retry without an error"
+                )
+                if _retry_ordered_action(
+                    state,
+                    ordered,
+                    retry_error,
+                    label=ordered.label,
+                ):
+                    continue
+                continue
+            if action_error is not None:
+                state.retain_retry_error(ordered.label, action_error)
+            _retain_incomplete_ordered_action(state, ordered)
+            _advance_ordered_action(state)
+    except BaseException as iteration_error:  # noqa: B036 - resume remaining
+        if active_index is not None and state.next_index == active_index:
+            _retry_ordered_action(
+                state,
+                ordered,
+                iteration_error,
+                label=state.iteration_failure_label,
+            )
+        else:
+            state.retain_once(
+                "iteration-after-progress",
+                state.iteration_failure_label,
+                iteration_error,
+            )
+            state.reset_retry_state()
+    return state.next_index >= len(state.actions)
+
+
+def _run_ordered_actions_trampoline_pass(state: _OrderedActionState) -> bool:
+    """Contain repeated failures at the Python-to-runner call boundary."""
+
+    active_index = state.next_index
+    ordered: _OrderedAction | None = None
+    try:
+        if active_index < len(state.actions):
+            action_input = state.actions[active_index]
+            if isinstance(action_input, _OrderedAction):
+                ordered = action_input
+        return _run_ordered_actions_pass(state)
+    except BaseException as entry_error:  # noqa: B036 - bounded resumption
+        if active_index < len(state.actions) and state.next_index == active_index:
+            _retry_ordered_action(
+                state,
+                ordered,
+                entry_error,
+                label=state.iteration_failure_label,
+            )
+        else:
+            state.retain_once(
+                "trampoline-after-progress",
+                state.iteration_failure_label,
+                entry_error,
+            )
+            state.reset_retry_state()
+        return state.next_index >= len(state.actions)
+
+
+def _run_ordered_actions(state: _OrderedActionState) -> None:
+    """Run ordered actions and resume every cancellation-sensitive seam.
+
+    Cleanup steps may expose an idempotent completion predicate.  Cancellation
+    immediately before their call receives a bounded retry window, while a close
+    that completed before cancellation is observed and never called again.  An
+    owner that remains incomplete after that window is attached to the primary
+    exception for explicit retry.  Plain validation actions retain the
+    historical one-attempt behavior: their failure already prevents a result
+    from escaping, but they own no resource that needs retry.
+    """
+
+    # ``iter(callable, sentinel)`` and a zero-length deque provide a C-level
+    # trampoline.  Each interrupted pass returns before the next one starts, so
+    # the bounded cancellation window does not grow the Python stack or retain
+    # one object per retry.
+    deque(
+        iter(partial(_run_ordered_actions_trampoline_pass, state), True),
+        maxlen=0,
+    )
+
+
+@contextmanager
+def _run_context_with_cleanup_actions(
+    cleanup_actions: tuple[_OrderedActionInput, ...],
+) -> Iterator[None]:
+    """Run every cleanup action without replacing a context-body primary."""
+
+    if not isinstance(cleanup_actions, tuple):
+        raise TypeError("context cleanup actions must be a tuple")
+    # Construct the cleanup state before the caller can acquire any resource.
+    # The finalizer then only installs the observed primary and starts the
+    # already-owned plan.
+    failures = _OrderedActionState(
+        actions=cleanup_actions,
+        iteration_failure_label=(
+            "publication authenticated cleanup iteration also failed"
+        ),
+        primary_error=None,
+    )
+    # An outer ``except`` leaves an ambient value in ``sys.exc_info()``. Track
+    # it separately so cleanup-only failure still propagates from a successful
+    # context body entered while that unrelated exception is being handled.
+    ambient_error = sys.exc_info()[1]
+    context_error: BaseException | None = None
+    try:
+        yield
+    except BaseException as error:  # noqa: B036 - preserve exact local primary
+        context_error = error
+        raise
+    finally:
+        locally_unwinding = context_error is not None
+        primary_error = context_error
+        failures.primary_error = primary_error
+        try:
+            active_error = sys.exc_info()[1]
+            locally_unwinding = context_error is not None or (
+                active_error is not None and active_error is not ambient_error
+            )
+            if primary_error is None and locally_unwinding:
+                primary_error = active_error
+            failures.primary_error = primary_error
+            failures.protect_pending_owners()
+            _run_ordered_actions(failures)
+            _prune_publication_cleanup_owners(failures.primary_error)
+        except BaseException as boundary_error:  # noqa: B036 - retain recovery
+            failures.retain_once(
+                "outer-trampoline-entry",
+                failures.iteration_failure_label,
+                boundary_error,
+            )
+            failures.protect_pending_owners()
+        if not locally_unwinding and failures.primary_error is not None:
+            raise failures.primary_error
+
+
+def _run_callback_with_post_validations(
+    callback: Callable[[], _T],
+    post_validations: tuple[tuple[str, Callable[[], None]], ...],
+) -> _T:
+    """Run one callback and ordered postconditions without losing first-primary.
+
+    Postconditions live in ``finally`` around the callback result store, so
+    cancellation after a callback has returned cannot turn an unchecked result
+    into success.  Every postcondition is attempted in order.  A callback
+    failure remains primary and receives each postcondition failure as a direct
+    note; without an earlier failure, the first postcondition failure is
+    primary and later failures become its notes.
+    """
+
+    if not callable(callback) or not isinstance(post_validations, tuple):
+        raise TypeError("callback validation requires callable inputs")
+    for label, validation in post_validations:
+        if not isinstance(label, str) or not label or not callable(validation):
+            raise TypeError("callback post-validations must be labeled callables")
+    # Own the complete post-validation plan before invoking callback code.
+    failures = _OrderedActionState(
+        actions=post_validations,
+        iteration_failure_label=(
+            "publication callback post-validation iteration also failed"
+        ),
+        primary_error=None,
+    )
+    # ``sys.exc_info()`` is inherited from an active ``except`` in a caller.
+    # Snapshot that ambient exception so it is never mistaken for a failure
+    # raised by this callback or its result/return cancellation window.
+    ambient_error = sys.exc_info()[1]
+    callback_error: BaseException | None = None
+    try:
+        result = callback()
+        return result
+    except BaseException as error:  # noqa: B036 - preserve exact local primary
+        callback_error = error
+        raise
+    finally:
+        # The explicit callback state normally identifies the locally active
+        # exception.  The active-vs-ambient comparison also covers a new
+        # BaseException injected in the result/return seam before the handler
+        # can store it.  Let locally active failures keep unwinding via the
+        # original bare raise so their traceback is unchanged.
+        locally_unwinding = callback_error is not None
+        primary_error = callback_error
+        failures.primary_error = primary_error
+        try:
+            active_error = sys.exc_info()[1]
+            locally_unwinding = callback_error is not None or (
+                active_error is not None and active_error is not ambient_error
+            )
+            if primary_error is None and locally_unwinding:
+                primary_error = active_error
+            failures.primary_error = primary_error
+            _run_ordered_actions(failures)
+        except BaseException as boundary_error:  # noqa: B036 - retain recovery
+            failures.retain_once(
+                "outer-trampoline-entry",
+                failures.iteration_failure_label,
+                boundary_error,
+            )
+        if not locally_unwinding and failures.primary_error is not None:
+            raise failures.primary_error
+
+
+def _run_publication_reader_callback(
+    reader: PublicationDirectoryReader,
+    callback: Callable[[PublicationDirectoryReader], _T],
+    validate_child_binding: Callable[[], None],
+) -> _T:
+    """Run a reader callback and always recheck validity plus child binding."""
+
+    return _run_callback_with_post_validations(
+        lambda: callback(reader),
+        (
+            (
+                "publication reader validity validation also failed",
+                reader._require_valid,
+            ),
+            (
+                "publication reader child namespace validation also failed",
+                validate_child_binding,
+            ),
+        ),
+    )
 
 
 @dataclass(slots=True)
@@ -627,6 +1189,17 @@ class _PosixResourceOwner:
         record = self._record_for(descriptor)
         if record is None:
             return
+        self.close_record(record)
+
+    def record_for_cleanup(self, descriptor: int) -> _PosixDescriptorRecord:
+        record = self._record_for(descriptor)
+        if record is None:
+            raise RuntimeError("publication descriptor is not owned")
+        return record
+
+    def close_record(self, record: _PosixDescriptorRecord) -> None:
+        """Close an exact record returned by :meth:`record_for_cleanup`."""
+
         close_error = self._close_record(record)
         if close_error is not None:
             raise close_error
@@ -643,6 +1216,8 @@ class _PosixResourceOwner:
                 "descriptor cleanup also failed",
                 close_error,
             )
+            if record.descriptor >= 0:
+                _attach_publication_cleanup_owner(primary_error, self)
 
     def close_all(self) -> None:
         primary_error: BaseException | None = None
@@ -657,6 +1232,11 @@ class _PosixResourceOwner:
         if primary_error is not None:
             raise primary_error
 
+    def close(self) -> None:
+        """Retry cleanup through the shared exception-owner protocol."""
+
+        self.close_all()
+
     def close_all_after_error(self, primary_error: BaseException) -> None:
         try:
             self.close_all()
@@ -666,6 +1246,7 @@ class _PosixResourceOwner:
                 "publication authority cleanup also failed",
                 close_error,
             )
+        _attach_publication_cleanup_owner(primary_error, self)
 
     def _record_for(self, descriptor: int) -> _PosixDescriptorRecord | None:
         for record in reversed(self._records):
@@ -831,6 +1412,17 @@ class _WindowsResourceOwner:
         record = self._record_for(handle)
         if record is None:
             return
+        self.close_record(record)
+
+    def record_for_cleanup(self, handle: int) -> _WindowsHandleRecord:
+        record = self._record_for(handle)
+        if record is None:
+            raise RuntimeError("publication HANDLE is not owned")
+        return record
+
+    def close_record(self, record: _WindowsHandleRecord) -> None:
+        """Close an exact record returned by :meth:`record_for_cleanup`."""
+
         close_error = self._close_record(record)
         if close_error is not None:
             raise close_error
@@ -847,6 +1439,8 @@ class _WindowsResourceOwner:
                 "Windows HANDLE cleanup also failed",
                 close_error,
             )
+            if record.handle:
+                _attach_publication_cleanup_owner(primary_error, self)
 
     def close_all(self) -> None:
         primary_error: BaseException | None = None
@@ -861,6 +1455,11 @@ class _WindowsResourceOwner:
         if primary_error is not None:
             raise primary_error
 
+    def close(self) -> None:
+        """Retry cleanup through the shared exception-owner protocol."""
+
+        self.close_all()
+
     def close_all_after_error(self, primary_error: BaseException) -> None:
         try:
             self.close_all()
@@ -870,6 +1469,7 @@ class _WindowsResourceOwner:
                 "Windows authority cleanup also failed",
                 close_error,
             )
+        _attach_publication_cleanup_owner(primary_error, self)
 
     def _record_for(self, handle: int) -> _WindowsHandleRecord | None:
         for record in reversed(self._records):
@@ -1080,6 +1680,7 @@ class _WindowsLexicalAuthorityOwner:
                 "Windows lexical authority cleanup also failed",
                 close_error,
             )
+        _attach_publication_cleanup_owner(primary_error, self)
 
 
 class _PublicationAuthorityOwner:
@@ -1093,6 +1694,11 @@ class _PublicationAuthorityOwner:
     @property
     def authority(self) -> _PublicationAuthority | None:
         return self._authority
+
+    @property
+    def closed(self) -> bool:
+        authority = self._authority
+        return authority is None or authority._closed
 
     def install(self, authority: _PublicationAuthority) -> None:
         if self._authority is not None:
@@ -1122,6 +1728,7 @@ class _PublicationAuthorityOwner:
             if close_complete:
                 self._authority = None
         if primary_error is not None:
+            _attach_publication_cleanup_owner(primary_error, self)
             raise primary_error
 
     def close_after_error(self, primary_error: BaseException) -> None:
@@ -1133,6 +1740,7 @@ class _PublicationAuthorityOwner:
                 "publication authority owner cleanup also failed",
                 close_error,
             )
+        _attach_publication_cleanup_owner(primary_error, self)
 
     def __enter__(self) -> _PublicationAuthorityOwner:
         return self
@@ -1377,25 +1985,55 @@ class DirectoryOrphan:
                 raise RuntimeError("directory orphan platform authority changed")
 
             def use_verified(reader: _PublicationTreeReader) -> _T:
-                before = reader.capture_ownership()
-                _require_matching_ownership(
-                    before,
-                    self.locator.ownership,
-                    label="directory orphan",
-                    allow_root_rename=True,
-                )
-                result = callback(reader)
-                after = reader.capture_ownership()
-                if after != before:
-                    raise RuntimeError("directory orphan changed while reopened")
-                return result
+                before: _TreeOwnership | None = None
 
-            return authority.read_child(
-                self.locator.child_name,
-                path=self.path,
-                label="directory orphan",
-                expected_ownership=self.locator.ownership,
-                callback=use_verified,
+                def consume() -> _T:
+                    nonlocal before
+                    before = reader.capture_ownership()
+                    _require_matching_ownership(
+                        before,
+                        self.locator.ownership,
+                        label="directory orphan",
+                        allow_root_rename=True,
+                    )
+                    return callback(reader)
+
+                def validate_after_ownership() -> None:
+                    after = reader.capture_ownership()
+                    _require_matching_ownership(
+                        after,
+                        self.locator.ownership,
+                        label="directory orphan",
+                        allow_root_rename=True,
+                    )
+                    if before is not None and after != before:
+                        raise RuntimeError("directory orphan changed while reopened")
+
+                return _run_callback_with_post_validations(
+                    consume,
+                    (
+                        (
+                            "directory orphan post-callback ownership validation "
+                            "also failed",
+                            validate_after_ownership,
+                        ),
+                    ),
+                )
+
+            return _run_callback_with_post_validations(
+                lambda: authority.read_child(
+                    self.locator.child_name,
+                    path=self.path,
+                    label="directory orphan",
+                    expected_ownership=self.locator.ownership,
+                    callback=use_verified,
+                ),
+                (
+                    (
+                        "directory orphan authority path validation also failed",
+                        authority.verify_path_binding,
+                    ),
+                ),
             )
 
     def rebind(self) -> _TreeOwnership:
@@ -1585,16 +2223,21 @@ def _open_posix_publication_authority(
                     ),
                     expected_ownership,
                 )
-                result = callback(reader)
-                reader._require_valid()
-                after = os.stat(
-                    name,
-                    dir_fd=owned_descriptor,
-                    follow_symlinks=False,
+
+                def validate_child_binding() -> None:
+                    after = os.stat(
+                        name,
+                        dir_fd=owned_descriptor,
+                        follow_symlinks=False,
+                    )
+                    if _directory_inode_identity(after) != root_identity:
+                        raise RuntimeError(f"{label} namespace binding changed")
+
+                return _run_publication_reader_callback(
+                    reader,
+                    callback,
+                    validate_child_binding,
                 )
-                if _directory_inode_identity(after) != root_identity:
-                    raise RuntimeError(f"{label} namespace binding changed")
-                return result
             except BaseException as exc:
                 primary_error = exc
                 raise
@@ -2139,6 +2782,8 @@ def _windows_open_child_by_id(
                 "Windows child HANDLE cleanup also failed",
                 close_error,
             )
+        if selected_owner._record_for(handle) is not None:
+            _attach_publication_cleanup_owner(primary_error, selected_owner)
         raise
 
 
@@ -2202,15 +2847,43 @@ def _open_windows_authenticated_file(
     max_bytes: int,
     expected: _ExpectedPublicationFile,
 ) -> Iterator[PublicationAuthenticatedFile]:
-    root_before = api.metadata(root_handle)
+    resources = _WindowsResourceOwner(api)
     parent_handle = root_handle
-    opened_directories: list[int] = []
     bindings: list[tuple[int, str, int, int, tuple[int, ...]]] = []
     file_handle = 0
     authenticated: PublicationAuthenticatedFile | None = None
+    cleanup_complete = False
     expected_directories = dict(expected.directory_identities)
     traversed: list[str] = []
-    try:
+
+    def finalize_authenticated_file() -> None:
+        if authenticated is not None:
+            authenticated._finalize()
+
+    def close_resources() -> None:
+        nonlocal cleanup_complete
+        resources.close_all()
+        cleanup_complete = True
+
+    cleanup_actions: tuple[_OrderedActionInput, ...] = (
+        (
+            "publication authenticated file finalization also failed",
+            finalize_authenticated_file,
+        ),
+        _OrderedAction(
+            label=(
+                "publication authenticated file HANDLE cleanup also failed; "
+                "publication authenticated directory HANDLE cleanup also failed"
+            ),
+            action=close_resources,
+            complete=lambda: cleanup_complete,
+            retry_incomplete="cancellation",
+            incomplete_owner=resources,
+        ),
+    )
+
+    with _run_context_with_cleanup_actions(cleanup_actions):
+        root_before = api.metadata(root_handle)
         for part in relative.parts[:-1]:
             traversed.append(part)
             relative_directory = "/".join(traversed)
@@ -2225,14 +2898,13 @@ def _open_windows_authenticated_file(
                 | _WINDOWS_FILE_READ_ATTRIBUTES
                 | _WINDOWS_SYNCHRONIZE,
                 expected_directory=True,
+                resource_owner=resources,
             )
             if opened.st_dev != root_before.st_dev:
-                api.close(child_handle)
                 raise RuntimeError("publication stream crosses a volume")
             if expected_directories.get(
                 relative_directory
             ) != _ownership_version_identity(opened):
-                api.close(child_handle)
                 raise RuntimeError(
                     "publication stream directory differs from captured ownership"
                 )
@@ -2245,7 +2917,6 @@ def _open_windows_authenticated_file(
                     _ownership_version_identity(opened),
                 )
             )
-            opened_directories.append(child_handle)
             parent_handle = child_handle
 
         entry = _windows_find_child(api, parent_handle, relative.name)
@@ -2259,6 +2930,7 @@ def _open_windows_authenticated_file(
             | _WINDOWS_FILE_READ_ATTRIBUTES
             | _WINDOWS_SYNCHRONIZE,
             expected_directory=False,
+            resource_owner=resources,
         )
         if opened_file.st_dev != root_before.st_dev:
             raise RuntimeError("publication stream crosses a volume")
@@ -2300,15 +2972,6 @@ def _open_windows_authenticated_file(
             verify_callback=verify,
         )
         yield authenticated
-    finally:
-        try:
-            if authenticated is not None:
-                authenticated._finalize()
-        finally:
-            if file_handle:
-                api.close(file_handle)
-            for handle in reversed(opened_directories):
-                api.close(handle)
 
 
 def _scan_windows_owned_directory(
@@ -2549,6 +3212,8 @@ def _open_windows_publication_authority(
                 "Windows publication authority cleanup also failed",
                 close_error,
             )
+        _attach_publication_cleanup_owner(primary_error, resources)
+        _attach_publication_cleanup_owner(primary_error, lexical_owner)
 
     def resources_closed() -> bool:
         return resources.closed and lexical_owner.closed
@@ -2684,12 +3349,17 @@ def _open_windows_publication_authority(
                     ),
                     expected_ownership,
                 )
-                result = callback(reader)
-                reader._require_valid()
-                rebound = _windows_find_child(api, owned_parent_handle, name)
-                if rebound is None or rebound.file_id != metadata.st_ino:
-                    raise RuntimeError(f"{label} namespace binding changed")
-                return result
+
+                def validate_child_binding() -> None:
+                    rebound = _windows_find_child(api, owned_parent_handle, name)
+                    if rebound is None or rebound.file_id != metadata.st_ino:
+                        raise RuntimeError(f"{label} namespace binding changed")
+
+                return _run_publication_reader_callback(
+                    reader,
+                    callback,
+                    validate_child_binding,
+                )
             except BaseException as exc:
                 primary_error = exc
                 raise
@@ -2911,18 +3581,48 @@ def _open_posix_authenticated_file(
     max_bytes: int,
     expected: _ExpectedPublicationFile,
 ) -> Iterator[PublicationAuthenticatedFile]:
-    root_before = os.fstat(root_descriptor)
-    root_device = root_before.st_dev
+    resources = _PosixResourceOwner()
     flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
     directory_flags = flags | os.O_DIRECTORY | getattr(os, "O_NONBLOCK", 0)
     file_flags = flags | getattr(os, "O_NONBLOCK", 0)
-    descriptors: list[int] = [os.dup(root_descriptor)]
+    descriptors: list[int] = []
     bindings: list[tuple[int, str, int, tuple[int, ...]]] = []
     file_descriptor = -1
     authenticated: PublicationAuthenticatedFile | None = None
+    cleanup_complete = False
     expected_directories = dict(expected.directory_identities)
     traversed: list[str] = []
-    try:
+
+    def finalize_authenticated_file() -> None:
+        if authenticated is not None:
+            authenticated._finalize()
+
+    def close_resources() -> None:
+        nonlocal cleanup_complete
+        resources.close_all()
+        cleanup_complete = True
+
+    cleanup_actions: tuple[_OrderedActionInput, ...] = (
+        (
+            "publication authenticated file finalization also failed",
+            finalize_authenticated_file,
+        ),
+        _OrderedAction(
+            label=(
+                "publication authenticated file descriptor cleanup also failed; "
+                "publication authenticated directory descriptor cleanup also failed"
+            ),
+            action=close_resources,
+            complete=lambda: cleanup_complete,
+            retry_incomplete="cancellation",
+            incomplete_owner=resources,
+        ),
+    )
+
+    with _run_context_with_cleanup_actions(cleanup_actions):
+        root_before = os.fstat(root_descriptor)
+        root_device = root_before.st_dev
+        descriptors.append(resources.duplicate(root_descriptor))
         for part in relative.parts[:-1]:
             traversed.append(part)
             relative_directory = "/".join(traversed)
@@ -2936,7 +3636,7 @@ def _open_posix_authenticated_file(
                 raise RuntimeError(
                     f"publication stream refuses directory: {root_path / relative}"
                 )
-            child = os.open(part, directory_flags, dir_fd=parent)
+            child = resources.open(part, directory_flags, dir_fd=parent)
             descriptors.append(child)
             opened = os.fstat(child)
             if _ownership_binding_identity(opened) != _ownership_binding_identity(
@@ -2962,7 +3662,7 @@ def _open_posix_authenticated_file(
             raise RuntimeError(
                 f"publication stream refuses non-file: {root_path / relative}"
             )
-        file_descriptor = os.open(name, file_flags, dir_fd=parent)
+        file_descriptor = resources.open(name, file_flags, dir_fd=parent)
         opened_file = os.fstat(file_descriptor)
         if _ownership_binding_identity(opened_file) != _ownership_binding_identity(
             metadata
@@ -3017,15 +3717,6 @@ def _open_posix_authenticated_file(
             verify_callback=verify,
         )
         yield authenticated
-    finally:
-        try:
-            if authenticated is not None:
-                authenticated._finalize()
-        finally:
-            if file_descriptor >= 0:
-                os.close(file_descriptor)
-            for descriptor in reversed(descriptors):
-                os.close(descriptor)
 
 
 def _ownership_hash_field(hasher, value: bytes) -> None:
@@ -3621,6 +4312,43 @@ def _require_tree_ownership(
     )
 
 
+def _run_authenticated_directory_callback(
+    reader: PublicationDirectoryReader,
+    expected_ownership: _TreeOwnership,
+    callback: Callable[[PublicationDirectoryReader], _T],
+) -> _T:
+    """Run one authenticated callback inside an exact ownership sandwich."""
+
+    def consume() -> _T:
+        before = reader.capture_ownership()
+        if before != expected_ownership:
+            raise RuntimeError(
+                "authenticated directory differs from expected ownership"
+            )
+        return callback(reader)
+
+    def validate_after_ownership() -> None:
+        after = reader.capture_ownership()
+        if after != expected_ownership:
+            raise RuntimeError("authenticated directory changed while it was consumed")
+
+    return _run_callback_with_post_validations(
+        consume,
+        (
+            (
+                "authenticated directory post-callback reader validity "
+                "validation also failed",
+                reader._require_valid,
+            ),
+            (
+                "authenticated directory post-callback ownership validation "
+                "also failed",
+                validate_after_ownership,
+            ),
+        ),
+    )
+
+
 def reopen_authenticated_directory(
     path: Path,
     expected_ownership: _TreeOwnership,
@@ -3651,32 +4379,25 @@ def reopen_authenticated_directory(
             authority_owner=authority_owner,
         )
 
-        def consume(reader: PublicationDirectoryReader) -> _T:
-            before = reader.capture_ownership()
-            if before != expected_ownership:
-                raise RuntimeError(
-                    "authenticated directory differs from expected ownership"
-                )
-            result = callback(reader)
-            # A validator may deliberately catch a stream/snapshot failure.
-            # Reject before another namespace observation can hide that failure.
-            reader._require_valid()
-            after = reader.capture_ownership()
-            if after != expected_ownership:
-                raise RuntimeError(
-                    "authenticated directory changed while it was consumed"
-                )
-            return result
-
-        result = authority.read_child(
-            lexical.name,
-            path=lexical,
-            label="authenticated directory",
-            expected_ownership=expected_ownership,
-            callback=consume,
+        return _run_callback_with_post_validations(
+            lambda: authority.read_child(
+                lexical.name,
+                path=lexical,
+                label="authenticated directory",
+                expected_ownership=expected_ownership,
+                callback=lambda reader: _run_authenticated_directory_callback(
+                    reader,
+                    expected_ownership,
+                    callback,
+                ),
+            ),
+            (
+                (
+                    "authenticated directory authority path validation also failed",
+                    authority.verify_path_binding,
+                ),
+            ),
         )
-        authority.verify_path_binding()
-        return result
 
 
 def discard_owned_directory(

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -259,6 +259,32 @@ publication. Preopened workspace publication applies the same ownership model
 to exact, scanner-bounded directory plans and returns a caller-owned receipt
 whose authenticated reader remains pinned through synchronous consumption.
 
+Callback-scoped directory results are likewise provisional until ordered
+reader-validity, exact-ownership, child-namespace, and parent-authority
+postconditions have been processed after callback success, failure, or
+cancellation. Authenticated-file exit preconstructs cleanup before acquiring a
+resource, then drives the retained owner across every registered descriptor or
+HANDLE even when cancellation lands before a caller can store the returned
+integer. Completion-aware owner cleanup grants a bounded retry window for
+cancellation before or during close, then returns any still-incomplete,
+idempotent owner on the primary exception for explicit retry. Later independent
+cleanup actions still run. An identity-reused foreign resource is diagnosed and
+never closed when its immutable identity observably differs from the owned
+resource. An exact same-inode descriptor ABA or same-FILE_ID HANDLE reuse is not
+distinguishable in Python and remains a native-owner promotion gate. One
+C-level trampoline gives runner entry, re-entry, planning, action, and loop
+failures the same per-action retry state while keeping Python stack and
+diagnostic space constant. Exhausting the nine-attempt window retains an
+incomplete idempotent owner on the primary and continues later actions. The
+first local callback, postflight, or cleanup failure stays primary; later
+failures are diagnostic only. Pure Python cannot guarantee execution when
+repeated interruption lands before the trampoline itself starts. A known
+primary therefore protects pending owners before that handoff, and the first
+outer-entry failure becomes the primary and protects them when no earlier
+failure exists. Closing that remaining arbitrary call-entry gap, the raw
+resource-return gap, and exact-identity ABA requires native ownership. This
+does not complete M1 producer wiring.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -33,6 +33,13 @@ def _write_tree(root: Path, name: str, value: str) -> None:
     (root / name).write_text(value, encoding="utf-8")
 
 
+def _exception_notes(error: BaseException) -> tuple[str, ...]:
+    return (
+        *tuple(getattr(error, "__notes__", ())),
+        *tuple(getattr(error, "_codenib_cleanup_notes", ())),
+    )
+
+
 class _FakeWindowsApi:
     """In-memory HANDLE/FILE_ID model; it intentionally has no path reads."""
 
@@ -3025,6 +3032,319 @@ def test_directory_orphan_reopens_through_parent_authority(tmp_path: Path) -> No
         saved_reader[0].capture_ownership()
 
 
+def test_directory_orphan_callback_primary_survives_post_content_drift(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "authority"
+    parent.mkdir()
+    destination = parent / "published"
+    _write_tree(destination, "old.txt", "old")
+    stage = parent / "stage"
+    _write_tree(stage, "new.txt", "new")
+    orphan = publish_staged_directory(stage, destination)
+    assert orphan is not None
+    primary = ValueError("callback failed")
+    saved_reader: list[atomic_module.PublicationDirectoryReader] = []
+
+    def mutate_then_fail(reader: atomic_module.PublicationDirectoryReader) -> None:
+        saved_reader.append(reader)
+        (orphan.path / "old.txt").write_text("mutated", encoding="utf-8")
+        raise primary
+
+    with pytest.raises(ValueError) as caught:
+        orphan.reopen(mutate_then_fail)
+
+    assert caught.value is primary
+    notes = _exception_notes(primary)
+    assert any(
+        "directory orphan post-callback ownership validation also failed" in note
+        and ("changed" in note or "differs" in note)
+        for note in notes
+    )
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_reader[0].capture_ownership()
+
+
+def _posix_cleanup_test_reader(
+    root: Path,
+) -> tuple[atomic_module.PublicationDirectoryReader, int]:
+    ownership = capture_directory_ownership(root)
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    root_descriptor = os.open(root, flags)
+    reader = atomic_module.PublicationDirectoryReader(
+        root,
+        ownership.root_identity,
+        lambda _required, _allow_empty, _policy: ownership,
+        lambda relative, max_bytes, expected: (
+            atomic_module._open_posix_authenticated_file(
+                root_descriptor,
+                root,
+                relative,
+                max_bytes=max_bytes,
+                expected=expected,
+            )
+        ),
+        ownership,
+    )
+    return reader, root_descriptor
+
+
+def _windows_cleanup_test_reader() -> tuple[
+    _FakeWindowsApi,
+    atomic_module.PublicationDirectoryReader,
+    int,
+]:
+    api = _FakeWindowsApi()
+    nested = api.add_directory(api.root_id, "nested")
+    api.add_file(nested, "payload.txt", b"payload")
+    root_path = Path("C:/authority")
+    root_handle = api.create_directory_handle(root_path)
+    ownership = atomic_module._capture_windows_directory_handle(
+        api,
+        root_handle,
+        root_path,
+        required_root_file=None,
+        allow_empty_root=False,
+        entry_policy=None,
+    )
+    reader = atomic_module.PublicationDirectoryReader(
+        root_path,
+        ownership.root_identity,
+        lambda _required, _allow_empty, _policy: ownership,
+        lambda relative, max_bytes, expected: (
+            atomic_module._open_windows_authenticated_file(
+                api,
+                root_handle,
+                root_path,
+                relative,
+                max_bytes=max_bytes,
+                expected=expected,
+            )
+        ),
+        ownership,
+    )
+    return api, reader, root_handle
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX directory descriptors",
+)
+@pytest.mark.parametrize("primary_type", [KeyboardInterrupt, SystemExit, GeneratorExit])
+def test_posix_authenticated_file_body_primary_survives_cleanup_faults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    primary_type: type[BaseException],
+) -> None:
+    root = tmp_path / "publication"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload.txt").write_bytes(b"payload")
+    reader, root_descriptor = _posix_cleanup_test_reader(root)
+    real_close = os.close
+    primary = primary_type("body-primary")
+    close_errors: list[OSError] = []
+
+    def fail_finalize(_authenticated: object) -> None:
+        raise RuntimeError("finalize-secondary")
+
+    def close_then_fail(descriptor: int) -> None:
+        real_close(descriptor)
+        error = OSError(f"close-secondary-{len(close_errors)}")
+        close_errors.append(error)
+        raise error
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(
+                atomic_module.PublicationAuthenticatedFile,
+                "_finalize",
+                fail_finalize,
+            )
+            faults.setattr(atomic_module.os, "close", close_then_fail)
+            with pytest.raises(primary_type, match="body-primary") as caught:
+                with reader.open_authenticated_file(
+                    "nested/payload.txt",
+                    max_bytes=16,
+                ):
+                    raise primary
+
+        assert caught.value is primary
+        notes = _exception_notes(primary)
+        assert any(
+            "file finalization also failed" in note and "finalize-secondary" in note
+            for note in notes
+        )
+        assert any("file descriptor cleanup also failed" in note for note in notes)
+        assert any("directory descriptor cleanup also failed" in note for note in notes)
+        assert len(close_errors) == 3
+        assert reader._authentication_failed is True
+        with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+            reader._require_valid()
+    finally:
+        reader._deactivate()
+        real_close(root_descriptor)
+
+
+@pytest.mark.parametrize("primary_type", [KeyboardInterrupt, SystemExit, GeneratorExit])
+def test_windows_authenticated_file_body_primary_survives_cleanup_faults(
+    monkeypatch: pytest.MonkeyPatch,
+    primary_type: type[BaseException],
+) -> None:
+    api, reader, root_handle = _windows_cleanup_test_reader()
+    real_close = api.close
+    primary = primary_type("body-primary")
+    close_errors: list[OSError] = []
+
+    def fail_finalize(_authenticated: object) -> None:
+        raise RuntimeError("finalize-secondary")
+
+    def close_then_fail(handle: int) -> None:
+        real_close(handle)
+        error = OSError(f"close-secondary-{len(close_errors)}")
+        close_errors.append(error)
+        raise error
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(
+                atomic_module.PublicationAuthenticatedFile,
+                "_finalize",
+                fail_finalize,
+            )
+            faults.setattr(api, "close", close_then_fail)
+            with pytest.raises(primary_type, match="body-primary") as caught:
+                with reader.open_authenticated_file(
+                    "nested/payload.txt",
+                    max_bytes=16,
+                ):
+                    raise primary
+
+        assert caught.value is primary
+        notes = _exception_notes(primary)
+        assert any(
+            "file finalization also failed" in note and "finalize-secondary" in note
+            for note in notes
+        )
+        assert any("file HANDLE cleanup also failed" in note for note in notes)
+        assert any("directory HANDLE cleanup also failed" in note for note in notes)
+        assert len(close_errors) == 2
+        assert reader._authentication_failed is True
+        with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+            reader._require_valid()
+    finally:
+        reader._deactivate()
+        real_close(root_handle)
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX directory descriptors",
+)
+@pytest.mark.parametrize("failure_phase", ["finalize", "close"])
+def test_posix_authenticated_file_cleanup_primary_is_exact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_phase: str,
+) -> None:
+    root = tmp_path / "publication"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload.txt").write_bytes(b"payload")
+    reader, root_descriptor = _posix_cleanup_test_reader(root)
+    real_close = os.close
+    cleanup_primary = SystemExit(f"{failure_phase}-primary")
+    close_calls = 0
+
+    def fail_finalize(_authenticated: object) -> None:
+        raise cleanup_primary
+
+    def close_with_first_fault(descriptor: int) -> None:
+        nonlocal close_calls
+        real_close(descriptor)
+        close_calls += 1
+        if close_calls == 1:
+            raise cleanup_primary
+
+    try:
+        with monkeypatch.context() as faults:
+            if failure_phase == "finalize":
+                faults.setattr(
+                    atomic_module.PublicationAuthenticatedFile,
+                    "_finalize",
+                    fail_finalize,
+                )
+            else:
+                faults.setattr(atomic_module.os, "close", close_with_first_fault)
+            with pytest.raises(SystemExit, match=f"{failure_phase}-primary") as caught:
+                with reader.open_authenticated_file(
+                    "nested/payload.txt",
+                    max_bytes=16,
+                ):
+                    pass
+
+        assert caught.value is cleanup_primary
+        if failure_phase == "close":
+            assert close_calls == 3
+        assert reader._authentication_failed is True
+        with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+            reader._require_valid()
+    finally:
+        reader._deactivate()
+        real_close(root_descriptor)
+
+
+@pytest.mark.parametrize("failure_phase", ["finalize", "close"])
+def test_windows_authenticated_file_cleanup_primary_is_exact(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_phase: str,
+) -> None:
+    api, reader, root_handle = _windows_cleanup_test_reader()
+    real_close = api.close
+    cleanup_primary = SystemExit(f"{failure_phase}-primary")
+    close_calls = 0
+
+    def fail_finalize(_authenticated: object) -> None:
+        raise cleanup_primary
+
+    def close_with_first_fault(handle: int) -> None:
+        nonlocal close_calls
+        real_close(handle)
+        close_calls += 1
+        if close_calls == 1:
+            raise cleanup_primary
+
+    try:
+        with monkeypatch.context() as faults:
+            if failure_phase == "finalize":
+                faults.setattr(
+                    atomic_module.PublicationAuthenticatedFile,
+                    "_finalize",
+                    fail_finalize,
+                )
+            else:
+                faults.setattr(api, "close", close_with_first_fault)
+            with pytest.raises(SystemExit, match=f"{failure_phase}-primary") as caught:
+                with reader.open_authenticated_file(
+                    "nested/payload.txt",
+                    max_bytes=16,
+                ):
+                    pass
+
+        assert caught.value is cleanup_primary
+        if failure_phase == "close":
+            assert close_calls == 2
+        assert reader._authentication_failed is True
+        with pytest.raises(RuntimeError, match="suppressed authentication failure"):
+            reader._require_valid()
+    finally:
+        reader._deactivate()
+        real_close(root_handle)
+    assert api.handles == {}
+
+
 def test_publication_reader_streams_and_authenticates_on_context_exit(
     tmp_path: Path,
 ) -> None:
@@ -3394,6 +3714,392 @@ def test_reopen_authenticated_directory_rejects_root_swap_when_ctime_advances(
     assert (foreign / "payload.txt").read_text(encoding="utf-8") == "foreign"
 
 
+@pytest.mark.parametrize(
+    "primary",
+    [
+        pytest.param(ValueError("callback failed"), id="value-error"),
+        pytest.param(KeyboardInterrupt("callback interrupted"), id="keyboard"),
+        pytest.param(SystemExit("callback exited"), id="system-exit"),
+    ],
+)
+def test_reopen_callback_primary_survives_post_content_drift_detection(
+    tmp_path: Path,
+    primary: BaseException,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    saved_readers: list[object] = []
+
+    def mutate_then_fail(reader: object) -> None:
+        assert isinstance(reader, atomic_module.PublicationDirectoryReader)
+        saved_readers.append(reader)
+        (directory / "payload.txt").write_text("mutated", encoding="utf-8")
+        raise primary
+
+    with pytest.raises(type(primary)) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            mutate_then_fail,
+        )
+
+    assert caught.value is primary
+    traceback_names: list[str] = []
+    traceback = caught.value.__traceback__
+    while traceback is not None:
+        traceback_names.append(traceback.tb_frame.f_code.co_name)
+        traceback = traceback.tb_next
+    assert "mutate_then_fail" in traceback_names
+    assert any(
+        "post-callback ownership validation also failed" in note
+        and ("changed" in note or "differs" in note)
+        for note in _exception_notes(primary)
+    )
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
+def test_reopen_active_outer_exception_raises_exact_postflight_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    outer_error = ValueError("ambient outer failure")
+    post_error = OSError(errno.EIO, "injected tree post-capture failure")
+    real_capture = atomic_module.PublicationDirectoryReader.capture_ownership
+    capture_calls = 0
+    saved_readers: list[atomic_module.PublicationDirectoryReader] = []
+
+    def fail_post_capture(reader: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        if capture_calls == 2:
+            raise post_error
+        return real_capture(reader, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_module.PublicationDirectoryReader,
+        "capture_ownership",
+        fail_post_capture,
+    )
+
+    def mutate_then_return(reader: atomic_module.PublicationDirectoryReader) -> int:
+        saved_readers.append(reader)
+        (directory / "payload.txt").write_text("mutated", encoding="utf-8")
+        return 7
+
+    try:
+        raise outer_error
+    except ValueError as active_outer:
+        assert active_outer is outer_error
+        with pytest.raises(OSError) as caught:
+            atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                mutate_then_return,
+            )
+
+    assert caught.value is post_error
+    assert capture_calls == 2
+    assert _exception_notes(outer_error) == ()
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
+def test_reopen_active_outer_exception_all_green_returns_result(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    outer_error = ValueError("ambient outer failure")
+    saved_readers: list[atomic_module.PublicationDirectoryReader] = []
+
+    def consume(reader: atomic_module.PublicationDirectoryReader) -> int:
+        saved_readers.append(reader)
+        return 7
+
+    try:
+        raise outer_error
+    except ValueError as active_outer:
+        assert active_outer is outer_error
+        result = atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            consume,
+        )
+
+    assert result == 7
+    assert _exception_notes(outer_error) == ()
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
+def test_reopen_callback_primary_inside_active_outer_exception_is_local(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    outer_error = ValueError("ambient outer failure")
+    callback_error = OSError(errno.EIO, "local callback failure")
+    saved_readers: list[atomic_module.PublicationDirectoryReader] = []
+
+    def mutate_then_fail(reader: atomic_module.PublicationDirectoryReader) -> None:
+        saved_readers.append(reader)
+        (directory / "payload.txt").write_text("mutated", encoding="utf-8")
+        raise callback_error
+
+    try:
+        raise outer_error
+    except ValueError as active_outer:
+        assert active_outer is outer_error
+        with pytest.raises(OSError) as caught:
+            atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                mutate_then_fail,
+            )
+
+    assert caught.value is callback_error
+    traceback_names: list[str] = []
+    traceback = callback_error.__traceback__
+    while traceback is not None:
+        traceback_names.append(traceback.tb_frame.f_code.co_name)
+        traceback = traceback.tb_next
+    assert "mutate_then_fail" in traceback_names
+    assert any(
+        "post-callback ownership validation also failed" in note
+        and ("changed" in note or "differs" in note)
+        for note in _exception_notes(callback_error)
+    )
+    assert _exception_notes(outer_error) == ()
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
+def test_reopen_callback_primary_survives_child_namespace_drift_detection(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    held = tmp_path / "held"
+    primary = ValueError("callback failed after namespace drift")
+
+    def replace_root_then_fail(_reader: object) -> None:
+        directory.rename(held)
+        _write_tree(directory, "payload.txt", "foreign")
+        raise primary
+
+    with pytest.raises(ValueError) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            replace_root_then_fail,
+        )
+
+    assert caught.value is primary
+    assert any(
+        "child namespace validation also failed" in note
+        and "namespace binding changed" in note
+        for note in _exception_notes(primary)
+    )
+
+
+def test_reopen_callback_primary_survives_authority_path_binding_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    primary = ValueError("callback failed before authority verification")
+    path_error = OSError(errno.EIO, "injected authority path verification failure")
+    verification_calls = 0
+
+    def fail_path_binding(_authority: object) -> None:
+        nonlocal verification_calls
+        verification_calls += 1
+        raise path_error
+
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "verify_path_binding",
+        fail_path_binding,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            lambda _reader: (_ for _ in ()).throw(primary),
+        )
+
+    assert caught.value is primary
+    assert verification_calls == 1
+    assert any(
+        "authority path validation also failed" in note
+        and "injected authority path verification failure" in note
+        for note in _exception_notes(primary)
+    )
+
+
+def test_reopen_callback_primary_survives_post_capture_eio(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    primary = ValueError("callback failed before post capture")
+    post_error = OSError(errno.EIO, "injected authenticated post-capture failure")
+    real_capture = atomic_module.PublicationDirectoryReader.capture_ownership
+    capture_calls = 0
+
+    def fail_post_capture(reader: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        if capture_calls == 2:
+            raise post_error
+        return real_capture(reader, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_module.PublicationDirectoryReader,
+        "capture_ownership",
+        fail_post_capture,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            lambda _reader: (_ for _ in ()).throw(primary),
+        )
+
+    assert caught.value is primary
+    assert capture_calls == 2
+    assert any(
+        "post-callback ownership validation also failed" in note
+        and "authenticated post-capture failure" in note
+        for note in _exception_notes(primary)
+    )
+
+
+@pytest.mark.parametrize("callback_fails", [True, False], ids=["callback", "return"])
+def test_reopen_postflight_faults_are_best_effort_and_ordered(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    callback_fails: bool,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    held = tmp_path / "held"
+    callback_error = ValueError("callback failed after replacing the child")
+    tree_error = OSError(errno.EIO, "injected tree post-capture failure")
+    validity_error = RuntimeError("injected reader validity failure")
+    parent_error = RuntimeError("injected parent binding failure")
+    cleanup_error = RuntimeError("injected authority cleanup failure")
+    real_capture = atomic_module.PublicationDirectoryReader.capture_ownership
+    real_close = atomic_module._PublicationAuthority.close
+    capture_calls = 0
+    validity_calls = 0
+    saved_readers: list[atomic_module.PublicationDirectoryReader] = []
+
+    def fail_tree_post_capture(reader: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        if capture_calls == 2:
+            raise tree_error
+        return real_capture(reader, **kwargs)
+
+    def fail_reader_validity(_reader: object) -> None:
+        nonlocal validity_calls
+        validity_calls += 1
+        if validity_calls == 2:
+            raise validity_error
+
+    def fail_parent_binding(_authority: object) -> None:
+        raise parent_error
+
+    def close_then_fail(authority: object) -> None:
+        real_close(authority)
+        raise cleanup_error
+
+    monkeypatch.setattr(
+        atomic_module.PublicationDirectoryReader,
+        "capture_ownership",
+        fail_tree_post_capture,
+    )
+    monkeypatch.setattr(
+        atomic_module.PublicationDirectoryReader,
+        "_require_valid",
+        fail_reader_validity,
+    )
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "verify_path_binding",
+        fail_parent_binding,
+    )
+    monkeypatch.setattr(
+        atomic_module._PublicationAuthority,
+        "close",
+        close_then_fail,
+    )
+
+    def replace_child_then_finish(
+        reader: atomic_module.PublicationDirectoryReader,
+    ) -> int:
+        saved_readers.append(reader)
+        directory.rename(held)
+        _write_tree(directory, "payload.txt", "foreign")
+        if callback_fails:
+            raise callback_error
+        return 7
+
+    with pytest.raises(BaseException) as caught:
+        atomic_module.reopen_authenticated_directory(
+            directory,
+            ownership,
+            replace_child_then_finish,
+        )
+
+    expected_primary = callback_error if callback_fails else tree_error
+    assert caught.value is expected_primary
+    assert capture_calls == 2
+    assert validity_calls == 2
+    notes = _exception_notes(expected_primary)
+    expected_note_fragments = (
+        *(
+            ("post-callback ownership validation also failed",)
+            if callback_fails
+            else ()
+        ),
+        "publication reader validity validation also failed",
+        "publication reader child namespace validation also failed",
+        "authenticated directory authority path validation also failed",
+        "publication authority owner cleanup also failed",
+    )
+    note_positions = [
+        next(index for index, note in enumerate(notes) if fragment in note)
+        for fragment in expected_note_fragments
+    ]
+    assert note_positions == sorted(note_positions)
+    if callback_fails:
+        traceback_names: list[str] = []
+        traceback = caught.value.__traceback__
+        while traceback is not None:
+            traceback_names.append(traceback.tb_frame.f_code.co_name)
+            traceback = traceback.tb_next
+        assert "replace_child_then_finish" in traceback_names
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="requires Linux fd accounting",
@@ -3534,6 +4240,60 @@ def test_reopen_authenticated_directory_fake_windows_rejects_suppressed_error(
     assert isinstance(children, dict)
     assert children["payload.txt"] == original_id
     assert children["foreign.txt"] == foreign_id
+
+
+def test_reopen_authenticated_directory_fake_windows_checks_child_after_primary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    directory_id = api.add_directory(api.root_id, "existing")
+    api.add_file(directory_id, "payload.txt", b"payload")
+    foreign_id = api.add_directory()
+    api.add_file(foreign_id, "payload.txt", b"foreign")
+    monkeypatch.setattr(atomic_module, "_windows_require_publication_api", lambda: None)
+    _install_fake_windows_api(monkeypatch, api)
+    path = Path("C:/authority/existing")
+    authority = atomic_module._open_windows_publication_authority(
+        path.parent,
+        parent_resource=None,
+        expected_parent_identity=None,
+    )
+    try:
+        ownership = authority.capture_child(
+            path.name,
+            path=path,
+            label="existing",
+        )
+    finally:
+        authority.close()
+    assert api.handles == {}
+    primary = KeyboardInterrupt("callback interrupted after child replacement")
+    saved_readers: list[object] = []
+
+    def replace_child_then_fail(reader: object) -> None:
+        saved_readers.append(reader)
+        children = api.nodes[api.root_id]["children"]
+        assert isinstance(children, dict)
+        children["held"] = children.pop("existing")
+        children["existing"] = foreign_id
+        raise primary
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        atomic_module.reopen_authenticated_directory(
+            path,
+            ownership,
+            replace_child_then_fail,
+        )
+
+    assert caught.value is primary
+    assert any(
+        "child namespace validation also failed" in note
+        and "namespace binding changed" in note
+        for note in _exception_notes(primary)
+    )
+    assert api.handles == {}
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="requires real Windows HANDLEs")
@@ -3901,6 +4661,66 @@ def _call_with_interrupt_after_store(
         assert injected, f"failed to inject after {local_name} result store"
 
 
+def _call_with_interrupt_at_back_edge(
+    function: object,
+    callback: object,
+    *,
+    predicate: object,
+    error: BaseException,
+) -> None:
+    assert callable(function)
+    assert callable(callback)
+    assert callable(predicate)
+    code = function.__code__
+    instructions = tuple(dis.get_instructions(function))
+    back_edges = tuple(
+        instruction
+        for instruction in instructions
+        if "JUMP" in instruction.opname
+        and isinstance(instruction.argval, int)
+        and instruction.argval < instruction.offset
+    )
+    assert back_edges
+    # The ordered runner may also have a handler-local back-edge.  Select the
+    # outer action-loop edge (the earliest destination) so a 3.12 line event
+    # cannot inject at handler fallthrough before the real normal back-edge.
+    loop_destination = min(instruction.argval for instruction in back_edges)
+    opcode_offsets = {
+        instruction.offset
+        for instruction in back_edges
+        if instruction.argval == loop_destination
+    }
+    line_offsets = {loop_destination}
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
+            return trace
+        if (
+            frame.f_code is code
+            and (
+                (event == "opcode" and frame.f_lasti in opcode_offsets)
+                or (event == "line" and frame.f_lasti in line_offsets)
+            )
+            and predicate(frame.f_locals)
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, "failed to inject at an ordered-action back-edge"
+
+
 def _posix_authority_resources(
     authority: object,
 ) -> atomic_module._PosixResourceOwner:
@@ -3918,6 +4738,1926 @@ def _assert_descriptor_closed(descriptor: int) -> None:
     with pytest.raises(OSError) as caught:
         os.fstat(descriptor)
     assert caught.value.errno == errno.EBADF
+
+
+@pytest.mark.parametrize("callback_fails", [True, False], ids=["primary", "return"])
+def test_ordered_post_validations_resume_after_back_edge_cancellation(
+    callback_fails: bool,
+) -> None:
+    callback_error = ValueError("callback primary")
+    interruption = KeyboardInterrupt("post-validation back-edge")
+    final_error = OSError(errno.EIO, "final validation failure")
+    calls: list[str] = []
+
+    def callback() -> int:
+        if callback_fails:
+            raise callback_error
+        return 7
+
+    def first_validation() -> None:
+        calls.append("first")
+
+    def final_validation() -> None:
+        calls.append("final")
+        raise final_error
+
+    def invoke() -> None:
+        atomic_module._run_callback_with_post_validations(
+            callback,
+            (
+                ("first post-validation also failed", first_validation),
+                ("final post-validation also failed", final_validation),
+            ),
+        )
+
+    with pytest.raises(BaseException) as caught:
+        _call_with_interrupt_at_back_edge(
+            atomic_module._run_ordered_actions_pass,
+            invoke,
+            predicate=lambda local: (
+                local["state"].next_index == 1 and calls == ["first"]
+            ),
+            error=interruption,
+        )
+
+    expected_primary = callback_error if callback_fails else interruption
+    assert caught.value is expected_primary
+    assert calls == ["first", "final"]
+    notes = _exception_notes(expected_primary)
+    expected_fragments = (
+        *(
+            ("publication callback post-validation iteration also failed",)
+            if callback_fails
+            else ()
+        ),
+        "final post-validation also failed",
+    )
+    positions = [
+        next(index for index, note in enumerate(notes) if fragment in note)
+        for fragment in expected_fragments
+    ]
+    assert positions == sorted(positions)
+
+
+def test_ordered_post_validations_protect_back_edge_after_action_error() -> None:
+    callback_error = ValueError("callback primary")
+    first_error = OSError(errno.EIO, "first validation failure")
+    interruption = SystemExit("validation error-handler back-edge")
+    calls: list[str] = []
+
+    def first_validation() -> None:
+        calls.append("first")
+        raise first_error
+
+    def final_validation() -> None:
+        calls.append("final")
+
+    def invoke() -> None:
+        atomic_module._run_callback_with_post_validations(
+            lambda: (_ for _ in ()).throw(callback_error),
+            (
+                ("first post-validation also failed", first_validation),
+                ("final post-validation also failed", final_validation),
+            ),
+        )
+
+    with pytest.raises(ValueError) as caught:
+        _call_with_interrupt_at_back_edge(
+            atomic_module._run_ordered_actions_pass,
+            invoke,
+            predicate=lambda local: (
+                local["state"].next_index == 1 and calls == ["first"]
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is callback_error
+    assert calls == ["first", "final"]
+    notes = _exception_notes(callback_error)
+    first_position = next(
+        index
+        for index, note in enumerate(notes)
+        if "first post-validation also failed" in note
+    )
+    interruption_position = next(
+        index
+        for index, note in enumerate(notes)
+        if "post-validation iteration also failed" in note
+    )
+    assert first_position < interruption_position
+
+
+@pytest.mark.parametrize("body_fails", [True, False], ids=["primary", "return"])
+def test_ordered_cleanup_resumes_after_back_edge_cancellation(
+    body_fails: bool,
+) -> None:
+    body_error = ValueError("context body primary")
+    interruption = KeyboardInterrupt("cleanup back-edge")
+    final_error = OSError(errno.EIO, "final cleanup failure")
+    calls: list[str] = []
+
+    def first_cleanup() -> None:
+        calls.append("first")
+
+    def final_cleanup() -> None:
+        calls.append("final")
+        raise final_error
+
+    def invoke() -> None:
+        with atomic_module._run_context_with_cleanup_actions(
+            (
+                ("first cleanup also failed", first_cleanup),
+                ("final cleanup also failed", final_cleanup),
+            )
+        ):
+            if body_fails:
+                raise body_error
+
+    with pytest.raises(BaseException) as caught:
+        _call_with_interrupt_at_back_edge(
+            atomic_module._run_ordered_actions_pass,
+            invoke,
+            predicate=lambda local: (
+                local["state"].next_index == 1 and calls == ["first"]
+            ),
+            error=interruption,
+        )
+
+    expected_primary = body_error if body_fails else interruption
+    assert caught.value is expected_primary
+    assert calls == ["first", "final"]
+    notes = _exception_notes(expected_primary)
+    expected_fragments = (
+        *(
+            ("publication authenticated cleanup iteration also failed",)
+            if body_fails
+            else ()
+        ),
+        "final cleanup also failed",
+    )
+    positions = [
+        next(index for index, note in enumerate(notes) if fragment in note)
+        for fragment in expected_fragments
+    ]
+    assert positions == sorted(positions)
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX descriptors",
+)
+def test_cleanup_back_edge_cancellation_closes_remaining_posix_descriptors() -> None:
+    first_read, first_write = os.pipe()
+    final_read, final_write = os.pipe()
+    all_descriptors = (first_read, first_write, final_read, final_write)
+    body_error = ValueError("context body primary")
+    interruption = KeyboardInterrupt("descriptor cleanup back-edge")
+    calls: list[str] = []
+
+    def close_first() -> None:
+        os.close(first_read)
+        calls.append("first")
+
+    def close_final() -> None:
+        os.close(final_read)
+        calls.append("final")
+
+    def invoke() -> None:
+        with atomic_module._run_context_with_cleanup_actions(
+            (
+                ("first descriptor cleanup also failed", close_first),
+                ("final descriptor cleanup also failed", close_final),
+            )
+        ):
+            raise body_error
+
+    try:
+        with pytest.raises(ValueError) as caught:
+            _call_with_interrupt_at_back_edge(
+                atomic_module._run_ordered_actions_pass,
+                invoke,
+                predicate=lambda local: (
+                    local["state"].next_index == 1 and calls == ["first"]
+                ),
+                error=interruption,
+            )
+
+        assert caught.value is body_error
+        assert calls == ["first", "final"]
+        _assert_descriptor_closed(first_read)
+        _assert_descriptor_closed(final_read)
+    finally:
+        for descriptor in all_descriptors:
+            try:
+                os.close(descriptor)
+            except OSError as error:
+                if error.errno != errno.EBADF:
+                    raise
+
+
+def test_cleanup_back_edge_cancellation_closes_remaining_windows_handles() -> None:
+    api = _FakeWindowsApi()
+    first_handle = api.create_directory_handle(Path("C:/authority"))
+    final_handle = api.duplicate_handle(first_handle)
+    body_error = ValueError("context body primary")
+    interruption = KeyboardInterrupt("HANDLE cleanup back-edge")
+    calls: list[str] = []
+
+    def close_first() -> None:
+        api.close(first_handle)
+        calls.append("first")
+
+    def close_final() -> None:
+        api.close(final_handle)
+        calls.append("final")
+
+    def invoke() -> None:
+        with atomic_module._run_context_with_cleanup_actions(
+            (
+                ("first HANDLE cleanup also failed", close_first),
+                ("final HANDLE cleanup also failed", close_final),
+            )
+        ):
+            raise body_error
+
+    try:
+        with pytest.raises(ValueError) as caught:
+            _call_with_interrupt_at_back_edge(
+                atomic_module._run_ordered_actions_pass,
+                invoke,
+                predicate=lambda local: (
+                    local["state"].next_index == 1 and calls == ["first"]
+                ),
+                error=interruption,
+            )
+
+        assert caught.value is body_error
+        assert calls == ["first", "final"]
+        assert api.handles == {}
+    finally:
+        for handle in tuple(api.handles):
+            api.close(handle)
+
+
+@pytest.mark.parametrize("surface", ["post-validation", "cleanup"])
+def test_hostile_add_note_cannot_replace_primary_or_skip_actions(
+    surface: str,
+) -> None:
+    class HostilePrimary(BaseException):
+        def __init__(self) -> None:
+            super().__init__("hostile primary")
+            self.override_calls = 0
+
+        def add_note(self, _note: str) -> None:
+            self.override_calls += 1
+            raise RuntimeError("hostile add_note override")
+
+    primary = HostilePrimary()
+    secondary = OSError(errno.EIO, "secondary action failure")
+    calls: list[str] = []
+
+    def first_action() -> None:
+        calls.append("first")
+        raise secondary
+
+    def final_action() -> None:
+        calls.append("final")
+
+    def invoke() -> None:
+        actions = (
+            ("first ordered action also failed", first_action),
+            ("final ordered action also failed", final_action),
+        )
+        if surface == "post-validation":
+            atomic_module._run_callback_with_post_validations(
+                lambda: (_ for _ in ()).throw(primary),
+                actions,
+            )
+        else:
+            with atomic_module._run_context_with_cleanup_actions(actions):
+                raise primary
+
+    with pytest.raises(HostilePrimary) as caught:
+        invoke()
+
+    assert caught.value is primary
+    assert primary.override_calls == 0
+    assert calls == ["first", "final"]
+    assert any(
+        "first ordered action also failed" in note
+        and "secondary action failure" in note
+        for note in _exception_notes(primary)
+    )
+
+
+def _interrupt_ordered_action_before_call(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    label: str,
+    errors: tuple[BaseException, ...],
+) -> list[str]:
+    real_attempt = atomic_module._attempt_ordered_action
+    remaining = list(errors)
+    events: list[str] = []
+
+    def interrupt(state: object, ordered: object) -> object:
+        if ordered.label == label and remaining:
+            error = remaining.pop(0)
+            events.append(type(error).__name__)
+            raise error
+        return real_attempt(state, ordered)
+
+    monkeypatch.setattr(atomic_module, "_attempt_ordered_action", interrupt)
+    return events
+
+
+def _call_with_interrupt_at_ordered_action_call(
+    callback: object,
+    *,
+    error: BaseException,
+) -> None:
+    """Inject at the real action CALL, not around the runner helper."""
+
+    assert callable(callback)
+    function = atomic_module._attempt_ordered_action
+    code = function.__code__
+    source, first_line = inspect.getsourcelines(function)
+    action_lines = {
+        first_line + offset
+        for offset, line in enumerate(source)
+        if "ordered.action()" in line
+    }
+    assert len(action_lines) == 1
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is code
+            and event == "line"
+            and frame.f_lineno in action_lines
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, "failed to inject at the ordered action CALL"
+
+
+def _interrupt_ordered_runner_entries(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    errors: tuple[BaseException, ...],
+    action_index: int = 0,
+) -> list[BaseException]:
+    """Raise repeatedly at the protected call into the ordered runner pass."""
+
+    real_pass = atomic_module._run_ordered_actions_pass
+    remaining = list(errors)
+    observed: list[BaseException] = []
+
+    def interrupt(state: object) -> bool:
+        if state.next_index == action_index and remaining:
+            error = remaining.pop(0)
+            observed.append(error)
+            raise error
+        return real_pass(state)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_run_ordered_actions_pass",
+        interrupt,
+    )
+    return observed
+
+
+def test_callback_post_validations_resume_after_repeated_runner_entry_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callback_error = ValueError("callback failed before post-validation")
+    first = KeyboardInterrupt("first post-validation runner entry")
+    second = SystemExit("second post-validation runner entry")
+    calls: list[str] = []
+    observed = _interrupt_ordered_runner_entries(
+        monkeypatch,
+        errors=(first, second),
+    )
+
+    with pytest.raises(ValueError) as caught:
+        atomic_module._run_callback_with_post_validations(
+            lambda: (_ for _ in ()).throw(callback_error),
+            (
+                ("first post-validation also failed", lambda: calls.append("first")),
+                ("final post-validation also failed", lambda: calls.append("final")),
+            ),
+        )
+
+    assert caught.value is callback_error
+    assert observed == [first, second]
+    assert calls == ["first", "final"]
+    assert any(
+        "post-validation iteration also failed" in note
+        and "first post-validation runner entry" in note
+        for note in _exception_notes(callback_error)
+    )
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX directory descriptors",
+)
+def test_posix_authenticated_cleanup_resumes_after_runner_entry_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "publication"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload.txt").write_bytes(b"payload")
+    reader, root_descriptor = _posix_cleanup_test_reader(root)
+    body_error = ValueError("authenticated body failed")
+    first = KeyboardInterrupt("first POSIX cleanup runner entry")
+    second = SystemExit("second POSIX cleanup runner entry")
+    owners: list[atomic_module._PosixResourceOwner] = []
+    real_close_all = atomic_module._PosixResourceOwner.close_all
+
+    def capture_owner(owner: atomic_module._PosixResourceOwner) -> None:
+        if not any(candidate is owner for candidate in owners):
+            owners.append(owner)
+        real_close_all(owner)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "close_all",
+        capture_owner,
+    )
+    observed = _interrupt_ordered_runner_entries(
+        monkeypatch,
+        errors=(first, second),
+    )
+
+    def invoke() -> None:
+        with reader.open_authenticated_file(
+            "nested/payload.txt",
+            max_bytes=16,
+        ) as authenticated:
+            assert authenticated.read() == b"payload"
+            raise body_error
+
+    try:
+        with pytest.raises(ValueError) as caught:
+            invoke()
+
+        assert caught.value is body_error
+        assert observed == [first, second]
+        assert owners and all(owner.closed for owner in owners)
+        assert any(
+            "cleanup iteration also failed" in note
+            and "first POSIX cleanup runner entry" in note
+            for note in _exception_notes(body_error)
+        )
+    finally:
+        reader._deactivate()
+        os.close(root_descriptor)
+
+
+def test_windows_authenticated_cleanup_resumes_after_runner_entry_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api, reader, root_handle = _windows_cleanup_test_reader()
+    body_error = ValueError("authenticated body failed")
+    first = SystemExit("first Windows cleanup runner entry")
+    second = KeyboardInterrupt("second Windows cleanup runner entry")
+    owners: list[atomic_module._WindowsResourceOwner] = []
+    real_close_all = atomic_module._WindowsResourceOwner.close_all
+
+    def capture_owner(owner: atomic_module._WindowsResourceOwner) -> None:
+        if not any(candidate is owner for candidate in owners):
+            owners.append(owner)
+        real_close_all(owner)
+
+    monkeypatch.setattr(
+        atomic_module._WindowsResourceOwner,
+        "close_all",
+        capture_owner,
+    )
+    observed = _interrupt_ordered_runner_entries(
+        monkeypatch,
+        errors=(first, second),
+    )
+
+    def invoke() -> None:
+        with reader.open_authenticated_file(
+            "nested/payload.txt",
+            max_bytes=16,
+        ) as authenticated:
+            assert authenticated.read() == b"payload"
+            raise body_error
+
+    try:
+        with pytest.raises(ValueError) as caught:
+            invoke()
+
+        assert caught.value is body_error
+        assert observed == [first, second]
+        assert owners and all(owner.closed for owner in owners)
+        assert set(api.handles) == {root_handle}
+        assert any(
+            "cleanup iteration also failed" in note
+            and "first Windows cleanup runner entry" in note
+            for note in _exception_notes(body_error)
+        )
+    finally:
+        reader._deactivate()
+        api.close(root_handle)
+
+    assert api.handles == {}
+
+
+def test_callback_post_validations_bound_permanent_runner_entry_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callback_error = ValueError("callback failed before post-validation")
+    interruptions = tuple(
+        KeyboardInterrupt(f"post-validation runner entry {index}")
+        for index in range(20)
+    )
+    calls: list[str] = []
+    observed = _interrupt_ordered_runner_entries(
+        monkeypatch,
+        errors=interruptions,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        atomic_module._run_callback_with_post_validations(
+            lambda: (_ for _ in ()).throw(callback_error),
+            (
+                (
+                    "blocked post-validation also failed",
+                    lambda: calls.append("blocked"),
+                ),
+                ("later post-validation also failed", lambda: calls.append("later")),
+            ),
+        )
+
+    expected_attempts = atomic_module._MAX_ORDERED_ACTION_CANCELLATION_RETRIES + 1
+    assert caught.value is callback_error
+    assert observed == list(interruptions[:expected_attempts])
+    assert calls == ["later"]
+    notes = _exception_notes(callback_error)
+    assert "post-validation runner entry 0" in notes[0]
+    assert "cancellation retry limit" in notes[-1]
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX descriptors",
+)
+def test_posix_owner_is_retained_after_permanent_runner_entry_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = atomic_module._PosixResourceOwner()
+    descriptor = owner.open(os.devnull, os.O_RDONLY)
+    record = owner.record_for_cleanup(descriptor)
+    primary = ValueError("body failed before POSIX cleanup")
+    interruptions = tuple(
+        KeyboardInterrupt(f"POSIX runner entry {index}") for index in range(20)
+    )
+    later_calls: list[str] = []
+    cleanup_complete = False
+
+    def close_owner() -> None:
+        nonlocal cleanup_complete
+        owner.close_all()
+        cleanup_complete = True
+
+    state = atomic_module._OrderedActionState(
+        actions=(
+            atomic_module._OrderedAction(
+                label="POSIX owner cleanup also failed",
+                action=close_owner,
+                complete=lambda: cleanup_complete,
+                retry_incomplete="cancellation",
+                incomplete_owner=owner,
+            ),
+            ("later cleanup also failed", lambda: later_calls.append("later")),
+        ),
+        iteration_failure_label="POSIX cleanup iteration also failed",
+        primary_error=primary,
+    )
+    observed = _interrupt_ordered_runner_entries(
+        monkeypatch,
+        errors=interruptions,
+    )
+
+    try:
+        atomic_module._run_ordered_actions(state)
+
+        expected_attempts = atomic_module._MAX_ORDERED_ACTION_CANCELLATION_RETRIES + 1
+        assert observed == list(interruptions[:expected_attempts])
+        assert state.primary_error is primary
+        assert state.next_index == 2
+        assert later_calls == ["later"]
+        assert record.descriptor == descriptor
+        os.fstat(descriptor)
+        assert primary.publication_cleanup_owners == (owner,)
+    finally:
+        owner.close_all()
+
+    assert owner.closed
+
+
+def test_windows_owner_is_retained_after_permanent_runner_entry_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    owner = atomic_module._WindowsResourceOwner(api)
+    handle = owner.acquire(lambda: api.create_directory_handle(Path("C:/authority")))
+    record = owner.record_for_cleanup(handle)
+    primary = ValueError("body failed before Windows cleanup")
+    interruptions = tuple(
+        SystemExit(f"Windows runner entry {index}") for index in range(20)
+    )
+    later_calls: list[str] = []
+    cleanup_complete = False
+
+    def close_owner() -> None:
+        nonlocal cleanup_complete
+        owner.close_all()
+        cleanup_complete = True
+
+    state = atomic_module._OrderedActionState(
+        actions=(
+            atomic_module._OrderedAction(
+                label="Windows owner cleanup also failed",
+                action=close_owner,
+                complete=lambda: cleanup_complete,
+                retry_incomplete="cancellation",
+                incomplete_owner=owner,
+            ),
+            ("later cleanup also failed", lambda: later_calls.append("later")),
+        ),
+        iteration_failure_label="Windows cleanup iteration also failed",
+        primary_error=primary,
+    )
+    observed = _interrupt_ordered_runner_entries(
+        monkeypatch,
+        errors=interruptions,
+    )
+
+    atomic_module._run_ordered_actions(state)
+
+    expected_attempts = atomic_module._MAX_ORDERED_ACTION_CANCELLATION_RETRIES + 1
+    assert observed == list(interruptions[:expected_attempts])
+    assert state.primary_error is primary
+    assert state.next_index == 2
+    assert later_calls == ["later"]
+    assert record.handle == handle
+    assert set(api.handles) == {handle}
+    assert primary.publication_cleanup_owners == (owner,)
+    owner.close_all()
+    assert owner.closed
+    assert api.handles == {}
+
+
+def test_outer_trampoline_entry_failure_retains_pending_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = ValueError("body failed before cleanup")
+    boundary_error = KeyboardInterrupt("before the C trampoline started")
+    calls: list[str] = []
+
+    class RetryOwner:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    owner = RetryOwner()
+    monkeypatch.setattr(
+        atomic_module,
+        "_run_ordered_actions",
+        lambda _state: (_ for _ in ()).throw(boundary_error),
+    )
+
+    with pytest.raises(ValueError) as caught:
+        with atomic_module._run_context_with_cleanup_actions(
+            (
+                atomic_module._OrderedAction(
+                    label="pending owner cleanup also failed",
+                    action=owner.close,
+                    complete=lambda: owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=owner,
+                ),
+                ("later cleanup also failed", lambda: calls.append("later")),
+            )
+        ):
+            raise primary
+
+    assert caught.value is primary
+    assert not owner.closed
+    assert calls == []
+    assert primary.publication_cleanup_owners == (owner,)
+    assert any(
+        "before the C trampoline started" in note for note in _exception_notes(primary)
+    )
+    owner.close()
+    assert owner.closed
+
+
+def test_completion_aware_action_retries_real_pre_call_cancellation() -> None:
+    interruption = KeyboardInterrupt("action CALL cancellation")
+    completed = False
+    calls: list[str] = []
+
+    def cleanup() -> None:
+        nonlocal completed
+        calls.append("cleanup")
+        completed = True
+
+    state = atomic_module._OrderedActionState(
+        actions=(
+            atomic_module._OrderedAction(
+                label="real cleanup CALL also failed",
+                action=cleanup,
+                complete=lambda: completed,
+                retry_incomplete="cancellation",
+            ),
+            ("final validation also failed", lambda: calls.append("final")),
+        ),
+        iteration_failure_label="real cleanup iteration also failed",
+        primary_error=None,
+    )
+
+    _call_with_interrupt_at_ordered_action_call(
+        lambda: atomic_module._run_ordered_actions(state),
+        error=interruption,
+    )
+
+    assert state.primary_error is interruption
+    assert state.next_index == 2
+    assert completed
+    assert calls == ["cleanup", "final"]
+
+
+def test_completion_aware_action_retries_repeated_pre_call_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = KeyboardInterrupt("first pre-call cancellation")
+    second = SystemExit("second pre-call cancellation")
+    completed = False
+    calls = 0
+
+    def finish() -> None:
+        nonlocal calls, completed
+        calls += 1
+        completed = True
+
+    label = "test completion-aware cleanup also failed"
+    events = _interrupt_ordered_action_before_call(
+        monkeypatch,
+        label=label,
+        errors=(first, second),
+    )
+    state = atomic_module._OrderedActionState(
+        actions=(
+            atomic_module._OrderedAction(
+                label=label,
+                action=finish,
+                complete=lambda: completed,
+                retry_incomplete="cancellation",
+            ),
+        ),
+        iteration_failure_label="test iteration also failed",
+        primary_error=None,
+    )
+
+    atomic_module._run_ordered_actions(state)
+
+    assert events == ["KeyboardInterrupt", "SystemExit"]
+    assert calls == 1
+    assert completed
+    assert state.next_index == 1
+    assert state.primary_error is first
+    assert not any(repr(second) in note for note in _exception_notes(first))
+
+
+@pytest.mark.parametrize(
+    "interruption_type",
+    [KeyboardInterrupt, SystemExit, GeneratorExit],
+)
+@pytest.mark.parametrize("surface", ["planning", "pre-call", "action", "advance"])
+@pytest.mark.parametrize("body_fails", [True, False], ids=["body", "cleanup"])
+def test_completion_aware_action_bounds_permanent_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+    interruption_type: type[BaseException],
+    surface: str,
+    body_fails: bool,
+) -> None:
+    interruption = interruption_type("permanent cleanup cancellation")
+    body_error = ValueError("body failed before permanent cleanup cancellation")
+    attempts = 0
+    later_calls = 0
+    real_attempt = atomic_module._attempt_ordered_action
+    real_advance = atomic_module._advance_ordered_action
+    real_coerce = atomic_module._coerce_ordered_action
+
+    class RetryOwner:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    owner = RetryOwner()
+
+    def interrupt_before_call(state: object, ordered: object) -> object:
+        nonlocal attempts
+        if surface == "pre-call":
+            attempts += 1
+            raise interruption
+        return real_attempt(state, ordered)
+
+    def permanently_interrupt() -> None:
+        nonlocal attempts
+        if surface == "action":
+            attempts += 1
+            raise interruption
+        owner.close()
+
+    def interrupt_planning(value: object) -> object:
+        nonlocal attempts
+        if surface == "planning" and isinstance(value, atomic_module._OrderedAction):
+            attempts += 1
+            raise interruption
+        return real_coerce(value)
+
+    def interrupt_advance(state: object) -> None:
+        nonlocal attempts
+        if surface == "advance":
+            attempts += 1
+            raise interruption
+        real_advance(state)
+
+    def run_later() -> None:
+        nonlocal later_calls
+        later_calls += 1
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_attempt_ordered_action",
+        interrupt_before_call,
+    )
+    monkeypatch.setattr(
+        atomic_module,
+        "_coerce_ordered_action",
+        interrupt_planning,
+    )
+    monkeypatch.setattr(
+        atomic_module,
+        "_advance_ordered_action",
+        interrupt_advance,
+    )
+    state = atomic_module._OrderedActionState(
+        actions=(
+            atomic_module._OrderedAction(
+                label="permanently interrupted cleanup also failed",
+                action=permanently_interrupt,
+                complete=lambda: owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=owner,
+            ),
+            ("later cleanup also failed", run_later),
+        ),
+        iteration_failure_label="permanent cleanup iteration also failed",
+        primary_error=(body_error if body_fails else None),
+    )
+
+    atomic_module._run_ordered_actions(state)
+
+    assert attempts == atomic_module._MAX_ORDERED_ACTION_CANCELLATION_RETRIES + 1
+    assert later_calls == 1
+    assert state.next_index == 2
+    expected = body_error if body_fails else interruption
+    assert state.primary_error is expected
+    notes = _exception_notes(expected)
+    assert len(notes) == (2 if body_fails else 1)
+    assert "cancellation retry limit" in notes[-1]
+    assert str(atomic_module._MAX_ORDERED_ACTION_CANCELLATION_RETRIES) in notes[-1]
+    expected_owners = () if surface == "advance" else (owner,)
+    assert getattr(expected, "publication_cleanup_owners", ()) == expected_owners
+    owner.close()
+    assert owner.closed
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX directory descriptors",
+)
+def test_posix_authenticated_cleanup_retries_pre_call_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "publication"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload.txt").write_bytes(b"payload")
+    reader, root_descriptor = _posix_cleanup_test_reader(root)
+    interruption = KeyboardInterrupt("descriptor cleanup pre-call cancellation")
+    owners: list[atomic_module._PosixResourceOwner] = []
+    real_close_all = atomic_module._PosixResourceOwner.close_all
+
+    def capture_owner(
+        owner: atomic_module._PosixResourceOwner,
+    ) -> None:
+        owners.append(owner)
+        real_close_all(owner)
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "close_all",
+        capture_owner,
+    )
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "record_for_cleanup",
+        lambda _owner, _descriptor: (_ for _ in ()).throw(
+            AssertionError("authenticated cleanup rebuilt a descriptor plan")
+        ),
+    )
+    events = _interrupt_ordered_action_before_call(
+        monkeypatch,
+        label=(
+            "publication authenticated file descriptor cleanup also failed; "
+            "publication authenticated directory descriptor cleanup also failed"
+        ),
+        errors=(interruption,),
+    )
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            with reader.open_authenticated_file(
+                "nested/payload.txt",
+                max_bytes=16,
+            ):
+                pass
+
+        assert caught.value is interruption
+        assert events == ["KeyboardInterrupt"]
+        assert owners and all(owner.closed for owner in owners)
+    finally:
+        reader._deactivate()
+        os.close(root_descriptor)
+
+
+def test_windows_authenticated_cleanup_retries_pre_call_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api, reader, root_handle = _windows_cleanup_test_reader()
+    interruption = SystemExit("HANDLE cleanup pre-call cancellation")
+    owners: list[atomic_module._WindowsResourceOwner] = []
+    real_close_all = atomic_module._WindowsResourceOwner.close_all
+
+    def capture_owner(
+        owner: atomic_module._WindowsResourceOwner,
+    ) -> None:
+        owners.append(owner)
+        real_close_all(owner)
+
+    monkeypatch.setattr(
+        atomic_module._WindowsResourceOwner,
+        "close_all",
+        capture_owner,
+    )
+    monkeypatch.setattr(
+        atomic_module._WindowsResourceOwner,
+        "record_for_cleanup",
+        lambda _owner, _handle: (_ for _ in ()).throw(
+            AssertionError("authenticated cleanup rebuilt a HANDLE plan")
+        ),
+    )
+    events = _interrupt_ordered_action_before_call(
+        monkeypatch,
+        label=(
+            "publication authenticated file HANDLE cleanup also failed; "
+            "publication authenticated directory HANDLE cleanup also failed"
+        ),
+        errors=(interruption,),
+    )
+    try:
+        with pytest.raises(SystemExit) as caught:
+            with reader.open_authenticated_file(
+                "nested/payload.txt",
+                max_bytes=16,
+            ):
+                pass
+
+        assert caught.value is interruption
+        assert events == ["SystemExit"]
+        assert owners and all(owner.closed for owner in owners)
+    finally:
+        reader._deactivate()
+        api.close(root_handle)
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX directory descriptors",
+)
+def test_posix_authenticated_cleanup_owns_open_before_caller_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "publication"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload.txt").write_bytes(b"payload")
+    reader, root_descriptor = _posix_cleanup_test_reader(root)
+    interruption = KeyboardInterrupt("after owned open before caller store")
+    escaped: list[tuple[atomic_module._PosixResourceOwner, int]] = []
+    real_open = atomic_module._PosixResourceOwner.open
+
+    def open_then_interrupt(
+        owner: atomic_module._PosixResourceOwner,
+        path: object,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        descriptor = real_open(owner, path, flags, mode, dir_fd=dir_fd)
+        if path == "nested" and not escaped:
+            escaped.append((owner, descriptor))
+            raise interruption
+        return descriptor
+
+    monkeypatch.setattr(
+        atomic_module._PosixResourceOwner,
+        "open",
+        open_then_interrupt,
+    )
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            with reader.open_authenticated_file(
+                "nested/payload.txt",
+                max_bytes=16,
+            ):
+                pass
+
+        assert caught.value is interruption
+        assert len(escaped) == 1
+        owner, descriptor = escaped[0]
+        assert owner.closed
+        _assert_descriptor_closed(descriptor)
+    finally:
+        reader._deactivate()
+        os.close(root_descriptor)
+
+
+def test_windows_authenticated_cleanup_owns_acquire_before_caller_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api, reader, root_handle = _windows_cleanup_test_reader()
+    interruption = SystemExit("after owned HANDLE acquire before caller store")
+    escaped: list[tuple[atomic_module._WindowsResourceOwner, int]] = []
+    real_acquire = atomic_module._WindowsResourceOwner.acquire
+
+    def acquire_then_interrupt(
+        owner: atomic_module._WindowsResourceOwner,
+        callback: object,
+    ) -> int:
+        assert callable(callback)
+        handle = real_acquire(owner, callback)
+        if not escaped:
+            escaped.append((owner, handle))
+            raise interruption
+        return handle
+
+    monkeypatch.setattr(
+        atomic_module._WindowsResourceOwner,
+        "acquire",
+        acquire_then_interrupt,
+    )
+    try:
+        with pytest.raises(SystemExit) as caught:
+            with reader.open_authenticated_file(
+                "nested/payload.txt",
+                max_bytes=16,
+            ):
+                pass
+
+        assert caught.value is interruption
+        assert len(escaped) == 1
+        owner, handle = escaped[0]
+        assert owner.closed
+        assert handle not in api.handles
+    finally:
+        reader._deactivate()
+        api.close(root_handle)
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX directory descriptors",
+)
+@pytest.mark.parametrize("body_fails", [True, False], ids=["body", "cleanup"])
+def test_posix_authenticated_cleanup_retains_owner_after_persistent_eio(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    body_fails: bool,
+) -> None:
+    root = tmp_path / "publication"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "payload.txt").write_bytes(b"payload")
+    reader, root_descriptor = _posix_cleanup_test_reader(root)
+    real_close = atomic_module.os.close
+    body_error = ValueError("authenticated body failed")
+    close_error = OSError(errno.EIO, "persistent descriptor close failure")
+    failed_descriptor = -1
+    retained_owner: atomic_module._PosixResourceOwner | None = None
+
+    def fail_one_descriptor(descriptor: int) -> None:
+        nonlocal failed_descriptor
+        if failed_descriptor < 0:
+            failed_descriptor = descriptor
+        if descriptor == failed_descriptor:
+            raise close_error
+        real_close(descriptor)
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(atomic_module.os, "close", fail_one_descriptor)
+            with pytest.raises(BaseException) as caught:
+                with reader.open_authenticated_file(
+                    "nested/payload.txt",
+                    max_bytes=16,
+                ):
+                    if body_fails:
+                        raise body_error
+
+        expected = body_error if body_fails else close_error
+        assert caught.value is expected
+        owners = expected.publication_cleanup_owners
+        matches = [
+            owner
+            for owner in owners
+            if isinstance(owner, atomic_module._PosixResourceOwner)
+        ]
+        assert len(matches) == 1
+        retained_owner = matches[0]
+        assert not retained_owner.closed
+        live = [
+            record.descriptor
+            for record in retained_owner._records
+            if record.descriptor >= 0
+        ]
+        assert live == [failed_descriptor]
+        os.fstat(failed_descriptor)
+    finally:
+        if retained_owner is not None:
+            retained_owner.close()
+        reader._deactivate()
+        real_close(root_descriptor)
+
+    assert retained_owner is not None and retained_owner.closed
+    _assert_descriptor_closed(failed_descriptor)
+
+
+@pytest.mark.parametrize("body_fails", [True, False], ids=["body", "cleanup"])
+def test_windows_authenticated_cleanup_retains_owner_after_persistent_eio(
+    monkeypatch: pytest.MonkeyPatch,
+    body_fails: bool,
+) -> None:
+    api, reader, root_handle = _windows_cleanup_test_reader()
+    real_close = api.close
+    body_error = ValueError("authenticated body failed")
+    close_error = OSError(errno.EIO, "persistent HANDLE close failure")
+    failed_handle = 0
+    retained_owner: atomic_module._WindowsResourceOwner | None = None
+
+    def fail_one_handle(handle: int) -> None:
+        nonlocal failed_handle
+        if not failed_handle:
+            failed_handle = handle
+        if handle == failed_handle:
+            raise close_error
+        real_close(handle)
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(api, "close", fail_one_handle)
+            with pytest.raises(BaseException) as caught:
+                with reader.open_authenticated_file(
+                    "nested/payload.txt",
+                    max_bytes=16,
+                ):
+                    if body_fails:
+                        raise body_error
+
+        expected = body_error if body_fails else close_error
+        assert caught.value is expected
+        owners = expected.publication_cleanup_owners
+        matches = [
+            owner
+            for owner in owners
+            if isinstance(owner, atomic_module._WindowsResourceOwner)
+        ]
+        assert len(matches) == 1
+        retained_owner = matches[0]
+        assert not retained_owner.closed
+        live = [record.handle for record in retained_owner._records if record.handle]
+        assert live == [failed_handle]
+        assert failed_handle in api.handles
+    finally:
+        if retained_owner is not None:
+            retained_owner.close()
+        reader._deactivate()
+        real_close(root_handle)
+
+    assert retained_owner is not None and retained_owner.closed
+    assert api.handles == {}
+
+
+def test_windows_child_open_retains_local_owner_after_cleanup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    api.add_file(api.root_id, "payload.txt", b"payload")
+    root_handle = api.create_directory_handle(Path("C:/authority"))
+    entry = atomic_module._windows_find_child(api, root_handle, "payload.txt")
+    assert entry is not None
+    real_metadata = api.metadata
+    real_close = api.close
+    metadata_calls = 0
+    opened_handle = 0
+    metadata_error = OSError(errno.EIO, "post-acquire metadata failure")
+    close_error = OSError(errno.EIO, "persistent local HANDLE close failure")
+    retained_owner: atomic_module._WindowsResourceOwner | None = None
+
+    def fail_second_metadata(handle: int) -> object:
+        nonlocal metadata_calls, opened_handle
+        if handle != root_handle:
+            metadata_calls += 1
+            opened_handle = handle
+            if metadata_calls == 2:
+                raise metadata_error
+        return real_metadata(handle)
+
+    def fail_opened_close(handle: int) -> None:
+        if handle == opened_handle:
+            raise close_error
+        real_close(handle)
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(api, "metadata", fail_second_metadata)
+            faults.setattr(api, "close", fail_opened_close)
+            with pytest.raises(OSError) as caught:
+                atomic_module._windows_open_child_by_id(
+                    api,
+                    root_handle,
+                    entry,
+                    desired_access=atomic_module._WINDOWS_FILE_READ_DATA,
+                    expected_directory=False,
+                )
+
+        assert caught.value is metadata_error
+        owners = metadata_error.publication_cleanup_owners
+        assert len(owners) == 1
+        retained_owner = owners[0]
+        assert isinstance(retained_owner, atomic_module._WindowsResourceOwner)
+        assert not retained_owner.closed
+        assert opened_handle in api.handles
+    finally:
+        if retained_owner is not None:
+            retained_owner.close()
+        real_close(root_handle)
+
+    assert retained_owner is not None and retained_owner.closed
+    assert api.handles == {}
+
+
+@pytest.mark.parametrize("use_parent_resource", [False, True])
+def test_windows_authority_factory_retains_incomplete_local_owner(
+    monkeypatch: pytest.MonkeyPatch,
+    use_parent_resource: bool,
+) -> None:
+    api = _FakeWindowsApi()
+    external_handle = (
+        api.create_directory_handle(Path("C:/authority")) if use_parent_resource else 0
+    )
+    primary = RuntimeError("authority construction failed")
+    close_error = OSError(errno.EIO, "persistent authority HANDLE close failure")
+    real_close = api.close
+    retained_owner: object | None = None
+
+    def fail_authority_init(_authority: object, **_kwargs: object) -> None:
+        raise primary
+
+    def fail_close(_handle: int) -> None:
+        raise close_error
+
+    try:
+        with monkeypatch.context() as faults:
+            _install_fake_windows_api(faults, api)
+            faults.setattr(
+                atomic_module._PublicationAuthority,
+                "__init__",
+                fail_authority_init,
+            )
+            faults.setattr(api, "close", fail_close)
+            with pytest.raises(RuntimeError) as caught:
+                atomic_module._open_windows_publication_authority(
+                    Path("C:/authority"),
+                    parent_resource=(external_handle or None),
+                    expected_parent_identity=None,
+                )
+
+        assert caught.value is primary
+        assert any(
+            "authority cleanup also failed" in note
+            for note in _exception_notes(primary)
+        )
+        assert len(primary.publication_cleanup_owners) == 1
+        retained_owner = primary.publication_cleanup_owners[0]
+        expected_type = (
+            atomic_module._WindowsResourceOwner
+            if use_parent_resource
+            else atomic_module._WindowsLexicalAuthorityOwner
+        )
+        assert isinstance(retained_owner, expected_type)
+        assert not retained_owner.closed
+        assert api.handles
+    finally:
+        if retained_owner is not None:
+            retained_owner.close()
+        if external_handle:
+            real_close(external_handle)
+
+    assert retained_owner is not None and retained_owner.closed
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX directory descriptors",
+)
+def test_posix_authority_factory_retains_incomplete_local_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = RuntimeError("authority construction failed")
+    close_error = OSError(errno.EIO, "persistent authority descriptor close failure")
+    retained_owner: atomic_module._PosixResourceOwner | None = None
+
+    def fail_authority_init(_authority: object, **_kwargs: object) -> None:
+        raise primary
+
+    def fail_close(_descriptor: int) -> None:
+        raise close_error
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(
+                atomic_module._PublicationAuthority,
+                "__init__",
+                fail_authority_init,
+            )
+            faults.setattr(atomic_module.os, "close", fail_close)
+            with pytest.raises(RuntimeError) as caught:
+                atomic_module._open_posix_publication_authority(
+                    tmp_path,
+                    parent_resource=None,
+                    expected_parent_identity=None,
+                )
+
+        assert caught.value is primary
+        assert any(
+            "authority cleanup also failed" in note
+            for note in _exception_notes(primary)
+        )
+        assert len(primary.publication_cleanup_owners) == 1
+        retained_owner = primary.publication_cleanup_owners[0]
+        assert isinstance(retained_owner, atomic_module._PosixResourceOwner)
+        assert not retained_owner.closed
+    finally:
+        if retained_owner is not None:
+            retained_owner.close()
+
+    assert retained_owner is not None and retained_owner.closed
+
+
+@pytest.mark.parametrize("body_fails", [True, False], ids=["body", "cleanup"])
+def test_ordered_cleanup_retains_multiple_incomplete_owners(
+    body_fails: bool,
+) -> None:
+    body_error = ValueError("ordered cleanup body failed")
+    cleanup_errors = (
+        OSError(errno.EIO, "first persistent cleanup failure"),
+        OSError(errno.EIO, "second persistent cleanup failure"),
+    )
+
+    class RetryOwner:
+        def __init__(self, error: OSError) -> None:
+            self.error = error
+            self.fail = True
+            self.closed = False
+
+        def close(self) -> None:
+            if self.fail:
+                raise self.error
+            self.closed = True
+
+    owners = tuple(RetryOwner(error) for error in cleanup_errors)
+    actions = tuple(
+        atomic_module._OrderedAction(
+            label=f"owner {index} cleanup also failed",
+            action=owner.close,
+            complete=lambda owner=owner: owner.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=owner,
+        )
+        for index, owner in enumerate(owners)
+    )
+
+    with pytest.raises(BaseException) as caught:
+        with atomic_module._run_context_with_cleanup_actions(actions):
+            if body_fails:
+                raise body_error
+
+    expected = body_error if body_fails else cleanup_errors[0]
+    assert caught.value is expected
+    assert expected.publication_cleanup_owners == owners
+    assert all(not owner.closed for owner in owners)
+    for owner in owners:
+        owner.fail = False
+        owner.close()
+    assert all(owner.closed for owner in owners)
+
+
+def test_cleanup_owner_attachment_bypasses_hostile_exception_attributes() -> None:
+    class HostilePrimary(BaseException):
+        def __getattribute__(self, name: str) -> object:
+            if name == "publication_cleanup_owners":
+                raise RuntimeError("hostile cleanup owner read")
+            return super().__getattribute__(name)
+
+        def __setattr__(self, name: str, value: object) -> None:
+            if name == "publication_cleanup_owners":
+                raise RuntimeError("hostile cleanup owner write")
+            super().__setattr__(name, value)
+
+    class RetryOwner:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    primary = HostilePrimary("hostile primary")
+    owner = RetryOwner()
+
+    with pytest.raises(HostilePrimary) as caught:
+        with atomic_module._run_context_with_cleanup_actions(
+            (
+                atomic_module._OrderedAction(
+                    label="hostile cleanup also failed",
+                    action=lambda: (_ for _ in ()).throw(
+                        OSError(errno.EIO, "cleanup failure")
+                    ),
+                    complete=lambda: False,
+                    incomplete_owner=owner,
+                ),
+            )
+        ):
+            raise primary
+
+    assert caught.value is primary
+    assert BaseException.__getattribute__(
+        primary,
+        "publication_cleanup_owners",
+    ) == (owner,)
+    atomic_module._attach_publication_cleanup_owner(primary, owner)
+    assert BaseException.__getattribute__(
+        primary,
+        "publication_cleanup_owners",
+    ) == (owner,)
+    owner.close()
+
+
+def test_cleanup_owner_attachment_preserves_exact_builtin_tuple() -> None:
+    class RetryOwner:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    primary = ValueError("cleanup failed")
+    first = RetryOwner()
+    second = RetryOwner()
+    BaseException.__setattr__(
+        primary,
+        "publication_cleanup_owners",
+        (first,),
+    )
+
+    atomic_module._attach_publication_cleanup_owner(primary, second)
+
+    retained = BaseException.__getattribute__(
+        primary,
+        "publication_cleanup_owners",
+    )
+    assert type(retained) is tuple
+    assert retained == (first, second)
+
+
+def test_cleanup_owner_attachment_does_not_iterate_tuple_subclass() -> None:
+    class HostileTuple(tuple):
+        def __iter__(self) -> object:
+            raise RuntimeError("hostile tuple iteration")
+
+    class RetryOwner:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    primary = ValueError("cleanup failed")
+    owner = RetryOwner()
+    BaseException.__setattr__(
+        primary,
+        "publication_cleanup_owners",
+        HostileTuple((object(),)),
+    )
+
+    atomic_module._attach_publication_cleanup_owner(primary, owner)
+
+    retained = BaseException.__getattribute__(
+        primary,
+        "publication_cleanup_owners",
+    )
+    assert type(retained) is tuple
+    assert retained == (owner,)
+
+
+def test_completion_observer_failure_does_not_block_later_cleanup() -> None:
+    observer_error = OSError(errno.EIO, "persistent completion observation failure")
+    calls: list[str] = []
+    state = atomic_module._OrderedActionState(
+        actions=(
+            atomic_module._OrderedAction(
+                label="first cleanup also failed",
+                action=lambda: calls.append("first"),
+                complete=lambda: (_ for _ in ()).throw(observer_error),
+                retry_incomplete="cancellation",
+            ),
+            ("later cleanup also failed", lambda: calls.append("later")),
+        ),
+        iteration_failure_label="cleanup iteration also failed",
+        primary_error=None,
+    )
+
+    atomic_module._run_ordered_actions(state)
+
+    assert calls == ["first", "later"]
+    assert state.next_index == 2
+    assert state.primary_error is observer_error
+
+
+def test_exact_record_cleanup_does_not_scan_retained_records() -> None:
+    class NoIterationList(list[object]):
+        def __iter__(self) -> object:
+            raise AssertionError("exact record cleanup scanned retained records")
+
+    posix_owner = atomic_module._PosixResourceOwner()
+    read_descriptor, write_descriptor = os.pipe()
+    duplicate = posix_owner.duplicate(read_descriptor)
+    posix_record = posix_owner.record_for_cleanup(duplicate)
+    posix_owner._records = NoIterationList(posix_owner._records)
+    try:
+        posix_owner.close_record(posix_record)
+    finally:
+        os.close(read_descriptor)
+        os.close(write_descriptor)
+
+    api = _FakeWindowsApi()
+    windows_owner = atomic_module._WindowsResourceOwner(api)
+    handle = windows_owner.acquire(lambda: api.create_directory_handle(Path("C:/")))
+    windows_record = windows_owner.record_for_cleanup(handle)
+    windows_owner._records = NoIterationList(windows_owner._records)
+    windows_owner.close_record(windows_record)
+
+    assert posix_record.descriptor < 0
+    assert windows_record.handle == 0
+    assert api.handles == {}
+
+
+def test_plain_ordered_action_is_not_repeated_if_cursor_cleanup_is_interrupted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    interruption = KeyboardInterrupt("after plain action cursor advance")
+    real_plain = atomic_module._run_plain_ordered_action
+    interrupted = False
+
+    def interrupt_after_action(state: object, ordered: object) -> None:
+        nonlocal interrupted
+        real_plain(state, ordered)
+        if not interrupted:
+            interrupted = True
+            raise interruption
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_run_plain_ordered_action",
+        interrupt_after_action,
+    )
+    state = atomic_module._OrderedActionState(
+        actions=(
+            ("first validation also failed", lambda: calls.append("first")),
+            ("second validation also failed", lambda: calls.append("second")),
+        ),
+        iteration_failure_label="validation iteration also failed",
+        primary_error=None,
+    )
+
+    atomic_module._run_ordered_actions(state)
+
+    assert calls == ["first", "second"]
+    assert state.primary_error is interruption
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor reuse semantics",
+)
+def test_ordered_posix_record_does_not_close_reentrant_replacement() -> None:
+    resources = atomic_module._PosixResourceOwner()
+    source_read, source_write = os.pipe()
+    foreign_read, foreign_write = os.pipe()
+    target = resources.duplicate(source_read)
+    record = resources.record_for_cleanup(target)
+    real_close = atomic_module.os.close
+    cancellation = KeyboardInterrupt("after descriptor close")
+    replacement = -1
+    cleanup_complete = False
+
+    def close_then_replace(descriptor: int) -> None:
+        nonlocal replacement
+        real_close(descriptor)
+        if descriptor == target:
+            replacement = os.dup2(foreign_read, target)
+            assert replacement == target
+            raise cancellation
+
+    def close_resources() -> None:
+        nonlocal cleanup_complete
+        resources.close_all()
+        cleanup_complete = True
+
+    atomic_module.os.close = close_then_replace
+    try:
+        state = atomic_module._OrderedActionState(
+            actions=(
+                atomic_module._OrderedAction(
+                    label="descriptor cleanup also failed",
+                    action=close_resources,
+                    complete=lambda: cleanup_complete,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=resources,
+                ),
+            ),
+            iteration_failure_label="descriptor iteration also failed",
+            primary_error=None,
+        )
+        atomic_module._run_ordered_actions(state)
+        assert state.primary_error is cancellation
+        assert record.descriptor < 0
+        assert cleanup_complete
+        assert not getattr(cancellation, "publication_cleanup_owners", ())
+        os.fstat(replacement)
+    finally:
+        atomic_module.os.close = real_close
+        resources.close_all()
+        real_close(source_read)
+        real_close(source_write)
+        real_close(foreign_read)
+        real_close(foreign_write)
+
+
+def test_ordered_windows_record_does_not_close_reentrant_replacement() -> None:
+    api = _FakeWindowsApi()
+    owner = atomic_module._WindowsResourceOwner(api)
+    target = owner.acquire(lambda: api.create_directory_handle(Path("C:/authority")))
+    record = owner.record_for_cleanup(target)
+    foreign_id = api.add_directory()
+    real_close = api.close
+    cancellation = SystemExit("after HANDLE close")
+    replacement = 0
+    cleanup_complete = False
+
+    def close_then_replace(handle: int) -> None:
+        nonlocal replacement
+        real_close(handle)
+        if handle == target:
+            api.next_handle = handle
+            replacement = api._new_handle(foreign_id)
+            assert replacement == target
+            raise cancellation
+
+    def close_resources() -> None:
+        nonlocal cleanup_complete
+        owner.close_all()
+        cleanup_complete = True
+
+    api.close = close_then_replace
+    try:
+        state = atomic_module._OrderedActionState(
+            actions=(
+                atomic_module._OrderedAction(
+                    label="HANDLE cleanup also failed",
+                    action=close_resources,
+                    complete=lambda: cleanup_complete,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=owner,
+                ),
+            ),
+            iteration_failure_label="HANDLE iteration also failed",
+            primary_error=None,
+        )
+        atomic_module._run_ordered_actions(state)
+        assert state.primary_error is cancellation
+        assert record.handle == 0
+        assert cleanup_complete
+        assert not getattr(cancellation, "publication_cleanup_owners", ())
+        assert api.handles[replacement] == foreign_id
+    finally:
+        api.close = real_close
+        owner.close_all()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires Linux descriptor reuse semantics",
+)
+def test_posix_owner_completion_flag_reports_foreign_reuse() -> None:
+    resources = atomic_module._PosixResourceOwner()
+    source_read, source_write = os.pipe()
+    foreign_read, foreign_write = os.pipe()
+    target = resources.duplicate(source_read)
+    record = resources.record_for_cleanup(target)
+    cleanup_complete = False
+
+    def close_resources() -> None:
+        nonlocal cleanup_complete
+        resources.close_all()
+        cleanup_complete = True
+
+    try:
+        os.close(target)
+        replacement = os.dup2(foreign_read, target)
+        assert replacement == target
+        state = atomic_module._OrderedActionState(
+            actions=(
+                atomic_module._OrderedAction(
+                    label="descriptor cleanup also failed",
+                    action=close_resources,
+                    complete=lambda: cleanup_complete,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=resources,
+                ),
+            ),
+            iteration_failure_label="descriptor iteration also failed",
+            primary_error=None,
+        )
+
+        atomic_module._run_ordered_actions(state)
+
+        assert isinstance(state.primary_error, RuntimeError)
+        assert "ownership changed" in str(state.primary_error)
+        assert not cleanup_complete
+        assert record.descriptor < 0
+        assert not getattr(
+            state.primary_error,
+            "publication_cleanup_owners",
+            (),
+        )
+        os.fstat(replacement)
+    finally:
+        resources.close_all()
+        for descriptor in (
+            source_read,
+            source_write,
+            foreign_read,
+            foreign_write,
+            target,
+        ):
+            try:
+                os.close(descriptor)
+            except OSError as error:
+                if error.errno != errno.EBADF:
+                    raise
+
+
+def test_windows_owner_completion_flag_reports_foreign_reuse() -> None:
+    api = _FakeWindowsApi()
+    owner = atomic_module._WindowsResourceOwner(api)
+    target = owner.acquire(lambda: api.create_directory_handle(Path("C:/authority")))
+    record = owner.record_for_cleanup(target)
+    foreign_id = api.add_directory()
+    cleanup_complete = False
+
+    def close_resources() -> None:
+        nonlocal cleanup_complete
+        owner.close_all()
+        cleanup_complete = True
+
+    api.close(target)
+    api.next_handle = target
+    replacement = api._new_handle(foreign_id)
+    assert replacement == target
+    state = atomic_module._OrderedActionState(
+        actions=(
+            atomic_module._OrderedAction(
+                label="HANDLE cleanup also failed",
+                action=close_resources,
+                complete=lambda: cleanup_complete,
+                retry_incomplete="cancellation",
+                incomplete_owner=owner,
+            ),
+        ),
+        iteration_failure_label="HANDLE iteration also failed",
+        primary_error=None,
+    )
+
+    atomic_module._run_ordered_actions(state)
+
+    assert isinstance(state.primary_error, RuntimeError)
+    assert "ownership changed" in str(state.primary_error)
+    assert not cleanup_complete
+    assert record.handle == 0
+    assert not getattr(state.primary_error, "publication_cleanup_owners", ())
+    assert api.handles[replacement] == foreign_id
+    owner.close_all()
+    api.close(replacement)
+
+
+def test_reopen_interrupt_after_callback_result_store_runs_post_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "existing"
+    _write_tree(directory, "payload.txt", "payload")
+    ownership = capture_directory_ownership(directory)
+    real_capture = atomic_module.PublicationDirectoryReader.capture_ownership
+    capture_calls = 0
+    saved_readers: list[object] = []
+    interruption = KeyboardInterrupt("after callback result store")
+
+    def count_capture(reader: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        return real_capture(reader, **kwargs)
+
+    def consume(reader: object) -> int:
+        saved_readers.append(reader)
+        return 7
+
+    monkeypatch.setattr(
+        atomic_module.PublicationDirectoryReader,
+        "capture_ownership",
+        count_capture,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _call_with_interrupt_after_store(
+            atomic_module._run_callback_with_post_validations,
+            "result",
+            lambda: atomic_module.reopen_authenticated_directory(
+                directory,
+                ownership,
+                consume,
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert capture_calls == 2
+    with pytest.raises(RuntimeError, match="no longer active"):
+        saved_readers[0].inventory()
 
 
 @pytest.mark.skipif(
@@ -4320,6 +7060,7 @@ def test_authority_owner_preserves_operation_error_over_close_failure(
         )
         assert any("cleanup failure" in note for note in notes)
         assert not authority._closed
+        assert primary_error.publication_cleanup_owners == (authority_owner,)
         os.fstat(target)
         for descriptor in descriptors[:-1]:
             _assert_descriptor_closed(descriptor)


### PR DESCRIPTION
## Summary

Harden callback post-validation and authenticated resource cleanup as an independent replacement for the stacked #592 change.

This PR is based directly on current `main`. It carries no compiler, CAS, manifest-import, or downstream artifact changes from the old storage stack.

## Changes

- run reader validity, exact ownership, child namespace, and parent authority checks after callback success, failure, or cancellation
- preserve the first callback, postflight, or cleanup failure while retaining later failures as diagnostics
- preconstruct POSIX and Windows cleanup plans before acquiring resources
- drive resource owners through bounded, constant-stack cancellation retries
- continue later independent cleanup actions when one action cannot complete
- retain incomplete idempotent cleanup owners on the primary exception for explicit retry
- avoid closing observably reused foreign descriptors or handles
- document the remaining pure-Python call-entry and exact-identity ABA limits that require native ownership

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Python 3.10 focused atomic suite: 236 passed, 10 skipped
- Python 3.11 expanded publication/storage suite: 492 passed, 10 skipped
- Python 3.12 focused atomic suite: 236 passed, 10 skipped
- local unit tier excluding two independently reproduced baseline environment failures: 4530 passed, 66 skipped
- changed-file pre-commit hooks: passed
- `git diff --check origin/main...HEAD`: passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of the code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] The changes generate no new warnings
- [x] Any dependent changes have been merged and published