### PR TITLE
feat(codegraph): make 0.2.1 agent-ready

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -290,7 +290,7 @@ jobs:
         run: python "$GITHUB_WORKSPACE/scripts/smoke_release_agent.py"
 
   graph-smoke:
-    name: Installed graph and Dependency Map
+    name: Installed CodeGraph and agent onboarding
     if: inputs.full
     needs: build
     runs-on: ubuntu-latest
@@ -315,7 +315,7 @@ jobs:
           name: python-package-distributions
           path: dist
 
-      - name: Install wheel and Python graph runtime
+      - name: Install wheel, Python graph runtime, and MCP
         run: |
           GRAPH_VENV="$RUNNER_TEMP/codenib-release-graph-${{ github.run_id }}-${{ github.run_attempt }}"
           python -m venv "$GRAPH_VENV"
@@ -323,7 +323,7 @@ jobs:
           "$GRAPH_VENV/bin/python" -m pip install --upgrade pip
           WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
           test -n "$WHEEL"
-          "$GRAPH_VENV/bin/python" -m pip install "${WHEEL}[graph]"
+          "$GRAPH_VENV/bin/python" -m pip install "${WHEEL}[graph,mcp]"
 
       - name: Provision the Python SCIP provider
         run: |
@@ -337,7 +337,7 @@ jobs:
           python - <<'PY'
           import importlib.util
 
-          required = ("google.protobuf", "igraph")
+          required = ("google.protobuf", "igraph", "mcp")
           missing = [name for name in required if importlib.util.find_spec(name) is None]
           if missing:
               raise SystemExit(f"missing graph runtimes: {missing}")
@@ -351,6 +351,6 @@ jobs:
               raise SystemExit(f"unexpected non-graph runtimes: {unexpected}")
           PY
 
-      - name: Exercise installed Dependency Map
+      - name: Exercise installed CodeGraph product path
         working-directory: ${{ runner.temp }}
         run: python "$GITHUB_WORKSPACE/scripts/smoke_release_graph.py"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-08-13
+
+### Added
+
+- A one-command `codenib codegraph init` path that installs repository-aware
+  graph providers, builds BM25 and symbol-graph views, and configures installed
+  Codex and Claude Code clients through their native MCP CLIs.
+- Machine-readable CodeGraph status, idempotent client receipts, safe uninstall,
+  and a no-write dry run.
+- Installed-wheel black-box coverage for `explore_context`,
+  `dependency_subgraph`, both client contracts, repeat initialization, and
+  checkout cleanliness.
+
+### Changed
+
+- The primary agent quickstart now leads with the local, model-free CodeGraph;
+  the Wiki and semantic routes remain available as independent product paths.
+
+### Security
+
+- Client setup refuses unmanaged name collisions and drifted managed
+  registrations. Uninstall removes only receipt-owned entries and preserves
+  repository indexes.
+
 ## [0.2.0] - 2026-08-05
 
 ### Added
@@ -132,7 +156,8 @@ All notable user-facing changes are recorded here. CodeNib follows
 - Prepared secretless PyPI publishing through a dedicated GitHub Actions OIDC
   workflow.
 
-[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/sysevol-ai/CodeNib/compare/v0.1.0...v0.2.0
 [0.2.0a2]: https://github.com/sysevol-ai/CodeNib/compare/620a82d...78e12ac
 [0.2.0a1]: https://github.com/sysevol-ai/CodeNib/tree/620a82d

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ SPDX-License-Identifier: Apache-2.0
     &nbsp;&middot;&nbsp;
     <a href="https://docs.codenib.ai/">Documentation</a>
     &nbsp;&middot;&nbsp;
+    <a href="https://docs.codenib.ai/codegraph/">CodeGraph</a>
+    &nbsp;&middot;&nbsp;
     <a href="https://docs.codenib.ai/mcp/">MCP</a>
     &nbsp;&middot;&nbsp;
     <a href="https://docs.codenib.ai/agent_integrations/">Agent Integrations</a>
@@ -35,22 +37,27 @@ SPDX-License-Identifier: Apache-2.0
     <a href="https://pypi.org/project/codenib/"><img src="https://img.shields.io/pypi/v/codenib.svg" alt="PyPI version"></a>
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0"></a>
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/pyproject.toml"><img src="https://img.shields.io/badge/Python-3.10%2B-3776AB.svg" alt="Python 3.10+"></a>
-    <img src="https://img.shields.io/badge/Release-0.2.0-2563EB.svg" alt="CodeNib 0.2.0">
+    <img src="https://img.shields.io/badge/Release-0.2.1-2563EB.svg" alt="CodeNib 0.2.1">
   </p>
 </div>
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.0"
-codenib wiki /path/to/your/repo
+python -m pip install "codenib[graph,mcp]==0.2.1"
+codenib codegraph init /path/to/your/repo
 ```
 
-Local, open source, and no cloud required. CodeNib combines BM25 and dense code
-search, adds optional SCIP symbol graphs, and incrementally rebuilds repository
-indexes as commits change. The same index powers the Wiki, Dependency Map, Ask,
-and MCP tools instead of making every agent rediscover the codebase.
+That one command detects the repository languages, installs the pinned
+package-level graph providers it can manage, builds BM25 plus a source-linked
+symbol graph, and registers the resulting MCP server with installed Codex and
+Claude Code clients. It is local, open source, requires no model or cloud, and
+does not write configuration or indexes into the target repository.
 
 ## News
 
+- **2026-08-13 — CodeNib 0.2.1 CodeGraph onboarding.** One command prepares a
+  repository graph and connects it to Codex and Claude Code, with idempotent
+  status, safe uninstall, and installed-wheel MCP graph verification.
+  [CodeGraph guide](https://docs.codenib.ai/codegraph/)
 - **2026-08-08 — RepoNavigator Jump adapter.** The published single-tool
   [RepoNavigator](https://arxiv.org/abs/2512.20957v6) contract now resolves
   symbol definitions through a persisted SCIP occurrence or injected LSP
@@ -100,33 +107,38 @@ publishing a partially updated view.
 
 ## Quickstart
 
-Requires Python 3.10+ and Git. The recommended local path includes the pinned
-CodeRankEmbed model and serves hybrid BM25+dense retrieval:
+Requires Python 3.10+ and Git. For an agent-ready CodeGraph with no model or API
+key, install the graph and MCP extras and run one command:
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.0"
-codenib doctor --require core --require wiki
+python -m pip install "codenib[graph,mcp]==0.2.1"
+codenib codegraph init /path/to/repository
+```
+
+`codegraph init` detects Codex and Claude Code, installs only the detected
+languages' package-managed providers, builds reusable `bm25` and
+`symbol_graph` views, and asks each native client CLI to own its configuration.
+Run `codenib codegraph status /path/to/repository` to diagnose the complete
+path or `codenib codegraph uninstall /path/to/repository` to remove only the
+managed client registrations. The index remains reusable.
+
+For a browser Wiki with hybrid BM25+dense retrieval, install the semantic extra:
+
+```bash
+python -m pip install "codenib[semantic]==0.2.1"
 codenib wiki /path/to/repository
 ```
 
-`codenib wiki` selects the semantic route because the installed environment
-contains its dependencies. A smaller `python -m pip install codenib==0.2.0`
-installation selects the deterministic BM25 fallback and downloads no model.
-The [0.2 release notes](https://docs.codenib.ai/releases/0.2.0/) record the
-upgrade boundary and verification evidence.
+Both paths keep reusable state under `~/.codenib/repositories` and leave the
+target checkout unchanged. Set `CODENIB_HOME` to relocate state. The
+[0.2.1 release notes](https://docs.codenib.ai/releases/0.2.1/) record the
+upgrade boundary and installed-product evidence.
 
-CodeNib detects the repository languages, builds a reusable index under
-`~/.codenib/repositories`, launches the local Wiki, and opens
-[http://localhost:3000](http://localhost:3000). The wheel includes the
-production Wiki frontend, so normal use does not require Node.js or npm and
-the target repository stays untouched. This command exercises the same compiler
-and serving runtime used by agents. Set `CODENIB_HOME` to relocate state.
-
-Check the environment or index without opening the Wiki:
+Preview the CodeGraph operations without installing, indexing, or configuring
+an agent:
 
 ```bash
-codenib doctor --require core --require wiki
-codenib index /path/to/repository
+codenib codegraph init /path/to/repository --dry-run
 ```
 
 For a structural view, CodeNib detects the repository languages and manages
@@ -134,7 +146,7 @@ only their package-level providers; operating-system and project prerequisites
 remain explicit:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.0"
+python -m pip install "codenib[graph]==0.2.1"
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
 ```
@@ -172,27 +184,21 @@ for ports, advanced indexing, and troubleshooting.
 
 ## Serve An Agent
 
-Install the MCP extra, build once, and serve the same repository manifest over
-stdio:
+The recommended path configures installed Codex and Claude Code clients through
+their native CLIs:
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.0"
-codenib index /path/to/repository
-codenib mcp /path/to/repository
+python -m pip install "codenib[graph,mcp]==0.2.1"
+codenib codegraph init /path/to/repository
 ```
 
-The MCP server advertises `search_context` as its default ranked entry point,
-then exposes the underlying BM25, vector, graph, and navigation operations for
-explicit control. It uses the compiled manifest to decide which calls have a
-fresh backing view. An agent can therefore reuse
-available repository work instead of rebuilding context through unbounded
-`grep` and `read` loops, while unavailable searches fail explicitly. BM25,
-semantic, regex, Zoekt, dependency, and static-navigation results retain source
-locations for follow-up reads and citations. Large search bodies are projected
-under one aggregate budget without changing rank; the bounded `read_source`
-tool recovers exact source windows from the verified checkout. See
-[MCP Server](https://docs.codenib.ai/mcp/)
-for client configuration and tool contracts.
+Ask the agent to start with `explore_context` for bounded, source-verified
+repository context and use `dependency_subgraph` for caller impact or callee
+dependencies. The MCP server also exposes ranked BM25, regex, definition,
+reference, route, and bounded source-read tools. See the
+[CodeGraph guide](https://docs.codenib.ai/codegraph/) for client scopes,
+diagnostics, uninstall behavior, and language prerequisites, and the
+[MCP Server](https://docs.codenib.ai/mcp/) for the complete tool contract.
 
 The same planner is available directly to Python agents:
 

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -14,6 +14,7 @@ import re
 import shlex
 import shutil
 import stat
+import subprocess
 import sys
 from collections import Counter
 from dataclasses import dataclass, field
@@ -380,6 +381,8 @@ def index_repository(
     embedding_dimension: int | None = None,
     embedding_endpoint: str | None = None,
     embedding_credential_env: str | None = None,
+    allow_graph_project_preparation: bool = True,
+    allow_partial_graph_languages: bool = True,
 ):
     """Build or update the requested repository views."""
     from .toolchains import activate_managed_toolchain
@@ -407,7 +410,8 @@ def index_repository(
         ),
         embedding_endpoint=embedding_endpoint,
         embedding_credential_env=embedding_credential_env,
-        allow_partial_graph_languages=True,
+        allow_partial_graph_languages=allow_partial_graph_languages,
+        allow_graph_project_preparation=allow_graph_project_preparation,
     )
     compiler = IndexCompiler(
         registry,
@@ -1764,6 +1768,613 @@ def _run_toolchain_install(args: argparse.Namespace) -> int:
     return 0 if refreshed.ready else 1
 
 
+def _codegraph_error(exc: BaseException) -> CLIError:
+    return CLIError(str(exc))
+
+
+def _codegraph_spec_for_args(repo_path: Path, args: argparse.Namespace):
+    from .codegraph_onboarding import (
+        CodeGraphOnboardingError,
+        load_codegraph_receipt,
+        make_server_spec,
+        resolve_codenib_command,
+    )
+
+    try:
+        receipt = load_codegraph_receipt(repo_path)
+        explicit = getattr(args, "server_command", None)
+        if receipt is not None and explicit is None:
+            return receipt.server, receipt
+        command, prefix = resolve_codenib_command(explicit)
+        server = make_server_spec(
+            repo_path,
+            command=command,
+            command_prefix=prefix,
+        )
+        if receipt is not None and receipt.server != server:
+            raise CodeGraphOnboardingError(
+                "--command differs from the managed MCP registration; run "
+                "`codenib codegraph uninstall` before changing it"
+            )
+        return server, receipt
+    except (CodeGraphOnboardingError, OSError) as exc:
+        raise _codegraph_error(exc) from exc
+
+
+def _codegraph_clients_for_init(args: argparse.Namespace) -> tuple[str, ...]:
+    from .codegraph_onboarding import (
+        CodeGraphOnboardingError,
+        resolve_requested_clients,
+    )
+
+    try:
+        return resolve_requested_clients(args.agent)
+    except (CodeGraphOnboardingError, OSError) as exc:
+        raise _codegraph_error(exc) from exc
+
+
+def _codegraph_languages_for_init(
+    repo_path: Path,
+    args: argparse.Namespace,
+    receipt,
+) -> tuple[str, ...]:
+    if args.language or receipt is None:
+        return tuple(_selected_languages(repo_path, args.language))
+
+    from .compiler.manifest import MANIFEST_FILENAME, RepoManifest
+    from .paths import repo_index_dir
+
+    try:
+        manifest = RepoManifest.load(repo_index_dir(repo_path) / MANIFEST_FILENAME)
+        if manifest.languages:
+            return tuple(manifest.languages)
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        pass
+    return tuple(_selected_languages(repo_path, ()))
+
+
+def _codegraph_preflight_clients(
+    repo_path: Path,
+    clients: Sequence[str],
+    server,
+    receipt,
+) -> dict[str, object]:
+    from .codegraph_onboarding import (
+        CodeGraphOnboardingError,
+        inspect_client_registration,
+    )
+
+    observed = {}
+    try:
+        for client in clients:
+            inspection = inspect_client_registration(client, server, repo_path)
+            observed[client] = inspection
+            managed = receipt is not None and receipt.client(client) is not None
+            if inspection.exists and not managed:
+                raise CodeGraphOnboardingError(
+                    f"{client} already has an unmanaged MCP server named "
+                    f"{server.name}; remove or rename it before continuing"
+                )
+            if inspection.exists and not inspection.matches:
+                raise CodeGraphOnboardingError(
+                    f"{client} MCP server {server.name} differs from the CodeNib "
+                    "receipt; inspect it before using --force with uninstall"
+                )
+        return observed
+    except (CodeGraphOnboardingError, OSError) as exc:
+        raise _codegraph_error(exc) from exc
+
+
+def _codegraph_toolchain_plan(repo_path: Path, languages: Sequence[str]):
+    from .toolchains import plan_repository_toolchain
+
+    return plan_repository_toolchain(repo_path, languages, scopes=("graph",))
+
+
+def _codegraph_plan_detail(plan) -> str:
+    details = [f"{item.display_name}: {item.executable}" for item in plan.missing]
+    details.extend(note for note in plan.notes if note.startswith("MISSING:"))
+    return "; ".join(details) or "unknown graph prerequisite"
+
+
+def _codegraph_checkout_snapshot(repo_path: Path) -> bytes:
+    """Return the exact Git worktree status used by the onboarding transaction."""
+
+    command = [
+        "git",
+        "-C",
+        str(repo_path),
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--ignore-submodules=none",
+    ]
+    try:
+        result = subprocess.run(command, check=False, capture_output=True)
+    except OSError as exc:
+        raise CLIError("CodeGraph initialization requires Git on PATH") from exc
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        suffix = f": {detail}" if detail else ""
+        raise CLIError("CodeGraph initialization requires a Git working tree" + suffix)
+    return bytes(result.stdout)
+
+
+def _require_unchanged_codegraph_checkout(
+    repo_path: Path,
+    expected: bytes,
+    *,
+    stage: str,
+) -> None:
+    observed = _codegraph_checkout_snapshot(repo_path)
+    if observed != expected:
+        raise CLIError(
+            f"CodeGraph {stage} changed the target checkout; inspect `git status` "
+            "and restore or commit the affected files before retrying"
+        )
+
+
+def _run_codegraph_init(args: argparse.Namespace) -> int:
+    from .codegraph_onboarding import (
+        CodeGraphOnboardingError,
+        CodeGraphReceipt,
+        add_client_registration,
+        inspect_client_registration,
+        inspect_server_command,
+        write_codegraph_receipt,
+    )
+    from .toolchains import install_requirements
+
+    repo_path = resolve_repo_path(args.repo)
+    server, receipt = _codegraph_spec_for_args(repo_path, args)
+    try:
+        server_inspection = inspect_server_command(server, repo_path)
+    except CodeGraphOnboardingError as exc:
+        raise _codegraph_error(exc) from exc
+    if not server_inspection.ready:
+        raise CLIError(
+            "CodeGraph MCP command is not this CodeNib runtime: "
+            + server_inspection.detail
+        )
+    languages = _codegraph_languages_for_init(repo_path, args, receipt)
+    clients = _codegraph_clients_for_init(args)
+    observed = _codegraph_preflight_clients(
+        repo_path,
+        clients,
+        server,
+        receipt,
+    )
+    checkout_snapshot = _codegraph_checkout_snapshot(repo_path)
+    if checkout_snapshot:
+        raise CLIError(
+            "CodeGraph initialization requires a clean Git checkout; commit or "
+            "stash tracked and untracked changes before retrying"
+        )
+    plan = _codegraph_toolchain_plan(repo_path, languages)
+
+    if args.dry_run:
+        try:
+            commands, manual = install_requirements(
+                plan.missing,
+                root=plan.root,
+                dry_run=True,
+            )
+        except RuntimeError as exc:
+            raise CLIError(str(exc)) from exc
+        print(f"Repository: {repo_path}")
+        print(f"Languages:  {', '.join(languages)}")
+        print("Planned CodeGraph actions:")
+        for command in commands:
+            print(f"  toolchain: {shlex.join(command)}")
+        for item in manual:
+            print(f"  prerequisite: {item}")
+        print("  index: bm25, symbol_graph")
+        for client in clients:
+            action = "reuse" if observed[client].matches else "add"
+            print(f"  {client}: {action} {server.name}")
+        print("Dry run complete; no tools, indexes, receipts, or clients changed.")
+        return 0
+
+    _require_modules(
+        ("igraph", "google.protobuf", "mcp"),
+        extra="graph,mcp",
+        feature="CodeGraph agent onboarding",
+    )
+    if plan.missing:
+        try:
+            commands, manual = install_requirements(plan.missing, root=plan.root)
+        except RuntimeError as exc:
+            raise CLIError(str(exc)) from exc
+        if commands:
+            print("Installed graph tools:")
+            for command in commands:
+                print(f"  {shlex.join(command)}")
+        if manual:
+            raise CLIError("CodeGraph needs manual prerequisites: " + "; ".join(manual))
+        plan = _codegraph_toolchain_plan(repo_path, languages)
+    if not plan.ready:
+        raise CLIError(
+            "CodeGraph toolchain is not ready: " + _codegraph_plan_detail(plan)
+        )
+    _require_unchanged_codegraph_checkout(
+        repo_path,
+        checkout_snapshot,
+        stage="toolchain setup",
+    )
+
+    _check_view_dependencies(("bm25", "symbol_graph"))
+    try:
+        manifest, failed = index_repository(
+            repo_path,
+            languages=languages,
+            views=("bm25", "symbol_graph"),
+            rebuild=args.rebuild,
+            allow_graph_project_preparation=False,
+            allow_partial_graph_languages=False,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        _require_unchanged_codegraph_checkout(
+            repo_path,
+            checkout_snapshot,
+            stage="indexing",
+        )
+        raise CLIError(str(exc)) from exc
+    _require_unchanged_codegraph_checkout(
+        repo_path,
+        checkout_snapshot,
+        stage="indexing",
+    )
+    _print_index_summary(manifest, ("bm25", "symbol_graph"))
+    if failed:
+        raise CLIError("CodeGraph indexing failed for: " + ", ".join(failed))
+
+    managed = receipt or CodeGraphReceipt(repo_path, server, ())
+    for client in clients:
+        if managed.client(client) is None:
+            managed = managed.with_client(client, state="pending")
+    try:
+        write_codegraph_receipt(managed)
+        for client in clients:
+            inspection = inspect_client_registration(client, server, repo_path)
+            if inspection.exists and not inspection.matches:
+                raise CodeGraphOnboardingError(
+                    f"{client} MCP server {server.name} changed during indexing; "
+                    "refusing to overwrite it"
+                )
+            if not inspection.exists:
+                add_client_registration(client, server, repo_path)
+                inspection = inspect_client_registration(client, server, repo_path)
+            if not inspection.matches:
+                raise CodeGraphOnboardingError(
+                    f"{client} did not retain the expected MCP registration"
+                )
+            managed = managed.with_client(client, state="configured")
+            write_codegraph_receipt(managed)
+    except (CodeGraphOnboardingError, OSError) as exc:
+        _require_unchanged_codegraph_checkout(
+            repo_path,
+            checkout_snapshot,
+            stage="agent registration",
+        )
+        raise _codegraph_error(exc) from exc
+    _require_unchanged_codegraph_checkout(
+        repo_path,
+        checkout_snapshot,
+        stage="agent registration",
+    )
+
+    print("\nCodeGraph is ready for coding agents.")
+    print(f"MCP server: {server.name}")
+    print(f"Clients:    {', '.join(clients)}")
+    print(f"Status:     codenib codegraph status {shlex.quote(str(repo_path))}")
+    print(
+        "Try asking your agent to use explore_context before editing and "
+        "dependency_subgraph for impact analysis."
+    )
+    return 0
+
+
+def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
+    from .compiler.checkout_identity import validate_checkout_identity
+    from .compiler.manifest import MANIFEST_FILENAME, RepoManifest
+    from .paths import repo_index_dir
+
+    manifest_path = repo_index_dir(repo_path) / MANIFEST_FILENAME
+    report: dict[str, object] = {
+        "manifest": str(manifest_path),
+        "bm25": False,
+        "symbol_graph": False,
+        "symbol_graph_complete": False,
+        "source_matches": False,
+        "languages": [],
+        "detail": "manifest not found",
+    }
+    try:
+        manifest = RepoManifest.load(manifest_path)
+        report["languages"] = list(manifest.languages)
+        report["bm25"] = manifest.index_is_current("bm25")
+        report["symbol_graph"] = manifest.index_is_current("symbol_graph")
+        graph_entry = manifest.indexes.get("symbol_graph")
+        report["symbol_graph_complete"] = bool(
+            report["symbol_graph"]
+            and graph_entry is not None
+            and graph_entry.config.get("allow_partial_languages") is False
+            and graph_entry.config.get("allow_partial_index") is False
+        )
+        validate_checkout_identity(
+            repo_path,
+            manifest,
+            artifact_root=manifest_path.parent,
+        )
+        report["source_matches"] = True
+        report["detail"] = (
+            "current"
+            if report["symbol_graph_complete"]
+            else "symbol_graph was built with partial-language admission"
+        )
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        report["detail"] = " ".join(str(exc).split())[:400]
+    report["ready"] = bool(
+        report["bm25"] and report["symbol_graph_complete"] and report["source_matches"]
+    )
+    return report
+
+
+def _codegraph_toolchain_report(
+    repo_path: Path,
+    languages: Sequence[str] | None = None,
+) -> dict[str, object]:
+    try:
+        selected = tuple(languages or _selected_languages(repo_path, ()))
+        plan = _codegraph_toolchain_plan(repo_path, selected)
+        return {
+            "ready": plan.ready,
+            "languages": list(selected),
+            "missing": [item.executable for item in plan.missing],
+            "notes": list(plan.notes),
+        }
+    except (CLIError, OSError, RuntimeError, ValueError) as exc:
+        return {
+            "ready": False,
+            "languages": [],
+            "missing": [],
+            "notes": [" ".join(str(exc).split())[:400]],
+        }
+
+
+def _codegraph_status_report(repo_path: Path) -> dict[str, object]:
+    from .codegraph_onboarding import (
+        CodeGraphOnboardingError,
+        codegraph_receipt_path,
+        inspect_client_registration,
+        inspect_server_command,
+        load_codegraph_receipt,
+    )
+
+    index = _codegraph_index_report(repo_path)
+    toolchain = _codegraph_toolchain_report(
+        repo_path,
+        index.get("languages") or None,
+    )
+    try:
+        receipt = load_codegraph_receipt(repo_path)
+    except CodeGraphOnboardingError as exc:
+        return {
+            "repository": str(repo_path),
+            "ready": False,
+            "index": index,
+            "toolchain": toolchain,
+            "server": None,
+            "server_command": {
+                "ready": False,
+                "detail": "integration receipt is invalid",
+            },
+            "clients": [],
+            "receipt_error": str(exc),
+        }
+    clients: list[dict[str, object]] = []
+    server_command = {"ready": False, "detail": "receipt not found"}
+    if receipt is not None:
+        try:
+            inspection = inspect_server_command(receipt.server, repo_path)
+            server_command = {
+                "ready": inspection.ready,
+                "detail": inspection.detail,
+            }
+        except CodeGraphOnboardingError as exc:
+            server_command = {"ready": False, "detail": str(exc)}
+        for managed in receipt.clients:
+            try:
+                inspection = inspect_client_registration(
+                    managed.name,
+                    receipt.server,
+                    repo_path,
+                )
+                clients.append(
+                    {
+                        "name": managed.name,
+                        "scope": managed.scope,
+                        "receipt_state": managed.state,
+                        "installed": inspection.installed,
+                        "configured": inspection.exists,
+                        "matches": inspection.matches,
+                        "detail": inspection.detail,
+                    }
+                )
+            except CodeGraphOnboardingError as exc:
+                clients.append(
+                    {
+                        "name": managed.name,
+                        "scope": managed.scope,
+                        "receipt_state": managed.state,
+                        "installed": True,
+                        "configured": False,
+                        "matches": False,
+                        "detail": str(exc),
+                    }
+                )
+    clients_ready = bool(clients) and all(
+        item["receipt_state"] == "configured" and item["matches"] for item in clients
+    )
+    server = (
+        {
+            "name": receipt.server.name,
+            "command": receipt.server.command,
+            "args": list(receipt.server.args),
+        }
+        if receipt is not None
+        else None
+    )
+    ready = bool(
+        index["ready"]
+        and toolchain["ready"]
+        and server_command["ready"]
+        and clients_ready
+    )
+    return {
+        "repository": str(repo_path),
+        "ready": ready,
+        "index": index,
+        "toolchain": toolchain,
+        "server_command": server_command,
+        "server": server,
+        "clients": clients,
+        "receipt": (
+            str(codegraph_receipt_path(repo_path)) if receipt is not None else None
+        ),
+    }
+
+
+def _run_codegraph_status(args: argparse.Namespace) -> int:
+    repo_path = resolve_repo_path(args.repo)
+    report = _codegraph_status_report(repo_path)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0 if report["ready"] else 1
+
+    print(f"CodeGraph:  {'READY' if report['ready'] else 'NOT READY'}")
+    print(f"Repository: {report['repository']}")
+    index = report["index"]
+    print(
+        "Index:      "
+        + (
+            "bm25 + symbol_graph are current"
+            if index["ready"]
+            else str(index["detail"])
+        )
+    )
+    toolchain = report["toolchain"]
+    toolchain_detail = "ready"
+    if not toolchain["ready"]:
+        parts = [*toolchain["missing"], *toolchain["notes"]]
+        toolchain_detail = "; ".join(parts) or "not ready"
+    print("Toolchain:  " + toolchain_detail)
+    server_command = report["server_command"]
+    print(
+        "MCP command: "
+        + ("ready" if server_command["ready"] else str(server_command["detail"]))
+    )
+    if not report["clients"]:
+        print("Clients:    no managed Codex or Claude Code registration")
+    for client in report["clients"]:
+        marker = "OK" if client["matches"] else "MISSING"
+        print(
+            f"  [{marker:<7}] {client['name']}: {client['detail']} "
+            f"({client['scope']})"
+        )
+    return 0 if report["ready"] else 1
+
+
+def _selected_uninstall_clients(
+    values: Sequence[str] | None,
+    receipt,
+) -> tuple[str, ...]:
+    from .codegraph_onboarding import CODEGRAPH_CLIENTS
+
+    requested = tuple(values or ("all",))
+    unknown = sorted(set(requested) - {"all", *CODEGRAPH_CLIENTS})
+    if unknown:
+        raise CLIError(f"unsupported agent client: {', '.join(unknown)}")
+    if "all" in requested and len(requested) != 1:
+        raise CLIError("--agent all cannot be combined with another client")
+    if requested == ("all",):
+        return tuple(item.name for item in receipt.clients)
+    return tuple(name for name in CODEGRAPH_CLIENTS if name in requested)
+
+
+def _run_codegraph_uninstall(args: argparse.Namespace) -> int:
+    from .codegraph_onboarding import (
+        CodeGraphOnboardingError,
+        inspect_client_registration,
+        load_codegraph_receipt,
+        remove_client_registration,
+        remove_codegraph_receipt,
+        write_codegraph_receipt,
+    )
+
+    repo_path = resolve_repo_path(args.repo)
+    try:
+        receipt = load_codegraph_receipt(repo_path)
+        if receipt is None:
+            print("No CodeNib-managed CodeGraph agent registration was found.")
+            return 0
+        selected = _selected_uninstall_clients(args.agent, receipt)
+        for client in selected:
+            managed = receipt.client(client)
+            if managed is None:
+                print(f"{client}: not managed for this repository")
+                continue
+            inspection = inspect_client_registration(
+                client,
+                receipt.server,
+                repo_path,
+            )
+            if not inspection.installed:
+                raise CodeGraphOnboardingError(
+                    f"cannot safely remove {client}: client command not found"
+                )
+            if inspection.exists and not inspection.matches and not args.force:
+                raise CodeGraphOnboardingError(
+                    f"refusing to remove drifted {client} registration "
+                    f"{receipt.server.name}; inspect it or repeat with --force"
+                )
+            if args.dry_run:
+                action = "remove" if inspection.exists else "reconcile missing"
+                print(f"{client}: would {action} {receipt.server.name}")
+                continue
+            if inspection.exists:
+                remove_client_registration(
+                    client,
+                    receipt.server,
+                    repo_path,
+                )
+                after = inspect_client_registration(
+                    client,
+                    receipt.server,
+                    repo_path,
+                )
+                if after.exists:
+                    raise CodeGraphOnboardingError(
+                        f"{client} still reports MCP server {receipt.server.name}"
+                    )
+            receipt = receipt.without_client(client)
+            if receipt.clients:
+                write_codegraph_receipt(receipt)
+            else:
+                remove_codegraph_receipt(receipt)
+            print(f"{client}: removed {receipt.server.name}")
+        if args.dry_run:
+            print("Dry run complete; no client configuration or receipt changed.")
+        elif receipt.clients:
+            print("CodeGraph indexes were preserved for the remaining clients.")
+        else:
+            print("Agent registrations removed; CodeGraph indexes were preserved.")
+        return 0
+    except (CodeGraphOnboardingError, OSError) as exc:
+        raise _codegraph_error(exc) from exc
+
+
 def _add_embedding_route_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--embedding-provider",
@@ -2092,6 +2703,90 @@ def build_parser() -> argparse.ArgumentParser:
         help="MCP tool surface to expose",
     )
     mcp_parser.set_defaults(handler=_run_mcp)
+
+    codegraph_parser = subparsers.add_parser(
+        "codegraph",
+        help="prepare CodeGraph and connect it to coding agents",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    codegraph_subparsers = codegraph_parser.add_subparsers(
+        dest="codegraph_command",
+        required=True,
+    )
+    codegraph_init_parser = codegraph_subparsers.add_parser(
+        "init",
+        help="install graph tools, index a repository, and configure MCP clients",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    codegraph_init_parser.add_argument("repo", nargs="?", default=".")
+    codegraph_init_parser.add_argument(
+        "--language",
+        action="append",
+        default=[],
+        help="source language override; repeat or use a comma-separated list",
+    )
+    codegraph_init_parser.add_argument(
+        "--agent",
+        action="append",
+        choices=("auto", "codex", "claude"),
+        help=(
+            "agent client to configure; repeat for both, or omit to auto-detect "
+            "installed clients"
+        ),
+    )
+    codegraph_init_parser.add_argument(
+        "--command",
+        dest="server_command",
+        help="CodeNib executable recorded in the MCP client configuration",
+    )
+    codegraph_init_parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="rebuild graph views instead of incrementally updating them",
+    )
+    codegraph_init_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show toolchain, index, and client actions without changing state",
+    )
+    codegraph_init_parser.set_defaults(handler=_run_codegraph_init)
+
+    codegraph_status_parser = codegraph_subparsers.add_parser(
+        "status",
+        help="verify the graph index, source identity, toolchain, and clients",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    codegraph_status_parser.add_argument("repo", nargs="?", default=".")
+    codegraph_status_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print a machine-readable status report",
+    )
+    codegraph_status_parser.set_defaults(handler=_run_codegraph_status)
+
+    codegraph_uninstall_parser = codegraph_subparsers.add_parser(
+        "uninstall",
+        help="remove only CodeNib-managed agent registrations",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    codegraph_uninstall_parser.add_argument("repo", nargs="?", default=".")
+    codegraph_uninstall_parser.add_argument(
+        "--agent",
+        action="append",
+        choices=("all", "codex", "claude"),
+        help="managed client to remove; repeat as needed (default: all)",
+    )
+    codegraph_uninstall_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="remove a managed server even when its native config has drifted",
+    )
+    codegraph_uninstall_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show removals without changing client configuration or receipts",
+    )
+    codegraph_uninstall_parser.set_defaults(handler=_run_codegraph_uninstall)
 
     toolchain_parser = subparsers.add_parser(
         "toolchain",

--- a/codenib/codegraph_onboarding.py
+++ b/codenib/codegraph_onboarding.py
@@ -1,0 +1,624 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Managed MCP client registration for the CodeGraph product path.
+
+The client applications own their configuration files.  CodeNib invokes their
+public CLIs, records only the registration it created, and refuses to overwrite
+or remove a registration whose observed command has drifted.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+from ._version import package_version
+from .paths import repo_state_dir, repository_state_key
+
+CODEGRAPH_CLIENTS = ("codex", "claude")
+CODEGRAPH_RECEIPT_SCHEMA = 1
+CODEGRAPH_RECEIPT_DIRNAME = "codegraph"
+CODEGRAPH_RECEIPT_FILENAME = "agent-integrations.json"
+
+_CLIENT_SCOPES = {"codex": "user", "claude": "local"}
+_CLIENT_STATES = frozenset({"pending", "configured"})
+_SERVER_NAME_PART = re.compile(r"[^a-z0-9._-]+")
+
+
+class CodeGraphOnboardingError(RuntimeError):
+    """A safe, user-actionable onboarding failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class MCPServerSpec:
+    """One stdio server registration shared by supported agent clients."""
+
+    name: str
+    command: str
+    args: tuple[str, ...]
+
+    @property
+    def argv(self) -> tuple[str, ...]:
+        return (self.command, *self.args)
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedClient:
+    """One client registration retained in the CodeNib receipt."""
+
+    name: str
+    scope: str
+    state: str
+
+
+@dataclass(frozen=True, slots=True)
+class CodeGraphReceipt:
+    """CodeNib-owned evidence for safe idempotency and removal."""
+
+    repository: Path
+    server: MCPServerSpec
+    clients: tuple[ManagedClient, ...]
+
+    def client(self, name: str) -> ManagedClient | None:
+        return next((item for item in self.clients if item.name == name), None)
+
+    def with_client(self, name: str, *, state: str) -> "CodeGraphReceipt":
+        if name not in CODEGRAPH_CLIENTS:
+            raise CodeGraphOnboardingError(f"unsupported agent client: {name}")
+        if state not in _CLIENT_STATES:
+            raise CodeGraphOnboardingError(f"invalid client receipt state: {state}")
+        retained = [item for item in self.clients if item.name != name]
+        retained.append(ManagedClient(name, _CLIENT_SCOPES[name], state))
+        retained.sort(key=lambda item: CODEGRAPH_CLIENTS.index(item.name))
+        return CodeGraphReceipt(self.repository, self.server, tuple(retained))
+
+    def without_client(self, name: str) -> "CodeGraphReceipt":
+        return CodeGraphReceipt(
+            self.repository,
+            self.server,
+            tuple(item for item in self.clients if item.name != name),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": CODEGRAPH_RECEIPT_SCHEMA,
+            "repository": str(self.repository),
+            "server": {
+                "name": self.server.name,
+                "command": self.server.command,
+                "args": list(self.server.args),
+            },
+            "clients": {
+                item.name: {"scope": item.scope, "state": item.state}
+                for item in self.clients
+            },
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ClientInspection:
+    """Observed state of one native client registration."""
+
+    client: str
+    installed: bool
+    exists: bool
+    matches: bool
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class ServerCommandInspection:
+    """Observed startup command identity for the managed MCP server."""
+
+    ready: bool
+    detail: str
+
+
+RunCommand = Callable[..., subprocess.CompletedProcess[str]]
+FindCommand = Callable[[str], str | None]
+
+
+def codegraph_receipt_path(repository: str | Path) -> Path:
+    """Return the per-checkout onboarding receipt path."""
+
+    return (
+        repo_state_dir(repository)
+        / CODEGRAPH_RECEIPT_DIRNAME
+        / CODEGRAPH_RECEIPT_FILENAME
+    )
+
+
+def codegraph_server_name(repository: str | Path) -> str:
+    """Return a readable, bounded, collision-resistant MCP server name."""
+
+    key = repository_state_key(repository)
+    slug, separator, digest = key.rpartition("-")
+    if not separator:
+        slug, digest = "repository", key[-12:]
+    slug = _SERVER_NAME_PART.sub("-", slug.lower()).strip("-._")[:32]
+    return f"codenib-{slug or 'repository'}-{digest}"
+
+
+def resolve_codenib_command(
+    explicit: str | None = None,
+    *,
+    which: FindCommand = shutil.which,
+) -> tuple[str, tuple[str, ...]]:
+    """Resolve a durable command used by the agent to start CodeNib."""
+
+    if explicit is not None:
+        value = explicit.strip()
+        if not value or any(character in value for character in "\x00\r\n"):
+            raise CodeGraphOnboardingError(
+                "--command must be a non-empty single-line executable"
+            )
+        resolved = which(value)
+        if resolved is None:
+            candidate = Path(value).expanduser()
+            if not candidate.is_absolute():
+                raise CodeGraphOnboardingError(
+                    f"CodeNib command is not executable or on PATH: {value}"
+                )
+            resolved = str(candidate)
+        if not os.path.isfile(resolved) or not os.access(resolved, os.X_OK):
+            raise CodeGraphOnboardingError(
+                f"CodeNib command is not executable: {resolved}"
+            )
+        return os.path.abspath(resolved), ()
+
+    resolved = which("codenib")
+    if resolved and os.path.isfile(resolved) and os.access(resolved, os.X_OK):
+        return os.path.abspath(resolved), ()
+    return os.path.abspath(sys.executable), ("-m", "codenib")
+
+
+def make_server_spec(
+    repository: str | Path,
+    *,
+    command: str,
+    command_prefix: Sequence[str] = (),
+) -> MCPServerSpec:
+    """Build the exact full-surface MCP command for one checkout."""
+
+    repo = Path(repository).expanduser().resolve()
+    if any(character in str(repo) for character in "\x00\r\n"):
+        raise CodeGraphOnboardingError(
+            "CodeGraph repository paths must not contain control line breaks"
+        )
+    return MCPServerSpec(
+        name=codegraph_server_name(repo),
+        command=command,
+        args=tuple(command_prefix) + ("mcp", str(repo), "--tool-surface", "full"),
+    )
+
+
+def resolve_requested_clients(
+    requested: Sequence[str] | None,
+    *,
+    which: FindCommand = shutil.which,
+) -> tuple[str, ...]:
+    """Resolve explicit or auto-detected clients in stable order."""
+
+    values = tuple(requested or ("auto",))
+    unknown = sorted(set(values) - {"auto", *CODEGRAPH_CLIENTS})
+    if unknown:
+        raise CodeGraphOnboardingError(
+            f"unsupported agent client: {', '.join(unknown)}"
+        )
+    if "auto" in values and len(values) != 1:
+        raise CodeGraphOnboardingError(
+            "--agent auto cannot be combined with an explicit client"
+        )
+    selected = (
+        tuple(client for client in CODEGRAPH_CLIENTS if which(client) is not None)
+        if values == ("auto",)
+        else tuple(client for client in CODEGRAPH_CLIENTS if client in values)
+    )
+    if not selected:
+        raise CodeGraphOnboardingError(
+            "no supported agent client was found; install Codex or Claude Code, "
+            "or pass --agent after its CLI is available"
+        )
+    missing = [client for client in selected if which(client) is None]
+    if missing:
+        raise CodeGraphOnboardingError(
+            f"agent client command not found: {', '.join(missing)}"
+        )
+    return selected
+
+
+def _strict_string(value: object, *, field: str) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or any(character in value for character in "\x00\r\n")
+    ):
+        raise CodeGraphOnboardingError(
+            f"invalid CodeGraph integration receipt field: {field}"
+        )
+    return value
+
+
+def _strict_keys(
+    value: object,
+    expected: set[str],
+    *,
+    field: str,
+) -> Mapping[str, object]:
+    if type(value) is not dict or set(value) != expected:
+        raise CodeGraphOnboardingError(
+            f"invalid CodeGraph integration receipt object: {field}"
+        )
+    return value
+
+
+def load_codegraph_receipt(repository: str | Path) -> CodeGraphReceipt | None:
+    """Load and strictly validate the per-checkout receipt, if present."""
+
+    repo = Path(repository).expanduser().resolve()
+    path = codegraph_receipt_path(repo)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise CodeGraphOnboardingError(
+            f"cannot read CodeGraph integration receipt {path}: {exc}"
+        ) from exc
+
+    root = _strict_keys(
+        payload,
+        {"schema_version", "repository", "server", "clients"},
+        field="root",
+    )
+    if type(root["schema_version"]) is not int or root["schema_version"] != 1:
+        raise CodeGraphOnboardingError(
+            "unsupported CodeGraph integration receipt schema"
+        )
+    recorded_repo = Path(
+        _strict_string(root["repository"], field="repository")
+    ).expanduser()
+    if not recorded_repo.is_absolute() or recorded_repo != repo:
+        raise CodeGraphOnboardingError(
+            "CodeGraph integration receipt repository does not match this checkout"
+        )
+
+    server_value = _strict_keys(
+        root["server"], {"name", "command", "args"}, field="server"
+    )
+    raw_args = server_value["args"]
+    if (
+        type(raw_args) is not list
+        or not raw_args
+        or not all(
+            type(item) is str
+            and item
+            and not any(character in item for character in "\x00\r\n")
+            for item in raw_args
+        )
+    ):
+        raise CodeGraphOnboardingError(
+            "invalid CodeGraph integration receipt field: server.args"
+        )
+    server = MCPServerSpec(
+        _strict_string(server_value["name"], field="server.name"),
+        _strict_string(server_value["command"], field="server.command"),
+        tuple(raw_args),
+    )
+    if not os.path.isabs(server.command):
+        raise CodeGraphOnboardingError(
+            "CodeGraph integration receipt has a non-absolute MCP command"
+        )
+    if server.name != codegraph_server_name(repo):
+        raise CodeGraphOnboardingError(
+            "CodeGraph integration receipt has an unexpected server name"
+        )
+    suffix = ("mcp", str(repo), "--tool-surface", "full")
+    prefix = server.args[: -len(suffix)]
+    if server.args[-len(suffix) :] != suffix or prefix not in ((), ("-m", "codenib")):
+        raise CodeGraphOnboardingError(
+            "CodeGraph integration receipt has an unexpected MCP command"
+        )
+
+    clients_value = root["clients"]
+    if type(clients_value) is not dict or not set(clients_value).issubset(
+        CODEGRAPH_CLIENTS
+    ):
+        raise CodeGraphOnboardingError(
+            "invalid CodeGraph integration receipt object: clients"
+        )
+    clients: list[ManagedClient] = []
+    for name in CODEGRAPH_CLIENTS:
+        if name not in clients_value:
+            continue
+        item = _strict_keys(
+            clients_value[name], {"scope", "state"}, field=f"clients.{name}"
+        )
+        scope = _strict_string(item["scope"], field=f"clients.{name}.scope")
+        state = _strict_string(item["state"], field=f"clients.{name}.state")
+        if scope != _CLIENT_SCOPES[name] or state not in _CLIENT_STATES:
+            raise CodeGraphOnboardingError(
+                f"invalid CodeGraph integration receipt client: {name}"
+            )
+        clients.append(ManagedClient(name, scope, state))
+    return CodeGraphReceipt(repo, server, tuple(clients))
+
+
+def write_codegraph_receipt(receipt: CodeGraphReceipt) -> Path:
+    """Atomically write a private, deterministic integration receipt."""
+
+    path = codegraph_receipt_path(receipt.repository)
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    payload = (
+        json.dumps(receipt.to_dict(), ensure_ascii=True, indent=2, sort_keys=True)
+        + "\n"
+    )
+    descriptor, temporary = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            fchmod = getattr(os, "fchmod", None)
+            if fchmod is not None:
+                fchmod(handle.fileno(), 0o600)
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    return path
+
+
+def remove_codegraph_receipt(receipt: CodeGraphReceipt) -> None:
+    """Remove the receipt after every managed client has been reconciled."""
+
+    codegraph_receipt_path(receipt.repository).unlink(missing_ok=True)
+
+
+def _invoke_client(
+    command: Sequence[str],
+    *,
+    repository: Path,
+    runner: RunCommand,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return runner(
+            tuple(command),
+            cwd=repository,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise CodeGraphOnboardingError(
+            f"command failed to start: {command[0]}: {exc}"
+        ) from exc
+
+
+def inspect_server_command(
+    server: MCPServerSpec,
+    repository: str | Path,
+    *,
+    runner: RunCommand = subprocess.run,
+) -> ServerCommandInspection:
+    """Verify that the recorded executable resolves this CodeNib runtime."""
+
+    if not os.path.isabs(server.command):
+        raise CodeGraphOnboardingError("managed MCP server command is not absolute")
+    mcp_suffix = (
+        "mcp",
+        str(Path(repository).expanduser().resolve()),
+        "--tool-surface",
+        "full",
+    )
+    if server.args[-len(mcp_suffix) :] != mcp_suffix:
+        raise CodeGraphOnboardingError("managed MCP server command is malformed")
+    prefix = server.args[: -len(mcp_suffix)]
+    result = _invoke_client(
+        (server.command, *prefix, "--version"),
+        repository=Path(repository).expanduser().resolve(),
+        runner=runner,
+    )
+    raw_output = result.stdout or result.stderr or ""
+    observed = " ".join((raw_output or "no output").split())
+    expected = f"codenib {package_version()}"
+    ready = result.returncode == 0 and expected in {
+        line.strip() for line in raw_output.splitlines()
+    }
+    return ServerCommandInspection(
+        ready,
+        expected if ready else f"expected {expected!r}, observed {observed[:240]!r}",
+    )
+
+
+def _codex_matches(output: str, server: MCPServerSpec) -> bool:
+    try:
+        value = json.loads(output)
+    except json.JSONDecodeError:
+        return False
+    if type(value) is not dict:
+        return False
+    transport = value.get("transport")
+    return bool(
+        value.get("name") == server.name
+        and value.get("enabled") is True
+        and type(transport) is dict
+        and transport.get("type") == "stdio"
+        and transport.get("command") == server.command
+        and transport.get("args") == list(server.args)
+        and transport.get("cwd") is None
+        and transport.get("env") in (None, {})
+    )
+
+
+def _claude_fields(output: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for line in output.splitlines():
+        if not line.startswith("  ") or ":" not in line:
+            continue
+        key, value = line.strip().split(":", 1)
+        if key and key not in fields:
+            fields[key] = value.strip()
+    return fields
+
+
+def _claude_matches(output: str, server: MCPServerSpec) -> bool:
+    fields = _claude_fields(output)
+    return bool(
+        fields.get("Scope", "").startswith("Local config")
+        and fields.get("Type") == "stdio"
+        and fields.get("Command") == server.command
+        and fields.get("Args") == " ".join(server.args)
+    )
+
+
+def inspect_client_registration(
+    client: str,
+    server: MCPServerSpec,
+    repository: str | Path,
+    *,
+    runner: RunCommand = subprocess.run,
+    which: FindCommand = shutil.which,
+) -> ClientInspection:
+    """Inspect one registration using the owning client's public CLI."""
+
+    if client not in CODEGRAPH_CLIENTS:
+        raise CodeGraphOnboardingError(f"unsupported agent client: {client}")
+    executable = which(client)
+    if executable is None:
+        return ClientInspection(client, False, False, False, "command not found")
+    command = (
+        (executable, "mcp", "get", "--json", server.name)
+        if client == "codex"
+        else (executable, "mcp", "get", server.name)
+    )
+    result = _invoke_client(
+        command,
+        repository=Path(repository).expanduser().resolve(),
+        runner=runner,
+    )
+    if result.returncode != 0:
+        detail = " ".join((result.stderr or result.stdout or "not configured").split())
+        missing_markers = ("no mcp server named", "not found")
+        if not any(marker in detail.lower() for marker in missing_markers):
+            raise CodeGraphOnboardingError(
+                f"cannot inspect {client} MCP configuration: {detail[:400]}"
+            )
+        return ClientInspection(client, True, False, False, detail[:240])
+    matches = (
+        _codex_matches(result.stdout, server)
+        if client == "codex"
+        else _claude_matches(result.stdout, server)
+    )
+    return ClientInspection(
+        client,
+        True,
+        True,
+        matches,
+        "configuration matches" if matches else "configuration differs",
+    )
+
+
+def add_client_registration(
+    client: str,
+    server: MCPServerSpec,
+    repository: str | Path,
+    *,
+    runner: RunCommand = subprocess.run,
+    which: FindCommand = shutil.which,
+) -> None:
+    """Ask a native client to add the exact stdio registration."""
+
+    executable = which(client)
+    if executable is None:
+        raise CodeGraphOnboardingError(f"agent client command not found: {client}")
+    if client == "codex":
+        command = (executable, "mcp", "add", server.name, "--", *server.argv)
+    elif client == "claude":
+        command = (
+            executable,
+            "mcp",
+            "add",
+            "--scope",
+            "local",
+            server.name,
+            "--",
+            *server.argv,
+        )
+    else:
+        raise CodeGraphOnboardingError(f"unsupported agent client: {client}")
+    result = _invoke_client(
+        command,
+        repository=Path(repository).expanduser().resolve(),
+        runner=runner,
+    )
+    if result.returncode != 0:
+        detail = " ".join((result.stderr or result.stdout or "unknown error").split())
+        raise CodeGraphOnboardingError(
+            f"{client} rejected the MCP registration: {detail[:400]}"
+        )
+
+
+def remove_client_registration(
+    client: str,
+    server: MCPServerSpec,
+    repository: str | Path,
+    *,
+    runner: RunCommand = subprocess.run,
+    which: FindCommand = shutil.which,
+) -> None:
+    """Ask a native client to remove one previously verified registration."""
+
+    executable = which(client)
+    if executable is None:
+        raise CodeGraphOnboardingError(f"agent client command not found: {client}")
+    command = (
+        (executable, "mcp", "remove", server.name)
+        if client == "codex"
+        else (executable, "mcp", "remove", server.name, "--scope", "local")
+    )
+    result = _invoke_client(
+        command,
+        repository=Path(repository).expanduser().resolve(),
+        runner=runner,
+    )
+    if result.returncode != 0:
+        detail = " ".join((result.stderr or result.stdout or "unknown error").split())
+        raise CodeGraphOnboardingError(f"{client} rejected MCP removal: {detail[:400]}")
+
+
+__all__ = [
+    "CODEGRAPH_CLIENTS",
+    "ClientInspection",
+    "CodeGraphOnboardingError",
+    "CodeGraphReceipt",
+    "MCPServerSpec",
+    "ServerCommandInspection",
+    "add_client_registration",
+    "codegraph_receipt_path",
+    "codegraph_server_name",
+    "inspect_client_registration",
+    "inspect_server_command",
+    "load_codegraph_receipt",
+    "make_server_spec",
+    "remove_client_registration",
+    "remove_codegraph_receipt",
+    "resolve_codenib_command",
+    "resolve_requested_clients",
+    "write_codegraph_receipt",
+]

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -721,6 +721,10 @@ class SymbolGraphBuilder:
     allow_partial_languages: bool = False
     allow_partial_index: bool = False
     source_coverage_fallback: bool = False
+    # Product onboarding may prohibit package-manager/build-system preparation
+    # inside the target checkout. Existing index callers retain the historical
+    # behavior unless they opt out explicitly.
+    allow_project_preparation: bool = True
     # Admission control for incremental updates. The default proves nothing and
     # says so, which combined with require_verification=True means the builder
     # behaves exactly like a full rebuild until a real verifier is configured.
@@ -774,6 +778,8 @@ class SymbolGraphBuilder:
             "graph_route": self.graph_route,
             "capture_artifact_receipts": True,
         }
+        if not self.allow_project_preparation:
+            build_kwargs["allow_project_preparation"] = False
         if self.allow_partial_index:
             build_kwargs["allow_partial_index"] = True
         result = build_graph_for_languages_with_report(
@@ -1122,6 +1128,7 @@ def register_default_builders(
     allow_partial_graph_languages: bool = False,
     allow_partial_graph_index: bool = False,
     graph_source_coverage_fallback: bool = False,
+    allow_graph_project_preparation: bool = True,
 ) -> None:
     """Register all standard index builders with sensible defaults."""
     langs = languages or ["python"]
@@ -1179,6 +1186,7 @@ def register_default_builders(
             allow_partial_languages=allow_partial_graph_languages,
             allow_partial_index=allow_partial_graph_index,
             source_coverage_fallback=graph_source_coverage_fallback,
+            allow_project_preparation=allow_graph_project_preparation,
             exclude_patterns=(
                 list(exclude_patterns)
                 if exclude_patterns is not None

--- a/codenib/ls_index/clangd_indexer.py
+++ b/codenib/ls_index/clangd_indexer.py
@@ -344,6 +344,9 @@ class ClangdIndexer:
         kwargs.pop("project_name", None)
         kwargs.pop("target_dir", None)
         kwargs.pop("cwd", None)
+        allow_project_preparation = kwargs.pop("allow_project_preparation", True)
+        if type(allow_project_preparation) is not bool:
+            raise ValueError("allow_project_preparation must be a boolean")
 
         if output_file is None:
             output_file = str(self.graph_file)
@@ -418,7 +421,7 @@ class ClangdIndexer:
                 and self.compdb_path is not None
                 and not self._is_preferred_compdb(self.compdb_path)
             )
-            if should_regenerate_compdb:
+            if should_regenerate_compdb and allow_project_preparation:
                 existing = self.compdb_path
                 if existing is not None:
                     existing = self._snapshot_compdb(existing, "discovered")
@@ -431,6 +434,11 @@ class ClangdIndexer:
                     logger.warning(
                         "Auto-generated compilation database is invalid: %s", generated
                     )
+            elif should_regenerate_compdb:
+                logger.info(
+                    "Skipping compilation database generation for read-only "
+                    "CodeGraph onboarding"
+                )
             if self.compdb_path is not None:
                 prepared_path = self.output_dir / "compile_commands.json"
                 if prepared_path.resolve() == self.compdb_path.resolve():

--- a/codenib/ls_router.py
+++ b/codenib/ls_router.py
@@ -402,6 +402,7 @@ def build_graph_for_languages_with_report(
     allow_partial: bool = False,
     allow_partial_index: bool = False,
     capture_artifact_receipts: bool = False,
+    allow_project_preparation: bool = True,
 ) -> GraphBuildResult:
     """Build a graph and report per-language availability.
 
@@ -420,6 +421,8 @@ def build_graph_for_languages_with_report(
     """
     if type(capture_artifact_receipts) is not bool:
         raise ValueError("capture_artifact_receipts must be a boolean")
+    if type(allow_project_preparation) is not bool:
+        raise ValueError("allow_project_preparation must be a boolean")
     normalized = _normalize_language_sequence(languages, graph_route=graph_route)
     base_output = Path(output_dir)
     pname = project_name or base_output.name
@@ -436,6 +439,8 @@ def build_graph_for_languages_with_report(
         pipeline_kwargs["include_references"] = True
     if capture_artifact_receipts:
         pipeline_kwargs["capture_artifact_receipts"] = True
+    if not allow_project_preparation:
+        pipeline_kwargs["allow_project_preparation"] = False
 
     def run_language(language: str, language_output: Path, language_project: str):
         indexer = LSIndexer(

--- a/codenib/scip_interface/scip_indexer_ruby.py
+++ b/codenib/scip_interface/scip_indexer_ruby.py
@@ -211,15 +211,28 @@ class SCIPRubyIndexer(SCIPIndexerBase):
 
         return SCIPRubyGraphDecoder
 
-    def generate_index(self, timeout: Optional[int] = None, **kwargs) -> bool:
+    def generate_index(
+        self,
+        timeout: Optional[int] = None,
+        allow_project_preparation: bool = True,
+        **kwargs,
+    ) -> bool:
+        if type(allow_project_preparation) is not bool:
+            raise ValueError("allow_project_preparation must be a boolean")
         if not self._check_indexer_available():
             return False
         command = self._build_index_command(**kwargs)
         if not command:
             return False
 
-        if not self._prepare_bundle(command, timeout=timeout):
+        if allow_project_preparation and not self._prepare_bundle(
+            command, timeout=timeout
+        ):
             return False
+        if not allow_project_preparation and _bundle_prefix(command):
+            logger.info(
+                "Skipping Bundler preparation for read-only CodeGraph onboarding"
+            )
 
         with self.profiler.section("generate_index") as section:
             try:

--- a/codenib/scip_interface/scip_indexer_ts.py
+++ b/codenib/scip_interface/scip_indexer_ts.py
@@ -534,6 +534,9 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
         # Drop Python-specific kwargs that may be forwarded by callers.
         kwargs.pop("target_dir", None)
         kwargs.pop("cwd", None)
+        allow_project_preparation = kwargs.pop("allow_project_preparation", True)
+        if type(allow_project_preparation) is not bool:
+            raise ValueError("allow_project_preparation must be a boolean")
 
         # Auto-select workspace mode when not explicitly provided.
         workspace_flags = ("yarn_workspaces", "pnpm_workspaces", "npm_workspaces")
@@ -594,7 +597,13 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
             needs_generate = False
 
         if needs_generate:
-            self._install_dependencies()
+            if allow_project_preparation:
+                self._install_dependencies()
+            else:
+                logger.info(
+                    "Skipping project dependency installation for read-only "
+                    "CodeGraph onboarding"
+                )
             patched_tsconfig = self._ensure_allow_js()
             if patched_tsconfig is not None:
                 kwargs["patched_tsconfig"] = str(patched_tsconfig)

--- a/codenib/scip_interface/scip_indexer_ts.py
+++ b/codenib/scip_interface/scip_indexer_ts.py
@@ -596,17 +596,21 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
         elif skip_level in ("graph", "decode", "raw") and self.index_file.exists():
             needs_generate = False
 
+        cleanup_patched_tsconfig = False
         if needs_generate:
             if allow_project_preparation:
                 self._install_dependencies()
+                patched_tsconfig = self._ensure_allow_js()
+                if patched_tsconfig is not None:
+                    kwargs["patched_tsconfig"] = str(patched_tsconfig)
+                    cleanup_patched_tsconfig = True
             else:
                 logger.info(
-                    "Skipping project dependency installation for read-only "
-                    "CodeGraph onboarding"
+                    "Skipping project dependency installation and temporary "
+                    "tsconfig generation for read-only CodeGraph onboarding"
                 )
-            patched_tsconfig = self._ensure_allow_js()
-            if patched_tsconfig is not None:
-                kwargs["patched_tsconfig"] = str(patched_tsconfig)
+                if not (self.project_root / "tsconfig.json").is_file():
+                    kwargs.setdefault("infer_tsconfig", True)
         else:
             logger.info(
                 "Skipping dependency install and tsconfig patching (cached artifacts exist)"
@@ -622,4 +626,5 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
                 **kwargs,
             )
         finally:
-            self._cleanup_patched_tsconfig()
+            if cleanup_patched_tsconfig:
+                self._cleanup_patched_tsconfig()

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -243,7 +243,7 @@ reasoning loop while replacing its repository data plane with
 localization baselines:
 
 ```bash
-python -m pip install "codenib[agent,graph]==0.2.0"
+python -m pip install "codenib[agent,graph]==0.2.1"
 codenib toolchain install /path/to/repository --scope graph
 ```
 

--- a/docs/codegraph.md
+++ b/docs/codegraph.md
@@ -1,0 +1,169 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Agent-ready CodeGraph
+
+CodeNib turns a local checkout into a reusable, source-linked graph and makes
+that graph available to Codex and Claude Code through MCP. The default path is
+local and model-free: it combines ranked BM25 retrieval with SCIP- or
+clangd-backed symbol relationships, definitions, references, dependencies, and
+bounded source reads.
+
+## One-command setup
+
+Install CodeNib 0.2.1 with the graph runtime and official MCP SDK:
+
+```bash
+python -m pip install "codenib[graph,mcp]==0.2.1"
+codenib codegraph init /absolute/path/to/repository
+```
+
+The initializer detects repository languages and installed agent clients. It
+then installs package-managed graph providers, builds `bm25` and
+`symbol_graph`, and invokes the native client CLIs:
+
+- Codex receives a user-level stdio MCP registration through `codex mcp add`.
+- Claude Code receives a local-scope registration through `claude mcp add` in
+  the selected repository.
+
+CodeNib does not edit Codex TOML, Claude JSON, `.mcp.json`, `AGENTS.md`, or
+`CLAUDE.md` itself. It never writes an index into the target checkout. A
+readable repository slug plus a path digest makes the server name unique, so
+several checkouts can coexist.
+
+Initialization requires a clean Git working tree and verifies the same status
+again after indexing and native client registration. CodeNib may install its
+own pinned language provider below `CODENIB_SCIP_TOOLS_DIR`, but this product
+path does not run a repository package manager, generate a compilation
+database, or prepare project-local dependencies. If a graph provider needs an
+existing `node_modules`, Ruby bundle, or `compile_commands.json`, the command
+reports that prerequisite instead of changing the checkout.
+
+When both clients are installed, both are configured. Select one explicitly or
+preview the complete plan:
+
+```bash
+codenib codegraph init . --agent codex
+codenib codegraph init . --agent claude
+codenib codegraph init . --agent codex --agent claude --dry-run
+```
+
+Running the same initialization again reuses a current index and matching
+native registrations. CodeNib refuses to overwrite an unmanaged server with
+the same name or a managed registration whose command has drifted.
+
+## Use it from an agent
+
+Start broad questions with `explore_context`. It composes ranked retrieval,
+symbol routing, dependency expansion, and verified source windows under one
+response budget:
+
+> Use CodeNib's `explore_context` to explain where request retries are
+> implemented. Cite the returned source paths and lines before proposing an
+> edit.
+
+Use `dependency_subgraph` for structural questions that keyword search cannot
+answer:
+
+> Use `dependency_subgraph` on `RetryPolicy.execute` with direction `impact`
+> and depth 2. Summarize callers that could change if its behavior changes.
+
+Useful full-surface tools include:
+
+| Tool | Product use |
+| --- | --- |
+| `explore_context` | Bounded, source-verified context for a repository question |
+| `dependency_subgraph` | Callers, callees, and one-hop dependency neighborhoods |
+| `search_bm25` | Exact identifiers and keywords |
+| `search_regex` | Patterns over CodeGraph file and symbol nodes |
+| `lsp_definition` / `lsp_references` | Static navigation backed by the graph or a verified live provider |
+| `read_source` | Exact 1-based source windows after retrieval or navigation |
+
+The server checks the live checkout against the indexed source identity when
+it starts. It does not silently serve a graph for changed source.
+
+## Status and updates
+
+The human report checks the toolchain, current source identity, both graph
+views, the CodeNib receipt, and every managed native registration:
+
+```bash
+codenib codegraph status /absolute/path/to/repository
+```
+
+Automation can use the same contract as JSON. Exit status is zero only when
+the complete path is ready:
+
+```bash
+codenib codegraph status /absolute/path/to/repository --json
+```
+
+After source changes, rerun `init`; compatible views update incrementally.
+Force a clean graph rebuild only when deliberately changing a builder or
+recovering incompatible state:
+
+```bash
+codenib codegraph init . --rebuild
+```
+
+## Safe uninstall
+
+Remove the client registrations without deleting the reusable index:
+
+```bash
+codenib codegraph uninstall /absolute/path/to/repository
+```
+
+CodeNib removes only clients named in its private per-repository receipt. It
+first asks the native CLI for the current configuration and refuses removal if
+the command differs. Inspect that registration before explicitly overriding
+the guard:
+
+```bash
+codenib codegraph uninstall . --agent codex --dry-run
+codenib codegraph uninstall . --agent codex --force
+```
+
+The `--force` flag affects only a receipt-owned server name. It does not remove
+unmanaged MCP entries, source files, graph providers, or indexes.
+
+## Language prerequisites
+
+CodeNib installs pinned npm, Go, Rustup, .NET, and RubyGem providers when their
+host package manager is available. It does not invoke `sudo` or silently
+prepare project-local dependencies. The initializer reports prerequisites such
+as clangd, a JDK, `compile_commands.json`, or project-local PHP tooling and
+stops before publishing an incomplete agent setup.
+
+Use the lower-level commands when diagnosing a language:
+
+```bash
+codenib toolchain status . --scope graph
+codenib doctor . --require graph
+```
+
+See [SCIP And Graph Indexing](scip_index.md) and the generated
+[Language Capabilities](language_capabilities.md) matrix for the current
+provider boundary.
+
+## Troubleshooting
+
+- **No supported client found:** install Codex or Claude Code, confirm its CLI
+  is on `PATH`, then rerun `init` with `--agent codex` or `--agent claude`.
+- **Missing Python runtime:** install the exact `codenib[graph,mcp]` extra in
+  the environment that provides the `codenib` command.
+- **Manual graph prerequisite:** follow the reported provider instruction, run
+  `codenib doctor . --require graph`, then rerun initialization.
+- **Dirty checkout:** commit or stash tracked and untracked files. CodeNib
+  checks again after each mutating phase and stops before reporting readiness
+  if a provider or client changes the checkout.
+- **Source identity mismatch:** rerun `codenib codegraph init .` for the current
+  checkout rather than serving a stale graph.
+- **Configuration differs:** inspect the named server with `codex mcp get` or
+  `claude mcp get`. CodeNib will not overwrite or remove drift implicitly.
+
+Set `CODENIB_HOME` to relocate indexes and the management receipt. Native
+client configuration remains in the location controlled by that client.

--- a/docs/github_pages.md
+++ b/docs/github_pages.md
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.1
 ```
 
 The prerelease tag keeps the compiler, frontend, Action, and artifact schema on
@@ -54,7 +54,7 @@ than natural-language retrieval quality:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.1
     with:
       preset: fast
 ```
@@ -71,7 +71,7 @@ artifact or Pages workflow:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.1
     with:
       preset: semantic
       embedding-provider: openai
@@ -141,7 +141,7 @@ The composite Action can be used directly when another static host or artifact
 store owns deployment:
 
 ```yaml
-- uses: sysevol-ai/CodeNib/.github/actions/publish@v0.2.0
+- uses: sysevol-ai/CodeNib/.github/actions/publish@v0.2.1
   id: codenib
   with:
     preset: fast

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,31 +26,36 @@ core decoder parity.
 | Goal | Section | Start with |
 |------|---------|------------|
 | Install CodeNib and explore a repository | [Get Started](get-started/index.md) | [Quickstart](quickstart.md) |
-| Serve repository context to coding agents | [Guides](guides/index.md) | [MCP Server](mcp.md) |
+| Give Codex or Claude Code a repository CodeGraph | [CodeGraph](codegraph.md) | `codenib codegraph init .` |
+| Serve custom repository context over MCP | [Guides](guides/index.md) | [MCP Server](mcp.md) |
 | Understand indexes, graphs, and incremental updates | [Concepts](concepts/index.md) | [Incremental Graph](incremental_graph/index.md) |
 | Browse source-generated Python contracts | [API Reference](api/codenib/index.md) | `codenib` public surface |
 | Extend, test, release, or evaluate CodeNib | [Development](development/index.md) | [Contributing a Language](contributing-a-language.md) |
 
 ## Quick Start
 
-This site tracks the `0.2` alpha. The recommended local install enables hybrid
-BM25+dense retrieval with the pinned CodeRankEmbed model.
+CodeNib 0.2.1 can prepare a local, model-free CodeGraph and register it with
+installed Codex and Claude Code clients in one command:
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.0"
+python -m pip install "codenib[graph,mcp]==0.2.1"
+codenib codegraph init /path/to/repository
+```
+
+The command installs package-managed language providers, builds reusable BM25
+and symbol-graph views under `~/.codenib`, and delegates MCP registration to
+the clients' own CLIs. The target checkout remains unchanged. Read the
+[CodeGraph guide](codegraph.md) for status, safe uninstall, client scopes, and
+tool examples.
+
+```bash
+python -m pip install "codenib[semantic]==0.2.1"
 codenib wiki /path/to/repository
 ```
 
-The CLI detects the installed semantic capability, writes a reusable manifest
-under `~/.codenib/repositories`, and opens the browser UI. Install
-`codenib==0.2.0` without extras for the smaller no-model BM25 fallback. Both
-paths leave the target checkout unchanged. Read the [Quickstart](quickstart.md)
-for provider setup and troubleshooting.
-
-```bash
-python -m pip install "codenib[mcp,semantic]==0.2.0"
-codenib mcp /path/to/repository
-```
+The separate Wiki path enables hybrid BM25+dense retrieval with the pinned
+CodeRankEmbed model. Read the [Quickstart](quickstart.md) for provider setup and
+browser troubleshooting.
 
 ## Serving Docs Locally
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -13,26 +13,32 @@ then reuse that manifest across agent sessions.
 
 ## Install And Index
 
-This page describes the current `0.2` alpha. The recommended agent-serving path
-installs MCP with semantic retrieval; the default `auto` preset resolves to
-BM25+dense in that environment:
+For Codex or Claude Code, the recommended 0.2.1 path prepares the graph index
+and native client configuration together:
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.0"
-codenib index /path/to/repository
+python -m pip install "codenib[graph,mcp]==0.2.1"
+codenib codegraph init /path/to/repository
 ```
 
-Use the smaller no-model fallback when semantic retrieval is not required:
+This keeps the checkout clean, uses each client CLI instead of editing its
+configuration directly, and enables `explore_context`,
+`dependency_subgraph`, BM25, regex, static definitions/references, and verified
+source reads. See [Agent-ready CodeGraph](codegraph.md) for the complete
+one-command lifecycle.
+
+For a custom MCP client or a retrieval-only setup, build and launch the server
+manually. The smaller no-model fallback is:
 
 ```bash
-python -m pip install "codenib[mcp]==0.2.0"
+python -m pip install "codenib[mcp]==0.2.1"
 codenib index /path/to/repository --preset fast
 ```
 
-Add static navigation and dependency tools without the embedding download:
+Add static navigation and dependency tools without an embedding download:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.0"
+python -m pip install "codenib[graph,mcp]==0.2.1"
 codenib toolchain install /path/to/repository --scope graph
 codenib index /path/to/repository --preset graph
 ```
@@ -114,8 +120,8 @@ absolute path to a repository previously indexed with `codenib index`. The
 declared launch is equivalent to:
 
 ```bash
-uvx --with "codenib[mcp]==0.2.0" \
-  "codenib==0.2.0" mcp /absolute/path/to/repository
+uvx --with "codenib[mcp]==0.2.1" \
+  "codenib==0.2.1" mcp /absolute/path/to/repository
 ```
 
 The Registry path is intentionally query-only and model-free. It can always
@@ -205,7 +211,7 @@ Parameter and return schemas live in
 The `full` preset requests BM25, vectors, a symbol graph, and Zoekt:
 
 ```bash
-python -m pip install "codenib[full]==0.2.0"
+python -m pip install "codenib[full]==0.2.1"
 codenib toolchain install /path/to/repository --scope graph
 codenib index /path/to/repository --preset full
 ```

--- a/docs/product_roadmap.md
+++ b/docs/product_roadmap.md
@@ -2,8 +2,8 @@
 
 ## Objective
 
-CodeNib should turn a local repository into a useful, source-grounded Wiki and
-repository exploration surface without requiring users to understand its
+CodeNib should turn a local repository into useful, source-grounded context for
+both coding agents and humans without requiring users to understand its
 internal index architecture.
 
 The release is ready when a new user can:
@@ -15,10 +15,25 @@ The release is ready when a new user can:
 5. explore dependencies and jump back to source;
 6. use a provider-native or OpenAI-compatible LiteLLM backend;
 7. restart and update the Wiki without rebuilding unrelated views.
+8. connect a source-linked CodeGraph to a supported coding agent without
+   manually editing MCP configuration.
 
 Passing unit tests or publishing a wheel is necessary but not sufficient.
 
 ## North-Star Journey
+
+The 0.2.1 agent path is local, model-free, and one command after installation:
+
+```bash
+pip install "codenib[graph,mcp]"
+codenib codegraph init /path/to/repository
+```
+
+It must keep the checkout clean, delegate client configuration to native CLIs,
+remain idempotent, expose a machine-readable readiness report, and reverse only
+its own registrations.
+
+The browser path remains:
 
 ```bash
 pip install "codenib[semantic]"
@@ -228,10 +243,33 @@ Acceptance evidence on 2026-07-26:
 - The real-repository v24 Overview published eight of eight planned facts from
   five cited source files with 1.0 citation coverage, three dense sections,
   no duplicate prose blocks, and no repair, fallback, or quality warning.
+
 - Desktop (1440x1000), intermediate (1024x900), and mobile (390x844) Wiki
   captures had no horizontal overflow, console errors, or page errors. The
   Dependency Map rendered a real retrieval-pipeline neighborhood with nine
   symbols, eight edges, and the partial-language coverage notice.
+
+### M7: Agent-ready CodeGraph
+
+Status: implementation complete for 0.2.1; installed release acceptance and
+main verification remain before publication.
+
+- Add one command that detects languages and clients, installs the safe managed
+  subset of graph providers, builds BM25 plus `symbol_graph`, and registers the
+  full MCP surface with Codex and Claude Code.
+- Keep agent configuration under native client ownership and CodeNib state
+  outside the target checkout. Do not create repository instruction or MCP
+  files implicitly.
+- Require and preserve a clean Git working tree. Install CodeNib-managed
+  providers outside the repository, but never run project package managers or
+  build-system preparation from the onboarding command.
+- Make repeated initialization a no-op for matching registrations. Fail closed
+  on unmanaged collisions and managed drift.
+- Provide human and JSON status plus receipt-scoped uninstall that preserves the
+  reusable index.
+- Exercise installed `explore_context` and `dependency_subgraph` calls, source
+  verification, both client contracts, idempotency, and uninstall in the
+  release graph smoke.
 
 ## Hosted Distribution Program
 

--- a/docs/product_roadmap.md
+++ b/docs/product_roadmap.md
@@ -251,8 +251,8 @@ Acceptance evidence on 2026-07-26:
 
 ### M7: Agent-ready CodeGraph
 
-Status: implementation complete for 0.2.1; installed release acceptance and
-main verification remain before publication.
+Status: implemented for 0.2.1. Publication is independently gated by installed
+release acceptance, exact-main verification, and explicit release authorization.
 
 - Add one command that detects languages and clients, installs the safe managed
   subset of graph providers, builds BM25 plus `symbol_graph`, and registers the

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,30 +6,82 @@ SPDX-License-Identifier: Apache-2.0
 
 # Quickstart
 
-This guide turns a local repository into a source-linked CodeNib Wiki. The
-recommended path combines BM25 and dense retrieval through a pinned local
-embedding model, so it needs no API key.
+This guide first connects a source-linked CodeGraph to Codex or Claude Code,
+then covers the browser Wiki and advanced retrieval paths. The CodeGraph path
+uses BM25 plus static symbol relationships and needs no model or API key.
 
 ## Install
 
 - Python 3.10 or newer
 - Git
 
-This documentation tracks the `0.2` feature line. Install the exact release and
-its local semantic dependencies from PyPI:
+Install the exact release with its graph and MCP dependencies from PyPI:
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.0"
+python -m pip install "codenib[graph,mcp]==0.2.1"
 codenib --version
-codenib doctor --require core --require wiki
 ```
 
-The version command must report `codenib 0.2.0`. Exact version pins keep the
-environment reproducible. Install `codenib==0.2.0` without extras when
-a smaller, no-model BM25 fallback is more important than natural-language
-retrieval quality.
+The version command must report `codenib 0.2.1`. Exact version pins keep the
+environment reproducible.
+
+## Connect A CodeGraph To Your Agent
+
+From any directory, point the initializer at the repository:
+
+```bash
+codenib codegraph init /path/to/repository
+```
+
+CodeNib performs five bounded steps:
+
+1. Detects supported source languages.
+2. Installs only package-managed graph providers required by those languages;
+   system and project prerequisites remain explicit.
+3. Builds or updates reusable `bm25` and `symbol_graph` views below
+   `~/.codenib/repositories`.
+4. Detects installed Codex and Claude Code clients and registers a uniquely
+   named stdio MCP server through each client's native CLI.
+5. Writes a private CodeNib management receipt outside the checkout so repeat
+   initialization is idempotent and uninstall can fail closed on drift.
+
+The command does not create `.mcp.json`, `AGENTS.md`, `CLAUDE.md`, or index
+files in the repository. Codex owns its user-level registration; Claude Code
+owns a local-scope registration associated with that repository.
+
+The repository must be a clean Git working tree. The initializer does not run
+project package managers or build systems; it checks the worktree again after
+indexing and registration. Existing language prerequisites such as
+`node_modules`, a Ruby bundle, or `compile_commands.json` remain under project
+owner control.
+
+Preview every planned action without a download or write:
+
+```bash
+codenib codegraph init /path/to/repository --dry-run
+```
+
+Verify the full path, including source freshness and native client
+configuration:
+
+```bash
+codenib codegraph status /path/to/repository
+codenib codegraph status /path/to/repository --json
+```
+
+Ask the agent to use `explore_context` before editing and
+`dependency_subgraph` when evaluating callers, callees, or change impact.
+See [Agent-ready CodeGraph](codegraph.md) for exact tool examples and safe
+uninstall behavior.
 
 ## Launch A Repository Wiki
+
+Install the semantic extra when the browser Wiki should use local dense
+retrieval in addition to BM25:
+
+```bash
+python -m pip install "codenib[semantic]==0.2.1"
+```
 
 ```bash
 codenib wiki /path/to/repository
@@ -158,7 +210,7 @@ To keep embeddings out of the local process, use a BYO OpenAI-compatible
 embedding service:
 
 ```bash
-python -m pip install "codenib[semantic-remote]==0.2.0"
+python -m pip install "codenib[semantic-remote]==0.2.1"
 export EMBEDDING_API_KEY=...
 codenib doctor --require semantic \
   --embedding-provider openai \
@@ -228,7 +280,7 @@ clangd, and live LSP providers are language-specific executables, so CodeNib
 plans them from the detected repository rather than installing every language:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.0"
+python -m pip install "codenib[graph]==0.2.1"
 codenib toolchain status /path/to/repository --scope graph
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
@@ -275,7 +327,7 @@ Static Wiki pages are the default. To generate conceptual page narratives
 through a LiteLLM-supported provider:
 
 ```bash
-python -m pip install "codenib[agent,semantic]==0.2.0"
+python -m pip install "codenib[agent,semantic]==0.2.1"
 export OPENAI_API_KEY=...
 codenib doctor --require agent \
   --model openai/gpt-4o-mini --api-key-env OPENAI_API_KEY --probe-model
@@ -306,7 +358,7 @@ codenib wiki . --generate --model anthropic/claude-sonnet-4-5
 Vertex AI additionally requires CodeNib's `vertex` extra:
 
 ```bash
-python -m pip install "codenib[agent,semantic,vertex]==0.2.0"
+python -m pip install "codenib[agent,semantic,vertex]==0.2.1"
 gcloud auth application-default login
 codenib wiki . --generate \
   --model vertex_ai/gemini-2.5-flash \
@@ -361,7 +413,7 @@ continues to work.
 ## Serve The Index Over MCP
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.0"
+python -m pip install "codenib[mcp,semantic]==0.2.1"
 codenib index /path/to/repository
 codenib mcp /path/to/repository
 ```

--- a/docs/releases/0.2.1.md
+++ b/docs/releases/0.2.1.md
@@ -1,0 +1,88 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CodeNib 0.2.1
+
+CodeNib 0.2.1 makes the source-linked CodeGraph a product path rather than a
+collection of indexing and MCP primitives. One command now prepares a
+repository and connects its graph to installed Codex and Claude Code clients:
+
+```bash
+python -m pip install --upgrade "codenib[graph,mcp]==0.2.1"
+codenib codegraph init /absolute/path/to/repository
+```
+
+The path is local and model-free. It detects repository languages, installs
+the pinned package-managed graph providers those languages need, builds BM25
+plus the symbol graph, and delegates MCP registration to each client CLI. The
+target Git checkout must start clean and is checked again after indexing and
+registration. The onboarding path never runs a project package manager or
+build-system preparation step.
+
+## Agent workflow
+
+The configured full MCP surface includes `explore_context` for bounded,
+source-verified repository context and `dependency_subgraph` for caller impact,
+callee dependencies, and dependency neighborhoods. Definition, reference,
+route, regex, ranked BM25, manifest, and bounded source-read tools remain
+available for explicit follow-up.
+
+Ask an agent to start with the graph rather than rediscovering the repository:
+
+> Use CodeNib's `explore_context` to locate and explain the implementation,
+> then use `dependency_subgraph` to check the impact before editing.
+
+## Managed lifecycle
+
+Initialization is idempotent. A private receipt below `CODENIB_HOME` records
+only registrations CodeNib created. Status verifies the live source identity,
+both required views, language toolchain, and native client configuration:
+
+```bash
+codenib codegraph status /absolute/path/to/repository
+codenib codegraph status /absolute/path/to/repository --json
+```
+
+Safe uninstall delegates removal back to the clients and preserves the graph
+index for later reuse:
+
+```bash
+codenib codegraph uninstall /absolute/path/to/repository
+```
+
+CodeNib does not create `.mcp.json`, `AGENTS.md`, or `CLAUDE.md`. It refuses to
+overwrite an unmanaged name and refuses to remove a receipt-owned registration
+whose command has drifted unless the user explicitly passes `--force`.
+
+## Verification
+
+The installed-wheel release gate now installs only the graph and MCP extras,
+provisions the pinned Python SCIP provider, and exercises the complete product
+path from outside the source checkout. It proves:
+
+- first-run and repeated initialization;
+- Codex and Claude Code native-command contracts through isolated client
+  harnesses;
+- a clean target Git checkout;
+- source-verified `explore_context` output over MCP stdio;
+- a real caller-to-callee `dependency_subgraph` edge;
+- the browser Dependency Map and its source anchor; and
+- safe client uninstall with the reusable index retained.
+
+The release workflow also continues the Python 3.10 through 3.14 install
+matrix, Wiki/MCP service smoke, upgrade smoke, sparse Ask, and graph/Dependency
+Map verification.
+
+## Compatibility and upgrade
+
+The existing `codenib index`, `codenib mcp`, Wiki, artifact, and registry paths
+remain available. Existing compatible 0.2 manifests remain reusable; rerunning
+`codegraph init` adds any missing BM25 or symbol-graph view and records the
+client lifecycle without moving repository state.
+
+The CodeGraph command needs the `graph` and `mcp` extras. Language-specific
+system or project prerequisites remain explicit, and `--dry-run` shows every
+managed install, index, and client action before it changes state.

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -23,7 +23,7 @@ Install the graph dependencies, check the target repository, and then select
 the graph preset:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.0"
+python -m pip install "codenib[graph]==0.2.1"
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
 codenib index /path/to/repository --preset graph

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -10,7 +10,7 @@ For one local repository, use the packaged two-command path in the
 [Quickstart](quickstart.md):
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.0"
+python -m pip install "codenib[semantic]==0.2.1"
 codenib wiki /path/to/repository
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,6 +166,8 @@ nav:
   - Get Started:
       - get-started/index.md
       - Quickstart: quickstart.md
+      - Agent-ready CodeGraph: codegraph.md
+      - Release 0.2.1: releases/0.2.1.md
       - Release 0.2.0: releases/0.2.0.md
       - GitHub Pages: github_pages.md
       - Web UI: web_demo.md
@@ -173,6 +175,7 @@ nav:
       - Language Capabilities: language_capabilities.md
   - Guides:
       - guides/index.md
+      - Agent-ready CodeGraph: codegraph.md
       - MCP Server: mcp.md
       - Agent Skills: agent_skills.md
       - Agent Integrations: agent_integrations.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codenib"
-version = "0.2.0"
+version = "0.2.1"
 description = "A multi-view data system for serving repository context to coding agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/smoke_release_graph.py
+++ b/scripts/smoke_release_graph.py
@@ -8,6 +8,8 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
+import json
 import os
 import shutil
 import subprocess
@@ -19,7 +21,13 @@ from contextlib import nullcontext
 from pathlib import Path
 from typing import Sequence
 
-from smoke_release_services import _free_port, _run, _stop_process_group, _wait_for_json
+from smoke_release_services import (
+    _free_port,
+    _run,
+    _stop_process_group,
+    _structured_result,
+    _wait_for_json,
+)
 
 
 def _fixture_repository(root: Path) -> Path:
@@ -139,11 +147,194 @@ def _assert_codemap(
             _stop_process_group(process)
 
 
+async def _assert_codegraph_mcp_async(
+    root: Path,
+    repo: Path,
+    *,
+    executable: str,
+    env: dict[str, str],
+) -> None:
+    from mcp import Client, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    stderr_path = root / "codegraph-mcp.log"
+    parameters = StdioServerParameters(
+        command=executable,
+        args=["mcp", str(repo), "--tool-surface", "full"],
+        cwd=root,
+        env=env,
+    )
+    try:
+        with stderr_path.open("w+", encoding="utf-8") as server_stderr:
+            transport = stdio_client(parameters, errlog=server_stderr)
+            async with Client(transport, mode="auto", cache=None) as client:
+                tools = await client.list_tools()
+                names = {tool.name for tool in tools.tools}
+                required = {"explore_context", "dependency_subgraph"}
+                if not required.issubset(names):
+                    raise RuntimeError(
+                        f"CodeGraph MCP tools are missing: {sorted(required - names)}"
+                    )
+
+                dependency = await client.call_tool(
+                    "dependency_subgraph",
+                    arguments={
+                        "symbol": "release_workflow",
+                        "direction": "dependencies",
+                        "depth": 1,
+                        "max_nodes": 12,
+                        "max_edges": 24,
+                    },
+                )
+                dependency_payload = _structured_result(dependency)
+                dependency_result = dependency_payload.get("result", dependency_payload)
+                node_names = {
+                    str(node.get("name") or "")
+                    for node in dependency_result.get("nodes", [])
+                }
+                if not any("release_sum" in name for name in node_names):
+                    raise RuntimeError(
+                        "CodeGraph MCP dependency traversal did not reach the "
+                        f"callee: {dependency_result!r}"
+                    )
+                if not dependency_result.get("edges"):
+                    raise RuntimeError(
+                        f"CodeGraph MCP dependency traversal has no edge: "
+                        f"{dependency_result!r}"
+                    )
+
+                explored = await client.call_tool(
+                    "explore_context",
+                    arguments={
+                        "query": "How does release_workflow calculate its result?",
+                        "symbols": ["release_workflow"],
+                        "top_k": 4,
+                        "budget": "fast",
+                        "direction": "dependencies",
+                    },
+                )
+                explore_payload = _structured_result(explored)
+                explore_result = explore_payload.get("result", explore_payload)
+                files = explore_result.get("files") or []
+                calculator = next(
+                    (item for item in files if item.get("file") == "calculator.py"),
+                    None,
+                )
+                if calculator is None:
+                    raise RuntimeError(
+                        f"CodeGraph MCP explore returned no calculator source: "
+                        f"{explore_result!r}"
+                    )
+                contexts = calculator.get("contexts") or []
+                if not contexts or not all(
+                    context.get("verified") is True for context in contexts
+                ):
+                    raise RuntimeError(
+                        "CodeGraph MCP explore did not return verified source: "
+                        f"{calculator!r}"
+                    )
+                if explore_result.get("summary", {}).get("dependency_graphs", 0) < 1:
+                    raise RuntimeError(
+                        "CodeGraph MCP explore did not compose graph relationships: "
+                        f"{explore_result!r}"
+                    )
+    except Exception:
+        details = stderr_path.read_text(encoding="utf-8", errors="replace")
+        print(f"\n--- CodeGraph MCP log ---\n{details}", file=sys.stderr)
+        raise
+
+
+def _assert_codegraph_mcp(
+    root: Path,
+    repo: Path,
+    *,
+    executable: str,
+    env: dict[str, str],
+) -> None:
+    print("+", executable, "mcp", str(repo), "--tool-surface", "full", flush=True)
+    asyncio.run(
+        _assert_codegraph_mcp_async(
+            root,
+            repo,
+            executable=executable,
+            env=env,
+        )
+    )
+
+
+_FAKE_AGENT_CLIENT = r"""#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+client = pathlib.Path(sys.argv[0]).name
+state_path = pathlib.Path(os.environ["CODENIB_FAKE_AGENT_STATE"])
+state = json.loads(state_path.read_text()) if state_path.exists() else {}
+clients = state.setdefault("clients", {})
+adds = state.setdefault("adds", {})
+args = sys.argv[1:]
+if args[:2] == ["mcp", "get"]:
+    name = args[-1]
+    server = clients.get(client)
+    if not server or server["name"] != name:
+        print("not found", file=sys.stderr)
+        raise SystemExit(1)
+    if client == "codex":
+        print(json.dumps({
+            "name": name,
+            "enabled": True,
+            "transport": {
+                "type": "stdio",
+                "command": server["command"],
+                "args": server["args"],
+                "cwd": None,
+                "env": None,
+            },
+        }))
+    else:
+        print(f"{name}:")
+        print("  Scope: Local config (private to you in this project)")
+        print("  Status: Connected")
+        print("  Type: stdio")
+        print(f"  Command: {server['command']}")
+        print(f"  Args: {' '.join(server['args'])}")
+        print("  Environment:")
+elif args[:2] == ["mcp", "add"]:
+    separator = args.index("--")
+    name = args[2] if client == "codex" else args[4]
+    command = args[separator + 1:]
+    clients[client] = {"name": name, "command": command[0], "args": command[1:]}
+    adds[client] = adds.get(client, 0) + 1
+    state_path.write_text(json.dumps(state, sort_keys=True))
+elif args[:2] == ["mcp", "remove"]:
+    clients.pop(client, None)
+    state_path.write_text(json.dumps(state, sort_keys=True))
+else:
+    print(f"unsupported fake {client} command: {args!r}", file=sys.stderr)
+    raise SystemExit(2)
+"""
+
+
+def _fake_agent_clients(root: Path, env: dict[str, str]) -> Path:
+    bin_dir = root / "agent-clients"
+    bin_dir.mkdir()
+    for name in ("codex", "claude"):
+        path = bin_dir / name
+        path.write_text(_FAKE_AGENT_CLIENT, encoding="utf-8")
+        path.chmod(0o755)
+    state_path = root / "agent-client-state.json"
+    env["CODENIB_FAKE_AGENT_STATE"] = str(state_path)
+    env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+    return state_path
+
+
 def smoke(root: Path, *, executable: str = "codenib") -> None:
     root.mkdir(parents=True, exist_ok=True)
     repo = _fixture_repository(root)
     env = os.environ.copy()
     env["CODENIB_HOME"] = str(root / "user-state")
+    agent_state = _fake_agent_clients(root, env)
 
     doctor = _run(
         [
@@ -166,22 +357,64 @@ def smoke(root: Path, *, executable: str = "codenib") -> None:
     _run(
         [
             executable,
-            "index",
+            "codegraph",
+            "init",
             str(repo),
-            "--preset",
-            "graph",
+            "--language",
+            "python",
+            "--command",
+            executable,
+        ],
+        cwd=root,
+        env=env,
+    )
+    report = json.loads(
+        _run(
+            [executable, "codegraph", "status", str(repo), "--json"],
+            cwd=root,
+            env=env,
+        ).stdout
+    )
+    if report.get("ready") is not True:
+        raise RuntimeError(f"CodeGraph onboarding status is not ready: {report!r}")
+    if {client.get("name") for client in report.get("clients", [])} != {
+        "codex",
+        "claude",
+    }:
+        raise RuntimeError(f"CodeGraph clients are incomplete: {report!r}")
+
+    first_state = json.loads(agent_state.read_text(encoding="utf-8"))
+    _run(
+        [
+            executable,
+            "codegraph",
+            "init",
+            str(repo),
             "--language",
             "python",
         ],
         cwd=root,
         env=env,
     )
+    second_state = json.loads(agent_state.read_text(encoding="utf-8"))
+    if second_state.get("adds") != first_state.get("adds"):
+        raise RuntimeError("idempotent CodeGraph init rewrote an agent registration")
+
     status = _run(["git", "status", "--porcelain"], cwd=repo, env=env).stdout
     if status:
         raise RuntimeError(f"graph indexing modified the repository: {status!r}")
 
+    _assert_codegraph_mcp(root, repo, executable=executable, env=env)
     _assert_codemap(root, repo, executable=executable, env=env)
-    print("Installed graph and Dependency Map smoke passed")
+    _run(
+        [executable, "codegraph", "uninstall", str(repo)],
+        cwd=root,
+        env=env,
+    )
+    removed = json.loads(agent_state.read_text(encoding="utf-8"))
+    if removed.get("clients"):
+        raise RuntimeError(f"CodeGraph uninstall left client state: {removed!r}")
+    print("Installed CodeGraph, agent onboarding, MCP, and Dependency Map smoke passed")
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/scripts/verify_mcp_registry.py
+++ b/scripts/verify_mcp_registry.py
@@ -90,7 +90,7 @@ def validate_registry_metadata(root: Path) -> tuple[str, dict[str, Any]]:
                 f"found {package.get(field)!r}"
             )
 
-    expected_extra = f"{PACKAGE_NAME}[mcp]=={version}"
+    expected_extra = f"{PACKAGE_NAME}[graph,mcp]=={version}"
     runtime_arguments = package.get("runtimeArguments")
     if not isinstance(runtime_arguments, list) or not any(
         argument.get("type") == "named"

--- a/server.json
+++ b/server.json
@@ -2,26 +2,26 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.codenib/codenib",
   "title": "CodeNib",
-  "description": "Ranked codebase search and static symbol navigation for coding agents.",
+  "description": "Source-linked CodeGraph exploration, ranked search, and static navigation for coding agents.",
   "websiteUrl": "https://codenib.ai",
   "repository": {
     "url": "https://github.com/sysevol-ai/CodeNib",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "codenib",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         {
           "type": "named",
           "name": "--with",
-          "value": "codenib[mcp]==0.2.0",
-          "description": "Install the version-matched CodeNib MCP runtime extra."
+          "value": "codenib[graph,mcp]==0.2.1",
+          "description": "Install the version-matched CodeNib CodeGraph and MCP runtime."
         }
       ],
       "transport": {

--- a/test/ls_index/test_index_quality.py
+++ b/test/ls_index/test_index_quality.py
@@ -279,3 +279,30 @@ def test_pipeline_rejects_nonempty_but_low_coverage_graph(tmp_path, monkeypatch)
     assert json.loads(report_path.read_text(encoding="utf-8"))["passed"] is False
     assert not indexer.graph_file.exists()
     assert indexer.graph_file.with_name("graph.rejected.pkl").exists()
+
+
+def test_read_only_pipeline_does_not_generate_a_compilation_database(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "main.c").write_text("int main(void) { return 0; }\n", encoding="utf-8")
+    indexer = ClangdIndexer(project, output_dir=tmp_path / "output")
+    monkeypatch.setattr(
+        indexer,
+        "_auto_generate_compdb",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("read-only onboarding must not run a build system")
+        ),
+    )
+    monkeypatch.setattr(indexer, "generate_index", lambda **_kwargs: False)
+
+    assert (
+        indexer.run_pipeline(
+            report_profile=False,
+            allow_project_preparation=False,
+        )
+        is None
+    )
+    assert not (project / "build").exists()
+    assert not (project / "compile_commands.json").exists()

--- a/test/scip/test_scip_ruby.py
+++ b/test/scip/test_scip_ruby.py
@@ -491,6 +491,34 @@ def test_scip_ruby_indexer_builds_registered_command(tmp_path, monkeypatch):
     assert indexer._get_decoder_class() is SCIPRubyGraphDecoder
 
 
+def test_read_only_scip_ruby_generation_skips_bundle_preparation(tmp_path, monkeypatch):
+    import codenib.scip_interface.scip_indexer_ruby as ruby_module
+
+    (tmp_path / "Gemfile").write_text(
+        'source "https://rubygems.org"\ngem "scip-ruby"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODENIB_RUBY_SCIP_CMD", "bundle exec scip-ruby")
+    indexer = SCIPRubyIndexer(tmp_path, output_dir=tmp_path / "out")
+    monkeypatch.setattr(indexer, "_check_indexer_available", lambda: True)
+    monkeypatch.setattr(
+        indexer,
+        "_prepare_bundle",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("read-only onboarding must not run Bundler preparation")
+        ),
+    )
+
+    def run(_command, **_kwargs):
+        indexer.index_file.write_text("scip\n", encoding="utf-8")
+
+    monkeypatch.setattr(ruby_module.subprocess, "run", run)
+
+    assert indexer.generate_index(allow_project_preparation=False)
+    assert not (tmp_path / ".bundle").exists()
+    assert not (tmp_path / "vendor").exists()
+
+
 def test_ruby_hybrid_indexer_uses_lsp_without_prepared_scip_bundle(tmp_path):
     (tmp_path / "Gemfile").write_text(
         'source "https://rubygems.org"\ngem "rake"\n',

--- a/test/scip/test_scip_typescript_runtime.py
+++ b/test/scip/test_scip_typescript_runtime.py
@@ -6,7 +6,10 @@
 
 import json
 
+import pytest
+
 from codenib.repository_filters import default_exclude_patterns
+from codenib.scip_interface.scip_indexer_base import SCIPIndexerBase
 from codenib.scip_interface.scip_indexer_ts import SCIPTypeScriptIndexer
 
 
@@ -45,3 +48,29 @@ def test_typescript_temporary_config_includes_repository_excludes(tmp_path):
 
     indexer._cleanup_patched_tsconfig()
     assert not patched_path.exists()
+
+
+def test_read_only_pipeline_skips_project_dependency_installation(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "package.json").write_text("{}\n", encoding="utf-8")
+    indexer = SCIPTypeScriptIndexer(project, output_dir=tmp_path / "index")
+
+    monkeypatch.setattr(
+        indexer,
+        "_install_dependencies",
+        lambda: pytest.fail("read-only onboarding must not install dependencies"),
+    )
+    monkeypatch.setattr(indexer, "_ensure_allow_js", lambda: None)
+    monkeypatch.setattr(
+        SCIPIndexerBase,
+        "run_pipeline",
+        lambda _self, **_kwargs: "graph",
+    )
+
+    assert (
+        indexer.run_pipeline(allow_project_preparation=False, report_profile=False)
+        == "graph"
+    )

--- a/test/scip/test_scip_typescript_runtime.py
+++ b/test/scip/test_scip_typescript_runtime.py
@@ -50,12 +50,12 @@ def test_typescript_temporary_config_includes_repository_excludes(tmp_path):
     assert not patched_path.exists()
 
 
-def test_read_only_pipeline_skips_project_dependency_installation(
-    tmp_path, monkeypatch
-):
+def test_read_only_pipeline_skips_all_project_preparation(tmp_path, monkeypatch):
     project = tmp_path / "repo"
     project.mkdir()
     (project / "package.json").write_text("{}\n", encoding="utf-8")
+    existing_patch = project / ".tsconfig.scip.json"
+    existing_patch.write_text('{"owned": "by-user"}\n', encoding="utf-8")
     indexer = SCIPTypeScriptIndexer(project, output_dir=tmp_path / "index")
 
     monkeypatch.setattr(
@@ -63,14 +63,26 @@ def test_read_only_pipeline_skips_project_dependency_installation(
         "_install_dependencies",
         lambda: pytest.fail("read-only onboarding must not install dependencies"),
     )
-    monkeypatch.setattr(indexer, "_ensure_allow_js", lambda: None)
+    monkeypatch.setattr(
+        indexer,
+        "_ensure_allow_js",
+        lambda: pytest.fail("read-only onboarding must not write a tsconfig"),
+    )
+    observed: dict[str, object] = {}
+
+    def run_pipeline(_self, **kwargs):
+        observed.update(kwargs)
+        return "graph"
+
     monkeypatch.setattr(
         SCIPIndexerBase,
         "run_pipeline",
-        lambda _self, **_kwargs: "graph",
+        run_pipeline,
     )
 
     assert (
         indexer.run_pipeline(allow_project_preparation=False, report_profile=False)
         == "graph"
     )
+    assert observed["infer_tsconfig"] is True
+    assert existing_patch.read_text(encoding="utf-8") == '{"owned": "by-user"}\n'

--- a/test/test_codegraph_onboarding.py
+++ b/test/test_codegraph_onboarding.py
@@ -1,0 +1,704 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codenib import cli
+from codenib.codegraph_onboarding import (
+    ClientInspection,
+    CodeGraphOnboardingError,
+    CodeGraphReceipt,
+    MCPServerSpec,
+    add_client_registration,
+    codegraph_receipt_path,
+    codegraph_server_name,
+    inspect_client_registration,
+    inspect_server_command,
+    load_codegraph_receipt,
+    make_server_spec,
+    remove_client_registration,
+    resolve_codenib_command,
+    resolve_requested_clients,
+    write_codegraph_receipt,
+)
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+
+
+def _repository(tmp_path: Path, name: str = "repo") -> Path:
+    repo = tmp_path / name
+    repo.mkdir()
+    (repo / "sample.py").write_text("def sample():\n    return 1\n", encoding="utf-8")
+    return repo
+
+
+def _initialize_git_repository(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.invalid"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "CodeNib Test"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(repo), "add", "sample.py"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-qm", "test fixture"],
+        check=True,
+    )
+
+
+def _server(repo: Path) -> MCPServerSpec:
+    return make_server_spec(repo, command="/opt/codenib/bin/codenib")
+
+
+def _manifest(repo: Path) -> RepoManifest:
+    fingerprint = "sha256-v2:" + "a" * 64
+    entries = {
+        name: IndexEntry(
+            index_type=name,
+            path=f"/state/{name}",
+            built_at="2026-08-13T00:00:00Z",
+            built_at_epoch=1.0,
+            status="fresh",
+            commit="",
+            source_fingerprint=fingerprint,
+        )
+        for name in ("bm25", "symbol_graph")
+    }
+    return RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint,
+        last_indexed_source_fingerprint=fingerprint,
+        languages=["python"],
+        indexes=entries,
+    )
+
+
+def test_codegraph_parser_exposes_init_status_and_uninstall() -> None:
+    parser = cli.build_parser()
+
+    init = parser.parse_args(
+        [
+            "codegraph",
+            "init",
+            ".",
+            "--agent",
+            "codex",
+            "--agent",
+            "claude",
+            "--dry-run",
+        ]
+    )
+    status = parser.parse_args(["codegraph", "status", ".", "--json"])
+    uninstall = parser.parse_args(
+        ["codegraph", "uninstall", ".", "--agent", "codex", "--force"]
+    )
+
+    assert init.codegraph_command == "init"
+    assert init.agent == ["codex", "claude"]
+    assert init.dry_run is True
+    assert status.codegraph_command == "status"
+    assert status.json is True
+    assert uninstall.codegraph_command == "uninstall"
+    assert uninstall.force is True
+
+
+def test_server_name_is_bounded_readable_and_checkout_specific(tmp_path: Path) -> None:
+    first = _repository(tmp_path, "A repository " + "x" * 100)
+    second = _repository(tmp_path, "other")
+
+    first_name = codegraph_server_name(first)
+    second_name = codegraph_server_name(second)
+
+    assert first_name.startswith("codenib-a-repository-")
+    assert len(first_name) <= 54
+    assert first_name != second_name
+    assert set(first_name) <= set("abcdefghijklmnopqrstuvwxyz0123456789._-")
+
+
+def test_command_resolution_prefers_installed_executable(tmp_path: Path) -> None:
+    executable = tmp_path / "codenib"
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+
+    command, prefix = resolve_codenib_command(
+        which=lambda value: str(executable) if value == "codenib" else None
+    )
+
+    assert command == str(executable)
+    assert prefix == ()
+
+
+def test_command_resolution_falls_back_to_current_python() -> None:
+    command, prefix = resolve_codenib_command(which=lambda _value: None)
+
+    assert Path(command).is_absolute()
+    assert prefix == ("-m", "codenib")
+
+
+def test_auto_client_resolution_is_stable_and_requires_a_client() -> None:
+    assert resolve_requested_clients(
+        None,
+        which=lambda value: f"/bin/{value}" if value in {"codex", "claude"} else None,
+    ) == ("codex", "claude")
+    assert resolve_requested_clients(
+        ["claude"],
+        which=lambda value: f"/bin/{value}" if value == "claude" else None,
+    ) == ("claude",)
+
+    with pytest.raises(CodeGraphOnboardingError, match="no supported agent"):
+        resolve_requested_clients(None, which=lambda _value: None)
+    with pytest.raises(CodeGraphOnboardingError, match="cannot be combined"):
+        resolve_requested_clients(
+            ["auto", "codex"],
+            which=lambda value: f"/bin/{value}",
+        )
+
+
+def test_receipt_round_trip_is_private_and_deterministic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _repository(tmp_path)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    receipt = CodeGraphReceipt(repo, _server(repo), ()).with_client(
+        "codex", state="configured"
+    )
+
+    path = write_codegraph_receipt(receipt)
+    first = path.read_bytes()
+    write_codegraph_receipt(receipt)
+
+    assert load_codegraph_receipt(repo) == receipt
+    assert path.read_bytes() == first
+    if os.name == "posix":
+        assert path.stat().st_mode & 0o777 == 0o600
+    assert path == codegraph_receipt_path(repo)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update(extra=True),
+        lambda value: value.update(schema_version=True),
+        lambda value: value["server"].update(args=["mcp", "/other"]),
+        lambda value: value["server"].update(command="relative-codenib"),
+        lambda value: value["clients"].update(codex={"scope": "user"}),
+    ],
+)
+def test_receipt_validation_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation,
+) -> None:
+    repo = _repository(tmp_path)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    receipt = CodeGraphReceipt(repo, _server(repo), ()).with_client(
+        "codex", state="configured"
+    )
+    path = write_codegraph_receipt(receipt)
+    value = json.loads(path.read_text(encoding="utf-8"))
+    mutation(value)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+    with pytest.raises(CodeGraphOnboardingError, match="receipt"):
+        load_codegraph_receipt(repo)
+
+
+class _NativeClientHarness:
+    def __init__(self) -> None:
+        self.configs: dict[str, MCPServerSpec] = {}
+        self.commands: list[tuple[str, ...]] = []
+
+    @staticmethod
+    def which(client: str) -> str | None:
+        return f"/clients/{client}" if client in {"codex", "claude"} else None
+
+    def run(self, command, **_kwargs):
+        argv = tuple(command)
+        self.commands.append(argv)
+        client = Path(argv[0]).name
+        operation = argv[2]
+        if operation == "get":
+            name = argv[-1]
+            server = self.configs.get(client)
+            if server is None or server.name != name:
+                return subprocess.CompletedProcess(argv, 1, "", "not found")
+            if client == "codex":
+                stdout = json.dumps(
+                    {
+                        "name": server.name,
+                        "enabled": True,
+                        "transport": {
+                            "type": "stdio",
+                            "command": server.command,
+                            "args": list(server.args),
+                            "cwd": None,
+                            "env": None,
+                        },
+                    }
+                )
+            else:
+                stdout = (
+                    f"{server.name}:\n"
+                    "  Scope: Local config (private to you in this project)\n"
+                    "  Status: Connected\n"
+                    "  Type: stdio\n"
+                    f"  Command: {server.command}\n"
+                    f"  Args: {' '.join(server.args)}\n"
+                    "  Environment:\n"
+                )
+            return subprocess.CompletedProcess(argv, 0, stdout, "")
+        if operation == "add":
+            separator = argv.index("--")
+            name = argv[3] if client == "codex" else argv[5]
+            server_argv = argv[separator + 1 :]
+            self.configs[client] = MCPServerSpec(
+                name,
+                server_argv[0],
+                tuple(server_argv[1:]),
+            )
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        if operation == "remove":
+            self.configs.pop(client, None)
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        raise AssertionError(argv)
+
+
+@pytest.mark.parametrize("client", ["codex", "claude"])
+def test_native_client_add_inspect_remove_contract(
+    tmp_path: Path,
+    client: str,
+) -> None:
+    repo = _repository(tmp_path, "repo with spaces")
+    server = _server(repo)
+    native = _NativeClientHarness()
+
+    missing = inspect_client_registration(
+        client,
+        server,
+        repo,
+        runner=native.run,
+        which=native.which,
+    )
+    add_client_registration(
+        client,
+        server,
+        repo,
+        runner=native.run,
+        which=native.which,
+    )
+    configured = inspect_client_registration(
+        client,
+        server,
+        repo,
+        runner=native.run,
+        which=native.which,
+    )
+    remove_client_registration(
+        client,
+        server,
+        repo,
+        runner=native.run,
+        which=native.which,
+    )
+
+    assert missing.exists is False
+    assert configured.matches is True
+    assert client not in native.configs
+    if client == "codex":
+        assert any(
+            command[1:4] == ("mcp", "get", "--json") for command in native.commands
+        )
+    else:
+        add = next(command for command in native.commands if command[2] == "add")
+        assert add[3:5] == ("--scope", "local")
+
+
+def test_native_client_inspection_does_not_treat_cli_failure_as_absent(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+
+    def fail(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 2, "", "configuration is invalid")
+
+    with pytest.raises(CodeGraphOnboardingError, match="cannot inspect codex"):
+        inspect_client_registration(
+            "codex",
+            _server(repo),
+            repo,
+            runner=fail,
+            which=lambda _value: "/clients/codex",
+        )
+
+
+def test_server_command_must_report_the_active_codenib_version(tmp_path: Path) -> None:
+    from codenib._version import package_version
+
+    repo = _repository(tmp_path)
+    server = make_server_spec(
+        repo,
+        command="/python",
+        command_prefix=("-m", "codenib"),
+    )
+    commands: list[tuple[str, ...]] = []
+
+    def runner(command, **_kwargs):
+        commands.append(tuple(command))
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            f"codenib {package_version()}\n",
+            "",
+        )
+
+    inspection = inspect_server_command(server, repo, runner=runner)
+
+    assert inspection.ready is True
+    assert commands == [("/python", "-m", "codenib", "--version")]
+
+    mismatch = inspect_server_command(
+        server,
+        repo,
+        runner=lambda command, **_kwargs: subprocess.CompletedProcess(
+            command, 0, "different tool\n", ""
+        ),
+    )
+    assert mismatch.ready is False
+
+
+def _ready_plan(repo: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        repository=repo,
+        root=repo / "tools",
+        languages=("python",),
+        requirements=(),
+        missing=(),
+        notes=(),
+        ready=True,
+    )
+
+
+def test_init_is_idempotent_and_writes_no_repository_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import codenib.codegraph_onboarding as onboarding
+
+    repo = _repository(tmp_path)
+    _initialize_git_repository(repo)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    configured: dict[str, MCPServerSpec] = {}
+    additions: list[str] = []
+
+    monkeypatch.setattr(
+        onboarding,
+        "resolve_requested_clients",
+        lambda _requested: ("codex", "claude"),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "resolve_codenib_command",
+        lambda _explicit=None: ("/opt/codenib/bin/codenib", ()),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "inspect_server_command",
+        lambda *_args, **_kwargs: SimpleNamespace(ready=True, detail="ready"),
+    )
+
+    def inspect(client, server, _repo):
+        current = configured.get(client)
+        return ClientInspection(
+            client,
+            True,
+            current is not None,
+            current == server,
+            "configuration matches" if current == server else "not configured",
+        )
+
+    def add(client, server, _repo):
+        additions.append(client)
+        configured[client] = server
+
+    monkeypatch.setattr(onboarding, "inspect_client_registration", inspect)
+    monkeypatch.setattr(onboarding, "add_client_registration", add)
+    monkeypatch.setattr(
+        cli, "_codegraph_toolchain_plan", lambda *_args: _ready_plan(repo)
+    )
+    monkeypatch.setattr(cli, "_require_modules", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli, "_check_view_dependencies", lambda *_args, **_kwargs: None)
+    index_calls: list[dict[str, object]] = []
+
+    def index_repository(*_args, **kwargs):
+        index_calls.append(kwargs)
+        return _manifest(repo), []
+
+    monkeypatch.setattr(cli, "index_repository", index_repository)
+    monkeypatch.setattr(cli, "_print_index_summary", lambda *_args: None)
+    args = cli.build_parser().parse_args(["codegraph", "init", str(repo)])
+    initial = sorted(path.relative_to(repo) for path in repo.rglob("*"))
+
+    assert cli._run_codegraph_init(args) == 0
+    assert cli._run_codegraph_init(args) == 0
+
+    receipt = load_codegraph_receipt(repo)
+    assert receipt is not None
+    assert [(item.name, item.state) for item in receipt.clients] == [
+        ("codex", "configured"),
+        ("claude", "configured"),
+    ]
+    assert additions == ["codex", "claude"]
+    assert all(call["allow_graph_project_preparation"] is False for call in index_calls)
+    assert all(call["allow_partial_graph_languages"] is False for call in index_calls)
+    assert sorted(path.relative_to(repo) for path in repo.rglob("*")) == initial
+    assert "CodeGraph is ready" in capsys.readouterr().out
+
+
+def test_init_rejects_dirty_checkout_before_toolchain_or_index_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.codegraph_onboarding as onboarding
+
+    repo = _repository(tmp_path)
+    _initialize_git_repository(repo)
+    (repo / "untracked.py").write_text("value = 1\n", encoding="utf-8")
+    monkeypatch.setattr(
+        onboarding,
+        "resolve_requested_clients",
+        lambda _requested: ("codex",),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "resolve_codenib_command",
+        lambda _explicit=None: ("/opt/codenib/bin/codenib", ()),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "inspect_server_command",
+        lambda *_args, **_kwargs: SimpleNamespace(ready=True, detail="ready"),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "inspect_client_registration",
+        lambda client, _server, _repo: ClientInspection(
+            client, True, False, False, "not configured"
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_codegraph_toolchain_plan",
+        lambda *_args: pytest.fail("dirty checkout must fail before toolchain work"),
+    )
+    args = cli.build_parser().parse_args(["codegraph", "init", str(repo)])
+
+    with pytest.raises(cli.CLIError, match="clean Git checkout"):
+        cli._run_codegraph_init(args)
+
+
+def test_repeated_init_reuses_manifest_language_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.compiler.manifest import MANIFEST_FILENAME
+    from codenib.paths import repo_index_dir
+
+    repo = _repository(tmp_path)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    manifest = _manifest(repo)
+    manifest.languages = ["ruby"]
+    manifest.save(repo_index_dir(repo) / MANIFEST_FILENAME)
+    args = cli.build_parser().parse_args(["codegraph", "init", str(repo)])
+
+    assert cli._codegraph_languages_for_init(repo, args, object()) == ("ruby",)
+
+
+def test_init_does_not_overwrite_registration_created_during_indexing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.codegraph_onboarding as onboarding
+
+    repo = _repository(tmp_path)
+    _initialize_git_repository(repo)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    inspections = 0
+
+    monkeypatch.setattr(
+        onboarding,
+        "resolve_requested_clients",
+        lambda _requested: ("codex",),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "resolve_codenib_command",
+        lambda _explicit=None: ("/opt/codenib/bin/codenib", ()),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "inspect_server_command",
+        lambda *_args, **_kwargs: SimpleNamespace(ready=True, detail="ready"),
+    )
+
+    def inspect(client, _server, _repo):
+        nonlocal inspections
+        inspections += 1
+        return ClientInspection(
+            client,
+            True,
+            inspections > 1,
+            False,
+            "configuration differs" if inspections > 1 else "not configured",
+        )
+
+    monkeypatch.setattr(onboarding, "inspect_client_registration", inspect)
+    monkeypatch.setattr(
+        onboarding,
+        "add_client_registration",
+        lambda *_args: pytest.fail("a raced registration must not be overwritten"),
+    )
+    monkeypatch.setattr(
+        cli, "_codegraph_toolchain_plan", lambda *_args: _ready_plan(repo)
+    )
+    monkeypatch.setattr(cli, "_require_modules", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli, "_check_view_dependencies", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli,
+        "index_repository",
+        lambda *_args, **_kwargs: (_manifest(repo), []),
+    )
+    monkeypatch.setattr(cli, "_print_index_summary", lambda *_args: None)
+    args = cli.build_parser().parse_args(
+        ["codegraph", "init", str(repo), "--language", "python"]
+    )
+
+    with pytest.raises(cli.CLIError, match="changed during indexing"):
+        cli._run_codegraph_init(args)
+
+
+def test_init_rejects_unmanaged_name_collision_before_indexing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.codegraph_onboarding as onboarding
+
+    repo = _repository(tmp_path)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    monkeypatch.setattr(
+        onboarding,
+        "resolve_requested_clients",
+        lambda _requested: ("codex",),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "resolve_codenib_command",
+        lambda _explicit=None: ("/opt/codenib/bin/codenib", ()),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "inspect_server_command",
+        lambda *_args, **_kwargs: SimpleNamespace(ready=True, detail="ready"),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "inspect_client_registration",
+        lambda client, _server, _repo: ClientInspection(
+            client, True, True, True, "configuration matches"
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_codegraph_toolchain_plan",
+        lambda *_args: pytest.fail("collision must fail before toolchain work"),
+    )
+    args = cli.build_parser().parse_args(["codegraph", "init", str(repo)])
+
+    with pytest.raises(cli.CLIError, match="unmanaged MCP server"):
+        cli._run_codegraph_init(args)
+
+
+def test_uninstall_refuses_drift_unless_forced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib.codegraph_onboarding as onboarding
+
+    repo = _repository(tmp_path)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    receipt = CodeGraphReceipt(repo, _server(repo), ()).with_client(
+        "codex", state="configured"
+    )
+    write_codegraph_receipt(receipt)
+    state = {"exists": True}
+    removals: list[str] = []
+
+    def inspect(client, _server, _repo):
+        return ClientInspection(
+            client,
+            True,
+            state["exists"],
+            False,
+            "configuration differs",
+        )
+
+    def remove(client, _server, _repo):
+        removals.append(client)
+        state["exists"] = False
+
+    monkeypatch.setattr(onboarding, "inspect_client_registration", inspect)
+    monkeypatch.setattr(onboarding, "remove_client_registration", remove)
+    normal = cli.build_parser().parse_args(["codegraph", "uninstall", str(repo)])
+    forced = cli.build_parser().parse_args(
+        ["codegraph", "uninstall", str(repo), "--force"]
+    )
+
+    with pytest.raises(cli.CLIError, match="refusing to remove drifted"):
+        cli._run_codegraph_uninstall(normal)
+    assert codegraph_receipt_path(repo).is_file()
+
+    assert cli._run_codegraph_uninstall(forced) == 0
+    assert removals == ["codex"]
+    assert not codegraph_receipt_path(repo).exists()
+
+
+def test_status_json_is_nonzero_without_managed_clients(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _repository(tmp_path)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    monkeypatch.setattr(
+        cli,
+        "_codegraph_index_report",
+        lambda _repo: {"ready": True, "detail": "current"},
+    )
+    monkeypatch.setattr(
+        cli,
+        "_codegraph_toolchain_report",
+        lambda *_args: {
+            "ready": True,
+            "languages": ["python"],
+            "missing": [],
+            "notes": [],
+        },
+    )
+    args = cli.build_parser().parse_args(["codegraph", "status", str(repo), "--json"])
+
+    assert cli._run_codegraph_status(args) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["ready"] is False
+    assert report["clients"] == []

--- a/test/test_mcp_registry.py
+++ b/test/test_mcp_registry.py
@@ -18,11 +18,11 @@ def test_registry_metadata_matches_package_and_uvx_contract() -> None:
 
     version, server = registry.validate_registry_metadata(root)
 
-    assert version == "0.2.0"
+    assert version == "0.2.1"
     assert server["name"] == "ai.codenib/codenib"
     package = server["packages"][0]
     assert package["identifier"] == "codenib"
-    assert package["runtimeArguments"][0]["value"] == ("codenib[mcp]==0.2.0")
+    assert package["runtimeArguments"][0]["value"] == ("codenib[graph,mcp]==0.2.1")
     assert package["packageArguments"][1]["format"] == "filepath"
 
 

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -65,8 +65,8 @@ def test_project_identity_and_tag_match_release_metadata() -> None:
     name, version = project_identity(root / "pyproject.toml")
 
     assert name == "codenib"
-    assert expected_tag(version) == "v0.2.0"
-    validate_tag("v0.2.0", version)
+    assert expected_tag(version) == "v0.2.1"
+    validate_tag("v0.2.1", version)
 
 
 def test_release_tag_must_match_project_version() -> None:
@@ -93,18 +93,19 @@ def test_packaged_readme_requires_mcp_registry_ownership() -> None:
         validate_readme_mcp_ownership("# CodeNib\n")
 
 
-def test_stable_release_notes_use_production_pypi_and_pages_permissions() -> None:
+def test_stable_release_notes_describe_the_codegraph_product_path() -> None:
     root = Path(__file__).resolve().parents[1]
-    notes = (root / "docs" / "releases" / "0.2.0.md").read_text(encoding="utf-8")
+    notes = (root / "docs" / "releases" / "0.2.1.md").read_text(encoding="utf-8")
 
-    assert '"codenib[semantic]==0.2.0"' in notes
-    assert '"codenib[mcp,semantic]==0.2.0"' in notes
-    assert "sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0" in notes
+    assert '"codenib[graph,mcp]==0.2.1"' in notes
+    assert "codenib codegraph init" in notes
+    assert "explore_context" in notes
+    assert "dependency_subgraph" in notes
+    assert "Codex" in notes
+    assert "Claude Code" in notes
     assert "test-files.pythonhosted.org" not in notes
     assert "--extra-index-url" not in notes
     assert "--index-url" not in notes
-    for permission in ("contents: read", "pages: write", "id-token: write"):
-        assert permission in notes
 
 
 @pytest.mark.parametrize(
@@ -112,6 +113,7 @@ def test_stable_release_notes_use_production_pypi_and_pages_permissions() -> Non
     (
         "README.md",
         "docs/agent_integrations.md",
+        "docs/codegraph.md",
         "docs/index.md",
         "docs/mcp.md",
         "docs/quickstart.md",
@@ -134,7 +136,7 @@ def test_public_install_commands_select_the_current_stable_release(
 
     assert install_lines
     assert "CODENIB_ALPHA_WHEEL=" not in text
-    assert all("==0.2.0" in line for line in install_lines)
+    assert all("==0.2.1" in line for line in install_lines)
 
 
 def test_registry_publishers_use_separate_workflows() -> None:

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -108,6 +108,17 @@ def test_stable_release_notes_describe_the_codegraph_product_path() -> None:
     assert "--index-url" not in notes
 
 
+def test_020_release_notes_retain_pages_permission_contract() -> None:
+    root = Path(__file__).resolve().parents[1]
+    notes = (root / "docs" / "releases" / "0.2.0.md").read_text(encoding="utf-8")
+
+    assert '"codenib[semantic]==0.2.0"' in notes
+    assert '"codenib[mcp,semantic]==0.2.0"' in notes
+    assert "sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0" in notes
+    for permission in ("contents: read", "pages: write", "id-token: write"):
+        assert permission in notes
+
+
 @pytest.mark.parametrize(
     "relative_path",
     (

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "codenib"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Make CodeGraph the primary CodeNib 0.2.1 product path: one command builds a complete graph and configures Codex and/or Claude Code through their native MCP CLIs.

## Changes

- Add `codenib codegraph init|status|uninstall` with idempotent, drift-aware native client registration and private receipts.
- Build current BM25 and complete symbol-graph views without modifying the target checkout or running project package-manager/build preparation.
- Add an installed-wheel release smoke covering setup, status, MCP `explore_context`, MCP `dependency_subgraph`, Dependency Map, repeat setup, and uninstall.
- Update the 0.2.1 package, MCP Registry metadata, roadmap, quickstart, release notes, and CodeGraph product documentation.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `255 passed` in the focused CLI, release, language-route, and compiler suite.
- `5193 passed, 71 skipped, 191 deselected` in the unit tier after excluding one exact-base-reproduced umask test.
- `36 passed, 18 skipped` in the integration tier.
- Clean-venv install of `codenib-0.2.1-py3-none-any.whl[graph,mcp]` passed the full CodeGraph product smoke.
- `pre-commit`, `mkdocs build --strict`, `uv lock --check`, MCP Registry verification, Twine checks, and release artifact verification passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
