### PR TITLE
feat(storage): expose workspace publication gate

### DIFF
--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -27,6 +27,7 @@ except ImportError:  # pragma: no cover - Windows fails closed when requested
 from . import _windows_fs_authority as _windows_fs
 from ._atomic_directory import (
     _MAX_OWNERSHIP_COMPONENT_BYTES,
+    _SAFE_OWNERSHIP_DIRECTORY_FDS,
     DirectoryOrphan,
     PublicationDirectoryReader,
     TreeFileRecord,
@@ -38,6 +39,7 @@ from ._atomic_directory import (
     _publish_staged_directory_with_authority,
     _rename_noreplace_at,
     _require_matching_ownership,
+    _require_rename_noreplace_platform,
     _validate_ownership_inventory_budget,
     directory_ownership_entry_identities,
     directory_ownership_file_records,
@@ -597,6 +599,25 @@ def _snapshot_workspace_plan(plan: object) -> WorkspacePlan:
 
 class UnsupportedWorkspaceCreation(RuntimeError):
     """Strict workspace creation is unavailable without a native creator."""
+
+
+def require_owned_workspace_publication_support() -> None:
+    """Fail before provisioning when strict workspace publication is unavailable."""
+
+    if not sys.platform.startswith("linux"):
+        raise UnsupportedWorkspaceCreation(
+            "strict workspace publication requires a supported Linux host"
+        )
+    if not _SAFE_OWNERSHIP_DIRECTORY_FDS:
+        raise UnsupportedWorkspaceCreation(
+            "strict workspace publication requires anchored directory-fd support"
+        )
+    try:
+        _require_rename_noreplace_platform()
+    except (OSError, RuntimeError) as exc:
+        raise UnsupportedWorkspaceCreation(
+            "strict workspace publication requires atomic no-replace rename support"
+        ) from exc
 
 
 @dataclass(slots=True)
@@ -2293,16 +2314,16 @@ class OwnedWorkspaceAuthority:
         self,
         relative: str | Path | PurePosixPath,
         chunks: Iterable[bytes],
-    ) -> None:
+    ) -> TreeFileRecord:
         self._require_owner_pid()
         self._reject_reentrant("write")
-        self._lock.run(lambda: self._write_file_locked(relative, chunks))
+        return self._lock.run(lambda: self._write_file_locked(relative, chunks))
 
     def _write_file_locked(
         self,
         relative: str | Path | PurePosixPath,
         chunks: Iterable[bytes],
-    ) -> None:
+    ) -> TreeFileRecord:
         self._require_owner_pid()
         if self._state not in {"adopted", "writing"}:
             raise RuntimeError(f"owned workspace cannot write while {self._state}")
@@ -2431,12 +2452,19 @@ class OwnedWorkspaceAuthority:
         assert record is not None
         try:
             self._written_files[path] = record
+            public_record = TreeFileRecord(
+                path=path,
+                mode=record[1],
+                size=record[2],
+                sha256=record[3],
+            )
             self._refresh_locked(require_complete=False)
             self._state = "writing"
         except BaseException as transition_error:
             self._state = "failed"
             self._close_resources_after_error_locked(transition_error)
             raise
+        return public_record
 
     def seal(self) -> object:
         self._require_owner_pid()
@@ -2473,13 +2501,31 @@ class OwnedWorkspaceAuthority:
         for path in ordered_paths:
             os.fsync(self._directory_descriptors[path])
 
-    def publish_into(self, receipt_owner: PublishedWorkspaceReceiptOwner) -> None:
+    def publish_into(
+        self,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        *,
+        validate_staged_directory: (
+            Callable[[PublicationDirectoryReader], None] | None
+        ) = None,
+        validate_published_destination: (
+            Callable[[PublicationDirectoryReader], None] | None
+        ) = None,
+    ) -> None:
         """Durably publish and install ownership in a pre-created caller slot."""
 
         self._require_owner_pid()
         self._reject_reentrant("publish")
         if not isinstance(receipt_owner, PublishedWorkspaceReceiptOwner):
             raise TypeError("receipt_owner must be a PublishedWorkspaceReceiptOwner")
+        if validate_staged_directory is not None and not callable(
+            validate_staged_directory
+        ):
+            raise TypeError("staged workspace validator must be callable")
+        if validate_published_destination is not None and not callable(
+            validate_published_destination
+        ):
+            raise TypeError("published workspace validator must be callable")
         transfer = _WorkspacePublicationTransfer(self)
         reservation = _WorkspaceReservation(transfer)
         try:
@@ -2488,6 +2534,8 @@ class OwnedWorkspaceAuthority:
                     receipt_owner,
                     transfer,
                     reservation,
+                    validate_staged_directory,
+                    validate_published_destination,
                 )
             )
         except BaseException as primary_error:  # noqa: B036 - reconcile owners
@@ -2504,6 +2552,10 @@ class OwnedWorkspaceAuthority:
         receipt_owner: PublishedWorkspaceReceiptOwner,
         transfer: _WorkspacePublicationTransfer,
         reservation: _WorkspaceReservation,
+        validate_staged_directory: Callable[[PublicationDirectoryReader], None] | None,
+        validate_published_destination: (
+            Callable[[PublicationDirectoryReader], None] | None
+        ),
     ) -> None:
         self._require_owner_pid()
         if self._state != "sealed" or self._sealed_ownership is None:
@@ -2559,6 +2611,8 @@ class OwnedWorkspaceAuthority:
             self._destination,
             expected_stage_root_ownership=sealed_ownership,
             expected_destination_ownership=self._expected_destination,
+            validate_staged_directory=validate_staged_directory,
+            validate_published_destination=validate_published_destination,
             commit_callback=install_receipt,
         )
 
@@ -3752,4 +3806,5 @@ __all__ = [
     "WorkspaceDirectory",
     "WorkspaceFile",
     "WorkspacePlan",
+    "require_owned_workspace_publication_support",
 ]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -256,8 +256,12 @@ provisioning fail before filesystem I/O. The current strict implementation is
 POSIX-only, requires callers to close the store to release its generation
 anchors, and does not make ordinary same-UID writable files immutable after
 publication. Preopened workspace publication applies the same ownership model
-to exact, scanner-bounded directory plans and returns a caller-owned receipt
-whose authenticated reader remains pinned through synchronous consumption.
+to exact, scanner-bounded directory plans. Its side-effect-free capability
+probe fails before provisioning on unsupported hosts; descriptor-bound writes
+return the authenticated file record, and staged and published validators run
+inside the same atomic publication boundary. The caller-owned receipt keeps its
+authenticated reader pinned through synchronous consumption. This remains a
+provider-neutral foundation: no compiler or context producer is wired to it.
 
 Callback-scoped directory results are likewise provisional until ordered
 reader-validity, exact-ownership, child-namespace, and parent-authority

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -35,6 +35,7 @@ from codenib._captured_directory import (
     WorkspaceDirectory,
     WorkspaceFile,
     WorkspacePlan,
+    require_owned_workspace_publication_support,
 )
 
 
@@ -1216,6 +1217,92 @@ def test_workspace_plan_uses_exact_ownership_scanner_budgets(
         )
 
 
+def test_owned_workspace_publication_support_gate_is_side_effect_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capability_checks: list[str] = []
+
+    def forbid_provisioning(*_args, **_kwargs) -> None:
+        raise AssertionError("support check attempted workspace provisioning")
+
+    monkeypatch.setattr(captured_directory.sys, "platform", "linux")
+    monkeypatch.setattr(captured_directory, "_SAFE_OWNERSHIP_DIRECTORY_FDS", True)
+    monkeypatch.setattr(
+        captured_directory,
+        "_require_rename_noreplace_platform",
+        lambda: capability_checks.append("rename-noreplace"),
+    )
+    monkeypatch.setattr(
+        captured_directory,
+        "_open_publication_authority",
+        forbid_provisioning,
+    )
+
+    assert require_owned_workspace_publication_support() is None
+    assert capability_checks == ["rename-noreplace"]
+    assert "require_owned_workspace_publication_support" in captured_directory.__all__
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32", "freebsd14"])
+def test_owned_workspace_publication_support_rejects_non_linux_before_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+) -> None:
+    def forbidden_probe() -> None:
+        raise AssertionError("unsupported platform reached rename capability probe")
+
+    monkeypatch.setattr(captured_directory.sys, "platform", platform)
+    monkeypatch.setattr(
+        captured_directory,
+        "_require_rename_noreplace_platform",
+        forbidden_probe,
+    )
+
+    with pytest.raises(UnsupportedWorkspaceCreation, match="Linux"):
+        require_owned_workspace_publication_support()
+
+
+def test_owned_workspace_publication_support_requires_anchored_directory_fds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden_probe() -> None:
+        raise AssertionError("unsafe directory-fd host reached rename capability probe")
+
+    monkeypatch.setattr(captured_directory.sys, "platform", "linux")
+    monkeypatch.setattr(captured_directory, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
+    monkeypatch.setattr(
+        captured_directory,
+        "_require_rename_noreplace_platform",
+        forbidden_probe,
+    )
+
+    with pytest.raises(UnsupportedWorkspaceCreation, match="directory-fd"):
+        require_owned_workspace_publication_support()
+
+
+def test_owned_workspace_publication_support_wraps_missing_rename_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unsupported_rename() -> None:
+        raise RuntimeError("renameat2 is missing")
+
+    monkeypatch.setattr(captured_directory.sys, "platform", "linux")
+    monkeypatch.setattr(captured_directory, "_SAFE_OWNERSHIP_DIRECTORY_FDS", True)
+    monkeypatch.setattr(
+        captured_directory,
+        "_require_rename_noreplace_platform",
+        unsupported_rename,
+    )
+
+    with pytest.raises(
+        UnsupportedWorkspaceCreation,
+        match="no-replace rename",
+    ) as raised:
+        require_owned_workspace_publication_support()
+
+    assert isinstance(raised.value.__cause__, RuntimeError)
+
+
 @pytest.mark.parametrize(
     ("directories", "files", "message"),
     [
@@ -1276,11 +1363,11 @@ def test_preopened_workspace_writes_only_planned_files_without_mkdir(
             plan=plan,
             expected_destination=None,
         )
-        workspace.write_file("root.bin", [b"root"])
-        workspace.write_file("nested/payload.bin", [b"payload"])
+        root_record = workspace.write_file("root.bin", [b"root"])
+        nested_record = workspace.write_file("nested/payload.bin", [b"payload"])
         ownership = workspace.seal()
 
-        assert directory_ownership_file_records(ownership) == (
+        expected_records = (
             atomic_directory.TreeFileRecord(
                 path="nested/payload.bin",
                 mode=0o644,
@@ -1298,6 +1385,8 @@ def test_preopened_workspace_writes_only_planned_files_without_mkdir(
                 ),
             ),
         )
+        assert (nested_record, root_record) == expected_records
+        assert directory_ownership_file_records(ownership) == expected_records
         assert os.lseek(parent_fd, 0, os.SEEK_CUR) == 37
         assert os.lseek(root_fd, 0, os.SEEK_CUR) == 37
         assert (stage / "nested" / "payload.bin").read_bytes() == b"payload"
@@ -1813,6 +1902,40 @@ def test_preopened_workspace_record_install_interruption_terminally_fails(
             workspace.seal()
 
 
+def test_preopened_workspace_record_construction_interruption_terminally_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="a" * 64,
+        files=(WorkspaceFile("payload", max_bytes=4),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+
+        def interrupt_record(*_args, **_kwargs):
+            raise KeyboardInterrupt("record construction interruption")
+
+        monkeypatch.setattr(captured_directory, "TreeFileRecord", interrupt_record)
+        with pytest.raises(KeyboardInterrupt, match="record construction interruption"):
+            workspace.write_file("payload", [b"safe"])
+
+        assert workspace.state == "closed"
+        assert (stage / "payload").read_bytes() == b"safe"
+        with pytest.raises(RuntimeError, match="cannot seal while closed"):
+            workspace.seal()
+
+
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
 def test_owned_workspace_child_closes_inherited_resources_without_parent_effect(
     tmp_path: Path,
@@ -2047,6 +2170,114 @@ def test_owned_workspace_publish_installs_fresh_durable_receipt(
         receipt_owner.close()
         assert receipt_owner.closed
         assert receipt.closed
+
+
+def test_owned_workspace_publish_runs_staged_and_published_validators(
+    tmp_path: Path,
+) -> None:
+    plan = WorkspacePlan(
+        subject_digest="3" * 64,
+        files=(WorkspaceFile("payload", max_bytes=9),),
+    )
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        record = workspace.write_file("payload", [b"validated"])
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+        observed: list[tuple[str, tuple[atomic_directory.TreeFileRecord, ...]]] = []
+
+        def validate_staged(
+            reader: atomic_directory.PublicationDirectoryReader,
+        ) -> None:
+            assert stage.is_dir()
+            assert not destination.exists()
+            assert reader.read_bytes("payload", max_bytes=9) == b"validated"
+            observed.append(("staged", reader.file_records()))
+
+        def validate_published(
+            reader: atomic_directory.PublicationDirectoryReader,
+        ) -> None:
+            assert not stage.exists()
+            assert destination.is_dir()
+            assert reader.read_bytes("payload", max_bytes=9) == b"validated"
+            observed.append(("published", reader.file_records()))
+
+        workspace.publish_into(
+            receipt_owner,
+            validate_staged_directory=validate_staged,
+            validate_published_destination=validate_published,
+        )
+
+        assert observed == [
+            ("staged", (record,)),
+            ("published", (record,)),
+        ]
+        assert receipt_owner.active
+        receipt_owner.close()
+
+
+@pytest.mark.parametrize(
+    ("validator_name", "message"),
+    [
+        ("validate_staged_directory", "staged workspace validator"),
+        ("validate_published_destination", "published workspace validator"),
+    ],
+)
+def test_owned_workspace_rejects_noncallable_validator_before_transfer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    validator_name: str,
+    message: str,
+) -> None:
+    plan = WorkspacePlan(subject_digest="3" * 64)
+    with _preopened_workspace(tmp_path, plan) as opened:
+        destination, stage, parent_fd, root_fd, directories = opened
+        workspace = OwnedWorkspaceAuthority()
+        workspace.adopt(
+            destination=destination,
+            stage_name=stage.name,
+            parent_descriptor=parent_fd,
+            root_descriptor=root_fd,
+            directory_descriptors=directories,
+            plan=plan,
+            expected_destination=None,
+        )
+        workspace.seal()
+        receipt_owner = PublishedWorkspaceReceiptOwner()
+
+        def forbidden_publish(*_args, **_kwargs) -> None:
+            raise AssertionError("noncallable validator reached atomic publication")
+
+        monkeypatch.setattr(
+            captured_directory,
+            "_publish_staged_directory_with_authority",
+            forbidden_publish,
+        )
+
+        with pytest.raises(TypeError, match=message):
+            workspace.publish_into(
+                receipt_owner,
+                **{validator_name: object()},
+            )
+
+        assert workspace.state == "sealed"
+        assert workspace._publication_transfer is None
+        assert workspace._resources_transferred is False
+        assert receipt_owner.state == "empty"
+        assert stage.is_dir()
+        assert not destination.exists()
+        workspace.close()
+        receipt_owner.close()
 
 
 def test_owned_workspace_detaches_caller_and_public_plan_mutation(


### PR DESCRIPTION
## Summary

Forward-port the remaining provider-neutral workspace publication slice from #590 onto the current storage authority foundation.

This replacement keeps the useful capability and validation contract without reintroducing the bounded-JSON and URL changes that already landed separately.

## Changes

- add a side-effect-free owned-workspace publication support probe
- return authenticated file records from workspace writes
- carry staged and published validators through the retained publication authority
- record the narrowed provider-neutral boundary in the storage roadmap
- add cancellation, identity, and validator-ordering regressions

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- post-#622 restack: `pytest -q test/test_atomic_directory.py test/test_captured_directory.py test/test_owned_file_publication.py --tb=short` (439 passed, 10 skipped)
- changed-range pre-commit hooks
- `git diff --check origin/main...HEAD`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Supersedes #590 after the bounded-JSON and credential-classifier slices landed in #616, the detached workspace identity foundation landed in #586, and the common resource cleanup boundary landed in #622.
