### PR TITLE
feat(storage): bind strict publication producers

### DIFF
--- a/codenib/_bounded_json.py
+++ b/codenib/_bounded_json.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Incremental, complexity-bounded parsing for large JSON document arrays."""
+"""Incremental, complexity-bounded framing for UTF-8 JSON documents."""
 
 from __future__ import annotations
 
@@ -19,6 +19,8 @@ DEFAULT_MAX_NODES_PER_ELEMENT = 100_000
 DEFAULT_MAX_LEXICAL_TOKENS = 200_000
 DEFAULT_MAX_DEPTH = 64
 DEFAULT_MAX_KEY_BYTES = 4_096
+DEFAULT_MAX_ATOM_BYTES = 1_024
+DEFAULT_MAX_STRING_BYTES = 64 * 1024 * 1024
 
 
 class BinaryReader(Protocol):
@@ -70,6 +72,260 @@ def validate_json_complexity(
             stack.extend((child, depth + 1) for child in current)
 
 
+def validate_bounded_json_stream(
+    source: BinaryReader,
+    *,
+    label: str,
+    max_bytes: int = DEFAULT_MAX_ELEMENT_BYTES,
+    max_nodes: int = DEFAULT_MAX_NODES_PER_ELEMENT,
+    max_lexical_tokens: int = DEFAULT_MAX_LEXICAL_TOKENS,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_key_bytes: int = DEFAULT_MAX_KEY_BYTES,
+    max_string_bytes: int = DEFAULT_MAX_STRING_BYTES,
+    max_atom_bytes: int = DEFAULT_MAX_ATOM_BYTES,
+) -> None:
+    """Bound arbitrary JSON lexical complexity before allocating its DOM.
+
+    This is deliberately a framing and resource-budget pass, not a text or
+    semantic JSON decoder. Framing uses JSON's ASCII structural bytes, so a
+    caller accepting publication JSON must strictly decode UTF-8 before its
+    subsequent semantic decode. Duplicate keys, non-finite constants, exact
+    number syntax, and decoded-string semantics remain the responsibility of
+    that decoder. Object keys count as lexical tokens but not value nodes;
+    container and scalar values use the same one-based depth and node model as
+    :func:`validate_json_complexity`. String and key byte limits count their
+    encoded lexical bytes between quotes, including escape syntax; callers may
+    additionally enforce decoded-key limits after parsing.
+    """
+
+    limits = (
+        max_bytes,
+        max_nodes,
+        max_lexical_tokens,
+        max_depth,
+        max_key_bytes,
+        max_string_bytes,
+        max_atom_bytes,
+    )
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value <= 0
+        for value in limits
+    ):
+        raise ValueError("bounded JSON limits must be positive integers")
+
+    # Frames contain ``[opening delimiter, parser state]``. The state is only
+    # as strict as needed to identify keys and value boundaries safely; the
+    # caller's decoder remains the JSON grammar authority.
+    frames: list[list[Any]] = []
+    root_state = "value"
+    in_string = False
+    string_is_key = False
+    escaped = False
+    string_bytes = 0
+    key_bytes = 0
+    in_atom = False
+    atom_bytes = 0
+    token_count = 0
+    node_count = 0
+    total_bytes = 0
+
+    def fail(message: str) -> None:
+        raise ValueError(f"{label} {message}")
+
+    def add_token() -> None:
+        nonlocal token_count
+        token_count += 1
+        if token_count > max_lexical_tokens:
+            fail(f"exceeds its {max_lexical_tokens}-token limit")
+
+    def start_value() -> None:
+        nonlocal node_count
+        depth = len(frames) + 1
+        if depth > max_depth:
+            fail(f"exceeds its {max_depth}-level depth limit")
+        node_count += 1
+        if node_count > max_nodes:
+            fail(f"exceeds its {max_nodes}-node limit")
+        add_token()
+
+    def finish_value() -> None:
+        nonlocal root_state
+        if frames:
+            frames[-1][1] = "comma_or_end"
+        else:
+            root_state = "done"
+
+    def expecting_value() -> bool:
+        if frames:
+            return frames[-1][1] in {"value", "value_or_end"}
+        return root_state == "value"
+
+    def start_string(*, key: bool) -> None:
+        nonlocal in_string, string_is_key, escaped, string_bytes, key_bytes
+        if key:
+            add_token()
+        else:
+            start_value()
+        in_string = True
+        string_is_key = key
+        escaped = False
+        string_bytes = 0
+        key_bytes = 0
+
+    def start_atom() -> None:
+        nonlocal in_atom, atom_bytes
+        start_value()
+        in_atom = True
+        atom_bytes = 0
+
+    while True:
+        block = source.read(_READ_BYTES)
+        if type(block) is not bytes or len(block) > _READ_BYTES:
+            raise ValueError(
+                "bounded JSON reader returned an invalid or oversized block"
+            )
+        if not block:
+            break
+        total_bytes += len(block)
+        if total_bytes > max_bytes:
+            fail(f"exceeds its {max_bytes}-byte limit")
+
+        index = 0
+        while index < len(block):
+            current = block[index]
+
+            if in_string:
+                if escaped:
+                    escaped = False
+                    string_bytes += 1
+                    if string_is_key:
+                        key_bytes += 1
+                    index += 1
+                else:
+                    match = _STRING_SPECIAL.search(block, index)
+                    if match is None:
+                        length = len(block) - index
+                        string_bytes += length
+                        if string_is_key:
+                            key_bytes += length
+                        index = len(block)
+                    else:
+                        special = match.start()
+                        length = special - index
+                        string_bytes += length
+                        if string_is_key:
+                            key_bytes += length
+                        if block[special] == ord("\\"):
+                            string_bytes += 1
+                            if string_is_key:
+                                key_bytes += 1
+                            escaped = True
+                        else:
+                            in_string = False
+                            if string_is_key:
+                                frames[-1][1] = "colon"
+                            else:
+                                finish_value()
+                        index = special + 1
+                if string_bytes > max_string_bytes:
+                    fail(f"string exceeds its {max_string_bytes}-byte limit")
+                if string_is_key and key_bytes > max_key_bytes:
+                    fail(f"contains a key exceeding {max_key_bytes} bytes")
+                continue
+
+            if in_atom:
+                if current in _ATOM_DELIMITERS:
+                    in_atom = False
+                    finish_value()
+                    continue
+                atom_bytes += 1
+                if atom_bytes > max_atom_bytes:
+                    fail(f"atom exceeds its {max_atom_bytes}-byte limit")
+                index += 1
+                continue
+
+            if current in _JSON_WHITESPACE:
+                match = _NON_JSON_WHITESPACE.search(block, index + 1)
+                index = len(block) if match is None else match.start()
+                continue
+
+            if not frames and root_state == "done":
+                fail("contains trailing data")
+
+            if frames:
+                opening, state = frames[-1]
+                if opening == ord("{"):
+                    if state == "key_or_end":
+                        if current == ord("}"):
+                            frames.pop()
+                            finish_value()
+                            index += 1
+                            continue
+                        if current != ord('"'):
+                            fail("contains an invalid object key")
+                        start_string(key=True)
+                        index += 1
+                        continue
+                    if state == "colon":
+                        if current != ord(":"):
+                            fail("contains an object key without a colon")
+                        frames[-1][1] = "value"
+                        index += 1
+                        continue
+                    if state == "comma_or_end":
+                        if current == ord("}"):
+                            frames.pop()
+                            finish_value()
+                            index += 1
+                            continue
+                        if current != ord(","):
+                            fail("contains an object value without a delimiter")
+                        frames[-1][1] = "key_or_end"
+                        index += 1
+                        continue
+                elif state == "comma_or_end":
+                    if current == ord("]"):
+                        frames.pop()
+                        finish_value()
+                        index += 1
+                        continue
+                    if current != ord(","):
+                        fail("contains an array value without a delimiter")
+                    frames[-1][1] = "value_or_end"
+                    index += 1
+                    continue
+                elif state == "value_or_end" and current == ord("]"):
+                    frames.pop()
+                    finish_value()
+                    index += 1
+                    continue
+
+            if not expecting_value():
+                fail("contains invalid JSON framing")
+            if current == ord('"'):
+                start_string(key=False)
+            elif current in {ord("{"), ord("[")}:
+                start_value()
+                state = "key_or_end" if current == ord("{") else "value_or_end"
+                frames.append([current, state])
+            elif current in {ord("}"), ord("]"), ord(","), ord(":")}:
+                fail("contains mismatched JSON delimiters")
+            else:
+                # Permit any bounded atom here. The strict decoder below this
+                # layer remains authoritative for literals, number syntax, and
+                # non-finite constants such as NaN/Infinity.
+                start_atom()
+                continue
+            index += 1
+
+    if in_string or escaped or frames:
+        fail("is truncated JSON")
+    if in_atom:
+        finish_value()
+    if root_state != "done":
+        fail("is empty or truncated JSON")
+
+
 class _ByteStream:
     def __init__(self, source: BinaryReader) -> None:
         self._source = source
@@ -115,6 +371,7 @@ class _ByteStream:
 _JSON_WHITESPACE = frozenset(b" \t\r\n")
 _ATOM_DELIMITERS = frozenset(b" \t\r\n,]}:")
 _STRING_SPECIAL = re.compile(rb'["\\]')
+_NON_JSON_WHITESPACE = re.compile(rb"[^ \t\r\n]")
 
 
 def _next_non_whitespace(stream: _ByteStream) -> int | None:
@@ -484,14 +741,18 @@ def write_chunks(handle: BinaryIO, chunks: Iterable[bytes]) -> tuple[int, str]:
 
 __all__ = [
     "DEFAULT_MAX_ARRAY_ITEMS",
+    "DEFAULT_MAX_ATOM_BYTES",
     "DEFAULT_MAX_DEPTH",
     "DEFAULT_MAX_ELEMENT_BYTES",
     "DEFAULT_MAX_KEY_BYTES",
+    "DEFAULT_MAX_LEXICAL_TOKENS",
     "DEFAULT_MAX_NODES_PER_ELEMENT",
+    "DEFAULT_MAX_STRING_BYTES",
     "canonical_json_array_chunks",
     "canonical_json_bytes",
     "canonical_json_value_chunks",
     "iter_bounded_json_array",
+    "validate_bounded_json_stream",
     "validate_json_complexity",
     "write_chunks",
 ]

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -2052,6 +2052,32 @@ class OwnedWorkspaceAuthority:
 
         return self._lock.run(get_plan)
 
+    @property
+    def destination(self) -> Path:
+        """Return the lexical destination bound during adoption."""
+
+        self._require_owner_pid()
+
+        def get_destination() -> Path:
+            if self._destination is None:
+                raise RuntimeError("owned workspace authority has not been adopted")
+            return self._destination
+
+        return self._lock.run(get_destination)
+
+    @property
+    def expected_destination_ownership(self) -> object | None:
+        """Return the exact adopted destination token, or ``None`` if missing."""
+
+        self._require_owner_pid()
+
+        def get_expected_destination() -> object | None:
+            if self._destination is None:
+                raise RuntimeError("owned workspace authority has not been adopted")
+            return self._expected_destination
+
+        return self._lock.run(get_expected_destination)
+
     @classmethod
     def create(cls, *_args: object, **_kwargs: object) -> OwnedWorkspaceAuthority:
         """Fail before mutation until a native create-and-open backend exists."""

--- a/codenib/_workspace_provider.py
+++ b/codenib/_workspace_provider.py
@@ -1,0 +1,428 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Callback-scoped strict workspace provisioning contracts.
+
+This module does not provision directories.  A provider is a trusted authority
+boundary which receives an exact immutable plan, supplies an already-adopted
+``OwnedWorkspaceAuthority`` to the operation, and keeps every provisioning
+resource reachable until the callback finishes.  Path-only ``mkdir`` followed
+by ``open`` is not a provider implementation.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal, Protocol, TypeVar
+
+from ._atomic_directory import (
+    PublicationDirectoryReader,
+    TreeFileRecord,
+    _annotate_secondary_error,
+)
+from ._captured_directory import (
+    OwnedWorkspaceAuthority,
+    PublishedWorkspaceReceiptOwner,
+    WorkspacePlan,
+    require_owned_workspace_publication_support,
+)
+from ._owned_file_publication import _CancellationSafeRLock
+
+_OperationResult = TypeVar("_OperationResult")
+_ValidationResult = TypeVar("_ValidationResult")
+DestinationExpectation = Literal["missing", "provider-bound-exact"]
+_SESSION_RECOVERY_LIMIT = 64
+_UNSET_RESULT = object()
+
+
+@dataclass(frozen=True, slots=True)
+class StrictWorkspaceRequest:
+    """One exact strict publication requested from an authority provider."""
+
+    purpose: str
+    destination: Path
+    plan: WorkspacePlan
+    destination_expectation: DestinationExpectation = "missing"
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.purpose, str)
+            or not self.purpose
+            or len(self.purpose.encode("utf-8", errors="strict")) > 128
+            or any(
+                ord(character) < 32 or ord(character) == 127
+                for character in self.purpose
+            )
+        ):
+            raise ValueError("strict workspace purpose must be bounded printable text")
+        if not isinstance(self.destination, Path):
+            raise TypeError("strict workspace destination must be a Path")
+        requested_destination = self.destination.expanduser()
+        if requested_destination.name in {"", ".", ".."}:
+            raise ValueError("strict workspace destination must name one directory")
+        destination = Path(os.path.abspath(os.fspath(requested_destination)))
+        if not isinstance(self.plan, WorkspacePlan):
+            raise TypeError("strict workspace request plan must be WorkspacePlan")
+        if self.destination_expectation not in {"missing", "provider-bound-exact"}:
+            raise ValueError("strict workspace destination expectation is invalid")
+        object.__setattr__(self, "destination", destination)
+
+
+class StrictWorkspaceSession(Protocol):
+    """Borrowed session valid only during a provider operation callback."""
+
+    @property
+    def request(self) -> StrictWorkspaceRequest: ...
+
+    def write_file(
+        self,
+        relative: str | Path | PurePosixPath,
+        chunks: Iterable[bytes],
+    ) -> TreeFileRecord: ...
+
+    def publish_validated(
+        self,
+        validator: Callable[
+            [PublicationDirectoryReader],
+            _ValidationResult,
+        ],
+    ) -> _ValidationResult: ...
+
+
+class StrictWorkspaceProvider(Protocol):
+    """Trusted callback-scoped provider of pre-opened workspace authority."""
+
+    def require_support(self) -> None: ...
+
+    def run_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        *,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], _OperationResult],
+    ) -> _OperationResult: ...
+
+
+class _AdoptedWorkspaceSession:
+    __slots__ = (
+        "_active",
+        "_published",
+        "_receipt_owner",
+        "_request",
+        "_workspace",
+    )
+
+    def __init__(
+        self,
+        request: StrictWorkspaceRequest,
+        workspace: OwnedWorkspaceAuthority,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+    ) -> None:
+        self._request = request
+        self._workspace = workspace
+        self._receipt_owner = receipt_owner
+        self._active = True
+        self._published = False
+
+    def _require_active(self) -> None:
+        if not self._active:
+            raise RuntimeError("strict workspace session is no longer active")
+
+    @property
+    def request(self) -> StrictWorkspaceRequest:
+        self._require_active()
+        return self._request
+
+    def write_file(
+        self,
+        relative: str | Path | PurePosixPath,
+        chunks: Iterable[bytes],
+    ) -> TreeFileRecord:
+        self._require_active()
+        if self._published:
+            raise RuntimeError("strict workspace session was already published")
+        return self._workspace.write_file(relative, chunks)
+
+    def publish_validated(
+        self,
+        validator: Callable[
+            [PublicationDirectoryReader],
+            _ValidationResult,
+        ],
+    ) -> _ValidationResult:
+        self._require_active()
+        if not callable(validator):
+            raise TypeError("strict workspace validator must be callable")
+        if self._published:
+            raise RuntimeError("strict workspace session was already published")
+        self._workspace.seal()
+        published: list[_ValidationResult] = []
+
+        def validate_staged(reader: PublicationDirectoryReader) -> None:
+            validator(reader)
+
+        def validate_published(reader: PublicationDirectoryReader) -> None:
+            published.append(validator(reader))
+
+        self._workspace.publish_into(
+            self._receipt_owner,
+            validate_staged_directory=validate_staged,
+            validate_published_destination=validate_published,
+        )
+        if len(published) != 1 or not self._receipt_owner.active:
+            raise RuntimeError(
+                "strict workspace publication did not install one active receipt"
+            )
+        receipt = self._receipt_owner.receipt
+        if (
+            receipt.path != self._request.destination
+            or receipt.plan != self._request.plan
+        ):
+            raise RuntimeError("strict workspace receipt differs from its request")
+        self._published = True
+        return published[0]
+
+    def _invalidate(self) -> None:
+        deferred: BaseException | None = None
+        for _attempt in range(_SESSION_RECOVERY_LIMIT):
+            try:
+                self._active = False
+            except BaseException as interruption:  # noqa: B036 - reconcile state
+                if deferred is None:
+                    deferred = interruption
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "strict workspace session revocation was interrupted again",
+                        interruption,
+                    )
+                continue
+            try:
+                inactive = not self._active
+            except BaseException as interruption:  # noqa: B036
+                if deferred is None:
+                    deferred = interruption
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "strict workspace session revocation check also failed",
+                        interruption,
+                    )
+                continue
+            if inactive:
+                if deferred is not None:
+                    raise deferred.with_traceback(deferred.__traceback__)
+                return
+        recovery_error = RuntimeError(
+            "strict workspace session revocation did not converge"
+        )
+        if deferred is not None:
+            raise recovery_error from deferred
+        raise recovery_error
+
+
+class _ProviderOperationGate:
+    """One-shot callback lease revoked before a provider call can escape."""
+
+    __slots__ = ("_active", "_called", "_lock", "_operation")
+
+    def __init__(
+        self,
+        operation: Callable[[StrictWorkspaceSession], _OperationResult],
+    ) -> None:
+        self._active = True
+        self._called = False
+        self._lock = _CancellationSafeRLock()
+        self._operation = operation
+
+    def __call__(self, session: StrictWorkspaceSession) -> _OperationResult:
+        def invoke() -> _OperationResult:
+            if not self._active:
+                raise RuntimeError("strict workspace operation is no longer active")
+            if self._called:
+                raise RuntimeError("strict workspace operation is one-shot")
+            self._called = True
+            return self._operation(session)
+
+        return self._lock.run(invoke)
+
+    @property
+    def called(self) -> bool:
+        return self._lock.run(lambda: self._called)
+
+    def _deactivate(self) -> None:
+        self._active = False
+
+    def revoke(self) -> None:
+        deferred: BaseException | None = None
+        for _attempt in range(_SESSION_RECOVERY_LIMIT):
+            try:
+                self._lock.run(self._deactivate)
+            except BaseException as interruption:  # noqa: B036
+                if deferred is None:
+                    deferred = interruption
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "strict workspace operation revocation was interrupted again",
+                        interruption,
+                    )
+                continue
+            try:
+                inactive = self._lock.run(lambda: not self._active)
+            except BaseException as interruption:  # noqa: B036
+                if deferred is None:
+                    deferred = interruption
+                else:
+                    _annotate_secondary_error(
+                        deferred,
+                        "strict workspace operation revocation check also failed",
+                        interruption,
+                    )
+                continue
+            if inactive:
+                if deferred is not None:
+                    raise deferred.with_traceback(deferred.__traceback__)
+                return
+        recovery_error = RuntimeError(
+            "strict workspace operation revocation did not converge"
+        )
+        if deferred is not None:
+            raise recovery_error from deferred
+        raise recovery_error
+
+
+def run_adopted_workspace_operation(
+    request: StrictWorkspaceRequest,
+    *,
+    workspace: OwnedWorkspaceAuthority,
+    receipt_owner: PublishedWorkspaceReceiptOwner,
+    operation: Callable[[StrictWorkspaceSession], _OperationResult],
+) -> _OperationResult:
+    """Run one operation against an already-adopted borrowed authority.
+
+    The provider remains responsible for closing ``workspace`` after a
+    pre-publication failure.  Once a receipt is installed, only
+    ``receipt_owner`` may close the transferred aggregate authority.
+    """
+
+    if not isinstance(request, StrictWorkspaceRequest):
+        raise TypeError("strict workspace request has an invalid type")
+    if not isinstance(workspace, OwnedWorkspaceAuthority):
+        raise TypeError("strict workspace authority has an invalid type")
+    if not isinstance(receipt_owner, PublishedWorkspaceReceiptOwner):
+        raise TypeError("strict workspace receipt owner has an invalid type")
+    if not callable(operation):
+        raise TypeError("strict workspace operation must be callable")
+    if receipt_owner.state != "empty":
+        raise RuntimeError("strict workspace receipt owner must be empty")
+    if workspace.plan != request.plan:
+        raise ValueError("adopted workspace plan differs from its request")
+    if workspace.state != "adopted":
+        raise RuntimeError("strict workspace authority must be freshly adopted")
+
+    session = _AdoptedWorkspaceSession(request, workspace, receipt_owner)
+    primary_error: BaseException | None = None
+    result: object = _UNSET_RESULT
+    try:
+        result = operation(session)
+    except BaseException as exc:  # noqa: B036 - revoke before propagation
+        primary_error = exc
+    try:
+        session._invalidate()
+    except BaseException as revoke_error:  # noqa: B036 - preserve operation fault
+        if primary_error is None:
+            primary_error = revoke_error
+        else:
+            _annotate_secondary_error(
+                primary_error,
+                "strict workspace session revocation also failed",
+                revoke_error,
+            )
+    if primary_error is not None:
+        raise primary_error.with_traceback(primary_error.__traceback__)
+    if result is _UNSET_RESULT:
+        raise RuntimeError("strict workspace operation returned no result")
+    if not session._published or not receipt_owner.active:
+        raise RuntimeError("strict workspace operation returned without publishing")
+    receipt = receipt_owner.receipt
+    if receipt.path != request.destination or receipt.plan != request.plan:
+        raise RuntimeError("strict workspace provider published the wrong request")
+    return result  # type: ignore[return-value]
+
+
+def run_strict_workspace(
+    provider: StrictWorkspaceProvider,
+    request: StrictWorkspaceRequest,
+    *,
+    receipt_owner: PublishedWorkspaceReceiptOwner,
+    operation: Callable[[StrictWorkspaceSession], _OperationResult],
+) -> _OperationResult:
+    """Preflight and invoke one trusted provider without an ambient fallback."""
+
+    if not isinstance(request, StrictWorkspaceRequest):
+        raise TypeError("strict workspace request has an invalid type")
+    if not isinstance(receipt_owner, PublishedWorkspaceReceiptOwner):
+        raise TypeError("strict workspace receipt owner has an invalid type")
+    if not callable(operation):
+        raise TypeError("strict workspace operation must be callable")
+    if receipt_owner.state != "empty":
+        raise RuntimeError("strict workspace receipt owner must be empty")
+
+    # The shared platform gate precedes even provider attribute lookup: a
+    # descriptor/property proxy is not allowed to run on an unsupported host.
+    require_owned_workspace_publication_support()
+    require_support = getattr(provider, "require_support", None)
+    run_workspace = getattr(provider, "run_workspace", None)
+    if not callable(require_support) or not callable(run_workspace):
+        raise TypeError("strict workspace provider has an invalid contract")
+    # The provider-specific gate also precedes its provisioning entry point.
+    require_support()
+    operation_gate = _ProviderOperationGate(operation)
+    primary_error: BaseException | None = None
+    result: object = _UNSET_RESULT
+    try:
+        result = run_workspace(
+            request,
+            receipt_owner=receipt_owner,
+            operation=operation_gate,
+        )
+    except BaseException as exc:  # noqa: B036 - revoke before propagation
+        primary_error = exc
+    try:
+        operation_gate.revoke()
+    except BaseException as revoke_error:  # noqa: B036
+        if primary_error is None:
+            primary_error = revoke_error
+        else:
+            _annotate_secondary_error(
+                primary_error,
+                "strict workspace provider callback revocation also failed",
+                revoke_error,
+            )
+    if primary_error is not None:
+        raise primary_error.with_traceback(primary_error.__traceback__)
+    if result is _UNSET_RESULT:
+        raise RuntimeError("strict workspace provider returned no result")
+    if not operation_gate.called:
+        raise RuntimeError("strict workspace provider did not invoke its operation")
+    if not receipt_owner.active:
+        raise RuntimeError("strict workspace provider returned without a receipt")
+    receipt = receipt_owner.receipt
+    if receipt.path != request.destination or receipt.plan != request.plan:
+        raise RuntimeError("strict workspace provider published the wrong request")
+    return result  # type: ignore[return-value]
+
+
+__all__ = [
+    "DestinationExpectation",
+    "StrictWorkspaceProvider",
+    "StrictWorkspaceRequest",
+    "StrictWorkspaceSession",
+    "run_adopted_workspace_operation",
+    "run_strict_workspace",
+]

--- a/codenib/_workspace_provider.py
+++ b/codenib/_workspace_provider.py
@@ -37,6 +37,78 @@ _ValidationResult = TypeVar("_ValidationResult")
 DestinationExpectation = Literal["missing", "provider-bound-exact"]
 _SESSION_RECOVERY_LIMIT = 64
 _UNSET_RESULT = object()
+_CONSUMED_SESSION_PROVENANCE = object()
+
+
+def _create_session_provenance_registry() -> tuple[
+    Callable[..., object],
+    Callable[[object, object, object, object], object],
+    Callable[[object], None],
+]:
+    bindings: dict[int, tuple[object, object, object, object]] = {}
+
+    def bind(
+        gate: object,
+        request: object,
+        session: object,
+        provenance: object,
+    ) -> None:
+        key = id(gate)
+        current = bindings.get(key)
+        if current is not None and current[0] is gate:
+            raise RuntimeError("strict workspace operation is already bound")
+        bindings[key] = (gate, request, session, provenance)
+
+    def consume(
+        gate: object,
+        request: object,
+        session: object,
+        provenance: object,
+    ) -> object:
+        key = id(gate)
+        current = bindings.get(key)
+        if (
+            current is None
+            or current[0] is not gate
+            or current[1] is not request
+            or current[2] is not session
+            or current[3] is not provenance
+        ):
+            raise TypeError("strict workspace session provenance is unbound")
+        del bindings[key]
+        return provenance
+
+    def discard(gate: object) -> None:
+        key = id(gate)
+        current = bindings.get(key)
+        if current is not None and current[0] is gate:
+            del bindings[key]
+
+    def run_adopted_workspace_operation(
+        request: StrictWorkspaceRequest,
+        *,
+        workspace: OwnedWorkspaceAuthority,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], _OperationResult],
+    ) -> _OperationResult:
+        """Run one bound operation against an already-adopted authority."""
+
+        return _run_adopted_workspace_operation(
+            bind,
+            request,
+            workspace=workspace,
+            receipt_owner=receipt_owner,
+            operation=operation,
+        )
+
+    return run_adopted_workspace_operation, consume, discard
+
+
+(
+    run_adopted_workspace_operation,
+    _CONSUME_SESSION_PROVENANCE,
+    _DISCARD_SESSION_PROVENANCE,
+) = _create_session_provenance_registry()
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,7 +166,13 @@ class StrictWorkspaceSession(Protocol):
 
 
 class StrictWorkspaceProvider(Protocol):
-    """Trusted callback-scoped provider of pre-opened workspace authority."""
+    """Trusted callback-scoped provider of pre-opened workspace authority.
+
+    Implementations provision and adopt the authority, then enter ``operation``
+    only through :func:`run_adopted_workspace_operation`.  Hand-built session
+    facades are rejected because they cannot prove the requested destination
+    expectation or share the revocation gate.
+    """
 
     def require_support(self) -> None: ...
 
@@ -110,6 +188,9 @@ class StrictWorkspaceProvider(Protocol):
 class _AdoptedWorkspaceSession:
     __slots__ = (
         "_active",
+        "_gate",
+        "_operation_provenance",
+        "_owner_pid",
         "_published",
         "_receipt_owner",
         "_request",
@@ -121,12 +202,21 @@ class _AdoptedWorkspaceSession:
         request: StrictWorkspaceRequest,
         workspace: OwnedWorkspaceAuthority,
         receipt_owner: PublishedWorkspaceReceiptOwner,
+        *,
+        operation_provenance: object,
     ) -> None:
         self._request = request
         self._workspace = workspace
         self._receipt_owner = receipt_owner
         self._active = True
+        self._operation_provenance = operation_provenance
+        self._owner_pid = os.getpid()
+        self._gate = _CancellationSafeRLock()
         self._published = False
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError("strict workspace session cannot cross a PID boundary")
 
     def _require_active(self) -> None:
         if not self._active:
@@ -134,18 +224,77 @@ class _AdoptedWorkspaceSession:
 
     @property
     def request(self) -> StrictWorkspaceRequest:
-        self._require_active()
-        return self._request
+        self._require_owner_pid()
+
+        def read() -> StrictWorkspaceRequest:
+            self._require_active()
+            return self._request
+
+        return self._gate.run(read)
+
+    def _require_request_binding(self) -> None:
+        self._require_owner_pid()
+        if self._workspace.plan != self._request.plan:
+            raise ValueError("adopted workspace plan differs from its request")
+        if self._workspace.destination != self._request.destination:
+            raise ValueError("adopted workspace destination differs from its request")
+        expected = (
+            "missing"
+            if self._workspace.expected_destination_ownership is None
+            else "provider-bound-exact"
+        )
+        if expected != self._request.destination_expectation:
+            raise ValueError(
+                "adopted workspace destination expectation differs from its request"
+            )
+
+    def _require_operation_request(self, request: StrictWorkspaceRequest) -> None:
+        self._require_owner_pid()
+
+        def require() -> None:
+            self._require_active()
+            if self._request is not request:
+                raise ValueError("strict workspace session belongs to another request")
+            self._require_request_binding()
+
+        self._gate.run(require)
+
+    def _require_operation_provenance(
+        self,
+        request: StrictWorkspaceRequest,
+        provenance: object,
+        *,
+        consume: bool,
+    ) -> None:
+        self._require_owner_pid()
+
+        def require() -> None:
+            self._require_active()
+            if self._request is not request:
+                raise ValueError("strict workspace session belongs to another request")
+            if self._operation_provenance is not provenance:
+                raise TypeError("strict workspace session provenance is invalid")
+            self._require_request_binding()
+            if consume:
+                self._operation_provenance = _CONSUMED_SESSION_PROVENANCE
+
+        self._gate.run(require)
 
     def write_file(
         self,
         relative: str | Path | PurePosixPath,
         chunks: Iterable[bytes],
     ) -> TreeFileRecord:
-        self._require_active()
-        if self._published:
-            raise RuntimeError("strict workspace session was already published")
-        return self._workspace.write_file(relative, chunks)
+        self._require_owner_pid()
+
+        def write() -> TreeFileRecord:
+            self._require_active()
+            if self._published:
+                raise RuntimeError("strict workspace session was already published")
+            self._require_request_binding()
+            return self._workspace.write_file(relative, chunks)
+
+        return self._gate.run(write)
 
     def publish_validated(
         self,
@@ -154,43 +303,63 @@ class _AdoptedWorkspaceSession:
             _ValidationResult,
         ],
     ) -> _ValidationResult:
-        self._require_active()
-        if not callable(validator):
-            raise TypeError("strict workspace validator must be callable")
-        if self._published:
-            raise RuntimeError("strict workspace session was already published")
-        self._workspace.seal()
-        published: list[_ValidationResult] = []
+        self._require_owner_pid()
 
-        def validate_staged(reader: PublicationDirectoryReader) -> None:
-            validator(reader)
+        def publish() -> _ValidationResult:
+            self._require_active()
+            if not callable(validator):
+                raise TypeError("strict workspace validator must be callable")
+            if self._published:
+                raise RuntimeError("strict workspace session was already published")
+            self._require_request_binding()
+            self._workspace.seal()
+            published: list[_ValidationResult] = []
 
-        def validate_published(reader: PublicationDirectoryReader) -> None:
-            published.append(validator(reader))
+            def validate_staged(reader: PublicationDirectoryReader) -> None:
+                validator(reader)
+                # This callback runs after the staged tree is validated but
+                # before the atomic rename.  Recheck the provider's adopted
+                # destination contract inside that exact publication window.
+                self._require_request_binding()
 
-        self._workspace.publish_into(
-            self._receipt_owner,
-            validate_staged_directory=validate_staged,
-            validate_published_destination=validate_published,
-        )
-        if len(published) != 1 or not self._receipt_owner.active:
-            raise RuntimeError(
-                "strict workspace publication did not install one active receipt"
+            def validate_published(reader: PublicationDirectoryReader) -> None:
+                result = validator(reader)
+                self._require_request_binding()
+                published.append(result)
+
+            # Sealing is a separate authority transition. Recheck again
+            # immediately before entering the authority's rename operation.
+            self._require_request_binding()
+            self._workspace.publish_into(
+                self._receipt_owner,
+                validate_staged_directory=validate_staged,
+                validate_published_destination=validate_published,
             )
-        receipt = self._receipt_owner.receipt
-        if (
-            receipt.path != self._request.destination
-            or receipt.plan != self._request.plan
-        ):
-            raise RuntimeError("strict workspace receipt differs from its request")
-        self._published = True
-        return published[0]
+            if len(published) != 1 or not self._receipt_owner.active:
+                raise RuntimeError(
+                    "strict workspace publication did not install one active receipt"
+                )
+            receipt = self._receipt_owner.receipt
+            if (
+                receipt.path != self._request.destination
+                or receipt.plan != self._request.plan
+            ):
+                raise RuntimeError("strict workspace receipt differs from its request")
+            self._published = True
+            return published[0]
+
+        return self._gate.run(publish)
+
+    def _deactivate(self) -> None:
+        self._require_owner_pid()
+        self._active = False
 
     def _invalidate(self) -> None:
+        self._require_owner_pid()
         deferred: BaseException | None = None
         for _attempt in range(_SESSION_RECOVERY_LIMIT):
             try:
-                self._active = False
+                self._gate.run(self._deactivate)
             except BaseException as interruption:  # noqa: B036 - reconcile state
                 if deferred is None:
                     deferred = interruption
@@ -202,7 +371,7 @@ class _AdoptedWorkspaceSession:
                     )
                 continue
             try:
-                inactive = not self._active
+                inactive = self._gate.run(lambda: not self._active)
             except BaseException as interruption:  # noqa: B036
                 if deferred is None:
                     deferred = interruption
@@ -228,36 +397,107 @@ class _AdoptedWorkspaceSession:
 class _ProviderOperationGate:
     """One-shot callback lease revoked before a provider call can escape."""
 
-    __slots__ = ("_active", "_called", "_lock", "_operation")
+    __slots__ = (
+        "_active",
+        "_called",
+        "_lock",
+        "_operation",
+        "_owner_pid",
+        "_request",
+    )
 
     def __init__(
         self,
+        request: StrictWorkspaceRequest,
         operation: Callable[[StrictWorkspaceSession], _OperationResult],
     ) -> None:
         self._active = True
         self._called = False
         self._lock = _CancellationSafeRLock()
         self._operation = operation
+        self._owner_pid = os.getpid()
+        self._request = request
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError(
+                "strict workspace provider operation cannot cross a PID boundary"
+            )
 
     def __call__(self, session: StrictWorkspaceSession) -> _OperationResult:
+        self._require_owner_pid()
+
         def invoke() -> _OperationResult:
             if not self._active:
                 raise RuntimeError("strict workspace operation is no longer active")
             if self._called:
                 raise RuntimeError("strict workspace operation is one-shot")
+            if type(session) is not _AdoptedWorkspaceSession:
+                raise TypeError(
+                    "strict workspace provider must supply an adopted session"
+                )
+            provenance = _CONSUME_SESSION_PROVENANCE(
+                self,
+                self._request,
+                session,
+                session._operation_provenance,
+            )
+            session._require_operation_provenance(
+                self._request,
+                provenance,
+                consume=True,
+            )
             self._called = True
             return self._operation(session)
 
         return self._lock.run(invoke)
 
+    def _bind_adopted_session(
+        self,
+        bind_provenance: Callable[[object, object, object, object], None],
+        request: StrictWorkspaceRequest,
+        session: _AdoptedWorkspaceSession,
+        provenance: object,
+    ) -> None:
+        self._require_owner_pid()
+
+        def bind() -> None:
+            if not self._active:
+                raise RuntimeError("strict workspace operation is no longer active")
+            if self._called:
+                raise RuntimeError("strict workspace operation is one-shot")
+            if request is not self._request:
+                raise ValueError("strict workspace session belongs to another request")
+            if type(session) is not _AdoptedWorkspaceSession:
+                raise TypeError(
+                    "strict workspace provider must supply an adopted session"
+                )
+            session._require_operation_provenance(
+                request,
+                provenance,
+                consume=False,
+            )
+            bind_provenance(
+                self,
+                request,
+                session,
+                provenance,
+            )
+
+        self._lock.run(bind)
+
     @property
     def called(self) -> bool:
+        self._require_owner_pid()
         return self._lock.run(lambda: self._called)
 
     def _deactivate(self) -> None:
+        self._require_owner_pid()
         self._active = False
+        _DISCARD_SESSION_PROVENANCE(self)
 
     def revoke(self) -> None:
+        self._require_owner_pid()
         deferred: BaseException | None = None
         for _attempt in range(_SESSION_RECOVERY_LIMIT):
             try:
@@ -296,7 +536,8 @@ class _ProviderOperationGate:
         raise recovery_error
 
 
-def run_adopted_workspace_operation(
+def _run_adopted_workspace_operation(
+    bind_provenance: Callable[[object, object, object, object], None],
     request: StrictWorkspaceRequest,
     *,
     workspace: OwnedWorkspaceAuthority,
@@ -310,22 +551,33 @@ def run_adopted_workspace_operation(
     ``receipt_owner`` may close the transferred aggregate authority.
     """
 
-    if not isinstance(request, StrictWorkspaceRequest):
+    if type(request) is not StrictWorkspaceRequest:
         raise TypeError("strict workspace request has an invalid type")
-    if not isinstance(workspace, OwnedWorkspaceAuthority):
+    if type(workspace) is not OwnedWorkspaceAuthority:
         raise TypeError("strict workspace authority has an invalid type")
-    if not isinstance(receipt_owner, PublishedWorkspaceReceiptOwner):
+    if type(receipt_owner) is not PublishedWorkspaceReceiptOwner:
         raise TypeError("strict workspace receipt owner has an invalid type")
-    if not callable(operation):
-        raise TypeError("strict workspace operation must be callable")
+    if type(operation) is not _ProviderOperationGate:
+        raise TypeError("strict workspace operation has invalid provenance")
     if receipt_owner.state != "empty":
         raise RuntimeError("strict workspace receipt owner must be empty")
-    if workspace.plan != request.plan:
-        raise ValueError("adopted workspace plan differs from its request")
     if workspace.state != "adopted":
         raise RuntimeError("strict workspace authority must be freshly adopted")
 
-    session = _AdoptedWorkspaceSession(request, workspace, receipt_owner)
+    operation_provenance = object()
+    session = _AdoptedWorkspaceSession(
+        request,
+        workspace,
+        receipt_owner,
+        operation_provenance=operation_provenance,
+    )
+    session._require_operation_request(request)
+    operation._bind_adopted_session(
+        bind_provenance,
+        request,
+        session,
+        operation_provenance,
+    )
     primary_error: BaseException | None = None
     result: object = _UNSET_RESULT
     try:
@@ -364,9 +616,9 @@ def run_strict_workspace(
 ) -> _OperationResult:
     """Preflight and invoke one trusted provider without an ambient fallback."""
 
-    if not isinstance(request, StrictWorkspaceRequest):
+    if type(request) is not StrictWorkspaceRequest:
         raise TypeError("strict workspace request has an invalid type")
-    if not isinstance(receipt_owner, PublishedWorkspaceReceiptOwner):
+    if type(receipt_owner) is not PublishedWorkspaceReceiptOwner:
         raise TypeError("strict workspace receipt owner has an invalid type")
     if not callable(operation):
         raise TypeError("strict workspace operation must be callable")
@@ -382,7 +634,7 @@ def run_strict_workspace(
         raise TypeError("strict workspace provider has an invalid contract")
     # The provider-specific gate also precedes its provisioning entry point.
     require_support()
-    operation_gate = _ProviderOperationGate(operation)
+    operation_gate = _ProviderOperationGate(request, operation)
     primary_error: BaseException | None = None
     result: object = _UNSET_RESULT
     try:

--- a/codenib/_workspace_provider.py
+++ b/codenib/_workspace_provider.py
@@ -402,6 +402,7 @@ class _ProviderOperationGate:
         "_called",
         "_lock",
         "_operation",
+        "_operation_outcome",
         "_owner_pid",
         "_request",
     )
@@ -415,6 +416,9 @@ class _ProviderOperationGate:
         self._called = False
         self._lock = _CancellationSafeRLock()
         self._operation = operation
+        self._operation_outcome: tuple[object, BaseException | None] | object = (
+            _UNSET_RESULT
+        )
         self._owner_pid = os.getpid()
         self._request = request
 
@@ -448,7 +452,13 @@ class _ProviderOperationGate:
                 consume=True,
             )
             self._called = True
-            return self._operation(session)
+            try:
+                result = self._operation(session)
+                self._record_operation_outcome(result, None)
+                return result
+            except BaseException as operation_error:  # noqa: B036
+                self._record_operation_outcome(_UNSET_RESULT, operation_error)
+                raise
 
         return self._lock.run(invoke)
 
@@ -490,6 +500,70 @@ class _ProviderOperationGate:
     def called(self) -> bool:
         self._require_owner_pid()
         return self._lock.run(lambda: self._called)
+
+    def _record_operation_outcome(
+        self,
+        result: object,
+        operation_error: BaseException | None,
+    ) -> None:
+        """Commit one callback outcome before allowing it to escape the gate."""
+
+        primary_error = operation_error
+        outcome = (result, operation_error)
+        for _attempt in range(_SESSION_RECOVERY_LIMIT):
+            try:
+                self._operation_outcome = outcome
+                if self._operation_outcome is not outcome:
+                    raise RuntimeError(
+                        "strict workspace callback outcome changed during commit"
+                    )
+            except BaseException as transition_error:  # noqa: B036
+                if primary_error is None:
+                    primary_error = transition_error
+                    outcome = (_UNSET_RESULT, primary_error)
+                elif transition_error is not primary_error:
+                    try:
+                        _annotate_secondary_error(
+                            primary_error,
+                            "strict workspace callback outcome commit also failed",
+                            transition_error,
+                        )
+                    except BaseException:  # noqa: B036 - diagnostic is best-effort
+                        pass
+                continue
+            if primary_error is not None:
+                raise primary_error.with_traceback(primary_error.__traceback__)
+            return
+
+        recovery_error = RuntimeError(
+            "strict workspace callback outcome commit did not converge"
+        )
+        if primary_error is not None:
+            try:
+                _annotate_secondary_error(
+                    primary_error,
+                    "strict workspace callback outcome recovery also failed",
+                    recovery_error,
+                )
+            except BaseException:  # noqa: B036 - diagnostic is best-effort
+                pass
+            raise primary_error.with_traceback(primary_error.__traceback__)
+        raise recovery_error
+
+    @property
+    def operation_outcome(self) -> tuple[bool, object, BaseException | None]:
+        """Return the exact user-callback outcome recorded by this gate."""
+
+        self._require_owner_pid()
+
+        def read() -> tuple[bool, object, BaseException | None]:
+            outcome = self._operation_outcome
+            if outcome is _UNSET_RESULT:
+                return False, _UNSET_RESULT, None
+            result, operation_error = outcome  # type: ignore[misc]
+            return True, result, operation_error
+
+        return self._lock.run(read)
 
     def _deactivate(self) -> None:
         self._require_owner_pid()
@@ -656,18 +730,97 @@ def run_strict_workspace(
                 "strict workspace provider callback revocation also failed",
                 revoke_error,
             )
+    outcome_read_error: BaseException | None = None
+    for _attempt in range(_SESSION_RECOVERY_LIMIT):
+        try:
+            callback_completed, callback_result, callback_error = (
+                operation_gate.operation_outcome
+            )
+        except BaseException as read_error:  # noqa: B036 - recover exact outcome
+            if outcome_read_error is None:
+                outcome_read_error = read_error
+            elif read_error is not outcome_read_error:
+                try:
+                    _annotate_secondary_error(
+                        outcome_read_error,
+                        "strict workspace callback outcome read failed again",
+                        read_error,
+                    )
+                except BaseException:  # noqa: B036 - diagnostic is best-effort
+                    pass
+            continue
+        break
+    else:
+        recovery_error = RuntimeError(
+            "strict workspace callback outcome read did not converge"
+        )
+        if primary_error is not None:
+            try:
+                _annotate_secondary_error(
+                    primary_error,
+                    "strict workspace callback outcome recovery also failed",
+                    outcome_read_error or recovery_error,
+                )
+            except BaseException:  # noqa: B036 - diagnostic is best-effort
+                pass
+            raise primary_error.with_traceback(primary_error.__traceback__)
+        if outcome_read_error is not None:
+            try:
+                _annotate_secondary_error(
+                    outcome_read_error,
+                    "strict workspace callback outcome recovery also failed",
+                    recovery_error,
+                )
+            except BaseException:  # noqa: B036 - diagnostic is best-effort
+                pass
+            raise outcome_read_error.with_traceback(outcome_read_error.__traceback__)
+        raise recovery_error
+
+    if callback_error is not None:
+        if primary_error is not None and primary_error is not callback_error:
+            try:
+                _annotate_secondary_error(
+                    callback_error,
+                    "strict workspace provider also failed after its callback",
+                    primary_error,
+                )
+            except BaseException:  # noqa: B036 - diagnostic is best-effort
+                pass
+        if outcome_read_error is not None and outcome_read_error is not callback_error:
+            try:
+                _annotate_secondary_error(
+                    callback_error,
+                    "strict workspace callback outcome read also failed",
+                    outcome_read_error,
+                )
+            except BaseException:  # noqa: B036 - diagnostic is best-effort
+                pass
+        raise callback_error.with_traceback(callback_error.__traceback__)
     if primary_error is not None:
+        if outcome_read_error is not None and outcome_read_error is not primary_error:
+            try:
+                _annotate_secondary_error(
+                    primary_error,
+                    "strict workspace callback outcome read also failed",
+                    outcome_read_error,
+                )
+            except BaseException:  # noqa: B036 - diagnostic is best-effort
+                pass
         raise primary_error.with_traceback(primary_error.__traceback__)
-    if result is _UNSET_RESULT:
-        raise RuntimeError("strict workspace provider returned no result")
+    if outcome_read_error is not None:
+        raise outcome_read_error.with_traceback(outcome_read_error.__traceback__)
     if not operation_gate.called:
         raise RuntimeError("strict workspace provider did not invoke its operation")
+    if not callback_completed:
+        raise RuntimeError("strict workspace provider callback returned no outcome")
+    if result is _UNSET_RESULT:
+        raise RuntimeError("strict workspace provider returned no result")
     if not receipt_owner.active:
         raise RuntimeError("strict workspace provider returned without a receipt")
     receipt = receipt_owner.receipt
     if receipt.path != request.destination or receipt.plan != request.plan:
         raise RuntimeError("strict workspace provider published the wrong request")
-    return result  # type: ignore[return-value]
+    return callback_result  # type: ignore[return-value]
 
 
 __all__ = [

--- a/codenib/artifacts/security.py
+++ b/codenib/artifacts/security.py
@@ -14,6 +14,16 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from .._atomic_directory import PublicationDirectoryReader
+from .._bounded_json import (
+    DEFAULT_MAX_ATOM_BYTES,
+    DEFAULT_MAX_DEPTH,
+    DEFAULT_MAX_KEY_BYTES,
+    DEFAULT_MAX_LEXICAL_TOKENS,
+    DEFAULT_MAX_NODES_PER_ELEMENT,
+    DEFAULT_MAX_STRING_BYTES,
+    validate_bounded_json_stream,
+    validate_json_complexity,
+)
 from .._secret_fields import assert_no_secret_fields
 
 _SENSITIVE_ENV_NAMES = {
@@ -33,6 +43,12 @@ _SENSITIVE_ENV_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET")
 _SCAN_CHUNK_BYTES = 1024 * 1024
 _MAX_CANONICAL_SCALAR_BYTES = 1_024
 _MAX_PUBLISHABLE_JSON_BYTES = 64 * 1024 * 1024
+_MAX_PUBLISHABLE_JSON_NODES = DEFAULT_MAX_NODES_PER_ELEMENT
+_MAX_PUBLISHABLE_JSON_TOKENS = DEFAULT_MAX_LEXICAL_TOKENS
+_MAX_PUBLISHABLE_JSON_DEPTH = DEFAULT_MAX_DEPTH
+_MAX_PUBLISHABLE_JSON_KEY_BYTES = DEFAULT_MAX_KEY_BYTES
+_MAX_PUBLISHABLE_JSON_STRING_BYTES = DEFAULT_MAX_STRING_BYTES
+_MAX_PUBLISHABLE_JSON_ATOM_BYTES = DEFAULT_MAX_ATOM_BYTES
 
 
 def assert_no_credential_fields(value: Any, *, source: str) -> None:
@@ -250,7 +266,11 @@ def assert_publishable_tree_reader(
     label: str,
     max_json_bytes: int = _MAX_PUBLISHABLE_JSON_BYTES,
 ) -> None:
-    """Apply publication policy through one authenticated tree authority."""
+    """Apply publication policy through one authenticated tree authority.
+
+    Publication JSON is UTF-8 without a byte-order mark. Its lexical resource
+    budgets are enforced before strict UTF-8 decoding and DOM allocation.
+    """
 
     if (
         isinstance(max_json_bytes, bool)
@@ -263,12 +283,15 @@ def assert_publishable_tree_reader(
     forbidden = _serialized_patterns(_forbidden_path_strings(roots))
     secrets = _secret_values(environ)
 
+    def is_json_path(path: str) -> bool:
+        return path.casefold().endswith(".json")
+
     def entry_policy(path: str, kind: str, mode: int, size: int) -> None:
         del mode
         encoded = path.encode("utf-8", errors="strict")
         if any(secret in encoded for secret in secrets):
             raise ValueError(f"{label} contains a configured credential in {path}")
-        if kind == "file" and path.endswith(".json") and size > max_json_bytes:
+        if kind == "file" and is_json_path(path) and size > max_json_bytes:
             raise ValueError(
                 f"{label} JSON file exceeds its {max_json_bytes}-byte limit: {path}"
             )
@@ -276,7 +299,23 @@ def assert_publishable_tree_reader(
     reader.capture_ownership(entry_policy=entry_policy)
     for record in reader.file_records():
         relative = record.path
-        if relative.endswith(".json"):
+        if is_json_path(relative):
+            json_label = f"{label} JSON {relative}"
+            with reader.open_authenticated_file(
+                relative,
+                max_bytes=max_json_bytes,
+            ) as source:
+                validate_bounded_json_stream(
+                    source,
+                    label=json_label,
+                    max_bytes=max_json_bytes,
+                    max_nodes=_MAX_PUBLISHABLE_JSON_NODES,
+                    max_lexical_tokens=_MAX_PUBLISHABLE_JSON_TOKENS,
+                    max_depth=_MAX_PUBLISHABLE_JSON_DEPTH,
+                    max_key_bytes=_MAX_PUBLISHABLE_JSON_KEY_BYTES,
+                    max_string_bytes=_MAX_PUBLISHABLE_JSON_STRING_BYTES,
+                    max_atom_bytes=_MAX_PUBLISHABLE_JSON_ATOM_BYTES,
+                )
             payload = reader.read_bytes(relative, max_bytes=max_json_bytes)
             match = _matching_kind_blocks(
                 (payload,),
@@ -284,8 +323,9 @@ def assert_publishable_tree_reader(
                 secrets=secrets,
             )
             try:
+                serialized = payload.decode("utf-8", errors="strict")
                 decoded = json.loads(
-                    payload,
+                    serialized,
                     object_pairs_hook=_reject_duplicate_json_object,
                     parse_int=_bounded_publication_int,
                     parse_float=_bounded_publication_float,
@@ -293,13 +333,21 @@ def assert_publishable_tree_reader(
                 )
             except (RecursionError, ValueError) as exc:
                 raise ValueError(
-                    f"{label} contains invalid JSON in {relative}"
+                    f"{label} contains invalid JSON "
+                    f"(UTF-8 without BOM required) in {relative}"
                 ) from exc
+            validate_json_complexity(
+                decoded,
+                label=json_label,
+                max_nodes=_MAX_PUBLISHABLE_JSON_NODES,
+                max_depth=_MAX_PUBLISHABLE_JSON_DEPTH,
+                max_key_bytes=_MAX_PUBLISHABLE_JSON_KEY_BYTES,
+            )
             assert_publishable_json_value(
                 decoded,
                 forbidden_paths=roots,
                 environ=environ,
-                label=f"{label} JSON {relative}",
+                label=json_label,
             )
         else:
             with reader.open_authenticated_file(

--- a/codenib/artifacts/security.py
+++ b/codenib/artifacts/security.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+from .._atomic_directory import PublicationDirectoryReader
 from .._secret_fields import assert_no_secret_fields
 
 _SENSITIVE_ENV_NAMES = {
@@ -29,12 +31,37 @@ _SENSITIVE_ENV_NAMES = {
 }
 _SENSITIVE_ENV_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET")
 _SCAN_CHUNK_BYTES = 1024 * 1024
+_MAX_CANONICAL_SCALAR_BYTES = 1_024
+_MAX_PUBLISHABLE_JSON_BYTES = 64 * 1024 * 1024
 
 
 def assert_no_credential_fields(value: Any, *, source: str) -> None:
     """Reject credential-shaped keys in metadata intended for publication."""
 
     assert_no_secret_fields(value, source=source)
+
+
+def _forbidden_path_strings(paths: Iterable[Path]) -> tuple[str, ...]:
+    values: set[str] = set()
+    for path in paths:
+        expanded = path.expanduser()
+        try:
+            raw = os.fsdecode(os.fspath(expanded))
+        except TypeError:
+            raw = str(expanded)
+        lexical = os.path.abspath(raw)
+        if os.path.isabs(raw):
+            values.add(raw)
+        values.update((lexical, Path(lexical).as_posix()))
+        try:
+            canonical = expanded.resolve()
+        except (OSError, RuntimeError, ValueError):
+            continue
+        values.add(str(canonical))
+        as_posix = getattr(canonical, "as_posix", None)
+        if callable(as_posix):
+            values.add(as_posix())
+    return tuple(sorted(value for value in values if value))
 
 
 def assert_publishable_json_value(
@@ -47,11 +74,7 @@ def assert_publishable_json_value(
     """Scan decoded JSON semantics without depending on their source encoding."""
 
     assert_no_credential_fields(value, source=label)
-    forbidden_values: list[str] = []
-    for path in forbidden_paths:
-        resolved = path.expanduser().resolve()
-        forbidden_values.extend((str(resolved), resolved.as_posix()))
-    forbidden = tuple(item for item in forbidden_values if item)
+    forbidden = _forbidden_path_strings(forbidden_paths)
     secrets = tuple(
         value
         for name, value in environ.items()
@@ -62,6 +85,13 @@ def assert_publishable_json_value(
             or name.upper().endswith(_SENSITIVE_ENV_SUFFIXES)
         )
     )
+
+    def check_text(text: str) -> None:
+        if any(pattern in text for pattern in forbidden):
+            raise ValueError(f"{label} contains an absolute build-machine path")
+        if any(pattern in text for pattern in secrets):
+            raise ValueError(f"{label} contains a configured credential")
+
     stack = [value]
     while stack:
         current = stack.pop()
@@ -69,23 +99,27 @@ def assert_publishable_json_value(
             for key, child in current.items():
                 if not isinstance(key, str):
                     raise ValueError(f"{label} contains a non-text JSON object key")
-                if any(pattern in key for pattern in forbidden):
-                    raise ValueError(f"{label} contains an absolute build-machine path")
-                if any(pattern in key for pattern in secrets):
-                    raise ValueError(f"{label} contains a configured credential")
+                check_text(key)
                 stack.append(child)
         elif isinstance(current, (list, tuple)):
             stack.extend(current)
         elif isinstance(current, str):
-            if any(pattern in current for pattern in forbidden):
-                raise ValueError(f"{label} contains an absolute build-machine path")
-            if any(pattern in current for pattern in secrets):
-                raise ValueError(f"{label} contains a configured credential")
-        elif current is None or isinstance(current, (bool, int)):
-            continue
+            check_text(current)
+        elif current is None or isinstance(current, bool):
+            check_text("null" if current is None else ("true" if current else "false"))
+        elif isinstance(current, int):
+            # Avoid materializing an attacker-sized integer representation.
+            if current.bit_length() > 3_404:
+                raise ValueError(f"{label} contains an oversized JSON integer")
+            scalar = str(current)
+            if len(scalar) > _MAX_CANONICAL_SCALAR_BYTES:
+                raise ValueError(f"{label} contains an oversized JSON integer")
+            check_text(scalar)
         elif isinstance(current, float):
             if not math.isfinite(current):
                 raise ValueError(f"{label} contains a non-finite JSON number")
+            scalar = json.dumps(current, allow_nan=False, separators=(",", ":"))
+            check_text(scalar)
         else:
             raise ValueError(
                 f"{label} contains unsupported JSON value: " f"{type(current).__name__}"
@@ -153,6 +187,139 @@ def _matching_kind(
     return None
 
 
+def _matching_kind_blocks(
+    blocks: Iterable[bytes],
+    *,
+    forbidden: tuple[bytes, ...],
+    secrets: tuple[bytes, ...],
+) -> str | None:
+    needles = tuple(
+        (kind, needle)
+        for kind, values in (("path", forbidden), ("secret", secrets))
+        for needle in values
+        if needle
+    )
+    if not needles:
+        return None
+    overlap = max(len(needle) for _kind, needle in needles) - 1
+    tail = b""
+    for chunk in blocks:
+        window = tail + chunk
+        for kind, needle in needles:
+            if needle in window:
+                return kind
+        tail = window[-overlap:] if overlap else b""
+    return None
+
+
+def _reject_duplicate_json_object(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate publication JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _bounded_publication_int(value: str) -> int:
+    if len(value) > _MAX_CANONICAL_SCALAR_BYTES:
+        raise ValueError("publication JSON integer is too large")
+    return int(value)
+
+
+def _bounded_publication_float(value: str) -> float:
+    if len(value) > _MAX_CANONICAL_SCALAR_BYTES:
+        raise ValueError("publication JSON number is too large")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("publication JSON number is not finite")
+    return parsed
+
+
+def _reject_publication_constant(value: str) -> None:
+    raise ValueError(f"publication JSON constant is not finite: {value}")
+
+
+def assert_publishable_tree_reader(
+    reader: PublicationDirectoryReader,
+    *,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+    label: str,
+    max_json_bytes: int = _MAX_PUBLISHABLE_JSON_BYTES,
+) -> None:
+    """Apply publication policy through one authenticated tree authority."""
+
+    if (
+        isinstance(max_json_bytes, bool)
+        or not isinstance(max_json_bytes, int)
+        or max_json_bytes <= 0
+        or max_json_bytes > _MAX_PUBLISHABLE_JSON_BYTES
+    ):
+        raise ValueError("publishable JSON byte limit is out of bounds")
+    roots = tuple(forbidden_paths)
+    forbidden = _serialized_patterns(_forbidden_path_strings(roots))
+    secrets = _secret_values(environ)
+
+    def entry_policy(path: str, kind: str, mode: int, size: int) -> None:
+        del mode
+        encoded = path.encode("utf-8", errors="strict")
+        if any(secret in encoded for secret in secrets):
+            raise ValueError(f"{label} contains a configured credential in {path}")
+        if kind == "file" and path.endswith(".json") and size > max_json_bytes:
+            raise ValueError(
+                f"{label} JSON file exceeds its {max_json_bytes}-byte limit: {path}"
+            )
+
+    reader.capture_ownership(entry_policy=entry_policy)
+    for record in reader.file_records():
+        relative = record.path
+        if relative.endswith(".json"):
+            payload = reader.read_bytes(relative, max_bytes=max_json_bytes)
+            match = _matching_kind_blocks(
+                (payload,),
+                forbidden=forbidden,
+                secrets=secrets,
+            )
+            try:
+                decoded = json.loads(
+                    payload,
+                    object_pairs_hook=_reject_duplicate_json_object,
+                    parse_int=_bounded_publication_int,
+                    parse_float=_bounded_publication_float,
+                    parse_constant=_reject_publication_constant,
+                )
+            except (RecursionError, ValueError) as exc:
+                raise ValueError(
+                    f"{label} contains invalid JSON in {relative}"
+                ) from exc
+            assert_publishable_json_value(
+                decoded,
+                forbidden_paths=roots,
+                environ=environ,
+                label=f"{label} JSON {relative}",
+            )
+        else:
+            with reader.open_authenticated_file(
+                relative,
+                max_bytes=record.size,
+            ) as source:
+                match = _matching_kind_blocks(
+                    source.iter_bytes(chunk_size=_SCAN_CHUNK_BYTES),
+                    forbidden=forbidden,
+                    secrets=secrets,
+                )
+        if match == "path":
+            raise ValueError(
+                f"{label} contains an absolute build-machine path in {relative}"
+            )
+        if match == "secret":
+            raise ValueError(f"{label} contains a configured credential in {relative}")
+    reader.capture_ownership(entry_policy=entry_policy)
+
+
 def _assert_publishable_file(
     path: Path,
     *,
@@ -207,5 +374,6 @@ __all__ = [
     "assert_no_credential_fields",
     "assert_publishable_json_value",
     "assert_publishable_tree",
+    "assert_publishable_tree_reader",
     "file_sha256",
 ]

--- a/codenib/graph/hierarchy.py
+++ b/codenib/graph/hierarchy.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import math
 import os
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import AbstractSet, Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from ..types import EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE, is_symbol_node
 from .code_graph import CodeGraph
@@ -161,20 +161,54 @@ def _hierarchy_path(file: str, source_root: Optional[str]) -> List[str]:
     return parts
 
 
-def _is_external_symbol(attrs: Dict[str, Any], repo_dir: Optional[str]) -> bool:
+def _captured_source_path(
+    file: str,
+    repo_dir: Optional[str],
+    source_paths: AbstractSet[str],
+) -> Optional[str]:
+    candidate = file.replace("\\", os.sep).replace("/", os.sep)
+    if os.path.isabs(candidate):
+        if not repo_dir:
+            return None
+        try:
+            candidate = os.path.relpath(candidate, os.path.abspath(repo_dir))
+        except ValueError:
+            return None
+    normalized = os.path.normpath(candidate)
+    if normalized in {"", ".", ".."} or normalized.startswith(".." + os.sep):
+        return None
+    relative = normalized.replace(os.sep, "/")
+    return relative if relative in source_paths else None
+
+
+def _is_external_symbol(
+    attrs: Dict[str, Any],
+    repo_dir: Optional[str],
+    source_paths: Optional[AbstractSet[str]] = None,
+) -> bool:
     file = attrs.get("file")
     start = attrs.get("start_line")
     if not isinstance(file, str) or not file or not isinstance(start, int):
         return True
+    if source_paths is not None:
+        return _captured_source_path(file, repo_dir, source_paths) is None
     if repo_dir:
         safe = os.path.normpath(file).lstrip(os.sep).lstrip("/")
         return not os.path.isfile(os.path.join(repo_dir, safe))
     return False
 
 
-def _file_key(attrs: Dict[str, Any], repo_dir: Optional[str]) -> str:
+def _file_key(
+    attrs: Dict[str, Any],
+    repo_dir: Optional[str],
+    source_paths: Optional[AbstractSet[str]] = None,
+) -> str:
     file = attrs.get("file")
-    if _is_external_symbol(attrs, repo_dir) or not isinstance(file, str) or not file:
+    if not isinstance(file, str) or not file:
+        return EXTERNAL_FILE
+    if source_paths is not None:
+        return _captured_source_path(file, repo_dir, source_paths) or EXTERNAL_FILE
+    if _is_external_symbol(attrs, repo_dir):
         return EXTERNAL_FILE
     return file.replace("\\", "/")
 
@@ -295,7 +329,10 @@ def _assign_depths(nodes: List[ContainmentNode]) -> None:
 
 
 def build_hierarchical_code_graph(
-    graph: CodeGraph, repo_dir: Optional[str] = None
+    graph: CodeGraph,
+    repo_dir: Optional[str] = None,
+    *,
+    source_paths: Optional[AbstractSet[str]] = None,
 ) -> HierarchicalCodeGraph:
     """Build a reusable repo-level compound graph from a :class:`CodeGraph`."""
 
@@ -312,7 +349,7 @@ def build_hierarchical_code_graph(
             continue
         symbol_vids[vertex.index] = name
         attrs_by_name[name] = attrs
-        file_by_name[name] = _file_key(attrs, repo_dir)
+        file_by_name[name] = _file_key(attrs, repo_dir, source_paths)
 
     source_root = _common_source_root(list(file_by_name.values()))
     importance = _reference_importance(graph, attrs_by_name.keys())

--- a/codenib/repository_summary.py
+++ b/codenib/repository_summary.py
@@ -8,8 +8,13 @@ from __future__ import annotations
 
 import os
 import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .source_fingerprint import RepositorySourceReader
 
 README_NAMES = ("README.md", "README.rst", "README.txt", "README", "readme.md")
+_MAX_BOUND_README_BYTES = 8 * 1024 * 1024
 
 _README_SKIP = re.compile(
     r"\b(install|download|getting started|to get started|usage|build from source"
@@ -158,4 +163,19 @@ def read_repository_summary(repo_dir: str, limit: int = 160) -> str:
                 return readme_summary(handle.read(), limit=limit)
         except OSError:
             return ""
+    return ""
+
+
+def read_bound_repository_summary(
+    source: RepositorySourceReader,
+    limit: int = 160,
+) -> str:
+    """Extract a summary only from exact descriptor-authenticated source bytes."""
+
+    for name in README_NAMES:
+        relative = source.captured_relative_path(name)
+        if relative is None:
+            continue
+        payload = source.read_prefix(relative, max_bytes=_MAX_BOUND_README_BYTES)
+        return readme_summary(payload.decode("utf-8", errors="replace"), limit=limit)
     return ""

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -60,6 +60,7 @@ SOURCE_FINGERPRINT_VERSION = 2
 
 _SOURCE_FINGERPRINT_V1_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _SOURCE_FINGERPRINT_V2_RE = re.compile(r"^sha256-v2:[0-9a-f]{64}$")
+_SOURCE_NEWLINE_RE = re.compile(rb"[\r\n]")
 _V2_MAGIC = b"codenib-source-fingerprint\x00\x02"
 _MAX_FRAME_BYTES = (1 << 64) - 1
 _MAX_SOURCE_COMPONENTS = 256
@@ -391,6 +392,7 @@ class _AuthenticatedLineRange:
         "_end_line",
         "_limit",
         "_line_number",
+        "_pending_cr",
         "_start_line",
     )
 
@@ -403,27 +405,64 @@ class _AuthenticatedLineRange:
         self._end_line = end_line
         self._limit = limit
         self._line_number = 1
+        self._pending_cr = False
+
+    def _retain(self, payload: bytes, start: int, stop: int) -> None:
+        if not (
+            stop > start and self._start_line <= self._line_number <= self._end_line
+        ):
+            return
+        remaining = self._limit - len(self.payload)
+        segment_size = stop - start
+        if segment_size > remaining:
+            if remaining > 0:
+                self.payload.extend(payload[start : start + remaining])
+            self.overflow = True
+        elif remaining > 0:
+            self.payload.extend(payload[start:stop])
 
     def update(self, payload: bytes) -> None:
         self.byte_count += len(payload)
         self.digest.update(payload)
 
         offset = 0
-        while offset < len(payload):
-            newline = payload.find(b"\n", offset)
-            stop = len(payload) if newline < 0 else newline + 1
-            if self._start_line <= self._line_number <= self._end_line:
-                segment = payload[offset:stop]
-                remaining = self._limit - len(self.payload)
-                if len(segment) > remaining:
-                    if remaining > 0:
-                        self.payload.extend(segment[:remaining])
-                    self.overflow = True
-                elif remaining > 0:
-                    self.payload.extend(segment)
-            if newline >= 0:
+        if self._pending_cr:
+            if not payload:
+                return
+            self._pending_cr = False
+            if payload.startswith(b"\n"):
+                self._retain(payload, 0, 1)
                 self._line_number += 1
-            offset = stop
+                offset = 1
+            else:
+                self._line_number += 1
+
+        segment_start = offset
+        for match in _SOURCE_NEWLINE_RE.finditer(payload, offset):
+            boundary = match.start()
+            if boundary < offset:
+                continue
+            value = payload[boundary]
+            if value == 0x0A:
+                offset = boundary + 1
+                self._retain(payload, segment_start, offset)
+                self._line_number += 1
+                segment_start = offset
+                continue
+
+            offset = boundary + 1
+            if offset == len(payload):
+                self._retain(payload, segment_start, offset)
+                self._pending_cr = True
+                segment_start = offset
+                continue
+            if payload[offset] == 0x0A:
+                offset += 1
+            self._retain(payload, segment_start, offset)
+            self._line_number += 1
+            segment_start = offset
+
+        self._retain(payload, segment_start, len(payload))
 
 
 def _snapshot_source_identity_value(value: object) -> object:
@@ -1114,20 +1153,62 @@ class RepositorySourceBinding:
                 raise TypeError("repository source path must be text")
             if not path or "\x00" in path:
                 return None
-            candidate = path.replace("\\", os.sep).replace("/", os.sep)
-            if os.path.isabs(candidate):
-                lexical = Path(os.path.abspath(candidate))
+
+            current_root_label = os.fspath(self.root)
+            current_root_bytes = os.fsencode(current_root_label)
+            label_byte_limit = len(current_root_bytes) + 1 + _MAX_SOURCE_PATH_BYTES
+            if len(path) > label_byte_limit:
+                return None
+            try:
+                encoded_path = os.fsencode(path)
+            except UnicodeError:
+                return None
+            if len(encoded_path) > label_byte_limit:
+                return None
+
+            portable = path.replace("\\", "/")
+            drive, tail = ntpath.splitdrive(portable)
+            # Python 3.13 no longer treats one leading slash as absolute in
+            # ntpath. POSIX-rooted persisted paths remain absolute regardless
+            # of the host running this compatibility lookup.
+            absolute = portable.startswith("/") or ntpath.isabs(portable)
+            if drive and not absolute:
+                return None
+
+            native_candidate = portable.replace("/", os.sep)
+            native_exact = os.path.isabs(native_candidate) and (
+                os.name != "nt" or bool(drive)
+            )
+            if native_exact:
+                lexical = Path(os.path.abspath(native_candidate))
                 try:
                     relative_path = lexical.relative_to(self.root)
                 except ValueError:
-                    return None
-                parts = relative_path.parts
-            else:
-                parts = Path(candidate).parts
+                    pass
+                else:
+                    relative = PurePosixPath(*relative_path.parts).as_posix()
+                    return relative if relative in self._records else None
+
+            component_text = tail.lstrip("/") if absolute else tail
+            parts = tuple(component_text.split("/"))
             if not parts or any(part in {"", ".", ".."} for part in parts):
                 return None
-            relative = PurePosixPath(*parts).as_posix()
-            return relative if relative in self._records else None
+
+            if (
+                len(encoded_path) > _MAX_SOURCE_PATH_BYTES
+                or len(parts) > _MAX_SOURCE_COMPONENTS
+            ):
+                return None
+
+            if not absolute:
+                relative = PurePosixPath(*parts).as_posix()
+                return relative if relative in self._records else None
+
+            for offset in range(len(parts)):
+                relative = PurePosixPath(*parts[offset:]).as_posix()
+                if relative in self._records:
+                    return relative
+            return None
 
     def borrow_reader(self) -> RepositorySourceReader:
         """Return a non-owning reader that becomes unusable when this closes."""

--- a/codenib/source_fingerprint.py
+++ b/codenib/source_fingerprint.py
@@ -17,7 +17,7 @@ import sys
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Iterable, Iterator, Mapping
 
 from ._contained_source import (
@@ -361,6 +361,71 @@ class _HashFanout:
             target.update(payload)
 
 
+class _AuthenticatedPrefix:
+    """Hash a complete source payload while retaining one bounded prefix."""
+
+    __slots__ = ("byte_count", "digest", "prefix", "_limit")
+
+    def __init__(self, limit: int) -> None:
+        self.byte_count = 0
+        self.digest = hashlib.sha256()
+        self.prefix = bytearray()
+        self._limit = limit
+
+    def update(self, payload: bytes) -> None:
+        self.byte_count += len(payload)
+        self.digest.update(payload)
+        remaining = self._limit - len(self.prefix)
+        if remaining > 0:
+            self.prefix.extend(payload[:remaining])
+
+
+class _AuthenticatedLineRange:
+    """Hash a complete source payload while retaining selected whole lines."""
+
+    __slots__ = (
+        "byte_count",
+        "digest",
+        "payload",
+        "overflow",
+        "_end_line",
+        "_limit",
+        "_line_number",
+        "_start_line",
+    )
+
+    def __init__(self, start_line: int, end_line: int, limit: int) -> None:
+        self.byte_count = 0
+        self.digest = hashlib.sha256()
+        self.payload = bytearray()
+        self.overflow = False
+        self._start_line = start_line
+        self._end_line = end_line
+        self._limit = limit
+        self._line_number = 1
+
+    def update(self, payload: bytes) -> None:
+        self.byte_count += len(payload)
+        self.digest.update(payload)
+
+        offset = 0
+        while offset < len(payload):
+            newline = payload.find(b"\n", offset)
+            stop = len(payload) if newline < 0 else newline + 1
+            if self._start_line <= self._line_number <= self._end_line:
+                segment = payload[offset:stop]
+                remaining = self._limit - len(self.payload)
+                if len(segment) > remaining:
+                    if remaining > 0:
+                        self.payload.extend(segment[:remaining])
+                    self.overflow = True
+                elif remaining > 0:
+                    self.payload.extend(segment)
+            if newline >= 0:
+                self._line_number += 1
+            offset = stop
+
+
 def _snapshot_source_identity_value(value: object) -> object:
     if type(value) is tuple:
         return tuple(_snapshot_source_identity_value(item) for item in value)
@@ -534,6 +599,7 @@ class RepositorySourceBinding:
         "_windows_authority",
         "_pid",
         "_lock",
+        "_process_locks",
         "_closed",
         "_poisoned",
         "_session_depth",
@@ -614,6 +680,7 @@ class RepositorySourceBinding:
         self._windows_authority = windows_authority
         self._pid = os.getpid()
         self._lock = _SourceLifecycleRLock()
+        self._process_locks = {self._pid: self._lock}
         self._closed = False
         self._poisoned = False
         self._session_depth = 0
@@ -630,13 +697,19 @@ class RepositorySourceBinding:
     def usable(self) -> bool:
         """Return whether this process may still attempt authenticated reads."""
 
+        if self._pid != os.getpid():
+            return False
         with self._state_lease():
-            return not self._closed and not self._poisoned and self._pid == os.getpid()
+            return not self._closed and not self._poisoned
 
     @property
     def closed(self) -> bool:
         """Return whether every retained filesystem authority is closed."""
 
+        if self._pid != os.getpid():
+            # A forked child owns an independent copy of these flags. Avoid an
+            # inherited parent-thread RLock while its cleanup reconciles fds.
+            return self._closed
         with self._state_lease():
             return self._closed
 
@@ -649,12 +722,14 @@ class RepositorySourceBinding:
 
     @contextmanager
     def _state_lease(self) -> Iterator[None]:
+        self._require_owner_pid()
         with _SourceLockLease(self._lock) as acquisition_failure:
             if acquisition_failure is not None:
                 raise acquisition_failure
             yield
 
     def _poison(self, reason: object) -> None:
+        self._require_owner_pid()
         try:
             with _SourceLockLease(self._lock) as deferred:
                 if self._failure_reason is None:
@@ -672,10 +747,13 @@ class RepositorySourceBinding:
             pass
 
     def _require_open(self) -> None:
+        self._require_owner_pid()
         if self._poisoned:
             raise RepositoryChangedError("repository source binding is poisoned")
         if self._closed:
             raise RuntimeError("repository source binding is closed")
+
+    def _require_owner_pid(self) -> None:
         if self._pid != os.getpid():
             raise RuntimeError("repository source binding cannot cross processes")
 
@@ -683,6 +761,7 @@ class RepositorySourceBinding:
     def _authentication_lease(self) -> Iterator[None]:
         """Hold the reentrant lock and poison on every interrupted operation."""
 
+        self._require_owner_pid()
         try:
             with _SourceLockLease(self._lock) as acquisition_failure:
                 if acquisition_failure is not None:
@@ -942,6 +1021,126 @@ class RepositorySourceBinding:
             )
         return payload
 
+    def _read_record_prefix(
+        self,
+        relative: str,
+        record: RepositorySourceFileRecord,
+        *,
+        max_bytes: int,
+    ) -> bytes:
+        if self._windows_authority is not None:
+            api = self._windows_api
+            if api is None:  # pragma: no cover - constructor invariant
+                raise AssertionError("Windows repository binding has no API")
+            resolver = _resolved_windows_repository_file_at(
+                self.root,
+                self._windows_authority,
+                relative,
+                expected_root_identity=self._root_identity,
+                expected_final_identity=record.lexical_identity,
+                api=api,
+            )
+        else:
+            resolver = _resolved_repository_file_at(
+                self.root,
+                self._root_descriptor,
+                relative,
+                expected_root_identity=self._root_identity,  # type: ignore[arg-type]
+                expected_final_identity=record.lexical_identity,  # type: ignore[arg-type]
+            )
+        authenticated = _AuthenticatedPrefix(max_bytes)
+        with resolver as source:
+            if not source.is_regular:
+                raise ValueError("source path is no longer a regular file")
+            source.update_hash(authenticated)
+        if (
+            authenticated.byte_count != record.size
+            or authenticated.digest.hexdigest() != record.sha256
+        ):
+            raise RepositoryChangedError(
+                "repository source file differs from its authenticated record"
+            )
+        return bytes(authenticated.prefix)
+
+    def _read_record_line_range(
+        self,
+        relative: str,
+        record: RepositorySourceFileRecord,
+        *,
+        start_line: int,
+        end_line: int,
+        max_bytes: int,
+    ) -> tuple[bytes, bool]:
+        if self._windows_authority is not None:
+            api = self._windows_api
+            if api is None:  # pragma: no cover - constructor invariant
+                raise AssertionError("Windows repository binding has no API")
+            resolver = _resolved_windows_repository_file_at(
+                self.root,
+                self._windows_authority,
+                relative,
+                expected_root_identity=self._root_identity,
+                expected_final_identity=record.lexical_identity,
+                api=api,
+            )
+        else:
+            resolver = _resolved_repository_file_at(
+                self.root,
+                self._root_descriptor,
+                relative,
+                expected_root_identity=self._root_identity,  # type: ignore[arg-type]
+                expected_final_identity=record.lexical_identity,  # type: ignore[arg-type]
+            )
+        authenticated = _AuthenticatedLineRange(start_line, end_line, max_bytes)
+        with resolver as source:
+            if not source.is_regular:
+                raise ValueError("source path is no longer a regular file")
+            source.update_hash(authenticated)
+        if (
+            authenticated.byte_count != record.size
+            or authenticated.digest.hexdigest() != record.sha256
+        ):
+            raise RepositoryChangedError(
+                "repository source file differs from its authenticated record"
+            )
+        return bytes(authenticated.payload), authenticated.overflow
+
+    def captured_relative_path(self, path: str) -> str | None:
+        """Return the exact captured POSIX path without consulting the filesystem."""
+
+        with self._state_lease():
+            self._require_open()
+            if not isinstance(path, str):
+                raise TypeError("repository source path must be text")
+            if not path or "\x00" in path:
+                return None
+            candidate = path.replace("\\", os.sep).replace("/", os.sep)
+            if os.path.isabs(candidate):
+                lexical = Path(os.path.abspath(candidate))
+                try:
+                    relative_path = lexical.relative_to(self.root)
+                except ValueError:
+                    return None
+                parts = relative_path.parts
+            else:
+                parts = Path(candidate).parts
+            if not parts or any(part in {"", ".", ".."} for part in parts):
+                return None
+            relative = PurePosixPath(*parts).as_posix()
+            return relative if relative in self._records else None
+
+    def borrow_reader(self) -> RepositorySourceReader:
+        """Return a non-owning reader that becomes unusable when this closes."""
+
+        with self._state_lease():
+            self._require_open()
+            return RepositorySourceReader(self)
+
+    def _borrowed_file_paths(self) -> frozenset[str]:
+        with self._state_lease():
+            self._require_open()
+            return frozenset(self._records)
+
     def read_bytes(self, relative: str, *, max_bytes: int) -> bytes:
         """Read one exact captured regular file and rebind the whole inventory."""
 
@@ -981,8 +1180,99 @@ class RepositorySourceBinding:
                     "repository source changed while it was being read"
                 ) from exc
 
-    def close(self) -> None:
-        with _SourceLockLease(self._lock) as first_failure:
+    def read_prefix(self, relative: str, *, max_bytes: int) -> bytes:
+        """Authenticate a complete captured file while retaining a bounded prefix."""
+
+        if (
+            isinstance(max_bytes, bool)
+            or not isinstance(max_bytes, int)
+            or max_bytes <= 0
+        ):
+            raise ValueError("source byte limit must be positive")
+        if not isinstance(relative, str):
+            raise TypeError("repository source path must be text")
+        record = self._records.get(relative)
+        if record is None:
+            raise ValueError("source path is not in the authenticated repository")
+
+        with self._authentication_lease():
+            try:
+                if self._session_depth == 0:
+                    self._verify_inventory()
+                payload = self._read_record_prefix(
+                    relative,
+                    record,
+                    max_bytes=max_bytes,
+                )
+                if self._session_depth == 0:
+                    self._verify_inventory()
+                return payload
+            except BaseException as exc:
+                self._poison(exc)
+                if isinstance(exc, RepositoryChangedError):
+                    raise
+                if not isinstance(exc, (OSError, RuntimeError, ValueError)):
+                    raise
+                raise RepositoryChangedError(
+                    "repository source changed while it was being read"
+                ) from exc
+
+    def read_line_range(
+        self,
+        relative: str,
+        *,
+        start_line: int,
+        end_line: int,
+        max_bytes: int,
+    ) -> bytes:
+        """Authenticate a whole file while retaining a bounded 1-based range."""
+
+        for name, value in (("start", start_line), ("end", end_line)):
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f"source {name} line must be a positive integer")
+        if end_line < start_line:
+            raise ValueError("source end line must not precede the start line")
+        if (
+            isinstance(max_bytes, bool)
+            or not isinstance(max_bytes, int)
+            or max_bytes <= 0
+        ):
+            raise ValueError("source byte limit must be positive")
+        if not isinstance(relative, str):
+            raise TypeError("repository source path must be text")
+        record = self._records.get(relative)
+        if record is None:
+            raise ValueError("source path is not in the authenticated repository")
+
+        overflow = False
+        with self._authentication_lease():
+            try:
+                if self._session_depth == 0:
+                    self._verify_inventory()
+                payload, overflow = self._read_record_line_range(
+                    relative,
+                    record,
+                    start_line=start_line,
+                    end_line=end_line,
+                    max_bytes=max_bytes,
+                )
+                if self._session_depth == 0:
+                    self._verify_inventory()
+            except BaseException as exc:
+                self._poison(exc)
+                if isinstance(exc, RepositoryChangedError):
+                    raise
+                if not isinstance(exc, (OSError, RuntimeError, ValueError)):
+                    raise
+                raise RepositoryChangedError(
+                    "repository source changed while it was being read"
+                ) from exc
+        if overflow:
+            raise ValueError("source line range exceeds its bounded read limit")
+        return payload
+
+    def _close_with_lock(self, lock: _SourceLifecycleRLock) -> None:
+        with _SourceLockLease(lock) as first_failure:
             if not self._closed:
                 # Closing may finish only part of an authority chain before an
                 # operational error. Never permit reads through that partially
@@ -1011,6 +1301,64 @@ class RepositorySourceBinding:
                 )
             if first_failure is not None:
                 raise first_failure
+
+    def close(self) -> None:
+        current_pid = os.getpid()
+        if current_pid == self._pid:
+            self._close_with_lock(self._lock)
+            return
+
+        # A lock held by another thread at fork can never be released in the
+        # child. Serialize child-only fd cleanup on a process-local lock, then
+        # report the ownership boundary after every inherited authority has
+        # been visited. The parent's object and descriptor table are unchanged.
+        child_lock = self._process_locks.setdefault(
+            current_pid,
+            _SourceLifecycleRLock(),
+        )
+        cleanup_failure: BaseException | None = None
+        try:
+            self._close_with_lock(child_lock)
+        except BaseException as exc:  # noqa: B036 - report PID boundary
+            cleanup_failure = exc
+        boundary = RuntimeError("repository source binding cannot cross processes")
+        if cleanup_failure is not None:
+            raise boundary from cleanup_failure
+        raise boundary
+
+
+class RepositorySourceReader:
+    """Borrowed authenticated source reader without ownership operations."""
+
+    __slots__ = ("_binding",)
+
+    def __init__(self, binding: RepositorySourceBinding) -> None:
+        self._binding = binding
+
+    @property
+    def file_paths(self) -> frozenset[str]:
+        return self._binding._borrowed_file_paths()
+
+    def captured_relative_path(self, path: str) -> str | None:
+        return self._binding.captured_relative_path(path)
+
+    def read_prefix(self, relative: str, *, max_bytes: int) -> bytes:
+        return self._binding.read_prefix(relative, max_bytes=max_bytes)
+
+    def read_line_range(
+        self,
+        relative: str,
+        *,
+        start_line: int,
+        end_line: int,
+        max_bytes: int,
+    ) -> bytes:
+        return self._binding.read_line_range(
+            relative,
+            start_line=start_line,
+            end_line=end_line,
+            max_bytes=max_bytes,
+        )
 
 
 def source_fingerprint_version(value: object) -> int | None:
@@ -2708,6 +3056,7 @@ __all__ = [
     "RepositorySourceBinding",
     "RepositorySourceFileRecord",
     "RepositorySourceIdentitySnapshot",
+    "RepositorySourceReader",
     "SOURCE_FINGERPRINT_VERSION",
     "SourceFingerprint",
     "capture_repository_source",

--- a/codenib/web/codemap.py
+++ b/codenib/web/codemap.py
@@ -21,7 +21,7 @@ import os
 import re
 from collections import deque
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from ..graph.code_graph import CodeGraph
 from ..graph.hierarchy import (
@@ -48,6 +48,9 @@ from .repository_files import (
     safe_repo_relative_path,
     valid_commit,
 )
+
+if TYPE_CHECKING:
+    from ..source_fingerprint import RepositorySourceReader
 
 # Node types eligible as a focus / default seed (skip file/dir/import nodes).
 _SYMBOL_TYPES = frozenset({"function", "method", "class"})
@@ -233,10 +236,23 @@ class _DerivedFiles:
     """
 
     def __init__(
-        self, repo_dir: Optional[str] = None, repo_commit: Optional[str] = None
+        self,
+        repo_dir: Optional[str] = None,
+        repo_commit: Optional[str] = None,
+        *,
+        source_reader: Optional[RepositorySourceReader] = None,
     ) -> None:
-        self._repo_dir = os.path.realpath(repo_dir) if repo_dir else None
-        self._repo_commit = repo_commit if valid_commit(repo_commit) else None
+        self._source_reader = source_reader
+        self._repo_dir = (
+            None
+            if source_reader is not None
+            else (os.path.realpath(repo_dir) if repo_dir else None)
+        )
+        self._repo_commit = (
+            None
+            if source_reader is not None
+            else (repo_commit if valid_commit(repo_commit) else None)
+        )
         self._cache: Dict[str, bool] = {}
         # Keep this potentially large set request-local. Concurrent requests
         # may evict the process-level entry, but this map never repeats the
@@ -259,6 +275,12 @@ class _DerivedFiles:
     def _classify(self, file_path: str) -> bool:
         if is_declaration_file(file_path) or is_non_source_file(file_path):
             return True
+        if self._source_reader is not None:
+            relative = self._source_reader.captured_relative_path(file_path)
+            if relative is None:
+                return False
+            head = self._source_reader.read_prefix(relative, max_bytes=2048)
+            return source_has_generated_marker(head)
         if not self._repo_dir:
             return False
         relative = safe_repo_relative_path(self._repo_dir, file_path)
@@ -455,6 +477,7 @@ def _is_external(
     repo_dir: Optional[str] = None,
     repo_commit: Optional[str] = None,
     repo_paths: object = _GIT_PATHS_UNSET,
+    source_reader: Optional[RepositorySourceReader] = None,
 ) -> bool:
     """True if a node has no openable in-repo source.
 
@@ -469,6 +492,8 @@ def _is_external(
     s = a.get("start_line")
     if not isinstance(s, int) or not isinstance(f, str) or not f:
         return True
+    if source_reader is not None:
+        return source_reader.captured_relative_path(f) is None
     if repo_dir:
         root = os.path.realpath(repo_dir)
         relative = safe_repo_relative_path(root, f)
@@ -895,6 +920,8 @@ def build_page_subgraph(
     max_nodes: int = 18,
     repo_dir: Optional[str] = None,
     hierarchy_graph: Optional[HierarchicalCodeGraph] = None,
+    *,
+    source_reader: Optional[RepositorySourceReader] = None,
 ) -> Dict[str, Any]:
     """Page-evidence-first reference subgraph over a wiki page's cited symbols.
 
@@ -989,7 +1016,11 @@ def build_page_subgraph(
             if other is None or other in seeds:
                 continue
             other_attrs = _attrs(graph, other)
-            if _is_external(other_attrs, repo_dir):
+            if _is_external(
+                other_attrs,
+                repo_dir,
+                source_reader=source_reader,
+            ):
                 continue
             candidate_order.setdefault(other, len(candidate_order))
             bridge_edges.setdefault(other, set()).add(key)
@@ -1090,7 +1121,11 @@ def build_page_subgraph(
                 "kind": a.get("type") or "symbol",
                 "depth": 0 if name in seeds else 1,
                 "is_root": name in seeds,  # highlight the page's own symbols
-                "external": _is_external(a, repo_dir),
+                "external": _is_external(
+                    a,
+                    repo_dir,
+                    source_reader=source_reader,
+                ),
             }
         )
 
@@ -1102,7 +1137,12 @@ def build_page_subgraph(
         edge.update(edge_anchors.fields((s, t)))
         edges.append(edge)
 
-    nodes, edges = _enrich(graph, nodes, edges, _DerivedFiles(repo_dir))
+    nodes, edges = _enrich(
+        graph,
+        nodes,
+        edges,
+        _DerivedFiles(repo_dir, source_reader=source_reader),
+    )
     hierarchy = (
         hierarchy_for_view(hierarchy_graph, nodes)
         if hierarchy_graph is not None

--- a/codenib/web/local.py
+++ b/codenib/web/local.py
@@ -69,6 +69,7 @@ def prepare_local_wiki(
     manifest_path: Path,
     *,
     frontend_port: int,
+    repository_slug: str | None = None,
     agent_wiki: bool = False,
     model: str | None = None,
     api_base: str | None = None,
@@ -79,6 +80,21 @@ def prepare_local_wiki(
     """Write the registry and config consumed by the existing Wiki service."""
     repo_path = lexical_repository_path(repo_path)
     manifest_path = Path(os.path.abspath(os.fspath(manifest_path.expanduser())))
+    if repository_slug is not None:
+        if (
+            not isinstance(repository_slug, str)
+            or not repository_slug
+            or "\x00" in repository_slug
+        ):
+            raise ValueError("explicit repository slug must be bounded non-empty text")
+        try:
+            slug_bytes = repository_slug.encode("utf-8", errors="strict")
+        except UnicodeEncodeError as exc:
+            raise ValueError(
+                "explicit repository slug must be valid UTF-8 text"
+            ) from exc
+        if len(slug_bytes) > 4_096:
+            raise ValueError("explicit repository slug must be bounded non-empty text")
     manifest = RepoManifest.load(str(manifest_path))
     if not is_secure_source_fingerprint_v2(manifest.source_fingerprint):
         raise ValueError("local wiki source reads require source fingerprint v2")
@@ -113,7 +129,10 @@ def prepare_local_wiki(
 
     data_dir = manifest_path.parent / "wiki"
     data_dir.mkdir(parents=True, exist_ok=True)
-    repo_name = _repository_slug(repo_path)
+    # Interactive callers retain the historical Git-origin display identity.
+    # Security-sensitive exporters pass an explicit provenance-safe label so
+    # ambient .git/config never becomes part of an authenticated publication.
+    repo_name = repository_slug or _repository_slug(repo_path)
     repo_id = _repo_id(repo_name.rsplit("/", 1)[-1])
     language = manifest.languages[0] if manifest.languages else "unknown"
     save_registry(

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -24,7 +24,7 @@ from ..compiler.manifest import IndexEntry, RepoManifest
 from ..index.embedding._lifecycle import close_vector_after_failure
 from ..log_utils import get_logger
 from ..provider_routes import normalize_endpoint, resolve_embedding_artifact_route
-from ..repository_summary import read_repository_summary
+from ..repository_summary import read_bound_repository_summary, read_repository_summary
 from .config import QAConfig, RepoEntry, load_registry
 from .schemas import GraphCoverage, RepoInfo
 
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from ..index.sparse_idx.bm25_index import BM25CodeIndexer
     from ..llm.litellm_chat import LiteLLMChat
     from ..native_index_authorization import NativeIndexAuthorization
+    from ..source_fingerprint import RepositorySourceReader
 
 logger = get_logger(__name__)
 
@@ -110,6 +111,9 @@ class RepoBundle:
     chat_available: bool = False
     view_loader: Optional[Callable[["RepoBundle"], None]] = None
     runtime_loader: Optional[Callable[["RepoBundle"], None]] = None
+    # Borrowed exact source reader. Its creator retains and closes the owning
+    # binding; escaped readers become unusable when that owner closes it.
+    source_reader: Optional["RepositorySourceReader"] = None
 
     def __post_init__(self) -> None:
         self._views_lock = Lock()
@@ -305,7 +309,13 @@ class RepoBundle:
             from ..graph.hierarchy import build_hierarchical_code_graph
 
             self._hierarchical_graph = build_hierarchical_code_graph(
-                graph, repo_dir=self.entry.repo_dir
+                graph,
+                repo_dir=self.entry.repo_dir,
+                source_paths=(
+                    self.source_reader.file_paths
+                    if self.source_reader is not None
+                    else None
+                ),
             )
             logger.info(
                 "codemap: built hierarchical graph for %r "
@@ -346,7 +356,11 @@ class RepoBundle:
         cached = getattr(self, "_description_cache", None)
         if cached is not None:
             return cached
-        desc = read_repository_summary(self.entry.repo_dir)
+        desc = (
+            read_bound_repository_summary(self.source_reader)
+            if self.source_reader is not None
+            else read_repository_summary(self.entry.repo_dir)
+        )
         self._description_cache = desc
         return desc
 

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -912,9 +912,10 @@ def export_static_wiki(
             exclude_roots=(manifest_path.parent,),
             _source_owner=cleanup_owner.retain,
         )
+        source_identity = source_binding.authenticated_identity_snapshot()
         if (
-            source_binding.fingerprint != expected_manifest.source_fingerprint
-            or source_binding.file_count != expected_manifest.file_count
+            source_identity.fingerprint != expected_manifest.source_fingerprint
+            or source_identity.file_count != expected_manifest.file_count
         ):
             raise ValueError("repository source content does not match the manifest")
         source_reader = source_binding.borrow_reader()
@@ -926,8 +927,8 @@ def export_static_wiki(
                 source_reader=source_reader,
             )
             if (
-                source_binding.fingerprint != bundle.manifest.source_fingerprint
-                or source_binding.file_count != bundle.manifest.file_count
+                source_identity.fingerprint != bundle.manifest.source_fingerprint
+                or source_identity.file_count != bundle.manifest.file_count
             ):
                 raise ValueError(
                     "repository source content does not match the loaded manifest"

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -10,7 +10,6 @@ import hashlib
 import json
 import os
 import re
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping
@@ -26,12 +25,20 @@ from .._atomic_directory import (
 )
 from .._captured_directory import OwnedDirectoryStage
 from .._version import package_version
-from ..artifacts.security import (
-    assert_publishable_tree_reader,
+from ..artifacts.runtime import (
+    SourceBindingCleanupOwner,
+    _raise_source_cleanup_failure,
+    _source_cleanup_owner_is_pending,
 )
+from ..artifacts.security import assert_publishable_tree_reader
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
-from ..source_fingerprint import lexical_repository_path
+from ..source_fingerprint import (
+    RepositorySourceReader,
+    capture_repository_source,
+    is_secure_source_fingerprint_v2,
+    lexical_repository_path,
+)
 from .launcher import find_frontend_dir
 from .local import prepare_local_wiki
 
@@ -248,6 +255,7 @@ def _page_graph(bundle: Any, page: Mapping[str, Any]) -> dict[str, Any]:
                 page.get("citations") or (),
                 repo_dir=bundle.entry.repo_dir,
                 hierarchy_graph=bundle.hierarchical_graph(),
+                source_reader=getattr(bundle, "source_reader", None),
             )
         )
     except Exception:  # noqa: BLE001 - an optional graph must not block the Wiki
@@ -677,32 +685,12 @@ def _view_provenance(manifest: RepoManifest) -> dict[str, Any]:
     return result
 
 
-def _github_repository_url(repo_path: Path) -> str | None:
-    result = subprocess.run(
-        ["git", "-C", str(repo_path), "remote", "get-url", "origin"],
-        capture_output=True,
-        check=False,
-        text=True,
-    )
-    if result.returncode != 0:
-        return None
-    origin = result.stdout.strip()
-    if origin.startswith("git@github.com:"):
-        path = origin.split(":", 1)[1]
-    else:
-        parsed = urlsplit(origin)
-        if (parsed.hostname or "").lower() != "github.com":
-            return None
-        path = parsed.path.lstrip("/")
-    if path.endswith(".git"):
-        path = path[:-4]
-    path = path.strip("/")
-    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", path):
-        return None
-    return f"https://github.com/{path}"
-
-
-def _load_static_bundle(local: Any, manifest_path: Path) -> Any:
+def _load_static_bundle(
+    local: Any,
+    manifest_path: Path,
+    *,
+    source_reader: RepositorySourceReader | None = None,
+) -> Any:
     """Load only the persisted views required to render static Wiki pages."""
 
     from ..index.sparse_idx.bm25_index import BM25CodeIndexer
@@ -732,6 +720,7 @@ def _load_static_bundle(local: Any, manifest_path: Path) -> Any:
         chat_available=False,
         view_loader=load_views,
         runtime_loader=None,
+        source_reader=source_reader,
     )
 
 
@@ -810,6 +799,40 @@ def _validated_output(
     return output_dir
 
 
+def _close_static_source(owner: SourceBindingCleanupOwner) -> None:
+    cleanup_failure: BaseException | None = None
+    try:
+        owner.close()
+    except BaseException as exc:  # noqa: B036 - retryable retained authority
+        cleanup_failure = exc
+    pending_owner = owner if _source_cleanup_owner_is_pending(owner) else None
+    if cleanup_failure is not None:
+        _raise_source_cleanup_failure(
+            cleanup_failure,
+            None,
+            pending_owner,
+        )
+    if pending_owner is not None:
+        _raise_source_cleanup_failure(
+            RuntimeError("static export source cleanup did not finish"),
+            None,
+            pending_owner,
+        )
+
+
+def _raise_after_static_source_cleanup(
+    owner: SourceBindingCleanupOwner,
+    primary: BaseException,
+) -> None:
+    cleanup_failure: BaseException | None = None
+    try:
+        owner.close()
+    except BaseException as exc:  # noqa: B036 - preserve body and retry owner
+        cleanup_failure = exc
+    pending_owner = owner if _source_cleanup_owner_is_pending(owner) else None
+    _raise_source_cleanup_failure(primary, cleanup_failure, pending_owner)
+
+
 def export_static_wiki(
     repo_path: Path,
     manifest_path: Path,
@@ -837,58 +860,97 @@ def export_static_wiki(
         repo_path,
         manifest_path,
         frontend_port=0,
+        repository_slug=repo_path.name or "repository",
         agent_wiki=False,
     )
 
     from ..wiki import WikiBuilder
 
-    bundle = _load_static_bundle(local, manifest_path)
-    builder = WikiBuilder(bundle)
-
-    tree = builder.page_tree()
-    page_ids = _page_ids(tree)
-    pages = []
-    graphs: dict[str, dict[str, Any]] = {}
-    for page_id in page_ids:
-        page = builder.page(page_id)
-        if page is None:
-            raise ValueError(f"Wiki page tree references a missing page: {page_id}")
-        normalized = _normalize_page(builder, page)
-        pages.append(normalized)
-        graphs[page_id] = _embed_page_graph_sources(
-            builder,
-            _page_graph(bundle, normalized),
-        )
-
-    repo_info = _model_dict(bundle.info())
-    capabilities = {name: False for name in dict(repo_info.get("capabilities") or {})}
-    capabilities.update(
-        {
-            "chat": False,
-            "codemap": False,
-            "edge_labels": False,
-            "source_citations": True,
-            "static_wiki": True,
-            "wiki_graph": any(graph.get("available") for graph in graphs.values()),
-        }
-    )
-    repo_info["capabilities"] = capabilities
-    repo_info["problem_statement"] = ""
-    repo_info["incremental"] = None
-    repo_info["source_url"] = _github_repository_url(repo_path)
-
+    cleanup_owner = SourceBindingCleanupOwner()
+    stage: OwnedDirectoryStage | None = None
     try:
-        stage = OwnedDirectoryStage.prepare(
-            output_dir,
-            required_destination_file=STATIC_EXPORT_MANIFEST,
-            allow_empty_destination=True,
+        expected_manifest = RepoManifest.load(str(manifest_path))
+        if not is_secure_source_fingerprint_v2(expected_manifest.source_fingerprint):
+            raise ValueError("static export source reads require source fingerprint v2")
+        source_binding = capture_repository_source(
+            repo_path,
+            exclude_roots=(manifest_path.parent,),
+            _source_owner=cleanup_owner.retain,
         )
-    except (OSError, RuntimeError) as exc:
-        raise ValueError(
-            "refusing to replace a non-empty directory that is not a CodeNib "
-            f"static export: {output_dir}"
-        ) from exc
-    try:
+        if (
+            source_binding.fingerprint != expected_manifest.source_fingerprint
+            or source_binding.file_count != expected_manifest.file_count
+        ):
+            raise ValueError("repository source content does not match the manifest")
+        source_reader = source_binding.borrow_reader()
+
+        with source_binding.read_session():
+            bundle = _load_static_bundle(
+                local,
+                manifest_path,
+                source_reader=source_reader,
+            )
+            if (
+                source_binding.fingerprint != bundle.manifest.source_fingerprint
+                or source_binding.file_count != bundle.manifest.file_count
+            ):
+                raise ValueError(
+                    "repository source content does not match the loaded manifest"
+                )
+            builder = WikiBuilder(bundle, source_reader=source_reader)
+
+            tree = builder.page_tree()
+            page_ids = _page_ids(tree)
+            pages = []
+            graphs: dict[str, dict[str, Any]] = {}
+            for page_id in page_ids:
+                page = builder.page(page_id)
+                if page is None:
+                    raise ValueError(
+                        f"Wiki page tree references a missing page: {page_id}"
+                    )
+                normalized = _normalize_page(builder, page)
+                pages.append(normalized)
+                graphs[page_id] = _embed_page_graph_sources(
+                    builder,
+                    _page_graph(bundle, normalized),
+                )
+
+            repo_info = _model_dict(bundle.info())
+            capabilities = {
+                name: False for name in dict(repo_info.get("capabilities") or {})
+            }
+            capabilities.update(
+                {
+                    "chat": False,
+                    "codemap": False,
+                    "edge_labels": False,
+                    "source_citations": True,
+                    "static_wiki": True,
+                    "wiki_graph": any(
+                        graph.get("available") for graph in graphs.values()
+                    ),
+                }
+            )
+            repo_info["capabilities"] = capabilities
+            repo_info["problem_statement"] = ""
+            repo_info["incremental"] = None
+            # The retained source authority does not authenticate Git config.
+            # Publishing no origin is safer than attributing a raced checkout.
+            repo_info["source_url"] = None
+
+        try:
+            stage = OwnedDirectoryStage.prepare(
+                output_dir,
+                required_destination_file=STATIC_EXPORT_MANIFEST,
+                allow_empty_destination=True,
+            )
+        except (OSError, RuntimeError) as exc:
+            raise ValueError(
+                "refusing to replace a non-empty directory that is not a CodeNib "
+                f"static export: {output_dir}"
+            ) from exc
+
         _copy_frontend(frontend, stage, base_path=base_path)
         _write_bytes(stage, "runtime-config.js", _runtime_config(base_path))
         _write_bytes(stage, "404.html", _not_found_page(base_path))
@@ -988,21 +1050,24 @@ def export_static_wiki(
                     "published static export differs from its staged identity"
                 )
 
+        source_binding.verify_snapshot()
+        _close_static_source(cleanup_owner)
         stage.publish(
             validate_staged_directory=validate_export,
             validate_published_destination=validate_export,
         )
         manifest_file = output_dir.joinpath(*manifest_file.parts)
-    except BaseException as primary_error:
-        try:
-            stage.discard()
-        except BaseException as discard_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "static export stage discard also failed",
-                discard_error,
-            )
-        raise
+    except BaseException as primary_error:  # noqa: B036 - preserve + re-raise
+        if stage is not None:
+            try:
+                stage.discard()
+            except BaseException as discard_error:  # noqa: B036 - preserve primary
+                _annotate_secondary_error(
+                    primary_error,
+                    "static export stage discard also failed",
+                    discard_error,
+                )
+        _raise_after_static_source_cleanup(cleanup_owner, primary_error)
 
     return StaticExportResult(
         output_dir=output_dir,

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -780,14 +780,14 @@ def _file_inventory(ownership: object) -> list[dict[str, Any]]:
     ]
 
 
-def _validated_output(
+def _reject_output_overlap(
+    output_dir: Path,
+    *,
     repo_path: Path,
     manifest_root: Path,
-    output_dir: Path,
-) -> Path:
-    repo_path = lexical_repository_path(repo_path)
-    manifest_root = lexical_directory_path(manifest_root)
-    output_dir = lexical_directory_path(output_dir)
+) -> None:
+    """Reject either direction of overlap with a protected source root."""
+
     for source, label in (
         (repo_path, "target repository"),
         (manifest_root, "index root"),
@@ -796,6 +796,41 @@ def _validated_output(
             raise ValueError(f"static export output must be outside the {label}")
         if output_dir in source.parents:
             raise ValueError(f"static export output must not contain the {label}")
+
+
+def _validated_output(
+    repo_path: Path,
+    manifest_path: Path,
+    output_dir: Path,
+) -> Path:
+    repo_path = lexical_repository_path(repo_path)
+    manifest_path = Path(os.path.abspath(os.fspath(manifest_path.expanduser())))
+    manifest_root = lexical_directory_path(manifest_path.parent)
+    output_dir = lexical_directory_path(output_dir)
+    _reject_output_overlap(
+        output_dir,
+        repo_path=repo_path,
+        manifest_root=manifest_root,
+    )
+
+    # Canonical names are a rejection-only cross-check for symlink aliases. The
+    # lexical paths above remain the paths used for every later read, authority
+    # capture, and publication; a resolved name never grants access or redirects
+    # the output. Resolve the manifest file itself so both a directory alias and
+    # a terminal manifest-file alias identify the physical index root.
+    try:
+        physical_repo_path = repo_path.resolve(strict=True)
+        physical_manifest_root = manifest_path.resolve(strict=True).parent
+        physical_output_dir = output_dir.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError(
+            "static export paths could not be checked for physical overlap"
+        ) from exc
+    _reject_output_overlap(
+        physical_output_dir,
+        repo_path=physical_repo_path,
+        manifest_root=physical_manifest_root,
+    )
     return output_dir
 
 
@@ -849,7 +884,7 @@ def export_static_wiki(
     output_dir = lexical_directory_path(output_dir)
     output_dir = _validated_output(
         repo_path,
-        manifest_path.parent,
+        manifest_path,
         output_dir,
     )
     base_path = normalize_base_path(base_path)

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import logging
 import os
 import re
 import subprocess
@@ -18,8 +17,8 @@ from typing import Any, Iterable, Mapping
 from urllib.parse import quote, unquote, urlsplit
 
 from .._atomic_directory import (
-    DirectoryOrphan,
     PublicationDirectoryReader,
+    _annotate_secondary_error,
     capture_directory_ownership,
     directory_ownership_file_records,
     lexical_directory_path,
@@ -38,26 +37,6 @@ from .local import prepare_local_wiki
 
 STATIC_EXPORT_SCHEMA_VERSION = "1.0"
 STATIC_EXPORT_MANIFEST = "codenib-static.json"
-logger = logging.getLogger(__name__)
-
-
-def _record_publication_orphan(
-    orphan: DirectoryOrphan | None,
-    *,
-    operation: str,
-) -> None:
-    if orphan is None:
-        return
-    logger.warning(
-        "Static export %s retained an orphan for quiescent GC: "
-        "path=%s digest=%s entries=%d bytes=%d verified=%s",
-        operation,
-        orphan.path,
-        orphan.ownership_digest,
-        orphan.entries,
-        orphan.byte_count,
-        orphan.verified_at_isolation,
-    )
 
 
 _DOCUMENT_BASE_RE = re.compile(r"<base\s+[^>]*href=(['\"])[^'\"]*\1[^>]*>", re.I)
@@ -1009,14 +988,20 @@ def export_static_wiki(
                     "published static export differs from its staged identity"
                 )
 
-        publication_orphan = stage.publish(
+        stage.publish(
             validate_staged_directory=validate_export,
             validate_published_destination=validate_export,
         )
-        _record_publication_orphan(publication_orphan, operation="publication")
         manifest_file = output_dir.joinpath(*manifest_file.parts)
-    except BaseException:
-        _record_publication_orphan(stage.discard(), operation="discard")
+    except BaseException as primary_error:
+        try:
+            stage.discard()
+        except BaseException as discard_error:  # noqa: B036 - preserve primary
+            _annotate_secondary_error(
+                primary_error,
+                "static export stage discard also failed",
+                discard_error,
+            )
         raise
 
     return StaticExportResult(

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -6,35 +6,59 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import logging
 import os
 import re
-import shutil
 import subprocess
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping
 from urllib.parse import quote, unquote, urlsplit
 
 from .._atomic_directory import (
+    DirectoryOrphan,
     PublicationDirectoryReader,
-    _annotate_secondary_error,
     capture_directory_ownership,
-    directory_ownership_root_identity,
-    discard_owned_directory,
+    directory_ownership_file_records,
     lexical_directory_path,
-    publish_staged_directory,
+    reopen_authenticated_directory,
 )
+from .._captured_directory import OwnedDirectoryStage
 from .._version import package_version
-from ..artifacts.security import assert_publishable_tree, file_sha256
+from ..artifacts.security import (
+    assert_publishable_tree_reader,
+)
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
+from ..source_fingerprint import lexical_repository_path
 from .launcher import find_frontend_dir
 from .local import prepare_local_wiki
 
 STATIC_EXPORT_SCHEMA_VERSION = "1.0"
 STATIC_EXPORT_MANIFEST = "codenib-static.json"
+logger = logging.getLogger(__name__)
+
+
+def _record_publication_orphan(
+    orphan: DirectoryOrphan | None,
+    *,
+    operation: str,
+) -> None:
+    if orphan is None:
+        return
+    logger.warning(
+        "Static export %s retained an orphan for quiescent GC: "
+        "path=%s digest=%s entries=%d bytes=%d verified=%s",
+        operation,
+        orphan.path,
+        orphan.ownership_digest,
+        orphan.entries,
+        orphan.byte_count,
+        orphan.verified_at_isolation,
+    )
+
 
 _DOCUMENT_BASE_RE = re.compile(r"<base\s+[^>]*href=(['\"])[^'\"]*\1[^>]*>", re.I)
 _DOCUMENT_REFERENCE_RE = re.compile(
@@ -53,6 +77,10 @@ _GRAPH_SOURCE_PAGE_MAX_BYTES = 1024 * 1024
 _GRAPH_SOURCE_MAX_ANCHORS = 64
 _GRAPH_NODE_CONTEXT_LINES = 3
 _GRAPH_ANCHOR_CONTEXT_LINES = 6
+_MAX_FRONTEND_FILES = 100_000
+_MAX_FRONTEND_BYTES = 2 * 1024 * 1024 * 1024
+_MAX_FRONTEND_FILE_BYTES = 256 * 1024 * 1024
+_MAX_FRONTEND_INDEX_BYTES = 16 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,17 +130,27 @@ def _json_bytes(value: Any) -> bytes:
     ).encode("utf-8")
 
 
-def _write_bytes(root: Path, relative: str, content: bytes) -> Path:
-    target = root.joinpath(*PurePosixPath(relative).parts).resolve()
-    if root != target and root not in target.parents:
-        raise ValueError(f"export path escapes the output directory: {relative}")
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_bytes(content)
-    return target
+def _write_bytes(
+    stage: OwnedDirectoryStage,
+    relative: str,
+    content: bytes,
+) -> PurePosixPath:
+    normalized = PurePosixPath(relative)
+    stage.write_file(
+        normalized,
+        (content,),
+        mode=0o644,
+        max_bytes=len(content),
+    )
+    return normalized
 
 
-def _write_json(root: Path, relative: str, value: Any) -> Path:
-    return _write_bytes(root, relative, _json_bytes(value))
+def _write_json(
+    stage: OwnedDirectoryStage,
+    relative: str,
+    value: Any,
+) -> PurePosixPath:
+    return _write_bytes(stage, relative, _json_bytes(value))
 
 
 def _model_dict(value: Any) -> dict[str, Any]:
@@ -508,14 +546,11 @@ def _prebuilt_frontend(explicit: str | os.PathLike[str] | None) -> Path:
     return frontend
 
 
-def _copy_frontend(source: Path, target: Path, *, base_path: str) -> None:
-    for candidate in source.rglob("*"):
-        if candidate.is_symlink():
-            raise ValueError(f"frontend contains a symbolic link: {candidate}")
-    shutil.copytree(source, target, dirs_exist_ok=True)
-
-    index = target / "index.html"
-    index_text = index.read_text(encoding="utf-8")
+def _mounted_frontend_index(payload: bytes, *, base_path: str) -> bytes:
+    try:
+        index_text = payload.decode("utf-8", errors="strict")
+    except UnicodeError as exc:
+        raise ValueError("prebuilt frontend index.html must be UTF-8") from exc
     index_text = _DOCUMENT_BASE_RE.sub("", index_text)
 
     def mount_reference(match: re.Match[str]) -> str:
@@ -553,7 +588,73 @@ def _copy_frontend(source: Path, target: Path, *, base_path: str) -> None:
         )
 
     index_text = _DOCUMENT_REFERENCE_RE.sub(mount_reference, index_text)
-    index.write_text(index_text, encoding="utf-8")
+    return index_text.encode("utf-8")
+
+
+def _copy_frontend(
+    source: Path,
+    stage: OwnedDirectoryStage,
+    *,
+    base_path: str,
+) -> None:
+    file_count = 0
+    byte_count = 0
+
+    def entry_policy(path: str, kind: str, mode: int, size: int) -> None:
+        nonlocal file_count, byte_count
+        del mode
+        if kind != "file":
+            return
+        file_count += 1
+        byte_count += size
+        if file_count > _MAX_FRONTEND_FILES:
+            raise ValueError(f"prebuilt frontend exceeds {_MAX_FRONTEND_FILES} files")
+        if size > _MAX_FRONTEND_FILE_BYTES or byte_count > _MAX_FRONTEND_BYTES:
+            raise ValueError("prebuilt frontend exceeds its bounded byte budget")
+        if path == "index.html" and size > _MAX_FRONTEND_INDEX_BYTES:
+            raise ValueError("prebuilt frontend index.html exceeds its byte limit")
+
+    ownership = capture_directory_ownership(
+        source,
+        required_root_file="index.html",
+        entry_policy=entry_policy,
+    )
+
+    def copy(reader: PublicationDirectoryReader) -> None:
+        for record in reader.file_records():
+            if record.path in {"runtime-config.js", "404.html"}:
+                continue
+            if record.path == STATIC_EXPORT_MANIFEST or record.path.startswith("data/"):
+                raise ValueError(
+                    f"prebuilt frontend collides with generated export data: "
+                    f"{record.path}"
+                )
+            mode = 0o755 if record.mode & 0o111 else 0o644
+            if record.path == "index.html":
+                payload = reader.read_bytes(
+                    record.path,
+                    max_bytes=_MAX_FRONTEND_INDEX_BYTES,
+                )
+                mounted = _mounted_frontend_index(payload, base_path=base_path)
+                stage.write_file(
+                    record.path,
+                    (mounted,),
+                    mode=mode,
+                    max_bytes=_MAX_FRONTEND_INDEX_BYTES,
+                )
+                continue
+            with reader.open_authenticated_file(
+                record.path,
+                max_bytes=_MAX_FRONTEND_FILE_BYTES,
+            ) as source_file:
+                stage.write_file(
+                    record.path,
+                    source_file.iter_bytes(chunk_size=1024 * 1024),
+                    mode=mode,
+                    max_bytes=record.size,
+                )
+
+    reopen_authenticated_directory(source, ownership, copy)
 
 
 def _runtime_config(base_path: str) -> bytes:
@@ -696,34 +797,29 @@ def _generation_summary(pages: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _file_inventory(root: Path) -> list[dict[str, Any]]:
-    files = []
-    for path in sorted(root.rglob("*")):
-        if not path.is_file() or path == root / STATIC_EXPORT_MANIFEST:
-            continue
-        size, digest = file_sha256(path)
-        files.append(
-            {
-                "path": path.relative_to(root).as_posix(),
-                "bytes": size,
-                "sha256": digest,
-            }
+def _file_inventory(ownership: object) -> list[dict[str, Any]]:
+    return [
+        {
+            "path": record.path,
+            "bytes": record.size,
+            "sha256": record.sha256,
+        }
+        for record in sorted(
+            directory_ownership_file_records(ownership),  # type: ignore[arg-type]
+            key=lambda item: PurePosixPath(item.path),
         )
-    return files
+        if record.path != STATIC_EXPORT_MANIFEST
+    ]
 
 
 def _validated_output(
     repo_path: Path,
     manifest_root: Path,
     output_dir: Path,
-) -> tuple[Path, object | None]:
-    repo_path = repo_path.resolve()
-    manifest_root = manifest_root.resolve()
+) -> Path:
+    repo_path = lexical_repository_path(repo_path)
+    manifest_root = lexical_directory_path(manifest_root)
     output_dir = lexical_directory_path(output_dir)
-    if output_dir.is_symlink():
-        raise ValueError(
-            f"static export output must not be a symbolic link: {output_dir}"
-        )
     for source, label in (
         (repo_path, "target repository"),
         (manifest_root, "index root"),
@@ -732,24 +828,7 @@ def _validated_output(
             raise ValueError(f"static export output must be outside the {label}")
         if output_dir in source.parents:
             raise ValueError(f"static export output must not contain the {label}")
-    if output_dir.exists() and not output_dir.is_dir():
-        raise ValueError(f"static export output is not a directory: {output_dir}")
-    try:
-        expected_ownership = (
-            capture_directory_ownership(
-                output_dir,
-                required_root_file=STATIC_EXPORT_MANIFEST,
-                allow_empty_root=True,
-            )
-            if output_dir.exists()
-            else None
-        )
-    except RuntimeError as exc:
-        raise ValueError(
-            "refusing to replace a non-empty directory that is not a CodeNib "
-            f"static export: {output_dir}"
-        ) from exc
-    return output_dir, expected_ownership
+    return output_dir
 
 
 def export_static_wiki(
@@ -763,9 +842,10 @@ def export_static_wiki(
 ) -> StaticExportResult:
     """Build a deterministic static Wiki from an existing repository manifest."""
 
-    repo_path = repo_path.expanduser().resolve()
-    manifest_path = manifest_path.expanduser().resolve()
-    output_dir, expected_output_ownership = _validated_output(
+    repo_path = lexical_repository_path(repo_path)
+    manifest_path = Path(os.path.abspath(os.fspath(manifest_path.expanduser())))
+    output_dir = lexical_directory_path(output_dir)
+    output_dir = _validated_output(
         repo_path,
         manifest_path.parent,
         output_dir,
@@ -818,19 +898,17 @@ def export_static_wiki(
     repo_info["incremental"] = None
     repo_info["source_url"] = _github_repository_url(repo_path)
 
-    output_dir.parent.mkdir(parents=True, exist_ok=True)
-    stage = lexical_directory_path(
-        Path(
-            tempfile.mkdtemp(
-                prefix=f".{output_dir.name}.tmp-",
-                dir=str(output_dir.parent),
-            )
+    try:
+        stage = OwnedDirectoryStage.prepare(
+            output_dir,
+            required_destination_file=STATIC_EXPORT_MANIFEST,
+            allow_empty_destination=True,
         )
-    )
-    stage_root_ownership = capture_directory_ownership(stage)
-    initial_stage_root_identity = directory_ownership_root_identity(
-        stage_root_ownership
-    )
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(
+            "refusing to replace a non-empty directory that is not a CodeNib "
+            f"static export: {output_dir}"
+        ) from exc
     try:
         _copy_frontend(frontend, stage, base_path=base_path)
         _write_bytes(stage, "runtime-config.js", _runtime_config(base_path))
@@ -858,13 +936,8 @@ def export_static_wiki(
                 graphs[page_id],
             )
 
-        assert_publishable_tree(
-            stage,
-            forbidden_paths=(repo_path, manifest_path.parent),
-            environ=environment,
-            label="static export",
-        )
         source_manifest = bundle.manifest
+        staged_payload_ownership = stage.capture_ownership()
         export_manifest = {
             "schema_version": STATIC_EXPORT_SCHEMA_VERSION,
             "repository": {
@@ -894,55 +967,27 @@ def export_static_wiki(
             "capabilities": capabilities,
             "generation": _generation_summary(pages),
             "base_path": base_path,
-            "files": _file_inventory(stage),
+            "files": _file_inventory(staged_payload_ownership),
         }
         manifest_file = _write_json(stage, STATIC_EXPORT_MANIFEST, export_manifest)
-        assert_publishable_tree(
-            stage,
-            forbidden_paths=(repo_path, manifest_path.parent),
-            environ=environment,
-            label="static export",
-        )
 
         expected_manifest_bytes = _json_bytes(export_manifest)
 
-        def validate_export_path(candidate: Path) -> None:
-            assert_publishable_tree(
+        expected_manifest_digest = hashlib.sha256(expected_manifest_bytes).hexdigest()
+
+        def validate_export(candidate: PublicationDirectoryReader) -> None:
+            assert_publishable_tree_reader(
                 candidate,
                 forbidden_paths=(repo_path, manifest_path.parent),
                 environ=environment,
                 label="static export",
             )
-            candidate_manifest = candidate / STATIC_EXPORT_MANIFEST
-            if (
-                not candidate_manifest.is_file()
-                or candidate_manifest.read_bytes() != expected_manifest_bytes
-                or _file_inventory(candidate) != export_manifest["files"]
-            ):
-                raise ValueError(
-                    "published static export differs from its staged identity"
-                )
-
-        # Carry the path validators' result across publication with one exact
-        # full-tree token. Publication callbacks receive a retained reader and
-        # must never reopen the staged or published path.
-        validate_export_path(stage)
-        publication_ownership = capture_directory_ownership(stage)
-        if (
-            directory_ownership_root_identity(publication_ownership)
-            != initial_stage_root_identity
-        ):
-            raise RuntimeError("static export stage root changed during build")
-        stage_root_ownership = publication_ownership
-        expected_manifest_size, expected_manifest_digest = file_sha256(manifest_file)
-
-        def validate_export(candidate: PublicationDirectoryReader) -> None:
             records = candidate.file_records()
             candidate_manifest = next(
                 (record for record in records if record.path == STATIC_EXPORT_MANIFEST),
                 None,
             )
-            actual_files = [
+            candidate_files = [
                 {
                     "path": record.path,
                     "bytes": record.size,
@@ -956,50 +1001,22 @@ def export_static_wiki(
             ]
             if (
                 candidate_manifest is None
-                or candidate_manifest.size != expected_manifest_size
+                or candidate_manifest.size != len(expected_manifest_bytes)
                 or candidate_manifest.sha256 != expected_manifest_digest
-                or candidate.read_bytes(
-                    STATIC_EXPORT_MANIFEST,
-                    max_bytes=expected_manifest_size,
-                )
-                != expected_manifest_bytes
-                or actual_files != export_manifest["files"]
+                or candidate_files != export_manifest["files"]
             ):
                 raise ValueError(
                     "published static export differs from its staged identity"
                 )
 
-        publish_staged_directory(
-            stage,
-            output_dir,
-            expected_stage_root_ownership=stage_root_ownership,
-            expected_destination_ownership=expected_output_ownership,
+        publication_orphan = stage.publish(
             validate_staged_directory=validate_export,
             validate_published_destination=validate_export,
         )
-        manifest_file = output_dir / manifest_file.relative_to(stage)
-    except BaseException as primary_error:
-        try:
-            observed_stage_ownership = capture_directory_ownership(stage)
-            if (
-                directory_ownership_root_identity(observed_stage_ownership)
-                == initial_stage_root_identity
-            ):
-                stage_root_ownership = observed_stage_ownership
-        except BaseException as capture_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "static export stage cleanup capture also failed",
-                capture_error,
-            )
-        try:
-            discard_owned_directory(stage, stage_root_ownership)
-        except BaseException as discard_error:  # noqa: B036 - preserve primary
-            _annotate_secondary_error(
-                primary_error,
-                "static export stage discard also failed",
-                discard_error,
-            )
+        _record_publication_orphan(publication_orphan, operation="publication")
+        manifest_file = output_dir.joinpath(*manifest_file.parts)
+    except BaseException:
+        _record_publication_orphan(stage.discard(), operation="discard")
         raise
 
     return StaticExportResult(

--- a/codenib/wiki/builder.py
+++ b/codenib/wiki/builder.py
@@ -15,10 +15,13 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
-from ..repository_summary import read_repository_summary
+from ..repository_summary import read_bound_repository_summary, read_repository_summary
 from .narrator import Narrator
+
+if TYPE_CHECKING:
+    from ..source_fingerprint import RepositorySourceReader
 
 # Symbol chunk types worth surfacing as "components" (mirrors SYMBOL_CHUNK_TYPES).
 _CONTAINER_TYPES = {
@@ -48,6 +51,7 @@ _LANG_FENCE = {
 _MAX_MODULES = 12
 _MAX_SYMBOLS_PER_PAGE = 12
 _MAX_SNIPPET_LINES = 28
+_MAX_BOUND_SOURCE_BYTES = 8 * 1024 * 1024
 _SUPPORTING_AREA_SEGMENTS = {
     "benchmark",
     "benchmarks",
@@ -154,12 +158,19 @@ def _representative_symbol(symbols: List[Symbol]) -> Symbol:
 class WikiBuilder:
     """Build wiki structure + content for one loaded repo bundle."""
 
-    def __init__(self, bundle, narrator: Optional[Narrator] = None) -> None:
+    def __init__(
+        self,
+        bundle,
+        narrator: Optional[Narrator] = None,
+        *,
+        source_reader: Optional[RepositorySourceReader] = None,
+    ) -> None:
         # bundle: codenib.web.repo_registry.RepoBundle
         self._bundle = bundle
         self._entry = bundle.entry
         self._language = bundle.entry.language
         self._narrator = narrator or Narrator(enabled=False)
+        self._source_reader = source_reader
         self._symbols_cache: Optional[tuple] = None
         self._project_summary_cache: Optional[str] = None
 
@@ -239,17 +250,55 @@ class WikiBuilder:
         start_line: int,
         end_line: int,
         fallback: str,
-        cache: Dict[str, Optional[tuple[str, ...]]],
+        cache: Dict[object, Optional[tuple[str, ...]]],
     ) -> str:
         """Read a bounded indexed span from the current repository checkout."""
 
-        repo_root = os.path.realpath(self._entry.repo_dir)
-        source_path = os.path.realpath(os.path.join(repo_root, file))
-        try:
-            if os.path.commonpath((repo_root, source_path)) != repo_root:
+        if self._source_reader is not None:
+            relative = self._source_reader.captured_relative_path(file)
+            if relative is None:
+                raise ValueError(
+                    "indexed source path is absent from the authenticated repository"
+                )
+            source_path = relative
+        else:
+            repo_root = os.path.realpath(self._entry.repo_dir)
+            source_path = os.path.realpath(os.path.join(repo_root, file))
+            try:
+                if os.path.commonpath((repo_root, source_path)) != repo_root:
+                    return fallback
+            except ValueError:
                 return fallback
-        except ValueError:
-            return fallback
+
+        if self._source_reader is not None:
+            if start_line < 0:
+                raise ValueError("indexed source range has a negative start line")
+            stop_line = min(
+                max(start_line + 1, end_line + 1),
+                start_line + _MAX_SNIPPET_LINES,
+            )
+            cache_key = (source_path, start_line, stop_line)
+            if cache_key not in cache:
+                payload = self._source_reader.read_line_range(
+                    source_path,
+                    start_line=start_line + 1,
+                    end_line=stop_line,
+                    max_bytes=_MAX_BOUND_SOURCE_BYTES,
+                )
+                cache[cache_key] = tuple(
+                    payload.decode("utf-8", errors="replace").splitlines()
+                )
+            lines = cache[cache_key]
+            if not lines:
+                raise ValueError(
+                    "indexed source range is absent from the authenticated file"
+                )
+            excerpt = "\n".join(lines)
+            if not excerpt.strip():
+                raise ValueError(
+                    "indexed source range has no authenticated source content"
+                )
+            return excerpt
 
         if source_path not in cache:
             try:
@@ -306,14 +355,23 @@ class WikiBuilder:
             )
         if not raw:
             return tuple()
-        root = self._index_root(raw[0][0])
+        root = self._index_root(raw[0][0]) if self._source_reader is None else ""
         prefix = (root + "/") if root else ""
-        source_cache: Dict[str, Optional[tuple[str, ...]]] = {}
+        source_cache: Dict[object, Optional[tuple[str, ...]]] = {}
         syms = []
         for f, name, symbol_type, start, end, content in raw:
-            relative_file = (
-                f[len(prefix) :] if prefix and f.startswith(prefix) else f.lstrip("/")
-            )
+            if self._source_reader is not None:
+                relative_file = self._source_reader.captured_relative_path(f)
+                if relative_file is None:
+                    raise ValueError(
+                        "indexed source path is absent from the authenticated repository"
+                    )
+            else:
+                relative_file = (
+                    f[len(prefix) :]
+                    if prefix and f.startswith(prefix)
+                    else f.lstrip("/")
+                )
             syms.append(
                 Symbol(
                     file=relative_file,
@@ -375,20 +433,25 @@ class WikiBuilder:
         if self._project_summary_cache is not None:
             return self._project_summary_cache
 
-        description = getattr(self._bundle, "_description", None)
-        if callable(description):
-            try:
-                summary = str(description() or "").strip()
-            except OSError:
-                summary = ""
-            if summary:
-                self._project_summary_cache = summary
-                return summary
+        if self._source_reader is None:
+            description = getattr(self._bundle, "_description", None)
+            if callable(description):
+                try:
+                    summary = str(description() or "").strip()
+                except OSError:
+                    summary = ""
+                if summary:
+                    self._project_summary_cache = summary
+                    return summary
 
         # Keep the index-derived builder useful with lightweight bundle objects
         # as well as RepoBundle. The parser rejects badges, headings, and
         # installation boilerplate rather than treating them as project purpose.
-        summary = read_repository_summary(self._entry.repo_dir)
+        summary = (
+            read_bound_repository_summary(self._source_reader)
+            if self._source_reader is not None
+            else read_repository_summary(self._entry.repo_dir)
+        )
         self._project_summary_cache = summary
         return summary
 
@@ -825,6 +888,36 @@ class WikiBuilder:
     def source(
         self, file: str, start: Optional[int] = None, end: Optional[int] = None
     ) -> Optional[dict]:
+        if self._source_reader is not None:
+            relative = self._source_reader.captured_relative_path(file)
+            if relative is None:
+                return None
+            if start is not None and end is not None:
+                first = max(1, start)
+                last = max(first - 1, end)
+            else:
+                first = 1
+                last = 400
+            if last < first:
+                content = b""
+            else:
+                try:
+                    content = self._source_reader.read_line_range(
+                        relative,
+                        start_line=first,
+                        end_line=last,
+                        max_bytes=_MAX_BOUND_SOURCE_BYTES,
+                    )
+                except ValueError:
+                    return None
+            chunk = content.decode("utf-8", errors="replace").splitlines(keepends=True)
+            return {
+                "file": relative,
+                "start_line": first,
+                "end_line": first + len(chunk) - 1,
+                "content": "".join(chunk),
+            }
+
         repo_dir = self._entry.repo_dir
         root = os.path.realpath(repo_dir)
         if os.path.isabs(file):

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -313,21 +313,27 @@ generation, authenticates the prebuilt frontend before copying it, and checks
 the complete staged and published inventories through callback-scoped readers.
 Source-derived pages, summaries, and graph metadata are read through one
 retained source-fingerprint-v2 binding and reverified before the directory
-swap. The compatibility export uses an explicit lexical repository label and
-omits ambient Git-origin provenance. Frontend, generated metadata, manifest
-identities, and JSON lexical/DOM
-complexity are bounded before the rename; retained JSON uses UTF-8 without a
-BOM so every backend observes one portable encoding. Failures retain only an
-ownership-described orphan for later quiescent reclamation instead of
-recursively deleting an online path. This is still a local compatibility
-publication path, not a catalog receipt.
+swap. Legacy build-machine absolute citations can be rerooted only through the
+longest exact suffix in the frozen source inventory, and bounded line excerpts
+recognize LF, CRLF, and CR while authenticating the complete file. The
+compatibility export uses an explicit lexical repository label and omits
+ambient Git-origin provenance. Index-manifest and output roots are checked for
+both lexical and rejection-only canonical overlap, without using a resolved
+path to authorize a read or publication. Frontend, generated metadata,
+manifest identities, and JSON lexical/DOM complexity are bounded before the
+rename; retained JSON uses UTF-8 without a BOM so every backend observes one
+portable encoding. Failures retain only an ownership-described orphan for
+later quiescent reclamation instead of recursively deleting an online path.
+This is still a local compatibility publication path, not a catalog receipt.
 `StrictWorkspaceProvider` builds on the foundation with a callback-scoped
 contract for a trusted provider to supply a pre-opened
 `OwnedWorkspaceAuthority`, exact workspace plan, destination expectation, and
 retained publication receipt owner. Session writes, validation, publication,
 and revocation share one cancellation-safe gate so a provider callback cannot
-publish after it escapes. No production provider or BM25/context producer is
-wired to that strict contract yet, so M1 remains in progress.
+publish after it escapes. The gate records the exact callback result or
+`BaseException`; a provider cannot substitute its return value or swallow a
+callback failure. No production provider or BM25/context producer is wired to
+that strict contract yet, so M1 remains in progress.
 
 Schema v2 now adds
 canonical idempotent job requests, immutable

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -311,15 +311,23 @@ the catalog-backed M2 generation coordinator or durable worker wiring.
 Static Wiki export now writes through one bounded `OwnedDirectoryStage`
 generation, authenticates the prebuilt frontend before copying it, and checks
 the complete staged and published inventories through callback-scoped readers.
-Frontend, generated metadata, and manifest identities are bounded before the
-rename; failures retain only an ownership-described orphan for later
-quiescent reclamation instead of recursively deleting an online path. This is
-still a local compatibility publication path, not a catalog receipt.
+Source-derived pages, summaries, and graph metadata are read through one
+retained source-fingerprint-v2 binding and reverified before the directory
+swap. The compatibility export uses an explicit lexical repository label and
+omits ambient Git-origin provenance. Frontend, generated metadata, manifest
+identities, and JSON lexical/DOM
+complexity are bounded before the rename; retained JSON uses UTF-8 without a
+BOM so every backend observes one portable encoding. Failures retain only an
+ownership-described orphan for later quiescent reclamation instead of
+recursively deleting an online path. This is still a local compatibility
+publication path, not a catalog receipt.
 `StrictWorkspaceProvider` builds on the foundation with a callback-scoped
 contract for a trusted provider to supply a pre-opened
 `OwnedWorkspaceAuthority`, exact workspace plan, destination expectation, and
-retained publication receipt owner. No production provider or BM25/context
-producer is wired to that strict contract yet, so M1 remains in progress.
+retained publication receipt owner. Session writes, validation, publication,
+and revocation share one cancellation-safe gate so a provider callback cannot
+publish after it escapes. No production provider or BM25/context producer is
+wired to that strict contract yet, so M1 remains in progress.
 
 Schema v2 now adds
 canonical idempotent job requests, immutable

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -308,6 +308,19 @@ captured vector tree. These compatibility and publication gates preserve the
 previous complete vector generation on interruption, but they do not complete
 the catalog-backed M2 generation coordinator or durable worker wiring.
 
+Static Wiki export now writes through one bounded `OwnedDirectoryStage`
+generation, authenticates the prebuilt frontend before copying it, and checks
+the complete staged and published inventories through callback-scoped readers.
+Frontend, generated metadata, and manifest identities are bounded before the
+rename; failures retain only an ownership-described orphan for later
+quiescent reclamation instead of recursively deleting an online path. This is
+still a local compatibility publication path, not a catalog receipt.
+`StrictWorkspaceProvider` builds on the foundation with a callback-scoped
+contract for a trusted provider to supply a pre-opened
+`OwnedWorkspaceAuthority`, exact workspace plan, destination expectation, and
+retained publication receipt owner. No production provider or BM25/context
+producer is wired to that strict contract yet, so M1 remains in progress.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/test/artifacts/test_publish.py
+++ b/test/artifacts/test_publish.py
@@ -11,7 +11,16 @@ from pathlib import Path
 import pytest
 
 from codenib import cli
+from codenib._atomic_directory import (
+    PublicationDirectoryReader,
+    capture_directory_ownership,
+    reopen_authenticated_directory,
+)
 from codenib.artifacts import CONTEXT_ARTIFACT_MANIFEST
+from codenib.artifacts.security import (
+    assert_publishable_json_value,
+    assert_publishable_tree_reader,
+)
 from codenib.compiler.index_compiler import IndexCompiler
 from codenib.paths import repo_index_dir
 from codenib.web.static_export import STATIC_EXPORT_MANIFEST
@@ -340,3 +349,76 @@ def test_publication_environment_marks_custom_embedding_key_as_secret(
     assert environment["CODENIB_PUBLICATION_CREDENTIAL_SECRET"] == (
         "runtime-secret-value"
     )
+
+
+@pytest.mark.parametrize("value", [12345678, 12345678.0])
+def test_publishability_scans_canonical_numeric_scalars(value: object) -> None:
+    with pytest.raises(ValueError, match="configured credential"):
+        assert_publishable_json_value(
+            {"innocent": value},
+            forbidden_paths=(),
+            environ={"MY_TOKEN": "12345678"},
+            label="numeric config",
+        )
+
+
+def test_publishability_always_rejects_lexical_path_when_resolve_is_redirected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lexical = tmp_path / "owned-repository"
+    foreign = tmp_path / "foreign-repository"
+    real_resolve = Path.resolve
+
+    def redirected_resolve(path: Path, *args: object, **kwargs: object) -> Path:
+        if path == lexical:
+            return foreign
+        return real_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", redirected_resolve)
+
+    with pytest.raises(ValueError, match="absolute build-machine path"):
+        assert_publishable_json_value(
+            {"path": str(lexical)},
+            forbidden_paths=(lexical,),
+            environ={},
+            label="redirected config",
+        )
+
+
+@pytest.mark.parametrize("relative", ["config.json", "note.txt"])
+def test_publishability_reader_rejects_lexical_path_when_resolve_is_redirected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    relative: str,
+) -> None:
+    lexical = tmp_path / "owned-repository"
+    foreign = tmp_path / "foreign-repository"
+    root = tmp_path / "publishable"
+    root.mkdir()
+    payload = (
+        json.dumps({"path": str(lexical)})
+        if relative.endswith(".json")
+        else f"source={lexical}\n"
+    )
+    (root / relative).write_text(payload, encoding="utf-8")
+    ownership = capture_directory_ownership(root)
+    real_resolve = Path.resolve
+
+    def redirected_resolve(path: Path, *args: object, **kwargs: object) -> Path:
+        if path == lexical:
+            return foreign
+        return real_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", redirected_resolve)
+
+    def validate(reader: PublicationDirectoryReader) -> None:
+        assert_publishable_tree_reader(
+            reader,
+            forbidden_paths=(lexical,),
+            environ={},
+            label="redirected tree",
+        )
+
+    with pytest.raises(ValueError, match="absolute build-machine path"):
+        reopen_authenticated_directory(root, ownership, validate)

--- a/test/artifacts/test_publish.py
+++ b/test/artifacts/test_publish.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+import codenib.artifacts.security as security_module
 from codenib import cli
 from codenib._atomic_directory import (
     PublicationDirectoryReader,
@@ -422,3 +423,188 @@ def test_publishability_reader_rejects_lexical_path_when_resolve_is_redirected(
 
     with pytest.raises(ValueError, match="absolute build-machine path"):
         reopen_authenticated_directory(root, ownership, validate)
+
+
+def _validate_publishable_reader(
+    root: Path,
+    *,
+    environ: dict[str, str] | None = None,
+) -> None:
+    ownership = capture_directory_ownership(root)
+
+    def validate(reader: PublicationDirectoryReader) -> None:
+        assert_publishable_tree_reader(
+            reader,
+            forbidden_paths=(),
+            environ={} if environ is None else environ,
+            label="bounded publication",
+        )
+
+    reopen_authenticated_directory(root, ownership, validate)
+
+
+@pytest.mark.parametrize(
+    ("limit_name", "limit", "payload", "message"),
+    [
+        (
+            "_MAX_PUBLISHABLE_JSON_NODES",
+            4,
+            b'{"a":0,"b":1,"c":2,"d":3}',
+            "4-node limit",
+        ),
+        (
+            "_MAX_PUBLISHABLE_JSON_TOKENS",
+            4,
+            b'{"a":0,"b":1}',
+            "4-token limit",
+        ),
+        (
+            "_MAX_PUBLISHABLE_JSON_DEPTH",
+            3,
+            b'{"a":{"b":{"c":0}}}',
+            "3-level depth limit",
+        ),
+        (
+            "_MAX_PUBLISHABLE_JSON_KEY_BYTES",
+            4,
+            b'{"abcde":0}',
+            "key exceeding 4 bytes",
+        ),
+        (
+            "_MAX_PUBLISHABLE_JSON_STRING_BYTES",
+            4,
+            b'{"a":"12345"}',
+            "string exceeds its 4-byte limit",
+        ),
+        (
+            "_MAX_PUBLISHABLE_JSON_ATOM_BYTES",
+            4,
+            b'{"a":12345}',
+            "atom exceeds its 4-byte limit",
+        ),
+    ],
+)
+def test_publishability_reader_rejects_json_complexity_before_dom(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    limit_name: str,
+    limit: int,
+    payload: bytes,
+    message: str,
+) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    (root / "config.json").write_bytes(payload)
+    monkeypatch.setattr(security_module, limit_name, limit)
+
+    def forbidden_loads(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("lexical complexity must be rejected before DOM allocation")
+
+    monkeypatch.setattr(security_module.json, "loads", forbidden_loads)
+
+    with pytest.raises(ValueError, match=message):
+        _validate_publishable_reader(root)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [b"{}", b"[]", b'"scalar"', b"7", b"true", b"null"],
+)
+def test_publishability_reader_accepts_bounded_arbitrary_top_level_json(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    (root / "config.json").write_bytes(payload)
+
+    _validate_publishable_reader(root)
+
+
+def test_publishability_reader_decodes_utf8_before_strict_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    (root / "config.json").write_bytes('{"value":"雪"}'.encode("utf-8"))
+    real_loads = json.loads
+    observed: list[str] = []
+
+    def observe_loads(serialized: str, **kwargs: object) -> object:
+        assert type(serialized) is str
+        observed.append(serialized)
+        return real_loads(serialized, **kwargs)
+
+    monkeypatch.setattr(security_module.json, "loads", observe_loads)
+
+    _validate_publishable_reader(root)
+
+    assert observed == ['{"value":"雪"}']
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(b"\xef\xbb\xbf0", id="utf-8-bom"),
+        pytest.param("0".encode("utf-16"), id="utf-16-bom"),
+        pytest.param("0".encode("utf-16-le"), id="utf-16-le"),
+        pytest.param("0".encode("utf-16-be"), id="utf-16-be"),
+        pytest.param("0".encode("utf-32"), id="utf-32-bom"),
+        pytest.param("0".encode("utf-32-le"), id="utf-32-le"),
+        pytest.param("0".encode("utf-32-be"), id="utf-32-be"),
+    ],
+)
+def test_publishability_reader_requires_utf8_without_bom(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    # Python's bytes decoder accepts these representations. Publication policy
+    # deliberately narrows that ambient behavior to one portable encoding.
+    assert json.loads(payload) == 0
+    root = tmp_path / "publication"
+    root.mkdir()
+    (root / "config.json").write_bytes(payload)
+
+    with pytest.raises(ValueError, match="UTF-8 without BOM required"):
+        _validate_publishable_reader(root)
+
+
+def test_publishability_reader_casefolds_json_suffix_before_validation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    (root / "CONFIG.JSON").write_text('{"safe":1,"\\u0073afe":2}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid JSON"):
+        _validate_publishable_reader(root)
+
+
+@pytest.mark.parametrize("payload", [b"NaN", b"Infinity", b"-Infinity"])
+def test_publishability_reader_preserves_nonfinite_json_rejection(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    (root / "config.json").write_bytes(payload)
+
+    with pytest.raises(ValueError, match="invalid JSON"):
+        _validate_publishable_reader(root)
+
+
+def test_publishability_reader_preserves_decoded_secret_rejection(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    (root / "config.json").write_text(
+        '{"value":"runtime-secret-value"}', encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="configured credential"):
+        _validate_publishable_reader(
+            root,
+            environ={"CUSTOM_TOKEN": "runtime-secret-value"},
+        )

--- a/test/test_bounded_json.py
+++ b/test/test_bounded_json.py
@@ -15,7 +15,11 @@ from pathlib import Path
 
 import pytest
 
-from codenib._bounded_json import canonical_json_array_chunks, iter_bounded_json_array
+from codenib._bounded_json import (
+    canonical_json_array_chunks,
+    iter_bounded_json_array,
+    validate_bounded_json_stream,
+)
 
 
 class _ChunkReader:
@@ -28,6 +32,98 @@ class _ChunkReader:
         block = self.payload[self.offset : self.offset + self.chunk_size]
         self.offset += len(block)
         return block
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [b'{"object":0}', b"[0,1]", b'"scalar"', b"7", b"true", b"null"],
+)
+def test_bounded_json_stream_accepts_arbitrary_top_level_values(
+    payload: bytes,
+) -> None:
+    validate_bounded_json_stream(io.BytesIO(payload), label="publication JSON")
+
+
+@pytest.mark.parametrize("block", [bytearray(b"{}"), "{}", None])
+def test_bounded_json_stream_rejects_non_bytes_reader_blocks(block: object) -> None:
+    class InvalidReader:
+        def read(self, _size: int = -1) -> object:
+            return block
+
+    with pytest.raises(ValueError, match="invalid or oversized block"):
+        validate_bounded_json_stream(InvalidReader(), label="publication JSON")
+
+
+def test_bounded_json_stream_rejects_oversized_reader_blocks() -> None:
+    class OversizedReader:
+        def read(self, size: int = -1) -> bytes:
+            assert size > 0
+            return b" " * (size + 1)
+
+    with pytest.raises(ValueError, match="invalid or oversized block"):
+        validate_bounded_json_stream(OversizedReader(), label="publication JSON")
+
+
+def test_bounded_json_stream_enforces_total_byte_limit() -> None:
+    with pytest.raises(ValueError, match="4-byte limit"):
+        validate_bounded_json_stream(
+            io.BytesIO(b'"1234"'),
+            label="publication JSON",
+            max_bytes=4,
+        )
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        (b'{"value":[', "truncated JSON"),
+        (b'{"value":[]]', "object value without a delimiter"),
+        (b"{} {}", "trailing data"),
+    ],
+)
+def test_bounded_json_stream_rejects_invalid_framing(
+    payload: bytes,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        validate_bounded_json_stream(io.BytesIO(payload), label="publication JSON")
+
+
+def test_bounded_json_stream_handles_strings_escapes_and_keys_across_blocks() -> None:
+    block_bytes = 1024 * 1024
+    long_string = b'"' + (b"s" * (block_bytes + 17)) + b'"'
+    escaped_string = b'"' + (b"e" * (block_bytes - 2)) + b"\\" + b'n-tail"'
+    long_key = b'{"' + (b"k" * (block_bytes + 17)) + b'":0}'
+    payloads = [
+        (long_string, {"max_key_bytes": 16}),
+        (escaped_string, {"max_key_bytes": 16}),
+        (long_key, {"max_key_bytes": block_bytes + 17}),
+    ]
+
+    for payload, limits in payloads:
+        validate_bounded_json_stream(
+            io.BytesIO(payload),
+            label="publication JSON",
+            max_bytes=len(payload),
+            max_string_bytes=len(payload),
+            **limits,
+        )
+
+    with pytest.raises(ValueError, match="string exceeds"):
+        validate_bounded_json_stream(
+            io.BytesIO(long_string),
+            label="publication JSON",
+            max_bytes=len(long_string),
+            max_string_bytes=block_bytes + 16,
+        )
+    with pytest.raises(ValueError, match="key exceeding"):
+        validate_bounded_json_stream(
+            io.BytesIO(long_key),
+            label="publication JSON",
+            max_bytes=len(long_key),
+            max_string_bytes=len(long_key),
+            max_key_bytes=block_bytes + 16,
+        )
 
 
 def test_bounded_array_handles_every_chunk_boundary() -> None:

--- a/test/test_captured_directory.py
+++ b/test/test_captured_directory.py
@@ -1363,6 +1363,8 @@ def test_preopened_workspace_writes_only_planned_files_without_mkdir(
             plan=plan,
             expected_destination=None,
         )
+        assert workspace.destination == destination
+        assert workspace.expected_destination_ownership is None
         root_record = workspace.write_file("root.bin", [b"root"])
         nested_record = workspace.write_file("nested/payload.bin", [b"payload"])
         ownership = workspace.seal()
@@ -2725,6 +2727,8 @@ def test_owned_workspace_existing_destination_receipt_retains_exact_orphan(
             plan=plan,
             expected_destination=expected_destination,
         )
+        assert workspace.destination == destination
+        assert workspace.expected_destination_ownership == expected_destination
         workspace.write_file("new", [b"new"])
         workspace.seal()
         receipt_owner = PublishedWorkspaceReceiptOwner()

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -251,6 +251,117 @@ def test_repository_source_binding_maps_only_captured_paths_and_reads_prefix(
         assert binding.read_prefix("pkg/source.py", max_bytes=6) == b"prefix"
 
 
+def test_repository_source_binding_reroots_only_frozen_absolute_suffixes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    for relative in (
+        "source.py",
+        "pkg/source.py",
+        "src/a.py",
+        "repo/src/a.py",
+        "one/shared.py",
+        "two/shared.py",
+    ):
+        source = repo / relative
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(relative, encoding="utf-8")
+
+    with capture_repository_source(repo) as binding:
+        with monkeypatch.context() as no_filesystem:
+            no_filesystem.setattr(
+                os.path,
+                "exists",
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("captured path lookup consulted the live filesystem")
+                ),
+            )
+            no_filesystem.setattr(
+                Path,
+                "exists",
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("captured path lookup consulted a Path")
+                ),
+            )
+            observed = (
+                binding.captured_relative_path("/old/build/machine/repo/pkg/source.py"),
+                binding.captured_relative_path(
+                    r"D:\agent\workspace\repo\pkg\source.py"
+                ),
+                binding.captured_relative_path(str(repo / "src/a.py")),
+                binding.captured_relative_path(f"{repo}/pkg/./source.py"),
+                binding.captured_relative_path(f"{repo}/pkg//source.py"),
+                binding.captured_relative_path(f"{repo}/pkg/../pkg/source.py"),
+                binding.captured_relative_path(f"{repo}/../repo/pkg/source.py"),
+                binding.captured_relative_path("prefix/pkg/source.py"),
+                binding.captured_relative_path("/old/pkg/../pkg/source.py"),
+                binding.captured_relative_path(r"C:pkg\source.py"),
+                binding.captured_relative_path("/old/build/missing.py"),
+                binding.captured_relative_path("/old/build/shared.py"),
+                binding.captured_relative_path("pkg/source.py\x00ignored"),
+                binding.captured_relative_path("\ud800"),
+                binding.captured_relative_path(
+                    "/" + "/".join(("part",) * 257) + "/pkg/source.py"
+                ),
+                binding.captured_relative_path("/" + ("x" * 4096) + "/pkg/source.py"),
+            )
+
+        assert observed == (
+            "pkg/source.py",
+            "pkg/source.py",
+            "src/a.py",
+            "pkg/source.py",
+            "pkg/source.py",
+            "pkg/source.py",
+            "pkg/source.py",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        with monkeypatch.context() as bounded_label:
+            bounded_label.setattr(
+                source_fingerprint_module.ntpath,
+                "splitdrive",
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("oversized source label reached path parsing")
+                ),
+            )
+            bounded_result = binding.captured_relative_path(
+                "/" + ("x" * (len(os.fsencode(repo)) + 4097))
+            )
+
+        assert bounded_result is None
+
+
+def test_repository_source_binding_keeps_deep_current_root_absolute_paths(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    relative = Path(*(("d",) * 255), "source.py")
+    source = repo / relative
+    source.parent.mkdir(parents=True)
+    source.write_text("deep", encoding="utf-8")
+
+    with capture_repository_source(repo) as binding:
+        expected = relative.as_posix()
+        assert len(relative.parts) == 256
+        assert binding.captured_relative_path(expected) == expected
+        assert binding.captured_relative_path(str(source)) == expected
+        assert (
+            binding.captured_relative_path(
+                "\\\\server\\share\\" + str(relative).replace("/", "\\")
+            )
+            == expected
+        )
+
+
 def test_repository_source_prefix_authenticates_bytes_beyond_returned_prefix(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -310,6 +421,128 @@ def test_repository_source_reader_streams_far_line_range_and_is_borrowed(
     binding.close()
     with pytest.raises(RuntimeError, match="closed|poisoned"):
         reader.captured_relative_path("source.py")
+
+
+@pytest.mark.parametrize(
+    ("separator", "expected"),
+    [
+        (b"\n", b"two\n"),
+        (b"\r\n", b"two\r\n"),
+        (b"\r", b"two\r"),
+    ],
+)
+def test_repository_source_line_range_supports_universal_newlines(
+    tmp_path: Path,
+    separator: bytes,
+    expected: bytes,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_bytes(separator.join((b"one", b"two", b"three")))
+
+    with capture_repository_source(repo) as binding:
+        assert (
+            binding.read_line_range(
+                "source.py",
+                start_line=2,
+                end_line=2,
+                max_bytes=32,
+            )
+            == expected
+        )
+
+
+def test_authenticated_line_range_handles_crlf_across_chunks() -> None:
+    chunks = (b"one\r", b"\ntwo\r", b"three\n")
+    authenticated = source_fingerprint_module._AuthenticatedLineRange(2, 2, 32)
+
+    for chunk in chunks:
+        authenticated.update(chunk)
+
+    payload = b"".join(chunks)
+    assert bytes(authenticated.payload) == b"two\r"
+    assert authenticated.byte_count == len(payload)
+    assert authenticated.digest.hexdigest() == hashlib.sha256(payload).hexdigest()
+
+
+@pytest.mark.parametrize("separator", [b"\n", b"\r"])
+def test_authenticated_line_range_scans_dense_newlines_once(
+    separator: bytes,
+) -> None:
+    class NoRepeatedFind(bytes):
+        def find(self, *_args, **_kwargs):
+            raise AssertionError("universal-newline scan repeated a suffix search")
+
+    line_count = 4096
+    payload = NoRepeatedFind((b"x" + separator) * line_count + b"target\r")
+    authenticated = source_fingerprint_module._AuthenticatedLineRange(
+        line_count + 1,
+        line_count + 1,
+        32,
+    )
+
+    authenticated.update(payload)
+
+    assert bytes(authenticated.payload) == b"target\r"
+    assert authenticated.byte_count == len(payload)
+    assert authenticated.digest.hexdigest() == hashlib.sha256(payload).hexdigest()
+
+
+def test_repository_source_line_range_preserves_mixed_and_trailing_cr(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_bytes(b"one\rtwo\r\nthree\nfour\r")
+
+    with capture_repository_source(repo) as binding:
+        assert (
+            binding.read_line_range(
+                "source.py",
+                start_line=2,
+                end_line=3,
+                max_bytes=32,
+            )
+            == b"two\r\nthree\n"
+        )
+        assert (
+            binding.read_line_range(
+                "source.py",
+                start_line=4,
+                end_line=4,
+                max_bytes=32,
+            )
+            == b"four\r"
+        )
+
+
+def test_repository_source_crlf_limit_does_not_poison_binding(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_bytes(b"one\r\ntwo\r\n")
+    binding = capture_repository_source(repo)
+
+    with pytest.raises(ValueError, match="bounded read limit"):
+        binding.read_line_range(
+            "source.py",
+            start_line=1,
+            end_line=1,
+            max_bytes=4,
+        )
+
+    assert binding.usable
+    assert (
+        binding.read_line_range(
+            "source.py",
+            start_line=2,
+            end_line=2,
+            max_bytes=5,
+        )
+        == b"two\r\n"
+    )
+    binding.close()
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -813,7 +813,11 @@ def test_repository_source_child_close_resets_inherited_locked_rlock(
     if child == 0:  # pragma: no cover - assertions are reported through the pipe
         try:
             os.close(read_descriptor)
-            binding.close()
+            try:
+                binding.close()
+            except RuntimeError as exc:
+                if "cannot cross processes" not in str(exc):
+                    raise
             os.write(write_descriptor, b"1" if binding.closed else b"0")
         except BaseException:  # noqa: B036 - report child failure through pipe
             os.write(write_descriptor, b"E")

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -235,6 +235,200 @@ def test_repository_source_binding_reads_exact_captured_records(
         assert binding.read_bytes("link.py", max_bytes=1024) == b"TARGET = 2\n"
 
 
+def test_repository_source_binding_maps_only_captured_paths_and_reads_prefix(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "pkg" / "source.py"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"prefix-data-that-continues\n")
+
+    with capture_repository_source(repo) as binding:
+        assert binding.captured_relative_path("pkg/source.py") == "pkg/source.py"
+        assert binding.captured_relative_path(str(source)) == "pkg/source.py"
+        assert binding.captured_relative_path("../source.py") is None
+        assert binding.captured_relative_path(str(tmp_path / "outside.py")) is None
+        assert binding.read_prefix("pkg/source.py", max_bytes=6) == b"prefix"
+
+
+def test_repository_source_prefix_authenticates_bytes_beyond_returned_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_bytes(b"same-prefix: trusted tail\n")
+    binding = capture_repository_source(repo)
+    source.write_bytes(b"same-prefix: altered tail\n")
+    monkeypatch.setattr(
+        RepositorySourceBinding,
+        "_verify_inventory",
+        lambda _binding: None,
+    )
+
+    with pytest.raises(RepositoryChangedError):
+        binding.read_prefix("source.py", max_bytes=len(b"same-prefix"))
+
+    binding.close()
+
+
+def test_repository_source_reader_streams_far_line_range_and_is_borrowed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    filler = (b"x" * 512) + b"\n"
+    source.write_bytes((filler * 20_000) + b"TARGET = 'far-offset'\nTAIL = 1\n")
+    binding = capture_repository_source(repo)
+    reader = binding.borrow_reader()
+
+    assert reader.file_paths == frozenset({"source.py"})
+    assert not hasattr(reader, "close")
+    assert (
+        reader.read_line_range(
+            "source.py",
+            start_line=20_001,
+            end_line=20_001,
+            max_bytes=1024,
+        )
+        == b"TARGET = 'far-offset'\n"
+    )
+
+    current_pid = os.getpid()
+    with monkeypatch.context() as process:
+        process.setattr(
+            source_fingerprint_module.os,
+            "getpid",
+            lambda: current_pid + 1,
+        )
+        with pytest.raises(RuntimeError, match="cross processes"):
+            reader.captured_relative_path("source.py")
+
+    binding.close()
+    with pytest.raises(RuntimeError, match="closed|poisoned"):
+        reader.captured_relative_path("source.py")
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_repository_source_reader_fork_rejects_before_inherited_lock(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_bytes(b"VALUE = 1\n")
+    binding = capture_repository_source(repo)
+    reader = binding.borrow_reader()
+    locked = threading.Event()
+    release = threading.Event()
+
+    def hold_parent_lock() -> None:
+        with binding._state_lease():
+            locked.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=hold_parent_lock)
+    holder.start()
+    assert locked.wait(timeout=2)
+    read_fd, write_fd = os.pipe()
+    child = os.fork()
+    if child == 0:  # pragma: no cover - assertions are reported over the pipe
+        os.close(read_fd)
+        signal.alarm(2)
+        outcomes = []
+        try:
+            reader.captured_relative_path("source.py")
+        except BaseException as exc:  # noqa: B036 - report exact boundary
+            outcomes.append(f"read:{type(exc).__name__}:{exc}")
+        try:
+            binding.close()
+        except BaseException as exc:  # noqa: B036 - cleanup then report boundary
+            outcomes.append(f"close:{type(exc).__name__}:{exc}")
+        outcomes.append(f"closed:{binding.closed}")
+        os.write(write_fd, "\n".join(outcomes).encode("utf-8"))
+        os.close(write_fd)
+        os._exit(0)
+
+    os.close(write_fd)
+    try:
+        outcome = os.read(read_fd, 4096).decode("utf-8")
+        waited, status = os.waitpid(child, 0)
+    finally:
+        os.close(read_fd)
+        release.set()
+        holder.join(timeout=2)
+        binding.close()
+
+    assert waited == child
+    assert os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0
+    assert (
+        "read:RuntimeError:repository source binding cannot cross processes" in outcome
+    )
+    assert (
+        "close:RuntimeError:repository source binding cannot cross processes" in outcome
+    )
+    assert "closed:True" in outcome
+    assert not holder.is_alive()
+
+
+def test_repository_source_line_range_authenticates_unreturned_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "source.py"
+    source.write_bytes(b"TARGET = 1\ntrusted tail\n")
+    binding = capture_repository_source(repo)
+    source.write_bytes(b"TARGET = 1\naltered tail\n")
+    monkeypatch.setattr(
+        RepositorySourceBinding,
+        "_verify_inventory",
+        lambda _binding: None,
+    )
+
+    with pytest.raises(RepositoryChangedError):
+        binding.read_line_range(
+            "source.py",
+            start_line=1,
+            end_line=1,
+            max_bytes=1024,
+        )
+
+    binding.close()
+
+
+def test_repository_source_line_range_limit_does_not_poison_binding(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.py").write_bytes((b"x" * 128) + b"\nNEXT = 1\n")
+    binding = capture_repository_source(repo)
+
+    with pytest.raises(ValueError, match="bounded read limit"):
+        binding.read_line_range(
+            "source.py",
+            start_line=1,
+            end_line=1,
+            max_bytes=16,
+        )
+
+    assert binding.usable
+    assert (
+        binding.read_line_range(
+            "source.py",
+            start_line=2,
+            end_line=2,
+            max_bytes=32,
+        )
+        == b"NEXT = 1\n"
+    )
+    binding.close()
+
+
 def test_repository_source_snapshot_revalidates_excluded_symlink_target(
     tmp_path: Path,
 ) -> None:

--- a/test/test_workspace_provider.py
+++ b/test/test_workspace_provider.py
@@ -1,0 +1,465 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import dis
+import hashlib
+import os
+import sys
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+import codenib._workspace_provider as workspace_provider
+from codenib._captured_directory import (
+    OwnedWorkspaceAuthority,
+    PublishedWorkspaceReceiptOwner,
+    UnsupportedWorkspaceCreation,
+    WorkspaceFile,
+    WorkspacePlan,
+)
+from codenib._workspace_provider import (
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_adopted_workspace_operation,
+    run_strict_workspace,
+)
+
+
+def _plan() -> WorkspacePlan:
+    return WorkspacePlan(
+        subject_digest=hashlib.sha256(b"workspace-provider-test").hexdigest(),
+        files=(WorkspaceFile(Path("payload.bin"), max_bytes=32),),
+    )
+
+
+def _interrupt_before_store_attr(
+    callback: Callable[[], object],
+    *,
+    target_code: object,
+    attribute: str,
+    error: BaseException,
+) -> None:
+    instructions = {
+        instruction.offset: instruction
+        for instruction in dis.get_instructions(target_code)
+    }
+    previous_trace = sys.gettrace()
+
+    def trace(frame, event, _arg):
+        if event == "call" and frame.f_code is target_code:
+            frame.f_trace_opcodes = True
+            return trace
+        if event == "opcode" and frame.f_code is target_code:
+            instruction = instructions.get(frame.f_lasti)
+            if (
+                instruction is not None
+                and instruction.opname == "STORE_ATTR"
+                and instruction.argval == attribute
+            ):
+                sys.settrace(None)
+                raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+
+
+class _TestProvider:
+    def __init__(self) -> None:
+        self.support_checks = 0
+        self.runs = 0
+        self.last_workspace: OwnedWorkspaceAuthority | None = None
+
+    def require_support(self) -> None:
+        self.support_checks += 1
+
+    def run_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        *,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], object],
+    ) -> object:
+        self.runs += 1
+        parent = request.destination.parent
+        parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        stage = parent / ".provider-stage"
+        stage.mkdir(mode=request.plan.root_mode)
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        parent_descriptor = os.open(parent, flags)
+        root_descriptor = os.open(stage, flags)
+        workspace = OwnedWorkspaceAuthority()
+        self.last_workspace = workspace
+        try:
+            workspace.adopt(
+                destination=request.destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_descriptor,
+                root_descriptor=root_descriptor,
+                directory_descriptors={},
+                plan=request.plan,
+                expected_destination=None,
+            )
+            return run_adopted_workspace_operation(
+                request,
+                workspace=workspace,
+                receipt_owner=receipt_owner,
+                operation=operation,
+            )
+        finally:
+            os.close(root_descriptor)
+            os.close(parent_descriptor)
+            if receipt_owner.state == "empty":
+                workspace.close()
+
+
+def test_request_is_lexical_and_rejects_invalid_contract(tmp_path: Path) -> None:
+    destination = tmp_path / "parent" / ".." / "parent" / "published"
+    request = StrictWorkspaceRequest("bm25-normalize", destination, _plan())
+
+    assert request.destination == Path(os.path.abspath(destination))
+    with pytest.raises(ValueError, match="purpose"):
+        StrictWorkspaceRequest("bad\nname", destination, _plan())
+    with pytest.raises(ValueError, match="expectation"):
+        StrictWorkspaceRequest(
+            "test",
+            destination,
+            _plan(),
+            destination_expectation="ambient",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="name one directory"):
+        StrictWorkspaceRequest("test", tmp_path / "parent" / "..", _plan())
+
+
+def test_provider_runs_one_callback_scoped_validated_publication(
+    tmp_path: Path,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+    escaped: list[StrictWorkspaceSession] = []
+    validations: list[bytes] = []
+
+    def operation(session: StrictWorkspaceSession) -> bytes:
+        escaped.append(session)
+        record = session.write_file("payload.bin", (b"owned",))
+        assert (record.path, record.mode, record.size) == (
+            "payload.bin",
+            0o600,
+            5,
+        )
+
+        def validate(reader):
+            payload = reader.read_bytes("payload.bin", max_bytes=32)
+            validations.append(payload)
+            return payload
+
+        return session.publish_validated(validate)
+
+    try:
+        assert (
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
+            == b"owned"
+        )
+        assert validations == [b"owned", b"owned"]
+        assert provider.support_checks == provider.runs == 1
+        assert owner.active
+        assert owner.receipt.path == request.destination
+        assert owner.receipt.plan == request.plan
+        assert (
+            owner.consume(
+                lambda _receipt, reader: reader.read_bytes(
+                    "payload.bin",
+                    max_bytes=32,
+                )
+            )
+            == b"owned"
+        )
+        with pytest.raises(RuntimeError, match="no longer active"):
+            _ = escaped[0].request
+        with pytest.raises(RuntimeError, match="no longer active"):
+            escaped[0].write_file("payload.bin", (b"late",))
+        with pytest.raises(RuntimeError, match="no longer active"):
+            escaped[0].publish_validated(lambda _reader: None)
+    finally:
+        owner.close()
+
+
+def test_operation_return_without_publish_fails_and_provider_closes(
+    tmp_path: Path,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+
+    with pytest.raises(RuntimeError, match="without publishing"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=owner,
+            operation=lambda session: session.write_file("payload.bin", (b"x",)),
+        )
+
+    assert owner.state == "empty"
+    assert provider.last_workspace is not None
+    assert provider.last_workspace.state == "closed"
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        KeyboardInterrupt("injected after receipt install"),
+        SystemExit("injected after receipt install"),
+    ],
+)
+def test_post_publish_interruption_keeps_caller_receipt_active(
+    tmp_path: Path,
+    interruption: BaseException,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        session.write_file("payload.bin", (b"owned",))
+        session.publish_validated(lambda _reader: None)
+        raise interruption
+
+    try:
+        with pytest.raises(type(interruption), match="after receipt install"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
+        assert owner.active
+        assert request.destination.joinpath("payload.bin").read_bytes() == b"owned"
+    finally:
+        owner.close()
+
+
+def test_shared_support_gate_runs_before_provider_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+
+    def unsupported() -> None:
+        raise UnsupportedWorkspaceCreation("injected unsupported host")
+
+    monkeypatch.setattr(
+        workspace_provider,
+        "require_owned_workspace_publication_support",
+        unsupported,
+    )
+    with pytest.raises(UnsupportedWorkspaceCreation, match="unsupported host"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=owner,
+            operation=lambda _session: None,
+        )
+
+    assert provider.support_checks == provider.runs == 0
+    assert not request.destination.exists()
+    assert not request.destination.parent.joinpath(".provider-stage").exists()
+
+
+def test_shared_support_gate_precedes_provider_attribute_lookup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class SideEffectProvider:
+        @property
+        def require_support(self):
+            events.append("provider-getattr")
+            return lambda: None
+
+        @property
+        def run_workspace(self):
+            events.append("provider-run-getattr")
+            return lambda *_args, **_kwargs: None
+
+    def unsupported() -> None:
+        events.append("shared-gate")
+        raise UnsupportedWorkspaceCreation("unsupported")
+
+    monkeypatch.setattr(
+        workspace_provider,
+        "require_owned_workspace_publication_support",
+        unsupported,
+    )
+    with pytest.raises(UnsupportedWorkspaceCreation, match="unsupported"):
+        run_strict_workspace(
+            SideEffectProvider(),
+            StrictWorkspaceRequest("test", tmp_path / "published", _plan()),
+            receipt_owner=PublishedWorkspaceReceiptOwner(),
+            operation=lambda _session: None,
+        )
+
+    assert events == ["shared-gate"]
+
+
+def test_session_revocation_recovers_from_store_cancellation(
+    tmp_path: Path,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+    escaped: list[StrictWorkspaceSession] = []
+
+    def operation(session: StrictWorkspaceSession) -> object:
+        escaped.append(session)
+        return object()
+
+    def run() -> object:
+        return run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=owner,
+            operation=operation,
+        )
+
+    with pytest.raises(KeyboardInterrupt, match="session revoke"):
+        _interrupt_before_store_attr(
+            run,
+            target_code=workspace_provider._AdoptedWorkspaceSession._invalidate.__code__,
+            attribute="_active",
+            error=KeyboardInterrupt("injected session revoke"),
+        )
+
+    assert owner.state == "empty"
+    assert provider.last_workspace is not None
+    assert provider.last_workspace.state == "closed"
+    with pytest.raises(RuntimeError, match="no longer active"):
+        _ = escaped[0].request
+
+
+def test_provider_cannot_retain_operation_callback(tmp_path: Path) -> None:
+    events: list[object] = []
+
+    class EscapingProvider:
+        escaped = None
+
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, _request, *, receipt_owner, operation):
+            del receipt_owner
+            self.escaped = operation
+            raise RuntimeError("provider returned early")
+
+    provider = EscapingProvider()
+    with pytest.raises(RuntimeError, match="returned early"):
+        run_strict_workspace(
+            provider,
+            StrictWorkspaceRequest("test", tmp_path / "published", _plan()),
+            receipt_owner=PublishedWorkspaceReceiptOwner(),
+            operation=lambda session: events.append(session),
+        )
+
+    assert provider.escaped is not None
+    with pytest.raises(RuntimeError, match="no longer active"):
+        provider.escaped("late-session")
+    assert events == []
+
+
+def test_double_publish_fails_but_retains_active_receipt(tmp_path: Path) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        session.write_file("payload.bin", (b"owned",))
+        session.publish_validated(lambda _reader: None)
+        session.publish_validated(lambda _reader: None)
+
+    try:
+        with pytest.raises(RuntimeError, match="already published"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
+        assert owner.active
+    finally:
+        owner.close()
+
+
+def test_wrong_active_receipt_is_rejected_without_losing_owner(
+    tmp_path: Path,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    wrong_request = StrictWorkspaceRequest(
+        "test",
+        tmp_path / "wrong-published",
+        request.plan,
+    )
+    delegate = _TestProvider()
+
+    class WrongProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, _request, *, receipt_owner, operation):
+            return delegate.run_workspace(
+                wrong_request,
+                receipt_owner=receipt_owner,
+                operation=operation,
+            )
+
+    owner = PublishedWorkspaceReceiptOwner()
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        session.write_file("payload.bin", (b"owned",))
+        session.publish_validated(lambda _reader: None)
+
+    try:
+        with pytest.raises(RuntimeError, match="wrong request"):
+            run_strict_workspace(
+                WrongProvider(),
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
+        assert owner.active
+        assert owner.receipt.path == wrong_request.destination
+    finally:
+        owner.close()
+
+
+def test_provider_return_without_invoking_operation_is_rejected(tmp_path: Path) -> None:
+    class BrokenProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, *_args, **_kwargs) -> object:
+            return object()
+
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    with pytest.raises(RuntimeError, match="did not invoke its operation"):
+        run_strict_workspace(
+            BrokenProvider(),
+            request,
+            receipt_owner=PublishedWorkspaceReceiptOwner(),
+            operation=lambda _session: None,
+        )

--- a/test/test_workspace_provider.py
+++ b/test/test_workspace_provider.py
@@ -4,11 +4,9 @@
 
 from __future__ import annotations
 
-import dis
 import hashlib
 import os
 import signal
-import sys
 import threading
 from pathlib import Path
 from typing import Callable
@@ -44,36 +42,32 @@ def _plan() -> WorkspacePlan:
 def _interrupt_before_store_attr(
     callback: Callable[[], object],
     *,
-    target_code: object,
+    target_type: type[object],
     attribute: str,
     error: BaseException,
+    injected: list[bool],
 ) -> None:
-    instructions = {
-        instruction.offset: instruction
-        for instruction in dis.get_instructions(target_code)
-    }
-    previous_trace = sys.gettrace()
+    inherited_setattr = target_type.__setattr__
+    had_local_setattr = "__setattr__" in target_type.__dict__
+    local_setattr = target_type.__dict__.get("__setattr__")
+    was_injected = False
 
-    def trace(frame, event, _arg):
-        if event == "call" and frame.f_code is target_code:
-            frame.f_trace_opcodes = True
-            return trace
-        if event == "opcode" and frame.f_code is target_code:
-            instruction = instructions.get(frame.f_lasti)
-            if (
-                instruction is not None
-                and instruction.opname == "STORE_ATTR"
-                and instruction.argval == attribute
-            ):
-                sys.settrace(None)
-                raise error
-        return trace
+    def interrupt_store(instance, name, value):
+        nonlocal was_injected
+        if name == attribute and not was_injected and hasattr(instance, attribute):
+            was_injected = True
+            raise error
+        inherited_setattr(instance, name, value)
 
-    sys.settrace(trace)
+    target_type.__setattr__ = interrupt_store  # type: ignore[method-assign]
     try:
         callback()
     finally:
-        sys.settrace(previous_trace)
+        if had_local_setattr:
+            target_type.__setattr__ = local_setattr  # type: ignore[method-assign]
+        else:
+            del target_type.__setattr__
+        injected.append(was_injected)
 
 
 class _TestProvider:
@@ -285,6 +279,271 @@ def test_provider_runs_one_callback_scoped_validated_publication(
             escaped[0].publish_validated(lambda _reader: None)
     finally:
         owner.close()
+
+
+def test_provider_cannot_substitute_the_callback_result(tmp_path: Path) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    delegate = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+
+    class SubstitutingProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, request, *, receipt_owner, operation):
+            delegate.run_workspace(
+                request,
+                receipt_owner=receipt_owner,
+                operation=operation,
+            )
+            return b"provider-substitution"
+
+    def operation(session: StrictWorkspaceSession) -> bytes:
+        session.write_file("payload.bin", (b"owned",))
+        session.publish_validated(lambda _reader: None)
+        return b"callback-result"
+
+    try:
+        assert (
+            run_strict_workspace(
+                SubstitutingProvider(),
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
+            == b"callback-result"
+        )
+        assert owner.active
+    finally:
+        if owner.active:
+            owner.close()
+
+
+@pytest.mark.parametrize(
+    "primary_type",
+    [KeyboardInterrupt, SystemExit, GeneratorExit],
+)
+def test_provider_cannot_swallow_the_callback_primary(
+    tmp_path: Path,
+    primary_type: type[BaseException],
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    delegate = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+    primary = primary_type("callback-primary")
+
+    class SwallowingProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, request, *, receipt_owner, operation):
+            try:
+                delegate.run_workspace(
+                    request,
+                    receipt_owner=receipt_owner,
+                    operation=operation,
+                )
+            except BaseException:  # noqa: B036 - exercise a broken provider
+                return b"provider-swallowed-callback"
+            raise AssertionError("callback primary was not raised")
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        session.write_file("payload.bin", (b"owned",))
+        session.publish_validated(lambda _reader: None)
+        raise primary
+
+    try:
+        with pytest.raises(primary_type, match="callback-primary") as caught:
+            run_strict_workspace(
+                SwallowingProvider(),
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
+
+        assert caught.value is primary
+        assert owner.active
+        assert request.destination.joinpath("payload.bin").read_bytes() == b"owned"
+    finally:
+        if owner.active:
+            owner.close()
+
+
+def test_callback_primary_survives_a_provider_secondary(tmp_path: Path) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    delegate = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+    primary = KeyboardInterrupt("callback-primary")
+    secondary = SystemExit("provider-secondary")
+
+    class FailingProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, request, *, receipt_owner, operation):
+            try:
+                delegate.run_workspace(
+                    request,
+                    receipt_owner=receipt_owner,
+                    operation=operation,
+                )
+            except BaseException:  # noqa: B036 - exercise a broken provider
+                raise secondary
+            raise AssertionError("callback primary was not raised")
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        session.write_file("payload.bin", (b"owned",))
+        session.publish_validated(lambda _reader: None)
+        raise primary
+
+    try:
+        with pytest.raises(KeyboardInterrupt, match="callback-primary") as caught:
+            run_strict_workspace(
+                FailingProvider(),
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
+
+        assert caught.value is primary
+        assert any(
+            "provider also failed after its callback" in note
+            and "provider-secondary" in note
+            for note in _notes(primary)
+        )
+        assert owner.active
+    finally:
+        if owner.active:
+            owner.close()
+
+
+def test_callback_outcome_commit_preserves_the_callback_primary(
+    tmp_path: Path,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    delegate = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+    primary = KeyboardInterrupt("callback-primary")
+    transition = SystemExit("outcome-commit-interruption")
+
+    class SwallowingProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, request, *, receipt_owner, operation):
+            try:
+                delegate.run_workspace(
+                    request,
+                    receipt_owner=receipt_owner,
+                    operation=operation,
+                )
+            except BaseException:  # noqa: B036 - exercise a broken provider
+                return b"provider-swallowed-callback"
+            raise AssertionError("callback primary was not raised")
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        session.write_file("payload.bin", (b"owned",))
+        session.publish_validated(lambda _reader: None)
+        raise primary
+
+    def run() -> object:
+        return run_strict_workspace(
+            SwallowingProvider(),
+            request,
+            receipt_owner=owner,
+            operation=operation,
+        )
+
+    injected: list[bool] = []
+    try:
+        with pytest.raises(KeyboardInterrupt, match="callback-primary") as caught:
+            _interrupt_before_store_attr(
+                run,
+                target_type=workspace_provider._ProviderOperationGate,
+                attribute="_operation_outcome",
+                error=transition,
+                injected=injected,
+            )
+
+        assert caught.value is primary
+        assert injected == [True]
+        assert any(
+            "outcome commit also failed" in note
+            and "outcome-commit-interruption" in note
+            for note in _notes(primary)
+        )
+        assert owner.active
+    finally:
+        if owner.active:
+            owner.close()
+
+
+def test_callback_outcome_read_preserves_the_callback_primary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    delegate = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+    primary = KeyboardInterrupt("callback-primary")
+    interruption = SystemExit("outcome-read-interruption")
+    outcome_property = workspace_provider._ProviderOperationGate.operation_outcome
+    outcome_getter = outcome_property.fget
+    assert outcome_getter is not None
+    reads = 0
+
+    def interrupted_outcome(self):
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            raise interruption
+        return outcome_getter(self)
+
+    monkeypatch.setattr(
+        workspace_provider._ProviderOperationGate,
+        "operation_outcome",
+        property(interrupted_outcome),
+    )
+
+    class SwallowingProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, request, *, receipt_owner, operation):
+            try:
+                delegate.run_workspace(
+                    request,
+                    receipt_owner=receipt_owner,
+                    operation=operation,
+                )
+            except BaseException:  # noqa: B036 - exercise a broken provider
+                return b"provider-swallowed-callback"
+            raise AssertionError("callback primary was not raised")
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        session.write_file("payload.bin", (b"owned",))
+        session.publish_validated(lambda _reader: None)
+        raise primary
+
+    try:
+        with pytest.raises(KeyboardInterrupt, match="callback-primary") as caught:
+            run_strict_workspace(
+                SwallowingProvider(),
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
+
+        assert caught.value is primary
+        assert reads == 2
+        assert any(
+            "outcome read also failed" in note and "outcome-read-interruption" in note
+            for note in _notes(primary)
+        )
+        assert owner.active
+    finally:
+        if owner.active:
+            owner.close()
 
 
 def test_operation_return_without_publish_fails_and_provider_closes(
@@ -605,14 +864,17 @@ def test_session_revocation_recovers_from_store_cancellation(
             operation=operation,
         )
 
+    injected: list[bool] = []
     with pytest.raises(KeyboardInterrupt, match="session revoke"):
         _interrupt_before_store_attr(
             run,
-            target_code=workspace_provider._AdoptedWorkspaceSession._deactivate.__code__,
+            target_type=workspace_provider._AdoptedWorkspaceSession,
             attribute="_active",
             error=KeyboardInterrupt("injected session revoke"),
+            injected=injected,
         )
 
+    assert injected == [True]
     assert owner.state == "empty"
     assert provider.last_workspace is not None
     assert provider.last_workspace.state == "closed"
@@ -644,15 +906,18 @@ def test_operation_primary_survives_session_revocation_failure(
             operation=operation,
         )
 
+    injected: list[bool] = []
     with pytest.raises(primary_type, match="operation-primary") as caught:
         _interrupt_before_store_attr(
             run,
-            target_code=workspace_provider._AdoptedWorkspaceSession._deactivate.__code__,
+            target_type=workspace_provider._AdoptedWorkspaceSession,
             attribute="_active",
             error=RuntimeError("session-revocation-secondary"),
+            injected=injected,
         )
 
     assert caught.value is primary
+    assert injected == [True]
     assert any(
         "session revocation also failed" in note
         and "session-revocation-secondary" in note
@@ -686,15 +951,18 @@ def test_provider_primary_survives_callback_revocation_failure(
             operation=lambda _session: None,
         )
 
+    injected: list[bool] = []
     with pytest.raises(primary_type, match="provider-primary") as caught:
         _interrupt_before_store_attr(
             run,
-            target_code=workspace_provider._ProviderOperationGate._deactivate.__code__,
+            target_type=workspace_provider._ProviderOperationGate,
             attribute="_active",
             error=RuntimeError("provider-revocation-secondary"),
+            injected=injected,
         )
 
     assert caught.value is primary
+    assert injected == [True]
     assert any(
         "provider callback revocation also failed" in note
         and "provider-revocation-secondary" in note

--- a/test/test_workspace_provider.py
+++ b/test/test_workspace_provider.py
@@ -7,13 +7,16 @@ from __future__ import annotations
 import dis
 import hashlib
 import os
+import signal
 import sys
+import threading
 from pathlib import Path
 from typing import Callable
 
 import pytest
 
 import codenib._workspace_provider as workspace_provider
+from codenib._atomic_directory import capture_directory_ownership
 from codenib._captured_directory import (
     OwnedWorkspaceAuthority,
     PublishedWorkspaceReceiptOwner,
@@ -21,6 +24,8 @@ from codenib._captured_directory import (
     WorkspaceFile,
     WorkspacePlan,
 )
+
+_DEFAULT_EXPECTATION = object()
 from codenib._workspace_provider import (
     StrictWorkspaceRequest,
     StrictWorkspaceSession,
@@ -72,10 +77,17 @@ def _interrupt_before_store_attr(
 
 
 class _TestProvider:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        adopted_destination: Path | None = None,
+        expected_destination: object = _DEFAULT_EXPECTATION,
+    ) -> None:
         self.support_checks = 0
         self.runs = 0
         self.last_workspace: OwnedWorkspaceAuthority | None = None
+        self.adopted_destination = adopted_destination
+        self.expected_destination = expected_destination
 
     def require_support(self) -> None:
         self.support_checks += 1
@@ -88,7 +100,8 @@ class _TestProvider:
         operation: Callable[[StrictWorkspaceSession], object],
     ) -> object:
         self.runs += 1
-        parent = request.destination.parent
+        destination = self.adopted_destination or request.destination
+        parent = destination.parent
         parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         stage = parent / ".provider-stage"
         stage.mkdir(mode=request.plan.root_mode)
@@ -98,15 +111,25 @@ class _TestProvider:
         root_descriptor = os.open(stage, flags)
         workspace = OwnedWorkspaceAuthority()
         self.last_workspace = workspace
+        expected_destination = self.expected_destination
+        if expected_destination is _DEFAULT_EXPECTATION:
+            expected_destination = (
+                capture_directory_ownership(
+                    destination,
+                    allow_empty_root=True,
+                )
+                if request.destination_expectation == "provider-bound-exact"
+                else None
+            )
         try:
             workspace.adopt(
-                destination=request.destination,
+                destination=destination,
                 stage_name=stage.name,
                 parent_descriptor=parent_descriptor,
                 root_descriptor=root_descriptor,
                 directory_descriptors={},
                 plan=request.plan,
-                expected_destination=None,
+                expected_destination=expected_destination,
             )
             return run_adopted_workspace_operation(
                 request,
@@ -119,6 +142,72 @@ class _TestProvider:
             os.close(parent_descriptor)
             if receipt_owner.state == "empty":
                 workspace.close()
+
+
+def _run_thread(
+    callback: Callable[[], object],
+    *,
+    values: list[object],
+    errors: list[BaseException],
+    finished: threading.Event,
+) -> None:
+    try:
+        values.append(callback())
+    except BaseException as exc:  # noqa: B036 - assert exact thread failures
+        errors.append(exc)
+    finally:
+        finished.set()
+
+
+def _notes(error: BaseException) -> tuple[str, ...]:
+    return tuple(getattr(error, "__notes__", ())) + tuple(
+        getattr(error, "_codenib_cleanup_notes", ())
+    )
+
+
+def _fork_expect_pid_boundary(
+    callback: Callable[[], object],
+    *,
+    expected_message: str,
+) -> tuple[int, str]:
+    read_descriptor, write_descriptor = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(read_descriptor)
+
+        def abort_blocked_child(*_args: object) -> None:
+            os._exit(90)
+
+        signal.signal(signal.SIGALRM, abort_blocked_child)
+        signal.alarm(3)
+        exit_code = 0
+        try:
+            callback()
+        except BaseException as error:  # noqa: B036 - report exact child failure
+            if isinstance(error, RuntimeError) and expected_message in str(error):
+                payload = b"expected PID boundary"
+            else:
+                payload = f"{type(error).__name__}: {error}".encode(
+                    "utf-8",
+                    errors="replace",
+                )
+                exit_code = 91
+        else:
+            payload = b"forked entry returned"
+            exit_code = 92
+        signal.alarm(0)
+        os.write(write_descriptor, payload)
+        os.close(write_descriptor)
+        os._exit(exit_code)
+
+    os.close(write_descriptor)
+    try:
+        payload = os.read(read_descriptor, 4096).decode("utf-8", errors="replace")
+    finally:
+        os.close(read_descriptor)
+    waited_pid, status = os.waitpid(child_pid, 0)
+    assert waited_pid == child_pid
+    return os.waitstatus_to_exitcode(status), payload
 
 
 def test_request_is_lexical_and_rejects_invalid_contract(tmp_path: Path) -> None:
@@ -216,6 +305,184 @@ def test_operation_return_without_publish_fails_and_provider_closes(
     assert owner.state == "empty"
     assert provider.last_workspace is not None
     assert provider.last_workspace.state == "closed"
+
+
+def test_adopted_workspace_rejects_wrong_destination_before_operation(
+    tmp_path: Path,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    wrong_destination = tmp_path / "wrong-published"
+    provider = _TestProvider(adopted_destination=wrong_destination)
+    owner = PublishedWorkspaceReceiptOwner()
+    called = False
+
+    def operation(_session: StrictWorkspaceSession) -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(ValueError, match="destination differs"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=owner,
+            operation=operation,
+        )
+
+    assert called is False
+    assert owner.state == "empty"
+    assert not request.destination.exists()
+    assert not wrong_destination.exists()
+
+
+def test_adopted_workspace_rejects_exact_binding_for_missing_request(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old").write_bytes(b"old")
+    exact = capture_directory_ownership(destination)
+    request = StrictWorkspaceRequest("test", destination, _plan())
+    provider = _TestProvider(expected_destination=exact)
+    owner = PublishedWorkspaceReceiptOwner()
+    called = False
+
+    def operation(_session: StrictWorkspaceSession) -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(ValueError, match="expectation differs"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=owner,
+            operation=operation,
+        )
+
+    assert called is False
+    assert owner.state == "empty"
+    assert (destination / "old").read_bytes() == b"old"
+
+
+def test_adopted_workspace_rejects_missing_binding_for_exact_request(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    request = StrictWorkspaceRequest(
+        "test",
+        destination,
+        _plan(),
+        destination_expectation="provider-bound-exact",
+    )
+    provider = _TestProvider(expected_destination=None)
+    owner = PublishedWorkspaceReceiptOwner()
+    called = False
+
+    def operation(_session: StrictWorkspaceSession) -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(ValueError, match="expectation differs"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=owner,
+            operation=operation,
+        )
+
+    assert called is False
+    assert owner.state == "empty"
+    assert not destination.exists()
+
+
+def test_provider_bound_exact_request_replaces_only_captured_destination(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old").write_bytes(b"old")
+    request = StrictWorkspaceRequest(
+        "test",
+        destination,
+        _plan(),
+        destination_expectation="provider-bound-exact",
+    )
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+
+    def operation(session: StrictWorkspaceSession) -> bytes:
+        session.write_file("payload.bin", (b"owned",))
+        return session.publish_validated(
+            lambda reader: reader.read_bytes("payload.bin", max_bytes=32)
+        )
+
+    try:
+        assert (
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
+            == b"owned"
+        )
+        assert owner.active
+        assert owner.receipt.orphan is not None
+        assert destination.joinpath("payload.bin").read_bytes() == b"owned"
+    finally:
+        owner.close()
+
+
+def test_adopted_workspace_rechecks_destination_before_write(tmp_path: Path) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        assert provider.last_workspace is not None
+        provider.last_workspace._destination = tmp_path / "changed"  # type: ignore[attr-defined]  # noqa: SLF001
+        session.write_file("payload.bin", (b"must-not-write",))
+
+    with pytest.raises(ValueError, match="destination differs"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=owner,
+            operation=operation,
+        )
+
+    assert owner.state == "empty"
+    assert not request.destination.exists()
+
+
+def test_adopted_workspace_rechecks_expectation_after_staged_validator(
+    tmp_path: Path,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        session.write_file("payload.bin", (b"owned",))
+
+        def validate(_reader) -> None:
+            assert provider.last_workspace is not None
+            provider.last_workspace._expected_destination = object()  # type: ignore[attr-defined]  # noqa: SLF001
+
+        session.publish_validated(validate)
+
+    try:
+        with pytest.raises(ValueError, match="expectation differs"):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            )
+
+        assert owner.state == "cleanup"
+        assert not request.destination.exists()
+    finally:
+        owner.close()
 
 
 @pytest.mark.parametrize(
@@ -341,7 +608,7 @@ def test_session_revocation_recovers_from_store_cancellation(
     with pytest.raises(KeyboardInterrupt, match="session revoke"):
         _interrupt_before_store_attr(
             run,
-            target_code=workspace_provider._AdoptedWorkspaceSession._invalidate.__code__,
+            target_code=workspace_provider._AdoptedWorkspaceSession._deactivate.__code__,
             attribute="_active",
             error=KeyboardInterrupt("injected session revoke"),
         )
@@ -351,6 +618,466 @@ def test_session_revocation_recovers_from_store_cancellation(
     assert provider.last_workspace.state == "closed"
     with pytest.raises(RuntimeError, match="no longer active"):
         _ = escaped[0].request
+
+
+@pytest.mark.parametrize(
+    "primary_type",
+    [KeyboardInterrupt, SystemExit, GeneratorExit],
+)
+def test_operation_primary_survives_session_revocation_failure(
+    tmp_path: Path,
+    primary_type: type[BaseException],
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+    primary = primary_type("operation-primary")
+
+    def operation(_session: StrictWorkspaceSession) -> None:
+        raise primary
+
+    def run() -> object:
+        return run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=owner,
+            operation=operation,
+        )
+
+    with pytest.raises(primary_type, match="operation-primary") as caught:
+        _interrupt_before_store_attr(
+            run,
+            target_code=workspace_provider._AdoptedWorkspaceSession._deactivate.__code__,
+            attribute="_active",
+            error=RuntimeError("session-revocation-secondary"),
+        )
+
+    assert caught.value is primary
+    assert any(
+        "session revocation also failed" in note
+        and "session-revocation-secondary" in note
+        for note in _notes(primary)
+    )
+    assert owner.state == "empty"
+
+
+@pytest.mark.parametrize(
+    "primary_type",
+    [KeyboardInterrupt, SystemExit, GeneratorExit],
+)
+def test_provider_primary_survives_callback_revocation_failure(
+    tmp_path: Path,
+    primary_type: type[BaseException],
+) -> None:
+    primary = primary_type("provider-primary")
+
+    class FailingProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, *_args, **_kwargs) -> object:
+            raise primary
+
+    def run() -> object:
+        return run_strict_workspace(
+            FailingProvider(),
+            StrictWorkspaceRequest("test", tmp_path / "published", _plan()),
+            receipt_owner=PublishedWorkspaceReceiptOwner(),
+            operation=lambda _session: None,
+        )
+
+    with pytest.raises(primary_type, match="provider-primary") as caught:
+        _interrupt_before_store_attr(
+            run,
+            target_code=workspace_provider._ProviderOperationGate._deactivate.__code__,
+            attribute="_active",
+            error=RuntimeError("provider-revocation-secondary"),
+        )
+
+    assert caught.value is primary
+    assert any(
+        "provider callback revocation also failed" in note
+        and "provider-revocation-secondary" in note
+        for note in _notes(primary)
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+@pytest.mark.parametrize(
+    "entry",
+    ["request", "write", "publish", "invalidate"],
+)
+def test_session_pid_boundary_precedes_inherited_gate(
+    tmp_path: Path,
+    entry: str,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    owner = PublishedWorkspaceReceiptOwner()
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        assert isinstance(session, workspace_provider._AdoptedWorkspaceSession)
+        gate_held = threading.Event()
+        release_gate = threading.Event()
+        holder_finished = threading.Event()
+        holder_values: list[object] = []
+        holder_errors: list[BaseException] = []
+
+        def hold_gate() -> None:
+            def block() -> None:
+                gate_held.set()
+                if not release_gate.wait(5):
+                    raise TimeoutError("session gate holder was not released")
+
+            session._gate.run(block)
+
+        holder = threading.Thread(
+            target=_run_thread,
+            kwargs={
+                "callback": hold_gate,
+                "values": holder_values,
+                "errors": holder_errors,
+                "finished": holder_finished,
+            },
+            daemon=True,
+        )
+        holder.start()
+        if not gate_held.wait(5):
+            raise TimeoutError("session gate holder did not acquire the gate")
+
+        def enter_from_child() -> object:
+            if entry == "request":
+                return session.request
+            if entry == "write":
+                return session.write_file("payload.bin", (b"child",))
+            if entry == "publish":
+                return session.publish_validated(lambda _reader: None)
+            session._invalidate()
+            return None
+
+        try:
+            exit_code, payload = _fork_expect_pid_boundary(
+                enter_from_child,
+                expected_message=(
+                    "strict workspace session cannot cross a PID boundary"
+                ),
+            )
+        finally:
+            release_gate.set()
+            assert holder_finished.wait(5)
+            holder.join(timeout=1)
+
+        assert not holder.is_alive()
+        assert holder_values == [None]
+        assert holder_errors == []
+        assert exit_code == 0, payload or "forked session entry hit its alarm"
+        assert payload == "expected PID boundary"
+
+        session.write_file("payload.bin", (b"parent",))
+        session.publish_validated(lambda _reader: None)
+
+    try:
+        run_strict_workspace(
+            _TestProvider(),
+            request,
+            receipt_owner=owner,
+            operation=operation,
+        )
+        assert owner.active
+        assert request.destination.joinpath("payload.bin").read_bytes() == b"parent"
+    finally:
+        if owner.active:
+            owner.close()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+@pytest.mark.parametrize("entry", ["callback", "called", "revoke"])
+def test_provider_operation_pid_boundary_precedes_inherited_gate(
+    tmp_path: Path,
+    entry: str,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    owner = PublishedWorkspaceReceiptOwner()
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        callback_started = threading.Event()
+        release_callback = threading.Event()
+        worker_finished = threading.Event()
+        worker_values: list[object] = []
+        worker_errors: list[BaseException] = []
+
+        operation_gate = workspace_provider._ProviderOperationGate(
+            request,
+            lambda _session: None,
+        )
+
+        def hold_gate() -> None:
+            def block() -> None:
+                callback_started.set()
+                if not release_callback.wait(5):
+                    raise TimeoutError("provider operation gate was not released")
+
+            operation_gate._lock.run(block)
+
+        worker = threading.Thread(
+            target=_run_thread,
+            kwargs={
+                "callback": hold_gate,
+                "values": worker_values,
+                "errors": worker_errors,
+                "finished": worker_finished,
+            },
+            daemon=True,
+        )
+        worker.start()
+        if not callback_started.wait(5):
+            raise TimeoutError("provider operation did not acquire its gate")
+
+        def enter_from_child() -> object:
+            if entry == "callback":
+                return operation_gate(session)
+            if entry == "called":
+                return operation_gate.called
+            operation_gate.revoke()
+            return None
+
+        try:
+            exit_code, payload = _fork_expect_pid_boundary(
+                enter_from_child,
+                expected_message=(
+                    "strict workspace provider operation cannot cross a PID boundary"
+                ),
+            )
+        finally:
+            release_callback.set()
+            assert worker_finished.wait(5)
+            worker.join(timeout=1)
+
+        assert not worker.is_alive()
+        assert worker_values == [None]
+        assert worker_errors == []
+        assert exit_code == 0, payload or "forked provider entry hit its alarm"
+        assert payload == "expected PID boundary"
+        operation_gate.revoke()
+
+        session.write_file("payload.bin", (b"parent",))
+        session.publish_validated(lambda _reader: None)
+
+    try:
+        run_strict_workspace(
+            _TestProvider(),
+            request,
+            receipt_owner=owner,
+            operation=operation,
+        )
+        assert owner.active
+        assert request.destination.joinpath("payload.bin").read_bytes() == b"parent"
+    finally:
+        if owner.active:
+            owner.close()
+
+
+def test_session_invalidation_waits_for_blocked_write_and_rejects_late_publish(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+    write_started = threading.Event()
+    release_write = threading.Event()
+    allow_late_publish = threading.Event()
+    operation_returned = threading.Event()
+    invalidation_started = threading.Event()
+    worker_finished = threading.Event()
+    runner_finished = threading.Event()
+    worker_values: list[object] = []
+    worker_errors: list[BaseException] = []
+    runner_values: list[object] = []
+    runner_errors: list[BaseException] = []
+    workers: list[threading.Thread] = []
+    real_invalidate = workspace_provider._AdoptedWorkspaceSession._invalidate
+
+    def track_invalidation(session) -> None:
+        invalidation_started.set()
+        real_invalidate(session)
+
+    monkeypatch.setattr(
+        workspace_provider._AdoptedWorkspaceSession,
+        "_invalidate",
+        track_invalidation,
+    )
+
+    def chunks():
+        write_started.set()
+        if not release_write.wait(5):
+            raise TimeoutError("blocked write was not released")
+        yield b"owned"
+
+    def operation(session: StrictWorkspaceSession) -> str:
+        def work() -> object:
+            session.write_file("payload.bin", chunks())
+            if not allow_late_publish.wait(5):
+                raise TimeoutError("late publication was not released")
+            return session.publish_validated(lambda _reader: None)
+
+        worker = threading.Thread(
+            target=_run_thread,
+            kwargs={
+                "callback": work,
+                "values": worker_values,
+                "errors": worker_errors,
+                "finished": worker_finished,
+            },
+            daemon=True,
+        )
+        workers.append(worker)
+        worker.start()
+        if not write_started.wait(5):
+            raise TimeoutError("worker did not enter its write")
+        operation_returned.set()
+        return "operation-returned"
+
+    runner = threading.Thread(
+        target=_run_thread,
+        kwargs={
+            "callback": lambda: run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            ),
+            "values": runner_values,
+            "errors": runner_errors,
+            "finished": runner_finished,
+        },
+        daemon=True,
+    )
+    try:
+        runner.start()
+        assert operation_returned.wait(5)
+        assert invalidation_started.wait(5)
+        assert not runner_finished.wait(0.1)
+        release_write.set()
+        assert runner_finished.wait(5)
+        allow_late_publish.set()
+        assert worker_finished.wait(5)
+        runner.join(timeout=1)
+        workers[0].join(timeout=1)
+    finally:
+        release_write.set()
+        allow_late_publish.set()
+
+    assert runner_values == []
+    assert len(runner_errors) == 1
+    assert isinstance(runner_errors[0], RuntimeError)
+    assert "without publishing" in str(runner_errors[0])
+    assert worker_values == []
+    assert len(worker_errors) == 1
+    assert isinstance(worker_errors[0], RuntimeError)
+    assert "no longer active" in str(worker_errors[0])
+    assert owner.state == "empty"
+    assert not request.destination.exists()
+
+
+def test_session_invalidation_waits_for_blocked_staged_validator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    provider = _TestProvider()
+    owner = PublishedWorkspaceReceiptOwner()
+    staged_validator_started = threading.Event()
+    release_validator = threading.Event()
+    operation_returned = threading.Event()
+    invalidation_started = threading.Event()
+    worker_finished = threading.Event()
+    runner_finished = threading.Event()
+    worker_values: list[object] = []
+    worker_errors: list[BaseException] = []
+    runner_values: list[object] = []
+    runner_errors: list[BaseException] = []
+    workers: list[threading.Thread] = []
+    validations = 0
+    real_invalidate = workspace_provider._AdoptedWorkspaceSession._invalidate
+
+    def track_invalidation(session) -> None:
+        invalidation_started.set()
+        real_invalidate(session)
+
+    monkeypatch.setattr(
+        workspace_provider._AdoptedWorkspaceSession,
+        "_invalidate",
+        track_invalidation,
+    )
+
+    def operation(session: StrictWorkspaceSession) -> str:
+        def work() -> object:
+            session.write_file("payload.bin", (b"owned",))
+
+            def validate(_reader) -> bytes:
+                nonlocal validations
+                validations += 1
+                if validations == 1:
+                    staged_validator_started.set()
+                    if not release_validator.wait(5):
+                        raise TimeoutError("staged validator was not released")
+                return b"validated"
+
+            return session.publish_validated(validate)
+
+        worker = threading.Thread(
+            target=_run_thread,
+            kwargs={
+                "callback": work,
+                "values": worker_values,
+                "errors": worker_errors,
+                "finished": worker_finished,
+            },
+            daemon=True,
+        )
+        workers.append(worker)
+        worker.start()
+        if not staged_validator_started.wait(5):
+            raise TimeoutError("worker did not enter the staged validator")
+        operation_returned.set()
+        return "operation-returned"
+
+    runner = threading.Thread(
+        target=_run_thread,
+        kwargs={
+            "callback": lambda: run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=owner,
+                operation=operation,
+            ),
+            "values": runner_values,
+            "errors": runner_errors,
+            "finished": runner_finished,
+        },
+        daemon=True,
+    )
+    try:
+        runner.start()
+        assert operation_returned.wait(5)
+        assert invalidation_started.wait(5)
+        assert not runner_finished.wait(0.1)
+        release_validator.set()
+        assert runner_finished.wait(5)
+        assert worker_finished.wait(5)
+        runner.join(timeout=1)
+        workers[0].join(timeout=1)
+        assert runner_errors == []
+        assert runner_values == ["operation-returned"]
+        assert worker_errors == []
+        assert worker_values == [b"validated"]
+        assert validations == 2
+        assert owner.active
+        assert request.destination.joinpath("payload.bin").read_bytes() == b"owned"
+    finally:
+        release_validator.set()
+        if owner.active:
+            owner.close()
 
 
 def test_provider_cannot_retain_operation_callback(tmp_path: Path) -> None:
@@ -382,6 +1109,119 @@ def test_provider_cannot_retain_operation_callback(tmp_path: Path) -> None:
     assert events == []
 
 
+def test_provider_cannot_invoke_operation_with_unbound_session(
+    tmp_path: Path,
+) -> None:
+    called = False
+
+    class UnboundProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, _request, *, receipt_owner, operation):
+            del receipt_owner
+            return operation(object())
+
+    def operation(_session: StrictWorkspaceSession) -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(TypeError, match="adopted session"):
+        run_strict_workspace(
+            UnboundProvider(),
+            StrictWorkspaceRequest("test", tmp_path / "published", _plan()),
+            receipt_owner=PublishedWorkspaceReceiptOwner(),
+            operation=operation,
+        )
+
+    assert called is False
+
+
+def test_provider_rejects_forged_session_subclass_before_user_callback(
+    tmp_path: Path,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    called = 0
+
+    class ForgedSession(workspace_provider._AdoptedWorkspaceSession):
+        def _require_operation_provenance(self, *_args, **_kwargs) -> None:
+            return None
+
+    class ForgingProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, _request, *, receipt_owner, operation):
+            forged = ForgedSession(
+                request,
+                object(),  # type: ignore[arg-type]
+                receipt_owner,
+                operation_provenance=object(),
+            )
+            return operation(forged)
+
+    def user_operation(_session: StrictWorkspaceSession) -> None:
+        nonlocal called
+        called += 1
+
+    with pytest.raises(TypeError, match="adopted session"):
+        run_strict_workspace(
+            ForgingProvider(),
+            request,
+            receipt_owner=PublishedWorkspaceReceiptOwner(),
+            operation=user_operation,
+        )
+
+    assert called == 0
+
+
+def test_provider_rejects_exact_unprovenanced_session_before_user_callback(
+    tmp_path: Path,
+) -> None:
+    request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
+    called = 0
+    field_forgery_rejected = False
+
+    class FakeWorkspace:
+        @property
+        def plan(self) -> WorkspacePlan:
+            raise AssertionError("forged workspace plan was inspected")
+
+    class ForgingProvider:
+        def require_support(self) -> None:
+            return None
+
+        def run_workspace(self, _request, *, receipt_owner, operation):
+            nonlocal field_forgery_rejected
+            forged_provenance = object()
+            forged = workspace_provider._AdoptedWorkspaceSession(
+                request,
+                FakeWorkspace(),  # type: ignore[arg-type]
+                receipt_owner,
+                operation_provenance=forged_provenance,
+            )
+            try:
+                operation._session_binding = (forged, forged_provenance)
+            except AttributeError:
+                field_forgery_rejected = True
+            return operation(forged)
+
+    def user_operation(_session: StrictWorkspaceSession) -> None:
+        nonlocal called
+        called += 1
+
+    with pytest.raises(TypeError, match="provenance is unbound"):
+        run_strict_workspace(
+            ForgingProvider(),
+            request,
+            receipt_owner=PublishedWorkspaceReceiptOwner(),
+            operation=user_operation,
+        )
+
+    assert called == 0
+    assert field_forgery_rejected is True
+
+
 def test_double_publish_fails_but_retains_active_receipt(tmp_path: Path) -> None:
     request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
     provider = _TestProvider()
@@ -405,7 +1245,7 @@ def test_double_publish_fails_but_retains_active_receipt(tmp_path: Path) -> None
         owner.close()
 
 
-def test_wrong_active_receipt_is_rejected_without_losing_owner(
+def test_provider_wrong_request_is_rejected_before_operation(
     tmp_path: Path,
 ) -> None:
     request = StrictWorkspaceRequest("test", tmp_path / "published", _plan())
@@ -428,23 +1268,25 @@ def test_wrong_active_receipt_is_rejected_without_losing_owner(
             )
 
     owner = PublishedWorkspaceReceiptOwner()
+    called = False
 
     def operation(session: StrictWorkspaceSession) -> None:
+        nonlocal called
+        called = True
         session.write_file("payload.bin", (b"owned",))
         session.publish_validated(lambda _reader: None)
 
-    try:
-        with pytest.raises(RuntimeError, match="wrong request"):
-            run_strict_workspace(
-                WrongProvider(),
-                request,
-                receipt_owner=owner,
-                operation=operation,
-            )
-        assert owner.active
-        assert owner.receipt.path == wrong_request.destination
-    finally:
-        owner.close()
+    with pytest.raises(ValueError, match="another request"):
+        run_strict_workspace(
+            WrongProvider(),
+            request,
+            receipt_owner=owner,
+            operation=operation,
+        )
+
+    assert called is False
+    assert owner.state == "empty"
+    assert not wrong_request.destination.exists()
 
 
 def test_provider_return_without_invoking_operation_is_rejected(tmp_path: Path) -> None:

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -4,16 +4,26 @@
 
 from __future__ import annotations
 
+import builtins
 import json
 from pathlib import Path, PureWindowsPath
 from types import SimpleNamespace
 
 import pytest
 
+import codenib.web.local as local_module
 import codenib.web.static_export as static_module
 from codenib.artifacts.security import assert_publishable_tree
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.graph.code_graph import CodeGraph
+from codenib.source_fingerprint import (
+    RepositoryChangedError,
+    RepositorySourceBinding,
+    fingerprint_repository,
+)
+from codenib.web.config import REGISTRY_FILENAME, RepoEntry, load_registry
+from codenib.web.repo_registry import RepoBundle
 from codenib.web.static_export import (
     _GRAPH_SOURCE_MAX_ANCHORS,
     _GRAPH_SOURCE_PAGE_MAX_BYTES,
@@ -23,10 +33,12 @@ from codenib.web.static_export import (
     export_static_wiki,
     normalize_base_path,
 )
+from codenib.wiki.builder import WikiBuilder
 
 
 class _Builder:
-    def __init__(self, _bundle) -> None:
+    def __init__(self, _bundle, *, source_reader=None) -> None:
+        self.source_reader = source_reader
         self.pages = {
             "overview": {
                 "id": "overview",
@@ -98,6 +110,8 @@ def _frontend(root: Path) -> Path:
 
 
 def _manifest(repo: Path, artifact: Path) -> tuple[RepoManifest, Path]:
+    repo.mkdir(parents=True, exist_ok=True)
+    source = fingerprint_repository(repo)
     entry = IndexEntry(
         index_type="bm25",
         path=str(artifact / "bm25"),
@@ -105,14 +119,14 @@ def _manifest(repo: Path, artifact: Path) -> tuple[RepoManifest, Path]:
         built_at_epoch=0.0,
         status="fresh",
         commit="abc123",
-        source_fingerprint="source-1",
+        source_fingerprint=source.value,
     )
     manifest = RepoManifest(
         repo_path=str(repo),
         commit="abc123",
-        source_fingerprint="source-1",
+        source_fingerprint=source.value,
         languages=["python"],
-        file_count=1,
+        file_count=source.file_count,
         indexes={"bm25": entry},
         capabilities={"sparse_search": True},
     )
@@ -160,13 +174,18 @@ def export_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         data_dir=artifact / "wiki",
         config_path=artifact / "wiki" / "config.yaml",
     )
+
+    def prepare_static(_repo, _manifest, **kwargs):
+        assert kwargs["repository_slug"] == repo.name
+        return local
+
     monkeypatch.setattr(
         "codenib.web.static_export.prepare_local_wiki",
-        lambda *_args, **_kwargs: local,
+        prepare_static,
     )
     monkeypatch.setattr(
         "codenib.web.static_export._load_static_bundle",
-        lambda _local, _manifest_path: bundle,
+        lambda _local, _manifest_path, **_kwargs: bundle,
     )
     monkeypatch.setattr("codenib.wiki.WikiBuilder", _Builder)
 
@@ -179,12 +198,131 @@ def export_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     )
 
 
+def test_explicit_static_slug_ignores_ambient_git_origin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "trusted-local"
+    repo.mkdir()
+    (repo / "source.py").write_text("value = 1\n", encoding="utf-8")
+    _manifest_value, manifest_path = _manifest(repo, tmp_path / "artifact")
+    origin_calls: list[Path] = []
+
+    def ambient_origin(path: Path) -> str:
+        origin_calls.append(path)
+        return "https://github.com/attacker/beta.git"
+
+    monkeypatch.setattr(local_module, "_origin_url", ambient_origin)
+
+    prepared = local_module.prepare_local_wiki(
+        repo,
+        manifest_path,
+        frontend_port=0,
+        repository_slug=repo.name,
+    )
+
+    entries = load_registry(str(prepared.data_dir / REGISTRY_FILENAME))
+    assert origin_calls == []
+    assert prepared.repo_id == "trusted-local"
+    assert len(entries) == 1
+    assert entries[0].repo == "trusted-local"
+
+
+def test_explicit_static_slug_rejects_surrogateescape_as_validation_error(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="valid UTF-8"):
+        local_module.prepare_local_wiki(
+            tmp_path,
+            tmp_path / "missing-manifest.json",
+            frontend_port=0,
+            repository_slug="repo-\udcff",
+        )
+
+
 def _tree_bytes(root: Path) -> dict[str, bytes]:
     return {
         path.relative_to(root).as_posix(): path.read_bytes()
         for path in sorted(root.rglob("*"))
         if path.is_file()
     }
+
+
+def _bound_source_export_setup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> SimpleNamespace:
+    repo = tmp_path / "repo"
+    runtime = repo / "src" / "runtime.py"
+    runtime.parent.mkdir(parents=True)
+    runtime.write_text(
+        "def run():\n    return 'trusted-source'\n",
+        encoding="utf-8",
+    )
+    readme = repo / "README.md"
+    readme.write_text(
+        "# Bound Demo\n\n"
+        "Bound Demo provides exact repository evidence for source exploration.\n",
+        encoding="utf-8",
+    )
+    artifact = tmp_path / "artifact"
+    manifest, manifest_path = _manifest(repo, artifact)
+    local = SimpleNamespace(
+        repo_id="demo",
+        data_dir=artifact / "wiki",
+        config_path=artifact / "wiki" / "config.yaml",
+    )
+    graph = CodeGraph()
+    graph._add_vertex(
+        "src/runtime.py:run()",
+        {
+            "type": "function",
+            "file": "src/runtime.py",
+            "start_line": 0,
+            "end_line": 1,
+            "unified_name": "src/runtime.py:run()",
+        },
+    )
+
+    def load_bundle(_local, _manifest_path, *, source_reader):
+        entry = RepoEntry(
+            instance_id="demo",
+            repo="owner/demo",
+            base_commit=manifest.commit,
+            language="python",
+            repo_dir=str(repo),
+            manifest_path=str(manifest_path),
+        )
+        document = SimpleNamespace(
+            page_content="def run():\n    return 'stale-index-content'\n",
+            metadata={
+                "file": str(runtime),
+                "name": "run",
+                "chunk_type": "function",
+                "start_line": 0,
+                "end_line": 1,
+            },
+        )
+        bundle = RepoBundle(
+            entry=entry,
+            manifest=manifest,
+            bm25=SimpleNamespace(documents=[document]),
+            source_reader=source_reader,
+        )
+        bundle._code_graph_loaded = True
+        bundle._code_graph = graph
+        return bundle
+
+    monkeypatch.setattr(static_module, "prepare_local_wiki", lambda *_a, **_k: local)
+    monkeypatch.setattr(static_module, "_load_static_bundle", load_bundle)
+    return SimpleNamespace(
+        repo=repo,
+        runtime=runtime,
+        readme=readme,
+        manifest_path=manifest_path,
+        frontend=_frontend(tmp_path),
+        output=tmp_path / "site",
+    )
 
 
 def test_static_bundle_rejects_bm25_that_no_longer_matches_manifest(tmp_path):
@@ -211,10 +349,6 @@ def test_static_export_is_deterministic_and_publishable(
     export_setup, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     setup = export_setup
-    monkeypatch.setattr(
-        "codenib.web.static_export._github_repository_url",
-        lambda _repo: "https://github.com/owner/demo",
-    )
     first = export_static_wiki(
         setup.repo,
         setup.manifest_path,
@@ -239,7 +373,7 @@ def test_static_export_is_deterministic_and_publishable(
     manifest = json.loads((setup.output / STATIC_EXPORT_MANIFEST).read_text())
     assert manifest["schema_version"] == "1.0"
     assert manifest["repository"]["commit"] == "abc123"
-    assert manifest["repository"]["url"] == "https://github.com/owner/demo"
+    assert manifest["repository"]["url"] is None
     assert manifest["source_locations"]["line_base"] == 1
     assert manifest["capabilities"]["static_wiki"] is True
     assert manifest["capabilities"]["chat"] is False
@@ -249,7 +383,7 @@ def test_static_export_is_deterministic_and_publishable(
 
     repos = json.loads((setup.output / "data" / "repos.json").read_text())
     assert repos[0]["problem_statement"] == ""
-    assert repos[0]["source_url"] == "https://github.com/owner/demo"
+    assert repos[0]["source_url"] is None
     page = json.loads(
         (
             setup.output / "data" / "repos" / "demo" / "pages" / "overview.json"
@@ -270,15 +404,231 @@ def test_static_export_is_deterministic_and_publishable(
     assert "href='#heading'" in index
 
 
+def test_static_export_reads_summary_excerpts_graph_and_paths_from_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = _bound_source_export_setup(tmp_path, monkeypatch)
+    real_read_prefix = RepositorySourceBinding.read_prefix
+    real_read_line_range = RepositorySourceBinding.read_line_range
+    prefix_reads: list[str] = []
+    line_reads: list[str] = []
+
+    def counted_read_prefix(self, relative, *, max_bytes):
+        prefix_reads.append(relative)
+        return real_read_prefix(self, relative, max_bytes=max_bytes)
+
+    def counted_read_line_range(
+        self,
+        relative,
+        *,
+        start_line,
+        end_line,
+        max_bytes,
+    ):
+        line_reads.append(relative)
+        return real_read_line_range(
+            self,
+            relative,
+            start_line=start_line,
+            end_line=end_line,
+            max_bytes=max_bytes,
+        )
+
+    real_open = builtins.open
+
+    def reject_ambient_source_open(file, *args, **kwargs):
+        try:
+            candidate = Path(file)
+        except TypeError:
+            return real_open(file, *args, **kwargs)
+        if candidate == setup.repo or setup.repo in candidate.parents:
+            raise AssertionError(
+                f"ambient repository read escaped binding: {candidate}"
+            )
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(
+        RepositorySourceBinding,
+        "read_prefix",
+        counted_read_prefix,
+    )
+    monkeypatch.setattr(
+        RepositorySourceBinding,
+        "read_line_range",
+        counted_read_line_range,
+    )
+    monkeypatch.setattr(builtins, "open", reject_ambient_source_open)
+
+    export_static_wiki(
+        setup.repo,
+        setup.manifest_path,
+        setup.output,
+        frontend_dir=setup.frontend,
+    )
+
+    repos = json.loads((setup.output / "data" / "repos.json").read_text())
+    assert repos[0]["description"].startswith("Bound Demo provides exact")
+    page = json.loads(
+        (setup.output / "data/repos/demo/pages/overview.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert page["citations"][0]["file"] == "src/runtime.py"
+    assert "trusted-source" in page["citations"][0]["content"]
+    assert "stale-index-content" not in page["citations"][0]["content"]
+    graph = json.loads(
+        (setup.output / "data/repos/demo/page-graphs/overview.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert "trusted-source" in graph["nodes"][0]["source"]["content"]
+    assert "README.md" in prefix_reads
+    assert "src/runtime.py" in prefix_reads  # generated-source header check
+    assert line_reads.count("src/runtime.py") >= 2
+
+
+def test_static_export_rejects_summary_source_drift_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = _bound_source_export_setup(tmp_path, monkeypatch)
+    real_read_prefix = RepositorySourceBinding.read_prefix
+    mutated = False
+
+    def mutate_summary_before_read(self, relative, *, max_bytes):
+        nonlocal mutated
+        if relative == "README.md" and not mutated:
+            mutated = True
+            setup.readme.write_text(
+                "# Drifted\n\nThis summary was changed after source binding.\n",
+                encoding="utf-8",
+            )
+        return real_read_prefix(self, relative, max_bytes=max_bytes)
+
+    monkeypatch.setattr(
+        RepositorySourceBinding,
+        "read_prefix",
+        mutate_summary_before_read,
+    )
+
+    with pytest.raises(RepositoryChangedError):
+        export_static_wiki(
+            setup.repo,
+            setup.manifest_path,
+            setup.output,
+            frontend_dir=setup.frontend,
+        )
+
+    assert mutated
+    assert not setup.output.exists()
+
+
+def test_static_export_rejects_graph_excerpt_drift_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = _bound_source_export_setup(tmp_path, monkeypatch)
+    real_source = WikiBuilder.source
+    mutated = False
+
+    def mutate_before_graph_source(self, file, start=None, end=None):
+        nonlocal mutated
+        if not mutated:
+            mutated = True
+            setup.runtime.write_text(
+                "def run():\n    return 'graph-drift'\n",
+                encoding="utf-8",
+            )
+        return real_source(self, file, start, end)
+
+    monkeypatch.setattr(WikiBuilder, "source", mutate_before_graph_source)
+
+    with pytest.raises(RepositoryChangedError):
+        export_static_wiki(
+            setup.repo,
+            setup.manifest_path,
+            setup.output,
+            frontend_dir=setup.frontend,
+        )
+
+    assert mutated
+    assert not setup.output.exists()
+
+
+def test_static_export_rejects_index_path_outside_bound_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = _bound_source_export_setup(tmp_path, monkeypatch)
+    real_captured_path = RepositorySourceBinding.captured_relative_path
+
+    def omit_runtime(binding, path):
+        if str(path).replace("\\", "/").endswith("src/runtime.py"):
+            return None
+        return real_captured_path(binding, path)
+
+    monkeypatch.setattr(
+        RepositorySourceBinding,
+        "captured_relative_path",
+        omit_runtime,
+    )
+
+    with pytest.raises(ValueError, match="absent from the authenticated repository"):
+        export_static_wiki(
+            setup.repo,
+            setup.manifest_path,
+            setup.output,
+            frontend_dir=setup.frontend,
+        )
+
+    assert not setup.output.exists()
+
+
+def test_static_export_rejects_source_root_swap_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = _bound_source_export_setup(tmp_path, monkeypatch)
+    real_copy = static_module._copy_frontend
+    swapped = False
+
+    def swap_source_root(*args, **kwargs):
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            saved = setup.repo.with_name("saved-repo")
+            setup.repo.rename(saved)
+            setup.runtime.parent.mkdir(parents=True)
+            setup.runtime.write_text(
+                "def run():\n    return 'replacement-root'\n",
+                encoding="utf-8",
+            )
+            setup.readme.write_text(
+                "# Replacement\n\nReplacement repository source tree.\n",
+                encoding="utf-8",
+            )
+        return real_copy(*args, **kwargs)
+
+    monkeypatch.setattr(static_module, "_copy_frontend", swap_source_root)
+
+    with pytest.raises(RepositoryChangedError):
+        export_static_wiki(
+            setup.repo,
+            setup.manifest_path,
+            setup.output,
+            frontend_dir=setup.frontend,
+        )
+
+    assert swapped
+    assert not setup.output.exists()
+
+
 def test_static_export_preserves_output_changed_during_build(
     export_setup,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     setup = export_setup
-    monkeypatch.setattr(
-        "codenib.web.static_export._github_repository_url",
-        lambda _repo: "https://github.com/owner/demo",
-    )
     export_static_wiki(
         setup.repo,
         setup.manifest_path,
@@ -323,10 +673,6 @@ def test_static_export_rejects_output_symlink(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     setup = export_setup
-    monkeypatch.setattr(
-        "codenib.web.static_export._github_repository_url",
-        lambda _repo: "https://github.com/owner/demo",
-    )
     victim = setup.output
     export_static_wiki(
         setup.repo,
@@ -385,15 +731,77 @@ def test_static_export_preserves_primary_when_stage_discard_fails(
     )
 
 
+def test_static_export_preserves_cancellation_and_retains_failed_source_cleanup(
+    export_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = KeyboardInterrupt("static-build-cancelled")
+    cleanup = SystemExit("static-source-close-cancelled")
+    real_close = RepositorySourceBinding.close
+
+    def cancel_copy(*_args, **_kwargs):
+        raise primary
+
+    def fail_before_close(_binding):
+        raise cleanup
+
+    monkeypatch.setattr(static_module, "_copy_frontend", cancel_copy)
+    monkeypatch.setattr(RepositorySourceBinding, "close", fail_before_close)
+
+    with pytest.raises(KeyboardInterrupt, match="static-build-cancelled") as caught:
+        export_static_wiki(
+            export_setup.repo,
+            export_setup.manifest_path,
+            export_setup.output,
+            frontend_dir=export_setup.frontend,
+        )
+
+    assert caught.value is primary
+    assert caught.value.__cause__ is cleanup
+    assert not export_setup.output.exists()
+    cleanup_owner = caught.value.source_cleanup_owner
+    assert not cleanup_owner.closed
+
+    monkeypatch.setattr(RepositorySourceBinding, "close", real_close)
+    cleanup_owner.close()
+    assert cleanup_owner.closed
+
+
+def test_static_export_close_after_cancellation_still_prevents_publication(
+    export_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cancellation = SystemExit("static-source-closed-then-cancelled")
+    real_close = RepositorySourceBinding.close
+    close_calls = 0
+
+    def close_then_cancel(binding):
+        nonlocal close_calls
+        close_calls += 1
+        real_close(binding)
+        raise cancellation
+
+    monkeypatch.setattr(RepositorySourceBinding, "close", close_then_cancel)
+
+    with pytest.raises(SystemExit, match="closed-then-cancelled") as caught:
+        export_static_wiki(
+            export_setup.repo,
+            export_setup.manifest_path,
+            export_setup.output,
+            frontend_dir=export_setup.frontend,
+        )
+
+    assert caught.value is cancellation
+    assert close_calls == 1
+    assert getattr(caught.value, "source_cleanup_owner", None) is None
+    assert not export_setup.output.exists()
+
+
 def test_static_export_never_overwrites_raced_runtime_config(
     export_setup,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     setup = export_setup
-    monkeypatch.setattr(
-        "codenib.web.static_export._github_repository_url",
-        lambda _repo: "https://github.com/owner/demo",
-    )
     real_write = static_module.OwnedDirectoryStage.write_file
     raced = False
 
@@ -431,10 +839,6 @@ def test_static_export_rejects_reversible_nested_directory_replacement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     setup = export_setup
-    monkeypatch.setattr(
-        "codenib.web.static_export._github_repository_url",
-        lambda _repo: "https://github.com/owner/demo",
-    )
     foreign = setup.output.parent / "foreign-data"
     foreign.mkdir()
     valuable = foreign / "valuable.txt"
@@ -528,8 +932,8 @@ def test_static_export_rejects_a_configured_secret(
     secret = "provider-secret-value"
 
     class SecretBuilder(_Builder):
-        def __init__(self, bundle) -> None:
-            super().__init__(bundle)
+        def __init__(self, bundle, *, source_reader=None) -> None:
+            super().__init__(bundle, source_reader=source_reader)
             self.pages["overview"]["markdown"] = f"# Overview\n\n{secret}"
 
     monkeypatch.setattr("codenib.wiki.WikiBuilder", SecretBuilder)
@@ -881,8 +1285,8 @@ def test_static_export_rejects_absolute_citation_paths(
     export_setup, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     class AbsolutePathBuilder(_Builder):
-        def __init__(self, bundle) -> None:
-            super().__init__(bundle)
+        def __init__(self, bundle, *, source_reader=None) -> None:
+            super().__init__(bundle, source_reader=source_reader)
             self.pages["overview"]["citations"][0]["file"] = "/tmp/source.py"
 
     monkeypatch.setattr("codenib.wiki.WikiBuilder", AbsolutePathBuilder)

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -350,6 +350,41 @@ def test_static_export_rejects_output_symlink(
     assert _tree_bytes(victim) == previous
 
 
+def test_static_export_preserves_primary_when_stage_discard_fails(
+    export_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = KeyboardInterrupt("static-build-primary")
+    secondary = SystemExit("static-discard-secondary")
+
+    def fail_copy(*_args, **_kwargs):
+        raise primary
+
+    def fail_discard(_stage):
+        raise secondary
+
+    monkeypatch.setattr(static_module, "_copy_frontend", fail_copy)
+    monkeypatch.setattr(static_module.OwnedDirectoryStage, "discard", fail_discard)
+
+    with pytest.raises(KeyboardInterrupt, match="static-build-primary") as caught:
+        export_static_wiki(
+            export_setup.repo,
+            export_setup.manifest_path,
+            export_setup.output,
+            frontend_dir=export_setup.frontend,
+        )
+
+    assert caught.value is primary
+    notes = tuple(getattr(primary, "__notes__", ())) + tuple(
+        getattr(primary, "_codenib_cleanup_notes", ())
+    )
+    assert any(
+        "static export stage discard also failed" in note
+        and "static-discard-secondary" in note
+        for note in notes
+    )
+
+
 def test_static_export_never_overwrites_raced_runtime_config(
     export_setup,
     monkeypatch: pytest.MonkeyPatch,

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -1281,6 +1281,49 @@ def test_static_export_rejects_index_root_overlap(export_setup) -> None:
         )
 
 
+def test_static_export_rejects_manifest_directory_alias_overlap(
+    export_setup,
+) -> None:
+    setup = export_setup
+    before = _tree_bytes(setup.artifact)
+    manifest_root_alias = setup.artifact.with_name("artifact-alias")
+    manifest_root_alias.symlink_to(setup.artifact, target_is_directory=True)
+    aliased_manifest = manifest_root_alias / setup.manifest_path.name
+    output = setup.artifact / "directory-alias-site"
+
+    with pytest.raises(ValueError, match="outside the index root"):
+        export_static_wiki(
+            setup.repo,
+            aliased_manifest,
+            output,
+            frontend_dir=setup.frontend,
+        )
+
+    assert manifest_root_alias.is_symlink()
+    assert not output.exists()
+    assert _tree_bytes(setup.artifact) == before
+
+
+def test_static_export_rejects_manifest_file_alias_overlap(export_setup) -> None:
+    setup = export_setup
+    before = _tree_bytes(setup.artifact)
+    manifest_alias = setup.artifact.parent / "manifest-alias.json"
+    manifest_alias.symlink_to(setup.manifest_path)
+    output = setup.artifact / "file-alias-site"
+
+    with pytest.raises(ValueError, match="outside the index root"):
+        export_static_wiki(
+            setup.repo,
+            manifest_alias,
+            output,
+            frontend_dir=setup.frontend,
+        )
+
+    assert manifest_alias.is_symlink()
+    assert not output.exists()
+    assert _tree_bytes(setup.artifact) == before
+
+
 def test_static_export_rejects_absolute_citation_paths(
     export_setup, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import codenib.web.static_export as static_module
 from codenib.artifacts.security import assert_publishable_tree
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
@@ -337,7 +338,7 @@ def test_static_export_rejects_output_symlink(
     output = setup.output.parent / "output-link"
     output.symlink_to(victim, target_is_directory=True)
 
-    with pytest.raises(ValueError, match="symbolic link"):
+    with pytest.raises(ValueError, match="not a directory or is a link"):
         export_static_wiki(
             setup.repo,
             setup.manifest_path,
@@ -349,7 +350,7 @@ def test_static_export_rejects_output_symlink(
     assert _tree_bytes(victim) == previous
 
 
-def test_static_export_does_not_follow_swapped_stage_symlink(
+def test_static_export_never_overwrites_raced_runtime_config(
     export_setup,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -358,27 +359,23 @@ def test_static_export_does_not_follow_swapped_stage_symlink(
         "codenib.web.static_export._github_repository_url",
         lambda _repo: "https://github.com/owner/demo",
     )
-    victim = setup.output.parent / "victim"
-    victim.mkdir()
-    (victim / "keep.txt").write_text("keep", encoding="utf-8")
-    stolen = setup.output.parent / "stolen-stage"
+    real_write = static_module.OwnedDirectoryStage.write_file
+    raced = False
 
-    from codenib.web import static_export as static_export_module
+    def race_runtime_config(self, relative, chunks, **kwargs):
+        nonlocal raced
+        if str(relative) == "runtime-config.js" and not raced:
+            raced = True
+            (self.path / "runtime-config.js").write_bytes(b"foreign-config")
+        return real_write(self, relative, chunks, **kwargs)
 
-    real_mkdtemp = static_export_module.tempfile.mkdtemp
-    swapped: Path | None = None
+    monkeypatch.setattr(
+        static_module.OwnedDirectoryStage,
+        "write_file",
+        race_runtime_config,
+    )
 
-    def swap_stage(*args, **kwargs):
-        nonlocal swapped
-        created = Path(real_mkdtemp(*args, **kwargs))
-        created.rename(stolen)
-        created.symlink_to(victim, target_is_directory=True)
-        swapped = created
-        return str(created)
-
-    monkeypatch.setattr(static_export_module.tempfile, "mkdtemp", swap_stage)
-
-    with pytest.raises(ValueError, match="link"):
+    with pytest.raises((RuntimeError, ValueError)):
         export_static_wiki(
             setup.repo,
             setup.manifest_path,
@@ -386,9 +383,83 @@ def test_static_export_does_not_follow_swapped_stage_symlink(
             frontend_dir=setup.frontend,
         )
 
-    assert swapped is not None and swapped.is_symlink()
-    assert stolen.is_dir()
-    assert (victim / "keep.txt").read_text(encoding="utf-8") == "keep"
+    assert raced
+    assert not setup.output.exists()
+    assert any(
+        path.read_bytes() == b"foreign-config"
+        for path in setup.output.parent.rglob("runtime-config.js")
+    )
+
+
+def test_static_export_rejects_reversible_nested_directory_replacement(
+    export_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = export_setup
+    monkeypatch.setattr(
+        "codenib.web.static_export._github_repository_url",
+        lambda _repo: "https://github.com/owner/demo",
+    )
+    foreign = setup.output.parent / "foreign-data"
+    foreign.mkdir()
+    valuable = foreign / "valuable.txt"
+    valuable.write_text("keep", encoding="utf-8")
+    real_stat = static_module.os.stat
+    real_write_json = static_module._write_json
+    armed = False
+    swapped = False
+
+    def arm_nested_swap(stage, relative, value):
+        nonlocal armed
+        if relative.endswith("/wiki.json"):
+            armed = True
+        return real_write_json(stage, relative, value)
+
+    def reversible_stat(path, *, dir_fd=None, follow_symlinks=True):
+        nonlocal swapped
+        if armed and not swapped and path == "data" and dir_fd is not None:
+            swapped = True
+            static_module.os.rename(
+                "data",
+                ".saved-data",
+                src_dir_fd=dir_fd,
+                dst_dir_fd=dir_fd,
+            )
+            static_module.os.rename(foreign, "data", dst_dir_fd=dir_fd)
+            try:
+                return real_stat(
+                    path,
+                    dir_fd=dir_fd,
+                    follow_symlinks=follow_symlinks,
+                )
+            finally:
+                static_module.os.rename("data", foreign, src_dir_fd=dir_fd)
+                static_module.os.rename(
+                    ".saved-data",
+                    "data",
+                    src_dir_fd=dir_fd,
+                    dst_dir_fd=dir_fd,
+                )
+        return real_stat(
+            path,
+            dir_fd=dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+
+    monkeypatch.setattr(static_module, "_write_json", arm_nested_swap)
+    monkeypatch.setattr(static_module.os, "stat", reversible_stat)
+
+    with pytest.raises(ValueError, match="component changed"):
+        export_static_wiki(
+            setup.repo,
+            setup.manifest_path,
+            setup.output,
+            frontend_dir=setup.frontend,
+        )
+
+    assert swapped
+    assert valuable.read_text(encoding="utf-8") == "keep"
+    assert not setup.output.exists()
 
 
 def test_publishability_rejects_json_escaped_windows_path(tmp_path: Path) -> None:
@@ -428,6 +499,34 @@ def test_static_export_rejects_a_configured_secret(
 
     monkeypatch.setattr("codenib.wiki.WikiBuilder", SecretBuilder)
 
+    with pytest.raises(ValueError, match="configured credential"):
+        export_static_wiki(
+            export_setup.repo,
+            export_setup.manifest_path,
+            export_setup.output,
+            frontend_dir=export_setup.frontend,
+            environ={"OPENAI_API_KEY": secret},
+        )
+    assert not export_setup.output.exists()
+
+
+def test_static_export_reader_rejects_late_decoded_secret(
+    export_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "pässwörd-secret"
+    original_write_json = static_module._write_json
+
+    def write_decoded_secret(stage, relative, value):
+        if relative.endswith("/pages/overview.json"):
+            value = {"value": secret}
+        return original_write_json(stage, relative, value)
+
+    monkeypatch.setattr(
+        static_module,
+        "_write_json",
+        write_decoded_secret,
+    )
     with pytest.raises(ValueError, match="configured credential"):
         export_static_wiki(
             export_setup.repo,

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -488,6 +488,41 @@ def test_static_export_reads_summary_excerpts_graph_and_paths_from_binding(
     assert line_reads.count("src/runtime.py") >= 2
 
 
+def test_static_export_does_not_trust_mutable_source_identity_projection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = _bound_source_export_setup(tmp_path, monkeypatch)
+    expected = RepoManifest.load(str(setup.manifest_path))
+    setup.runtime.write_text(
+        "def run():\n    return 'changed-before-capture'\n",
+        encoding="utf-8",
+    )
+    real_capture = static_module.capture_repository_source
+
+    def replace_public_identity(*args, **kwargs):
+        binding = real_capture(*args, **kwargs)
+        binding.fingerprint = expected.source_fingerprint
+        binding.file_count = expected.file_count
+        return binding
+
+    monkeypatch.setattr(
+        static_module,
+        "capture_repository_source",
+        replace_public_identity,
+    )
+
+    with pytest.raises(RepositoryChangedError, match="public identity changed"):
+        export_static_wiki(
+            setup.repo,
+            setup.manifest_path,
+            setup.output,
+            frontend_dir=setup.frontend,
+        )
+
+    assert not setup.output.exists()
+
+
 def test_static_export_rejects_summary_source_drift_before_publication(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -888,7 +923,10 @@ def test_static_export_rejects_reversible_nested_directory_replacement(
     monkeypatch.setattr(static_module, "_write_json", arm_nested_swap)
     monkeypatch.setattr(static_module.os, "stat", reversible_stat)
 
-    with pytest.raises(ValueError, match="component changed"):
+    with pytest.raises(
+        (RuntimeError, ValueError),
+        match="component changed|publication parent path changed",
+    ):
         export_static_wiki(
             setup.repo,
             setup.manifest_path,

--- a/test/wiki/test_builder.py
+++ b/test/wiki/test_builder.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 import pytest
 
 from codenib.repository_summary import readme_summary
+from codenib.source_fingerprint import capture_repository_source
 from codenib.wiki.builder import (
     Symbol,
     WikiBuilder,
@@ -234,6 +235,36 @@ def test_symbol_content_is_hydrated_from_source(repo_dir):
     )
     assert "normalized retrieval tokens" not in page["markdown"]
     assert "def run():" in page["citations"][0]["content"]
+
+
+def test_bound_source_hydrates_far_offset_symbol_without_prefix_truncation(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "pkg" / "far.py"
+    source.parent.mkdir(parents=True)
+    filler = (b"# " + (b"x" * 510) + b"\n") * 17_000
+    source.write_bytes(filler + b"def target(): return 'far-offset'\n")
+    document = _Doc(
+        "stale index payload",
+        {
+            "file": str(source),
+            "name": "target",
+            "chunk_type": "function",
+            "start_line": 17_000,
+            "end_line": 17_000,
+        },
+    )
+    bundle = _make_bundle(str(tmp_path))
+    bundle.vector_store = None
+    bundle.bm25 = SimpleNamespace(documents=[document])
+
+    with capture_repository_source(tmp_path) as binding:
+        builder = WikiBuilder(bundle, source_reader=binding.borrow_reader())
+
+        assert builder._symbols()[0].content == "def target(): return 'far-offset'"
+        excerpt = builder.source("pkg/far.py", 17_001, 17_001)
+        assert excerpt is not None
+        assert excerpt["content"] == "def target(): return 'far-offset'\n"
 
 
 def test_source_traversal_guard(repo_dir):


### PR DESCRIPTION
## Summary

Restack the strict publication producer work onto the focused workspace authority from #619 and the source, vector, atomic-cleanup, and resource-ownership foundations already merged to `main`.

This replacement removes the obsolete stacked history while preserving the producer contracts, authenticated repository reads, and static export hardening.

## Changes

- bound publishable JSON and metadata before DOM allocation
- add the callback-scoped strict workspace provider contract
- migrate static Wiki export to retained source authority and authenticated staged/published validation
- route summaries, citations, graph excerpts, and codemap reads through the bounded repository-source reader
- compare static-export manifests against a verified detached identity rather than mutable public projections
- preserve first-failure and cancellation semantics across stage and source cleanup
- document the strict producer boundary and remaining provider integration work

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- post-#619 restack focused producer/export suite: 754 passed, 15 skipped
- all 11 commits are range-diff equivalent to the original replacement stack
- changed-range pre-commit hooks
- `git diff --check origin/main...HEAD`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Supersedes the now-closed #591. #619 and its #622 resource-cleanup prerequisite are merged, and this branch is restacked directly onto current `main`.
