### PR TITLE
fix(release): publish curated version notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ on:
       - "server.json"
       - "test/test_mcp_registry.py"
       - "test/test_release_artifacts.py"
+      - "docs/releases/**"
       - "web/**"
       - "CHANGELOG.md"
       - "CONTRIBUTING.md"
@@ -251,22 +252,30 @@ jobs:
       - name: Resolve release channel
         id: channel
         run: |
-          PRERELEASE="$(python - <<'PY'
+          readarray -t RELEASE_METADATA < <(python - <<'PY'
           import re
           import tomllib
           from pathlib import Path
 
           with Path("pyproject.toml").open("rb") as handle:
               version = str(tomllib.load(handle)["project"]["version"])
+          print(version)
           print("true" if re.search(r"(?:a|b|rc)\d+|\.dev\d+", version) else "false")
           PY
-          )"
+          )
+          VERSION="${RELEASE_METADATA[0]}"
+          PRERELEASE="${RELEASE_METADATA[1]}"
+          RELEASE_NOTES="docs/releases/$VERSION.md"
+          test -f "$RELEASE_NOTES"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "notes_file=$RELEASE_NOTES" >> "$GITHUB_OUTPUT"
 
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
           PRERELEASE: ${{ steps.channel.outputs.prerelease }}
+          RELEASE_NOTES: ${{ steps.channel.outputs.notes_file }}
         run: |
           RELEASE_FLAGS=(--latest)
           if [ "$PRERELEASE" = "true" ]; then
@@ -278,6 +287,6 @@ jobs:
             dist/SHA256SUMS \
             --repo "$GITHUB_REPOSITORY" \
             --title "CodeNib $GITHUB_REF_NAME" \
-            --generate-notes \
+            --notes-file "$RELEASE_NOTES" \
             "${RELEASE_FLAGS[@]}" \
             --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
-## [0.2.1] - 2026-08-13
+## [0.2.1] - 2026-08-14
 
 ### Added
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -125,18 +125,23 @@ on PyPI.
 1. Move relevant entries from `Unreleased` into a dated version section in
    `CHANGELOG.md`.
 2. Confirm `pyproject.toml` uses the release version, `server.json` matches it,
-   and the README citation and `mcp-name` marker remain present.
+   `docs/releases/<version>.md` contains the curated public release notes, and
+   the README citation and `mcp-name` marker remain present.
 3. Run `pre-commit run --all-files` and the local package smoke.
 4. Merge the release commit to `main` and confirm its package gates pass.
 5. Confirm the TestPyPI trusted publisher is visible, then dispatch the
    TestPyPI Release workflow from `main`.
 6. Confirm the TestPyPI registry-download and installed-CLI smoke job passes.
+   Record its exact head SHA, freeze the release surface, and require the
+   production tag to resolve to that same commit.
 7. Complete the public-surface gate above.
 8. Confirm the production PyPI publisher exactly names owner `sysevol-ai`,
    repository `CodeNib`, workflow `release.yml`, and environment `pypi`.
 9. Confirm the `codenib.ai` MCP proof TXT record and protected
    `mcp-registry-publish` environment secret are active.
-10. Create and push an annotated `v<version>` tag.
+10. Create and push an annotated `v<version>` tag at the accepted TestPyPI SHA.
+    Do not include intervening `main` changes without repeating the candidate
+    workflow.
 11. Confirm PyPI, MCP Registry discovery, and the generated GitHub Release all
     identify the same version and that a stable release is marked latest.
 12. After the first successful production OIDC publication, revoke the

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -67,6 +67,37 @@ def validate_tag(tag: str | None, version: str) -> None:
         )
 
 
+def validate_release_notes(project_file: Path, notes_dir: Path | None = None) -> Path:
+    """Require curated, version-matched notes before any release publication."""
+    name, version = project_identity(project_file)
+    root = project_file.resolve().parent
+    directory = notes_dir if notes_dir is not None else root / "docs" / "releases"
+    notes = directory / f"{version}.md"
+    try:
+        text = notes.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ReleaseValidationError(
+            f"missing curated release notes for {name} {version}: {notes}"
+        ) from exc
+
+    heading = f"# CodeNib {version}"
+    if heading not in text:
+        raise ReleaseValidationError(
+            f"{notes} must contain the version heading {heading!r}"
+        )
+    if f"=={version}" not in text:
+        raise ReleaseValidationError(
+            f"{notes} must contain an exact {version} installation example"
+        )
+    forbidden = ("test-files.pythonhosted.org", "--extra-index-url", "--index-url")
+    found = [marker for marker in forbidden if marker in text]
+    if found:
+        raise ReleaseValidationError(
+            f"{notes} contains prerelease installation markers: {', '.join(found)}"
+        )
+    return notes
+
+
 def _single(paths: list[Path], kind: str) -> Path:
     if len(paths) != 1:
         found = ", ".join(path.name for path in paths) or "none"
@@ -175,6 +206,7 @@ def validate_release(
 ) -> tuple[Path, Path]:
     name, version = project_identity(project_file)
     validate_tag(tag, version)
+    validate_release_notes(project_file)
 
     wheel = _single(sorted(dist_dir.glob("*.whl")), "wheel")
     sdist = _single(sorted(dist_dir.glob("*.tar.gz")), "sdist")

--- a/test/storage/test_sqlite_jobs.py
+++ b/test/storage/test_sqlite_jobs.py
@@ -1296,14 +1296,16 @@ def test_job_finish_and_slot_release_roll_back_together(tmp_path) -> None:
         lease = catalog.acquire_job_lease(
             job.job_id, owner_id="worker", lease_duration_ms=30_000
         )
-        catalog._connection.execute("""
+        catalog._connection.execute(
+            """
             CREATE TRIGGER fail_job_slot_release
             BEFORE UPDATE ON ref_job_leases
             WHEN NEW.job_id IS NULL
             BEGIN
                 SELECT RAISE(ABORT, 'simulated slot release failure');
             END
-            """)
+            """
+        )
 
         with pytest.raises(sqlite3.IntegrityError, match="simulated slot"):
             catalog.finish_job_attempt(

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -17,6 +17,7 @@ from scripts.verify_release_artifacts import (
     project_identity,
     validate_readme_citation,
     validate_readme_mcp_ownership,
+    validate_release_notes,
     validate_tag,
 )
 
@@ -72,6 +73,52 @@ def test_project_identity_and_tag_match_release_metadata() -> None:
 def test_release_tag_must_match_project_version() -> None:
     with pytest.raises(ReleaseValidationError, match="does not match"):
         validate_tag("v0.1.0", "0.2.0")
+
+
+def test_curated_release_notes_match_the_project_version(tmp_path: Path) -> None:
+    project = tmp_path / "pyproject.toml"
+    project.write_text(
+        '[project]\nname = "codenib"\nversion = "0.2.1"\n',
+        encoding="utf-8",
+    )
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    notes = notes_dir / "0.2.1.md"
+    notes.write_text(
+        "# CodeNib 0.2.1\n\nInstall with `codenib[graph,mcp]==0.2.1`.\n",
+        encoding="utf-8",
+    )
+
+    assert validate_release_notes(project, notes_dir) == notes
+
+
+@pytest.mark.parametrize(
+    ("body", "message"),
+    (
+        ("# CodeNib 0.2.0\n\ncodenib==0.2.1\n", "version heading"),
+        ("# CodeNib 0.2.1\n\ncodenib\n", "installation example"),
+        (
+            "# CodeNib 0.2.1\n\ncodenib==0.2.1 --extra-index-url x\n",
+            "prerelease installation markers",
+        ),
+    ),
+)
+def test_curated_release_notes_reject_invalid_contract(
+    tmp_path: Path,
+    body: str,
+    message: str,
+) -> None:
+    project = tmp_path / "pyproject.toml"
+    project.write_text(
+        '[project]\nname = "codenib"\nversion = "0.2.1"\n',
+        encoding="utf-8",
+    )
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "0.2.1.md").write_text(body, encoding="utf-8")
+
+    with pytest.raises(ReleaseValidationError, match=message):
+        validate_release_notes(project, notes_dir)
 
 
 def test_packaged_readme_requires_the_arxiv_citation() -> None:
@@ -184,6 +231,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert production["concurrency"]["cancel-in-progress"] == (
         "${{ github.ref_type != 'tag' }}"
     )
+    assert "docs/releases/**" in production["on"]["pull_request"]["paths"]
 
     assert set(production["jobs"]) == {
         "verify",
@@ -250,9 +298,17 @@ def test_registry_publishers_use_separate_workflows() -> None:
         step["name"]: step for step in production["jobs"]["github-release"]["steps"]
     }
     assert release_steps["Resolve release channel"]["id"] == "channel"
+    resolve_release = release_steps["Resolve release channel"]["run"]
+    assert 'RELEASE_NOTES="docs/releases/$VERSION.md"' in resolve_release
+    assert 'test -f "$RELEASE_NOTES"' in resolve_release
+    assert release_steps["Create release"]["env"]["RELEASE_NOTES"] == (
+        "${{ steps.channel.outputs.notes_file }}"
+    )
     create_release = release_steps["Create release"]["run"]
     assert "RELEASE_FLAGS=(--latest)" in create_release
     assert "RELEASE_FLAGS=(--prerelease)" in create_release
+    assert '--notes-file "$RELEASE_NOTES"' in create_release
+    assert "--generate-notes" not in create_release
     assert '"${RELEASE_FLAGS[@]}"' in create_release
 
     assert set(test["jobs"]) == {


### PR DESCRIPTION
## Summary

Make the 0.2.1 publication path use the curated CodeGraph release notes and bind the production tag to the exact TestPyPI candidate that was accepted.

## Changes

- fail release artifact verification when `docs/releases/<version>.md` is missing, mismatched, or contains prerelease installation routes
- publish the curated version notes as the GitHub Release body instead of using unfocused auto-generated notes
- run the Release workflow when curated release notes change
- document the TestPyPI SHA freeze and update the 0.2.1 release date
- format an existing SQLite rollback fixture so the full-repository pre-commit release gate is clean

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validated with:

- `49 passed` across release artifacts, MCP registry, release metadata, and CI policy tests in an isolated 0.2.1 environment
- isolated wheel/sdist build, `twine check`, and release artifact verification
- installed base-wheel CLI smoke
- installed `graph,mcp` CodeGraph smoke covering Codex and Claude Code registration, idempotency, MCP exploration/dependencies, Dependency Map, checkout cleanliness, and uninstall
- `mkdocs build --strict`
- `pre-commit run --all-files`
- focused SQLite rollback test and `git diff --check`

- clean detached 0.2.1 environment full unit tier: `5213 passed, 71 skipped, 190 deselected`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
