### PR TITLE
fix(release): accept authenticated source mismatch

### DIFF
--- a/scripts/smoke_release_services.py
+++ b/scripts/smoke_release_services.py
@@ -563,6 +563,7 @@ def _assert_stale_snapshot_rejected(
     stale_messages = (
         "repository checkout does not match the indexed snapshot",
         "repository source files do not match the indexed content",
+        "repository source content does not match the manifest",
     )
     if result.returncode != 2 or not any(
         message in result.stderr for message in stale_messages

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
 
+from scripts import smoke_release_services
 from scripts.verify_release_artifacts import (
     ReleaseValidationError,
     expected_tag,
@@ -17,6 +19,45 @@ from scripts.verify_release_artifacts import (
     validate_readme_mcp_ownership,
     validate_tag,
 )
+
+
+def test_release_service_smoke_accepts_authenticated_source_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "calculator.py").write_text("VALUE = 1\n", encoding="utf-8")
+    git_commands: list[tuple[str, ...]] = []
+
+    def record_git(command, *, cwd, env=None):
+        assert cwd == repo
+        git_commands.append(tuple(command))
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(smoke_release_services, "_run", record_git)
+    monkeypatch.setattr(
+        smoke_release_services.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0],
+            2,
+            "",
+            "error: repository source content does not match the manifest\n",
+        ),
+    )
+
+    smoke_release_services._assert_stale_snapshot_rejected(
+        tmp_path,
+        repo,
+        executable="codenib",
+        env={},
+    )
+
+    assert git_commands == [
+        ("git", "add", "calculator.py"),
+        ("git", "commit", "--quiet", "-m", "advance fixture"),
+    ]
 
 
 def test_project_identity_and_tag_match_release_metadata() -> None:


### PR DESCRIPTION
## Summary

Keep the installed Wiki/MCP release smoke aligned with the source-authority error emitted for a stale repository checkout.

## Changes

- accept the manifest-bound source mismatch as a valid fail-closed stale-snapshot rejection
- add a direct regression test for exit status 2 and the new diagnostic

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/test_release_artifacts.py --tb=short` (14 passed)
- `pre-commit run --files scripts/smoke_release_services.py test/test_release_artifacts.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Root cause: the service correctly rejected the stale checkout with status 2 after #588, but the smoke harness recognized only the two legacy diagnostics.

Failure evidence: https://github.com/sysevol-ai/CodeNib/actions/runs/31746352844
