### PR TITLE
docs(readme): refresh PyPI version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
   </p>
   <p>
     <a href="https://github.com/sysevol-ai/CodeNib/actions/workflows/ci-full.yml"><img src="https://github.com/sysevol-ai/CodeNib/actions/workflows/ci-full.yml/badge.svg" alt="CI"></a>
-    <a href="https://pypi.org/project/codenib/"><img src="https://img.shields.io/pypi/v/codenib.svg" alt="PyPI version"></a>
+    <a href="https://pypi.org/project/codenib/"><img src="https://img.shields.io/pypi/v/codenib.svg?cacheSeconds=300" alt="PyPI version"></a>
     <a href="https://docs.codenib.ai/codegraph/#one-command-setup"><img src="https://img.shields.io/badge/Claude_Code-D97757?logo=claude&amp;logoColor=fff" alt="Claude Code supported"></a>
     <a href="https://docs.codenib.ai/codegraph/#one-command-setup"><img src="https://img.shields.io/badge/Codex-000?logo=openai&amp;logoColor=fff" alt="Codex supported"></a>
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0"></a>


### PR DESCRIPTION
## Summary

Refresh the README PyPI version badge after the 0.2.1 release.

## Changes

- Add a cache-busting query parameter to the Shields.io PyPI badge URL.
- Force GitHub Camo to fetch the current 0.2.1 badge instead of serving its cached 0.2.0 SVG.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes

Validated that the new badge URL renders `pypi: v0.2.1`, and ran README pre-commit hooks plus `git diff --check`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
