### PR TITLE
fix(codegraph): harden 0.2.1 onboarding readiness

### DIFF
--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -217,13 +217,17 @@ def _split_values(values: Iterable[str] | None) -> list[str]:
     return result
 
 
-def detect_languages(repo_path: str | os.PathLike[str]) -> list[str]:
-    """Detect supported source languages, ordered by source-file count."""
+def _detect_languages_for_surface(
+    repo_path: str | os.PathLike[str],
+    *,
+    surface: str,
+) -> list[str]:
+    """Detect registered source languages for one capability surface."""
     from .languages import extension_to_language_map
     from .source_fingerprint import lexical_repository_path
 
     root = lexical_repository_path(repo_path)
-    extension_map = extension_to_language_map("chunker")
+    extension_map = extension_to_language_map(surface)
     counts: Counter[str] = Counter()
 
     for _current_root, dirs, files in os.walk(root):
@@ -245,6 +249,12 @@ def detect_languages(repo_path: str | os.PathLike[str]) -> list[str]:
             key=lambda item: (-item[1], item[0]),
         )
     ]
+
+
+def detect_languages(repo_path: str | os.PathLike[str]) -> list[str]:
+    """Detect chunkable source languages, ordered by source-file count."""
+
+    return _detect_languages_for_surface(repo_path, surface="chunker")
 
 
 def normalize_languages(values: Iterable[str]) -> list[str]:
@@ -328,6 +338,38 @@ def _selected_languages(repo_path: Path, explicit: Iterable[str]) -> list[str]:
     if not languages:
         raise CLIError(
             "no supported source language was detected; pass --language explicitly"
+        )
+    return languages
+
+
+def _selected_codegraph_languages(
+    repo_path: Path,
+    explicit: Iterable[str],
+) -> list[str]:
+    """Select only languages with a registered symbol-graph backend."""
+
+    from .languages import graph_indexer_path, normalize_graph_language
+
+    requested = _split_values(explicit)
+    if requested:
+        selected: list[str] = []
+        for value in requested:
+            language = normalize_graph_language(value)
+            if language is None or graph_indexer_path(language) is None:
+                raise CLIError(f"language has no symbol-graph provider: {value}")
+            if language not in selected:
+                selected.append(language)
+        return selected
+
+    languages = [
+        language
+        for language in _detect_languages_for_surface(repo_path, surface="graph")
+        if graph_indexer_path(language) is not None
+    ]
+    if not languages:
+        raise CLIError(
+            "no graph-capable source language was detected; pass --language "
+            "for a registered symbol-graph provider"
         )
     return languages
 
@@ -514,8 +556,20 @@ def _run_index(
 
 
 def _run_mcp(args: argparse.Namespace) -> int:
-    _require_modules(("mcp",), extra="mcp", feature="the MCP server")
+    runtime_probe = bool(getattr(args, "runtime_probe", False))
+    if runtime_probe:
+        _require_modules(
+            ("mcp", "igraph", "google.protobuf"),
+            extra="graph,mcp",
+            feature="the CodeGraph MCP server",
+        )
+    else:
+        _require_modules(("mcp",), extra="mcp", feature="the MCP server")
     from .mcp.server import main as mcp_main
+
+    if runtime_probe:
+        print("codenib codegraph mcp runtime ready")
+        return 0
 
     if args.artifact:
         command = [
@@ -1818,19 +1872,10 @@ def _codegraph_languages_for_init(
     args: argparse.Namespace,
     receipt,
 ) -> tuple[str, ...]:
-    if args.language or receipt is None:
-        return tuple(_selected_languages(repo_path, args.language))
-
-    from .compiler.manifest import MANIFEST_FILENAME, RepoManifest
-    from .paths import repo_index_dir
-
-    try:
-        manifest = RepoManifest.load(repo_index_dir(repo_path) / MANIFEST_FILENAME)
-        if manifest.languages:
-            return tuple(manifest.languages)
-    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
-        pass
-    return tuple(_selected_languages(repo_path, ()))
+    del receipt
+    # An omitted --language always means auto-detect the current checkout. This
+    # keeps repeated onboarding in sync when a repository adds another language.
+    return tuple(_selected_codegraph_languages(repo_path, args.language))
 
 
 def _codegraph_preflight_clients(
@@ -1868,7 +1913,12 @@ def _codegraph_preflight_clients(
 def _codegraph_toolchain_plan(repo_path: Path, languages: Sequence[str]):
     from .toolchains import plan_repository_toolchain
 
-    return plan_repository_toolchain(repo_path, languages, scopes=("graph",))
+    return plan_repository_toolchain(
+        repo_path,
+        languages,
+        scopes=("graph",),
+        allow_project_preparation=False,
+    )
 
 
 def _codegraph_plan_detail(plan) -> str:
@@ -1969,12 +2019,24 @@ def _run_codegraph_init(args: argparse.Namespace) -> int:
             print(f"  toolchain: {shlex.join(command)}")
         for item in manual:
             print(f"  prerequisite: {item}")
+        project_blockers = [
+            note.removeprefix("MISSING: ")
+            for note in plan.notes
+            if note.startswith("MISSING:")
+        ]
+        for blocker in project_blockers:
+            print(f"  prerequisite: {blocker}")
         print("  index: bm25, symbol_graph")
         for client in clients:
             action = "reuse" if observed[client].matches else "add"
             print(f"  {client}: {action} {server.name}")
+        ready_after_install = not manual and not project_blockers
+        print(
+            "Readiness:  "
+            + ("ready after planned tool install" if ready_after_install else "blocked")
+        )
         print("Dry run complete; no tools, indexes, receipts, or clients changed.")
-        return 0
+        return 0 if ready_after_install else 1
 
     _require_modules(
         ("igraph", "google.protobuf", "mcp"),
@@ -2076,6 +2138,10 @@ def _run_codegraph_init(args: argparse.Namespace) -> int:
 
 
 def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
+    from .compiler.artifact_fingerprints import (
+        bm25_artifact_files_match,
+        regular_file_fingerprint,
+    )
     from .compiler.checkout_identity import validate_checkout_identity
     from .compiler.manifest import MANIFEST_FILENAME, RepoManifest
     from .paths import repo_index_dir
@@ -2084,7 +2150,11 @@ def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
     report: dict[str, object] = {
         "manifest": str(manifest_path),
         "bm25": False,
+        "bm25_manifest_current": False,
+        "bm25_artifact_matches": False,
         "symbol_graph": False,
+        "symbol_graph_manifest_current": False,
+        "symbol_graph_artifact_matches": False,
         "symbol_graph_complete": False,
         "source_matches": False,
         "languages": [],
@@ -2093,9 +2163,46 @@ def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
     try:
         manifest = RepoManifest.load(manifest_path)
         report["languages"] = list(manifest.languages)
-        report["bm25"] = manifest.index_is_current("bm25")
-        report["symbol_graph"] = manifest.index_is_current("symbol_graph")
+        bm25_entry = manifest.indexes.get("bm25")
         graph_entry = manifest.indexes.get("symbol_graph")
+        report["bm25_manifest_current"] = manifest.index_is_current("bm25")
+        report["symbol_graph_manifest_current"] = manifest.index_is_current(
+            "symbol_graph"
+        )
+        if report["bm25_manifest_current"] and bm25_entry is not None:
+            report["bm25_artifact_matches"] = bm25_artifact_files_match(
+                bm25_entry.path,
+                expected_fingerprints=bm25_entry.config.get(
+                    "artifact_file_fingerprints"
+                ),
+            )
+        if report["symbol_graph_manifest_current"] and graph_entry is not None:
+            expected_graph = graph_entry.config.get("graph_artifact")
+            if (
+                type(expected_graph) is dict
+                and set(expected_graph) == {"relative_path", "size", "sha256"}
+                and expected_graph.get("relative_path") == "graph.pkl"
+                and type(expected_graph.get("size")) is int
+                and expected_graph["size"] >= 0
+                and type(expected_graph.get("sha256")) is str
+            ):
+                try:
+                    observed_graph = regular_file_fingerprint(
+                        Path(graph_entry.path) / "graph.pkl"
+                    )
+                except (OSError, ValueError):
+                    observed_graph = None
+                report["symbol_graph_artifact_matches"] = observed_graph == {
+                    "size": expected_graph["size"],
+                    "sha256": expected_graph["sha256"],
+                }
+        report["bm25"] = bool(
+            report["bm25_manifest_current"] and report["bm25_artifact_matches"]
+        )
+        report["symbol_graph"] = bool(
+            report["symbol_graph_manifest_current"]
+            and report["symbol_graph_artifact_matches"]
+        )
         report["symbol_graph_complete"] = bool(
             report["symbol_graph"]
             and graph_entry is not None
@@ -2108,11 +2215,22 @@ def _codegraph_index_report(repo_path: Path) -> dict[str, object]:
             artifact_root=manifest_path.parent,
         )
         report["source_matches"] = True
-        report["detail"] = (
-            "current"
-            if report["symbol_graph_complete"]
-            else "symbol_graph was built with partial-language admission"
-        )
+        blockers: list[str] = []
+        if not report["bm25_manifest_current"]:
+            blockers.append("bm25 manifest entry is missing, failed, or stale")
+        elif not report["bm25_artifact_matches"]:
+            blockers.append(
+                "bm25 artifact is missing or does not match its fingerprint"
+            )
+        if not report["symbol_graph_manifest_current"]:
+            blockers.append("symbol_graph manifest entry is missing, failed, or stale")
+        elif not report["symbol_graph_artifact_matches"]:
+            blockers.append(
+                "symbol_graph artifact is missing or does not match its fingerprint"
+            )
+        elif not report["symbol_graph_complete"]:
+            blockers.append("symbol_graph was built with partial-language admission")
+        report["detail"] = "; ".join(blockers) or "current"
     except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
         report["detail"] = " ".join(str(exc).split())[:400]
     report["ready"] = bool(
@@ -2126,7 +2244,7 @@ def _codegraph_toolchain_report(
     languages: Sequence[str] | None = None,
 ) -> dict[str, object]:
     try:
-        selected = tuple(languages or _selected_languages(repo_path, ()))
+        selected = tuple(languages or _selected_codegraph_languages(repo_path, ()))
         plan = _codegraph_toolchain_plan(repo_path, selected)
         return {
             "ready": plan.ready,
@@ -2701,6 +2819,11 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("full", "explore"),
         default="full",
         help="MCP tool surface to expose",
+    )
+    mcp_parser.add_argument(
+        "--runtime-probe",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
     mcp_parser.set_defaults(handler=_run_mcp)
 

--- a/codenib/codegraph_onboarding.py
+++ b/codenib/codegraph_onboarding.py
@@ -437,12 +437,32 @@ def inspect_server_command(
     raw_output = result.stdout or result.stderr or ""
     observed = " ".join((raw_output or "no output").split())
     expected = f"codenib {package_version()}"
-    ready = result.returncode == 0 and expected in {
+    version_ready = result.returncode == 0 and expected in {
         line.strip() for line in raw_output.splitlines()
+    }
+    if not version_ready:
+        return ServerCommandInspection(
+            False,
+            f"expected {expected!r}, observed {observed[:240]!r}",
+        )
+    probe = _invoke_client(
+        (server.command, *server.args, "--runtime-probe"),
+        repository=Path(repository).expanduser().resolve(),
+        runner=runner,
+    )
+    probe_output = probe.stdout or probe.stderr or ""
+    probe_marker = "codenib codegraph mcp runtime ready"
+    ready = probe.returncode == 0 and probe_marker in {
+        line.strip() for line in probe_output.splitlines()
     }
     return ServerCommandInspection(
         ready,
-        expected if ready else f"expected {expected!r}, observed {observed[:240]!r}",
+        (
+            expected
+            if ready
+            else "CodeGraph MCP runtime probe failed: "
+            + " ".join((probe_output or "no output").split())[:240]
+        ),
     )
 
 

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -738,13 +738,14 @@ class SymbolGraphBuilder:
     def artifact_identity(self) -> Dict[str, Any]:
         graph_languages = self.languages or [self.language]
         return {
-            "builder_schema": 4,
+            "builder_schema": 5,
             "languages": list(graph_languages),
             "graph_route": self.graph_route,
             "exclude_patterns": sorted(self.exclude_patterns),
             "allow_partial_languages": self.allow_partial_languages,
             "allow_partial_index": self.allow_partial_index,
             "source_coverage_fallback": self.source_coverage_fallback,
+            "allow_project_preparation": self.allow_project_preparation,
             "target_dir": None,
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }

--- a/codenib/graph/setup.py
+++ b/codenib/graph/setup.py
@@ -301,6 +301,7 @@ def _cpp_setup(
     *,
     repository: Path,
     command_resolver: CommandResolver,
+    allow_project_preparation: bool,
 ) -> GraphLanguageSetup:
     spec = get_language_spec("cpp")
     assert spec is not None
@@ -331,9 +332,16 @@ def _cpp_setup(
     bear_ready = (
         makefile and bool(command_resolver("bear")) and bool(command_resolver("make"))
     )
-    project_ready = bool(existing or cmake_ready or bear_ready)
+    project_ready = bool(
+        existing or (allow_project_preparation and (cmake_ready or bear_ready))
+    )
     if existing:
         detail = str(existing)
+    elif not allow_project_preparation:
+        detail = (
+            "read-only graph onboarding requires an existing usable "
+            "compile_commands.json"
+        )
     elif cmake_ready:
         detail = "CMake project; compile_commands.json can be generated"
     elif bear_ready:
@@ -556,6 +564,7 @@ def _language_setup(
     *,
     repository: Path,
     command_resolver: CommandResolver,
+    allow_project_preparation: bool,
 ) -> GraphLanguageSetup:
     spec = get_language_spec(language)
     if spec is None or not spec.graph_language or not spec.graph_indexer:
@@ -572,6 +581,7 @@ def _language_setup(
         return _cpp_setup(
             repository=repository,
             command_resolver=command_resolver,
+            allow_project_preparation=allow_project_preparation,
         )
     if spec.key == "ruby":
         return _ruby_setup(
@@ -643,6 +653,7 @@ def diagnose_graph_setup(
     *,
     command_resolver: CommandResolver | None = None,
     module_checker: ModuleChecker | None = None,
+    allow_project_preparation: bool = True,
 ) -> GraphSetupReport:
     """Inspect the exact graph providers needed by ``languages``.
 
@@ -650,6 +661,8 @@ def diagnose_graph_setup(
     never installs tools, creates environments, or mutates the repository.
     """
 
+    if type(allow_project_preparation) is not bool:
+        raise ValueError("allow_project_preparation must be a boolean")
     root = Path(repository).expanduser().resolve()
     command_resolver = command_resolver or resolve_command
     module_checker = module_checker or _module_available
@@ -683,6 +696,7 @@ def diagnose_graph_setup(
                 key,
                 repository=root,
                 command_resolver=command_resolver,
+                allow_project_preparation=allow_project_preparation,
             )
         )
     return GraphSetupReport(

--- a/codenib/scip_interface/scip_indexer_go.py
+++ b/codenib/scip_interface/scip_indexer_go.py
@@ -67,11 +67,7 @@ class SCIPGoIndexer(SCIPIndexerBase):
 
     def _build_index_command(self, **kwargs) -> List[str]:
         """Build the command to generate the SCIP index for Go."""
-        # scip-go runs from project root and outputs index.scip by default.
-        # We move/rename the output afterward if needed, but scip-go doesn't
-        # have a --output flag in all versions, so we rely on the default.
-        cmd = ["scip-go"]
-        return cmd
+        return ["scip-go", "--output", str(self.index_file)]
 
     def _get_decoder_class(self):
         """Get the decoder class for Go."""
@@ -94,6 +90,7 @@ class SCIPGoIndexer(SCIPIndexerBase):
             return False
 
         cmd = self._build_index_command(**kwargs)
+        self.index_file.unlink(missing_ok=True)
 
         logger.debug(f"Running command: {' '.join(cmd)}")
 
@@ -114,24 +111,19 @@ class SCIPGoIndexer(SCIPIndexerBase):
                 if e.stderr:
                     logger.error(f"stderr: {e.stderr}")
                 success = False
+            except BaseException:
+                self.index_file.unlink(missing_ok=True)
+                raise
 
         duration = section.duration
 
-        if success:
-            # scip-go outputs index.scip in the project root by default.
-            # Move it to our output directory if needed.
-            default_output = self.project_root / "index.scip"
-            if default_output.exists() and default_output != self.index_file:
-                import shutil
-
-                shutil.move(str(default_output), str(self.index_file))
-
+        if success and not self.index_file.is_symlink() and self.index_file.is_file():
             logger.info(f"Successfully generated SCIP index at {self.index_file}")
             logger.info(f"Index generation took: {duration:.2f} seconds")
             return True
-        else:
-            logger.error(f"Index generation failed after {duration:.2f} seconds")
-            return False
+        self.index_file.unlink(missing_ok=True)
+        logger.error(f"Index generation failed after {duration:.2f} seconds")
+        return False
 
     def run_pipeline(
         self,

--- a/codenib/scip_interface/scip_indexer_rust.py
+++ b/codenib/scip_interface/scip_indexer_rust.py
@@ -244,6 +244,7 @@ class SCIPRustIndexer(SCIPIndexerBase):
         kwargs.pop("project_name", None)
         kwargs.pop("target_dir", None)
         kwargs.pop("cwd", None)
+        kwargs.pop("allow_project_preparation", None)
 
         return super().run_pipeline(
             output_file=output_file,

--- a/codenib/toolchains.py
+++ b/codenib/toolchains.py
@@ -282,8 +282,12 @@ def plan_repository_toolchain(
     root: Path | None = None,
     command_resolver: Callable[[str], str | None] | None = None,
     module_checker: Callable[[str], bool] | None = None,
+    allow_project_preparation: bool = True,
 ) -> ToolchainPlan:
     """Build a read-only install/status plan for a repository."""
+
+    if type(allow_project_preparation) is not bool:
+        raise ValueError("allow_project_preparation must be a boolean")
 
     from .graph.setup import diagnose_graph_setup
 
@@ -300,6 +304,7 @@ def plan_repository_toolchain(
             languages,
             command_resolver=resolver,
             module_checker=module_checker,
+            allow_project_preparation=allow_project_preparation,
         )
         if not report.runtime.ready:
             notes.append(

--- a/docs/product_roadmap.md
+++ b/docs/product_roadmap.md
@@ -264,9 +264,16 @@ release acceptance, exact-main verification, and explicit release authorization.
   providers outside the repository, but never run project package managers or
   build-system preparation from the onboarding command.
 - Make repeated initialization a no-op for matching registrations. Fail closed
-  on unmanaged collisions and managed drift.
+  on unmanaged collisions and managed drift. Auto mode re-detects the current
+  checkout on every run and admits only languages with registered graph
+  providers, so newly added languages are not hidden by an older receipt.
 - Provide human and JSON status plus receipt-scoped uninstall that preserves the
-  reusable index.
+  reusable index. Readiness revalidates the BM25 and graph artifact
+  fingerprints and probes the recorded MCP command's graph runtime, rather than
+  trusting a matching package version or manifest state alone.
+- Treat dry-run project prerequisites as blocking, require an existing usable
+  C/C++ compilation database for read-only onboarding, and direct provider
+  output to CodeNib state instead of the target checkout.
 - Exercise installed `explore_context` and `dependency_subgraph` calls, source
   verification, both client contracts, idempotency, and uninstall in the
   release graph smoke.

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -1207,7 +1207,8 @@ class TestSymbolGraphBuilder:
         assert status.metadata["edge_count"] == 0
         assert status.metadata["language"] == "python"
         assert status.metadata["languages"] == ["python"]
-        assert status.metadata["builder_schema"] == 4
+        assert status.metadata["builder_schema"] == 5
+        assert status.metadata["allow_project_preparation"] is True
         assert status.metadata["target_dir"] is None
         assert status.metadata["update_mode"] == "full_rebuild"
         assert status.metadata["scip_decoded_artifacts"] == {}
@@ -1231,6 +1232,15 @@ class TestSymbolGraphBuilder:
                 },
             )
         ]
+
+    def test_artifact_identity_tracks_project_preparation_policy(self):
+        enabled = SymbolGraphBuilder(allow_project_preparation=True)
+        disabled = SymbolGraphBuilder(allow_project_preparation=False)
+
+        assert enabled.artifact_identity()["builder_schema"] == 5
+        assert enabled.artifact_identity()["allow_project_preparation"] is True
+        assert disabled.artifact_identity()["allow_project_preparation"] is False
+        assert enabled.artifact_identity() != disabled.artifact_identity()
 
     def test_build_records_existing_decoded_scip_artifact(self, monkeypatch, tmp_path):
         from codenib import ls_router

--- a/test/graph/test_setup.py
+++ b/test/graph/test_setup.py
@@ -81,6 +81,37 @@ def test_cpp_setup_requires_a_compilation_database_route(tmp_path: Path) -> None
     assert report.languages[0].resolved_command == "/tools/clangd"
 
 
+def test_cpp_read_only_setup_requires_an_existing_compilation_database(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "CMakeLists.txt").write_text(
+        "cmake_minimum_required(VERSION 3.20)\n",
+        encoding="utf-8",
+    )
+    resolver = _resolver({"clangd": "/tools/clangd", "cmake": "/tools/cmake"})
+
+    preparable = diagnose_graph_setup(
+        tmp_path,
+        ["cpp"],
+        command_resolver=resolver,
+        module_checker=lambda _name: True,
+    )
+    read_only = diagnose_graph_setup(
+        tmp_path,
+        ["cpp"],
+        command_resolver=resolver,
+        module_checker=lambda _name: True,
+        allow_project_preparation=False,
+    )
+
+    assert preparable.ready is True
+    assert read_only.ready is False
+    assert read_only.languages[0].missing == ["compilation database"]
+    assert "existing usable compile_commands.json" in (
+        read_only.languages[0].prerequisites[-1].detail
+    )
+
+
 def test_setup_payload_contains_actionable_language_specific_data(
     tmp_path: Path,
 ) -> None:

--- a/test/scip/test_scip_go_runtime.py
+++ b/test/scip/test_scip_go_runtime.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codenib.scip_interface.scip_indexer_base import SCIPIndexerBase
+from codenib.scip_interface.scip_indexer_go import SCIPGoIndexer
+from codenib.scip_interface.scip_indexer_rust import SCIPRustIndexer
+
+
+def _go_indexer(tmp_path: Path) -> SCIPGoIndexer:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "go.mod").write_text("module example.test/repo\n", encoding="utf-8")
+    return SCIPGoIndexer(repository, output_dir=tmp_path / "state")
+
+
+def test_go_indexer_writes_directly_to_the_state_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    indexer = _go_indexer(tmp_path)
+    commands: list[tuple[str, ...]] = []
+    monkeypatch.setattr(indexer, "_check_indexer_available", lambda: True)
+
+    def run(command, **kwargs):
+        commands.append(tuple(command))
+        assert kwargs["cwd"] == indexer.project_root
+        assert not (indexer.project_root / "index.scip").exists()
+        indexer.index_file.write_bytes(b"scip")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", run)
+
+    assert indexer.generate_index() is True
+    assert commands == [("scip-go", "--output", str(indexer.index_file))]
+    assert indexer.index_file.read_bytes() == b"scip"
+    assert not (indexer.project_root / "index.scip").exists()
+
+
+@pytest.mark.parametrize("failure", ["command", "cancel"])
+def test_go_indexer_discards_partial_state_output_after_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    indexer = _go_indexer(tmp_path)
+    monkeypatch.setattr(indexer, "_check_indexer_available", lambda: True)
+
+    def run(command, **_kwargs):
+        indexer.index_file.write_bytes(b"partial")
+        if failure == "command":
+            raise subprocess.CalledProcessError(1, command)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(subprocess, "run", run)
+
+    if failure == "command":
+        assert indexer.generate_index() is False
+    else:
+        with pytest.raises(KeyboardInterrupt):
+            indexer.generate_index()
+    assert not indexer.index_file.exists()
+    assert not (indexer.project_root / "index.scip").exists()
+
+
+def test_rust_pipeline_consumes_read_only_project_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    captured: dict[str, object] = {}
+
+    def run_pipeline(_self, **kwargs):
+        captured.update(kwargs)
+        return "graph"
+
+    monkeypatch.setattr(SCIPIndexerBase, "run_pipeline", run_pipeline)
+    indexer = SCIPRustIndexer(repository, output_dir=tmp_path / "state")
+
+    assert (
+        indexer.run_pipeline(
+            allow_project_preparation=False,
+            custom_option="kept",
+            report_profile=False,
+        )
+        == "graph"
+    )
+    assert "allow_project_preparation" not in captured
+    assert captured["custom_option"] == "kept"
+    assert captured["report_profile"] is False

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -879,6 +879,29 @@ def test_mcp_parser_limits_tool_surface_and_defaults_to_full() -> None:
     assert exc_info.value.code == 2
 
 
+def test_mcp_runtime_probe_checks_the_complete_codegraph_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from codenib.mcp import server
+
+    required: list[tuple[tuple[str, ...], str]] = []
+    monkeypatch.setattr(
+        cli,
+        "_require_modules",
+        lambda modules, **kwargs: required.append((tuple(modules), kwargs["extra"])),
+    )
+    monkeypatch.setattr(
+        server,
+        "main",
+        lambda _command: pytest.fail("runtime probe must not start the MCP server"),
+    )
+
+    assert cli.run(["mcp", "--runtime-probe"]) == 0
+    assert required == [(("mcp", "igraph", "google.protobuf"), "graph,mcp")]
+    assert capsys.readouterr().out == "codenib codegraph mcp runtime ready\n"
+
+
 def test_mcp_manifest_forwards_explore_tool_surface(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/test/test_codegraph_onboarding.py
+++ b/test/test_codegraph_onboarding.py
@@ -356,17 +356,34 @@ def test_server_command_must_report_the_active_codenib_version(tmp_path: Path) -
 
     def runner(command, **_kwargs):
         commands.append(tuple(command))
+        output = (
+            "codenib codegraph mcp runtime ready\n"
+            if command[-1] == "--runtime-probe"
+            else f"codenib {package_version()}\n"
+        )
         return subprocess.CompletedProcess(
             command,
             0,
-            f"codenib {package_version()}\n",
+            output,
             "",
         )
 
     inspection = inspect_server_command(server, repo, runner=runner)
 
     assert inspection.ready is True
-    assert commands == [("/python", "-m", "codenib", "--version")]
+    assert commands == [
+        ("/python", "-m", "codenib", "--version"),
+        (
+            "/python",
+            "-m",
+            "codenib",
+            "mcp",
+            str(repo.resolve()),
+            "--tool-surface",
+            "full",
+            "--runtime-probe",
+        ),
+    ]
 
     mismatch = inspect_server_command(
         server,
@@ -376,6 +393,19 @@ def test_server_command_must_report_the_active_codenib_version(tmp_path: Path) -
         ),
     )
     assert mismatch.ready is False
+
+    failed_probe = inspect_server_command(
+        server,
+        repo,
+        runner=lambda command, **_kwargs: subprocess.CompletedProcess(
+            command,
+            0 if command[-1] == "--version" else 1,
+            f"codenib {package_version()}\n" if command[-1] == "--version" else "",
+            "missing graph runtime" if command[-1] == "--runtime-probe" else "",
+        ),
+    )
+    assert failed_probe.ready is False
+    assert "runtime probe failed" in failed_probe.detail
 
 
 def _ready_plan(repo: Path) -> SimpleNamespace:
@@ -509,7 +539,7 @@ def test_init_rejects_dirty_checkout_before_toolchain_or_index_work(
         cli._run_codegraph_init(args)
 
 
-def test_repeated_init_reuses_manifest_language_selection(
+def test_repeated_auto_init_redetects_graph_languages_from_current_checkout(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -519,11 +549,105 @@ def test_repeated_init_reuses_manifest_language_selection(
     repo = _repository(tmp_path)
     monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
     manifest = _manifest(repo)
-    manifest.languages = ["ruby"]
+    manifest.languages = ["python"]
     manifest.save(repo_index_dir(repo) / MANIFEST_FILENAME)
+    (repo / "new.go").write_text("package example\n", encoding="utf-8")
     args = cli.build_parser().parse_args(["codegraph", "init", str(repo)])
 
-    assert cli._codegraph_languages_for_init(repo, args, object()) == ("ruby",)
+    assert cli._codegraph_languages_for_init(repo, args, object()) == (
+        "go",
+        "python",
+    )
+
+
+def test_codegraph_language_selection_ignores_chunk_only_languages(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    (repo / "Example.swift").write_text("let value = 1\n", encoding="utf-8")
+    (repo / "plugin.lua").write_text("return {}\n", encoding="utf-8")
+    args = cli.build_parser().parse_args(["codegraph", "init", str(repo)])
+
+    assert cli._codegraph_languages_for_init(repo, args, None) == ("python",)
+
+
+def test_codegraph_language_selection_rejects_unsupported_explicit_language(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    args = cli.build_parser().parse_args(
+        ["codegraph", "init", str(repo), "--language", "swift"]
+    )
+
+    with pytest.raises(cli.CLIError, match="no symbol-graph provider"):
+        cli._codegraph_languages_for_init(repo, args, None)
+
+
+def test_dry_run_reports_project_prerequisites_and_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import codenib.codegraph_onboarding as onboarding
+    import codenib.toolchains as toolchains
+
+    repo = _repository(tmp_path)
+    _initialize_git_repository(repo)
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
+    monkeypatch.setattr(
+        onboarding,
+        "resolve_codenib_command",
+        lambda _explicit=None: ("/opt/codenib/bin/codenib", ()),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "inspect_server_command",
+        lambda *_args, **_kwargs: SimpleNamespace(ready=True, detail="ready"),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "inspect_client_registration",
+        lambda client, _server, _repo: ClientInspection(
+            client, True, False, False, "not configured"
+        ),
+    )
+    plan = SimpleNamespace(
+        root=tmp_path / "tools",
+        missing=(),
+        notes=(
+            "MISSING: Go project prerequisite go.mod: missing from repository root",
+        ),
+        ready=False,
+    )
+    monkeypatch.setattr(cli, "_codegraph_toolchain_plan", lambda *_args: plan)
+    monkeypatch.setattr(
+        toolchains,
+        "install_requirements",
+        lambda *_args, **_kwargs: ([], []),
+    )
+    monkeypatch.setattr(
+        cli,
+        "index_repository",
+        lambda *_args, **_kwargs: pytest.fail("dry-run must not build indexes"),
+    )
+    args = cli.build_parser().parse_args(
+        [
+            "codegraph",
+            "init",
+            str(repo),
+            "--agent",
+            "codex",
+            "--language",
+            "go",
+            "--dry-run",
+        ]
+    )
+
+    assert cli._run_codegraph_init(args) == 1
+    output = capsys.readouterr().out
+    assert "prerequisite: Go project prerequisite go.mod" in output
+    assert "Readiness:  blocked" in output
+    assert "no tools, indexes, receipts, or clients changed" in output
 
 
 def test_init_does_not_overwrite_registration_created_during_indexing(
@@ -702,3 +826,119 @@ def test_status_json_is_nonzero_without_managed_clients(
     report = json.loads(capsys.readouterr().out)
     assert report["ready"] is False
     assert report["clients"] == []
+
+
+def test_human_status_does_not_call_a_graph_only_index_current(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _repository(tmp_path)
+    monkeypatch.setattr(
+        cli,
+        "_codegraph_status_report",
+        lambda _repo: {
+            "repository": str(repo),
+            "ready": False,
+            "index": {
+                "ready": False,
+                "detail": "bm25 artifact is missing or does not match its fingerprint",
+            },
+            "toolchain": {"ready": True, "missing": [], "notes": []},
+            "server_command": {"ready": True, "detail": "ready"},
+            "clients": [],
+        },
+    )
+    args = cli.build_parser().parse_args(["codegraph", "status", str(repo)])
+
+    assert cli._run_codegraph_status(args) == 1
+    output = capsys.readouterr().out
+    assert "bm25 artifact is missing" in output
+    assert "bm25 + symbol_graph are current" not in output
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_detail"),
+    [
+        ("remove-bm25", "bm25 artifact is missing"),
+        ("corrupt-graph", "symbol_graph artifact is missing"),
+    ],
+)
+def test_index_status_verifies_persisted_artifact_fingerprints(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+    expected_detail: str,
+) -> None:
+    from codenib.compiler import checkout_identity
+    from codenib.compiler.artifact_fingerprints import (
+        bm25_artifact_file_fingerprints,
+        regular_file_fingerprint,
+    )
+    from codenib.compiler.manifest import MANIFEST_FILENAME
+    from codenib.paths import repo_index_dir
+
+    repo = _repository(tmp_path)
+    state = tmp_path / "state"
+    monkeypatch.setenv("CODENIB_HOME", str(state))
+    bm25 = state / "artifacts" / "bm25"
+    graph = state / "artifacts" / "symbol_graph"
+    bm25.mkdir(parents=True)
+    graph.mkdir(parents=True)
+    (bm25 / "documents.json").write_text("[]\n", encoding="utf-8")
+    (bm25 / "bm25_metadata.json").write_text("{}\n", encoding="utf-8")
+    (graph / "graph.pkl").write_bytes(b"graph-generation-one")
+    fingerprint = "sha256-v2:" + "b" * 64
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        source_fingerprint=fingerprint,
+        last_indexed_source_fingerprint=fingerprint,
+        languages=["python"],
+        indexes={
+            "bm25": IndexEntry(
+                index_type="bm25",
+                path=str(bm25),
+                built_at="2026-08-13T00:00:00Z",
+                built_at_epoch=1.0,
+                status="fresh",
+                config={
+                    "artifact_file_fingerprints": (
+                        bm25_artifact_file_fingerprints(bm25)
+                    )
+                },
+                source_fingerprint=fingerprint,
+            ),
+            "symbol_graph": IndexEntry(
+                index_type="symbol_graph",
+                path=str(graph),
+                built_at="2026-08-13T00:00:00Z",
+                built_at_epoch=1.0,
+                status="fresh",
+                config={
+                    "allow_partial_languages": False,
+                    "allow_partial_index": False,
+                    "graph_artifact": {
+                        "relative_path": "graph.pkl",
+                        **regular_file_fingerprint(graph / "graph.pkl"),
+                    },
+                },
+                source_fingerprint=fingerprint,
+            ),
+        },
+    )
+    manifest.save(repo_index_dir(repo) / MANIFEST_FILENAME)
+    monkeypatch.setattr(
+        checkout_identity,
+        "validate_checkout_identity",
+        lambda *_args, **_kwargs: None,
+    )
+
+    assert cli._codegraph_index_report(repo)["ready"] is True
+    if mutation == "remove-bm25":
+        (bm25 / "documents.json").unlink()
+    else:
+        (graph / "graph.pkl").write_bytes(b"graph-generation-two")
+
+    report = cli._codegraph_index_report(repo)
+    assert report["ready"] is False
+    assert expected_detail in report["detail"]

--- a/test/test_codegraph_onboarding.py
+++ b/test/test_codegraph_onboarding.py
@@ -596,6 +596,11 @@ def test_dry_run_reports_project_prerequisites_and_exits_nonzero(
     monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "state"))
     monkeypatch.setattr(
         onboarding,
+        "resolve_requested_clients",
+        lambda _requested: ("codex",),
+    )
+    monkeypatch.setattr(
+        onboarding,
         "resolve_codenib_command",
         lambda _explicit=None: ("/opt/codenib/bin/codenib", ()),
     )

--- a/test/test_toolchains.py
+++ b/test/test_toolchains.py
@@ -106,6 +106,22 @@ def test_repository_plan_uses_language_registry_for_graph_and_lsp(
     ]
 
 
+def test_repository_plan_forwards_read_only_project_policy(tmp_path: Path) -> None:
+    (tmp_path / "CMakeLists.txt").write_text("project(example)\n", encoding="utf-8")
+    available = {"clangd": "/tools/clangd", "cmake": "/tools/cmake"}
+
+    plan = toolchains.plan_repository_toolchain(
+        tmp_path,
+        ["cpp"],
+        command_resolver=available.get,
+        module_checker=lambda _name: True,
+        allow_project_preparation=False,
+    )
+
+    assert plan.ready is False
+    assert any("existing usable compile_commands.json" in note for note in plan.notes)
+
+
 def test_dry_run_renders_pinned_npm_install_without_writing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Hardens the CodeGraph 0.2.1 onboarding path after the post-merge review of #621. The follow-up makes readiness reflect the executable runtime, current repository languages, persisted artifact bytes, and the read-only graph build contract.

## Changes

- Re-detect graph-capable languages on every automatic init and reject chunk-only providers.
- Probe the recorded MCP command's graph runtime and verify BM25/graph artifact fingerprints in status.
- Make dry-run project blockers non-zero and require an existing C/C++ compilation database.
- Write Go SCIP output directly to CodeNib state, consume the Rust read-only option, and bind project preparation into graph artifact identity.
- Add focused regressions and update the durable 0.2.1 product roadmap.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Focused CodeGraph/CLI/toolchain/SCIP/compiler tests: 364 passed, 4 skipped.
- Unit tier: 5208 passed, 71 skipped, 191 deselected; one exact-main umask fixture was excluded after independent reproduction.
- Integration tier: 36 passed, 18 skipped.
- Fresh wheel with graph,mcp extras: CodeGraph init/status, Codex and Claude registration, MCP explore/dependency calls, Dependency Map, idempotent init, and uninstall passed.
- pre-commit and MkDocs strict passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published