### PR TITLE
fix(storage): retain exact resources across interruption

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -928,6 +928,8 @@ def _run_ordered_actions(state: _OrderedActionState) -> None:
 @contextmanager
 def _run_context_with_cleanup_actions(
     cleanup_actions: tuple[_OrderedActionInput, ...],
+    *,
+    cleanup_on_success: bool = True,
 ) -> Iterator[None]:
     """Run every cleanup action without replacing a context-body primary."""
 
@@ -948,16 +950,23 @@ def _run_context_with_cleanup_actions(
     # context body entered while that unrelated exception is being handled.
     ambient_error = sys.exc_info()[1]
     context_error: BaseException | None = None
+    # These values are read after the protected finalizer boundary.  Publish
+    # them before entering the caller's body so an exception injected at the
+    # first finalizer opcode can never expose an unbound local.
+    locally_unwinding = False
+    primary_error: BaseException | None = None
     try:
         yield
     except BaseException as error:  # noqa: B036 - preserve exact local primary
         context_error = error
+        failures.primary_error = error
+        failures.protect_pending_owners()
         raise
     finally:
-        locally_unwinding = context_error is not None
-        primary_error = context_error
-        failures.primary_error = primary_error
         try:
+            locally_unwinding = context_error is not None
+            primary_error = context_error
+            failures.primary_error = primary_error
             active_error = sys.exc_info()[1]
             locally_unwinding = context_error is not None or (
                 active_error is not None and active_error is not ambient_error
@@ -965,9 +974,10 @@ def _run_context_with_cleanup_actions(
             if primary_error is None and locally_unwinding:
                 primary_error = active_error
             failures.primary_error = primary_error
-            failures.protect_pending_owners()
-            _run_ordered_actions(failures)
-            _prune_publication_cleanup_owners(failures.primary_error)
+            if cleanup_on_success or locally_unwinding:
+                failures.protect_pending_owners()
+                _run_ordered_actions(failures)
+                _prune_publication_cleanup_owners(failures.primary_error)
         except BaseException as boundary_error:  # noqa: B036 - retain recovery
             failures.retain_once(
                 "outer-trampoline-entry",
@@ -1073,6 +1083,21 @@ class _PosixDescriptorRecord:
     identity: tuple[int, ...] | None = None
 
 
+@dataclass(slots=True)
+class _ExactResourceCleanupOwner:
+    """Retry one exact resource record without sweeping its aggregate owner."""
+
+    action: Callable[[], None]
+    complete: Callable[[], bool]
+
+    @property
+    def closed(self) -> bool:
+        return self.complete() is True
+
+    def close(self) -> None:
+        self.action()
+
+
 class _PosixResourceOwner:
     """Track POSIX descriptors without removing ownership before close.
 
@@ -1117,73 +1142,53 @@ class _PosixResourceOwner:
         *,
         dir_fd: int | None = None,
     ) -> int:
-        descriptor = -1
-        record: _PosixDescriptorRecord | None = None
-        try:
+        # Publish an empty owner record before the native acquisition.  The
+        # only remaining unowned edge is the documented native-return to first
+        # STORE_ATTR boundary; record construction and registration can no
+        # longer fail after a live descriptor already exists.
+        record = _PosixDescriptorRecord(-1)
+        self._records.append(record)
+        exact_owner = self._exact_record_cleanup_owner(record)
+
+        with _run_context_with_cleanup_actions(
+            (
+                _OrderedAction(
+                    label="descriptor acquisition cleanup also failed",
+                    action=exact_owner.close,
+                    complete=lambda: exact_owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=exact_owner,
+                ),
+            ),
+            cleanup_on_success=False,
+        ):
             if dir_fd is None:
-                descriptor = os.open(path, flags, mode)
+                record.descriptor = os.open(path, flags, mode)
             else:
-                descriptor = os.open(path, flags, mode, dir_fd=dir_fd)
-            record = _PosixDescriptorRecord(descriptor)
-            self._records.append(record)
-            record.identity = _resource_owner_identity(os.fstat(descriptor))
-            return descriptor
-        except BaseException as primary_error:
-            if descriptor >= 0:
-                if record is None:
-                    record = _PosixDescriptorRecord(descriptor)
-                if not any(candidate is record for candidate in self._records):
-                    try:
-                        self._records.append(record)
-                    except BaseException as registration_error:  # noqa: B036
-                        _annotate_secondary_error(
-                            primary_error,
-                            "descriptor ownership registration also failed",
-                            registration_error,
-                        )
-                        close_error = self._close_record(record)
-                        if close_error is not None:
-                            _annotate_secondary_error(
-                                primary_error,
-                                "unregistered descriptor cleanup also failed",
-                                close_error,
-                            )
-                        raise primary_error
-                self.close_record_after_error(record, primary_error)
-            raise
+                record.descriptor = os.open(path, flags, mode, dir_fd=dir_fd)
+            record.identity = _resource_owner_identity(os.fstat(record.descriptor))
+            return record.descriptor
 
     def duplicate(self, descriptor: int) -> int:
-        duplicate = -1
-        record: _PosixDescriptorRecord | None = None
-        try:
-            duplicate = os.dup(descriptor)
-            record = _PosixDescriptorRecord(duplicate)
-            self._records.append(record)
-            record.identity = _resource_owner_identity(os.fstat(duplicate))
-            return duplicate
-        except BaseException as primary_error:
-            if duplicate >= 0:
-                if record is None:
-                    record = _PosixDescriptorRecord(duplicate)
-                if not any(candidate is record for candidate in self._records):
-                    try:
-                        self._records.append(record)
-                    except BaseException as registration_error:  # noqa: B036
-                        _annotate_secondary_error(
-                            primary_error,
-                            "descriptor ownership registration also failed",
-                            registration_error,
-                        )
-                        close_error = self._close_record(record)
-                        if close_error is not None:
-                            _annotate_secondary_error(
-                                primary_error,
-                                "unregistered descriptor cleanup also failed",
-                                close_error,
-                            )
-                        raise primary_error
-                self.close_record_after_error(record, primary_error)
-            raise
+        record = _PosixDescriptorRecord(-1)
+        self._records.append(record)
+        exact_owner = self._exact_record_cleanup_owner(record)
+
+        with _run_context_with_cleanup_actions(
+            (
+                _OrderedAction(
+                    label="descriptor duplication cleanup also failed",
+                    action=exact_owner.close,
+                    complete=lambda: exact_owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=exact_owner,
+                ),
+            ),
+            cleanup_on_success=False,
+        ):
+            record.descriptor = os.dup(descriptor)
+            record.identity = _resource_owner_identity(os.fstat(record.descriptor))
+            return record.descriptor
 
     def close_descriptor(self, descriptor: int) -> None:
         record = self._record_for(descriptor)
@@ -1209,15 +1214,81 @@ class _PosixResourceOwner:
         record: _PosixDescriptorRecord,
         primary_error: BaseException,
     ) -> None:
-        close_error = self._close_record(record)
-        if close_error is not None:
-            _annotate_secondary_error(
-                primary_error,
-                "descriptor cleanup also failed",
-                close_error,
+        self._run_record_cleanup_after_error(
+            self._record_cleanup_state(record, primary_error),
+            primary_error,
+        )
+
+    def _record_cleanup_complete(self, record: _PosixDescriptorRecord) -> bool:
+        descriptor = record.descriptor
+        if descriptor < 0:
+            return True
+        try:
+            observed = os.fstat(descriptor)
+        except OSError as probe_error:
+            if probe_error.errno == errno.EBADF:
+                record.descriptor = -1
+                return True
+            return False
+        except BaseException:  # noqa: B036 - uncertain ownership stays retained
+            return False
+        try:
+            observed_identity = _resource_owner_identity(observed)
+        except BaseException:  # noqa: B036 - uncertain ownership stays retained
+            return False
+        if record.identity is not None and observed_identity != record.identity:
+            record.descriptor = -1
+            return True
+        return False
+
+    def _record_cleanup_state(
+        self,
+        record: _PosixDescriptorRecord,
+        primary_error: BaseException,
+    ) -> _OrderedActionState:
+        exact_owner = self._exact_record_cleanup_owner(record)
+        cleanup = _OrderedActionState(
+            actions=(
+                _OrderedAction(
+                    label="descriptor cleanup also failed",
+                    action=exact_owner.close,
+                    complete=lambda: exact_owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=exact_owner,
+                ),
+            ),
+            iteration_failure_label="descriptor cleanup iteration also failed",
+            primary_error=primary_error,
+        )
+        cleanup.protect_pending_owners()
+        return cleanup
+
+    def _exact_record_cleanup_owner(
+        self,
+        record: _PosixDescriptorRecord,
+    ) -> _ExactResourceCleanupOwner:
+        return _ExactResourceCleanupOwner(
+            action=partial(self.close_record, record),
+            complete=partial(self._record_cleanup_complete, record),
+        )
+
+    @staticmethod
+    def _run_record_cleanup_after_error(
+        cleanup: _OrderedActionState,
+        primary_error: BaseException,
+    ) -> None:
+        try:
+            cleanup.primary_error = primary_error
+            cleanup.protect_pending_owners()
+            _run_ordered_actions(cleanup)
+            _prune_publication_cleanup_owners(primary_error)
+        except BaseException as boundary_error:  # noqa: B036 - keep first
+            cleanup.retain_once(
+                "outer-trampoline-entry",
+                cleanup.iteration_failure_label,
+                boundary_error,
             )
-            if record.descriptor >= 0:
-                _attach_publication_cleanup_owner(primary_error, self)
+            cleanup.protect_pending_owners()
 
     def close_all(self) -> None:
         primary_error: BaseException | None = None
@@ -1360,38 +1431,29 @@ class _WindowsResourceOwner:
         return all(record.handle == 0 for record in self._records)
 
     def acquire(self, callback: Callable[[], int]) -> int:
-        handle = 0
-        record: _WindowsHandleRecord | None = None
-        try:
-            handle = callback()
-            record = _WindowsHandleRecord(handle)
-            self._records.append(record)
-            metadata = self._api.metadata(handle)
+        # As on POSIX, publish the empty record before invoking the native
+        # acquisition callback so Python-side construction/registration cannot
+        # orphan an already returned HANDLE.
+        record = _WindowsHandleRecord(0)
+        self._records.append(record)
+        exact_owner = self._exact_record_cleanup_owner(record)
+
+        with _run_context_with_cleanup_actions(
+            (
+                _OrderedAction(
+                    label="Windows HANDLE acquisition cleanup also failed",
+                    action=exact_owner.close,
+                    complete=lambda: exact_owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=exact_owner,
+                ),
+            ),
+            cleanup_on_success=False,
+        ):
+            record.handle = callback()
+            metadata = self._api.metadata(record.handle)
             record.identity = _resource_owner_identity(metadata)
-            return handle
-        except BaseException as primary_error:
-            if handle:
-                if record is None:
-                    record = _WindowsHandleRecord(handle)
-                if not any(candidate is record for candidate in self._records):
-                    try:
-                        self._records.append(record)
-                    except BaseException as registration_error:  # noqa: B036
-                        _annotate_secondary_error(
-                            primary_error,
-                            "HANDLE ownership registration also failed",
-                            registration_error,
-                        )
-                        close_error = self._close_record(record)
-                        if close_error is not None:
-                            _annotate_secondary_error(
-                                primary_error,
-                                "unregistered HANDLE cleanup also failed",
-                                close_error,
-                            )
-                        raise primary_error
-                self.close_record_after_error(record, primary_error)
-            raise
+            return record.handle
 
     def bind_identity(self, handle: int, metadata: _WindowsHandleMetadata) -> None:
         record = self._record_for(handle)
@@ -1432,15 +1494,84 @@ class _WindowsResourceOwner:
         record: _WindowsHandleRecord,
         primary_error: BaseException,
     ) -> None:
-        close_error = self._close_record(record)
-        if close_error is not None:
-            _annotate_secondary_error(
-                primary_error,
-                "Windows HANDLE cleanup also failed",
-                close_error,
+        self._run_record_cleanup_after_error(
+            self._record_cleanup_state(record, primary_error),
+            primary_error,
+        )
+
+    def _record_cleanup_complete(self, record: _WindowsHandleRecord) -> bool:
+        handle = record.handle
+        if not handle:
+            return True
+        try:
+            observed = self._api.metadata(handle)
+        except KeyError:
+            record.handle = 0
+            return True
+        except OSError as probe_error:
+            if _windows_handle_is_invalid_error(probe_error):
+                record.handle = 0
+                return True
+            return False
+        except BaseException:  # noqa: B036 - uncertain ownership stays retained
+            return False
+        try:
+            observed_identity = _resource_owner_identity(observed)
+        except BaseException:  # noqa: B036 - uncertain ownership stays retained
+            return False
+        if record.identity is not None and observed_identity != record.identity:
+            record.handle = 0
+            return True
+        return False
+
+    def _record_cleanup_state(
+        self,
+        record: _WindowsHandleRecord,
+        primary_error: BaseException,
+    ) -> _OrderedActionState:
+        exact_owner = self._exact_record_cleanup_owner(record)
+        cleanup = _OrderedActionState(
+            actions=(
+                _OrderedAction(
+                    label="Windows HANDLE cleanup also failed",
+                    action=exact_owner.close,
+                    complete=lambda: exact_owner.closed,
+                    retry_incomplete="cancellation",
+                    incomplete_owner=exact_owner,
+                ),
+            ),
+            iteration_failure_label=("Windows HANDLE cleanup iteration also failed"),
+            primary_error=primary_error,
+        )
+        cleanup.protect_pending_owners()
+        return cleanup
+
+    def _exact_record_cleanup_owner(
+        self,
+        record: _WindowsHandleRecord,
+    ) -> _ExactResourceCleanupOwner:
+        return _ExactResourceCleanupOwner(
+            action=partial(self.close_record, record),
+            complete=partial(self._record_cleanup_complete, record),
+        )
+
+    @staticmethod
+    def _run_record_cleanup_after_error(
+        cleanup: _OrderedActionState,
+        primary_error: BaseException,
+    ) -> None:
+        try:
+            cleanup.primary_error = primary_error
+            cleanup.protect_pending_owners()
+            _run_ordered_actions(cleanup)
+            _prune_publication_cleanup_owners(primary_error)
+        except BaseException as boundary_error:  # noqa: B036 - keep first
+            cleanup.retain_once(
+                "outer-trampoline-entry",
+                cleanup.iteration_failure_label,
+                boundary_error,
             )
-            if record.handle:
-                _attach_publication_cleanup_owner(primary_error, self)
+            cleanup.protect_pending_owners()
 
     def close_all(self) -> None:
         primary_error: BaseException | None = None
@@ -2738,7 +2869,7 @@ def _windows_open_child_by_id(
     *,
     desired_access: int,
     expected_directory: bool | None,
-    resource_owner: _WindowsResourceOwner | None = None,
+    resource_owner: _WindowsResourceOwner,
 ) -> tuple[int, _WindowsHandleMetadata]:
     if not entry.file_id:
         raise RuntimeError("Windows directory entry has no reliable FILE_ID")
@@ -2747,10 +2878,7 @@ def _windows_open_child_by_id(
     is_directory = bool(entry.attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
     if expected_directory is not None and is_directory != expected_directory:
         raise ValueError("Windows publication child has the wrong object type")
-    selected_owner = (
-        _WindowsResourceOwner(api) if resource_owner is None else resource_owner
-    )
-    handle = selected_owner.acquire(
+    handle = resource_owner.acquire(
         lambda: api.open_by_id(
             parent_handle,
             entry.file_id,
@@ -2758,6 +2886,7 @@ def _windows_open_child_by_id(
             is_directory=is_directory,
         )
     )
+    record = resource_owner.record_for_cleanup(handle)
     try:
         metadata = api.metadata(handle)
         if (
@@ -2769,21 +2898,13 @@ def _windows_open_child_by_id(
             or metadata.st_file_attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
         ):
             raise RuntimeError("Windows FILE_ID child changed while it was opened")
-        selected_owner.bind_identity(handle, metadata)
-        if resource_owner is None:
-            selected_owner.release(handle)
+        resource_owner.bind_identity(handle, metadata)
         return handle, metadata
     except BaseException as primary_error:
-        try:
-            selected_owner.close_handle(handle)
-        except BaseException as close_error:  # noqa: B036 - keep primary
-            _annotate_secondary_error(
-                primary_error,
-                "Windows child HANDLE cleanup also failed",
-                close_error,
-            )
-        if selected_owner._record_for(handle) is not None:
-            _attach_publication_cleanup_owner(primary_error, selected_owner)
+        resource_owner._run_record_cleanup_after_error(
+            resource_owner._record_cleanup_state(record, primary_error),
+            primary_error,
+        )
         raise
 
 
@@ -2797,6 +2918,7 @@ def _windows_owned_file_record(
     budget: _OwnershipBudget,
     relative: str,
     entry_policy: DirectoryEntryPolicy | None,
+    resource_owner: _WindowsResourceOwner,
 ) -> tuple[int, str, tuple[int, ...]]:
     handle, opened = _windows_open_child_by_id(
         api,
@@ -2806,8 +2928,21 @@ def _windows_owned_file_record(
         | _WINDOWS_FILE_READ_ATTRIBUTES
         | _WINDOWS_SYNCHRONIZE,
         expected_directory=False,
+        resource_owner=resource_owner,
     )
-    try:
+    record = resource_owner.record_for_cleanup(handle)
+    exact_owner = resource_owner._exact_record_cleanup_owner(record)
+    with _run_context_with_cleanup_actions(
+        (
+            _OrderedAction(
+                label="Windows ownership file HANDLE cleanup also failed",
+                action=exact_owner.close,
+                complete=lambda: exact_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=exact_owner,
+            ),
+        )
+    ):
         if opened.st_dev != root_device:
             raise RuntimeError(f"directory ownership crosses a volume: {path}")
         size = opened.st_size
@@ -2831,8 +2966,6 @@ def _windows_owned_file_record(
         rebound = _windows_find_child(api, parent_handle, entry.name)
         if rebound is None or rebound.file_id != entry.file_id:
             raise RuntimeError(f"directory ownership file changed: {path}")
-    finally:
-        api.close(handle)
     budget.byte_count += size
     return size, digest.hexdigest(), _ownership_version_identity(after)
 
@@ -2989,6 +3122,7 @@ def _scan_windows_owned_directory(
     depth: int,
     required_root_file: str | None = None,
     allow_empty_root: bool = False,
+    resource_owner: _WindowsResourceOwner,
 ) -> bytes:
     if depth > _MAX_SAFE_REMOVAL_DEPTH:
         raise RuntimeError("directory ownership scan exceeds its depth limit")
@@ -3038,8 +3172,23 @@ def _scan_windows_owned_directory(
                 | _WINDOWS_FILE_READ_ATTRIBUTES
                 | _WINDOWS_SYNCHRONIZE,
                 expected_directory=True,
+                resource_owner=resource_owner,
             )
-            try:
+            child_record = resource_owner.record_for_cleanup(child_handle)
+            exact_owner = resource_owner._exact_record_cleanup_owner(child_record)
+            with _run_context_with_cleanup_actions(
+                (
+                    _OrderedAction(
+                        label=(
+                            "Windows ownership directory HANDLE cleanup also failed"
+                        ),
+                        action=exact_owner.close,
+                        complete=lambda exact_owner=exact_owner: exact_owner.closed,
+                        retry_incomplete="cancellation",
+                        incomplete_owner=exact_owner,
+                    ),
+                )
+            ):
                 if opened.st_dev != root_device:
                     raise RuntimeError(
                         f"directory ownership crosses a volume: {child_path}"
@@ -3063,6 +3212,7 @@ def _scan_windows_owned_directory(
                     entry_identities=entry_identities,
                     entry_policy=entry_policy,
                     depth=depth + 1,
+                    resource_owner=resource_owner,
                 )
                 after = api.metadata(child_handle)
                 if _ownership_version_identity(after) != _ownership_version_identity(
@@ -3071,8 +3221,6 @@ def _scan_windows_owned_directory(
                     raise RuntimeError(
                         f"directory ownership directory changed: {child_path}"
                     )
-            finally:
-                api.close(child_handle)
             rebound = _windows_find_child(api, handle, entry.name)
             if rebound is None or rebound.file_id != entry.file_id:
                 raise RuntimeError(
@@ -3096,6 +3244,7 @@ def _scan_windows_owned_directory(
                 budget=budget,
                 relative=relative,
                 entry_policy=entry_policy,
+                resource_owner=resource_owner,
             )
             digest_bytes = bytes.fromhex(digest)
             file_mode = stat.S_IMODE(file_identity[2])
@@ -3133,44 +3282,66 @@ def _capture_windows_directory_handle(
     entry_policy: DirectoryEntryPolicy | None,
 ) -> _TreeOwnership:
     _required_root_file_bytes(required_root_file)
-    opened = api.metadata(handle)
-    if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
-        raise RuntimeError(f"directory ownership root changed: {path}")
-    if not opened.st_dev or not opened.st_ino:
-        raise RuntimeError("directory ownership root has no reliable FILE_ID identity")
-    budget = _OwnershipBudget()
-    inventory: list[tuple[str, str]] = []
-    file_records: list[TreeFileRecord] = []
-    entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
-    digest = _scan_windows_owned_directory(
-        api,
-        handle,
-        path,
-        (),
-        root_device=opened.st_dev,
-        budget=budget,
-        inventory=inventory,
-        file_records=file_records,
-        entry_identities=entry_identities,
-        entry_policy=entry_policy,
-        depth=0,
-        required_root_file=required_root_file,
-        allow_empty_root=allow_empty_root,
-    )
-    after = api.metadata(handle)
-    if _ownership_version_identity(after) != _ownership_version_identity(opened):
-        raise RuntimeError(f"directory ownership root changed: {path}")
-    return _TreeOwnership(
-        root_identity=_directory_inode_identity(opened),
-        root_version_identity=_ownership_version_identity(opened),
-        digest=digest.hex(),
-        entries=budget.entries,
-        byte_count=budget.byte_count,
-        metadata_bytes=budget.metadata_bytes,
-        inventory=tuple(sorted(inventory)),
-        file_records=tuple(sorted(file_records, key=lambda record: record.path)),
-        entry_identities=tuple(sorted(entry_identities)),
-    )
+    resources = _WindowsResourceOwner(api)
+    cleanup_complete = False
+
+    def close_resources() -> None:
+        nonlocal cleanup_complete
+        resources.close_all()
+        cleanup_complete = True
+
+    with _run_context_with_cleanup_actions(
+        (
+            _OrderedAction(
+                label="Windows ownership scan HANDLE cleanup also failed",
+                action=close_resources,
+                complete=lambda: cleanup_complete,
+                retry_incomplete="cancellation",
+                incomplete_owner=resources,
+            ),
+        )
+    ):
+        opened = api.metadata(handle)
+        if _is_link_or_reparse(opened) or not stat.S_ISDIR(opened.st_mode):
+            raise RuntimeError(f"directory ownership root changed: {path}")
+        if not opened.st_dev or not opened.st_ino:
+            raise RuntimeError(
+                "directory ownership root has no reliable FILE_ID identity"
+            )
+        budget = _OwnershipBudget()
+        inventory: list[tuple[str, str]] = []
+        file_records: list[TreeFileRecord] = []
+        entry_identities: list[tuple[str, str, tuple[int, ...]]] = []
+        digest = _scan_windows_owned_directory(
+            api,
+            handle,
+            path,
+            (),
+            root_device=opened.st_dev,
+            budget=budget,
+            inventory=inventory,
+            file_records=file_records,
+            entry_identities=entry_identities,
+            entry_policy=entry_policy,
+            depth=0,
+            required_root_file=required_root_file,
+            allow_empty_root=allow_empty_root,
+            resource_owner=resources,
+        )
+        after = api.metadata(handle)
+        if _ownership_version_identity(after) != _ownership_version_identity(opened):
+            raise RuntimeError(f"directory ownership root changed: {path}")
+        return _TreeOwnership(
+            root_identity=_directory_inode_identity(opened),
+            root_version_identity=_ownership_version_identity(opened),
+            digest=digest.hex(),
+            entries=budget.entries,
+            byte_count=budget.byte_count,
+            metadata_bytes=budget.metadata_bytes,
+            inventory=tuple(sorted(inventory)),
+            file_records=tuple(sorted(file_records, key=lambda record: record.path)),
+            entry_identities=tuple(sorted(entry_identities)),
+        )
 
 
 def _open_windows_publication_authority(

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -4661,6 +4661,189 @@ def _call_with_interrupt_after_store(
         assert injected, f"failed to inject after {local_name} result store"
 
 
+def _call_with_interrupt_after_attribute_store(
+    function: object,
+    attribute_name: str,
+    callback: object,
+    *,
+    predicate: object | None = None,
+    error: BaseException,
+) -> None:
+    """Interrupt immediately after an acquisition owner publishes one field."""
+
+    assert callable(function)
+    assert callable(callback)
+    assert predicate is None or callable(predicate)
+    code = function.__code__
+    instructions = tuple(dis.get_instructions(function))
+    store_indexes = {
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_ATTR" and instruction.argval == attribute_name
+    }
+    assert store_indexes
+    opcode_offsets_after_store = {
+        instructions[index + 1].offset for index in store_indexes
+    }
+    store_offsets = {instructions[index].offset for index in store_indexes}
+    line_offset_candidates = {
+        instruction.offset
+        for instruction in instructions
+        if instruction.starts_line is not None
+        and instruction.offset > max(store_offsets)
+    }
+    assert line_offset_candidates
+    line_offsets_after_store = {min(line_offset_candidates)}
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
+            return trace
+        if (
+            frame.f_code is code
+            and (
+                (event == "opcode" and frame.f_lasti in opcode_offsets_after_store)
+                or (event == "line" and frame.f_lasti in line_offsets_after_store)
+            )
+            and (
+                attribute_name == "identity"
+                and getattr(frame.f_locals.get("record"), "identity", None) is not None
+                or attribute_name == "descriptor"
+                and getattr(frame.f_locals.get("record"), "descriptor", -1) >= 0
+                or attribute_name == "handle"
+                and bool(getattr(frame.f_locals.get("record"), "handle", 0))
+            )
+            and (predicate is None or predicate(frame.f_locals))
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, f"failed to inject after {attribute_name} publication"
+
+
+def _call_with_interrupt_on_source_line(
+    function: object,
+    source_fragment: str,
+    callback: object,
+    *,
+    predicate: object | None = None,
+    error: BaseException,
+) -> None:
+    """Inject before one exact source line across supported trace versions."""
+
+    assert callable(function)
+    assert callable(callback)
+    assert predicate is None or callable(predicate)
+    code = function.__code__
+    source, first_line = inspect.getsourcelines(function)
+    target_lines = {
+        first_line + offset
+        for offset, line in enumerate(source)
+        if line.strip() == source_fragment
+    }
+    assert len(target_lines) == 1
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is code
+            and event == "line"
+            and frame.f_lineno in target_lines
+            and (predicate is None or predicate(frame.f_locals))
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, f"failed to inject on source line: {source_fragment}"
+
+
+def _call_with_interrupt_after_call_result_store(
+    function: object,
+    local_name: str,
+    callback: object,
+    *,
+    error: BaseException,
+) -> None:
+    """Interrupt after one CALL result is stored in a selected local."""
+
+    assert callable(function)
+    assert callable(callback)
+    code = function.__code__
+    instructions = tuple(dis.get_instructions(function))
+    store_indexes = {
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_FAST"
+        and instruction.argval == local_name
+        and any(
+            candidate.opname.startswith("CALL") for candidate in instructions[:index]
+        )
+    }
+    opcode_offsets_after_store = {
+        instructions[index + 1].offset for index in store_indexes
+    }
+    store_offsets = {instructions[index].offset for index in store_indexes}
+    line_offsets_after_store = {
+        instruction.offset
+        for instruction in instructions
+        if instruction.starts_line is not None
+        and any(instruction.offset > store_offset for store_offset in store_offsets)
+    }
+    assert store_indexes
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: object, event: str, _arg: object) -> object:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
+            return trace
+        if (
+            frame.f_code is code
+            and (
+                (event == "opcode" and frame.f_lasti in opcode_offsets_after_store)
+                or (event == "line" and frame.f_lasti in line_offsets_after_store)
+            )
+            and local_name in frame.f_locals
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, f"failed to inject after {local_name} result store"
+
+
 def _call_with_interrupt_at_back_edge(
     function: object,
     callback: object,
@@ -5477,6 +5660,49 @@ def test_outer_trampoline_entry_failure_retains_pending_owner(
     assert owner.closed
 
 
+def test_context_finalizer_entry_interrupt_has_bound_unwind_state() -> None:
+    primary = OSError(errno.EIO, "context body primary")
+    interruption = KeyboardInterrupt("context finalizer entry")
+    completed = False
+
+    def close_exact_owner() -> None:
+        nonlocal completed
+        completed = True
+
+    owner = atomic_module._ExactResourceCleanupOwner(
+        action=close_exact_owner,
+        complete=lambda: completed,
+    )
+
+    def invoke() -> None:
+        with atomic_module._run_context_with_cleanup_actions(
+            (
+                atomic_module._OrderedAction(
+                    label="exact cleanup also failed",
+                    action=owner.close,
+                    complete=lambda: owner.closed,
+                    incomplete_owner=owner,
+                ),
+            )
+        ):
+            raise primary
+
+    with pytest.raises(OSError) as caught:
+        _call_with_interrupt_on_source_line(
+            atomic_module._run_context_with_cleanup_actions.__wrapped__,
+            "locally_unwinding = context_error is not None",
+            invoke,
+            error=interruption,
+        )
+
+    assert caught.value is primary
+    assert not owner.closed
+    assert primary.publication_cleanup_owners == (owner,)
+    assert any("context finalizer entry" in note for note in _exception_notes(primary))
+    owner.close()
+    assert owner.closed
+
+
 def test_completion_aware_action_retries_real_pre_call_cancellation() -> None:
     interruption = KeyboardInterrupt("action CALL cancellation")
     completed = False
@@ -5740,13 +5966,6 @@ def test_windows_authenticated_cleanup_retries_pre_call_cancellation(
         "close_all",
         capture_owner,
     )
-    monkeypatch.setattr(
-        atomic_module._WindowsResourceOwner,
-        "record_for_cleanup",
-        lambda _owner, _handle: (_ for _ in ()).throw(
-            AssertionError("authenticated cleanup rebuilt a HANDLE plan")
-        ),
-    )
     events = _interrupt_ordered_action_before_call(
         monkeypatch,
         label=(
@@ -5992,7 +6211,7 @@ def test_windows_authenticated_cleanup_retains_owner_after_persistent_eio(
     assert api.handles == {}
 
 
-def test_windows_child_open_retains_local_owner_after_cleanup_failure(
+def test_windows_child_open_retains_exact_owner_after_cleanup_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     api = _FakeWindowsApi()
@@ -6006,7 +6225,11 @@ def test_windows_child_open_retains_local_owner_after_cleanup_failure(
     opened_handle = 0
     metadata_error = OSError(errno.EIO, "post-acquire metadata failure")
     close_error = OSError(errno.EIO, "persistent local HANDLE close failure")
-    retained_owner: atomic_module._WindowsResourceOwner | None = None
+    aggregate = atomic_module._WindowsResourceOwner(api)
+    unrelated_handle = aggregate.acquire(
+        lambda: api.create_directory_handle(Path("C:/unrelated"))
+    )
+    retained_owner: object | None = None
 
     def fail_second_metadata(handle: int) -> object:
         nonlocal metadata_calls, opened_handle
@@ -6033,18 +6256,276 @@ def test_windows_child_open_retains_local_owner_after_cleanup_failure(
                     entry,
                     desired_access=atomic_module._WINDOWS_FILE_READ_DATA,
                     expected_directory=False,
+                    resource_owner=aggregate,
                 )
 
         assert caught.value is metadata_error
         owners = metadata_error.publication_cleanup_owners
         assert len(owners) == 1
         retained_owner = owners[0]
-        assert isinstance(retained_owner, atomic_module._WindowsResourceOwner)
         assert not retained_owner.closed
         assert opened_handle in api.handles
     finally:
         if retained_owner is not None:
             retained_owner.close()
+        assert unrelated_handle in api.handles
+        aggregate.close()
+        real_close(root_handle)
+
+    assert retained_owner is not None and retained_owner.closed
+    assert api.handles == {}
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="requires POSIX descriptors",
+)
+def test_posix_record_cleanup_entry_interrupt_retains_original_exact_owner(
+    tmp_path: Path,
+) -> None:
+    owner = atomic_module._PosixResourceOwner()
+    child = owner.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    unrelated = owner.open(
+        tmp_path,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    record = owner.record_for_cleanup(child)
+    primary = OSError(errno.EIO, "POSIX operation primary")
+    interruption = KeyboardInterrupt("POSIX exact cleanup helper entry")
+    retained_owner: object | None = None
+
+    try:
+        _call_with_interrupt_on_source_line(
+            atomic_module._PosixResourceOwner._run_record_cleanup_after_error,
+            "cleanup.primary_error = primary_error",
+            lambda: owner.close_record_after_error(record, primary),
+            predicate=lambda local: local["cleanup"].primary_error is primary,
+            error=interruption,
+        )
+
+        owners = primary.publication_cleanup_owners
+        assert len(owners) == 1
+        retained_owner = owners[0]
+        assert isinstance(retained_owner, atomic_module._ExactResourceCleanupOwner)
+        assert not retained_owner.closed
+        os.fstat(child)
+        os.fstat(unrelated)
+        assert any(
+            "POSIX exact cleanup helper entry" in note
+            for note in _exception_notes(primary)
+        )
+    finally:
+        if retained_owner is not None:
+            retained_owner.close()
+        os.fstat(unrelated)
+        owner.close()
+
+    assert retained_owner is not None and retained_owner.closed
+    _assert_descriptor_closed(child)
+    _assert_descriptor_closed(unrelated)
+
+
+def test_windows_child_cleanup_entry_interrupt_retains_original_exact_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    api.add_file(api.root_id, "payload.txt", b"payload")
+    root_handle = api.create_directory_handle(Path("C:/authority"))
+    entry = atomic_module._windows_find_child(api, root_handle, "payload.txt")
+    assert entry is not None
+    owner = atomic_module._WindowsResourceOwner(api)
+    unrelated = owner.acquire(lambda: api.create_directory_handle(Path("C:/unrelated")))
+    primary = OSError(errno.EIO, "Windows child metadata primary")
+    interruption = SystemExit("Windows exact cleanup helper entry")
+    real_metadata = api.metadata
+    metadata_calls = 0
+    child_handle = 0
+    retained_owner: object | None = None
+
+    def fail_child_recheck(handle: int) -> object:
+        nonlocal metadata_calls, child_handle
+        if handle != root_handle and handle != unrelated:
+            metadata_calls += 1
+            child_handle = handle
+            if metadata_calls == 2:
+                raise primary
+        return real_metadata(handle)
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(api, "metadata", fail_child_recheck)
+            with pytest.raises(OSError) as caught:
+                _call_with_interrupt_on_source_line(
+                    atomic_module._WindowsResourceOwner._run_record_cleanup_after_error,
+                    "cleanup.primary_error = primary_error",
+                    lambda: atomic_module._windows_open_child_by_id(
+                        api,
+                        root_handle,
+                        entry,
+                        desired_access=atomic_module._WINDOWS_FILE_READ_DATA,
+                        expected_directory=False,
+                        resource_owner=owner,
+                    ),
+                    predicate=lambda local: local["cleanup"].primary_error is primary,
+                    error=interruption,
+                )
+
+        assert caught.value is primary
+        owners = primary.publication_cleanup_owners
+        assert len(owners) == 1
+        retained_owner = owners[0]
+        assert isinstance(retained_owner, atomic_module._ExactResourceCleanupOwner)
+        assert not retained_owner.closed
+        assert child_handle in api.handles
+        assert unrelated in api.handles
+        assert any(
+            "Windows exact cleanup helper entry" in note
+            for note in _exception_notes(primary)
+        )
+    finally:
+        if retained_owner is not None:
+            retained_owner.close()
+        assert unrelated in api.handles
+        owner.close()
+        api.close(root_handle)
+
+    assert retained_owner is not None and retained_owner.closed
+    assert api.handles == {}
+
+
+def test_windows_owned_file_read_primary_survives_exact_close_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    api.add_file(api.root_id, "payload.txt", b"payload")
+    root_handle = api.create_directory_handle(Path("C:/authority"))
+    entry = atomic_module._windows_find_child(api, root_handle, "payload.txt")
+    assert entry is not None
+    owner = atomic_module._WindowsResourceOwner(api)
+    unrelated = owner.acquire(lambda: api.create_directory_handle(Path("C:/unrelated")))
+    read_error = OSError(errno.EIO, "Windows ownership file read failure")
+    close_error = OSError(errno.EIO, "Windows ownership file close failure")
+    real_read = api.read
+    real_close = api.close
+    child_handle = 0
+    retained_owner: object | None = None
+
+    def fail_child_read(handle: int, size: int) -> bytes:
+        nonlocal child_handle
+        if handle not in {root_handle, unrelated}:
+            child_handle = handle
+            raise read_error
+        return real_read(handle, size)
+
+    def fail_child_close(handle: int) -> None:
+        if handle == child_handle:
+            raise close_error
+        real_close(handle)
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(api, "read", fail_child_read)
+            faults.setattr(api, "close", fail_child_close)
+            with pytest.raises(OSError) as caught:
+                atomic_module._windows_owned_file_record(
+                    api,
+                    root_handle,
+                    entry,
+                    Path("C:/authority/payload.txt"),
+                    root_device=7,
+                    budget=atomic_module._OwnershipBudget(),
+                    relative="payload.txt",
+                    entry_policy=None,
+                    resource_owner=owner,
+                )
+
+        assert caught.value is read_error
+        owners = read_error.publication_cleanup_owners
+        assert len(owners) == 1
+        retained_owner = owners[0]
+        assert isinstance(retained_owner, atomic_module._ExactResourceCleanupOwner)
+        assert not retained_owner.closed
+        assert child_handle in api.handles
+        assert unrelated in api.handles
+        assert any(
+            "Windows ownership file close failure" in note
+            for note in _exception_notes(read_error)
+        )
+    finally:
+        if retained_owner is not None:
+            retained_owner.close()
+        assert unrelated in api.handles
+        owner.close()
+        real_close(root_handle)
+
+    assert retained_owner is not None and retained_owner.closed
+    assert api.handles == {}
+
+
+def test_windows_owned_directory_scan_primary_survives_exact_close_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    child_id = api.add_directory(api.root_id, "nested")
+    root_handle = api.create_directory_handle(Path("C:/authority"))
+    owner = atomic_module._WindowsResourceOwner(api)
+    unrelated = owner.acquire(lambda: api.create_directory_handle(Path("C:/unrelated")))
+    scan_error = OSError(errno.EIO, "Windows ownership directory scan failure")
+    close_error = OSError(errno.EIO, "Windows ownership directory close failure")
+    real_iter = api.iter_directory
+    real_close = api.close
+    child_handle = 0
+    retained_owner: object | None = None
+
+    def fail_child_scan(handle: int):
+        nonlocal child_handle
+        if api.handles[handle] == child_id:
+            child_handle = handle
+            raise scan_error
+        yield from real_iter(handle)
+
+    def fail_child_close(handle: int) -> None:
+        if handle == child_handle:
+            raise close_error
+        real_close(handle)
+
+    try:
+        with monkeypatch.context() as faults:
+            faults.setattr(api, "iter_directory", fail_child_scan)
+            faults.setattr(api, "close", fail_child_close)
+            with pytest.raises(OSError) as caught:
+                atomic_module._scan_windows_owned_directory(
+                    api,
+                    root_handle,
+                    Path("C:/authority"),
+                    (),
+                    root_device=7,
+                    budget=atomic_module._OwnershipBudget(),
+                    inventory=[],
+                    file_records=[],
+                    entry_identities=[],
+                    entry_policy=None,
+                    depth=0,
+                    resource_owner=owner,
+                )
+
+        assert caught.value is scan_error
+        owners = scan_error.publication_cleanup_owners
+        assert len(owners) == 1
+        retained_owner = owners[0]
+        assert isinstance(retained_owner, atomic_module._ExactResourceCleanupOwner)
+        assert not retained_owner.closed
+        assert child_handle in api.handles
+        assert unrelated in api.handles
+        assert any(
+            "Windows ownership directory close failure" in note
+            for note in _exception_notes(scan_error)
+        )
+    finally:
+        if retained_owner is not None:
+            retained_owner.close()
+        assert unrelated in api.handles
+        owner.close()
         real_close(root_handle)
 
     assert retained_owner is not None and retained_owner.closed
@@ -6664,14 +7145,18 @@ def test_reopen_interrupt_after_callback_result_store_runs_post_capture(
     not sys.platform.startswith("linux"),
     reason="requires Linux descriptor semantics",
 )
-def test_posix_owner_recovers_interrupt_after_open_result_store(tmp_path: Path) -> None:
+@pytest.mark.parametrize("attribute", ["descriptor", "identity"])
+def test_posix_owner_recovers_interrupt_after_open_result_store(
+    tmp_path: Path,
+    attribute: str,
+) -> None:
     owner = atomic_module._PosixResourceOwner()
-    error = KeyboardInterrupt("after os.open result store")
+    error = KeyboardInterrupt(f"after owned {attribute} publication")
 
     with pytest.raises(KeyboardInterrupt) as caught:
-        _call_with_interrupt_after_store(
+        _call_with_interrupt_after_attribute_store(
             atomic_module._PosixResourceOwner.open,
-            "descriptor",
+            attribute,
             lambda: owner.open(
                 tmp_path,
                 os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
@@ -6681,6 +7166,322 @@ def test_posix_owner_recovers_interrupt_after_open_result_store(tmp_path: Path) 
 
     assert caught.value is error
     assert owner.closed
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires POSIX descriptor semantics",
+)
+@pytest.mark.parametrize("operation", ["open", "duplicate"])
+def test_posix_owner_publishes_record_before_native_acquisition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    owner = atomic_module._PosixResourceOwner()
+    primary = KeyboardInterrupt("record construction interrupted")
+    construction_calls = 0
+    acquired: list[int] = []
+    real_open = atomic_module.os.open
+    real_dup = atomic_module.os.dup
+    source = -1
+
+    def fail_record_construction(_descriptor: int) -> object:
+        nonlocal construction_calls
+        construction_calls += 1
+        raise primary
+
+    def capture_open(*args: object, **kwargs: object) -> int:
+        descriptor = real_open(*args, **kwargs)
+        acquired.append(descriptor)
+        return descriptor
+
+    def capture_duplicate(descriptor: int) -> int:
+        duplicate = real_dup(descriptor)
+        acquired.append(duplicate)
+        return duplicate
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_PosixDescriptorRecord",
+        fail_record_construction,
+    )
+    try:
+        if operation == "open":
+            monkeypatch.setattr(atomic_module.os, "open", capture_open)
+
+            def callback() -> int:
+                return owner.open(
+                    tmp_path,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                )
+
+        else:
+            source = real_open(
+                tmp_path,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
+            monkeypatch.setattr(atomic_module.os, "dup", capture_duplicate)
+
+            def callback() -> int:
+                return owner.duplicate(source)
+
+        with pytest.raises(KeyboardInterrupt) as caught:
+            callback()
+
+        assert caught.value is primary
+        assert construction_calls == 1
+        assert acquired == []
+        assert owner.closed
+    finally:
+        for descriptor in acquired:
+            os.close(descriptor)
+        if source >= 0:
+            os.close(source)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires POSIX descriptor semantics",
+)
+@pytest.mark.parametrize("operation", ["open", "duplicate"])
+def test_posix_acquisition_cleanup_retains_primary_and_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    owner = atomic_module._PosixResourceOwner()
+    primary = OSError(errno.EIO, "descriptor identity binding failed")
+    cleanup_interruption = KeyboardInterrupt("descriptor cleanup was interrupted")
+    real_identity = atomic_module._resource_owner_identity
+    identity_calls = 0
+    source = -1
+
+    def fail_binding_then_cleanup(metadata: object) -> tuple[int, ...]:
+        nonlocal identity_calls
+        identity_calls += 1
+        if identity_calls == 1:
+            raise primary
+        raise cleanup_interruption
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_resource_owner_identity",
+        fail_binding_then_cleanup,
+    )
+    try:
+        if operation == "open":
+
+            def callback() -> int:
+                return owner.open(
+                    tmp_path,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                )
+
+        else:
+            source = os.open(
+                tmp_path,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
+
+            def callback() -> int:
+                return owner.duplicate(source)
+
+        with pytest.raises(OSError) as caught:
+            callback()
+
+        assert caught.value is primary
+        assert identity_calls > 1
+        retained = BaseException.__getattribute__(
+            primary,
+            "publication_cleanup_owners",
+        )
+        assert len(retained) == 1
+        assert not retained[0].closed
+        live = [
+            record.descriptor for record in owner._records if record.descriptor >= 0
+        ]
+        assert len(live) == 1
+        os.fstat(live[0])
+    finally:
+        monkeypatch.setattr(
+            atomic_module,
+            "_resource_owner_identity",
+            real_identity,
+        )
+        for retry_owner in BaseException.__getattribute__(
+            primary,
+            "publication_cleanup_owners",
+        ):
+            retry_owner.close()
+        if source >= 0:
+            os.close(source)
+
+    assert owner.closed
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires POSIX descriptor semantics",
+)
+@pytest.mark.parametrize("operation", ["open", "duplicate"])
+def test_posix_acquisition_cleanup_contains_result_store_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    owner = atomic_module._PosixResourceOwner()
+    primary = OSError(errno.EIO, "descriptor identity binding failed")
+    close_error = OSError(errno.EIO, "persistent descriptor close failure")
+    interruption = KeyboardInterrupt("after descriptor close result store")
+    real_identity = atomic_module._resource_owner_identity
+    real_close = atomic_module.os.close
+    identity_calls = 0
+    source = -1
+
+    def fail_initial_identity(metadata: object) -> tuple[int, ...]:
+        nonlocal identity_calls
+        identity_calls += 1
+        if identity_calls == 1:
+            raise primary
+        return real_identity(metadata)
+
+    def fail_owned_close(descriptor: int) -> None:
+        if any(record.descriptor == descriptor for record in owner._records):
+            raise close_error
+        real_close(descriptor)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_resource_owner_identity",
+        fail_initial_identity,
+    )
+    monkeypatch.setattr(atomic_module.os, "close", fail_owned_close)
+    try:
+        if operation == "open":
+
+            def callback() -> int:
+                return owner.open(
+                    tmp_path,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                )
+
+        else:
+            source = os.open(
+                tmp_path,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
+
+            def callback() -> int:
+                return owner.duplicate(source)
+
+        with pytest.raises(OSError) as caught:
+            _call_with_interrupt_after_call_result_store(
+                atomic_module._PosixResourceOwner.close_record,
+                "close_error",
+                callback,
+                error=interruption,
+            )
+
+        assert caught.value is primary
+        retained = BaseException.__getattribute__(
+            primary,
+            "publication_cleanup_owners",
+        )
+        assert len(retained) == 1
+        live = [
+            record.descriptor for record in owner._records if record.descriptor >= 0
+        ]
+        assert len(live) == 1
+        os.fstat(live[0])
+    finally:
+        monkeypatch.setattr(atomic_module.os, "close", real_close)
+        monkeypatch.setattr(
+            atomic_module,
+            "_resource_owner_identity",
+            real_identity,
+        )
+        for retry_owner in BaseException.__getattribute__(
+            primary,
+            "publication_cleanup_owners",
+        ):
+            retry_owner.close()
+        if source >= 0:
+            real_close(source)
+
+    assert owner.closed
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="requires POSIX descriptor semantics",
+)
+@pytest.mark.parametrize("operation", ["open", "duplicate"])
+def test_posix_acquisition_cleanup_contains_runner_entry_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    owner = atomic_module._PosixResourceOwner()
+    primary = OSError(errno.EIO, "descriptor identity binding failed")
+    interruption = KeyboardInterrupt("descriptor cleanup runner entry")
+    real_identity = atomic_module._resource_owner_identity
+    source = -1
+    identity_calls = 0
+
+    def fail_initial_identity(metadata: object) -> tuple[int, ...]:
+        nonlocal identity_calls
+        identity_calls += 1
+        if identity_calls == 1:
+            raise primary
+        return real_identity(metadata)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_resource_owner_identity",
+        fail_initial_identity,
+    )
+    observed = _interrupt_ordered_runner_entries(
+        monkeypatch,
+        errors=(interruption,),
+    )
+    try:
+        if operation == "open":
+
+            def callback() -> int:
+                return owner.open(
+                    tmp_path,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                )
+
+        else:
+            source = os.open(
+                tmp_path,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
+
+            def callback() -> int:
+                return owner.duplicate(source)
+
+        with pytest.raises(OSError) as caught:
+            callback()
+
+        assert caught.value is primary
+        assert observed == [interruption]
+        assert owner.closed
+        assert any(
+            "descriptor cleanup runner entry" in note
+            for note in _exception_notes(primary)
+        )
+    finally:
+        monkeypatch.setattr(
+            atomic_module,
+            "_resource_owner_identity",
+            real_identity,
+        )
+        owner.close()
+        if source >= 0:
+            os.close(source)
 
 
 @pytest.mark.skipif(
@@ -6774,7 +7575,7 @@ def test_posix_factory_recovers_interrupt_in_child_open_registration(
     error = SystemExit("after child descriptor store")
 
     with pytest.raises(SystemExit) as caught:
-        _call_with_interrupt_after_store(
+        _call_with_interrupt_after_attribute_store(
             atomic_module._PosixResourceOwner.open,
             "descriptor",
             lambda: atomic_module._open_posix_publication_authority(
@@ -6793,15 +7594,19 @@ def test_posix_factory_recovers_interrupt_in_child_open_registration(
     not sys.platform.startswith("linux"),
     reason="requires Linux descriptor semantics",
 )
-def test_posix_owner_recovers_interrupt_after_dup_result_store(tmp_path: Path) -> None:
+@pytest.mark.parametrize("attribute", ["descriptor", "identity"])
+def test_posix_owner_recovers_interrupt_after_dup_result_store(
+    tmp_path: Path,
+    attribute: str,
+) -> None:
     descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
     owner = atomic_module._PosixResourceOwner()
-    error = KeyboardInterrupt("after os.dup result store")
+    error = KeyboardInterrupt(f"after owned {attribute} publication")
     try:
         with pytest.raises(KeyboardInterrupt) as caught:
-            _call_with_interrupt_after_store(
+            _call_with_interrupt_after_attribute_store(
                 atomic_module._PosixResourceOwner.duplicate,
-                "duplicate",
+                attribute,
                 lambda: owner.duplicate(descriptor),
                 error=error,
             )
@@ -7418,15 +8223,18 @@ def test_windows_factory_recovers_interrupt_after_registered_handle_return(
         api.close(external)
 
 
-def test_windows_owner_recovers_interrupt_after_handle_result_store() -> None:
+@pytest.mark.parametrize("attribute", ["handle", "identity"])
+def test_windows_owner_recovers_interrupt_after_handle_result_store(
+    attribute: str,
+) -> None:
     api = _FakeWindowsApi()
     owner = atomic_module._WindowsResourceOwner(api)
-    error = KeyboardInterrupt("after raw HANDLE result store")
+    error = KeyboardInterrupt(f"after owned {attribute} publication")
 
     with pytest.raises(KeyboardInterrupt) as caught:
-        _call_with_interrupt_after_store(
+        _call_with_interrupt_after_attribute_store(
             atomic_module._WindowsResourceOwner.acquire,
-            "handle",
+            attribute,
             lambda: owner.acquire(
                 lambda: api.create_directory_handle(Path("C:/authority"))
             ),
@@ -7435,6 +8243,208 @@ def test_windows_owner_recovers_interrupt_after_handle_result_store() -> None:
 
     assert caught.value is error
     assert owner.closed
+    assert api.handles == {}
+
+
+def test_windows_owner_publishes_record_before_native_acquisition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    owner = atomic_module._WindowsResourceOwner(api)
+    primary = KeyboardInterrupt("record construction interrupted")
+    construction_calls = 0
+    acquisition_calls = 0
+
+    def fail_record_construction(_handle: int) -> object:
+        nonlocal construction_calls
+        construction_calls += 1
+        raise primary
+
+    def acquire_handle() -> int:
+        nonlocal acquisition_calls
+        acquisition_calls += 1
+        return api.create_directory_handle(Path("C:/authority"))
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_WindowsHandleRecord",
+        fail_record_construction,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        owner.acquire(acquire_handle)
+
+    assert caught.value is primary
+    assert construction_calls == 1
+    assert acquisition_calls == 0
+    assert owner.closed
+    assert api.handles == {}
+
+
+def test_windows_acquisition_cleanup_retains_primary_and_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    owner = atomic_module._WindowsResourceOwner(api)
+    primary = OSError(errno.EIO, "HANDLE identity binding failed")
+    cleanup_interruption = SystemExit("HANDLE cleanup was interrupted")
+    real_identity = atomic_module._resource_owner_identity
+    identity_calls = 0
+
+    def fail_binding_then_cleanup(metadata: object) -> tuple[int, ...]:
+        nonlocal identity_calls
+        identity_calls += 1
+        if identity_calls == 1:
+            raise primary
+        raise cleanup_interruption
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_resource_owner_identity",
+        fail_binding_then_cleanup,
+    )
+    try:
+        with pytest.raises(OSError) as caught:
+            owner.acquire(lambda: api.create_directory_handle(Path("C:/authority")))
+
+        assert caught.value is primary
+        assert identity_calls > 1
+        retained = BaseException.__getattribute__(
+            primary,
+            "publication_cleanup_owners",
+        )
+        assert len(retained) == 1
+        assert not retained[0].closed
+        live = [record.handle for record in owner._records if record.handle]
+        assert len(live) == 1
+        assert live[0] in api.handles
+    finally:
+        monkeypatch.setattr(
+            atomic_module,
+            "_resource_owner_identity",
+            real_identity,
+        )
+        for retry_owner in BaseException.__getattribute__(
+            primary,
+            "publication_cleanup_owners",
+        ):
+            retry_owner.close()
+
+    assert owner.closed
+    assert api.handles == {}
+
+
+def test_windows_acquisition_cleanup_contains_result_store_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    owner = atomic_module._WindowsResourceOwner(api)
+    primary = OSError(errno.EIO, "HANDLE identity binding failed")
+    close_error = OSError(errno.EIO, "persistent HANDLE close failure")
+    interruption = SystemExit("after HANDLE close result store")
+    real_identity = atomic_module._resource_owner_identity
+    real_close = api.close
+    identity_calls = 0
+
+    def fail_initial_identity(metadata: object) -> tuple[int, ...]:
+        nonlocal identity_calls
+        identity_calls += 1
+        if identity_calls == 1:
+            raise primary
+        return real_identity(metadata)
+
+    def fail_owned_close(handle: int) -> None:
+        if any(record.handle == handle for record in owner._records):
+            raise close_error
+        real_close(handle)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_resource_owner_identity",
+        fail_initial_identity,
+    )
+    monkeypatch.setattr(api, "close", fail_owned_close)
+    try:
+        with pytest.raises(OSError) as caught:
+            _call_with_interrupt_after_call_result_store(
+                atomic_module._WindowsResourceOwner.close_record,
+                "close_error",
+                lambda: owner.acquire(
+                    lambda: api.create_directory_handle(Path("C:/authority"))
+                ),
+                error=interruption,
+            )
+
+        assert caught.value is primary
+        retained = BaseException.__getattribute__(
+            primary,
+            "publication_cleanup_owners",
+        )
+        assert len(retained) == 1
+        live = [record.handle for record in owner._records if record.handle]
+        assert len(live) == 1
+        assert live[0] in api.handles
+    finally:
+        monkeypatch.setattr(api, "close", real_close)
+        monkeypatch.setattr(
+            atomic_module,
+            "_resource_owner_identity",
+            real_identity,
+        )
+        for retry_owner in BaseException.__getattribute__(
+            primary,
+            "publication_cleanup_owners",
+        ):
+            retry_owner.close()
+
+    assert owner.closed
+    assert api.handles == {}
+
+
+def test_windows_acquisition_cleanup_contains_runner_entry_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeWindowsApi()
+    owner = atomic_module._WindowsResourceOwner(api)
+    primary = OSError(errno.EIO, "HANDLE identity binding failed")
+    interruption = SystemExit("HANDLE cleanup runner entry")
+    real_identity = atomic_module._resource_owner_identity
+    identity_calls = 0
+
+    def fail_initial_identity(metadata: object) -> tuple[int, ...]:
+        nonlocal identity_calls
+        identity_calls += 1
+        if identity_calls == 1:
+            raise primary
+        return real_identity(metadata)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_resource_owner_identity",
+        fail_initial_identity,
+    )
+    observed = _interrupt_ordered_runner_entries(
+        monkeypatch,
+        errors=(interruption,),
+    )
+    try:
+        with pytest.raises(OSError) as caught:
+            owner.acquire(lambda: api.create_directory_handle(Path("C:/authority")))
+
+        assert caught.value is primary
+        assert observed == [interruption]
+        assert owner.closed
+        assert any(
+            "HANDLE cleanup runner entry" in note for note in _exception_notes(primary)
+        )
+    finally:
+        monkeypatch.setattr(
+            atomic_module,
+            "_resource_owner_identity",
+            real_identity,
+        )
+        owner.close()
+
     assert api.handles == {}
 
 


### PR DESCRIPTION
## Summary

Harden the shared atomic-directory ownership path so native resources remain reachable and exactly cleanable when interruption lands around acquisition or cleanup.

This low-level fix is intentionally separate from #619 because it changes the common POSIX and Windows publication foundation and should land before the workspace API feature.

## Changes

- publish POSIX descriptor and Windows HANDLE records before native acquisition
- route unwind through exact-record cleanup owners without sweeping unrelated resources
- retain cleanup ownership across interrupted close and result handoff
- preserve the first failure while reconciling cleanup failures
- carry the same ownership protocol through Windows recursive scans
- add adversarial acquisition, cleanup, identity, and cancellation regressions

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Python 3.10, 3.12, and 3.14 atomic-directory tests: 256 passed, 10 skipped on each runtime
- Python 3.14 direct-consumer storage suites: 512 passed, 10 skipped
- local unit tier excluding the unavailable Docker sandbox: 5152 passed, 71 skipped, 190 deselected
- Black, isort, flake8, py_compile, and git diff --check

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published