### PR TITLE
fix(web): stabilize source-linked demo generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,11 @@ jobs:
 
   registry-auth-preflight:
     name: Verify MCP Registry ownership
-    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+    # The protected environment admits only v* tags. Branch dispatches still
+    # exercise release verification without requesting its production secret.
+    if: >-
+      github.ref_type == 'tag' &&
+      startsWith(github.ref_name, 'v')
     needs: verify
     runs-on: ubuntu-latest
     environment:
@@ -86,7 +90,12 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    if: github.ref_type == 'tag'
+    # A manual tag dispatch may diagnose Registry authentication, but must
+    # never replay a production publication.
+    if: >-
+      github.event_name == 'push' &&
+      github.ref_type == 'tag' &&
+      startsWith(github.ref_name, 'v')
     needs: registry-auth-preflight
     runs-on: ubuntu-latest
     environment:
@@ -106,7 +115,10 @@ jobs:
 
   publish-mcp-registry:
     name: Publish to MCP Registry
-    if: github.ref_type == 'tag'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref_type == 'tag' &&
+      startsWith(github.ref_name, 'v')
     needs: verify-pypi-install
     runs-on: ubuntu-latest
     environment:
@@ -151,7 +163,10 @@ jobs:
 
   verify-pypi-install:
     name: Verify installed PyPI package
-    if: github.ref_type == 'tag'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref_type == 'tag' &&
+      startsWith(github.ref_name, 'v')
     needs: publish-pypi
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -228,7 +243,10 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    if: github.ref_type == 'tag'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref_type == 'tag' &&
+      startsWith(github.ref_name, 'v')
     needs:
       - publish-pypi
       - publish-mcp-registry

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ web/*.tsbuildinfo
 .env.local
 web_before
 qa_config.local.yaml
+qa_config.api.yaml

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ CODENIB_RESULTS_DIR ?= $(CODENIB_HOME)/results
 CODENIB_SCIP_TOOLS_DIR ?= $(CODENIB_TEMP_DIR)/scip-tools
 GO_VERSION ?= 1.26.4
 GO_OS ?= linux
-GO_ARCH ?= amd64
+GO_ARCH ?= $(if $(filter aarch64 arm64,$(shell uname -m)),arm64,amd64)
+GO_TOOL_ID = $(GO_VERSION)-$(GO_OS)-$(GO_ARCH)
 GO_URL ?= https://go.dev/dl/go$(GO_VERSION).$(GO_OS)-$(GO_ARCH).tar.gz
 SCIP_GO_MODULE ?= github.com/scip-code/scip-go/cmd/scip-go
 SCIP_GO_VERSION ?= v0.2.7
@@ -232,6 +233,8 @@ endef
 .PHONY: jdtls-tool csharp-lsp-tool ruby-lsp-tool intelephense-tool kotlin-lsp-tool
 .PHONY: dev test test-all test-slow ask-quality branding-assets branding-check
 .PHONY: web-deps web-start web-stop web-restart web-reclaim web-status web-logs web-follow
+.PHONY: wiki-cache-audit wiki-cache-prewarm demo-index-rebuild
+.PHONY: demo-ask-benchmark demo-wiki-benchmark
 
 install:
 	pip install -e .
@@ -305,14 +308,14 @@ go-tool:
 	$(call require-command,tar)
 	mkdir -p "$(CODENIB_SCIP_TOOLS_DIR)"
 	@if [ ! -f "$(CODENIB_SCIP_TOOLS_DIR)/go/.codenib-version" ] \
-		|| ! grep -qx "$(GO_VERSION)" "$(CODENIB_SCIP_TOOLS_DIR)/go/.codenib-version"; then \
+		|| ! grep -qx "$(GO_TOOL_ID)" "$(CODENIB_SCIP_TOOLS_DIR)/go/.codenib-version"; then \
 		rm -rf "$(CODENIB_SCIP_TOOLS_DIR)/go" \
 			"$(CODENIB_SCIP_TOOLS_DIR)/go$(GO_VERSION).$(GO_OS)-$(GO_ARCH).tar.gz"; \
 		curl -fL "$(GO_URL)" \
 			-o "$(CODENIB_SCIP_TOOLS_DIR)/go$(GO_VERSION).$(GO_OS)-$(GO_ARCH).tar.gz"; \
 		tar -xzf "$(CODENIB_SCIP_TOOLS_DIR)/go$(GO_VERSION).$(GO_OS)-$(GO_ARCH).tar.gz" \
 			-C "$(CODENIB_SCIP_TOOLS_DIR)"; \
-		echo "$(GO_VERSION)" > "$(CODENIB_SCIP_TOOLS_DIR)/go/.codenib-version"; \
+		echo "$(GO_TOOL_ID)" > "$(CODENIB_SCIP_TOOLS_DIR)/go/.codenib-version"; \
 	fi
 
 scip-go-tool: go-tool
@@ -1040,3 +1043,18 @@ web-logs:
 
 web-follow:
 	./scripts/dev_web.sh follow
+
+wiki-cache-audit:
+	python scripts/audit_wiki_cache.py $(WIKI_CACHE_AUDIT_ARGS)
+
+wiki-cache-prewarm:
+	python scripts/prewarm_wiki_cache.py $(WIKI_CACHE_PREWARM_ARGS)
+
+demo-index-rebuild:
+	python scripts/rebuild_demo_indexes.py $(DEMO_INDEX_REBUILD_ARGS)
+
+demo-ask-benchmark:
+	python scripts/benchmark_demo_ask.py $(DEMO_ASK_BENCHMARK_ARGS)
+
+demo-wiki-benchmark:
+	python scripts/benchmark_demo_wiki.py $(DEMO_WIKI_BENCHMARK_ARGS)

--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ running the credential- or toolchain-dependent tiers.
 
 ## Status
 
-CodeNib `0.1.0` is a developer preview. The CLI and manifest format are usable,
-but public interfaces may still change before a stable release. Historical
+CodeNib `0.2.1` is a beta release. The CLI and manifest format are usable, but
+public interfaces may still change before a stable release. Historical
 research artifacts retain their published dataset identifiers; the maintained
 package, import namespace, commands, and repository use `CodeNib`. See
 [Naming](https://docs.codenib.ai/branding/).

--- a/codenib/agent/runner.py
+++ b/codenib/agent/runner.py
@@ -1211,7 +1211,11 @@ limited tool budget, so converge once the implementing location is confirmed.
                 "content": (
                     "Stop searching. Using what you have already read, give "
                     "your complete final answer now, citing the relevant "
-                    "files and symbols."
+                    "files and symbols. Include only implementation claims "
+                    "directly supported by retrieved evidence. If a wrapper "
+                    "chain is incomplete, state that limitation instead of "
+                    "inferring a definition or downstream behavior from its "
+                    "identifier."
                 ),
             }
         )

--- a/codenib/code_chunking/base.py
+++ b/codenib/code_chunking/base.py
@@ -256,12 +256,12 @@ class BaseCodeChunker(ABC):
 
     def _find_first_child(self, node, target_types: Tuple[str, ...]):
         """Depth-first search for the first child node matching one of target_types."""
-        for child in node.children:
+        stack = list(reversed(node.children))
+        while stack:
+            child = stack.pop()
             if child.type in target_types:
                 return child
-            found = self._find_first_child(child, target_types)
-            if found:
-                return found
+            stack.extend(reversed(child.children))
         return None
 
     def _extract_signature_text_default(
@@ -564,14 +564,15 @@ class BaseCodeChunker(ABC):
     def _find_nodes_by_type(self, root_node, node_type: str):
         """Find all nodes with the given type in the tree."""
         nodes = []
-
-        def traverse(node):
+        stack = [root_node]
+        while stack:
+            node = stack.pop()
             if node.type == node_type:
                 nodes.append(node)
-            for child in node.children:
-                traverse(child)
-
-        traverse(root_node)
+            # Reverse before pushing to retain the recursive implementation's
+            # source-order depth-first traversal without consuming Python call
+            # stack on generated C/C++ expression trees thousands of nodes deep.
+            stack.extend(reversed(node.children))
         return nodes
 
     def save_chunks_to_json(self, chunks: List[CodeChunk], output_path: str):

--- a/codenib/compiler/cache_lock.py
+++ b/codenib/compiler/cache_lock.py
@@ -507,12 +507,38 @@ def _require_posix_primitives() -> None:
         )
 
 
+def _make_bounded_cache_directories(cache: Path) -> None:
+    """Create a missing cache suffix without broad intermediate modes.
+
+    ``os.makedirs(..., mode=0o700)`` applies ``mode`` only to the leaf.  With
+    a cooperative umask such as 0002, newly created intermediate directories
+    would therefore remain group-writable.  Discover only the missing suffix
+    and create each member explicitly; existing parents retain their modes.
+    A concurrent creator may win any individual mkdir, in which case the
+    final descriptor validation remains authoritative.
+    """
+
+    missing: list[Path] = []
+    current = cache
+    while not current.exists():
+        missing.append(current)
+        parent = current.parent
+        if parent == current:  # pragma: no cover - filesystem root exists
+            break
+        current = parent
+    for directory in reversed(missing):
+        try:
+            os.mkdir(directory, mode=0o700)
+        except FileExistsError:
+            continue
+
+
 @contextmanager
 def _open_posix_cache_directory(cache_dir: str | Path) -> Iterator[tuple[Path, int]]:
     _require_posix_primitives()
     cache = _cache_path(cache_dir)
     try:
-        os.makedirs(cache, mode=0o700, exist_ok=True)
+        _make_bounded_cache_directories(cache)
         descriptor = os.open(cache, _directory_open_flags())
     except OSError as exc:
         raise RuntimeError(f"could not open compiler cache directory: {cache}") from exc

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -29,6 +29,7 @@ from ..index.embedding.model_policy import (
     DEFAULT_EMBEDDING_MODEL,
     resolve_embedding_load_policy,
 )
+from ..index.embedding.text_policy import REMOTE_EMBEDDING_DOCUMENT_MAX_CHARS
 from ..provider_routes import (
     InferenceRoute,
     normalize_endpoint,
@@ -101,9 +102,10 @@ class BM25IndexBuilder:
     languages: List[str] = field(default_factory=lambda: ["python"])
     max_k: int = 128
     max_lines_per_chunk: int = 300
+    additional_ignore_dirs: List[str] = field(default_factory=list)
 
     def artifact_identity(self) -> Dict[str, Any]:
-        return {
+        identity = {
             # v8 refuses skipped files and retains non-symbol source context.
             "builder_schema": 8,
             "languages": list(self.languages),
@@ -113,6 +115,11 @@ class BM25IndexBuilder:
             "include_header_epilogue": True,
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
+        if self.additional_ignore_dirs:
+            identity["additional_ignore_dirs"] = sorted(
+                set(self.additional_ignore_dirs)
+            )
+        return identity
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
         repo_path: str = kwargs["repo_path"]
@@ -122,9 +129,11 @@ class BM25IndexBuilder:
         from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 
         primary = self.languages[0] if self.languages else "python"
+        repo_config = RepoChunkingConfig(languages=self.languages)
+        repo_config.ignore_dirs.update(self.additional_ignore_dirs)
         chunker = CodeChunker(
             language=primary,
-            repo_config=RepoChunkingConfig(languages=self.languages),
+            repo_config=repo_config,
             max_lines_per_chunk=self.max_lines_per_chunk,
             include_header_epilogue=True,
         )
@@ -183,14 +192,17 @@ class VectorIndexBuilder:
     build_levels: List[str] = field(default_factory=lambda: ["l0", "l2"])
     max_lines_per_chunk: int = 300
     index_metric: str = "ip"
+    embedding_document_max_chars: int = REMOTE_EMBEDDING_DOCUMENT_MAX_CHARS
+    additional_ignore_dirs: List[str] = field(default_factory=list)
 
     def artifact_identity(self) -> Dict[str, Any]:
         """Return the embedding contract required to reopen this artifact."""
 
         route = self._embedding_route()
-        return {
-            # v6 commits vector, chunk, cache, and incremental state together.
-            "builder_schema": 6,
+        identity = {
+            # v7 deterministically bounds remote document inputs in addition
+            # to committing vector, chunk, cache, and incremental state.
+            "builder_schema": 7,
             "embedding_model": route.model,
             "embedding_provider": route.provider,
             "embedding_dimension": self.embedding_dimension,
@@ -206,6 +218,13 @@ class VectorIndexBuilder:
             "chunking_failure_policy": "fail",
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
+        if route.provider == "openai":
+            identity["embedding_document_max_chars"] = self.embedding_document_max_chars
+        if self.additional_ignore_dirs:
+            identity["additional_ignore_dirs"] = sorted(
+                set(self.additional_ignore_dirs)
+            )
+        return identity
 
     def _embedding_route(self) -> InferenceRoute:
         return resolve_inference_route(
@@ -242,6 +261,8 @@ class VectorIndexBuilder:
                 kwargs[key] = nested
             else:
                 kwargs[key] = value
+        if route.provider == "openai":
+            kwargs["max_input_chars"] = self.embedding_document_max_chars
         runtime_endpoint = normalize_endpoint(kwargs.get("base_url"))
         if runtime_endpoint is not None and runtime_endpoint != route.endpoint:
             raise ValueError(
@@ -385,6 +406,7 @@ class VectorIndexBuilder:
                 # would stamp stale vectors with the current source identity.
                 force_rebuild=True,
                 strict_chunking=True,
+                additional_ignore_dirs=self.additional_ignore_dirs,
                 # ``build`` owns the complete private generation tree.  Its
                 # outer OwnedDirectoryStage is the publication boundary.
                 _atomic_publish=False,
@@ -1126,6 +1148,7 @@ def register_default_builders(
     embedding_batch_size: Optional[int] = None,
     embedding_max_seq_length: Optional[int] = None,
     exclude_patterns: Optional[List[str]] = None,
+    additional_chunk_ignore_dirs: Optional[List[str]] = None,
     allow_partial_graph_languages: bool = False,
     allow_partial_graph_index: bool = False,
     graph_source_coverage_fallback: bool = False,
@@ -1133,7 +1156,14 @@ def register_default_builders(
 ) -> None:
     """Register all standard index builders with sensible defaults."""
     langs = languages or ["python"]
-    registry.register("bm25", BM25IndexBuilder(languages=langs))
+    chunk_ignore_dirs = sorted(set(additional_chunk_ignore_dirs or ()))
+    registry.register(
+        "bm25",
+        BM25IndexBuilder(
+            languages=langs,
+            additional_ignore_dirs=chunk_ignore_dirs,
+        ),
+    )
 
     embedding_provider = normalize_provider(embedding_provider)
     embedding_kwargs: Dict[str, Any] = {}
@@ -1176,6 +1206,7 @@ def register_default_builders(
             embedding_endpoint=embedding_endpoint,
             embedding_credential_env=embedding_credential_env,
             embedding_runtime_kwargs=embedding_runtime_kwargs,
+            additional_ignore_dirs=chunk_ignore_dirs,
         ),
     )
     registry.register(

--- a/codenib/compiler/manifest_storage.py
+++ b/codenib/compiler/manifest_storage.py
@@ -1492,6 +1492,10 @@ def _profile_config(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
     for axis in (*axes, *optional_axes):
         if axis not in entry.metadata:
             continue
+        if axis not in config:
+            raise _IncompleteProfile(
+                f"view {view_type!r} profile axis {axis!r} is missing from config"
+            )
         try:
             config_value = _canonical_bytes({"value": config[axis]})
             metadata_value = _canonical_bytes({"value": entry.metadata[axis]})

--- a/codenib/compiler/manifest_storage.py
+++ b/codenib/compiler/manifest_storage.py
@@ -45,7 +45,7 @@ REPO_MANIFEST_BM25_GENERATION_CONTRACT = "codenib.repo-manifest-bm25-generation.
 REPO_MANIFEST_VECTOR_GENERATION_CONTRACT = "codenib.repo-manifest-vector-generation.v1"
 
 PORTABLE_STORAGE_VIEWS = frozenset({"bm25", "vector"})
-CURRENT_PORTABLE_BUILDER_SCHEMAS = {"bm25": 8, "vector": 6}
+CURRENT_PORTABLE_BUILDER_SCHEMAS = {"bm25": 8, "vector": 7}
 
 DEFAULT_MAX_MANIFEST_BYTES = 16 * 1024 * 1024
 _MAX_JSON_DEPTH = 64
@@ -170,6 +170,11 @@ VECTOR_PROFILE_AXES = (
     "max_lines_per_chunk",
     "chunking_failure_policy",
     "repository_filter_policy",
+)
+_BM25_OPTIONAL_PROFILE_AXES = ("additional_ignore_dirs",)
+_VECTOR_OPTIONAL_PROFILE_AXES = (
+    "additional_ignore_dirs",
+    "embedding_document_max_chars",
 )
 
 _BM25_NON_PROFILE_CONFIG_FIELDS = frozenset(
@@ -1458,13 +1463,16 @@ def _require_profile_axes(
 def _profile_config(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
     config = entry.config
     axes: tuple[str, ...]
+    optional_axes: tuple[str, ...]
     non_profile: frozenset[str]
     embedding_load_policy: dict[str, Any] | None = None
     if view_type == "bm25":
         axes = BM25_PROFILE_AXES
+        optional_axes = _BM25_OPTIONAL_PROFILE_AXES
         non_profile = _BM25_NON_PROFILE_CONFIG_FIELDS
     elif view_type == "vector":
         axes = VECTOR_PROFILE_AXES
+        optional_axes = _VECTOR_OPTIONAL_PROFILE_AXES
         non_profile = _VECTOR_NON_PROFILE_CONFIG_FIELDS
     else:  # pragma: no cover - selection excludes unsupported views
         raise _IncompleteProfile(f"unsupported view profile: {view_type}")
@@ -1472,16 +1480,16 @@ def _profile_config(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
     _reject_unknown_config_fields(
         config,
         view_type=view_type,
-        profile_axes=axes,
+        profile_axes=(*axes, *optional_axes),
         non_profile_fields=non_profile,
     )
     _reject_unknown_metadata_fields(
         entry.metadata,
         view_type=view_type,
-        profile_axes=axes,
+        profile_axes=(*axes, *optional_axes),
         non_profile_fields=non_profile,
     )
-    for axis in axes:
+    for axis in (*axes, *optional_axes):
         if axis not in entry.metadata:
             continue
         try:
@@ -1522,6 +1530,11 @@ def _profile_config(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
         config["repository_filter_policy"],
         f"view {view_type!r} repository_filter_policy",
     )
+    if "additional_ignore_dirs" in config:
+        _text_list(
+            config["additional_ignore_dirs"],
+            f"view {view_type!r} additional_ignore_dirs",
+        )
 
     if view_type == "bm25":
         _positive_int(config["max_k"], "view 'bm25' max_k")
@@ -1568,13 +1581,32 @@ def _profile_config(entry: IndexEntry, *, view_type: str) -> dict[str, Any]:
                     "revision": None,
                     "trust_remote_code": False,
                 }
+            if route.provider == "openai":
+                if "embedding_document_max_chars" not in config:
+                    raise _IncompleteProfile(
+                        "view 'vector' remote embedding document bound is missing"
+                    )
+                _positive_int(
+                    config["embedding_document_max_chars"],
+                    "view 'vector' embedding_document_max_chars",
+                )
+            elif "embedding_document_max_chars" in config:
+                raise _IncompleteProfile(
+                    "view 'vector' local embedding route has a remote document bound"
+                )
+        except _IncompleteProfile:
+            raise
         except (TypeError, ValueError) as exc:
             raise _IncompleteProfile(
                 "view 'vector' embedding route or model policy is incomplete or "
                 "inconsistent"
             ) from exc
 
-    compatibility = {axis: config[axis] for axis in axes if axis != "builder_schema"}
+    compatibility = {
+        axis: config[axis]
+        for axis in (*axes, *optional_axes)
+        if axis != "builder_schema" and axis in config
+    }
     if embedding_load_policy is not None:
         # The load policy is derived without filesystem discovery.  Keeping it
         # explicit prevents policy defaults from becoming an identity wildcard.

--- a/codenib/graph/code_graph.py
+++ b/codenib/graph/code_graph.py
@@ -78,7 +78,7 @@ def persisted_graph_schema_version(input_path) -> Optional[int]:
             if opcode.name in integer_opcodes and isinstance(argument, int):
                 return argument
             return None
-    except (ValueError, pickle.UnpicklingError):
+    except Exception:  # noqa: BLE001 - every malformed prefix is unavailable
         return None
     return None
 

--- a/codenib/graph/code_graph.py
+++ b/codenib/graph/code_graph.py
@@ -4,6 +4,7 @@
 
 import bisect
 import pickle
+import pickletools
 from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -41,6 +42,45 @@ from ..types import (
 # v5: symbol vertices carry optional semantic symbol_kind plus explicit
 #     has_definition provenance; decoders may emit anchored import edges.
 _SCHEMA_VERSION = 5
+
+
+def current_graph_schema_version() -> int:
+    """Return the graph schema understood by this runtime."""
+
+    return _SCHEMA_VERSION
+
+
+def persisted_graph_schema_version(input_path) -> Optional[int]:
+    """Inspect the leading schema field without unpickling the graph payload.
+
+    ``save_graph`` writes ``schema_version`` as the first mapping entry. Reading
+    a short pickle prefix avoids importing a potentially large igraph object
+    merely to decide whether a Demo capability can be advertised.
+    """
+
+    try:
+        with open(input_path, "rb") as handle:
+            prefix = handle.read(128)
+    except OSError:
+        return None
+
+    found_key = False
+    memo_opcodes = {"MEMOIZE", "BINPUT", "LONG_BINPUT", "PUT"}
+    integer_opcodes = {"INT", "BININT", "BININT1", "BININT2", "LONG1", "LONG4"}
+    try:
+        for opcode, argument, _position in pickletools.genops(prefix):
+            if not found_key:
+                if argument == "schema_version":
+                    found_key = True
+                continue
+            if opcode.name in memo_opcodes:
+                continue
+            if opcode.name in integer_opcodes and isinstance(argument, int):
+                return argument
+            return None
+    except (ValueError, pickle.UnpicklingError):
+        return None
+    return None
 
 
 @dataclass(slots=True)

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -336,6 +336,7 @@ def build_hierarchical_vector_store(
     profiler: Optional[Profiler] = None,
     force_rebuild: bool = False,
     strict_chunking: bool = False,
+    additional_ignore_dirs: Optional[List[str]] = None,
     artifact_metadata: Optional[Dict[str, Any]] = None,
     native_index_authorization: NativeIndexAuthorization | None = None,
     _atomic_publish: bool = True,
@@ -421,6 +422,7 @@ def build_hierarchical_vector_store(
     languages = languages or ["python"]
     build_levels = normalized_levels
     repo_cfg = RepoChunkingConfig(languages=languages)
+    repo_cfg.ignore_dirs.update(additional_ignore_dirs or ())
 
     chunks_by_level = {}
     level_configs = {

--- a/codenib/index/embedding/text_policy.py
+++ b/codenib/index/embedding/text_policy.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic text bounds for remote embedding requests."""
+
+REMOTE_EMBEDDING_DOCUMENT_MAX_CHARS = 16_000
+_OMISSION_MARKER = "\n\n[CodeNib: middle omitted for embedding]\n\n"
+
+
+def bounded_remote_embedding_document(
+    text: str,
+    *,
+    max_chars: int = REMOTE_EMBEDDING_DOCUMENT_MAX_CHARS,
+) -> str:
+    """Keep a stable head/tail view within a remote model's context budget."""
+
+    if isinstance(max_chars, bool) or not isinstance(max_chars, int):
+        raise ValueError("embedding max_input_chars must be an integer")
+    if max_chars <= len(_OMISSION_MARKER):
+        raise ValueError("embedding max_input_chars is too small")
+    if len(text) <= max_chars:
+        return text
+    available = max_chars - len(_OMISSION_MARKER)
+    head_chars = available * 3 // 4
+    tail_chars = available - head_chars
+    return text[:head_chars] + _OMISSION_MARKER + text[-tail_chars:]

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -49,6 +49,10 @@ from .model_policy import (
     EmbeddingLoadPolicy,
     resolve_embedding_load_policy_from_options,
 )
+from .text_policy import (
+    REMOTE_EMBEDDING_DOCUMENT_MAX_CHARS,
+    bounded_remote_embedding_document,
+)
 
 logger = get_logger(__name__)
 
@@ -529,11 +533,26 @@ class _HuggingFaceEmbeddingWrapper:
 class _OpenAIEmbeddingWrapper:
     """Wraps the OpenAI SDK to expose ``embed_query`` / ``embed_documents``."""
 
-    def __init__(self, model: str, request_options: Optional[Dict] = None, **kwargs):
+    def __init__(
+        self,
+        model: str,
+        request_options: Optional[Dict] = None,
+        batch_size: int = 64,
+        max_input_chars: int = REMOTE_EMBEDDING_DOCUMENT_MAX_CHARS,
+        **kwargs,
+    ):
         from openai import OpenAI
 
+        if isinstance(batch_size, bool) or not isinstance(batch_size, int):
+            raise ValueError("embedding batch_size must be an integer")
+        if batch_size <= 0:
+            raise ValueError("embedding batch_size must be positive")
         self._model = model
         self._request_options = dict(request_options or {})
+        self._batch_size = batch_size
+        self._max_input_chars = max_input_chars
+        # Validate the bound before constructing the first request.
+        bounded_remote_embedding_document("", max_chars=max_input_chars)
         self._client = OpenAI(**kwargs)
 
     def embed_query(self, text: str) -> List[float]:
@@ -545,12 +564,57 @@ class _OpenAIEmbeddingWrapper:
         return resp.data[0].embedding
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
-        resp = self._client.embeddings.create(
-            input=texts,
-            model=self._model,
-            **self._request_options,
-        )
+        texts = [
+            bounded_remote_embedding_document(
+                text,
+                max_chars=self._max_input_chars,
+            )
+            for text in texts
+        ]
+        embeddings: List[List[float]] = []
+        for start in range(0, len(texts), self._batch_size):
+            embeddings.extend(
+                self._embed_document_batch(texts[start : start + self._batch_size])
+            )
+        return embeddings
+
+    def _embed_document_batch(self, texts: List[str]) -> List[List[float]]:
+        try:
+            resp = self._client.embeddings.create(
+                input=texts,
+                model=self._model,
+                **self._request_options,
+            )
+        except Exception as exc:
+            if len(texts) <= 1 or not self._request_exceeded_context(exc):
+                raise
+            midpoint = len(texts) // 2
+            logger.warning(
+                "Embedding request exceeded the provider context; retrying "
+                "as batches of %d and %d documents",
+                midpoint,
+                len(texts) - midpoint,
+            )
+            return [
+                *self._embed_document_batch(texts[:midpoint]),
+                *self._embed_document_batch(texts[midpoint:]),
+            ]
         return [d.embedding for d in sorted(resp.data, key=lambda x: x.index)]
+
+    @staticmethod
+    def _request_exceeded_context(exc: Exception) -> bool:
+        if getattr(exc, "status_code", None) != 400:
+            return False
+        message = str(exc).lower()
+        return any(
+            marker in message
+            for marker in (
+                "maximum context length",
+                "input_tokens",
+                "too many tokens",
+                "context_length_exceeded",
+            )
+        )
 
 
 def _to_document(obj: Any) -> _Document:

--- a/codenib/scip_interface/rust_analyzer.py
+++ b/codenib/scip_interface/rust_analyzer.py
@@ -12,6 +12,7 @@ import shutil
 from ..toolchains import RUST_TOOLCHAIN
 
 DEFAULT_RUST_TOOLCHAIN = RUST_TOOLCHAIN
+RUST_ANALYZER_ENV = "CODENIB_RUST_ANALYZER"
 
 
 def rust_toolchain() -> str:
@@ -22,9 +23,16 @@ def rust_toolchain() -> str:
 def rust_analyzer_command(*args: str) -> list[str]:
     """Build a rust-analyzer command.
 
+    An explicit executable is useful when a repository triggers a bug in the
+    managed release and an operator needs to validate a newer rust-analyzer
+    without replacing the project-wide pin.
+
     Prefer ``rustup run`` so PATH entries for standalone rust-analyzer binaries
     cannot bypass the requested toolchain.
     """
+    executable = os.environ.get(RUST_ANALYZER_ENV)
+    if executable:
+        return [os.path.expanduser(executable), *args]
     toolchain = rust_toolchain()
     if toolchain and shutil.which("rustup"):
         return ["rustup", "run", toolchain, "rust-analyzer", *args]

--- a/codenib/scip_interface/scip_indexer_ts.py
+++ b/codenib/scip_interface/scip_indexer_ts.py
@@ -471,8 +471,55 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
                 f"{self.project_root.resolve()}/**/*.tsx",
             ],
         }
+        project_root = self.project_root.resolve().as_posix().rstrip("/")
+        anchored_excludes = []
+        for raw_pattern in self.exclude_patterns:
+            pattern = str(raw_pattern).strip()
+            if not pattern:
+                continue
+            candidate = Path(pattern)
+            anchored = (
+                candidate.as_posix()
+                if candidate.is_absolute()
+                else f"{project_root}/{pattern.lstrip('/')}"
+            )
+            if anchored not in anchored_excludes:
+                anchored_excludes.append(anchored)
+        if anchored_excludes:
+            payload["exclude"] = anchored_excludes
         if base_config is not None:
             payload["extends"] = str(base_config.resolve())
+            try:
+                raw_content = base_config.read_text(encoding="utf-8")
+                stripped = re.sub(
+                    r'"(?:[^"\\]|\\.)*"|(/\*.*?\*/|//[^\n]*)',
+                    lambda match: "" if match.group(1) else match.group(0),
+                    raw_content,
+                    flags=re.DOTALL,
+                )
+                stripped = re.sub(r",\s*([}\]])", r"\1", stripped)
+                inherited_config = json.loads(stripped)
+            except (OSError, json.JSONDecodeError):
+                inherited_config = {}
+            if not isinstance(inherited_config, dict):
+                inherited_config = {}
+            inherited_excludes = inherited_config.get("exclude")
+            if isinstance(inherited_excludes, list):
+                anchored_excludes = []
+                for raw_pattern in [*inherited_excludes, *self.exclude_patterns]:
+                    pattern = str(raw_pattern).strip()
+                    if not pattern:
+                        continue
+                    candidate = Path(pattern)
+                    anchored = (
+                        candidate.as_posix()
+                        if candidate.is_absolute()
+                        else f"{project_root}/{pattern.lstrip('/')}"
+                    )
+                    if anchored not in anchored_excludes:
+                        anchored_excludes.append(anchored)
+                if anchored_excludes:
+                    payload["exclude"] = anchored_excludes
         self.output_dir.mkdir(parents=True, exist_ok=True)
         config_path = self.output_dir / self._READ_ONLY_TSCONFIG_NAME
         config_path.write_text(

--- a/codenib/scip_interface/scip_indexer_ts.py
+++ b/codenib/scip_interface/scip_indexer_ts.py
@@ -7,6 +7,7 @@
 """
 SCIP indexer for TypeScript and JavaScript projects using scip-typescript.
 """
+
 import json
 import re
 import shutil
@@ -305,6 +306,7 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
                 logger.warning("Fallback install also failed: %s", e2)
 
     _PATCHED_TSCONFIG_NAME = ".tsconfig.scip.json"
+    _READ_ONLY_TSCONFIG_NAME = ".tsconfig.scip.readonly.json"
 
     def _ensure_allow_js(self) -> Optional[Path]:
         """Create a temporary tsconfig with JS and repository-filter settings.
@@ -435,6 +437,50 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
         patched_path = self.project_root / self._PATCHED_TSCONFIG_NAME
         patched_path.unlink(missing_ok=True)
 
+    def _create_read_only_tsconfig(self) -> Path:
+        """Create an external config without writing into the source tree.
+
+        ``scip-typescript --infer-tsconfig`` writes ``tsconfig.json`` in its
+        working directory, and it does not recognize ``jsconfig.json`` on its
+        own.  A config in the artifact directory can extend either repository
+        config while keeping a shared checkout byte-for-byte unchanged.
+        """
+
+        base_config = next(
+            (
+                candidate
+                for candidate in (
+                    self.project_root / "tsconfig.json",
+                    self.project_root / "jsconfig.json",
+                )
+                if candidate.is_file()
+            ),
+            None,
+        )
+        payload: dict[str, object] = {
+            "compilerOptions": {"allowJs": True},
+            # A config's implicit include is relative to the config file, not
+            # to the extended config. Make the repository surface explicit
+            # because this wrapper intentionally lives outside the checkout.
+            "include": [
+                f"{self.project_root.resolve()}/**/*.js",
+                f"{self.project_root.resolve()}/**/*.jsx",
+                f"{self.project_root.resolve()}/**/*.mjs",
+                f"{self.project_root.resolve()}/**/*.cjs",
+                f"{self.project_root.resolve()}/**/*.ts",
+                f"{self.project_root.resolve()}/**/*.tsx",
+            ],
+        }
+        if base_config is not None:
+            payload["extends"] = str(base_config.resolve())
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        config_path = self.output_dir / self._READ_ONLY_TSCONFIG_NAME
+        config_path.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        return config_path
+
     def _normalize_workspace_kwargs(self, kwargs: dict) -> dict:
         """
         Ensure workspace flags are consistent with available package managers.
@@ -541,7 +587,15 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
         # Auto-select workspace mode when not explicitly provided.
         workspace_flags = ("yarn_workspaces", "pnpm_workspaces", "npm_workspaces")
         has_workspace_mode = any(kwargs.get(flag) for flag in workspace_flags)
-        if not has_workspace_mode:
+        has_root_config = (self.project_root / "tsconfig.json").is_file() or (
+            self.project_root / "jsconfig.json"
+        ).is_file()
+        if not has_workspace_mode and not has_root_config:
+            # A root config is an explicit project boundary and may already
+            # include every workspace source. Passing a workspace flag instead
+            # makes scip-typescript enumerate package manifests and can turn a
+            # healthy root project (for example Vue) into a successful but
+            # nearly empty index when its member packages have no tsconfig.
             # pnpm defines workspaces in pnpm-workspace.yaml (not package.json),
             # so check for it independently.
             has_pnpm_workspace_yaml = (
@@ -597,6 +651,7 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
             needs_generate = False
 
         cleanup_patched_tsconfig = False
+        read_only_tsconfig: Optional[Path] = None
         if needs_generate:
             if allow_project_preparation:
                 self._install_dependencies()
@@ -606,11 +661,13 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
                     cleanup_patched_tsconfig = True
             else:
                 logger.info(
-                    "Skipping project dependency installation and temporary "
-                    "tsconfig generation for read-only CodeGraph onboarding"
+                    "Skipping project dependency installation for read-only "
+                    "CodeGraph onboarding"
                 )
                 if not (self.project_root / "tsconfig.json").is_file():
-                    kwargs.setdefault("infer_tsconfig", True)
+                    read_only_tsconfig = self._create_read_only_tsconfig()
+                    kwargs["patched_tsconfig"] = str(read_only_tsconfig)
+                    kwargs["infer_tsconfig"] = False
         else:
             logger.info(
                 "Skipping dependency install and tsconfig patching (cached artifacts exist)"
@@ -628,3 +685,5 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
         finally:
             if cleanup_patched_tsconfig:
                 self._cleanup_patched_tsconfig()
+            if read_only_tsconfig is not None:
+                read_only_tsconfig.unlink(missing_ok=True)

--- a/codenib/scip_interface/typescript_semantics.py
+++ b/codenib/scip_interface/typescript_semantics.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import re
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -22,6 +23,7 @@ _DOCUMENTATION_RE = re.compile(r'(?:^|\n)\s*documentation:\s*"((?:\\.|[^"\\])*)"
 _TS_SIGNATURE_RE = re.compile(r"^```(?:ts|typescript)\\n(class|interface|enum|type)\s")
 _ROLES_RE = re.compile(r"symbol_roles:\s*(\d+)")
 _RANGE_RE = re.compile(r"(?:^|\n)\s*range:\s*(\d+)")
+_STATIC_MODULE_PARSERS = threading.local()
 
 
 def _snake_case(value: str) -> str:
@@ -126,39 +128,73 @@ def _point_in_span(
     return span[0] <= point < span[1]
 
 
-def _static_module_nodes(source: bytes, suffix: str):
-    from tree_sitter import Parser
-    from tree_sitter_language_pack import get_language
+def _static_module_parser(language_name: str):
+    """Reuse one native parser per language and thread.
 
-    language_name = "tsx" if suffix.lower() in {".tsx", ".jsx"} else "typescript"
-    language = get_language(language_name)
-    try:
-        parser = Parser(language)
-    except TypeError:  # tree-sitter < 0.25 compatibility
-        parser = Parser()
-        parser.language = language
-    root = parser.parse(source).root_node
-    return [
-        node
-        for node in root.named_children
-        if node.type == "import_statement"
-        or (
-            node.type == "export_statement"
+    Some language-pack builds corrupt native state when parsers for different
+    grammars are repeatedly created and destroyed in the same decoder pass.
+    Thread-local reuse avoids both that lifecycle bug and cross-thread parser
+    sharing.
+    """
+
+    from tree_sitter_language_pack import get_parser
+
+    parsers = getattr(_STATIC_MODULE_PARSERS, "parsers", None)
+    if parsers is None:
+        parsers = {}
+        _STATIC_MODULE_PARSERS.parsers = parsers
+    parser = parsers.get(language_name)
+    if parser is None:
+        # Use the language-pack parser directly. Constructing the separate
+        # ``tree_sitter.Parser`` binding around language-pack capsules corrupts
+        # native state after enough mixed TypeScript/JavaScript files on arm64.
+        parser = get_parser(language_name)
+        parsers[language_name] = parser
+    return parser
+
+
+def _static_module_nodes(source: bytes, suffix: str):
+    normalized_suffix = suffix.lower()
+    if normalized_suffix == ".tsx":
+        language_name = "tsx"
+    elif normalized_suffix in {".js", ".jsx"}:
+        # JavaScript's grammar natively includes JSX. Parsing large generated
+        # JavaScript (Babel's Makefile.js is one example) with the TypeScript
+        # grammar can corrupt tree-sitter's native state rather than merely
+        # returning error nodes.
+        language_name = "javascript"
+    else:
+        language_name = "typescript"
+    parser = _static_module_parser(language_name)
+    tree = parser.parse_bytes(source)
+    root_node = tree.root_node()
+    nodes = []
+    for index in range(root_node.named_child_count()):
+        node = root_node.named_child(index)
+        kind = node.kind()
+        if kind == "import_statement" or (
+            kind == "export_statement"
             and node.child_by_field_name("source") is not None
-        )
-    ]
+        ):
+            nodes.append(node)
+    # A tree-sitter ``Node`` borrows native memory owned by its ``Tree``. Keep
+    # the tree alive while callers read node coordinates; returning bare nodes
+    # can become a use-after-free once Python collects this local tree (large
+    # workspaces made that surface as a decoder segfault).
+    return source, parser, tree, nodes
 
 
 def _static_module_anchors(source: bytes, suffix: str):
+    _source, _parser, _tree, nodes = _static_module_nodes(source, suffix)
     return [
         (
             (
-                (node.start_point.row, node.start_point.column),
-                (node.end_point.row, node.end_point.column),
+                (node.start_position().row, node.start_position().column),
+                (node.end_position().row, node.end_position().column),
             ),
-            node.start_point.row,
+            node.start_position().row,
         )
-        for node in _static_module_nodes(source, suffix)
+        for node in nodes
     ]
 
 
@@ -167,16 +203,17 @@ def typescript_static_module_fingerprint(
 ) -> tuple[tuple[object, ...], ...]:
     """Fingerprint static import/re-export text and its source coordinates."""
 
+    _source, _parser, _tree, nodes = _static_module_nodes(source, suffix)
     return tuple(
         (
-            node.type,
-            node.start_point.row,
-            node.start_point.column,
-            node.end_point.row,
-            node.end_point.column,
-            source[node.start_byte : node.end_byte],
+            node.kind(),
+            node.start_position().row,
+            node.start_position().column,
+            node.end_position().row,
+            node.end_position().column,
+            source[node.start_byte() : node.end_byte()],
         )
-        for node in _static_module_nodes(source, suffix)
+        for node in nodes
     )
 
 
@@ -203,67 +240,75 @@ def enrich_typescript_import_edges(
     root = Path(project_root) if project_root is not None else None
     project_packages = _typescript_project_packages(decoded_content)
     added = 0
-    for document in extract_scip_blocks(decoded_content, "documents"):
-        path_match = re.search(r'relative_path:\s*"([^"]+)"', document)
-        if not path_match:
-            continue
-        source_file = Path(path_match.group(1)).as_posix()
-        if source_file not in code_graph.name_to_vertex:
-            continue
-        module_anchors = []
-        source_path = _safe_source_path(root, source_file) if root is not None else None
-        if source_path is not None:
-            try:
-                module_anchors = _static_module_anchors(
-                    source_path.read_bytes(), source_path.suffix
+    # A large decoded workspace already carries tens of thousands of reference
+    # edges. Adding import edges to igraph one at a time rebuilds its adjacency
+    # indexes after every insertion (quadratic work and, on Babel-scale graphs,
+    # a native igraph crash). Buffer the complete enrichment pass and publish
+    # it with one add_edges call.
+    with code_graph.batch_edges():
+        for document in extract_scip_blocks(decoded_content, "documents"):
+            path_match = re.search(r'relative_path:\s*"([^"]+)"', document)
+            if not path_match:
+                continue
+            source_file = Path(path_match.group(1)).as_posix()
+            if source_file not in code_graph.name_to_vertex:
+                continue
+            module_anchors = []
+            source_path = (
+                _safe_source_path(root, source_file) if root is not None else None
+            )
+            if source_path is not None:
+                try:
+                    module_anchors = _static_module_anchors(
+                        source_path.read_bytes(), source_path.suffix
+                    )
+                except (OSError, RuntimeError, TypeError, ValueError):
+                    pass
+            for occurrence in extract_scip_blocks(document, "occurrences"):
+                values = [int(value) for value in _RANGE_RE.findall(occurrence)]
+                if len(values) < 3:
+                    continue
+                roles_match = _ROLES_RE.search(occurrence)
+                roles = int(roles_match.group(1)) if roles_match else 0
+                if roles & 1:
+                    continue
+                point = (values[0], values[1])
+                statement_line = next(
+                    (
+                        anchor_line
+                        for span, anchor_line in module_anchors
+                        if _point_in_span(point, span)
+                    ),
+                    None,
                 )
-            except (OSError, RuntimeError, TypeError, ValueError):
-                pass
-        for occurrence in extract_scip_blocks(document, "occurrences"):
-            values = [int(value) for value in _RANGE_RE.findall(occurrence)]
-            if len(values) < 3:
-                continue
-            roles_match = _ROLES_RE.search(occurrence)
-            roles = int(roles_match.group(1)) if roles_match else 0
-            if roles & 1:
-                continue
-            point = (values[0], values[1])
-            statement_line = next(
-                (
-                    anchor_line
-                    for span, anchor_line in module_anchors
-                    if _point_in_span(point, span)
-                ),
-                None,
-            )
-            if not (roles & 2) and statement_line is None:
-                continue
-            symbol = extract_symbol(occurrence)
-            target = _typescript_symbol_target(symbol or "")
-            if target is None:
-                continue
-            target_package, target_file = target
-            if target_package[0].startswith("@types/"):
-                continue
-            if target_package[0] != "." and target_package not in project_packages:
-                continue
-            if target_file == source_file:
-                continue
-            target_id = code_graph.name_to_vertex.get(target_file)
-            if target_id is None:
-                continue
-            target_attrs = code_graph.graph.vs[target_id].attributes()
-            if target_attrs.get("type") != NODE_TYPE_FILE:
-                continue
-            before = code_graph.graph.ecount()
-            code_graph._add_edge(
-                source_file,
-                target_file,
-                EDGE_TYPE_IMPORT,
-                anchor_file=source_file,
-                anchor_line=(
-                    statement_line if statement_line is not None else values[0]
-                ),
-            )
-            added += int(code_graph.graph.ecount() > before)
+                if not (roles & 2) and statement_line is None:
+                    continue
+                symbol = extract_symbol(occurrence)
+                target = _typescript_symbol_target(symbol or "")
+                if target is None:
+                    continue
+                target_package, target_file = target
+                if target_package[0].startswith("@types/"):
+                    continue
+                if target_package[0] != "." and target_package not in project_packages:
+                    continue
+                if target_file == source_file:
+                    continue
+                target_id = code_graph.name_to_vertex.get(target_file)
+                if target_id is None:
+                    continue
+                target_attrs = code_graph.graph.vs[target_id].attributes()
+                if target_attrs.get("type") != NODE_TYPE_FILE:
+                    continue
+                before = len(code_graph._edge_index)
+                code_graph._add_edge(
+                    source_file,
+                    target_file,
+                    EDGE_TYPE_IMPORT,
+                    anchor_file=source_file,
+                    anchor_line=(
+                        statement_line if statement_line is not None else values[0]
+                    ),
+                )
+                added += int(len(code_graph._edge_index) > before)
     return added

--- a/codenib/toolchains.py
+++ b/codenib/toolchains.py
@@ -209,6 +209,7 @@ def managed_bin_dirs(root: Path | None = None) -> tuple[Path, ...]:
     directories = [
         root,
         root / "node-tools" / "node_modules" / ".bin",
+        root / "go" / "bin",
         root / "go-tools" / "bin",
         root / "dotnet-tools",
         root / "dotnet",

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -24,6 +24,7 @@ import os
 from contextlib import asynccontextmanager
 from functools import partial
 from pathlib import Path, PurePosixPath
+from time import perf_counter
 from urllib.parse import quote
 
 from fastapi import FastAPI, HTTPException, Request
@@ -99,6 +100,11 @@ async def lifespan(app: FastAPI):
     registry = RepoRegistry(
         config,
         native_index_authorization_resolver=authorize_local_manifest_vector,
+        # The Web demo may serve BM25 when a legacy/missing vector view cannot
+        # be authorized. The vector bytes are never opened on this path; strict
+        # authorization and integrity failures still fail closed once a v2
+        # source-bound capability is present.
+        allow_missing_native_index_authorization=True,
     )
     logger.info("Loading QA repos from %s ...", config.registry_path)
     registry.load_all()
@@ -128,6 +134,24 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def add_request_timing(request: Request, call_next):
+    """Expose backend time and log slow API paths without query contents."""
+
+    started_at = perf_counter()
+    response = await call_next(request)
+    duration_ms = (perf_counter() - started_at) * 1000
+    response.headers.append("Server-Timing", f"codenib;dur={duration_ms:.1f}")
+    if request.url.path.startswith("/api/") and duration_ms >= 2_000:
+        logger.info(
+            "Slow API request: %s %s %.1f ms",
+            request.method,
+            request.url.path,
+            duration_ms,
+        )
+    return response
 
 
 @app.exception_handler(RequestValidationError)
@@ -399,17 +423,38 @@ async def wiki_page_graph(repo_id: str, page_id: str) -> dict:
     Lets a wiki page render as a *view over the graph* (subsystem symbols + how
     they connect), using the same ``{nodes, edges}`` payload as ``/codemap``.
     """
-    page = await asyncio.to_thread(_wiki(repo_id).page, page_id)
-    if page is None:
-        raise HTTPException(status_code=404, detail=f"Unknown wiki page: {page_id!r}")
+    builder = _wiki(repo_id)
+    page_citations = getattr(builder, "page_citations", None)
+    if callable(page_citations):
+        citations = await asyncio.to_thread(page_citations, page_id)
+        if citations is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Unknown wiki page: {page_id!r}",
+            )
+    else:
+        # The deterministic WikiBuilder does not make a model call, so its
+        # existing page contract remains a safe compatibility fallback.
+        page = await asyncio.to_thread(builder.page, page_id)
+        if page is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Unknown wiki page: {page_id!r}",
+            )
+        citations = page.get("citations", []) if isinstance(page, dict) else []
     bundle = _bundle(repo_id)
     graph = await asyncio.to_thread(bundle.code_graph)
     if graph is None:
-        return {"available": False, "nodes": [], "edges": [], "mermaid": ""}
+        return {
+            "available": False,
+            "nodes": [],
+            "edges": [],
+            "mermaid": "",
+            "note": bundle.graph_unavailable_note(),
+        }
     from .codemap import build_page_subgraph
 
     hierarchy_graph = await asyncio.to_thread(bundle.hierarchical_graph)
-    citations = page.get("citations", []) if isinstance(page, dict) else []
     return await asyncio.to_thread(
         build_page_subgraph,
         graph,

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -722,8 +722,10 @@ async def chat(req: ChatRequest) -> ChatResponse:
         logger.error("agent run failed for %r: %s", req.repo_id, exc, exc_info=True)
         raise HTTPException(status_code=500, detail="agent run failed") from exc
 
-    return agent_result_to_response(
-        result, repo_path=getattr(bundle.manifest, "repo_path", "")
+    return await asyncio.to_thread(
+        agent_result_to_response,
+        result,
+        repo_path=getattr(bundle.entry, "repo_dir", ""),
     )
 
 

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -361,9 +361,18 @@ async def list_repos() -> list[RepoInfo]:
 
 
 @app.get("/api/repos/{repo_id}/wiki")
-async def wiki_tree(repo_id: str) -> dict:
+async def wiki_tree(repo_id: str, cached_only: bool = False) -> dict:
     builder = _wiki(repo_id)
-    pages = await asyncio.to_thread(builder.page_tree)
+    if cached_only:
+        cached_page_tree = getattr(builder, "cached_page_tree", None)
+        pages = (
+            await asyncio.to_thread(cached_page_tree)
+            if callable(cached_page_tree)
+            else None
+        )
+        pages = pages or []
+    else:
+        pages = await asyncio.to_thread(builder.page_tree)
     return {"repo": _bundle(repo_id).entry.repo, "pages": pages}
 
 

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -377,13 +377,17 @@ async def wiki_tree(repo_id: str, cached_only: bool = False) -> dict:
 
 
 @app.get("/api/repos/{repo_id}/wiki/{page_id}")
-async def wiki_page(repo_id: str, page_id: str) -> dict:
+async def wiki_page(
+    repo_id: str,
+    page_id: str,
+    materialize_media: bool = True,
+) -> dict:
     page = await asyncio.to_thread(_wiki(repo_id).page, page_id)
     if page is None:
         raise HTTPException(status_code=404, detail=f"Unknown wiki page: {page_id!r}")
     if "media_slots" not in page:
         page = {**page, "media_slots": []}
-    if page.get("media_slots"):
+    if materialize_media and page.get("media_slots"):
         page = await asyncio.to_thread(_materialize_wiki_media, repo_id, page_id, page)
     if "generation" not in page:
         page = {

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -726,6 +726,7 @@ async def chat(req: ChatRequest) -> ChatResponse:
         agent_result_to_response,
         result,
         repo_path=getattr(bundle.entry, "repo_dir", ""),
+        repo_commit=getattr(bundle.entry, "base_commit", ""),
     )
 
 

--- a/codenib/web/codemap.py
+++ b/codenib/web/codemap.py
@@ -966,6 +966,15 @@ def build_page_subgraph(
             break
 
     if not names:
+        if citations:
+            note = (
+                f"This page cites {len(citations)} source location"
+                f"{'s' if len(citations) != 1 else ''}, but none match symbols "
+                "in the active graph snapshot. Rebuild the symbol graph from "
+                "the same repository snapshot as the Wiki indexes."
+            )
+        else:
+            note = "This page has no source citations to map yet."
         return {
             "available": False,
             "root": "",
@@ -975,7 +984,7 @@ def build_page_subgraph(
             "edges": [],
             "hierarchy": empty_hierarchy(),
             "mermaid": "",
-            "note": "No graph symbols for this page.",
+            "note": note,
         }
 
     seeds = set(names)  # the page's own cited symbols (highlighted)

--- a/codenib/web/config.py
+++ b/codenib/web/config.py
@@ -33,6 +33,7 @@ from ..provider_routes import normalize_provider
 DEFAULT_CONFIG_PATH = "qa_config.yaml"
 CACHE_DIR_NAME = REPO_INDEX_DIRNAME
 REGISTRY_FILENAME = "qa_registry.json"
+CONFIG_EXTENDS_KEY = "extends"
 
 
 def _model_provider(model: str) -> Optional[str]:
@@ -40,6 +41,75 @@ def _model_provider(model: str) -> Optional[str]:
 
     provider, separator, _ = str(model or "").strip().partition("/")
     return provider.lower() if separator else None
+
+
+def _merge_config_data(
+    base: Dict[str, Any],
+    overlay: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return a recursive config merge where the overlay always wins.
+
+    Mappings are merged so a profile can override one nested model option
+    without copying the rest of the base profile. Scalars, lists, and explicit
+    ``null`` values replace the inherited value.
+    """
+
+    merged = dict(base)
+    for key, value in overlay.items():
+        if key == CONFIG_EXTENDS_KEY:
+            continue
+        inherited = merged.get(key)
+        if isinstance(inherited, dict) and isinstance(value, dict):
+            merged[key] = _merge_config_data(inherited, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _config_parents(value: Any, *, source: Path) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        parents = [value]
+    elif isinstance(value, list) and all(isinstance(item, str) for item in value):
+        parents = value
+    else:
+        raise ValueError(
+            f"{source}: {CONFIG_EXTENDS_KEY} must be a path or list of paths"
+        )
+    if any(not parent.strip() for parent in parents):
+        raise ValueError(f"{source}: {CONFIG_EXTENDS_KEY} paths cannot be empty")
+    return parents
+
+
+def _load_config_data(path: Path, *, chain: tuple[Path, ...] = ()) -> Dict[str, Any]:
+    """Load one YAML profile and recursively merge its relative parents."""
+
+    resolved = path.expanduser().resolve()
+    if resolved in chain:
+        cycle = " -> ".join(str(item) for item in (*chain, resolved))
+        raise ValueError(f"demo config extends cycle: {cycle}")
+    if not resolved.is_file():
+        if chain:
+            raise FileNotFoundError(f"demo config parent does not exist: {resolved}")
+        return {}
+
+    with resolved.open(encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"demo config must contain a YAML mapping: {resolved}")
+
+    merged: Dict[str, Any] = {}
+    next_chain = (*chain, resolved)
+    for parent in _config_parents(loaded.get(CONFIG_EXTENDS_KEY), source=resolved):
+        parent_path = Path(parent).expanduser()
+        if not parent_path.is_absolute():
+            parent_path = resolved.parent / parent_path
+        merged = _merge_config_data(
+            merged,
+            _load_config_data(parent_path, chain=next_chain),
+        )
+    return _merge_config_data(merged, loaded)
 
 
 @dataclass(slots=True)
@@ -229,12 +299,9 @@ class QAConfig:
 
 
 def load_config(path: Optional[str] = None) -> QAConfig:
-    """Load demo config from YAML, applying env overrides."""
+    """Load a layered demo config from YAML, then apply env overrides."""
     cfg_path = path or os.environ.get("CODENIB_DEMO_CONFIG", DEFAULT_CONFIG_PATH)
-    data = {}
-    if Path(cfg_path).exists():
-        with open(cfg_path) as f:
-            data = yaml.safe_load(f) or {}
+    data = _load_config_data(Path(cfg_path))
 
     defaults = QAConfig()
     cfg = QAConfig(

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -14,6 +14,7 @@ concurrent queries are safe.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from importlib.util import find_spec
 from threading import Lock
@@ -25,6 +26,7 @@ from ..index.embedding._lifecycle import close_vector_after_failure
 from ..log_utils import get_logger
 from ..provider_routes import normalize_endpoint, resolve_embedding_artifact_route
 from ..repository_summary import read_bound_repository_summary, read_repository_summary
+from ..source_fingerprint import is_secure_source_fingerprint_v2
 from .config import QAConfig, RepoEntry, load_registry
 from .schemas import GraphCoverage, RepoInfo
 
@@ -54,6 +56,10 @@ _DEMO_SYSTEM_PROMPT = (
     "When evidence exposes a candidate identifier, run a targeted search for "
     "its exact identifier and defining file; do not claim it is absent while "
     "an unresolved candidate identifier remains. "
+    "Trace wrapper chains breadth-first: combine every unresolved identifier "
+    "visible in the current evidence into one focused follow-up search instead "
+    "of spending one search on each wrapper. Do not name a downstream "
+    "implementation as fact until its implementation evidence was retrieved. "
     "Explain behaviour only after finding implementation evidence. Treat tests, "
     "examples, documentation, and validation scripts as corroboration, not as "
     "runtime mechanisms, unless the user asks about them explicitly. Distinguish "
@@ -65,7 +71,8 @@ _DEMO_SYSTEM_PROMPT = (
     "the fields used by an actual branch or comparison: computing age or a "
     "timestamp after a predicate does not make time the freshness criterion. "
     "Distinguish building an artifact from marking it stale, publishing it, "
-    "and loading it. Write a direct, well-structured final answer and name the "
+    "and loading it. Keep the final answer under 500 words unless the user asks "
+    "for more depth. Write a direct, well-structured final answer and name the "
     "strongest two to five repository-relative files or symbols so the reader "
     "can open them. For every action requested by the user, follow wrappers to "
     "the concrete implementation; a name or docstring saying that a method "
@@ -141,17 +148,50 @@ class RepoBundle:
         with self._runtime_lock:
             if self._runtime_loaded:
                 return
+            # A standalone maintenance worker may have released the views
+            # between the optimistic check above and this runtime lease.
+            self.ensure_views()
             if self.runtime_loader is None:
                 raise RuntimeError("repo runtime loader is not configured")
             self.runtime_loader(self)
             self._runtime_loaded = True
 
+    def release_views(self) -> bool:
+        """Release retrieval artifacts when no interactive runtime owns them.
+
+        This is intended for bounded maintenance jobs such as Wiki prewarming.
+        An initialized Ask runner retains its retrieval contexts, so those
+        bundles deliberately stay loaded for the lifetime of the process.
+        """
+
+        with self._runtime_lock:
+            if self._runtime_loaded:
+                return False
+            with self._views_lock:
+                if self._runtime_loaded:
+                    return False
+                vector_store = self.vector_store
+                self.vector_store = None
+                self.bm25 = None
+                self._views_loaded = self.view_loader is None
+                self._file_count_cache = None
+                if vector_store is not None:
+                    vector_store.close()
+                return True
+
     def info(self) -> RepoInfo:
         capabilities = dict(self.manifest.capabilities)
         # The prebuilt indexes ship a symbol graph that the manifest doesn't
         # declare; surface a "codemap" capability so the UI can offer the mode.
-        capabilities["codemap"] = (
-            self._graph_path() is not None and find_spec("igraph") is not None
+        graph_path = self._graph_path()
+        graph_load_failed = getattr(self, "_code_graph_loaded", False) and (
+            getattr(self, "_code_graph", None) is None
+        )
+        capabilities["codemap"] = bool(
+            graph_path is not None
+            and find_spec("igraph") is not None
+            and self._graph_schema_is_current()
+            and not graph_load_failed
         )
         capabilities["chat"] = self.chat_available
         display_name = self.entry.repo
@@ -257,12 +297,34 @@ class RepoBundle:
             return True
         return str(getattr(entry, "source_fingerprint", "") or "") == manifest_source
 
+    def _graph_schema_version(self) -> Optional[int]:
+        """Return the persisted graph schema using a bounded, safe prefix read."""
+
+        cached = getattr(self, "_graph_schema_version_cache", "?")
+        if cached != "?":
+            return cached
+        path = self._graph_path()
+        if path is None:
+            version = None
+        else:
+            from ..graph.code_graph import persisted_graph_schema_version
+
+            version = persisted_graph_schema_version(path)
+        self._graph_schema_version_cache = version
+        return version
+
+    def _graph_schema_is_current(self) -> bool:
+        from ..graph.code_graph import current_graph_schema_version
+
+        return self._graph_schema_version() == current_graph_schema_version()
+
     def code_graph(self) -> Optional[CodeGraph]:
         """Lazily load + cache the repo's symbol graph (None if unavailable)."""
         if getattr(self, "_code_graph_loaded", False):
             return self._code_graph
         self._code_graph_loaded = True
         self._code_graph = None
+        self._code_graph_error = None
         path = self._graph_path()
         if path is None:
             return None
@@ -275,12 +337,34 @@ class RepoBundle:
             )
         except Exception as exc:  # noqa: BLE001 - stale/old-format graph: skip codemap
             logger.warning("codemap: graph at %s unusable: %s", path, exc)
+            self._code_graph_error = str(exc)
             self._code_graph = None
         return self._code_graph
 
     def graph_unavailable_note(self) -> str:
         """Return an actionable reason when the dependency graph cannot load."""
 
+        from ..graph.code_graph import current_graph_schema_version
+
+        persisted_schema = self._graph_schema_version()
+        current_schema = current_graph_schema_version()
+        if persisted_schema is not None and persisted_schema != current_schema:
+            return (
+                f"Dependency graph uses schema {persisted_schema}, but this server "
+                f"requires schema {current_schema}. Rebuild symbol_graph for this "
+                "repository."
+            )
+        load_error = str(getattr(self, "_code_graph_error", "") or "")
+        schema_mismatch = re.search(
+            r"schema_version=([^,]+), expected ([^.]+)", load_error
+        )
+        if schema_mismatch:
+            observed, expected = schema_mismatch.groups()
+            return (
+                f"Dependency graph uses schema {observed}, but this server "
+                f"requires schema {expected}. Rebuild symbol_graph for this "
+                "repository."
+            )
         entry = self.manifest.indexes.get("symbol_graph")
         if entry is None:
             return (
@@ -600,6 +684,23 @@ class RepoRegistry:
                     raise ValueError(
                         "hybrid mode requires a current vector manifest entry"
                     )
+                bundle.vector_store = None
+                bundle.bm25 = bm25_index
+                return
+
+            if (
+                self._allow_missing_native_index_authorization
+                and not is_secure_source_fingerprint_v2(
+                    getattr(manifest, "source_fingerprint", None)
+                )
+            ):
+                logger.warning(
+                    "Skipping legacy native vector view at %s without source "
+                    "fingerprint v2; BM25 remains available. Rebuild the "
+                    "repository manifest and vector artifact to restore hybrid "
+                    "retrieval.",
+                    vec_entry.path,
+                )
                 bundle.vector_store = None
                 bundle.bm25 = bm25_index
                 return

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -17,7 +17,7 @@ import os
 import re
 from dataclasses import dataclass
 from importlib.util import find_spec
-from threading import Lock
+from threading import Lock, RLock
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
@@ -499,6 +499,7 @@ class RepoRegistry:
         # One embedding model per model name, shared across repos: the GPU model
         # is loaded once instead of once per CodeVectorStore (one per repo).
         self._embeddings: Dict[Tuple[str, str, int, Optional[str], str], object] = {}
+        self._embedding_load_lock = RLock()
 
     def load_all(self) -> None:
         """Load every dataset repo in the registry whose manifest exists."""
@@ -616,42 +617,47 @@ class RepoRegistry:
             client_kwargs = route.client_kwargs()
         embedding_kwargs.update(client_kwargs)
 
-        missing_embedding = object()
-        previous_embedding = self._embeddings.get(cache_key, missing_embedding)
-        vector_store = _vector_store_type()(
-            embedding_model=route.model,
-            embedding_provider=route.provider,
-            dimension=route.dimension,
-            index_metric=effective_route_config.get("index_metric", "ip"),
-            store_path=vec_entry.path,
-            embedding=self._embeddings.get(cache_key),
-            artifact_metadata=semantic_contract,
-            **embedding_kwargs,
-        )
-        candidate_embedding = missing_embedding
-        try:
-            candidate_embedding = vector_store.embedding
-            vector_store.load(
-                vec_entry.path,
-                native_index_authorization=native_index_authorization,
+        # Loading a cold local embedding model is the expensive part of opening
+        # a repository view.  Serialize construction and authenticated load so
+        # parallel prewarm workers cannot each observe an empty cache and place
+        # a duplicate model on the GPU before either one publishes it.
+        with self._embedding_load_lock:
+            missing_embedding = object()
+            previous_embedding = self._embeddings.get(cache_key, missing_embedding)
+            vector_store = _vector_store_type()(
+                embedding_model=route.model,
+                embedding_provider=route.provider,
+                dimension=route.dimension,
+                index_metric=effective_route_config.get("index_metric", "ip"),
+                store_path=vec_entry.path,
+                embedding=self._embeddings.get(cache_key),
+                artifact_metadata=semantic_contract,
+                **embedding_kwargs,
             )
-            # Publish the reusable client only after the authenticated vector
-            # view loaded successfully.  The exception handler below rolls
-            # this handoff back if cancellation lands before the return.
-            self._embeddings[cache_key] = candidate_embedding
-            return vector_store
-        except BaseException as primary:  # noqa: B036 - close partial state
-            if (
-                candidate_embedding is not missing_embedding
-                and self._embeddings.get(cache_key, missing_embedding)
-                is candidate_embedding
-            ):
-                if previous_embedding is missing_embedding:
-                    self._embeddings.pop(cache_key, None)
-                else:
-                    self._embeddings[cache_key] = previous_embedding
-            close_vector_after_failure(vector_store, primary)
-            raise
+            candidate_embedding = missing_embedding
+            try:
+                candidate_embedding = vector_store.embedding
+                vector_store.load(
+                    vec_entry.path,
+                    native_index_authorization=native_index_authorization,
+                )
+                # Publish the reusable client only after the authenticated vector
+                # view loaded successfully.  The exception handler below rolls
+                # this handoff back if cancellation lands before the return.
+                self._embeddings[cache_key] = candidate_embedding
+                return vector_store
+            except BaseException as primary:  # noqa: B036 - close partial state
+                if (
+                    candidate_embedding is not missing_embedding
+                    and self._embeddings.get(cache_key, missing_embedding)
+                    is candidate_embedding
+                ):
+                    if previous_embedding is missing_embedding:
+                        self._embeddings.pop(cache_key, None)
+                    else:
+                        self._embeddings[cache_key] = previous_embedding
+                close_vector_after_failure(vector_store, primary)
+                raise
 
     def _create_ask_llm(self) -> "LiteLLMChat":
         """Create the interactive model without mutating process-wide config."""

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -344,7 +344,19 @@ class RepoBundle:
     def graph_unavailable_note(self) -> str:
         """Return an actionable reason when the dependency graph cannot load."""
 
-        from ..graph.code_graph import current_graph_schema_version
+        if find_spec("igraph") is None:
+            return (
+                "Dependency graph support is unavailable. Install CodeNib with "
+                "the graph extra to inspect symbol_graph artifacts."
+            )
+        try:
+            from ..graph.code_graph import current_graph_schema_version
+        except ModuleNotFoundError as exc:
+            return (
+                "Dependency graph support is unavailable because the optional "
+                f"dependency {exc.name!r} is missing. Install CodeNib with the "
+                "graph extra."
+            )
 
         persisted_schema = self._graph_schema_version()
         current_schema = current_graph_schema_version()

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from codenib.agent.boundary import to_agent_repr
 
-from .repository_files import live_source_slice
+from .repository_files import git_source_slice, live_source_slice
 
 _MAX_REPO_ID_CHARS = 512
 _MAX_PATH_CHARS = 4096
@@ -293,6 +293,7 @@ def _select_answer_citations(
     *,
     limit: int = 5,
     repo_path: str = "",
+    repo_commit: str = "",
 ) -> List[Citation]:
     """Keep strong answer citations that resolve to exact repository source."""
 
@@ -319,12 +320,21 @@ def _select_answer_citations(
         if repo_path:
             if not citation.file or citation.start_line is None:
                 continue
-            source = live_source_slice(
-                repo_path,
-                citation.file,
-                citation.start_line,
-                citation.end_line or citation.start_line,
-            )
+            if repo_commit:
+                source = git_source_slice(
+                    repo_path,
+                    repo_commit,
+                    citation.file,
+                    citation.start_line,
+                    citation.end_line or citation.start_line,
+                )
+            else:
+                source = live_source_slice(
+                    repo_path,
+                    citation.file,
+                    citation.start_line,
+                    citation.end_line or citation.start_line,
+                )
             if not source or not str(source.get("content") or "").strip():
                 continue
             content = str(source["content"])
@@ -344,7 +354,11 @@ def _select_answer_citations(
     return renderable
 
 
-def agent_result_to_response(result: Any, repo_path: str = "") -> ChatResponse:
+def agent_result_to_response(
+    result: Any,
+    repo_path: str = "",
+    repo_commit: str = "",
+) -> ChatResponse:
     """Flatten an ``AgentResult`` into the API response.
 
     Retrieved locations are de-duplicated and narrowed to the strongest files
@@ -382,6 +396,7 @@ def agent_result_to_response(result: Any, repo_path: str = "") -> ChatResponse:
             result.answer or "",
             citations,
             repo_path=repo_path,
+            repo_commit=repo_commit,
         ),
         tool_calls=tool_calls,
         total_turns=result.total_turns,

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -18,6 +18,8 @@ from pydantic import BaseModel, Field, model_validator
 
 from codenib.agent.boundary import to_agent_repr
 
+from .repository_files import live_source_slice
+
 _MAX_REPO_ID_CHARS = 512
 _MAX_PATH_CHARS = 4096
 _MAX_EDGE_LABEL_CHARS = 1024
@@ -25,6 +27,7 @@ _MAX_EDGE_ANCHORS = 32
 _MAX_CHAT_MESSAGES = 128
 _MAX_CHAT_MESSAGE_CHARS = 64 * 1024
 _MAX_CHAT_TOTAL_CHARS = 256 * 1024
+_MAX_CITATION_CONTENT_CHARS = 16 * 1024
 
 
 class WindowStats(BaseModel):
@@ -289,8 +292,9 @@ def _select_answer_citations(
     citations: List[Citation],
     *,
     limit: int = 5,
+    repo_path: str = "",
 ) -> List[Citation]:
-    """Keep the strongest source locations actually named in the final answer."""
+    """Keep strong answer citations that resolve to exact repository source."""
 
     symbol_matches = [
         citation
@@ -309,7 +313,35 @@ def _select_answer_citations(
 
     if not selected:
         selected = citations
-    return selected[:limit]
+
+    renderable: List[Citation] = []
+    for citation in selected:
+        if repo_path:
+            if not citation.file or citation.start_line is None:
+                continue
+            source = live_source_slice(
+                repo_path,
+                citation.file,
+                citation.start_line,
+                citation.end_line or citation.start_line,
+            )
+            if not source or not str(source.get("content") or "").strip():
+                continue
+            content = str(source["content"])
+            if len(content) > _MAX_CITATION_CONTENT_CHARS:
+                content = content[:_MAX_CITATION_CONTENT_CHARS] + "\n... (truncated)"
+            citation = citation.model_copy(
+                update={
+                    "file": source.get("file") or citation.file,
+                    "start_line": source.get("start_line") or citation.start_line,
+                    "end_line": source.get("end_line") or citation.end_line,
+                    "content": content,
+                }
+            )
+        renderable.append(citation)
+        if len(renderable) >= limit:
+            break
+    return renderable
 
 
 def agent_result_to_response(result: Any, repo_path: str = "") -> ChatResponse:
@@ -346,7 +378,11 @@ def agent_result_to_response(result: Any, repo_path: str = "") -> ChatResponse:
 
     return ChatResponse(
         answer=result.answer or "",
-        citations=_select_answer_citations(result.answer or "", citations),
+        citations=_select_answer_citations(
+            result.answer or "",
+            citations,
+            repo_path=repo_path,
+        ),
         tool_calls=tool_calls,
         total_turns=result.total_turns,
         total_duration_ms=result.total_duration_ms,

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -23,7 +23,13 @@ import html
 import json
 import os
 import re
+import tempfile
+import threading
+from contextlib import nullcontext
+from time import perf_counter, time
 from typing import Any, Dict, List, Optional, Sequence
+
+from filelock import FileLock
 
 from ..log_utils import get_logger
 from ..repository_summary import readme_summary
@@ -87,7 +93,11 @@ _MAX_EXCERPT_LINES = 14
 _OUTLINE_PROMPT_VERSION = "13"
 _PAGE_PROMPT_VERSION = "106"
 _MAX_PLAN_REPAIRS = 3
+_MAX_FACT_PLAN_MODEL_CALLS = 3
+_MAX_COMPOSITION_PLAN_REPAIRS = 1
 _MAX_STYLE_REPAIRS = 2
+_MAX_DEGRADED_PAGE_RETRIES = 2
+_DEGRADED_PAGE_RETRY_COOLDOWN_SECONDS = 6 * 60 * 60
 # The overview is asked for a section per outline area, and a repository
 # outline runs to 9-17 of them. Twelve symbols could not ground that many,
 # so the coverage guard fired on pages that simply had nothing to say about
@@ -114,6 +124,7 @@ _COMPOSITION_PLAN_WARNING_MARKERS = (
     "must use an allocated relation",
     "needs a section-level",
     "substantially repeat an admitted fact",
+    "substantially repeats section",
     "needs one publishable, non-redundant claim",
     "needs at least two supported facts",
     "names a source file as a subsystem",
@@ -707,6 +718,22 @@ def _blocking_plan_warnings(warnings: Sequence[str]) -> List[str]:
         for warning in _hard_plan_warnings(warnings)
         if warning not in composition
     ]
+
+
+def _plan_repair_limit(warnings: Sequence[str]) -> int:
+    """Return the useful repair budget for the current diagnostics.
+
+    Unsupported facts may need more than one structural correction. Pure
+    composition feedback gets one chance: repeatedly asking a model to
+    reorganise already-grounded prose is expensive and rarely changes whether
+    the page is safe to publish.
+    """
+
+    if _blocking_plan_warnings(warnings):
+        return _MAX_PLAN_REPAIRS
+    if _composition_plan_warnings(warnings):
+        return _MAX_COMPOSITION_PLAN_REPAIRS
+    return 0
 
 
 def _plan_repair_score(
@@ -1393,7 +1420,103 @@ def _renderable_plan(
             else:
                 rendered_section.pop("lead", None)
             rendered_sections.append(rendered_section)
-    rendered["sections"] = rendered_sections
+    # Models commonly allocate the same high-level fact to several Overview
+    # topics.  Per-section de-duplication above cannot catch that, and the
+    # resulting page reads like a repeated symbol inventory even though every
+    # sentence is individually grounded.  Keep the first distinct claim and
+    # section globally, using the same conservative overlap floor as the
+    # reader-facing quality report.  Distinct code subjects remain distinct
+    # even when their surrounding workflow vocabulary is similar.
+    distinct_sections = []
+    admitted_claims: list[str] = []
+    intro_subject = _leading_code_subject(intro)
+    prior_sections: list[tuple[set[str], set[str]]] = (
+        [(intro_terms, {intro_subject} if intro_subject else set())]
+        if len(intro_terms) >= 6
+        else []
+    )
+    for section in rendered_sections:
+        distinct_claims = []
+        for claim in section.get("claims") or []:
+            statement = str(claim.get("statement") or "")
+            terms = _redundancy_terms(statement)
+            subject = _leading_code_subject(statement)
+            duplicate = False
+            for admitted in admitted_claims:
+                admitted_terms = _redundancy_terms(admitted)
+                smaller = min(len(terms), len(admitted_terms))
+                admitted_subject = _leading_code_subject(admitted)
+                if (
+                    smaller >= 6
+                    and len(terms & admitted_terms) / smaller >= 0.85
+                    and not (
+                        subject and admitted_subject and subject != admitted_subject
+                    )
+                ):
+                    duplicate = True
+                    break
+            if not duplicate:
+                distinct_claims.append(claim)
+        if not distinct_claims:
+            continue
+
+        rendered_section = copy.deepcopy(section)
+        rendered_section["claims"] = distinct_claims
+        claim_statements = [
+            str(claim.get("statement") or "") for claim in distinct_claims
+        ]
+        lead = rendered_section.get("lead") or {}
+        lead_statements = [
+            str(statement)
+            for statement in lead.get("statements") or []
+            if str(statement).strip()
+        ]
+        lead_statements = [
+            statement
+            for statement in lead_statements
+            if not any(
+                _substantially_repeats(statement, admitted)
+                for admitted in (*admitted_claims, *claim_statements)
+            )
+        ]
+        if lead_statements and lead.get("evidence"):
+            rendered_section["lead"] = {
+                "statements": lead_statements,
+                "evidence": list(lead.get("evidence") or []),
+            }
+        else:
+            rendered_section.pop("lead", None)
+
+        section_terms = set().union(
+            *(
+                _prose_terms(statement)
+                for statement in (*lead_statements, *claim_statements)
+            )
+        )
+        section_subjects = {
+            subject
+            for statement in (*lead_statements, *claim_statements)
+            if (subject := _leading_code_subject(statement))
+        }
+        repeats_prior_section = any(
+            min(len(section_terms), len(prior_terms)) >= 6
+            and len(section_terms & prior_terms)
+            / min(len(section_terms), len(prior_terms))
+            >= 0.8
+            and not (
+                section_subjects
+                and prior_subjects
+                and section_subjects.isdisjoint(prior_subjects)
+            )
+            for prior_terms, prior_subjects in prior_sections
+        )
+        if repeats_prior_section:
+            continue
+        distinct_sections.append(rendered_section)
+        admitted_claims.extend(claim_statements)
+        if section_terms:
+            prior_sections.append((section_terms, section_subjects))
+    rendered["sections"] = distinct_sections
     return rendered
 
 
@@ -1593,6 +1716,35 @@ def _fact_plan_markdown(
     return "\n\n".join(blocks)
 
 
+def _compact_dense_plan(
+    plan: dict[str, Any],
+    quality: dict[str, Any],
+) -> dict[str, Any]:
+    """Drop optional Overview sections that the rendered quality gate rejects."""
+
+    rejected = {
+        str(title)
+        for title in (
+            *(quality.get("thin_sections") or []),
+            *(quality.get("redundant_sections") or []),
+        )
+    }
+    if not rejected:
+        return plan
+    compacted = copy.deepcopy(plan)
+    compacted["sections"] = [
+        section
+        for section in compacted.get("sections") or []
+        if str(section.get("title") or "") not in rejected
+    ]
+    # Overview still needs three complementary areas. If pruning would erase
+    # that floor, retain the auditable degraded candidate instead of making a
+    # superficially green but empty landing page.
+    if len(compacted["sections"]) < 3:
+        return plan
+    return compacted
+
+
 def _candidate_score(
     report: dict[str, Any],
     quality: dict[str, Any],
@@ -1715,8 +1867,15 @@ def _ensure_cited_intro(
     if canonical_readme and intro is not None:
         text, evidence_id = intro
         canonical = _canonical_readme_sentence(text, repository_name)
-        if canonical:
+        canonical_plain = re.sub(r"[`*_[\]()#>-]", " ", canonical)
+        canonical_plain = re.sub(r"\s+", " ", canonical_plain).strip()
+        # Removing a promotional tail can leave a grammatical but useless
+        # fragment (for example, ``jq is a lightweight.``).  Such a fragment
+        # must not replace the longer source-supported thesis already rendered
+        # by the fact plan.
+        if canonical and len(canonical_plain) >= 40:
             sections = markdown[first_section.start() :] if first_section else ""
+            sections = _drop_redundant_purpose_section(sections, canonical)
             return f"{canonical} [{evidence_id}]\n\n{sections.lstrip()}".rstrip()
         intro = None
 
@@ -1730,6 +1889,26 @@ def _ensure_cited_intro(
         return markdown
     text, evidence_id = intro
     return f"{text} [{evidence_id}]\n\n{markdown.lstrip()}"
+
+
+def _drop_redundant_purpose_section(markdown: str, intro: str) -> str:
+    """Drop a Purpose block that only restates the canonical Overview intro."""
+
+    headings = list(re.finditer(r"^##\s+(.+?)\s*$", markdown, flags=re.MULTILINE))
+    for index, heading in enumerate(headings):
+        if heading.group(1).strip().casefold() != "purpose and scope":
+            continue
+        end = (
+            headings[index + 1].start() if index + 1 < len(headings) else len(markdown)
+        )
+        body = markdown[heading.end() : end]
+        intro_terms = _prose_terms(intro)
+        body_terms = _prose_terms(body)
+        smaller = min(len(intro_terms), len(body_terms))
+        if smaller < 6 or len(intro_terms & body_terms) / smaller < 0.8:
+            return markdown
+        return (markdown[: heading.start()] + markdown[end:]).strip()
+    return markdown
 
 
 _PLAN_PROMPT = """\
@@ -2888,10 +3067,100 @@ class AgentWiki:
         self._outline: Optional[Dict[str, Any]] = None
         self._pages: Dict[str, Dict[str, Any]] = {}
         self._retrieval_routes: Dict[tuple, tuple[str, ...]] = {}
+        # FastAPI serves Wiki work in a thread pool. Coalesce concurrent cold
+        # requests so one page/outline costs one provider call and one cache
+        # publication instead of generating duplicate prose in parallel.
+        self._outline_generation_lock = threading.Lock()
+        self._page_generation_locks_guard = threading.Lock()
+        self._page_generation_locks: Dict[str, Any] = {}
+        self._page_evidence_locks_guard = threading.Lock()
+        self._page_evidence_locks: Dict[str, Any] = {}
+        self._page_evidence: Dict[str, List[EvidenceItem]] = {}
+        # ``_retrieve`` records route provenance on the instance before
+        # ``_evidence_items`` consumes it. Keep that short pair atomic across
+        # page workers so one page cannot inherit another page's route labels.
+        self._evidence_retrieval_lock = threading.Lock()
+        # Page generation runs in a FastAPI worker thread. Preserve planning
+        # observations per thread so tests and extensions that replace
+        # ``_fact_plan`` keep the long-standing three-argument call contract.
+        self._fact_plan_observations = threading.local()
 
     # -- caching -----------------------------------------------------------
 
     def _key(self, suffix: str) -> str:
+        """Return a stable cache identity for equivalent repository views."""
+
+        entry = self._bundle.entry
+        commit = getattr(entry, "commit_short", "") or getattr(entry, "base_commit", "")
+        manifest = getattr(self._bundle, "manifest", None)
+        indexes = getattr(manifest, "indexes", {})
+        view_parts = []
+        for name, view in sorted(indexes.items()):
+            config = getattr(view, "config", {}) or {}
+            config_hash = hashlib.sha1(
+                json.dumps(
+                    config,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ).encode("utf-8")
+            ).hexdigest()[:10]
+            metadata = getattr(view, "metadata", {}) or {}
+            receipt = {
+                key: metadata[key]
+                for key in (
+                    "artifact_digest",
+                    "artifact_schema",
+                    "batch_digest",
+                    "builder_schema",
+                    "digest",
+                    "payload_digest",
+                    "reuse_key",
+                    "schema_version",
+                    "tree_digest",
+                )
+                if key in metadata
+            }
+            receipt_hash = hashlib.sha1(
+                json.dumps(
+                    receipt,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ).encode("utf-8")
+            ).hexdigest()[:10]
+            view_parts.append(
+                f"{name}:{getattr(view, 'status', '')}:"
+                f"{getattr(view, 'commit', '')}:"
+                f"{getattr(view, 'source_fingerprint', '')}:"
+                f"{config_hash}:{receipt_hash}"
+            )
+        view_identity = ",".join(view_parts)
+        source_identity = (
+            getattr(manifest, "source_fingerprint", "")
+            or getattr(manifest, "last_indexed_source_fingerprint", "")
+            or getattr(manifest, "commit", "")
+            or commit
+        )
+        prompt_version = (
+            _OUTLINE_PROMPT_VERSION if suffix == "outline" else _PAGE_PROMPT_VERSION
+        )
+        # Deliberately model-independent: the key identifies *what* was asked
+        # (prompt version + repo snapshot + index state), not *who* answered.
+        # Binding the model/endpoint into the key made every backend swap
+        # discard the whole corpus (~800 pages, hours of generation). The
+        # producing model is recorded in the cache entry instead — see
+        # ``_write_cache`` — mirroring EdgeLabeler's namespace-only keying.
+        raw = (
+            f"stable-v2/{prompt_version}/"
+            f"{getattr(entry, 'instance_id', 'repo')}@{commit}/"
+            f"{source_identity}/{view_identity}/{suffix}"
+        )
+        return hashlib.sha1(raw.encode()).hexdigest()[:16]
+
+    def _legacy_key(self, suffix: str) -> str:
+        """Return the timestamp-bound key used before stable cache identity."""
+
         entry = self._bundle.entry
         commit = getattr(entry, "commit_short", "") or getattr(entry, "base_commit", "")
         indexes = getattr(getattr(self._bundle, "manifest", None), "indexes", {})
@@ -2912,19 +3181,12 @@ class AgentWiki:
                 f"{getattr(view, 'source_fingerprint', '')}:"
                 f"{getattr(view, 'built_at_epoch', '')}:{config_hash}"
             )
-        view_identity = ",".join(view_parts)
         prompt_version = (
             _OUTLINE_PROMPT_VERSION if suffix == "outline" else _PAGE_PROMPT_VERSION
         )
-        # Deliberately model-independent: the key identifies *what* was asked
-        # (prompt version + repo snapshot + index state), not *who* answered.
-        # Binding the model/endpoint into the key made every backend swap
-        # discard the whole corpus (~800 pages, hours of generation). The
-        # producing model is recorded in the cache entry instead — see
-        # ``_write_cache`` — mirroring EdgeLabeler's namespace-only keying.
         raw = (
             f"{prompt_version}/{getattr(entry, 'instance_id', 'repo')}@{commit}/"
-            f"{view_identity}/{suffix}"
+            f"{','.join(view_parts)}/{suffix}"
         )
         return hashlib.sha1(raw.encode()).hexdigest()[:16]
 
@@ -2945,7 +3207,18 @@ class AgentWiki:
         if not self._cache_dir:
             return None
         os.makedirs(self._cache_dir, exist_ok=True)
-        return os.path.join(self._cache_dir, f"agentwiki_{self._key(suffix)}.json")
+        return self._cache_candidate_paths(suffix)[0]
+
+    def _cache_candidate_paths(self, suffix: str) -> tuple[str, ...]:
+        """Return stable then legacy cache paths without touching the disk."""
+
+        if not self._cache_dir:
+            return ()
+        keys = (self._key(suffix), self._legacy_key(suffix))
+        return tuple(
+            os.path.join(self._cache_dir, f"agentwiki_{key}.json")
+            for key in dict.fromkeys(keys)
+        )
 
     @staticmethod
     def _page_cache_suffix(meta: Dict[str, Any]) -> str:
@@ -2962,33 +3235,189 @@ class AgentWiki:
         return f"page_{meta.get('id', 'page')}_{identity}"
 
     def _read_cache(self, suffix: str) -> Optional[Any]:
-        path = self._cache_path(suffix)
-        if path and os.path.isfile(path):
+        paths = self._cache_candidate_paths(suffix)
+        for index, path in enumerate(paths):
+            if not os.path.isfile(path):
+                continue
             try:
                 with open(path, encoding="utf-8") as fh:
-                    return json.load(fh).get("data")
+                    envelope = json.load(fh)
             except (OSError, json.JSONDecodeError):
-                return None
+                continue
+            if not isinstance(envelope, dict) or "data" not in envelope:
+                continue
+            if index > 0 and paths:
+                # Adopt the current timestamp-bound entry into the stable key
+                # before a future equivalent index rebuild changes its legacy
+                # identity. Preserve the original model provenance envelope.
+                try:
+                    self._atomic_write_cache(paths[0], envelope, if_absent=True)
+                except (OSError, TypeError):
+                    pass
+            return envelope.get("data")
         return None
+
+    @staticmethod
+    def _atomic_write_cache(
+        path: str,
+        envelope: dict[str, Any],
+        *,
+        if_absent: bool = False,
+    ) -> None:
+        """Publish one complete JSON envelope under an inter-process lock."""
+
+        parent = os.path.dirname(path)
+        os.makedirs(parent, exist_ok=True)
+        with FileLock(f"{path}.lock"):
+            if if_absent and os.path.isfile(path):
+                return
+            descriptor, temporary_path = tempfile.mkstemp(
+                prefix=f".{os.path.basename(path)}.",
+                suffix=".tmp",
+                dir=parent,
+            )
+            try:
+                with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                    json.dump(envelope, handle)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(temporary_path, path)
+                temporary_path = ""
+                try:
+                    directory_descriptor = os.open(parent, os.O_RDONLY)
+                    try:
+                        os.fsync(directory_descriptor)
+                    finally:
+                        os.close(directory_descriptor)
+                except OSError:
+                    pass
+            finally:
+                if temporary_path:
+                    try:
+                        os.unlink(temporary_path)
+                    except OSError:
+                        pass
+
+    def _cache_generation_lock(self, suffix: str) -> Any:
+        path = self._cache_path(suffix)
+        if not path:
+            return nullcontext()
+        return FileLock(f"{path}.generate.lock")
+
+    @staticmethod
+    def _cached_page_is_degraded(page: Any) -> bool:
+        """Return whether persisted prose is intentionally hidden from readers."""
+
+        if not isinstance(page, dict):
+            return False
+        generation = page.get("generation") or {}
+        return bool(
+            generation.get("mode") == "degraded"
+            and (
+                generation.get("fallback") == "fact_plan"
+                or (page.get("quality") or {}).get("valid") is False
+            )
+        )
+
+    @staticmethod
+    def _cached_page_needs_regeneration(page: Any) -> bool:
+        """Return whether a bad persisted page is due for a bounded retry.
+
+        A failed planning pass still carries useful evidence metadata, so it is
+        written for auditability.  It is not durable Wiki content, though: a
+        later process may have a healthy provider response and should get a
+        bounded, cooled-down chance to replace it instead of serving diagnostic
+        prose forever or retrying it on every process restart.
+        """
+
+        if not AgentWiki._cached_page_is_degraded(page):
+            return False
+        generation = page.get("generation") or {}
+        retry = generation.get("retry") or {}
+        attempts = int(retry.get("attempts") or 0)
+        if attempts >= _MAX_DEGRADED_PAGE_RETRIES:
+            return False
+        next_attempt_epoch = retry.get("next_attempt_epoch")
+        return not isinstance(next_attempt_epoch, (int, float)) or time() >= float(
+            next_attempt_epoch
+        )
+
+    @staticmethod
+    def _record_page_retry(
+        page: Any,
+        *,
+        previous: Any = None,
+        now_epoch: Optional[float] = None,
+    ) -> None:
+        """Persist retry state on an attempted page without changing prose."""
+
+        if not isinstance(page, dict):
+            return
+        generation = page.get("generation")
+        if not isinstance(generation, dict):
+            return
+        previous_generation = (
+            previous.get("generation") if isinstance(previous, dict) else None
+        ) or {}
+        previous_retry = previous_generation.get("retry") or {}
+        previous_retryable = bool(
+            previous_generation.get("mode") == "degraded"
+            and (
+                previous_generation.get("fallback") == "fact_plan"
+                or (previous.get("quality") or {}).get("valid") is False
+            )
+        )
+        attempts = int(previous_retry.get("attempts") or 0)
+        if previous_retryable:
+            attempts += 1
+        retryable = bool(
+            generation.get("mode") == "degraded"
+            and (
+                generation.get("fallback") == "fact_plan"
+                or (page.get("quality") or {}).get("valid") is False
+            )
+        )
+        if not retryable and not previous_retryable:
+            return
+        now = time() if now_epoch is None else float(now_epoch)
+        if retryable and attempts < _MAX_DEGRADED_PAGE_RETRIES:
+            state = "scheduled"
+            next_attempt_epoch: Optional[float] = (
+                now + _DEGRADED_PAGE_RETRY_COOLDOWN_SECONDS
+            )
+        elif retryable:
+            state = "exhausted"
+            next_attempt_epoch = None
+        else:
+            state = "recovered"
+            next_attempt_epoch = None
+        generation["retry"] = {
+            "state": state,
+            "attempts": attempts,
+            "max_attempts": _MAX_DEGRADED_PAGE_RETRIES,
+            "last_attempt_epoch": round(now, 3),
+            "next_attempt_epoch": (
+                round(next_attempt_epoch, 3) if next_attempt_epoch is not None else None
+            ),
+        }
 
     def _write_cache(self, suffix: str, data: Any) -> None:
         path = self._cache_path(suffix)
         if not path:
             return
         try:
-            with open(path, "w", encoding="utf-8") as fh:
-                json.dump(
-                    {
-                        # Provenance only — none of this is part of the cache
-                        # key, so a later backend swap reuses this entry.
-                        "model": self._model,
-                        "api_base": self._api_base or "",
-                        "llm_identity": self._cache_llm_identity,
-                        "data": data,
-                    },
-                    fh,
-                )
-        except OSError:
+            self._atomic_write_cache(
+                path,
+                {
+                    # Provenance only — none of this is part of the cache key,
+                    # so a later backend swap reuses this entry.
+                    "model": self._model,
+                    "api_base": self._api_base or "",
+                    "llm_identity": self._cache_llm_identity,
+                    "data": data,
+                },
+            )
+        except (OSError, TypeError):
             pass
 
     # -- outline + nav -----------------------------------------------------
@@ -2996,16 +3425,20 @@ class AgentWiki:
     def outline(self) -> Dict[str, Any]:
         if self._outline is not None:
             return self._outline
-        cached = self._read_cache("outline")
-        if cached and cached.get("pages"):
-            self._outline = cached
-            return cached
-        data = generate_outline(self._bundle, self._model, llm=self._client())
-        self._normalize(data.get("pages", []), seen=set(), first=True)
-        self._outline = data
-        if data.get("pages"):
-            self._write_cache("outline", data)
-        return data
+        with self._outline_generation_lock:
+            if self._outline is not None:
+                return self._outline
+            with self._cache_generation_lock("outline"):
+                cached = self._read_cache("outline")
+                if cached and cached.get("pages"):
+                    self._outline = cached
+                    return cached
+                data = generate_outline(self._bundle, self._model, llm=self._client())
+                self._normalize(data.get("pages", []), seen=set(), first=True)
+                self._outline = data
+                if data.get("pages"):
+                    self._write_cache("outline", data)
+                return data
 
     def _normalize(self, pages: List[Dict[str, Any]], seen: set, first: bool) -> None:
         """Ensure unique slug ids; force the first page id to 'overview'."""
@@ -3022,17 +3455,42 @@ class AgentWiki:
             self._normalize(p.get("children", []) or [], seen, first=False)
 
     def page_tree(self) -> List[dict]:
-        def refs(pages: List[Dict[str, Any]]) -> List[dict]:
+        outline_pages = self.outline().get("pages", [])
+
+        def refs(pages: List[Dict[str, Any]], *, top_level: bool = False) -> List[dict]:
             return [
                 {
                     "id": p["id"],
                     "title": p.get("title", p["id"]),
+                    "cache_state": self._page_cache_state(
+                        self._overview_page_meta(p, outline_pages[1:])
+                        if top_level and p.get("id") == "overview"
+                        else p
+                    ),
                     "children": refs(p.get("children", []) or []),
                 }
                 for p in pages
             ]
 
-        return refs(self.outline().get("pages", []))
+        return refs(outline_pages, top_level=True)
+
+    def _page_cache_state(self, meta: Dict[str, Any]) -> str:
+        """Return a reader-facing cache state without generating the page."""
+
+        page_id = str(meta.get("id") or "")
+        page = self._pages.get(page_id)
+        if page is None:
+            page = self._read_cache(self._page_cache_suffix(meta))
+        if not isinstance(page, dict):
+            return "cold"
+        invalid = self._cached_page_is_degraded(page)
+        if invalid:
+            return (
+                "retryable"
+                if self._cached_page_needs_regeneration(page)
+                else "degraded"
+            )
+        return "ready"
 
     def _find(
         self, page_id: str, pages: Optional[List[Dict[str, Any]]] = None
@@ -3049,8 +3507,100 @@ class AgentWiki:
 
     # -- page generation ---------------------------------------------------
 
-    def page(self, page_id: str) -> Optional[dict]:
-        if page_id in self._pages:
+    def _page_generation_lock(self, page_id: str) -> Any:
+        with self._page_generation_locks_guard:
+            return self._page_generation_locks.setdefault(page_id, threading.Lock())
+
+    def _page_evidence_lock(self, cache_suffix: str) -> Any:
+        with self._page_evidence_locks_guard:
+            return self._page_evidence_locks.setdefault(cache_suffix, threading.Lock())
+
+    def _source_evidence(self, meta: Dict[str, Any]) -> List[EvidenceItem]:
+        """Retrieve source evidence once per page without invoking a model."""
+
+        cache_suffix = self._page_cache_suffix(meta)
+        cached = self._page_evidence.get(cache_suffix)
+        if cached is not None:
+            return cached
+        with self._page_evidence_lock(cache_suffix):
+            cached = self._page_evidence.get(cache_suffix)
+            if cached is not None:
+                return cached
+            with self._evidence_retrieval_lock:
+                nodes = self._retrieve(
+                    meta,
+                    top_k=(
+                        _OVERVIEW_RETRIEVAL_LIMIT
+                        if meta.get("id") == "overview"
+                        else 12
+                    ),
+                )
+                evidence = self._evidence_items(nodes)
+            self._page_evidence[cache_suffix] = evidence
+            return evidence
+
+    @staticmethod
+    def _citation_payload(evidence: Sequence[EvidenceItem]) -> List[dict[str, Any]]:
+        return [
+            {
+                "file": item.file,
+                "start_line": item.start_line,
+                "end_line": item.end_line,
+                "node_name": item.symbol,
+                "type": item.kind,
+                "score": None,
+                "content": None,
+            }
+            for item in evidence
+        ]
+
+    def page_citations(self, page_id: str) -> Optional[List[dict[str, Any]]]:
+        """Resolve graph seeds for a page without generating its prose."""
+
+        meta = self._find(page_id)
+        if meta is None:
+            return None
+        if page_id == "overview":
+            meta = self._overview_page_meta(
+                meta,
+                self.outline().get("pages", [])[1:],
+            )
+        page_suffix = self._page_cache_suffix(meta)
+        page = self._pages.get(page_id) or self._read_cache(page_suffix)
+        if isinstance(page, dict) and isinstance(page.get("citations"), list):
+            return page["citations"]
+
+        evidence_suffix = f"evidence_{page_suffix}"
+        cached = self._read_cache(evidence_suffix)
+        if isinstance(cached, dict) and isinstance(cached.get("citations"), list):
+            return cached["citations"]
+        with self._cache_generation_lock(evidence_suffix):
+            cached = self._read_cache(evidence_suffix)
+            if isinstance(cached, dict) and isinstance(cached.get("citations"), list):
+                return cached["citations"]
+            citations = self._citation_payload(self._source_evidence(meta))
+            self._write_cache(
+                evidence_suffix,
+                {"id": page_id, "citations": citations},
+            )
+            return citations
+
+    def page(
+        self,
+        page_id: str,
+        *,
+        retry_degraded_now: bool = False,
+    ) -> Optional[dict]:
+        """Return a page, optionally retrying hidden degraded prose immediately.
+
+        ``retry_degraded_now`` is an explicit operator action used by the cache
+        prewarmer after an index or model upgrade. Normal reader traffic still
+        observes the persisted cooldown and retry ceiling.
+        """
+
+        if page_id in self._pages and not (
+            retry_degraded_now and self._cached_page_is_degraded(self._pages[page_id])
+        ):
             return self._pages[page_id]
         meta = self._find(page_id)
         if meta is None:
@@ -3061,27 +3611,58 @@ class AgentWiki:
                 self.outline().get("pages", [])[1:],
             )
         cache_suffix = self._page_cache_suffix(meta)
-        cached = self._read_cache(cache_suffix)
-        if cached:
-            if "media_slots" not in cached:
-                evidence_meta = cached.get("evidence") or {}
-                cached = {
-                    **cached,
-                    "media_slots": plan_media_slots(
-                        page_id=str(cached.get("id") or meta.get("id") or ""),
-                        title=str(cached.get("title") or meta.get("title") or ""),
-                        citations=cached.get("citations") or (),
-                        diagram=str(cached.get("diagram") or ""),
+        with self._page_generation_lock(page_id):
+            if page_id in self._pages and not (
+                retry_degraded_now
+                and self._cached_page_is_degraded(self._pages[page_id])
+            ):
+                return self._pages[page_id]
+            with self._cache_generation_lock(cache_suffix):
+                cached = self._read_cache(cache_suffix)
+                force_retry = bool(
+                    retry_degraded_now and self._cached_page_is_degraded(cached)
+                )
+                if (
+                    cached
+                    and not force_retry
+                    and not self._cached_page_needs_regeneration(cached)
+                ):
+                    if "media_slots" not in cached:
+                        evidence_meta = cached.get("evidence") or {}
+                        cached = {
+                            **cached,
+                            "media_slots": plan_media_slots(
+                                page_id=str(cached.get("id") or meta.get("id") or ""),
+                                title=str(
+                                    cached.get("title") or meta.get("title") or ""
+                                ),
+                                citations=cached.get("citations") or (),
+                                diagram=str(cached.get("diagram") or ""),
+                                relations=evidence_meta.get("relations") or (),
+                            ),
+                        }
+                        self._write_cache(cache_suffix, cached)
+                    self._pages[page_id] = cached
+                    return cached
+                if cached:
+                    logger.info(
+                        "Regenerating degraded Wiki page for %s",
+                        page_id,
+                    )
+                page = self._generate_page(meta)
+                if "media_slots" not in page:
+                    evidence_meta = page.get("evidence") or {}
+                    page["media_slots"] = plan_media_slots(
+                        page_id=str(page.get("id") or meta.get("id") or ""),
+                        title=str(page.get("title") or meta.get("title") or ""),
+                        citations=page.get("citations") or (),
+                        diagram=str(page.get("diagram") or ""),
                         relations=evidence_meta.get("relations") or (),
-                    ),
-                }
-                self._write_cache(cache_suffix, cached)
-            self._pages[page_id] = cached
-            return cached
-        page = self._generate_page(meta)
-        self._pages[page_id] = page
-        self._write_cache(cache_suffix, page)
-        return page
+                    )
+                self._record_page_retry(page, previous=cached)
+                self._pages[page_id] = page
+                self._write_cache(cache_suffix, page)
+                return page
 
     def _retrieve(self, meta: Dict[str, Any], top_k: int = 12) -> List[Any]:
         ensure_views = getattr(self._bundle, "ensure_views", None)
@@ -4108,7 +4689,57 @@ class AgentWiki:
         meta: Dict[str, Any],
         evidence: List[EvidenceItem],
         relations: List[RelationItem],
+        *,
+        metrics: Optional[Dict[str, Any]] = None,
     ) -> tuple[dict[str, Any], List[str]]:
+        planning_started = perf_counter()
+        if metrics is None:
+            metrics = {}
+        else:
+            metrics.clear()
+        metrics.update(
+            {
+                "model_calls": 0,
+                "model_failures": 0,
+                "model_call_ms": 0.0,
+                "initial_attempts": 0,
+                "fresh_replans": 0,
+                "repair_attempts": 0,
+            }
+        )
+
+        def complete_plan(
+            content: str,
+            *,
+            phase: str,
+            max_tokens: int,
+        ) -> str:
+            call_started = perf_counter()
+            metrics["model_calls"] += 1
+            if phase == "initial":
+                metrics["initial_attempts"] += 1
+            elif phase == "fresh_replan":
+                metrics["fresh_replans"] += 1
+            elif phase == "repair":
+                metrics["repair_attempts"] += 1
+            try:
+                return self._client().complete(
+                    [{"role": "user", "content": content}],
+                    max_tokens=max_tokens,
+                    temperature=0.0,
+                )
+            except Exception:
+                metrics["model_failures"] += 1
+                raise
+            finally:
+                metrics["model_call_ms"] += (perf_counter() - call_started) * 1000
+
+        def finish_metrics() -> None:
+            metrics["planning_ms"] = (perf_counter() - planning_started) * 1000
+            for key in ("model_call_ms", "planning_ms"):
+                metrics[key] = round(float(metrics[key]), 1)
+            self._fact_plan_observations.latest = dict(metrics)
+
         prompt = _PLAN_PROMPT.format(
             repo=getattr(self._bundle.entry, "repo", "this repository"),
             title=meta.get("title", ""),
@@ -4121,14 +4752,15 @@ class AgentWiki:
         )
         allowed = [item.id for item in evidence] + [item.id for item in relations]
         errors: List[str] = []
+        sticky_blocks: dict[str, Any] = {}
         try:
-            text = self._client().complete(
-                [{"role": "user", "content": prompt}],
+            text = complete_plan(
+                prompt,
+                phase="initial",
                 # A plan now carries framing, a scan table and up to six
                 # sections; 1200 truncated the JSON mid-object, which parsed as
                 # "no supported sections" and sent every page through repair.
                 max_tokens=3000,
-                temperature=0.0,
             )
             plan, errors = parse_fact_plan(text, allowed)
             # Framing and the scan table are validated on their own evidence and
@@ -4228,11 +4860,95 @@ class AgentWiki:
                 best_score = supplemented_score
                 plan = best_plan
                 warnings = best_warnings
+        planning_unavailable = "model planning unavailable" in errors
+        # A repair prompt is useful when a plan has a few bad claims.  When
+        # source admission removed every claim, however, repeatedly revising
+        # that empty/poisoned plan tends to preserve the original mistake.
+        # Retry once from the original evidence before entering the repair
+        # loop. Hosted models occasionally produce one malformed or
+        # over-generalized response even at temperature zero; a clean replan is
+        # both faster and more reliable than three repairs of an empty plan.
+        if not best_plan.get("sections") and not planning_unavailable:
+            logger.info(
+                "Wiki fact plan for %s had no admissible claims; replanning "
+                "from source evidence",
+                meta.get("id"),
+            )
+            try:
+                replanned_text = complete_plan(
+                    prompt,
+                    phase="fresh_replan",
+                    max_tokens=3000,
+                )
+                replanned_plan, replanned_errors = parse_fact_plan(
+                    replanned_text,
+                    allowed,
+                )
+                replanned_sticky_blocks = {
+                    key: copy.deepcopy(replanned_plan[key])
+                    for key in ("purpose", "map", "flow", "see_also")
+                    if replanned_plan.get(key)
+                }
+                replanned_plan = _normalize_plan_support(
+                    replanned_plan,
+                    evidence,
+                    relations,
+                )
+                replanned_plan = _renderable_plan(
+                    replanned_plan,
+                    evidence,
+                    relations,
+                )
+                replanned_plan = _supplement_topic_relation_flows(
+                    meta,
+                    replanned_plan,
+                    relations,
+                    evidence,
+                )
+                replanned_plan = _normalize_plan_support(
+                    replanned_plan,
+                    evidence,
+                    relations,
+                )
+                replanned_plan = _renderable_plan(
+                    replanned_plan,
+                    evidence,
+                    relations,
+                )
+                replanned_quality_warnings = (
+                    _plan_quality_warnings(
+                        meta,
+                        replanned_plan,
+                        evidence,
+                        relations,
+                    )
+                    if replanned_plan.get("sections")
+                    else [empty_warning]
+                )
+                replanned_warnings = [
+                    *replanned_errors,
+                    *replanned_quality_warnings,
+                ]
+                replanned_score = _plan_repair_score(
+                    replanned_plan,
+                    replanned_warnings,
+                )
+                if replanned_score < best_score:
+                    best_plan = replanned_plan
+                    best_warnings = replanned_warnings
+                    best_score = replanned_score
+                    sticky_blocks = replanned_sticky_blocks
+            except Exception as exc:  # noqa: BLE001 - continue to plan repair
+                logger.debug("wiki clean fact replan unavailable: %s", exc)
+            plan = best_plan
+            warnings = best_warnings
         repairs = 0
         hard_warnings = _hard_plan_warnings(best_warnings)
-        planning_unavailable = "model planning unavailable" in errors
         while (
-            hard_warnings and not planning_unavailable and repairs < _MAX_PLAN_REPAIRS
+            hard_warnings
+            and not planning_unavailable
+            and repairs < _plan_repair_limit(best_warnings)
+            and metrics["model_calls"] < _MAX_FACT_PLAN_MODEL_CALLS
         ):
             repairs += 1
             repair_prompt = _PLAN_REPAIR_PROMPT.format(
@@ -4249,10 +4965,10 @@ class AgentWiki:
                 relations=self._relations_context(relations),
             )
             try:
-                repaired_text = self._client().complete(
-                    [{"role": "user", "content": repair_prompt}],
+                repaired_text = complete_plan(
+                    repair_prompt,
+                    phase="repair",
                     max_tokens=2600,
-                    temperature=0.0,
                 )
                 repaired_plan, repaired_errors = parse_fact_plan(repaired_text, allowed)
                 repaired_plan = _normalize_plan_support(
@@ -4318,6 +5034,7 @@ class AgentWiki:
         if best_plan.get("sections"):
             for key, value in sticky_blocks.items():
                 best_plan.setdefault(key, value)
+            finish_metrics()
             return best_plan, best_warnings
 
         claims = [
@@ -4346,6 +5063,7 @@ class AgentWiki:
         }
         fallback = _normalize_plan_support(fallback, evidence, relations)
         fallback = _renderable_plan(fallback, evidence, relations)
+        finish_metrics()
         return fallback, best_warnings
 
     def _rel(self, file: Optional[str]) -> Optional[str]:
@@ -4493,18 +5211,18 @@ class AgentWiki:
             return draft
 
     def _generate_page(self, meta: Dict[str, Any]) -> dict:
+        generation_started = perf_counter()
         repo_dir = str(getattr(self._bundle.entry, "repo_dir", "") or "").rstrip(os.sep)
         repository_name = (
             os.path.basename(repo_dir)
             or str(getattr(self._bundle.entry, "repo", "") or "")
             or str(getattr(self._bundle.entry, "instance_id", "") or "")
         )
-        nodes = self._retrieve(
-            meta,
-            top_k=(_OVERVIEW_RETRIEVAL_LIMIT if meta.get("id") == "overview" else 12),
-        )
-        evidence = self._evidence_items(nodes)
+        retrieval_started = perf_counter()
+        evidence = self._source_evidence(meta)
+        retrieval_ms = (perf_counter() - retrieval_started) * 1000
         if not evidence:
+            total_ms = (perf_counter() - generation_started) * 1000
             return {
                 "id": meta["id"],
                 "title": meta.get("title", meta["id"]),
@@ -4519,6 +5237,18 @@ class AgentWiki:
                     "mode": "degraded",
                     "model": self._model,
                     "reason": "no_source_evidence",
+                    "metrics": {
+                        "total_ms": round(total_ms, 1),
+                        "retrieval_ms": round(retrieval_ms, 1),
+                        "relation_ms": 0.0,
+                        "planning_ms": 0.0,
+                        "model_call_ms": 0.0,
+                        "model_calls": 0,
+                        "model_failures": 0,
+                        "initial_attempts": 0,
+                        "fresh_replans": 0,
+                        "repair_attempts": 0,
+                    },
                 },
                 "grounding": {
                     "valid": False,
@@ -4528,9 +5258,28 @@ class AgentWiki:
                 },
             }
 
+        relation_started = perf_counter()
         relations = self._relation_items(evidence, meta)
+        relation_ms = (perf_counter() - relation_started) * 1000
+        self._fact_plan_observations.latest = {}
         plan, plan_warnings = self._fact_plan(meta, evidence, relations)
+        planning_metrics: Dict[str, Any] = {
+            "planning_ms": 0.0,
+            "model_call_ms": 0.0,
+            "model_calls": 0,
+            "model_failures": 0,
+            "initial_attempts": 0,
+            "fresh_replans": 0,
+            "repair_attempts": 0,
+            **getattr(self._fact_plan_observations, "latest", {}),
+        }
         plan = self._resolve_page_references(plan, str(meta.get("id") or ""))
+        # Reference resolution and repair merging can leave a claim that no
+        # longer carries executable support in its final form.  Re-run the
+        # same admission and global de-duplication consumed by the renderer so
+        # the quality report evaluates exactly what readers will see.
+        plan = _normalize_plan_support(plan, evidence, relations)
+        plan = _renderable_plan(plan, evidence, relations)
         model_planning_failed = "model planning unavailable" in plan_warnings
         dense_sections = meta.get("id") == "overview"
         quality_requirements = {
@@ -4576,6 +5325,40 @@ class AgentWiki:
             plan,
             **quality_requirements,
         )
+        repaired = False
+        if structured_render and dense_sections and not quality["valid"]:
+            compacted_plan = _compact_dense_plan(plan, quality)
+            if compacted_plan is not plan:
+                compacted_markdown = _fact_plan_markdown(
+                    compacted_plan,
+                    evidence,
+                    relations,
+                )
+                compacted_markdown = _ensure_cited_intro(
+                    compacted_markdown,
+                    evidence,
+                    canonical_readme=True,
+                    repository_name=repository_name,
+                )
+                compacted_report = grounding_report(
+                    compacted_markdown,
+                    evidence,
+                    relations,
+                )
+                compacted_quality = _page_quality_report(
+                    compacted_markdown,
+                    compacted_plan,
+                    **quality_requirements,
+                )
+                if _candidate_score(
+                    compacted_report,
+                    compacted_quality,
+                ) > _candidate_score(report, quality):
+                    plan = compacted_plan
+                    markdown = compacted_markdown
+                    report = compacted_report
+                    quality = compacted_quality
+                    repaired = True
         logger.debug(
             "wiki page candidate %s: grounding=%s quality=%s",
             meta.get("id"),
@@ -4583,7 +5366,6 @@ class AgentWiki:
             quality,
         )
         best = (markdown, report, quality)
-        repaired = False
         if (
             (
                 not report["valid"]
@@ -4790,18 +5572,14 @@ class AgentWiki:
         else:
             generation_reason = "quality_guard"
 
-        citations = [
-            {
-                "file": item.file,
-                "start_line": item.start_line,
-                "end_line": item.end_line,
-                "node_name": item.symbol,
-                "type": item.kind,
-                "score": None,
-                "content": None,
-            }
-            for item in evidence
-        ]
+        citations = self._citation_payload(evidence)
+        total_ms = (perf_counter() - generation_started) * 1000
+        generation_metrics = {
+            "total_ms": round(total_ms, 1),
+            "retrieval_ms": round(retrieval_ms, 1),
+            "relation_ms": round(relation_ms, 1),
+            **planning_metrics,
+        }
         return {
             "id": meta["id"],
             "title": meta.get("title", meta["id"]),
@@ -4825,6 +5603,7 @@ class AgentWiki:
                 "renderer": "fact_plan" if structured_render else "narrative",
                 "plan_warnings": plan_warnings,
                 "reason": generation_reason,
+                "metrics": generation_metrics,
             },
             "grounding": report,
             "quality": quality,

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -66,6 +66,7 @@ from .quality import page_quality_report as _page_quality_report
 from .quality import prose_terms as _prose_terms
 from .quality import redundancy_terms as _redundancy_terms
 from .quality import section_synthesis_report as _section_synthesis_report
+from .quality import sentence_boundary_count as _sentence_boundary_count
 
 logger = get_logger(__name__)
 
@@ -2491,7 +2492,7 @@ def _plan_quality_warnings(
         warnings.append("page thesis must be a source-grounded claim")
     else:
         thesis_statement, _thesis_ids = admitted_thesis
-        if len(re.findall(r"[.!?](?=\s|$)", thesis_statement)) > 1:
+        if _sentence_boundary_count(thesis_statement) > 1:
             warnings.append("page thesis must contain exactly one sentence")
 
     claims = [claim for section in sections for claim in section.get("claims") or []]
@@ -2504,7 +2505,7 @@ def _plan_quality_warnings(
     narrates_relation_anchors = False
     for claim in claims:
         statement = str(claim.get("statement") or "")
-        if len(re.findall(r"[.!?](?=\s|$)", statement)) > 1:
+        if _sentence_boundary_count(statement) > 1:
             multi_sentence_claims.append(statement)
         narrates_evidence_ids |= bool(re.search(r"(?<!\[)\b[ER]\d+\b", statement))
         narrates_relation_anchors |= bool(
@@ -5573,6 +5574,11 @@ class AgentWiki:
             generation_reason = "quality_guard"
 
         citations = self._citation_payload(evidence)
+        # ``RelationItem`` is a frozen, slotted dataclass and intentionally has
+        # no ``__dict__``.  Reuse the canonical evidence serializer so a cold
+        # page with graph relations cannot finish an otherwise successful model
+        # call and then fail while planning its optional media metadata.
+        evidence_payload = evidence_metadata(evidence, relations)
         total_ms = (perf_counter() - generation_started) * 1000
         generation_metrics = {
             "total_ms": round(total_ms, 1),
@@ -5590,9 +5596,9 @@ class AgentWiki:
                 page_id=str(meta.get("id") or ""),
                 title=str(meta.get("title") or meta.get("id") or ""),
                 citations=citations,
-                relations=[item.__dict__ for item in relations],
+                relations=evidence_payload["relations"],
             ),
-            "evidence": evidence_metadata(evidence, relations),
+            "evidence": evidence_payload,
             "generation": {
                 "mode": "generated" if generated else "degraded",
                 "model": self._model,

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -2654,7 +2654,8 @@ def _plan_quality_warnings(
             )
     component_claims = role_counts.get("component", 0)
     if (
-        len(claims) >= 4
+        meta.get("id") == "overview"
+        and len(claims) >= 4
         and component_claims / len(claims) > 0.65
         and not supported_flows
     ):

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -2503,6 +2503,7 @@ def _plan_quality_warnings(
     multi_sentence_claims = []
     narrates_evidence_ids = False
     narrates_relation_anchors = False
+    require_relation_backing = meta.get("id") == "overview"
     for claim in claims:
         statement = str(claim.get("statement") or "")
         if _sentence_boundary_count(statement) > 1:
@@ -2549,6 +2550,9 @@ def _plan_quality_warnings(
             known_relation_pair = any(
                 relation_endpoints_named(statement, item) for item in relations
             )
+            source_stated = any(
+                evidence_matches_claim(statement, item) for item in cited_evidence
+            )
             if is_interaction_claim(statement) and (
                 (
                     bool(cited_relations)
@@ -2559,11 +2563,8 @@ def _plan_quality_warnings(
                 )
                 or (
                     not cited_relations
-                    and not known_relation_pair
-                    and any(
-                        evidence_matches_claim(statement, item)
-                        for item in cited_evidence
-                    )
+                    and source_stated
+                    and (not require_relation_backing or not known_relation_pair)
                 )
             ):
                 supported_flows.append(claim)

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -3422,11 +3422,13 @@ class AgentWiki:
         if not isinstance(page, dict):
             return False
         generation = page.get("generation") or {}
+        grounding = page.get("grounding") or {}
         return bool(
             generation.get("mode") == "degraded"
             and (
                 generation.get("fallback") == "fact_plan"
                 or (page.get("quality") or {}).get("valid") is False
+                or grounding.get("valid") is False
             )
         )
 
@@ -3479,23 +3481,11 @@ class AgentWiki:
             previous.get("generation") if isinstance(previous, dict) else None
         ) or {}
         previous_retry = previous_generation.get("retry") or {}
-        previous_retryable = bool(
-            previous_generation.get("mode") == "degraded"
-            and (
-                previous_generation.get("fallback") == "fact_plan"
-                or (previous.get("quality") or {}).get("valid") is False
-            )
-        )
+        previous_retryable = AgentWiki._cached_page_is_degraded(previous)
         attempts = int(previous_retry.get("attempts") or 0)
         if previous_retryable:
             attempts += 1
-        retryable = bool(
-            generation.get("mode") == "degraded"
-            and (
-                generation.get("fallback") == "fact_plan"
-                or (page.get("quality") or {}).get("valid") is False
-            )
-        )
+        retryable = AgentWiki._cached_page_is_degraded(page)
         if not retryable and not previous_retryable:
             return
         now = time() if now_epoch is None else float(now_epoch)

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -3764,11 +3764,15 @@ class AgentWiki:
         observes the persisted cooldown and retry ceiling.
         """
 
-        if page_id in self._pages and not (
-            retry_degraded_now
-            and self._cached_page_needs_operator_retry(self._pages[page_id])
+        in_memory_page = self._pages.get(page_id)
+        if in_memory_page is not None and not (
+            (
+                retry_degraded_now
+                and self._cached_page_needs_operator_retry(in_memory_page)
+            )
+            or self._cached_page_needs_regeneration(in_memory_page)
         ):
-            return self._pages[page_id]
+            return in_memory_page
         meta = self._find(page_id)
         if meta is None:
             return None
@@ -3779,11 +3783,15 @@ class AgentWiki:
             )
         cache_suffix = self._page_cache_suffix(meta)
         with self._page_generation_lock(page_id):
-            if page_id in self._pages and not (
-                retry_degraded_now
-                and self._cached_page_needs_operator_retry(self._pages[page_id])
+            in_memory_page = self._pages.get(page_id)
+            if in_memory_page is not None and not (
+                (
+                    retry_degraded_now
+                    and self._cached_page_needs_operator_retry(in_memory_page)
+                )
+                or self._cached_page_needs_regeneration(in_memory_page)
             ):
-                return self._pages[page_id]
+                return in_memory_page
             with self._cache_generation_lock(cache_suffix):
                 cached = self._read_cache(cache_suffix)
                 force_retry = bool(

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -2653,7 +2653,11 @@ def _plan_quality_warnings(
                 "grounded in its allocated evidence"
             )
     component_claims = role_counts.get("component", 0)
-    if len(claims) >= 4 and component_claims / len(claims) > 0.65:
+    if (
+        len(claims) >= 4
+        and component_claims / len(claims) > 0.65
+        and not supported_flows
+    ):
         warnings.append(
             "page is dominated by isolated component facts instead of a system "
             "explanation"

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -545,10 +545,9 @@ def _normalize_callable_command_labels(
     statement: str,
     evidence: Sequence[EvidenceItem],
 ) -> str:
-    """Replace a model's CLI label with the callable kind recorded in source."""
+    """Replace model callable labels with the kind recorded in source."""
 
-    def replace(match: re.Match[str]) -> str:
-        identifier = match.group("identifier")
+    def recorded_label(identifier: str) -> str:
         leaf = re.sub(
             r"\([^)]*\)$",
             "",
@@ -570,14 +569,30 @@ def _normalize_callable_command_labels(
             == leaf
         }
         if not kinds:
-            return match.group(0)
-        label = next(iter(kinds)) if len(kinds) == 1 else "callable"
-        return f"{label} `{identifier}`"
+            return ""
+        return next(iter(kinds)) if len(kinds) == 1 else "callable"
+
+    def replace_command(match: re.Match[str]) -> str:
+        identifier = match.group("identifier")
+        label = recorded_label(identifier)
+        return f"{label} `{identifier}`" if label else match.group(0)
+
+    normalized = re.sub(
+        r"\bcommand\s+`(?P<identifier>[^`\n]+)`",
+        replace_command,
+        statement,
+        flags=re.IGNORECASE,
+    )
+
+    def replace_postpositive(match: re.Match[str]) -> str:
+        identifier = match.group("identifier")
+        label = recorded_label(identifier)
+        return f"`{identifier}` {label}" if label else match.group(0)
 
     return re.sub(
-        r"\bcommand\s+`(?P<identifier>[^`\n]+)`",
-        replace,
-        statement,
+        r"`(?P<identifier>[^`\n]+)`\s+(?:class|function|method)\b",
+        replace_postpositive,
+        normalized,
         flags=re.IGNORECASE,
     )
 
@@ -1144,6 +1159,64 @@ def _supplement_topic_relation_flows(
             if added >= target_count:
                 break
     return supplemented
+
+
+def _relation_backed_recovery_plan(
+    meta: Dict[str, Any],
+    evidence: Sequence[EvidenceItem],
+    relations: Sequence[RelationItem],
+) -> dict[str, Any]:
+    """Build a minimal readable plan from fully evidenced call endpoints."""
+
+    def endpoint_symbol(endpoint: str) -> str:
+        return endpoint.rsplit(":", 1)[-1].strip()
+
+    def symbol_leaf(symbol: str) -> str:
+        value = re.sub(r"\([^)]*\)$", "", symbol.strip()).casefold()
+        return re.split(r"::|\.", value)[-1]
+
+    evidence_by_leaf: dict[str, list[str]] = {}
+    for item in evidence:
+        leaf = symbol_leaf(item.symbol.rsplit(":", 1)[-1])
+        if leaf:
+            evidence_by_leaf.setdefault(leaf, []).append(item.id)
+
+    claims: list[dict[str, Any]] = []
+    for relation in relations:
+        source = endpoint_symbol(relation.source)
+        target = endpoint_symbol(relation.target)
+        source_ids = evidence_by_leaf.get(symbol_leaf(source), [])
+        target_ids = evidence_by_leaf.get(symbol_leaf(target), [])
+        if (
+            not source.endswith("()")
+            or not target.endswith("()")
+            or not source_ids
+            or not target_ids
+        ):
+            continue
+        claims.append(
+            {
+                "role": "flow",
+                "statement": f"`{source}` calls `{target}`",
+                "evidence": list(
+                    dict.fromkeys([relation.id, *source_ids, *target_ids])
+                ),
+            }
+        )
+        if len(claims) >= 3:
+            break
+
+    if not claims or not evidence:
+        return {}
+    plan = {
+        "thesis": {
+            "statement": str(meta.get("summary") or "").strip(),
+            "evidence": [evidence[0].id],
+        },
+        "sections": [{"title": "Verified call path", "claims": claims}],
+    }
+    plan = _normalize_plan_support(plan, evidence, relations)
+    return _renderable_plan(plan, evidence, relations)
 
 
 def _renderable_plan(
@@ -3358,6 +3431,14 @@ class AgentWiki:
         )
 
     @staticmethod
+    def _cached_page_needs_operator_retry(page: Any) -> bool:
+        """Return whether an operator should revisit any degraded generation."""
+
+        if not isinstance(page, dict):
+            return False
+        return (page.get("generation") or {}).get("mode") == "degraded"
+
+    @staticmethod
     def _cached_page_needs_regeneration(page: Any) -> bool:
         """Return whether a bad persisted page is due for a bounded retry.
 
@@ -3530,6 +3611,22 @@ class AgentWiki:
             )
         return "ready"
 
+    def page_needs_operator_retry(self, page_id: str) -> bool:
+        """Inspect one cache entry for maintenance without changing UI state."""
+
+        meta = self._find(page_id)
+        if meta is None:
+            return False
+        if page_id == "overview":
+            meta = self._overview_page_meta(
+                meta,
+                self.outline().get("pages", [])[1:],
+            )
+        page = self._pages.get(page_id)
+        if page is None:
+            page = self._read_cache(self._page_cache_suffix(meta))
+        return self._cached_page_needs_operator_retry(page)
+
     def _find(
         self, page_id: str, pages: Optional[List[Dict[str, Any]]] = None
     ) -> Optional[Dict[str, Any]]:
@@ -3629,7 +3726,7 @@ class AgentWiki:
         *,
         retry_degraded_now: bool = False,
     ) -> Optional[dict]:
-        """Return a page, optionally retrying hidden degraded prose immediately.
+        """Return a page, optionally retrying degraded generation immediately.
 
         ``retry_degraded_now`` is an explicit operator action used by the cache
         prewarmer after an index or model upgrade. Normal reader traffic still
@@ -3637,7 +3734,8 @@ class AgentWiki:
         """
 
         if page_id in self._pages and not (
-            retry_degraded_now and self._cached_page_is_degraded(self._pages[page_id])
+            retry_degraded_now
+            and self._cached_page_needs_operator_retry(self._pages[page_id])
         ):
             return self._pages[page_id]
         meta = self._find(page_id)
@@ -3652,13 +3750,14 @@ class AgentWiki:
         with self._page_generation_lock(page_id):
             if page_id in self._pages and not (
                 retry_degraded_now
-                and self._cached_page_is_degraded(self._pages[page_id])
+                and self._cached_page_needs_operator_retry(self._pages[page_id])
             ):
                 return self._pages[page_id]
             with self._cache_generation_lock(cache_suffix):
                 cached = self._read_cache(cache_suffix)
                 force_retry = bool(
-                    retry_degraded_now and self._cached_page_is_degraded(cached)
+                    retry_degraded_now
+                    and self._cached_page_needs_operator_retry(cached)
                 )
                 if (
                     cached
@@ -5074,6 +5173,25 @@ class AgentWiki:
                 best_plan.setdefault(key, value)
             finish_metrics()
             return best_plan, best_warnings
+
+        relation_recovery = _relation_backed_recovery_plan(
+            meta,
+            evidence,
+            relations,
+        )
+        relation_recovery_warnings = (
+            _plan_quality_warnings(
+                meta,
+                relation_recovery,
+                evidence,
+                relations,
+            )
+            if relation_recovery.get("sections")
+            else [empty_warning]
+        )
+        if relation_recovery.get("sections") and not relation_recovery_warnings:
+            finish_metrics()
+            return relation_recovery, []
 
         claims = [
             {

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -2585,7 +2585,12 @@ def _plan_quality_warnings(
             f"{len(multi_sentence_claims)} claim statement(s) contain multiple "
             "sentences; keep each claim to one sentence"
         )
-    if relations and len(evidence) >= 2 and not supported_flows:
+    if (
+        meta.get("id") == "overview"
+        and relations
+        and len(evidence) >= 2
+        and not supported_flows
+    ):
         examples = "; ".join(
             f"{item.id}: `{item.source}` -> `{item.target}`" for item in relations[:3]
         )
@@ -5288,7 +5293,13 @@ class AgentWiki:
             "require_cited_intro": True,
             "require_narrative_novelty": dense_sections,
             "require_narrative_density": True,
-            "require_interaction": bool(relations and len(evidence) >= 2),
+            # Overview promises an architectural through-line. A regular topic
+            # page may legitimately compare sibling formats or contracts even
+            # when the graph contains incidental relations; forcing a handoff
+            # there creates repair calls without improving the explanation.
+            "require_interaction": bool(
+                dense_sections and relations and len(evidence) >= 2
+            ),
             "require_grounded_thesis": True,
             "minimum_source_evidence": (min(4, len(evidence)) if dense_sections else 0),
             "required_claim_roles": (("flow",) if dense_sections and relations else ()),

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -2332,6 +2332,19 @@ def _normalize_plan_support(
             for section in normalized_sections
             for claim in section.get("claims") or []
         ]
+        framing_sources = [plan.get("purpose") or {}] + [
+            section.get("lead") or {} for section in normalized_sections
+        ]
+        candidates.extend(
+            {
+                "statement": statement,
+                "evidence": list(framing.get("evidence") or []),
+                "role": "purpose",
+            }
+            for framing in framing_sources
+            for raw_statement in framing.get("statements") or []
+            if (statement := str(raw_statement or "").strip())
+        )
         role_priority = {
             "purpose": 0,
             "entry": 1,

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -3368,6 +3368,21 @@ class AgentWiki:
             return envelope.get("data")
         return None
 
+    def _read_cache_read_only(self, suffix: str) -> Optional[Any]:
+        """Read one cache entry without migrating or publishing cache data."""
+
+        for path in self._cache_candidate_paths(suffix):
+            if not os.path.isfile(path):
+                continue
+            try:
+                with open(path, encoding="utf-8") as handle:
+                    envelope = json.load(handle)
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(envelope, dict) and "data" in envelope:
+                return envelope.get("data")
+        return None
+
     @staticmethod
     def _atomic_write_cache(
         path: str,
@@ -3563,18 +3578,24 @@ class AgentWiki:
             p["id"] = pid
             self._normalize(p.get("children", []) or [], seen, first=False)
 
-    def page_tree(self) -> List[dict]:
-        outline_pages = self.outline().get("pages", [])
-
+    def _page_tree_refs(
+        self,
+        outline_pages: List[Dict[str, Any]],
+        *,
+        read_only: bool = False,
+    ) -> List[dict]:
         def refs(pages: List[Dict[str, Any]], *, top_level: bool = False) -> List[dict]:
             return [
                 {
                     "id": p["id"],
                     "title": p.get("title", p["id"]),
                     "cache_state": self._page_cache_state(
-                        self._overview_page_meta(p, outline_pages[1:])
-                        if top_level and p.get("id") == "overview"
-                        else p
+                        (
+                            self._overview_page_meta(p, outline_pages[1:])
+                            if top_level and p.get("id") == "overview"
+                            else p
+                        ),
+                        read_only=read_only,
                     ),
                     "children": refs(p.get("children", []) or []),
                 }
@@ -3583,13 +3604,33 @@ class AgentWiki:
 
         return refs(outline_pages, top_level=True)
 
-    def _page_cache_state(self, meta: Dict[str, Any]) -> str:
+    def page_tree(self) -> List[dict]:
+        outline_pages = self.outline().get("pages", [])
+        return self._page_tree_refs(outline_pages)
+
+    def cached_page_tree(self) -> Optional[List[dict]]:
+        """Return the cached page tree without generating or publishing data."""
+
+        outline = self._outline
+        if outline is None:
+            outline = self._read_cache_read_only("outline")
+        if not isinstance(outline, dict) or not isinstance(outline.get("pages"), list):
+            return None
+        return self._page_tree_refs(outline["pages"], read_only=True)
+
+    def _page_cache_state(
+        self,
+        meta: Dict[str, Any],
+        *,
+        read_only: bool = False,
+    ) -> str:
         """Return a reader-facing cache state without generating the page."""
 
         page_id = str(meta.get("id") or "")
         page = self._pages.get(page_id)
         if page is None:
-            page = self._read_cache(self._page_cache_suffix(meta))
+            reader = self._read_cache_read_only if read_only else self._read_cache
+            page = reader(self._page_cache_suffix(meta))
         if not isinstance(page, dict):
             return "cold"
         invalid = self._cached_page_is_degraded(page)

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -44,6 +44,7 @@ from .evidence import (
     evidence_metadata,
     grounding_report,
     infer_claim_role,
+    is_entry_only_section_title,
     is_interaction_claim,
     parse_fact_plan,
     promotional_phrases,
@@ -2264,6 +2265,20 @@ def _normalize_plan_support(
             )
             claim["statement"] = statement
             role = str(claim.get("role") or infer_claim_role(statement))
+            inferred_role = infer_claim_role(statement)
+            code_identifiers = set(re.findall(r"`([^`\n]+)`", statement))
+            if (
+                role == "flow"
+                and not is_interaction_claim(statement)
+                and inferred_role != "flow"
+                and len(code_identifiers) >= 2
+            ):
+                # Model role labels are hints, not evidence. A local statement
+                # can name its owner and stored type without asserting a
+                # component handoff; retain the source-backed fact under its
+                # deterministic role instead of forcing an impossible repair.
+                role = inferred_role
+                claim["role"] = role
             if role != "flow":
                 if (
                     not cited_evidence
@@ -2375,9 +2390,7 @@ def _plan_quality_warnings(
     )
     for section in sections:
         title = str(section.get("title") or "untitled")
-        entry_section = bool(
-            re.search(r"\b(?:public|entry\s+points?)\b", title, re.IGNORECASE)
-        )
+        entry_section = is_entry_only_section_title(title)
         if (
             not page_is_about_helpers
             and public_evidence >= 2

--- a/codenib/wiki/cache_audit.py
+++ b/codenib/wiki/cache_audit.py
@@ -78,7 +78,7 @@ def audit_wiki_cache(
     """
 
     cache_root = os.path.abspath(os.fspath(cache_dir))
-    selected = set(repo_ids or ())
+    selected = {str(repo_id) for repo_id in repo_ids or ()}
     totals = Counter()
     modes = Counter()
     missing_overviews: list[str] = []
@@ -99,7 +99,15 @@ def audit_wiki_cache(
     }
     repo_reports: list[dict[str, Any]] = []
 
-    for info in registry.list_infos():
+    infos = list(registry.list_infos())
+    available_repo_ids = {str(info.id) for info in infos}
+    unknown_repo_ids = sorted(selected - available_repo_ids)
+    if unknown_repo_ids:
+        raise ValueError(
+            "unknown repository selector(s): " + ", ".join(unknown_repo_ids)
+        )
+
+    for info in infos:
         repo_id = str(info.id)
         if selected and repo_id not in selected:
             continue
@@ -226,10 +234,17 @@ def audit_wiki_cache(
             }
         )
 
-    all_cache_paths = {
-        os.path.abspath(path)
-        for path in glob.glob(os.path.join(cache_root, "agentwiki_*.json"))
-    }
+    if selected:
+        # Cache keys are hashed, so an arbitrary file cannot be attributed to a
+        # selected repository without resolving that repository's outline.
+        # Keep subset accounting scoped to the selected repositories instead
+        # of calling every unselected repository's valid cache orphaned.
+        all_cache_paths = {path for path in current_cache_paths if os.path.isfile(path)}
+    else:
+        all_cache_paths = {
+            os.path.abspath(path)
+            for path in glob.glob(os.path.join(cache_root, "agentwiki_*.json"))
+        }
     orphan_paths = all_cache_paths - current_cache_paths
     orphan_bytes = sum(
         os.path.getsize(path) for path in orphan_paths if os.path.isfile(path)

--- a/codenib/wiki/cache_audit.py
+++ b/codenib/wiki/cache_audit.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only coverage and quality audit for persisted AgentWiki pages."""
+
+from __future__ import annotations
+
+import glob
+import json
+import math
+import os
+from collections import Counter
+from typing import Any, Callable, Iterable, Optional
+
+from .agent_wiki import AgentWiki
+
+
+def _summary(values: Iterable[float]) -> dict[str, Any]:
+    ordered = sorted(float(value) for value in values)
+    if not ordered:
+        return {"count": 0, "p50": None, "p95": None, "max": None}
+
+    def percentile(fraction: float) -> float:
+        index = max(0, min(len(ordered) - 1, math.ceil(len(ordered) * fraction) - 1))
+        return round(ordered[index], 1)
+
+    return {
+        "count": len(ordered),
+        "p50": percentile(0.50),
+        "p95": percentile(0.95),
+        "max": round(ordered[-1], 1),
+    }
+
+
+def _coverage(cached: int, total: int) -> dict[str, Any]:
+    return {
+        "cached": cached,
+        "total": total,
+        "missing": max(0, total - cached),
+        "percent": round((cached / total * 100) if total else 100.0, 1),
+    }
+
+
+def _cache_paths(cache_root: str, wiki: AgentWiki, suffix: str) -> tuple[str, ...]:
+    """Resolve stable and legacy cache files without creating a directory."""
+
+    paths = wiki._cache_candidate_paths(suffix)
+    if paths:
+        return paths
+    return (os.path.join(cache_root, f"agentwiki_{wiki._key(suffix)}.json"),)
+
+
+def _read_cache(paths: Iterable[str]) -> Optional[Any]:
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict) and "data" in payload:
+            return payload.get("data")
+    return None
+
+
+def audit_wiki_cache(
+    registry: Any,
+    *,
+    model: str,
+    cache_dir: str | os.PathLike[str],
+    repo_ids: Optional[Iterable[str]] = None,
+    wiki_factory: Callable[..., AgentWiki] = AgentWiki,
+) -> dict[str, Any]:
+    """Inspect only cache entries reachable from each current Wiki outline.
+
+    The function never calls ``outline()`` or ``page()`` and therefore never
+    invokes a model. Missing outlines are reported instead of generated.
+    """
+
+    cache_root = os.path.abspath(os.fspath(cache_dir))
+    selected = set(repo_ids or ())
+    totals = Counter()
+    modes = Counter()
+    missing_overviews: list[str] = []
+    missing_outlines: list[str] = []
+    degraded_pages: list[dict[str, Any]] = []
+    quality_invalid_pages: list[dict[str, Any]] = []
+    fallback_pages: list[dict[str, Any]] = []
+    retry_scheduled_pages: list[dict[str, Any]] = []
+    retry_exhausted_pages: list[dict[str, Any]] = []
+    current_cache_paths: set[str] = set()
+    metric_samples: dict[str, list[float]] = {
+        "total_ms": [],
+        "retrieval_ms": [],
+        "planning_ms": [],
+        "model_call_ms": [],
+        "model_calls": [],
+        "repair_attempts": [],
+    }
+    repo_reports: list[dict[str, Any]] = []
+
+    for info in registry.list_infos():
+        repo_id = str(info.id)
+        if selected and repo_id not in selected:
+            continue
+        bundle = registry.get(repo_id)
+        if bundle is None:
+            continue
+        wiki = wiki_factory(bundle, model=model, cache_dir=cache_root)
+        outline_paths = _cache_paths(cache_root, wiki, "outline")
+        current_cache_paths.update(os.path.abspath(path) for path in outline_paths)
+        outline = _read_cache(outline_paths)
+        if not isinstance(outline, dict) or not outline.get("pages"):
+            missing_outlines.append(repo_id)
+            repo_reports.append(
+                {
+                    "repo": repo_id,
+                    "pages": _coverage(0, 0),
+                    "root_pages": _coverage(0, 0),
+                    "child_pages": _coverage(0, 0),
+                    "overview_cached": False,
+                    "outline_cached": False,
+                }
+            )
+            continue
+
+        wiki._outline = outline
+        repo_counts = Counter()
+
+        def inspect(
+            raw_meta: dict[str, Any],
+            depth: int,
+            *,
+            repo_counts: Counter = repo_counts,
+            repo_id: str = repo_id,
+            wiki: AgentWiki = wiki,
+            outline: dict[str, Any] = outline,
+        ) -> None:
+            totals["pages"] += 1
+            repo_counts["pages"] += 1
+            scope = "root" if depth == 0 else "child"
+            totals[f"{scope}_pages"] += 1
+            repo_counts[f"{scope}_pages"] += 1
+            is_overview = raw_meta.get("id") == "overview"
+            if is_overview:
+                totals["overviews"] += 1
+                meta = wiki._overview_page_meta(
+                    raw_meta,
+                    (outline.get("pages") or [])[1:],
+                )
+            else:
+                meta = raw_meta
+
+            suffix = wiki._page_cache_suffix(meta)
+            paths = _cache_paths(cache_root, wiki, suffix)
+            current_cache_paths.update(os.path.abspath(path) for path in paths)
+            evidence_paths = _cache_paths(cache_root, wiki, f"evidence_{suffix}")
+            current_cache_paths.update(os.path.abspath(path) for path in evidence_paths)
+            page = _read_cache(paths)
+            if isinstance(page, dict):
+                totals["cached_pages"] += 1
+                repo_counts["cached_pages"] += 1
+                totals[f"cached_{scope}_pages"] += 1
+                repo_counts[f"cached_{scope}_pages"] += 1
+                if is_overview:
+                    totals["cached_overviews"] += 1
+
+                generation = page.get("generation") or {}
+                mode = str(generation.get("mode") or "unknown")
+                modes[mode] += 1
+                record = {
+                    "repo": repo_id,
+                    "id": str(page.get("id") or meta.get("id") or ""),
+                    "title": str(page.get("title") or meta.get("title") or ""),
+                    "mode": mode,
+                    "reason": generation.get("reason"),
+                    "fallback": generation.get("fallback"),
+                    "quality_valid": (page.get("quality") or {}).get("valid"),
+                    "retry": generation.get("retry"),
+                }
+                if mode == "degraded":
+                    degraded_pages.append(record)
+                if generation.get("fallback"):
+                    fallback_pages.append(record)
+                if (page.get("quality") or {}).get("valid") is False:
+                    quality_invalid_pages.append(record)
+                retry_state = (generation.get("retry") or {}).get("state")
+                if retry_state == "scheduled":
+                    retry_scheduled_pages.append(record)
+                elif retry_state == "exhausted":
+                    retry_exhausted_pages.append(record)
+
+                metrics = generation.get("metrics") or {}
+                for name in metric_samples:
+                    value = metrics.get(name)
+                    if isinstance(value, (int, float)) and not isinstance(value, bool):
+                        metric_samples[name].append(float(value))
+            elif is_overview:
+                missing_overviews.append(repo_id)
+
+            for child in raw_meta.get("children") or []:
+                if isinstance(child, dict):
+                    inspect(child, depth + 1)
+
+        for root in outline.get("pages") or []:
+            if isinstance(root, dict):
+                inspect(root, 0)
+
+        repo_reports.append(
+            {
+                "repo": repo_id,
+                "pages": _coverage(
+                    repo_counts["cached_pages"],
+                    repo_counts["pages"],
+                ),
+                "root_pages": _coverage(
+                    repo_counts["cached_root_pages"],
+                    repo_counts["root_pages"],
+                ),
+                "child_pages": _coverage(
+                    repo_counts["cached_child_pages"],
+                    repo_counts["child_pages"],
+                ),
+                "overview_cached": repo_id not in missing_overviews,
+                "outline_cached": True,
+            }
+        )
+
+    all_cache_paths = {
+        os.path.abspath(path)
+        for path in glob.glob(os.path.join(cache_root, "agentwiki_*.json"))
+    }
+    orphan_paths = all_cache_paths - current_cache_paths
+    orphan_bytes = sum(
+        os.path.getsize(path) for path in orphan_paths if os.path.isfile(path)
+    )
+    cache_bytes = sum(
+        os.path.getsize(path) for path in all_cache_paths if os.path.isfile(path)
+    )
+    return {
+        "schema_version": 1,
+        "repositories": len(repo_reports),
+        "coverage": {
+            "all": _coverage(totals["cached_pages"], totals["pages"]),
+            "overview": _coverage(
+                totals["cached_overviews"],
+                totals["overviews"],
+            ),
+            "root": _coverage(
+                totals["cached_root_pages"],
+                totals["root_pages"],
+            ),
+            "child": _coverage(
+                totals["cached_child_pages"],
+                totals["child_pages"],
+            ),
+        },
+        "generation_modes": dict(sorted(modes.items())),
+        "generation_metrics": {
+            name: _summary(values) for name, values in metric_samples.items()
+        },
+        "missing_outlines": sorted(missing_outlines),
+        "missing_overviews": sorted(missing_overviews),
+        "degraded_pages": sorted(
+            degraded_pages,
+            key=lambda item: (item["repo"], item["id"]),
+        ),
+        "quality_invalid_pages": sorted(
+            quality_invalid_pages,
+            key=lambda item: (item["repo"], item["id"]),
+        ),
+        "fallback_pages": sorted(
+            fallback_pages,
+            key=lambda item: (item["repo"], item["id"]),
+        ),
+        "retry_scheduled_pages": sorted(
+            retry_scheduled_pages,
+            key=lambda item: (item["repo"], item["id"]),
+        ),
+        "retry_exhausted_pages": sorted(
+            retry_exhausted_pages,
+            key=lambda item: (item["repo"], item["id"]),
+        ),
+        "storage": {
+            "files": len(all_cache_paths),
+            "bytes": cache_bytes,
+            "orphan_files": len(orphan_paths),
+            "orphan_bytes": orphan_bytes,
+        },
+        "repos": sorted(repo_reports, key=lambda item: item["repo"]),
+    }
+
+
+__all__ = ["audit_wiki_cache"]

--- a/codenib/wiki/evidence.py
+++ b/codenib/wiki/evidence.py
@@ -184,7 +184,8 @@ _PROMOTIONAL_RE = re.compile(
 )
 _FLOW_RE = re.compile(
     r"\b(call(?:s|ed|ing)?|delegat(?:e|es|ed|ing)|dispatch(?:es|ed|ing)?|"
-    r"feed(?:s|ing)?|hand(?:s|ed)?\s+(?:off|to)|"
+    r"feed(?:s|ing)?|forward(?:s|ed|ing)?\s+.+\s+to|"
+    r"hand(?:s|ed)?\s+(?:off|to)|"
     r"interact(?:s|ed|ing)?\s+with|invok(?:e|es|ed|ing)|"
     r"load(?:s|ed|ing)?\s+.+\s+from|pass(?:es|ed|ing)?\s+.+\s+to|"
     r"publish(?:es|ed)?|read(?:s)?\s+.+\s+from|"
@@ -202,7 +203,8 @@ _RETURN_FLOW_RE = re.compile(
 )
 _STRONG_HANDOFF_RE = re.compile(
     r"\b(?:"
-    r"dispatch(?:es|ed|ing)?\s+.+\s+to|hand(?:s|ed)?\s+(?:off|to)|"
+    r"dispatch(?:es|ed|ing)?\s+.+\s+to|"
+    r"forward(?:s|ed|ing)?\s+.+\s+to|hand(?:s|ed)?\s+(?:off|to)|"
     r"interact(?:s|ed|ing)?\s+with|"
     r"load(?:s|ed|ing)?\s+.+\s+from|pass(?:es|ed|ing)?\s+.+\s+to|"
     r"provid(?:e|es|ed|ing)\s+.+\s+to|"

--- a/codenib/wiki/evidence.py
+++ b/codenib/wiki/evidence.py
@@ -486,9 +486,37 @@ def describes_private_entry(statement: str, *, role: str = "") -> bool:
     """Whether prose presents a private identifier as a public/user entry."""
 
     text = statement or ""
-    return bool(
-        _PRIVATE_IDENTIFIER_RE.search(text)
-        and (role == "entry" or _EXPLICIT_ENTRY_RE.search(text))
+    private_identifiers = list(_PRIVATE_IDENTIFIER_RE.finditer(text))
+    if not private_identifiers:
+        return False
+
+    code_identifiers = list(_CODE_RE.finditer(text))
+    if role == "entry":
+        # An entry claim may still explain that its public subject delegates to
+        # a private helper. Only reject it when the claim's primary code subject
+        # is itself private.
+        return bool(
+            code_identifiers
+            and _PRIVATE_IDENTIFIER_RE.fullmatch(code_identifiers[0].group(0))
+        )
+
+    if not _EXPLICIT_ENTRY_RE.search(text):
+        return False
+
+    before_entry = re.compile(
+        r"(?:entry\s*point|public\s+(?:api|callable|command|endpoint|function|method)|"
+        r"users?\s+(?:call|execute|invoke|run))\s*$",
+        re.IGNORECASE,
+    )
+    after_entry = re.compile(
+        r"^\s*(?:(?:is|acts\s+as|serves\s+as)\s+)?(?:the\s+)?(?:entry\s*point|"
+        r"public\s+(?:api|callable|command|endpoint|function|method)|endpoint)\b",
+        re.IGNORECASE,
+    )
+    return any(
+        before_entry.search(text[max(0, match.start() - 64) : match.start()])
+        or after_entry.search(text[match.end() : match.end() + 64])
+        for match in private_identifiers
     )
 
 

--- a/codenib/wiki/evidence.py
+++ b/codenib/wiki/evidence.py
@@ -26,6 +26,13 @@ _CITATION_TAIL_RE = re.compile(
     r"(?:\s*\[(?:E|R)\d+\])+\s*[.!?]?\s*$",
 )
 _CODE_RE = re.compile(r"`([^`\n]+)`")
+# Markdown permits a code span to use any run of backticks as long as the
+# closing run has the same length. Parsing only single ticks makes adjacent
+# spans around ``double-fenced`` code look like bogus identifiers taken from
+# the prose between them (for example "." and "calls").
+_MARKDOWN_CODE_SPAN_RE = re.compile(
+    r"(?<!`)(?P<fence>`+)(?!`)(?P<code>[^\n]*?)(?<!`)(?P=fence)(?!`)",
+)
 # Publication floor: at least half a page's blocks must carry their source.
 _MIN_CITATION_COVERAGE = 0.5
 _TABLE_DIVIDER_RE = re.compile(r"^\s*\|[\s:|-]+\|\s*$")
@@ -41,6 +48,16 @@ def is_internal_wiki_navigation(block: str) -> bool:
     return bool(lines) and all(
         _INTERNAL_WIKI_NAV_ITEM_RE.fullmatch(line) for line in lines
     )
+
+
+def _markdown_code_spans(text: str) -> List[str]:
+    """Return complete inline-code values without crossing Markdown fences."""
+
+    return [
+        match.group("code")
+        for match in _MARKDOWN_CODE_SPAN_RE.finditer(text or "")
+        if match.group("code").strip()
+    ]
 
 
 def _corpus_contains_exact(corpus: str, value: str) -> bool:
@@ -902,7 +919,7 @@ def grounding_report(
 
     known_files = {item.file.lower().lstrip("./") for item in evidence}
     unsupported_identifiers = []
-    for identifier in _CODE_RE.findall(without_fences):
+    for identifier in _markdown_code_spans(without_fences):
         normalized = identifier.strip()
         source_name = re.sub(r":\d+(?:-\d+)?$", "", normalized)
         call_name_match = re.fullmatch(

--- a/codenib/wiki/evidence.py
+++ b/codenib/wiki/evidence.py
@@ -207,7 +207,8 @@ _STRONG_HANDOFF_RE = re.compile(
     r"forward(?:s|ed|ing)?\s+.+\s+to|hand(?:s|ed)?\s+(?:off|to)|"
     r"interact(?:s|ed|ing)?\s+with|"
     r"load(?:s|ed|ing)?\s+.+\s+from|pass(?:es|ed|ing)?\s+.+\s+to|"
-    r"provid(?:e|es|ed|ing)\s+.+\s+to|"
+    # Exclude adjectival ``provided values``; present-tense handoffs remain.
+    r"provid(?:e|es|ing)\s+.+\s+to|"
     r"quer(?:y|ies|ied|ying)\s+.+\s+(?:through|via)|"
     r"read(?:s)?\s+.+\s+from|receiv(?:e|es|ed|ing)\s+.+\s+from|"
     r"retriev(?:e|es|ed|ing)\s+.+\s+from|"
@@ -226,6 +227,10 @@ _COMPONENT_TERM_RE = re.compile(
 )
 _ENTRY_RE = re.compile(
     r"\b(command|entry\s*point|endpoint|public|request|users?)\b",
+    re.IGNORECASE,
+)
+_ENTRY_ONLY_SECTION_RE = re.compile(
+    r"(?:public(?:\s+(?:api|entry\s+points?))?|entry\s+points?)",
     re.IGNORECASE,
 )
 _EXPLICIT_ENTRY_RE = re.compile(
@@ -520,6 +525,12 @@ def describes_private_entry(statement: str, *, role: str = "") -> bool:
         or after_entry.search(text[match.end() : match.end() + 64])
         for match in private_identifiers
     )
+
+
+def is_entry_only_section_title(title: str) -> bool:
+    """Whether an entire section is framed solely as a public entry surface."""
+
+    return bool(_ENTRY_ONLY_SECTION_RE.fullmatch((title or "").strip()))
 
 
 def promotional_phrases(text: str) -> List[str]:
@@ -1062,6 +1073,7 @@ __all__ = [
     "evidence_metadata",
     "evidence_matches_claim",
     "grounding_report",
+    "is_entry_only_section_title",
     "parse_fact_plan",
     "promotional_phrases",
     "relation_endpoints_named",

--- a/codenib/wiki/prewarm.py
+++ b/codenib/wiki/prewarm.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded Wiki cache prewarming with machine-readable results."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+from time import perf_counter
+from typing import Any, Callable, Iterable, Optional
+
+
+def _flatten(pages: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    flattened: list[dict[str, Any]] = []
+    for page in pages:
+        if not isinstance(page, dict):
+            continue
+        flattened.append(page)
+        flattened.extend(_flatten(page.get("children") or []))
+    return flattened
+
+
+def _scope_pages(
+    pages: list[dict[str, Any]],
+    scope: str,
+) -> list[dict[str, Any]]:
+    if scope == "overview":
+        return [page for page in _flatten(pages) if page.get("id") == "overview"][:1]
+    if scope == "root":
+        return [page for page in pages if isinstance(page, dict)]
+    if scope == "all":
+        return _flatten(pages)
+    raise ValueError(f"unsupported prewarm scope: {scope!r}")
+
+
+def prewarm_wiki_cache(
+    registry: Any,
+    *,
+    wiki_factory: Callable[[Any], Any],
+    repo_ids: Optional[Iterable[str]] = None,
+    scope: str = "overview",
+    workers: int = 2,
+    max_pages: Optional[int] = None,
+    dry_run: bool = False,
+    retry_degraded_now: bool = False,
+    release_views: bool = False,
+) -> dict[str, Any]:
+    """Generate only cold or due-for-retry pages in a bounded worker pool."""
+
+    started = perf_counter()
+    selected = set(repo_ids or ())
+    worker_count = max(1, min(int(workers), 8))
+    limit = None if max_pages is None else max(0, int(max_pages))
+    results: list[dict[str, Any]] = []
+    repo_records: list[tuple[str, Any]] = []
+    selected_for_generation = 0
+    selection_lock = Lock()
+
+    for info in registry.list_infos():
+        repo_id = str(info.id)
+        if selected and repo_id not in selected:
+            continue
+        bundle = registry.get(repo_id)
+        if bundle is None:
+            continue
+        repo_records.append((repo_id, bundle))
+
+    def reserve_generation() -> bool:
+        nonlocal selected_for_generation
+        with selection_lock:
+            if limit is not None and selected_for_generation >= limit:
+                return False
+            selected_for_generation += 1
+            return True
+
+    def process_repo(repo_id: str, bundle: Any) -> list[dict[str, Any]]:
+        repo_results: list[dict[str, Any]] = []
+        wiki = wiki_factory(bundle)
+        try:
+            tree = wiki.page_tree()
+        except Exception as exc:  # noqa: BLE001 - report one repo, keep the batch
+            repo_results.append(
+                {
+                    "repo": repo_id,
+                    "id": "",
+                    "title": "",
+                    "before": "unknown",
+                    "status": "error",
+                    "error": f"outline unavailable: {exc}",
+                }
+            )
+        else:
+            scoped = _scope_pages(tree, scope)
+            if scope == "overview" and not scoped:
+                repo_results.append(
+                    {
+                        "repo": repo_id,
+                        "id": "overview",
+                        "title": "Overview",
+                        "before": "missing",
+                        "status": "error",
+                        "error": "outline has no Overview page",
+                    }
+                )
+            else:
+                for page_ref in scoped:
+                    page_id = str(page_ref.get("id") or "")
+                    title = str(page_ref.get("title") or page_id)
+                    before = str(page_ref.get("cache_state") or "unknown")
+                    if before == "ready":
+                        repo_results.append(
+                            {
+                                "repo": repo_id,
+                                "id": page_id,
+                                "title": title,
+                                "before": before,
+                                "status": "skipped_ready",
+                            }
+                        )
+                        continue
+                    if before == "degraded" and not retry_degraded_now:
+                        repo_results.append(
+                            {
+                                "repo": repo_id,
+                                "id": page_id,
+                                "title": title,
+                                "before": before,
+                                "status": "skipped_retry_cooldown",
+                            }
+                        )
+                        continue
+                    if not reserve_generation():
+                        repo_results.append(
+                            {
+                                "repo": repo_id,
+                                "id": page_id,
+                                "title": title,
+                                "before": before,
+                                "status": "skipped_limit",
+                            }
+                        )
+                        continue
+                    if dry_run:
+                        repo_results.append(
+                            {
+                                "repo": repo_id,
+                                "id": page_id,
+                                "title": title,
+                                "before": before,
+                                "status": "planned",
+                            }
+                        )
+                        continue
+                    page_started = perf_counter()
+                    try:
+                        if retry_degraded_now:
+                            page = wiki.page(page_id, retry_degraded_now=True)
+                        else:
+                            page = wiki.page(page_id)
+                        if not isinstance(page, dict):
+                            raise RuntimeError(
+                                "page was not found after outline selection"
+                            )
+                        generation = page.get("generation") or {}
+                        repo_results.append(
+                            {
+                                "repo": repo_id,
+                                "id": page_id,
+                                "title": title,
+                                "before": before,
+                                "status": "warmed",
+                                "duration_ms": round(
+                                    (perf_counter() - page_started) * 1000,
+                                    1,
+                                ),
+                                "generation_mode": generation.get("mode"),
+                                "quality_valid": (page.get("quality") or {}).get(
+                                    "valid"
+                                ),
+                                "metrics": generation.get("metrics"),
+                            }
+                        )
+                    except Exception as exc:  # noqa: BLE001 - retain other pages
+                        repo_results.append(
+                            {
+                                "repo": repo_id,
+                                "id": page_id,
+                                "title": title,
+                                "before": before,
+                                "status": "error",
+                                "duration_ms": round(
+                                    (perf_counter() - page_started) * 1000,
+                                    1,
+                                ),
+                                "error": str(exc),
+                            }
+                        )
+        if release_views:
+            release = getattr(bundle, "release_views", None)
+            if callable(release):
+                try:
+                    release()
+                except Exception as exc:  # noqa: BLE001 - report cleanup
+                    repo_results.append(
+                        {
+                            "repo": repo_id,
+                            "id": "",
+                            "title": "",
+                            "before": "loaded",
+                            "status": "release_error",
+                            "error": str(exc),
+                        }
+                    )
+        return repo_results
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = [
+            executor.submit(process_repo, repo_id, bundle)
+            for repo_id, bundle in repo_records
+        ]
+        for future in as_completed(futures):
+            results.extend(future.result())
+
+    results.sort(key=lambda item: (item["repo"], item["id"]))
+    counts: dict[str, int] = {}
+    for result in results:
+        status = str(result["status"])
+        counts[status] = counts.get(status, 0) + 1
+    return {
+        "schema_version": 1,
+        "scope": scope,
+        "dry_run": dry_run,
+        "retry_degraded_now": retry_degraded_now,
+        "release_views": release_views,
+        "workers": worker_count,
+        "repositories": len(repo_records),
+        "selected_for_generation": selected_for_generation,
+        "duration_ms": round((perf_counter() - started) * 1000, 1),
+        "counts": dict(sorted(counts.items())),
+        "pages": results,
+    }
+
+
+__all__ = ["prewarm_wiki_cache"]

--- a/codenib/wiki/prewarm.py
+++ b/codenib/wiki/prewarm.py
@@ -109,7 +109,19 @@ def prewarm_wiki_cache(
                     page_id = str(page_ref.get("id") or "")
                     title = str(page_ref.get("title") or page_id)
                     before = str(page_ref.get("cache_state") or "unknown")
-                    if before == "ready":
+                    retry_ready = False
+                    needs_operator_retry = getattr(
+                        wiki,
+                        "page_needs_operator_retry",
+                        None,
+                    )
+                    if (
+                        before == "ready"
+                        and retry_degraded_now
+                        and callable(needs_operator_retry)
+                    ):
+                        retry_ready = bool(needs_operator_retry(page_id))
+                    if before == "ready" and not retry_ready:
                         repo_results.append(
                             {
                                 "repo": repo_id,

--- a/codenib/wiki/prewarm.py
+++ b/codenib/wiki/prewarm.py
@@ -85,8 +85,8 @@ def prewarm_wiki_cache(
 
     def process_repo(repo_id: str, bundle: Any) -> list[dict[str, Any]]:
         repo_results: list[dict[str, Any]] = []
-        wiki = wiki_factory(bundle)
         try:
+            wiki = wiki_factory(bundle)
             if dry_run:
                 cached_page_tree = getattr(wiki, "cached_page_tree", None)
                 tree = cached_page_tree() if callable(cached_page_tree) else None

--- a/codenib/wiki/prewarm.py
+++ b/codenib/wiki/prewarm.py
@@ -50,7 +50,7 @@ def prewarm_wiki_cache(
     """Generate only cold or due-for-retry pages in a bounded worker pool."""
 
     started = perf_counter()
-    selected = set(repo_ids or ())
+    selected = {str(repo_id) for repo_id in repo_ids or ()}
     worker_count = max(1, min(int(workers), 8))
     limit = None if max_pages is None else max(0, int(max_pages))
     results: list[dict[str, Any]] = []
@@ -58,7 +58,15 @@ def prewarm_wiki_cache(
     selected_for_generation = 0
     selection_lock = Lock()
 
-    for info in registry.list_infos():
+    infos = list(registry.list_infos())
+    available_repo_ids = {str(info.id) for info in infos}
+    unknown_repo_ids = sorted(selected - available_repo_ids)
+    if unknown_repo_ids:
+        raise ValueError(
+            "unknown repository selector(s): " + ", ".join(unknown_repo_ids)
+        )
+
+    for info in infos:
         repo_id = str(info.id)
         if selected and repo_id not in selected:
             continue

--- a/codenib/wiki/prewarm.py
+++ b/codenib/wiki/prewarm.py
@@ -87,7 +87,11 @@ def prewarm_wiki_cache(
         repo_results: list[dict[str, Any]] = []
         wiki = wiki_factory(bundle)
         try:
-            tree = wiki.page_tree()
+            if dry_run:
+                cached_page_tree = getattr(wiki, "cached_page_tree", None)
+                tree = cached_page_tree() if callable(cached_page_tree) else None
+            else:
+                tree = wiki.page_tree()
         except Exception as exc:  # noqa: BLE001 - report one repo, keep the batch
             repo_results.append(
                 {
@@ -100,18 +104,32 @@ def prewarm_wiki_cache(
                 }
             )
         else:
-            scoped = _scope_pages(tree, scope)
-            if scope == "overview" and not scoped:
+            if dry_run and tree is None:
                 repo_results.append(
                     {
                         "repo": repo_id,
-                        "id": "overview",
-                        "title": "Overview",
+                        "id": "outline",
+                        "title": "Wiki outline",
+                        "kind": "outline",
                         "before": "missing",
-                        "status": "error",
-                        "error": "outline has no Overview page",
+                        "status": "planned",
                     }
                 )
+                scoped = []
+            else:
+                scoped = _scope_pages(tree or [], scope)
+            if scope == "overview" and not scoped:
+                if not (dry_run and tree is None):
+                    repo_results.append(
+                        {
+                            "repo": repo_id,
+                            "id": "overview",
+                            "title": "Overview",
+                            "before": "missing",
+                            "status": "error",
+                            "error": "outline has no Overview page",
+                        }
+                    )
             else:
                 for page_ref in scoped:
                     page_id = str(page_ref.get("id") or "")

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -254,8 +254,14 @@ def section_narrative_report(markdown: str) -> dict[str, Any]:
         re.finditer(r"^##\s+(.+?)\s*$", without_fences, flags=re.MULTILINE)
     )
     intro_end = section_matches[0].start() if section_matches else len(without_fences)
-    intro_terms = prose_terms(without_fences[:intro_end])
-    prior = [("intro", intro_terms)]
+    intro_body = without_fences[:intro_end]
+    intro_terms = prose_terms(intro_body)
+    intro_subjects = {
+        subject
+        for sentence in _prose_sentences(intro_body)
+        if (subject := leading_code_subject(sentence))
+    }
+    prior = [("intro", intro_terms, intro_subjects)]
     redundant_sections: List[str] = []
     comparisons: dict[str, dict[str, Any]] = {}
 
@@ -266,12 +272,20 @@ def section_narrative_report(markdown: str) -> dict[str, Any]:
             else len(without_fences)
         )
         title = match.group(1).strip()
-        terms = prose_terms(without_fences[match.end() : end])
+        body = without_fences[match.end() : end]
+        terms = prose_terms(body)
+        subjects = {
+            subject
+            for sentence in _prose_sentences(body)
+            if (subject := leading_code_subject(sentence))
+        }
         best_against = ""
         best_overlap = 0.0
-        for prior_title, prior_terms in prior:
+        for prior_title, prior_terms, prior_subjects in prior:
             smaller = min(len(terms), len(prior_terms))
             overlap = len(terms & prior_terms) / smaller if smaller >= 6 else 0.0
+            if subjects and prior_subjects and subjects.isdisjoint(prior_subjects):
+                overlap = 0.0
             if overlap > best_overlap:
                 best_against = prior_title
                 best_overlap = overlap
@@ -281,7 +295,7 @@ def section_narrative_report(markdown: str) -> dict[str, Any]:
         }
         if best_overlap >= 0.8:
             redundant_sections.append(title)
-        prior.append((title, terms))
+        prior.append((title, terms, subjects))
 
     return {
         "redundant_sections": redundant_sections,
@@ -381,6 +395,7 @@ def section_sentence_redundancy_report(markdown: str) -> dict[str, Any]:
             for sentence in sentences
         ]
         subjects = [leading_code_subject(sentence) for sentence in sentences]
+        interactions = [is_interaction_claim(sentence) for sentence in sentences]
         for left in range(len(sentences)):
             for right in range(left + 1, len(sentences)):
                 smaller = min(len(terms[left]), len(terms[right]))
@@ -399,10 +414,16 @@ def section_sentence_redundancy_report(markdown: str) -> dict[str, Any]:
                     and subjects[right]
                     and subjects[left] != subjects[right]
                 )
+                # A handoff and a local responsibility can legitimately name
+                # the same subject and data. Treating their shared vocabulary
+                # as a duplicate rejects useful workflow prose such as "calls
+                # print_file_ranges" followed by how diff ranges are built.
+                distinct_claim_kinds = interactions[left] != interactions[right]
                 if (
                     overlap >= 0.7
                     and not distinct_handoffs
                     and not distinct_named_subjects
+                    and not distinct_claim_kinds
                 ):
                     repetitions.append(
                         {

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -433,6 +433,11 @@ def section_sentence_redundancy_report(markdown: str) -> dict[str, Any]:
                     and subjects[right]
                     and subjects[left] != subjects[right]
                 )
+                distinct_code_subjects = bool(
+                    identifiers[left]
+                    and identifiers[right]
+                    and identifiers[left].isdisjoint(identifiers[right])
+                )
                 # A handoff and a local responsibility can legitimately name
                 # the same subject and data. Treating their shared vocabulary
                 # as a duplicate rejects useful workflow prose such as "calls
@@ -442,6 +447,7 @@ def section_sentence_redundancy_report(markdown: str) -> dict[str, Any]:
                     overlap >= 0.7
                     and not distinct_handoffs
                     and not distinct_named_subjects
+                    and not distinct_code_subjects
                     and not distinct_claim_kinds
                 ):
                     repetitions.append(
@@ -620,7 +626,9 @@ def plan_narrative_report(
     )
     component_claims = roles.get("component", 0)
     component_ratio = component_claims / len(claims) if claims else 0.0
-    component_dominated = bool(len(claims) >= 4 and component_ratio > 0.65)
+    component_dominated = bool(
+        len(claims) >= 4 and component_ratio > 0.65 and supported_interactions == 0
+    )
     return {
         "claim_roles": roles,
         "supported_interaction_claims": supported_interactions,

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -15,6 +15,7 @@ from .evidence import (
     describes_private_entry,
     evidence_matches_claim,
     infer_claim_role,
+    is_entry_only_section_title,
     is_interaction_claim,
     is_internal_wiki_navigation,
     promotional_phrases,
@@ -49,6 +50,10 @@ _FRAMING_SECTION_TITLES = frozenset({"purpose and scope", "at a glance"})
 _PROTECTED_SENTENCE_FRAGMENT = re.compile(
     r"`[^`\n]*`|(?<!\w)'[^'\n]+'(?!\w)|(?<!\w)\"[^\"\n]+\"(?!\w)"
 )
+_SENTENCE_LITERAL_TRANSLATION = str.maketrans(
+    {".": "\ue000", "!": "\ue001", "?": "\ue002"}
+)
+_SENTENCE_LITERAL_RESTORE = str.maketrans({"\ue000": ".", "\ue001": "!", "\ue002": "?"})
 
 
 def sentence_boundary_count(text: str) -> int:
@@ -110,8 +115,13 @@ def _prose_sentences(markdown: str) -> list[str]:
         without_fences,
         flags=re.MULTILINE,
     )
+    protected = _PROTECTED_SENTENCE_FRAGMENT.sub(
+        lambda match: match.group(0).translate(_SENTENCE_LITERAL_TRANSLATION),
+        without_headings,
+    )
     sentences = []
-    for sentence in re.split(r"(?<=[.!?])\s+", without_headings):
+    for sentence in re.split(r"(?<=[.!?])\s+", protected):
+        sentence = sentence.translate(_SENTENCE_LITERAL_RESTORE)
         cleaned = _EVIDENCE_MARKER.sub("", sentence)
         cleaned = re.sub(r"\s+", " ", cleaned).strip()
         plain = re.sub(r"[`*_[\]()#>-]", "", cleaned).strip()
@@ -182,6 +192,13 @@ def leading_code_subject(text: str) -> str:
     if not match:
         return ""
     return re.sub(r"\([^)]*\)$", "", match.group(1)).casefold()
+
+
+def leading_parallel_subject(text: str) -> str:
+    """Return a short subject from a leading ``For ...`` comparison clause."""
+
+    match = re.match(r"^\s*for\s+([a-z][a-z0-9_-]*)\b", text, re.IGNORECASE)
+    return match.group(1).casefold() if match else ""
 
 
 def duplicate_prose_blocks(markdown: str) -> List[List[int]]:
@@ -414,6 +431,9 @@ def section_sentence_redundancy_report(markdown: str) -> dict[str, Any]:
             for sentence in sentences
         ]
         subjects = [leading_code_subject(sentence) for sentence in sentences]
+        parallel_subjects = [
+            leading_parallel_subject(sentence) for sentence in sentences
+        ]
         interactions = [is_interaction_claim(sentence) for sentence in sentences]
         for left in range(len(sentences)):
             for right in range(left + 1, len(sentences)):
@@ -433,10 +453,20 @@ def section_sentence_redundancy_report(markdown: str) -> dict[str, Any]:
                     and subjects[right]
                     and subjects[left] != subjects[right]
                 )
+                distinct_parallel_subjects = bool(
+                    parallel_subjects[left]
+                    and parallel_subjects[right]
+                    and parallel_subjects[left] != parallel_subjects[right]
+                )
                 distinct_code_subjects = bool(
                     identifiers[left]
                     and identifiers[right]
                     and identifiers[left].isdisjoint(identifiers[right])
+                )
+                distinct_named_details = bool(
+                    identifiers[left]
+                    and identifiers[right]
+                    and len(identifiers[left] ^ identifiers[right]) >= 2
                 )
                 # A handoff and a local responsibility can legitimately name
                 # the same subject and data. Treating their shared vocabulary
@@ -447,7 +477,9 @@ def section_sentence_redundancy_report(markdown: str) -> dict[str, Any]:
                     overlap >= 0.7
                     and not distinct_handoffs
                     and not distinct_named_subjects
+                    and not distinct_parallel_subjects
                     and not distinct_code_subjects
+                    and not distinct_named_details
                     and not distinct_claim_kinds
                 ):
                     repetitions.append(
@@ -486,11 +518,7 @@ def prose_integrity_report(markdown: str) -> dict[str, Any]:
         re.finditer(r"^##\s+(.+?)\s*$", without_citations, flags=re.MULTILINE)
     )
     for index, match in enumerate(section_matches):
-        if not re.search(
-            r"\b(?:public|entry\s+points?)\b",
-            match.group(1),
-            re.IGNORECASE,
-        ):
+        if not is_entry_only_section_title(match.group(1)):
             continue
         end = (
             section_matches[index + 1].start()

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -645,7 +645,6 @@ def plan_narrative_report(
             or private_entry_claims
             or multi_sentence_claims
             or thesis_sentence_count > 1
-            or component_dominated
         ),
         "thesis_grounded": thesis_grounded,
     }
@@ -758,6 +757,7 @@ def page_quality_report(
         and integrity_report["prose_integrity_valid"]
         and sentence_report["sentence_redundancy_valid"]
         and plan_report["plan_role_integrity_valid"]
+        and (not require_dense_sections or not plan_report["component_dominated"])
         and (not require_grounded_thesis or plan_report["thesis_grounded"])
         and source_evidence_count >= minimum_source_evidence
         and not missing_claim_roles

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -46,6 +46,25 @@ _REFERENCE_NARRATION = re.compile(
     re.IGNORECASE,
 )
 _FRAMING_SECTION_TITLES = frozenset({"purpose and scope", "at a glance"})
+_PROTECTED_SENTENCE_FRAGMENT = re.compile(
+    r"`[^`\n]*`|(?<!\w)'[^'\n]+'(?!\w)|(?<!\w)\"[^\"\n]+\"(?!\w)"
+)
+
+
+def sentence_boundary_count(text: str) -> int:
+    """Count prose sentence endings without treating literals as prose.
+
+    Fact-plan claims routinely describe prompts such as ``'Overwrite? (y/N):'``
+    or code containing punctuation.  Those literals belong to the surrounding
+    sentence; counting their punctuation as another sentence creates an
+    impossible repair loop for otherwise valid source-backed claims.
+    """
+
+    scrubbed = _PROTECTED_SENTENCE_FRAGMENT.sub(
+        lambda match: re.sub(r"[.!?]", "", match.group(0)),
+        text or "",
+    )
+    return len(re.findall(r"[.!?](?=\s|$)", scrubbed))
 
 
 def _without_internal_wiki_navigation(markdown: str) -> str:
@@ -537,7 +556,7 @@ def plan_narrative_report(
     }
     for claim in claims:
         statement = str(claim.get("statement") or "")
-        if len(re.findall(r"[.!?](?=\s|$)", statement)) > 1:
+        if sentence_boundary_count(statement) > 1:
             multi_sentence_claims.append(statement)
         role = str(claim.get("role") or infer_claim_role(statement))
         roles[role] = roles.get(role, 0) + 1
@@ -593,7 +612,7 @@ def plan_narrative_report(
     thesis_statement = (
         str(thesis.get("statement") or "") if isinstance(thesis, dict) else ""
     )
-    thesis_sentence_count = len(re.findall(r"[.!?](?=\s|$)", thesis_statement))
+    thesis_sentence_count = sentence_boundary_count(thesis_statement)
     thesis_grounded = bool(
         isinstance(thesis, dict)
         and thesis_statement.strip()
@@ -1006,5 +1025,6 @@ __all__ = [
     "section_narrative_report",
     "section_sentence_redundancy_report",
     "section_synthesis_report",
+    "sentence_boundary_count",
     "summarize_page_audits",
 ]

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -588,8 +588,8 @@ def plan_narrative_report(
                     (relation_backed and relation_stated)
                     or (
                         not relation_backed
-                        and not known_relation_pair
                         and source_stated
+                        and (not require_relation_backing or not known_relation_pair)
                     )
                 )
             else:

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -48,7 +48,9 @@ _REFERENCE_NARRATION = re.compile(
 )
 _FRAMING_SECTION_TITLES = frozenset({"purpose and scope", "at a glance"})
 _PROTECTED_SENTENCE_FRAGMENT = re.compile(
-    r"`[^`\n]*`|(?<!\w)'[^'\n]+'(?!\w)|(?<!\w)\"[^\"\n]+\"(?!\w)"
+    r"`[^`\n]*`|(?<!\w)'[^'\n]+'(?!\w)|(?<!\w)\"[^\"\n]+\"(?!\w)|"
+    r"\b(?:e\.g|i\.e|vs|etc)\.",
+    re.IGNORECASE,
 )
 _SENTENCE_LITERAL_TRANSLATION = str.maketrans(
     {".": "\ue000", "!": "\ue001", "?": "\ue002"}

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -826,8 +826,10 @@ def audit_page(page: dict[str, Any]) -> dict[str, Any]:
             and not duplicate_blocks
         )
     require_novelty = page.get("id") == "overview"
-    require_interaction = bool(
-        quality.get("require_interaction") or (relation_count and evidence_count >= 2)
+    require_interaction = (
+        bool(quality.get("require_interaction"))
+        if "require_interaction" in quality
+        else bool(relation_count and evidence_count >= 2)
     )
     interaction_valid = (
         not require_interaction or density["interaction_sentence_count"] >= 1

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -201,6 +201,17 @@ def leading_parallel_subject(text: str) -> str:
     return match.group(1).casefold() if match else ""
 
 
+def leading_condition_terms(text: str) -> set[str]:
+    """Return normalized terms from a leading conditional clause."""
+
+    match = re.match(
+        r"^\s*(?:if|unless|when|while)\s+(.+?)(?:,\s|$)",
+        text,
+        re.IGNORECASE,
+    )
+    return redundancy_terms(match.group(1)) if match else set()
+
+
 def duplicate_prose_blocks(markdown: str) -> List[List[int]]:
     """Find paragraph pairs where one largely restates the other."""
 
@@ -211,6 +222,7 @@ def duplicate_prose_blocks(markdown: str) -> List[List[int]]:
     )
     terms = []
     subjects = []
+    identifiers = []
     for raw in re.split(r"\n\s*\n", without_fences):
         block = raw.strip()
         if not block or block.startswith("#"):
@@ -219,6 +231,12 @@ def duplicate_prose_blocks(markdown: str) -> List[List[int]]:
         if len(block_terms) >= 6:
             terms.append(block_terms)
             subjects.append(leading_code_subject(block))
+            identifiers.append(
+                {
+                    re.sub(r"\([^)]*\)$", "", item).casefold()
+                    for item in re.findall(r"`([^`\n]+)`", block)
+                }
+            )
 
     duplicates: List[List[int]] = []
     for left in range(len(terms)):
@@ -228,7 +246,23 @@ def duplicate_prose_blocks(markdown: str) -> List[List[int]]:
             distinct_named_subjects = bool(
                 subjects[left] and subjects[right] and subjects[left] != subjects[right]
             )
-            if overlap >= 0.85 and not distinct_named_subjects:
+            named_elaboration = bool(
+                (not identifiers[left] and len(identifiers[right]) >= 2)
+                or (not identifiers[right] and len(identifiers[left]) >= 2)
+            )
+            expanded_named_context = bool(
+                identifiers[left]
+                and identifiers[right]
+                and identifiers[left] != identifiers[right]
+                and max(len(terms[left]), len(terms[right]))
+                >= min(len(terms[left]), len(terms[right])) + 8
+            )
+            if (
+                overlap >= 0.85
+                and not distinct_named_subjects
+                and not named_elaboration
+                and not expanded_named_context
+            ):
                 duplicates.append([left + 1, right + 1])
     return duplicates
 
@@ -435,6 +469,13 @@ def section_sentence_redundancy_report(markdown: str) -> dict[str, Any]:
             leading_parallel_subject(sentence) for sentence in sentences
         ]
         interactions = [is_interaction_claim(sentence) for sentence in sentences]
+        conditional_terms = [
+            leading_condition_terms(sentence) for sentence in sentences
+        ]
+        conditional_negations = [
+            bool(item & {"invalid", "never", "no", "not", "without"})
+            for item in conditional_terms
+        ]
         for left in range(len(sentences)):
             for right in range(left + 1, len(sentences)):
                 smaller = min(len(terms[left]), len(terms[right]))
@@ -468,11 +509,34 @@ def section_sentence_redundancy_report(markdown: str) -> dict[str, Any]:
                     and identifiers[right]
                     and len(identifiers[left] ^ identifiers[right]) >= 2
                 )
+                named_sentence_elaboration = bool(
+                    (
+                        not identifiers[left]
+                        and identifiers[right]
+                        and len(terms[right]) >= len(terms[left]) + 4
+                    )
+                    or (
+                        not identifiers[right]
+                        and identifiers[left]
+                        and len(terms[left]) >= len(terms[right]) + 4
+                    )
+                )
                 # A handoff and a local responsibility can legitimately name
                 # the same subject and data. Treating their shared vocabulary
                 # as a duplicate rejects useful workflow prose such as "calls
                 # print_file_ranges" followed by how diff ranges are built.
                 distinct_claim_kinds = interactions[left] != interactions[right]
+                distinct_conditional_kinds = bool(conditional_terms[left]) != bool(
+                    conditional_terms[right]
+                )
+                distinct_conditional_branches = bool(
+                    conditional_terms[left]
+                    and conditional_terms[right]
+                    and (
+                        len(conditional_terms[left] ^ conditional_terms[right]) >= 2
+                        or conditional_negations[left] != conditional_negations[right]
+                    )
+                )
                 if (
                     overlap >= 0.7
                     and not distinct_handoffs
@@ -480,7 +544,10 @@ def section_sentence_redundancy_report(markdown: str) -> dict[str, Any]:
                     and not distinct_parallel_subjects
                     and not distinct_code_subjects
                     and not distinct_named_details
+                    and not named_sentence_elaboration
                     and not distinct_claim_kinds
+                    and not distinct_conditional_kinds
+                    and not distinct_conditional_branches
                 ):
                     repetitions.append(
                         {

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CodeNib Blog
+
+Engineering notes about compiling repositories into reusable, source-verified
+context for people and coding agents.
+
+## Latest
+
+### [One Repository Index for Humans and Agents](local-code-intelligence-dgx-spark.md)
+
+**August 17, 2026** — A complete local CodeNib deployment on NVIDIA DGX Spark,
+with Qwen3.6 served through vLLM, a local embedding endpoint, a source-linked
+Wiki, CodeGraph, and MCP clients sharing one verified repository manifest.

--- a/docs/blog/local-code-intelligence-dgx-spark.md
+++ b/docs/blog/local-code-intelligence-dgx-spark.md
@@ -1,0 +1,303 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# One Repository Index for Humans and Agents
+
+_Running a source-linked Wiki, CodeGraph, and MCP context locally on NVIDIA
+DGX Spark._
+
+**Published August 17, 2026**
+
+Most code RAG systems end with chunks in a vector database and one chatbot.
+That is useful, but it leaves every other consumer to build another partial
+view of the same repository. A developer browses one representation, an agent
+searches another, and a graph tool quietly works from a third snapshot. Their
+answers may look plausible even after the checkout has changed.
+
+We built CodeNib around a different unit: a verified repository artifact.
+CodeNib compiles a checkout into independently managed retrieval, source, and
+structural views, publishes their capabilities through one manifest, and
+serves that same artifact to both people and agents.
+
+The result is one local code-intelligence layer with several consumers:
+
+- a searchable, source-linked Wiki for people;
+- BM25, dense, regex/trigram, Zoekt, fusion, and reranking paths;
+- definitions, references, callers, callees, and dependency neighborhoods;
+- an MCP server for Codex, Claude Code, and generic MCP clients; and
+- research and evaluation adapters such as LocAgent, RepoNavigator, OrcaLoca,
+  and SWE-Explore.
+
+The repository compiler and CodeGraph path do not require an LLM. Generation
+is an optional consumer of the compiled context, so the same artifact can be
+used with a local model, a hosted model, or no model at all.
+
+## The Artifact Is the Product Boundary
+
+The architecture is deliberately split between compilation and serving:
+
+```text
+repository@commit
+        |
+        v
+incremental repository compiler
+        |
+        +-- BM25
+        +-- dense vectors
+        +-- source chunks
+        +-- symbol graph and SCIP/LSP navigation
+        +-- optional Zoekt and reranking views
+        |
+        v
+verified, capability-bearing manifest
+        |
+        +-- source-linked Wiki
+        +-- local Ask
+        +-- CodeGraph and Dependency Map
+        +-- MCP clients and coding agents
+```
+
+Each view has its own builder configuration, state, and artifact location.
+Adding a dense view does not require rebuilding a current graph. A compatible
+source change can reuse unchanged vector content or repair a supported graph
+transition. If CodeNib cannot verify an incremental transition, it rebuilds
+instead of publishing a partially updated view.
+
+The manifest binds those views to repository identity, commit, filtered source
+fingerprint, and artifact hashes. The Wiki and MCP server recheck the live
+checkout before exposing source. If the source no longer matches, CodeNib
+refuses to silently present the old index as current context.
+
+That fail-closed behavior matters more than the choice of model. A stronger
+model cannot repair evidence retrieved from the wrong revision.
+
+## A Fully Local Reference Deployment
+
+We run one end-to-end local profile on an NVIDIA DGX Spark. This is a reference
+deployment, not a hardware requirement: BM25 and CodeGraph are model-free, and
+smaller models or hosted OpenAI-compatible endpoints can consume the same
+manifest.
+
+| Layer | Local reference profile |
+| --- | --- |
+| Hardware | NVIDIA DGX Spark, GB10, 128 GB unified memory, Arm64 |
+| Generation | `Qwen/Qwen3.6-35B-A3B-FP8` |
+| Embeddings | `Qwen/Qwen3-Embedding-0.6B` |
+| Model runtime | Two loopback-only vLLM OpenAI-compatible endpoints |
+| Repository runtime | CodeNib 0.2.1 Wiki, CodeGraph, and MCP |
+| Generation endpoint | `http://127.0.0.1:8080/v1` |
+| Embedding endpoint | `http://127.0.0.1:8081/v1` |
+
+DGX Spark provides a GB10 and 128 GB of coherent unified system memory; the
+current hardware specification is available in the
+[NVIDIA DGX Spark documentation](https://docs.nvidia.com/dgx/dgx-spark/hardware.html).
+Qwen3.6-35B-A3B has 35 billion total parameters with 3 billion activated, and
+its FP8 release documents vLLM and SGLang serving in the
+[official model card](https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8).
+
+In this profile, repository source, retrieval, embeddings, generation, the web
+application, and MCP all stay on the same machine. The model servers bind to
+loopback because neither endpoint needs to be exposed to the network.
+
+## Start the Model Endpoints
+
+Qwen recommends a current vLLM release for Qwen3.6. We use a text-only,
+single-GPU endpoint and reduce the maximum context from the model's native
+limit to reserve memory for CodeNib, embeddings, and KV cache on the same
+machine:
+
+```bash
+vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --served-model-name qwen3.6-35b \
+  --max-model-len 65536 \
+  --language-model-only \
+  --reasoning-parser qwen3 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":1}'
+```
+
+The MTP option is an optimization, not a CodeNib requirement. Remove
+`--speculative-config` when establishing a baseline or when using a vLLM build
+without the corresponding Qwen MTP support.
+
+Run embeddings on a second local endpoint:
+
+```bash
+vllm serve Qwen/Qwen3-Embedding-0.6B \
+  --host 127.0.0.1 \
+  --port 8081 \
+  --runner pooling \
+  --gpu-memory-utilization 0.08
+```
+
+Confirm both OpenAI-compatible services before starting CodeNib:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/models | jq .
+curl -s http://127.0.0.1:8081/v1/models | jq .
+```
+
+Runtime releases, kernels, model revisions, context length, and memory
+utilization should be pinned for a reproducible benchmark. The commands above
+show the deployment shape; they are not a universal performance preset for
+every vLLM release or model revision.
+
+## Compile the Repository Once
+
+Install the graph, MCP, model-backed Wiki, and remote-compatible embedding
+clients. The embedding service is local, but CodeNib uses its OpenAI-compatible
+protocol, hence the `semantic-remote` extra:
+
+```bash
+python -m pip install \
+  "codenib[agent,graph,mcp,semantic-remote]==0.2.1"
+```
+
+First build the model-free CodeGraph path. It detects supported languages,
+builds BM25 plus a source-linked symbol graph, and registers the local MCP
+server with installed Codex and Claude Code clients:
+
+```bash
+export REPOSITORY=/absolute/path/to/repository
+codenib codegraph init "$REPOSITORY"
+codenib codegraph status "$REPOSITORY"
+```
+
+Then add the dense view and launch the generated Wiki against the two local
+model endpoints. vLLM does not require a key when bound locally, but the
+OpenAI-compatible clients expect a non-empty credential name, so this example
+uses a non-secret placeholder:
+
+```bash
+export CODENIB_LOCAL_API_KEY=local-only
+
+codenib wiki "$REPOSITORY" \
+  --preset semantic \
+  --generate \
+  --model openai/qwen3.6-35b \
+  --api-base http://127.0.0.1:8080/v1 \
+  --api-key-env CODENIB_LOCAL_API_KEY \
+  --embedding-provider openai \
+  --embedding-model Qwen/Qwen3-Embedding-0.6B \
+  --embedding-dimension 1024 \
+  --embedding-endpoint http://127.0.0.1:8081/v1 \
+  --embedding-api-key-env CODENIB_LOCAL_API_KEY
+```
+
+The semantic update preserves the independently current graph view produced by
+`codegraph init`. Subsequent runs reuse current artifacts and update affected
+views when the source changes.
+
+For a generic MCP client, the same repository is served over stdio:
+
+```json
+{
+  "mcpServers": {
+    "codenib": {
+      "command": "codenib",
+      "args": ["mcp", "/absolute/path/to/repository"]
+    }
+  }
+}
+```
+
+No inference endpoint is required for MCP retrieval. Tools such as
+`explore_context`, `dependency_subgraph`, `search_bm25`, `search_regex`,
+`lsp_definition`, `lsp_references`, and `read_source` operate on the verified
+manifest and checkout.
+
+## One Question, Three Surfaces
+
+Consider this repository question:
+
+> How does CodeNib prevent an index built for one commit from being used after
+> the repository changes?
+
+In the Wiki, the answer is prose with clickable source paths and line ranges.
+Following a citation opens the exact code span beside the explanation.
+
+In CodeGraph, the same investigation can start from the verification symbols
+and expand toward callers, callees, references, and dependency neighborhoods.
+
+Through MCP, an agent can begin with `explore_context`, inspect the returned
+source identity and verified ranges, and call `read_source` only for the exact
+windows it needs. It does not need to regenerate a private vector index for
+every session or trust prose detached from the checkout.
+
+All three surfaces consume the same manifest. They differ in presentation and
+query plan, not in repository identity.
+
+## Where the Waiting Time Goes
+
+"Local" does not mean every first request is instantaneous. There are three
+different cold paths that should not be collapsed into one loading spinner:
+
+1. **Repository authorization and artifact loading.** CodeNib recaptures the
+   filtered source identity and opens the selected views.
+2. **Query retrieval.** Warm BM25, dense, and graph queries are normally much
+   cheaper than generation.
+3. **Uncached prose generation.** A first Wiki page or Ask answer may require a
+   model call; a source-linked cached page does not.
+
+Our August 2026 demo acceptance smoke covered 26 repositories. Warm dense
+queries took 11-25 ms. After a backend restart, already generated Overview
+pages were served in roughly 3-4 ms on their first cache read and around 0.7 ms
+warm. Repository authorization and full-view loading ranged from about 0.5
+seconds for Requests and bat to 16.2 seconds for Babel. Three fixed local
+Qwen3.6 Ask cases completed in 19.6-23.5 seconds end to end.
+
+Those numbers are operational smoke evidence from one host, not a general
+model leaderboard. The sample of generation questions is too small for a
+quality or throughput claim. It does establish an important diagnostic split:
+an old 17-second bat page wait was not a 17-second vector query. Most of that
+path was uncached page generation and application orchestration; the repository
+views loaded in about 0.6 seconds.
+
+For published performance comparisons, we will report model revision,
+runtime, context length, TTFT, output tokens per second, cold index time,
+incremental update time, cache state, and end-to-end latency separately.
+
+## Local and Hosted Are Deployment Profiles
+
+CodeNib does not force the inference backend. Our public hosted demo currently
+uses DeepSeek for user-facing generation to keep interactive latency more
+predictable, while retaining the same source-bound retrieval architecture. The
+recorded DGX Spark profile uses Qwen3.6 and local embeddings with no hosted
+generation call.
+
+This split is intentional. Earlier malformed Wiki pages were not caused by an
+OpenAI/DeepSeek request incompatibility. They came from stale or unauthorized
+vector fallback, cold outline and page generation, and internal diagnostic
+prose reaching the reader. The repaired path bounds model calls, rejects
+invalid candidates, caches source-linked pages, and keeps degraded generation
+states explicit.
+
+## What Comes Next
+
+The next compatibility targets are current llama.cpp stdio MCP clients,
+Ollama, and OpenCode. They do not need another repository index: the useful
+test is whether each client can consume the existing MCP surface reliably and
+preserve its source citations.
+
+CodeNib also includes an experimental retrieval-augmented speculative serving
+runtime with an OpenAI-compatible endpoint. We treat that as a separate
+acceleration track. The deployment above uses vLLM as the stable model-serving
+layer; speculative serving will be promoted only with reproducible wall-clock
+comparisons and clearly stated request limitations.
+
+The product principle remains simple:
+
+> Index a codebase once. Explore it as a Wiki, search it as context, and serve
+> it to any coding agent.
+
+Start with the [CodeGraph guide](../codegraph.md), connect an agent through the
+[MCP guide](../mcp.md), or inspect the
+[local and hosted deployment profiles](../running-locally.md). CodeNib is
+Apache-2.0 licensed at
+[github.com/sysevol-ai/CodeNib](https://github.com/sysevol-ai/CodeNib).

--- a/docs/experiments/demo_model_bakeoff_2026-08.md
+++ b/docs/experiments/demo_model_bakeoff_2026-08.md
@@ -1,0 +1,125 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Demo model and cold-start bake-off (2026-08-16)
+
+This note records the production-demo acceptance run after rebuilding all 26
+repositories with secure source fingerprints and hybrid BM25/vector/graph
+views. The fixed Ask cases are Requests proxy bypass, Gin route registration,
+and Vue scheduler flushing. File recall and named-term coverage are
+deterministic checks; citation validity requires every returned citation to
+carry a real file and positive line range.
+
+## Result
+
+Use the hosted API profile for public generation and retain the local model as
+an operator-selectable fallback:
+
+- **Ask:** `deepseek/deepseek-v4-flash` through the DeepSeek API.
+- **Wiki:** `deepseek/deepseek-v4-flash` through the DeepSeek OpenAI-compatible
+  endpoint.
+- **Embeddings:** `Qwen/Qwen3-Embedding-0.6B` through the dedicated local
+  endpoint.
+- **Local fallback:** `Qwen/Qwen3.6-35B-A3B-FP8` through vLLM, with one MTP
+  draft token.
+
+[Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B) and
+[Muse Glimmer 30B](https://huggingface.co/meta-models/Muse-Glimmer-30B) both
+worked, but neither improved the fixed quality signals. Their latency is too
+high for the interactive default on this host. Meta's
+[Muse Glimmer announcement](https://research.meta.ai/blog/introducing-muse-glimmer-open-agentic-model/)
+and the official [GGUF weights](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF)
+remain useful references for a future faster runtime or a background-agent
+profile.
+
+## Ask benchmark
+
+| Candidate | Cases | Wall time | File recall | Term coverage | Valid citation ranges | Outcome |
+|---|---:|---:|---:|---:|---:|---|
+| DeepSeek V4 Flash API | 3/3 | 12.54-12.64s; p50 12.60s | 0.722 | 1.000 | 3/3 | Public default |
+| Qwen3.6 FP8, cold repository views | 3/3 | 20.54-29.26s; p50 22.17s | 0.722 | 1.000 | 3/3 | Baseline cold path |
+| Qwen3.6 FP8, warm repository views | 3/3 | 19.62-23.54s; p50 21.63s | 0.722 | 1.000 | 3/3 | Keep as local fallback |
+| Qwen3.8-27B, standard | 3/3 | 98.41-161.21s; p50 136.69s | 0.722 | 0.889 | 3/3 | Reject on latency and lower term coverage |
+| Qwen3.8-27B, MTP=3 | 1/1 Requests | 42.09s | 1.000 | 1.000 | 1/1 | Still 1.8x slower than warm Qwen3.6 Requests |
+| Muse Glimmer 30B Q4_K_M, low reasoning | 3/3 | 110.47-150.57s; p50 132.55s | 0.722 | 1.000 | 3/3 | Reject on latency; no quality gain |
+
+The DeepSeek API profile completed Requests, Gin, and Vue in 12.60s, 12.54s,
+and 12.64s. It retained the Qwen baseline's 0.722 mean file recall, complete
+named-term coverage, and valid citation ranges while reducing median wall time
+by about 42% relative to warm Qwen3.6. The per-case warm Qwen3.6 times were
+23.54s (Requests), 19.62s (Gin), and 21.63s (Vue). Muse produced the same
+deterministic quality result in 150.57s, 132.55s, and 110.47s respectively,
+while making 3-6 retrieval calls and returning much longer answers. Muse's
+default `reasoning_strength=high` also continued requesting a tool during
+CodeNib's forced final-answer turn; setting the model's ATEM template kwarg to
+`low` made the three-turn tool protocol complete successfully.
+
+## Wiki benchmark
+
+Both candidates used the same cached Requests outline, fresh isolated page
+caches, and the same source-bound retrieval views.
+
+| Candidate | Wall time | Model calls | Grounding | Citation coverage | Quality | Outcome |
+|---|---:|---:|---:|---:|---:|---|
+| DeepSeek V4 Flash | 12.58s | 1 | valid | 1.000 | valid | Keep as default |
+| Muse Glimmer 30B Q4_K_M | 95.23s | 1 | valid | 1.000 | valid | 7.6x slower, no gate improvement |
+
+DeepSeek is therefore protocol-compatible. The earlier broken pages were not
+caused by a DeepSeek/OpenAI request mismatch. They came from stale or
+unauthorized vector fallbacks, cold outline/page generation, and diagnostic
+fact-plan prose that passed through to readers. The repaired path bounds model
+calls, keeps invalid candidates out of the UI, retries degraded pages under an
+operator-controlled budget, and deterministically removes repeated or thin
+Overview sections.
+
+## Index and page latency
+
+All 26 manifests carry secure source fingerprint v2 identities and passed an
+authenticated hybrid-view load plus a live dense query. Dense queries took
+11-25ms after load. Cold full-view authorization/load time is dominated by
+source recapture and artifact loading on large repositories:
+
+| Repository | Cold view load |
+|---|---:|
+| Requests | 0.51s |
+| bat | 0.60s |
+| SymPy | 5.54s |
+| Terraform | 6.09s |
+| Ruff | 8.10s |
+| MicroPython | 11.73s |
+| Babel | 16.15s |
+
+This separates the old bat 17-second page wait from index loading: bat's view
+loads in about 0.6s, while an uncached remote Wiki generation has a much larger
+long tail. After prewarming, all 26 Overview pages are current, with zero
+missing, quality-invalid, fallback, scheduled-retry, or exhausted-retry
+entries. A restarted backend served cached Overview pages in 3-4ms cold and
+about 0.7ms warm; the bat source-linked graph took about 72ms. TOC construction
+was 2-4ms after the one-time post-restart repository object initialization.
+
+## Reproduction
+
+```bash
+make demo-ask-benchmark \
+  DEMO_ASK_BENCHMARK_ARGS="--candidate qwen3.6-35b --timeout 300"
+
+make demo-wiki-benchmark \
+  DEMO_WIKI_BENCHMARK_ARGS="--config qa_config.local.yaml \
+    --candidate deepseek-v4-flash --repo psf__requests"
+
+make wiki-cache-prewarm \
+  WIKI_CACHE_PREWARM_ARGS="--config qa_config.local.yaml --scope overview \
+    --workers 2 --retry-degraded-now --fail-on-error \
+    --fail-on-quality-invalid"
+
+make wiki-cache-audit \
+  WIKI_CACHE_AUDIT_ARGS="--config qa_config.local.yaml --require-overviews \
+    --fail-on-fallback --fail-on-quality-invalid"
+```
+
+Benchmark JSON from this run was written under `/tmp/codenib/`; it is runtime
+evidence rather than a tracked artifact because it contains host-specific
+paths, endpoints, and timings.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -104,6 +104,21 @@ authentication before PyPI upload; the Registry job repeats it immediately
 before publication. The DNS record belongs at the domain apex, not
 `_mcp-auth.codenib.ai`.
 
+A manual Release workflow dispatch from a branch performs release-artifact and
+Registry-metadata verification but deliberately skips protected DNS
+authentication, because the `mcp-registry-publish` environment admits only
+`v*` tags. To repeat only the authenticated ownership preflight, dispatch the
+workflow against a `v*` tag whose checked-in `release.yml` contains the manual
+dispatch guard:
+
+```bash
+gh workflow run release.yml --ref v<version>
+```
+
+Inspect older tags before dispatching them. Production PyPI, MCP Registry, and
+GitHub Release jobs must require both a `push` event and a `v*` tag; a manual
+tag dispatch must never replay publication.
+
 ## Public Surface Gate
 
 Before the production tag, make the repository public and manually dispatch

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -4,18 +4,18 @@ SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Running the Web UI with a Local GPU LLM
+# Running the Web UI with a Local GPU or Hosted API
 
 This guide runs generated Wiki pages and Ask against a local repository using a
-local GPU LLM, without cloud credentials. The repository must contain at least
-one [supported source language](language_capabilities.md), or you must pass an
+local GPU LLM or a hosted API profile. The repository must contain at least one
+[supported source language](language_capabilities.md), or you must pass an
 explicit supported `--language`.
 
 The setup has three services running in separate terminals:
 
 | Service | Script | Where to run |
 |---------|--------|--------------|
-| LLM server (llama-cpp-python) | `scripts/start_llm.sh` | GPU node |
+| LLM server (local profile only) | `scripts/start_llm.sh` | GPU node |
 | CodeNib backend (FastAPI) | `scripts/start_web.sh` | Main machine |
 | Vite frontend | `cd web && npm run dev` | Main machine |
 
@@ -29,7 +29,7 @@ The setup has three services running in separate terminals:
 - Node.js `^20.19.0` or `>=22.12.0`, plus npm: `make web-deps` (once)
 - Conda env `codenib` active
 
-### GPU node
+### GPU node (local profile only)
 
 - Access to a node with CUDA 12.4+ driver and enough VRAM (7B model needs ~5 GB)
 - `llama-cpp-python[server]` with GPU support installed in the `codenib` env:
@@ -84,7 +84,24 @@ already-running backend after registering a repository.
 
 ---
 
-## Step 2 — Configure the LLM
+## Step 2 — Choose a model profile
+
+Demo YAML supports relative inheritance through `extends`. The intended stack
+keeps repository and retrieval settings separate from the generation route:
+
+```text
+qa_config.yaml                 shared defaults
+└── qa_config.local.yaml       machine paths, indexes, embeddings, local LLM
+    └── qa_config.api.yaml     hosted generation override
+```
+
+Child values override parents, nested mappings are merged, and environment
+variables override the final merged YAML. This lets the API profile retain the
+same indexes and cache as local serving without duplicating machine-specific
+paths. An explicit YAML `null` clears an inherited endpoint, credential, or
+option. Both profile files are ignored by Git.
+
+### Local serve profile
 
 No tracked config edit is required. `scripts/start_web.sh` points the backend at
 the local OpenAI-compatible endpoint by exporting:
@@ -105,11 +122,27 @@ Override `CODENIB_DEMO_CONFIG` or `CODENIB_DEMO_MODEL` before running
 `start_web.sh` if your local server exposes a different model name or config
 path.
 
+### Hosted API profile
+
+Create the thin API overlay after the local profile, then provide the key only
+through the environment:
+
+```bash
+cp qa_config.local.yaml.example qa_config.local.yaml
+cp qa_config.api.yaml.example qa_config.api.yaml
+export CODENIB_DEMO_API_KEY="$DEEPSEEK_API_KEY"
+```
+
+The supplied API profile routes both Ask and Wiki prose through DeepSeek while
+reusing the local profile's repository registry, hybrid indexes, embedding
+endpoint, and Wiki cache. Change only `qa_config.api.yaml` to use another
+hosted provider.
+
 ---
 
 ## Step 3 — Start all three services
 
-### Terminal 1 — LLM server (on GPU node)
+### Terminal 1 — LLM server (local profile only, on GPU node)
 
 ```bash
 cd ~/projects/CodeNib/CodeNib
@@ -121,13 +154,23 @@ server on port 8080.
 
 ### Terminal 2 — CodeNib backend (on main machine)
 
+Local serve:
+
 ```bash
 cd ~/projects/CodeNib/CodeNib
 bash scripts/start_web.sh
 ```
 
-The script asks for the GPU node hostname (default: `vscode-dsmlp-l40s`) and
-starts the FastAPI backend on port 8000 pointed at your LLM server.
+Hosted API service:
+
+```bash
+cd ~/projects/CodeNib/CodeNib
+CODENIB_DEMO_PROFILE=api bash scripts/start_web.sh
+```
+
+The local profile asks for the GPU node hostname and points port 8000 at that
+LLM server. The API profile loads `qa_config.api.yaml`, skips the GPU prompt,
+and uses the configured hosted endpoint.
 
 ### Terminal 3 — Frontend (on main machine)
 
@@ -150,8 +193,11 @@ Opens at **http://localhost:3000**.
 Wiki pages are cached under `<data_dir>/wiki_cache` (by default
 `.codenib_qa/wiki_cache`) so subsequent loads avoid another model call.
 **Refresh this wiki** only re-fetches the current tree and page; it does not
-invalidate that cache or force generation. To regenerate, stop the backend,
-delete the `wiki_cache` directory, and start the backend again.
+invalidate that cache or force generation. After repairing a model or index,
+prefer the bounded `wiki-cache-prewarm --retry-degraded-now` maintenance path
+shown below; it preserves healthy pages and retries only degraded entries.
+Prompt/index identity changes naturally select a new cache key, so deleting the
+whole cache should not be part of the normal workflow.
 
 ---
 
@@ -162,10 +208,11 @@ delete the `wiki_cache` directory, and start the backend again.
 | `GPU: False` from llama_cpp | Wrong wheel installed. Reinstall with `--extra-index-url` as shown above. |
 | `ContextWindowExceededError` | LLM server started without `--n_ctx 8192`. The start script sets this automatically. |
 | `Connection refused` on port 8080 | LLM server not running, or firewall blocking the GPU node port. Check Terminal 1. |
-| Wiki says "Couldn't load this page" | Check backend terminal for `WARNING outline generation failed`. Usually an LLM connectivity issue. |
+| Wiki says "Couldn't load this page" | Read the HTTP status and backend detail displayed in the page, then check the backend log. Provider/generation failures point to the Wiki model. A legacy source-fingerprint warning means vector retrieval was safely skipped and BM25 remains available; rebuild the manifest and vector artifact with the current CodeNib version to restore hybrid retrieval. |
 | `repos: 0` at `/api/health` | `qa_registry.json` missing or wrong path. Check `.codenib_qa/qa_registry.json`. |
 | Backend stuck on "Loading repositories…" | Index not built. Run Step 1 again. |
-| Wiki still shows degraded text after fixing the model | Stop the backend, remove `<data_dir>/wiki_cache`, and restart it so both in-memory and on-disk results are cleared. |
+| Frontend still shows old code | Inspect the Vite cwd with `make web-status`. Stop a current-user process rooted in an old checkout or detached snapshot and restart from the checkout being edited; do not reclaim another user's listener. |
+| Wiki still shows degraded text after fixing the model | Run `make wiki-cache-prewarm WIKI_CACHE_PREWARM_ARGS="--config <config> --scope overview --workers 2 --retry-degraded-now"`. This explicitly retries degraded pages without deleting healthy cache entries. |
 
 ---
 

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -76,6 +76,13 @@ tools remain explicit. Preview the exact operations without writing anything:
 codenib toolchain install . --scope all --dry-run
 ```
 
+Rust graph construction uses the managed Rustup toolchain by default. For a
+repository-specific upstream analyzer crash, an operator may temporarily set
+`CODENIB_RUST_ANALYZER=/absolute/path/to/rust-analyzer`; both static SCIP
+construction and live Rust LSP then use that exact executable. Keep the
+override explicit and validate the resulting graph before publication rather
+than silently changing the project-wide pin.
+
 ## Install Local Toolchains From Source
 
 For a CodeNib source checkout, the Makefile retains broad maintainer and CI

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -416,9 +416,13 @@ make demo-ask-benchmark \
 ```
 
 The report records end-to-end and backend-reported latency, citation location
-validity, expected-file recall, and expected-term coverage. Compare candidates
-with identical indexes, backend settings, cases, and repeat counts; a successful
-model ping is not a demo-quality or latency result.
+validity, expected-file recall, and expected-term coverage. The command exits
+nonzero if any case has invalid citation locations or falls below the default
+0.3 file-recall or term-coverage threshold. Use `--min-file-recall` and
+`--min-term-coverage` to raise those per-case thresholds for a release gate.
+Compare candidates with identical indexes, backend settings, cases, thresholds,
+and repeat counts; a successful model ping is not a demo-quality or latency
+result.
 
 Wiki prose has a separate gate because it uses a separate model and quality
 contract. It reuses each repository's current cached outline, writes candidate

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -437,9 +437,9 @@ new outline, so every candidate receives the same source-bound page plan. A run
 fails when generation errors, falls back to diagnostic mode, or produces a page
 that does not pass the normal Wiki quality gate.
 
-The August 2026 production comparison of Qwen3.6, Qwen3.8-27B, DeepSeek V4
-Flash, and Muse Glimmer 30B is recorded in
-[Demo model and cold-start bake-off](experiments/demo_model_bakeoff_2026-08.md).
+Use the retained JSON reports to compare Qwen3.6, Qwen3.8-27B, DeepSeek V4
+Flash, Muse Glimmer 30B, or another candidate under the same indexes, backend
+settings, cases, and repeat counts.
 
 ## Running over SSH
 

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -80,6 +80,14 @@ export CODENIB_DEMO_PREBUILT_DIR=/path/to/prebuilt
 
 The path is fully configurable; nothing is hardcoded to a specific machine.
 
+Native vector reuse also requires a secure source fingerprint v2 in the
+repository manifest. The interactive Web service treats a missing or legacy
+fingerprint as an unavailable vector view: it does not open the vector artifact,
+logs a warning, and continues with BM25 retrieval. Once a v2 fingerprint is
+present, authorization rejection and artifact-integrity failures still fail
+closed. Rebuild both the manifest and vector artifact with the current CodeNib
+version to restore hybrid retrieval; do not edit fingerprint fields by hand.
+
 ## 2. Launch the backend
 
 From the repository root (so the relative `data_dir` resolves):
@@ -101,9 +109,29 @@ curl -s http://127.0.0.1:8000/api/health   # {"status":"ok","repos":N}
 
 ### Configuration and env overrides
 
-Config lives in `qa_config.yaml` (override path with `CODENIB_DEMO_CONFIG`);
-environment variables beat the YAML (`load_config()` in
-`codenib/web/config.py`):
+Config lives in `qa_config.yaml` (override path with `CODENIB_DEMO_CONFIG`). A
+profile may set `extends` to one relative parent path or an ordered list of
+parents. Parents are applied left to right, the child wins, nested mappings are
+merged, and environment variables beat the final YAML (`load_config()` in
+`codenib/web/config.py`). Missing parents and inheritance cycles fail at
+startup instead of silently selecting defaults.
+
+The checked-in templates support two generation profiles without duplicating
+index and cache settings:
+
+| Profile | Template | Generation route |
+|---|---|---|
+| Local serve | `qa_config.local.yaml.example` | OpenAI-compatible local Qwen/vLLM endpoint |
+| API service | `qa_config.api.yaml.example` | DeepSeek hosted API for Ask and Wiki |
+
+Copy them to the ignored `qa_config.local.yaml` and `qa_config.api.yaml` files.
+The API profile extends the local profile, so both routes use the same source
+registry, retrieval artifacts, embeddings, and Wiki cache. Set
+`CODENIB_DEMO_PROFILE=api` with `scripts/start_web.sh`, or point a service
+directly at `CODENIB_DEMO_CONFIG=qa_config.api.yaml`. Keep API keys in
+`CODENIB_DEMO_API_KEY` or the provider's standard environment variable.
+
+Environment overrides are:
 
 | Config key | Env override | Purpose |
 |---|---|---|
@@ -243,6 +271,176 @@ contract: it proxies `/api/*` to the local FastAPI process and leaves
 `0.0.0.0` usable from another machine without exposing a loopback API URL to
 that browser.
 
+For a long-lived reverse-proxied demo, build once and serve the production
+bundle instead of leaving Vite's development server running:
+
+```bash
+cd web
+npm run build
+CODENIB_API_BASE=http://127.0.0.1:8000 \
+  npm run preview -- --host 127.0.0.1 --port 3001
+```
+
+The document base keeps relative Vite chunks rooted correctly when a browser
+opens or refreshes a nested route such as `/<repo>/ask`. Static export removes
+that document base and rewrites the same assets to its configured Pages mount,
+so sub-path exports remain portable.
+
+### What the loading states mean
+
+- The route-level `Loading CodeNib…` is a lazily loaded frontend chunk. A
+  production build avoids the development transform and React StrictMode
+  request replay costs.
+- A Wiki page is normally a disk- or memory-cache read. On its first load, the
+  backend retrieves source evidence and may ask the configured Wiki model to
+  generate prose. Concurrent requests for the same cold outline or page are
+  coalesced into one generation call.
+- A degraded fact-plan fallback is retained as diagnostic evidence, but it is
+  not treated as durable page content. A fresh backend process retries that
+  page from the original evidence, and the reader UI withholds the internal
+  fallback instead of displaying `is indexed from` inventory text.
+- Ask is a multi-turn model run. Retrieval itself is usually short; model
+  turns and the growing evidence context dominate latency. `max_turns` is the
+  main latency/coverage trade-off, so tune it with repeated, source-checked
+  questions rather than a ping prompt.
+- Source panes and dependency graphs load independently after the narrative;
+  they do not need to hold the page in a generic loading state.
+- Repository cards inspect the small leading schema field of `graph.pkl`
+  without loading the graph. An older persisted schema disables `codemap`
+  immediately; the page-graph API returns the required rebuild version instead
+  of advertising an indexed graph and then returning an unexplained empty map.
+
+The Wiki and Ask views replace a bare spinner with the active stage and elapsed
+time. A direct Wiki deep link starts with its requested page instead of first
+fetching `overview`. API responses also expose backend processing time through
+the `Server-Timing: codenib;dur=...` header. Requests that spend at least two
+seconds in the backend are logged by method, path, and duration; query strings
+and Ask contents are deliberately omitted.
+
+### Audit the Wiki cache
+
+The cache auditor reads only entries reachable from the current registry and
+outline identities; it never generates an outline or page and therefore never
+calls the Wiki model:
+
+```bash
+make wiki-cache-audit \
+  WIKI_CACHE_AUDIT_ARGS="--config qa_config.local.yaml --require-overviews"
+```
+
+Its JSON report separates Overview, root-page, and child-page coverage; lists
+degraded, fallback, and quality-invalid pages; and reports stale/orphaned cache
+storage. Newly generated pages also contribute retrieval, planning, model-call,
+repair-count, and total-latency summaries. Existing cache entries created before
+those metrics were introduced remain readable and are simply excluded from the
+latency sample. Add `--fail-on-fallback` and `--fail-on-quality-invalid` to use
+the report as an acceptance gate.
+
+Prewarm the landing page for every registered repository with a small bounded
+worker pool after reviewing the selection in dry-run mode:
+
+```bash
+make wiki-cache-prewarm \
+  WIKI_CACHE_PREWARM_ARGS="--config qa_config.local.yaml --scope overview --dry-run"
+make wiki-cache-prewarm \
+  WIKI_CACHE_PREWARM_ARGS="--config qa_config.local.yaml --scope overview --workers 2 --retry-degraded-now --fail-on-error --fail-on-quality-invalid"
+```
+
+`overview` is the safe public-demo default; `root` includes every top-level
+section and `all` includes child pages. The prewarmer skips healthy entries and
+quality failures still inside their retry cooldown. The sidebar reports each
+page as cached, cold, retryable, or needing review; the browser preloads at most
+two adjacent pages only when they are already cached, so navigation does not
+silently create model spend.
+
+`--retry-degraded-now` is an explicit operator action: it bypasses the retry
+cooldown for degraded pages in this prewarm run without changing the bounded
+reader-traffic policy. It does not regenerate healthy cached prose.
+The standalone prewarmer groups pages by repository and releases that
+repository's BM25/vector views as soon as its group finishes, so a 26-repository
+run retains at most the configured worker count of large retrieval bundles.
+Pass `--keep-views` only when profiling retained-view memory deliberately.
+
+### Rebuild demo indexes safely
+
+When a manifest predates secure source fingerprints, rebuild its BM25, vector,
+and symbol-graph views together instead of editing the manifest. Preview the
+registry selection first, then publish either all repositories or a repeated
+set of repository ids:
+
+```bash
+make demo-index-rebuild \
+  DEMO_INDEX_REBUILD_ARGS="--config qa_config.local.yaml --dry-run"
+make demo-index-rebuild \
+  DEMO_INDEX_REBUILD_ARGS="--config qa_config.local.yaml --repo sharkdp__bat"
+```
+
+The command builds into `<data_dir>/rebuilds-source-v2`, validates the source
+binding, commit, fresh-view status, and complete vector artifact, then replaces
+only the manifest while holding the compiler cache lock. A demo graph with
+fewer than 25 nodes is also rejected, catching tools that exit successfully
+after indexing the wrong workspace boundary. The command preserves the original
+as `repo_manifest.json.pre-source-v2` and refuses publication if the live
+manifest changed while the private generation was being built.
+
+Some demo checkouts populate optional dependency SDKs after cloning. Keep a
+repository-specific exclusion explicit and persisted in the BM25/vector
+artifact identity instead of silently adding that directory to the global
+source policy. For example, MicroPython's populated `lib/` tree is external
+dependency material and otherwise contributes hundreds of thousands of noisy
+chunks:
+
+```bash
+make demo-index-rebuild \
+  DEMO_INDEX_REBUILD_ARGS="--config qa_config.local.yaml --repo micropython__micropython --ignore-dir micropython__micropython:lib"
+```
+
+The source fingerprint still binds the entire visible checkout; the exclusion
+only defines the retrieval corpus. Consequently, a dependency-tree change is
+detected conservatively even though those files are not searchable.
+
+The managed Rust analyzer remains the default. If one repository exposes an
+upstream analyzer crash, set `CODENIB_RUST_ANALYZER` to an explicit validated
+executable for that rebuild; this opt-in override does not replace the pinned
+toolchain for other repositories.
+
+### Compare Ask model candidates
+
+With the candidate served behind the configured OpenAI-compatible endpoint,
+run the fixed Requests, Gin, and Vue source-grounding gate and retain its JSON:
+
+```bash
+make demo-ask-benchmark \
+  DEMO_ASK_BENCHMARK_ARGS="--candidate qwen-current --repeat 2" \
+  > demo-ask-qwen-current.json
+```
+
+The report records end-to-end and backend-reported latency, citation location
+validity, expected-file recall, and expected-term coverage. Compare candidates
+with identical indexes, backend settings, cases, and repeat counts; a successful
+model ping is not a demo-quality or latency result.
+
+Wiki prose has a separate gate because it uses a separate model and quality
+contract. It reuses each repository's current cached outline, writes candidate
+pages only to an isolated temporary cache, and retains metrics rather than the
+generated prose:
+
+```bash
+make demo-wiki-benchmark \
+  DEMO_WIKI_BENCHMARK_ARGS="--config qa_config.local.yaml --candidate deepseek-current --repo psf__requests"
+make demo-wiki-benchmark \
+  DEMO_WIKI_BENCHMARK_ARGS="--config qa_config.local.yaml --candidate local-candidate --model openai/local-model --api-base http://127.0.0.1:8080/v1 --repo psf__requests"
+```
+
+Run cache prewarming first: the benchmark intentionally refuses to generate a
+new outline, so every candidate receives the same source-bound page plan. A run
+fails when generation errors, falls back to diagnostic mode, or produces a page
+that does not pass the normal Wiki quality gate.
+
+The August 2026 production comparison of Qwen3.6, Qwen3.8-27B, DeepSeek V4
+Flash, and Muse Glimmer 30B is recorded in
+[Demo model and cold-start bake-off](experiments/demo_model_bakeoff_2026-08.md).
+
 ## Running over SSH
 
 With the default or loopback API configuration, the browser talks only to the
@@ -284,8 +482,10 @@ the right. The middle column leads with the graph, then the prose:
 The **Refresh this wiki** button re-fetches the page tree and active page from
 the backend. It does not clear the in-memory or on-disk generation cache, run a
 new index build, or force model regeneration. To regenerate model-authored
-pages after changing provider settings, stop the backend, remove
-`<data_dir>/wiki_cache`, and start it again.
+pages after changing provider settings, run the bounded prewarmer with
+`--retry-degraded-now`; healthy pages remain cached. A deliberate prompt or
+index identity change selects new cache entries without deleting unrelated
+healthy content.
 
 ### No more Mermaid
 
@@ -477,7 +677,13 @@ re-fetches `POST /api/chat`; every submit is its own answer.
 | Symptom | Cause / fix |
 |---|---|
 | Stuck on "Loading repositories…" | Backend unreachable from the Vite proxy or production runtime configuration. Confirm `:8000` is up (`curl 127.0.0.1:8000/api/health`); over SSH only `:3000` needs forwarding in source-development mode. Hard-refresh after the backend finishes loading. |
+| Direct `/<repo>/ask` refresh is blank | Rebuild the frontend from a checkout whose `index.html` contains the live document base. Without it, relative Vite assets resolve below the nested route and return 404. Static exports remove and remount this base automatically. |
+| Vite says `This host is not allowed` | Add the exact public proxy hostname to `server.allowedHosts` (and `preview.allowedHosts` when using `vite preview`). Keep host checking enabled; do not use `allowedHosts: true`. The checked-in config already admits `demo.codenib.ai`. |
+| Wiki says "Couldn't load this page" | Read the status and backend detail now shown in the page. A provider or generation error points to the Wiki model; a legacy source-fingerprint warning means the Web service is serving BM25 until the manifest and vector artifact are rebuilt. Older or strict runtimes may instead return `native vector authorization requires source fingerprint v2`. |
+| Wiki stays on "Preparing a source-linked page…" | This is a cold page generation, not the Ask model. Check the Wiki provider and its timeout, then inspect whether another identical request is already in flight. Later requests reuse the disk cache. |
 | Ask shows a backend error | The configured model endpoint is unreachable, provider authentication is unavailable, or the model call failed. Check the backend log and run `codenib doctor --require agent` with the same model settings; add `--probe-model` to send live text, tool, and structured-output probes. |
-| Wiki prose looks deterministic after changing models | Generation fell back because the earlier model call failed, or the existing page cache was reused. Stop the backend, clear `<data_dir>/wiki_cache`, and restart it after fixing the provider. |
+| Wiki prose looks deterministic after changing models | Source-checked page caches are model-independent by design, so changing the configured model does not rewrite healthy pages. Degraded fact-plan fallbacks are retried automatically by a fresh backend process; clear the matching cache only when intentionally regenerating a healthy page with another model. |
+| Frontend changes do not appear | Run `make web-status` and inspect the Vite process cwd. Stop a current-user process rooted in an old checkout or detached snapshot, then start the frontend from the checkout being edited. Never reclaim a listener owned by another user. |
 | Dependency Map shows setup commands | The repo has no usable symbol graph, so the `codemap` capability is off. Install `codenib[graph]` and rebuild with `codenib wiki . --preset graph`. |
+| Page graph says its schema is incompatible | The prose and graph are separate artifacts. The page can remain source-cited while an older `graph.pkl` is rejected. Rebuild `symbol_graph` with the current CodeNib version; do not edit the pickle's version field. |
 | `repos: 0` at `/api/health` | No registry. Run `scripts/build_qa_index.py` (or fix `data_dir`/`prebuilt_dir`). |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,6 +163,9 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Blog:
+      - blog/index.md
+      - One Repository Index for Humans and Agents: blog/local-code-intelligence-dgx-spark.md
   - Get Started:
       - get-started/index.md
       - Quickstart: quickstart.md

--- a/qa_config.api.yaml.example
+++ b/qa_config.api.yaml.example
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Copy this file to qa_config.api.yaml after creating qa_config.local.yaml.
+# This profile retains the local profile's repository, cache, embedding, and
+# retrieval settings while routing user-facing generation through DeepSeek.
+# qa_config.api.yaml is ignored by git; keep credentials in environment vars.
+
+extends: qa_config.local.yaml
+
+model: deepseek/deepseek-v4-flash
+model_api_base: https://api.deepseek.com
+# Clear any placeholder inherited from a local OpenAI-compatible server. Set
+# CODENIB_DEMO_API_KEY (or DEEPSEEK_API_KEY for provider-native routing).
+model_api_key: null
+model_options:
+  timeout: 45
+  extra_body:
+    thinking:
+      type: disabled
+
+# Use the same API route for Wiki prose. Because the provider prefix matches
+# `model`, the Wiki path safely reuses the Ask endpoint and credential.
+wiki_model: deepseek/deepseek-v4-flash
+wiki_api_base: null
+wiki_api_key: null
+
+# Bound the interactive tool loop to keep hosted latency and cost predictable.
+max_turns: 3
+max_tokens: 4096

--- a/qa_config.local.yaml.example
+++ b/qa_config.local.yaml.example
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Copy this file to qa_config.local.yaml for local GPU LLM runs.
-# qa_config.local.yaml is ignored by git.
+# qa_config.local.yaml is ignored by git. It inherits shared repository,
+# retrieval, and UI defaults from the tracked base configuration.
+
+extends: qa_config.yaml
 
 model: openai/qwen2.5-coder
 mode: hybrid

--- a/qa_config.yaml
+++ b/qa_config.yaml
@@ -9,6 +9,8 @@
 #
 # `model` is a LiteLLM model string; override with CODENIB_DEMO_MODEL.
 # Keep secrets in environment variables, not this file.
+# Profile files may inherit this common configuration with
+# `extends: qa_config.yaml`; child values win and mappings are merged.
 
 model: gpt-4o
 # Optional: use a different model for generated wiki prose and edge labels.

--- a/scripts/audit_wiki_cache.py
+++ b/scripts/audit_wiki_cache.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Report current AgentWiki cache coverage without generating any pages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from codenib.log_utils import set_console_log_level  # noqa: E402
+from codenib.web.config import load_config  # noqa: E402
+from codenib.web.native_authority import authorize_local_manifest_vector  # noqa: E402
+from codenib.web.repo_registry import RepoRegistry  # noqa: E402
+from codenib.wiki.cache_audit import audit_wiki_cache  # noqa: E402
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        help="QA config path; defaults to CODENIB_DEMO_CONFIG or qa_config.yaml",
+    )
+    parser.add_argument(
+        "--repo",
+        action="append",
+        dest="repos",
+        help="Audit one repository id; repeat to select more than one",
+    )
+    parser.add_argument("--compact", action="store_true", help="Emit compact JSON")
+    parser.add_argument(
+        "--require-overviews",
+        action="store_true",
+        help="Exit non-zero when an outline or Overview page is not cached",
+    )
+    parser.add_argument(
+        "--fail-on-fallback",
+        action="store_true",
+        help="Exit non-zero when a current page uses a diagnostic fallback",
+    )
+    parser.add_argument(
+        "--fail-on-quality-invalid",
+        action="store_true",
+        help="Exit non-zero when a current cached page fails its quality gate",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    set_console_log_level("WARNING")
+    config = load_config(args.config)
+    registry = RepoRegistry(
+        config,
+        native_index_authorization_resolver=authorize_local_manifest_vector,
+        allow_missing_native_index_authorization=True,
+    )
+    registry.load_all()
+    report = audit_wiki_cache(
+        registry,
+        model=config.wiki_generation_model,
+        cache_dir=os.path.join(os.path.abspath(config.data_dir), "wiki_cache"),
+        repo_ids=args.repos,
+    )
+    print(
+        json.dumps(
+            report,
+            indent=None if args.compact else 2,
+            separators=(",", ":") if args.compact else None,
+            sort_keys=True,
+        )
+    )
+    failed = bool(
+        (
+            args.require_overviews
+            and (report["missing_outlines"] or report["missing_overviews"])
+        )
+        or (args.fail_on_fallback and report["fallback_pages"])
+        or (args.fail_on_quality_invalid and report["quality_invalid_pages"])
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_demo_ask.py
+++ b/scripts/benchmark_demo_ask.py
@@ -195,8 +195,12 @@ def main(argv: list[str] | None = None) -> int:
         cases = json.loads(args.case_file.read_text(encoding="utf-8"))
     else:
         cases = list(_DEFAULT_CASES)
-    if not isinstance(cases, list) or not all(isinstance(case, dict) for case in cases):
-        raise ValueError("benchmark cases must be a JSON list of objects")
+    if (
+        not isinstance(cases, list)
+        or not cases
+        or not all(isinstance(case, dict) for case in cases)
+    ):
+        raise ValueError("benchmark cases must be a non-empty JSON list of objects")
 
     runs: list[dict[str, Any]] = []
     failed = False

--- a/scripts/benchmark_demo_ask.py
+++ b/scripts/benchmark_demo_ask.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark the configured demo Ask model on fixed source-grounded cases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import urllib.error
+import urllib.request
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Iterable
+
+_DEFAULT_CASES = (
+    {
+        "id": "requests_proxy",
+        "repo": "psf__requests",
+        "question": "Where is proxy bypass logic implemented and how does it work?",
+        "expected_files": ["src/requests/utils.py"],
+        "expected_terms": [
+            "should_bypass_proxies",
+            "get_environ_proxies",
+            "resolve_proxies",
+        ],
+    },
+    {
+        "id": "gin_routes",
+        "repo": "gin-gonic__gin",
+        "question": "How is a GET route registered and inserted into the method tree?",
+        "expected_files": ["routergroup.go", "gin.go", "tree.go"],
+        "expected_terms": ["RouterGroup.GET", "addRoute", "methodTrees"],
+    },
+    {
+        "id": "vue_scheduler",
+        "repo": "vuejs__core",
+        "question": "How are component update jobs queued and flushed?",
+        "expected_files": [
+            "packages/runtime-core/src/scheduler.ts",
+            "packages/runtime-core/src/renderer.ts",
+        ],
+        "expected_terms": ["queueJob", "queueFlush", "flushJobs"],
+    },
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", default="http://127.0.0.1:8001")
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument(
+        "--case-file",
+        type=Path,
+        help="Optional JSON list replacing the built-in three-repository gate",
+    )
+    parser.add_argument("--repeat", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=300.0)
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def evaluate_response(case: dict[str, Any], response: dict[str, Any]) -> dict[str, Any]:
+    """Return deterministic grounding/coverage signals for one Ask response."""
+
+    answer = str(response.get("answer") or "")
+    answer_folded = answer.casefold()
+    citations = response.get("citations") or []
+    cited_files = {
+        str(citation.get("file") or "")
+        for citation in citations
+        if isinstance(citation, dict)
+    }
+    expected_files = [str(value) for value in case.get("expected_files") or []]
+    expected_terms = [str(value) for value in case.get("expected_terms") or []]
+    found_files = [value for value in expected_files if value in cited_files]
+    found_terms = [
+        value for value in expected_terms if value.casefold() in answer_folded
+    ]
+    citation_locations_valid = bool(citations) and all(
+        isinstance(citation, dict)
+        and bool(citation.get("file"))
+        and isinstance(citation.get("start_line"), int)
+        and citation["start_line"] >= 1
+        and isinstance(citation.get("end_line"), int)
+        and citation["end_line"] >= citation["start_line"]
+        for citation in citations
+    )
+
+    def fraction(found: Iterable[str], expected: list[str]) -> float:
+        return round(len(tuple(found)) / len(expected), 3) if expected else 1.0
+
+    return {
+        "answer_chars": len(answer),
+        "citation_count": len(citations),
+        "tool_call_count": len(response.get("tool_calls") or []),
+        "total_turns": response.get("total_turns"),
+        "reported_duration_ms": response.get("total_duration_ms"),
+        "citation_locations_valid": citation_locations_valid,
+        "expected_file_recall": fraction(found_files, expected_files),
+        "expected_term_coverage": fraction(found_terms, expected_terms),
+        "found_files": found_files,
+        "found_terms": found_terms,
+    }
+
+
+def _request(
+    endpoint: str,
+    case: dict[str, Any],
+    *,
+    timeout: float,
+) -> tuple[dict[str, Any], float, str | None]:
+    payload = json.dumps(
+        {
+            "repo_id": case["repo"],
+            "messages": [{"role": "user", "content": case["question"]}],
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"{endpoint.rstrip('/')}/api/chat",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    started = perf_counter()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as raw:
+            response = json.load(raw)
+            server_timing = raw.headers.get("Server-Timing")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Ask returned HTTP {exc.code}: {detail}") from exc
+    return response, round((perf_counter() - started) * 1000, 1), server_timing
+
+
+def _summary(values: list[float]) -> dict[str, float | int | None]:
+    if not values:
+        return {"count": 0, "median": None, "min": None, "max": None}
+    return {
+        "count": len(values),
+        "median": round(statistics.median(values), 1),
+        "min": round(min(values), 1),
+        "max": round(max(values), 1),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.case_file:
+        cases = json.loads(args.case_file.read_text(encoding="utf-8"))
+    else:
+        cases = list(_DEFAULT_CASES)
+    if not isinstance(cases, list) or not all(isinstance(case, dict) for case in cases):
+        raise ValueError("benchmark cases must be a JSON list of objects")
+
+    runs: list[dict[str, Any]] = []
+    failed = False
+    for repetition in range(max(1, args.repeat)):
+        for case in cases:
+            record = {
+                "case": str(case.get("id") or ""),
+                "repo": str(case.get("repo") or ""),
+                "repetition": repetition + 1,
+            }
+            try:
+                response, wall_ms, server_timing = _request(
+                    args.endpoint,
+                    case,
+                    timeout=max(1.0, args.timeout),
+                )
+                record.update(evaluate_response(case, response))
+                record.update(
+                    {
+                        "status": "ok",
+                        "wall_ms": wall_ms,
+                        "server_timing": server_timing,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001 - retain the other cases
+                failed = True
+                record.update({"status": "error", "error": str(exc)})
+            runs.append(record)
+
+    successful = [run for run in runs if run["status"] == "ok"]
+    report = {
+        "schema_version": 1,
+        "candidate": args.candidate,
+        "endpoint": args.endpoint,
+        "case_count": len(cases),
+        "repeat": max(1, args.repeat),
+        "summary": {
+            "successful": len(successful),
+            "failed": len(runs) - len(successful),
+            "wall_ms": _summary([float(run["wall_ms"]) for run in successful]),
+            "expected_file_recall_mean": (
+                round(
+                    statistics.mean(
+                        float(run["expected_file_recall"]) for run in successful
+                    ),
+                    3,
+                )
+                if successful
+                else None
+            ),
+            "expected_term_coverage_mean": (
+                round(
+                    statistics.mean(
+                        float(run["expected_term_coverage"]) for run in successful
+                    ),
+                    3,
+                )
+                if successful
+                else None
+            ),
+        },
+        "runs": runs,
+    }
+    print(
+        json.dumps(
+            report,
+            indent=None if args.compact else 2,
+            separators=(",", ":") if args.compact else None,
+            sort_keys=True,
+        )
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_demo_ask.py
+++ b/scripts/benchmark_demo_ask.py
@@ -51,7 +51,7 @@ _DEFAULT_CASES = (
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--endpoint", default="http://127.0.0.1:8001")
+    parser.add_argument("--endpoint", default="http://127.0.0.1:8000")
     parser.add_argument("--candidate", required=True)
     parser.add_argument(
         "--case-file",

--- a/scripts/benchmark_demo_ask.py
+++ b/scripts/benchmark_demo_ask.py
@@ -48,6 +48,19 @@ _DEFAULT_CASES = (
     },
 )
 
+_DEFAULT_MIN_FILE_RECALL = 0.3
+_DEFAULT_MIN_TERM_COVERAGE = 0.3
+
+
+def _unit_fraction(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number from 0 to 1") from exc
+    if not 0.0 <= parsed <= 1.0:
+        raise argparse.ArgumentTypeError("must be a number from 0 to 1")
+    return parsed
+
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -60,6 +73,18 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--repeat", type=int, default=1)
     parser.add_argument("--timeout", type=float, default=300.0)
+    parser.add_argument(
+        "--min-file-recall",
+        type=_unit_fraction,
+        default=_DEFAULT_MIN_FILE_RECALL,
+        help="Minimum expected-file recall required for every case (default: 0.3)",
+    )
+    parser.add_argument(
+        "--min-term-coverage",
+        type=_unit_fraction,
+        default=_DEFAULT_MIN_TERM_COVERAGE,
+        help="Minimum expected-term coverage required for every case (default: 0.3)",
+    )
     parser.add_argument("--compact", action="store_true")
     return parser
 
@@ -148,6 +173,22 @@ def _summary(values: list[float]) -> dict[str, float | int | None]:
     }
 
 
+def _grounding_failures(
+    result: dict[str, Any],
+    *,
+    min_file_recall: float,
+    min_term_coverage: float,
+) -> list[str]:
+    failures = []
+    if not result["citation_locations_valid"]:
+        failures.append("citation_locations_invalid")
+    if float(result["expected_file_recall"]) < min_file_recall:
+        failures.append("expected_file_recall_below_threshold")
+    if float(result["expected_term_coverage"]) < min_term_coverage:
+        failures.append("expected_term_coverage_below_threshold")
+    return failures
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     if args.case_file:
@@ -173,9 +214,19 @@ def main(argv: list[str] | None = None) -> int:
                     timeout=max(1.0, args.timeout),
                 )
                 record.update(evaluate_response(case, response))
+                grounding_failures = _grounding_failures(
+                    record,
+                    min_file_recall=args.min_file_recall,
+                    min_term_coverage=args.min_term_coverage,
+                )
+                grounding_passed = not grounding_failures
+                if not grounding_passed:
+                    failed = True
                 record.update(
                     {
-                        "status": "ok",
+                        "status": "ok" if grounding_passed else "grounding_failed",
+                        "grounding_passed": grounding_passed,
+                        "grounding_failures": grounding_failures,
                         "wall_ms": wall_ms,
                         "server_timing": server_timing,
                     }
@@ -185,35 +236,43 @@ def main(argv: list[str] | None = None) -> int:
                 record.update({"status": "error", "error": str(exc)})
             runs.append(record)
 
-    successful = [run for run in runs if run["status"] == "ok"]
+    completed = [run for run in runs if run["status"] != "error"]
+    successful = [run for run in completed if run["status"] == "ok"]
     report = {
         "schema_version": 1,
         "candidate": args.candidate,
         "endpoint": args.endpoint,
         "case_count": len(cases),
         "repeat": max(1, args.repeat),
+        "thresholds": {
+            "min_file_recall": args.min_file_recall,
+            "min_term_coverage": args.min_term_coverage,
+        },
         "summary": {
             "successful": len(successful),
             "failed": len(runs) - len(successful),
-            "wall_ms": _summary([float(run["wall_ms"]) for run in successful]),
+            "grounding_failed": sum(
+                run["status"] == "grounding_failed" for run in completed
+            ),
+            "wall_ms": _summary([float(run["wall_ms"]) for run in completed]),
             "expected_file_recall_mean": (
                 round(
                     statistics.mean(
-                        float(run["expected_file_recall"]) for run in successful
+                        float(run["expected_file_recall"]) for run in completed
                     ),
                     3,
                 )
-                if successful
+                if completed
                 else None
             ),
             "expected_term_coverage_mean": (
                 round(
                     statistics.mean(
-                        float(run["expected_term_coverage"]) for run in successful
+                        float(run["expected_term_coverage"]) for run in completed
                     ),
                     3,
                 )
-                if successful
+                if completed
                 else None
             ),
         },

--- a/scripts/benchmark_demo_wiki.py
+++ b/scripts/benchmark_demo_wiki.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark a Wiki prose model against cached, source-bound outlines."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import math
+import os
+import statistics
+import sys
+import tempfile
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Iterable
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from codenib.llm.litellm_chat import LiteLLMChat  # noqa: E402
+from codenib.log_utils import set_console_log_level  # noqa: E402
+from codenib.web.config import load_config  # noqa: E402
+from codenib.web.native_authority import authorize_local_manifest_vector  # noqa: E402
+from codenib.web.repo_registry import RepoRegistry  # noqa: E402
+from codenib.wiki.agent_wiki import AgentWiki  # noqa: E402
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config")
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--model")
+    parser.add_argument("--api-base")
+    parser.add_argument(
+        "--api-key-env",
+        help="Read a candidate API key from this environment variable",
+    )
+    parser.add_argument(
+        "--model-options-json",
+        help="JSON object merged into the candidate model call options",
+    )
+    parser.add_argument(
+        "--repo",
+        action="append",
+        dest="repos",
+        help="Repository id with an already-cached current outline (repeatable)",
+    )
+    parser.add_argument("--repeat", type=int, default=1)
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def evaluate_page(page: dict[str, Any]) -> dict[str, Any]:
+    """Extract model-independent Wiki quality and grounding signals."""
+
+    generation = page.get("generation") or {}
+    quality = page.get("quality") or {}
+    grounding = page.get("grounding") or {}
+    return {
+        "generation_mode": generation.get("mode"),
+        "fallback": generation.get("fallback"),
+        "quality_valid": quality.get("valid"),
+        "grounding_valid": grounding.get("valid"),
+        "citation_coverage": grounding.get("citation_coverage"),
+        "evidence_count": grounding.get("evidence_count"),
+        "relation_count": grounding.get("relation_count"),
+        "citation_count": len(page.get("citations") or []),
+        "markdown_chars": len(str(page.get("markdown") or "")),
+        "metrics": generation.get("metrics") or {},
+    }
+
+
+def _percentile(values: Iterable[float], fraction: float) -> float | None:
+    ordered = sorted(float(value) for value in values)
+    if not ordered:
+        return None
+    index = max(0, min(len(ordered) - 1, math.ceil(len(ordered) * fraction) - 1))
+    return round(ordered[index], 1)
+
+
+def _summary(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    successful = [run for run in runs if run["status"] == "ok"]
+    wall = [float(run["wall_ms"]) for run in successful]
+    return {
+        "successful": len(successful),
+        "failed": len(runs) - len(successful),
+        "quality_valid": sum(run.get("quality_valid") is True for run in successful),
+        "degraded": sum(run.get("generation_mode") == "degraded" for run in successful),
+        "wall_ms": {
+            "p50": round(statistics.median(wall), 1) if wall else None,
+            "p95": _percentile(wall, 0.95),
+            "max": round(max(wall), 1) if wall else None,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    set_console_log_level("WARNING")
+    config = load_config(args.config)
+    model = args.model or config.wiki_generation_model
+    api_base = args.api_base or config.wiki_generation_api_base
+    if args.api_key_env:
+        api_key = os.environ.get(args.api_key_env)
+        if not api_key:
+            raise ValueError(f"environment variable {args.api_key_env!r} is empty")
+    elif args.api_base:
+        # Local OpenAI-compatible servers usually require a non-empty client
+        # value but do not authenticate it. External candidate routes should
+        # provide --api-key-env explicitly instead of borrowing another
+        # provider's configured secret.
+        api_key = "not-needed"
+    else:
+        api_key = config.wiki_generation_api_key
+    options = (
+        dict(config.wiki_generation_options or {})
+        if args.model is None and args.api_base is None
+        else {}
+    )
+    if args.model_options_json:
+        candidate_options = json.loads(args.model_options_json)
+        if not isinstance(candidate_options, dict):
+            raise ValueError("--model-options-json must contain a JSON object")
+        options.update(candidate_options)
+
+    registry = RepoRegistry(
+        config,
+        native_index_authorization_resolver=authorize_local_manifest_vector,
+        allow_missing_native_index_authorization=True,
+    )
+    registry.load_all()
+    selected = list(dict.fromkeys(args.repos or ["psf__requests"]))
+    production_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
+    outlines: dict[str, dict[str, Any]] = {}
+    bundles: dict[str, Any] = {}
+    for repo_id in selected:
+        bundle = registry.get(repo_id)
+        if bundle is None:
+            raise ValueError(f"unknown repository id: {repo_id!r}")
+        reference = AgentWiki(
+            bundle,
+            model=config.wiki_generation_model,
+            cache_dir=production_cache,
+        )
+        outline = reference._read_cache("outline")
+        if not isinstance(outline, dict) or not outline.get("pages"):
+            raise RuntimeError(
+                f"{repo_id} has no current cached outline; prewarm it before "
+                "running a model comparison"
+            )
+        outlines[repo_id] = outline
+        bundles[repo_id] = bundle
+
+    runs: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="codenib-wiki-benchmark-") as cache_root:
+        for repetition in range(max(1, args.repeat)):
+            for repo_id in selected:
+                record: dict[str, Any] = {
+                    "repo": repo_id,
+                    "page": "overview",
+                    "repetition": repetition + 1,
+                }
+                run_cache = os.path.join(cache_root, repo_id, str(repetition + 1))
+                llm = LiteLLMChat(
+                    model=model,
+                    temperature=0.2,
+                    max_tokens=4096,
+                    api_base=api_base,
+                    api_key=api_key,
+                    extra_kwargs=options,
+                )
+                wiki = AgentWiki(
+                    bundles[repo_id],
+                    model=model,
+                    cache_dir=run_cache,
+                    llm=llm,
+                    api_base=api_base,
+                    api_key=api_key,
+                )
+                wiki._outline = copy.deepcopy(outlines[repo_id])
+                started = perf_counter()
+                try:
+                    page = wiki.page("overview")
+                    if not isinstance(page, dict):
+                        raise RuntimeError("Overview generation returned no page")
+                    record.update(evaluate_page(page))
+                    record.update(
+                        {
+                            "status": "ok",
+                            "wall_ms": round((perf_counter() - started) * 1000, 1),
+                        }
+                    )
+                except Exception as exc:  # noqa: BLE001 - retain other cells
+                    record.update(
+                        {
+                            "status": "error",
+                            "wall_ms": round((perf_counter() - started) * 1000, 1),
+                            "error": str(exc),
+                        }
+                    )
+                runs.append(record)
+
+    report = {
+        "schema_version": 1,
+        "candidate": args.candidate,
+        "model": model,
+        "api_base": str(api_base) if api_base is not None else None,
+        "repositories": selected,
+        "repeat": max(1, args.repeat),
+        "summary": _summary(runs),
+        "runs": runs,
+    }
+    print(
+        json.dumps(
+            report,
+            indent=None if args.compact else 2,
+            separators=(",", ":") if args.compact else None,
+            sort_keys=True,
+        )
+    )
+    failed = any(
+        run["status"] != "ok"
+        or run.get("quality_valid") is not True
+        or run.get("generation_mode") == "degraded"
+        for run in runs
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_qa_index.py
+++ b/scripts/build_qa_index.py
@@ -35,27 +35,15 @@ _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
-from codenib.compiler.index_builders import (  # noqa: E402
-    BM25IndexBuilder,
-    IndexBuilderRegistry,
-    VectorIndexBuilder,
-)
-from codenib.compiler.index_compiler import (  # noqa: E402
-    IndexCompiler,
-    IndexCompilerConfig,
-)
-from codenib.compiler.manifest import (  # noqa: E402
-    MANIFEST_FILENAME,
-    IndexEntry,
-    RepoManifest,
-)
+from codenib.compiler.index_builders import BM25IndexBuilder  # noqa: E402
+from codenib.compiler.index_builders import IndexBuilderRegistry, VectorIndexBuilder
+from codenib.compiler.index_compiler import IndexCompiler  # noqa: E402
+from codenib.compiler.index_compiler import IndexCompilerConfig
+from codenib.compiler.manifest import MANIFEST_FILENAME  # noqa: E402
+from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.dataset.codenib_base import CodeNibBaseDataset  # noqa: E402
-from codenib.web.config import (  # noqa: E402
-    CACHE_DIR_NAME,
-    RepoEntry,
-    load_config,
-    save_registry,
-)
+from codenib.web.config import RepoEntry  # noqa: E402
+from codenib.web.config import CACHE_DIR_NAME, load_config, save_registry
 
 # Map dataset language_group -> tree-sitter chunker languages.
 # Keys are normalized single-label tokens (lower-case, no slashes). The dataset
@@ -170,6 +158,24 @@ def _count_files(repo_path: str) -> int:
     for _, _, files in os.walk(repo_path):
         count += len(files)
     return count
+
+
+def _vector_builder(cfg, languages: List[str]) -> VectorIndexBuilder:
+    """Build with the same explicit embedding route the Web runtime reopens."""
+
+    runtime_kwargs = {}
+    if cfg.embedding_api_key:
+        # Runtime-only; VectorIndexBuilder excludes this mapping from its
+        # persisted compatibility identity and manifest metadata.
+        runtime_kwargs["api_key"] = cfg.embedding_api_key
+    return VectorIndexBuilder(
+        languages=languages,
+        embedding_model=cfg.embedding_model,
+        embedding_provider=cfg.embedding_provider,
+        embedding_dimension=cfg.embedding_dimension,
+        embedding_endpoint=cfg.embedding_base_url,
+        embedding_runtime_kwargs=runtime_kwargs,
+    )
 
 
 def build_one_prebuilt(cfg, row, force: bool) -> RepoEntry:
@@ -303,14 +309,7 @@ def build_one(cfg, row, force: bool) -> RepoEntry:
         builders = IndexBuilderRegistry()
         builders.register("bm25", BM25IndexBuilder(languages=languages))
         if "vector" in index_types:
-            builders.register(
-                "vector",
-                VectorIndexBuilder(
-                    languages=languages,
-                    embedding_model=cfg.embedding_model,
-                    embedding_dimension=cfg.embedding_dimension,
-                ),
-            )
+            builders.register("vector", _vector_builder(cfg, languages))
         compiler = IndexCompiler(
             builders,
             IndexCompilerConfig(index_types=index_types, languages=languages),
@@ -326,14 +325,7 @@ def build_one(cfg, row, force: bool) -> RepoEntry:
         builders = IndexBuilderRegistry()
         builders.register("bm25", BM25IndexBuilder(languages=languages))
         if "vector" in index_types:
-            builders.register(
-                "vector",
-                VectorIndexBuilder(
-                    languages=languages,
-                    embedding_model=cfg.embedding_model,
-                    embedding_dimension=cfg.embedding_dimension,
-                ),
-            )
+            builders.register("vector", _vector_builder(cfg, languages))
         compiler = IndexCompiler(
             builders,
             IndexCompilerConfig(index_types=index_types, languages=languages),

--- a/scripts/prewarm_wiki_cache.py
+++ b/scripts/prewarm_wiki_cache.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prewarm bounded Wiki page scopes and report generation quality/latency."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from codenib.llm.litellm_chat import LiteLLMChat  # noqa: E402
+from codenib.log_utils import set_console_log_level  # noqa: E402
+from codenib.web.config import load_config  # noqa: E402
+from codenib.web.native_authority import authorize_local_manifest_vector  # noqa: E402
+from codenib.web.repo_registry import RepoRegistry  # noqa: E402
+from codenib.wiki.agent_wiki import AgentWiki  # noqa: E402
+from codenib.wiki.prewarm import prewarm_wiki_cache  # noqa: E402
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        help="QA config path; defaults to CODENIB_DEMO_CONFIG or qa_config.yaml",
+    )
+    parser.add_argument(
+        "--repo",
+        action="append",
+        dest="repos",
+        help="Prewarm one repository id; repeat to select more than one",
+    )
+    parser.add_argument(
+        "--scope",
+        choices=("overview", "root", "all"),
+        default="overview",
+    )
+    parser.add_argument("--workers", type=int, default=2)
+    parser.add_argument("--max-pages", type=int)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--compact", action="store_true")
+    parser.add_argument("--fail-on-error", action="store_true")
+    parser.add_argument("--fail-on-quality-invalid", action="store_true")
+    parser.add_argument(
+        "--keep-views",
+        action="store_true",
+        help="Retain loaded retrieval views until this maintenance process exits",
+    )
+    parser.add_argument(
+        "--retry-degraded-now",
+        action="store_true",
+        help=(
+            "Explicitly retry degraded pages now, bypassing their reader-facing "
+            "cooldown after an index or model upgrade"
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    set_console_log_level("WARNING")
+    config = load_config(args.config)
+    registry = RepoRegistry(
+        config,
+        native_index_authorization_resolver=authorize_local_manifest_vector,
+        allow_missing_native_index_authorization=True,
+    )
+    registry.load_all()
+    cache_dir = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
+
+    def wiki_factory(bundle):
+        llm = LiteLLMChat(
+            model=config.wiki_generation_model,
+            temperature=0.2,
+            max_tokens=4096,
+            api_base=config.wiki_generation_api_base,
+            api_key=config.wiki_generation_api_key,
+            extra_kwargs=config.wiki_generation_options,
+        )
+        return AgentWiki(
+            bundle,
+            model=config.wiki_generation_model,
+            cache_dir=cache_dir,
+            llm=llm,
+            api_base=config.wiki_generation_api_base,
+            api_key=config.wiki_generation_api_key,
+        )
+
+    report = prewarm_wiki_cache(
+        registry,
+        wiki_factory=wiki_factory,
+        repo_ids=args.repos,
+        scope=args.scope,
+        workers=args.workers,
+        max_pages=args.max_pages,
+        dry_run=args.dry_run,
+        retry_degraded_now=args.retry_degraded_now,
+        release_views=not args.keep_views,
+    )
+    print(
+        json.dumps(
+            report,
+            indent=None if args.compact else 2,
+            separators=(",", ":") if args.compact else None,
+            sort_keys=True,
+        )
+    )
+    failed = bool(
+        (
+            args.fail_on_error
+            and any(
+                page["status"] in {"error", "release_error"} for page in report["pages"]
+            )
+        )
+        or (
+            args.fail_on_quality_invalid
+            and any(page.get("quality_valid") is False for page in report["pages"])
+        )
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rebuild_demo_indexes.py
+++ b/scripts/rebuild_demo_indexes.py
@@ -196,6 +196,19 @@ def _parse_repo_ignore_dirs(values: list[str]) -> dict[str, list[str]]:
     return {repo: sorted(set(directories)) for repo, directories in parsed.items()}
 
 
+def _validate_repo_ignore_dirs(
+    repo_ignore_dirs: dict[str, list[str]],
+    available_repo_ids: set[str],
+) -> None:
+    """Reject exclusions that would otherwise be silently ignored."""
+
+    unknown = sorted(set(repo_ignore_dirs) - available_repo_ids)
+    if unknown:
+        raise ValueError(
+            "Unknown repository ids in --ignore-dir: " + ", ".join(unknown)
+        )
+
+
 def _validated_graph_node_count(graph_dir: str, minimum: int) -> int:
     """Load the published graph surface and enforce the demo quality floor."""
 
@@ -347,6 +360,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     registry.load_all()
     try:
+        _validate_repo_ignore_dirs(
+            repo_ignore_dirs,
+            {str(info.id) for info in registry.list_infos()},
+        )
         bundles = _select_registry_bundles(registry, args.repos, args.max_repos)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)

--- a/scripts/rebuild_demo_indexes.py
+++ b/scripts/rebuild_demo_indexes.py
@@ -94,6 +94,30 @@ def _configure_process_safe_directories(repo_paths: list[str]) -> None:
     os.environ["GIT_CONFIG_COUNT"] = str(offset + len(set(repo_paths)))
 
 
+def _select_registry_bundles(
+    registry,
+    repo_ids: list[str] | None,
+    max_repos: int | None,
+) -> list:
+    """Validate selectors against the full registry before limiting work."""
+
+    infos = list(registry.list_infos())
+    selected = {str(repo_id) for repo_id in repo_ids or ()}
+    available = {str(info.id) for info in infos}
+    missing = sorted(selected - available)
+    if missing:
+        raise ValueError(f"Unknown repository ids: {missing}")
+    bundles = [
+        registry.get(str(info.id))
+        for info in infos
+        if not selected or str(info.id) in selected
+    ]
+    bundles = [bundle for bundle in bundles if bundle is not None]
+    if max_repos is not None:
+        bundles = bundles[: max(0, max_repos)]
+    return bundles
+
+
 def _builders(
     config,
     manifest: RepoManifest,
@@ -322,18 +346,10 @@ def main(argv: list[str] | None = None) -> int:
         allow_missing_native_index_authorization=True,
     )
     registry.load_all()
-    selected = set(args.repos or ())
-    bundles = [
-        registry.get(str(info.id))
-        for info in registry.list_infos()
-        if not selected or str(info.id) in selected
-    ]
-    bundles = [bundle for bundle in bundles if bundle is not None]
-    if args.max_repos is not None:
-        bundles = bundles[: max(0, args.max_repos)]
-    missing = sorted(selected - {str(bundle.entry.instance_id) for bundle in bundles})
-    if missing:
-        print(f"Unknown repository ids: {missing}", file=sys.stderr)
+    try:
+        bundles = _select_registry_bundles(registry, args.repos, args.max_repos)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
         return 2
     _configure_process_safe_directories(
         [str(bundle.entry.repo_dir) for bundle in bundles]

--- a/scripts/rebuild_demo_indexes.py
+++ b/scripts/rebuild_demo_indexes.py
@@ -259,21 +259,11 @@ def _rebuild_one(
     stage = output_root / repo_id
     stage.mkdir(parents=True, exist_ok=True)
     stage_manifest_path = stage / MANIFEST_FILENAME
-    staged = None
-    if stage_manifest_path.is_file():
-        try:
-            candidate = RepoManifest.load(stage_manifest_path)
-            if (
-                os.path.realpath(candidate.repo_path)
-                == os.path.realpath(bundle.entry.repo_dir)
-                and candidate.commit == bundle.entry.base_commit
-                and is_secure_source_fingerprint_v2(candidate.source_fingerprint)
-            ):
-                staged = candidate
-        except (OSError, ValueError, KeyError, TypeError):
-            staged = None
-    if staged is None:
-        manifest.save(stage_manifest_path)
+    # The staging directory may retain large view artifacts between repair
+    # attempts, but its manifest is not authoritative.  Always reset compiler
+    # control state from the current publication target so removed views,
+    # languages, and capabilities cannot be resurrected by an older stage.
+    manifest.save(stage_manifest_path)
     compiler = IndexCompiler(
         _builders(
             config,

--- a/scripts/rebuild_demo_indexes.py
+++ b/scripts/rebuild_demo_indexes.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rebuild current demo views with source fingerprint v2 and publish safely."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import shutil
+import sys
+from pathlib import Path
+from time import perf_counter
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from codenib.compiler.cache_lock import compiler_cache_lock  # noqa: E402
+from codenib.compiler.index_builders import (  # noqa: E402
+    IndexBuilderRegistry,
+    SymbolGraphBuilder,
+    VectorIndexBuilder,
+    register_default_builders,
+)
+from codenib.compiler.index_compiler import IndexCompiler  # noqa: E402
+from codenib.compiler.index_compiler import IndexCompilerConfig
+from codenib.compiler.manifest import MANIFEST_FILENAME, RepoManifest  # noqa: E402
+from codenib.index.embedding.artifact_integrity import (  # noqa: E402
+    require_complete_vector_view,
+)
+from codenib.log_utils import set_console_log_level  # noqa: E402
+from codenib.source_fingerprint import is_secure_source_fingerprint_v2  # noqa: E402
+from codenib.toolchains import activate_managed_toolchain  # noqa: E402
+from codenib.web.config import load_config  # noqa: E402
+from codenib.web.native_authority import authorize_local_manifest_vector  # noqa: E402
+from codenib.web.repo_registry import RepoRegistry  # noqa: E402
+
+_SUPPORTED_VIEWS = ("bm25", "vector", "symbol_graph")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config")
+    parser.add_argument(
+        "--repo",
+        action="append",
+        dest="repos",
+        help="Rebuild one current registry id; repeat to select more",
+    )
+    parser.add_argument("--max-repos", type=int)
+    parser.add_argument("--output-root")
+    parser.add_argument(
+        "--min-graph-nodes",
+        type=int,
+        default=25,
+        help=(
+            "Refuse publication when a rebuilt demo symbol graph has fewer "
+            "nodes (default: 25; use 0 only for an intentional tiny fixture)"
+        ),
+    )
+    parser.add_argument(
+        "--ignore-dir",
+        action="append",
+        default=[],
+        metavar="REPO_ID:DIR_NAME",
+        help=(
+            "Exclude a dependency/generated directory name from one demo "
+            "repository's BM25 and vector views; repeat as needed"
+        ),
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--stop-on-error", action="store_true")
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def _configure_process_safe_directories(repo_paths: list[str]) -> None:
+    """Authorize exact shared checkouts for child git commands in this process."""
+
+    try:
+        offset = int(os.environ.get("GIT_CONFIG_COUNT", "0"))
+    except ValueError:
+        offset = 0
+    for index, repo_path in enumerate(dict.fromkeys(repo_paths), start=offset):
+        os.environ[f"GIT_CONFIG_KEY_{index}"] = "safe.directory"
+        os.environ[f"GIT_CONFIG_VALUE_{index}"] = os.path.realpath(repo_path)
+    os.environ["GIT_CONFIG_COUNT"] = str(offset + len(set(repo_paths)))
+
+
+def _builders(
+    config,
+    manifest: RepoManifest,
+    *,
+    additional_chunk_ignore_dirs: list[str] | None = None,
+) -> IndexBuilderRegistry:
+    registry = IndexBuilderRegistry()
+    graph_entry = manifest.indexes.get("symbol_graph")
+    graph_config = (graph_entry.config if graph_entry else {}) or {}
+    graph_route = str(graph_config.get("graph_route") or "active")
+    register_default_builders(
+        registry,
+        languages=list(manifest.languages),
+        graph_route=graph_route,
+        embedding_model=config.embedding_model,
+        embedding_provider=config.embedding_provider,
+        embedding_endpoint=config.embedding_base_url,
+        embedding_dimension=config.embedding_dimension,
+        additional_chunk_ignore_dirs=additional_chunk_ignore_dirs,
+    )
+    vector_builder = registry.get("vector")
+    if isinstance(vector_builder, VectorIndexBuilder) and config.embedding_api_key:
+        vector_builder.embedding_runtime_kwargs["api_key"] = config.embedding_api_key
+    if graph_entry is not None:
+        graph_languages = list(
+            graph_config.get("languages")
+            or [graph_config.get("language") or manifest.languages[0]]
+        )
+        registry.register(
+            "symbol_graph",
+            SymbolGraphBuilder(
+                language=graph_languages[0],
+                languages=graph_languages,
+                graph_route=graph_route,
+                allow_partial_languages=bool(
+                    graph_config.get("allow_partial_languages", False)
+                ),
+                allow_partial_index=bool(
+                    graph_config.get("allow_partial_index", False)
+                ),
+                source_coverage_fallback=bool(
+                    graph_config.get("source_coverage_fallback", False)
+                ),
+                # Demo checkouts are shared, immutable source inputs. Package
+                # manager preparation can rewrite lockfiles (and would make
+                # the source fingerprint race its own build), so only consume
+                # dependencies already present in the checkout.
+                allow_project_preparation=False,
+            ),
+        )
+    return registry
+
+
+def _digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _parse_repo_ignore_dirs(values: list[str]) -> dict[str, list[str]]:
+    """Parse explicit per-repository directory basenames."""
+
+    parsed: dict[str, list[str]] = {}
+    for value in values:
+        repo_id, separator, directory = value.partition(":")
+        if (
+            not separator
+            or not repo_id.strip()
+            or not directory.strip()
+            or directory in {".", ".."}
+            or "/" in directory
+            or "\\" in directory
+        ):
+            raise ValueError(
+                "--ignore-dir must use REPO_ID:DIR_NAME with one directory basename"
+            )
+        parsed.setdefault(repo_id.strip(), []).append(directory.strip())
+    return {repo: sorted(set(directories)) for repo, directories in parsed.items()}
+
+
+def _validated_graph_node_count(graph_dir: str, minimum: int) -> int:
+    """Load the published graph surface and enforce the demo quality floor."""
+
+    from codenib.graph.code_graph import CodeGraph
+
+    graph_path = Path(graph_dir) / "graph.pkl"
+    node_count = CodeGraph.load_graph(graph_path).get_graph().vcount()
+    required = max(0, minimum)
+    if node_count < required:
+        raise RuntimeError(
+            f"rebuilt symbol graph has only {node_count} nodes; "
+            f"publication gate requires {required}"
+        )
+    return node_count
+
+
+def _rebuild_one(
+    *,
+    config,
+    bundle,
+    output_root: Path,
+    dry_run: bool,
+    min_graph_nodes: int,
+    additional_chunk_ignore_dirs: list[str],
+) -> dict[str, object]:
+    started = perf_counter()
+    repo_id = str(bundle.entry.instance_id)
+    target = Path(bundle.entry.manifest_path)
+    if target.is_symlink() or not target.is_file():
+        raise ValueError(f"manifest must be a regular file: {target}")
+    original = target.read_bytes()
+    manifest = RepoManifest.from_dict(json.loads(original))
+    unsupported = sorted(set(manifest.indexes) - set(_SUPPORTED_VIEWS))
+    if unsupported:
+        raise ValueError(f"unsupported existing views: {unsupported}")
+    views = [name for name in _SUPPORTED_VIEWS if name in manifest.indexes]
+    if not views:
+        raise ValueError("manifest has no rebuildable views")
+    if dry_run:
+        return {
+            "repo": repo_id,
+            "status": "planned",
+            "views": views,
+            "manifest": str(target),
+            "additional_chunk_ignore_dirs": additional_chunk_ignore_dirs,
+        }
+
+    stage = output_root / repo_id
+    stage.mkdir(parents=True, exist_ok=True)
+    stage_manifest_path = stage / MANIFEST_FILENAME
+    staged = None
+    if stage_manifest_path.is_file():
+        try:
+            candidate = RepoManifest.load(stage_manifest_path)
+            if (
+                os.path.realpath(candidate.repo_path)
+                == os.path.realpath(bundle.entry.repo_dir)
+                and candidate.commit == bundle.entry.base_commit
+                and is_secure_source_fingerprint_v2(candidate.source_fingerprint)
+            ):
+                staged = candidate
+        except (OSError, ValueError, KeyError, TypeError):
+            staged = None
+    if staged is None:
+        manifest.save(stage_manifest_path)
+    compiler = IndexCompiler(
+        _builders(
+            config,
+            manifest,
+            additional_chunk_ignore_dirs=additional_chunk_ignore_dirs,
+        ),
+        IndexCompilerConfig(
+            index_types=views,
+            languages=list(manifest.languages),
+        ),
+    )
+    # This is an explicit repair/rebuild command, so do not let a previously
+    # completed private generation turn a rerun into a no-op. That matters when
+    # an upstream indexer exited zero but a later quality gate found a
+    # pathologically small graph.
+    rebuilt = compiler.compile_repo(
+        bundle.entry.repo_dir,
+        index_types=views,
+        cache_dir=str(stage),
+    )
+    if not is_secure_source_fingerprint_v2(rebuilt.source_fingerprint):
+        raise RuntimeError("compiler did not publish source fingerprint v2")
+    failed = [
+        name
+        for name in views
+        if not rebuilt.index_is_current(name)
+        or rebuilt.indexes[name].status != "fresh"
+        or rebuilt.indexes[name].source_fingerprint != rebuilt.source_fingerprint
+    ]
+    if failed:
+        raise RuntimeError(f"rebuilt views failed source binding: {failed}")
+    if "vector" in views:
+        require_complete_vector_view(rebuilt.indexes["vector"].path)
+    graph_node_count = None
+    if "symbol_graph" in views:
+        graph_node_count = _validated_graph_node_count(
+            rebuilt.indexes["symbol_graph"].path,
+            min_graph_nodes,
+        )
+    expected_commit = str(bundle.entry.base_commit or "")
+    if expected_commit and rebuilt.commit != expected_commit:
+        raise RuntimeError(
+            f"rebuilt commit {rebuilt.commit!r} does not match registry "
+            f"commit {expected_commit!r}"
+        )
+
+    with compiler_cache_lock(target.parent):
+        current = target.read_bytes()
+        if _digest(current) != _digest(original):
+            raise RuntimeError("manifest changed during rebuild; refusing publication")
+        backup = target.with_name(f"{target.name}.pre-source-v2")
+        if not backup.exists():
+            shutil.copy2(target, backup)
+        rebuilt.save(target)
+
+    return {
+        "repo": repo_id,
+        "status": "rebuilt",
+        "views": views,
+        "manifest": str(target),
+        "source_fingerprint": rebuilt.source_fingerprint,
+        "duration_seconds": round(perf_counter() - started, 2),
+        "graph_node_count": graph_node_count,
+        "additional_chunk_ignore_dirs": additional_chunk_ignore_dirs,
+        "artifacts": {name: rebuilt.indexes[name].path for name in views},
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    set_console_log_level("INFO")
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    activate_managed_toolchain()
+    config = load_config(args.config)
+    try:
+        repo_ignore_dirs = _parse_repo_ignore_dirs(args.ignore_dir)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    registry = RepoRegistry(
+        config,
+        native_index_authorization_resolver=authorize_local_manifest_vector,
+        allow_missing_native_index_authorization=True,
+    )
+    registry.load_all()
+    selected = set(args.repos or ())
+    bundles = [
+        registry.get(str(info.id))
+        for info in registry.list_infos()
+        if not selected or str(info.id) in selected
+    ]
+    bundles = [bundle for bundle in bundles if bundle is not None]
+    if args.max_repos is not None:
+        bundles = bundles[: max(0, args.max_repos)]
+    missing = sorted(selected - {str(bundle.entry.instance_id) for bundle in bundles})
+    if missing:
+        print(f"Unknown repository ids: {missing}", file=sys.stderr)
+        return 2
+    _configure_process_safe_directories(
+        [str(bundle.entry.repo_dir) for bundle in bundles]
+    )
+    output_root = Path(
+        args.output_root
+        or os.path.join(os.path.abspath(config.data_dir), "rebuilds-source-v2")
+    )
+    results = []
+    for bundle in bundles:
+        repo_id = str(bundle.entry.instance_id)
+        print(f"Rebuilding {repo_id}…", file=sys.stderr, flush=True)
+        try:
+            results.append(
+                _rebuild_one(
+                    config=config,
+                    bundle=bundle,
+                    output_root=output_root,
+                    dry_run=args.dry_run,
+                    min_graph_nodes=args.min_graph_nodes,
+                    additional_chunk_ignore_dirs=repo_ignore_dirs.get(repo_id, []),
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - report the rest of the batch
+            results.append({"repo": repo_id, "status": "error", "error": str(exc)})
+            if args.stop_on_error:
+                break
+    report = {
+        "schema_version": 1,
+        "dry_run": args.dry_run,
+        "selected": len(bundles),
+        "counts": {
+            status: sum(1 for item in results if item["status"] == status)
+            for status in sorted({str(item["status"]) for item in results})
+        },
+        "repositories": results,
+    }
+    print(
+        json.dumps(
+            report,
+            indent=None if args.compact else 2,
+            separators=(",", ":") if args.compact else None,
+            sort_keys=True,
+        )
+    )
+    return 1 if any(item["status"] == "error" for item in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/start_web.sh
+++ b/scripts/start_web.sh
@@ -12,9 +12,11 @@ CONDA_ENV="${CONDA_ENV:-codenib}"
 BACKEND_PORT="${CODENIB_DEMO_PORT:-8000}"
 LLM_PORT="${LLM_PORT:-8080}"
 DEFAULT_GPU_HOST="vscode-dsmlp-l40s"
+LOCAL_MODEL_FALLBACK="openai/qwen2.5-coder"
 PROFILE="${CODENIB_DEMO_PROFILE:-local}"
 MODEL_OVERRIDE="${CODENIB_DEMO_MODEL:-}"
-CONFIG_PATH="${CODENIB_DEMO_CONFIG:-}"
+CONFIG_OVERRIDE="${CODENIB_DEMO_CONFIG:-}"
+CONFIG_PATH="$CONFIG_OVERRIDE"
 
 case "$PROFILE" in
     local|api) ;;
@@ -81,7 +83,18 @@ REGISTRY=$(printf '%s\n' "$CONFIG_DETAILS" | sed -n '1p')
 CONFIG_MODEL=$(printf '%s\n' "$CONFIG_DETAILS" | sed -n '2p')
 CONFIG_API_BASE=$(printf '%s\n' "$CONFIG_DETAILS" | sed -n '3p')
 CONFIG_HAS_API_KEY=$(printf '%s\n' "$CONFIG_DETAILS" | sed -n '4p')
-SELECTED_MODEL="${MODEL_OVERRIDE:-$CONFIG_MODEL}"
+if [ -n "$MODEL_OVERRIDE" ]; then
+    SELECTED_MODEL="$MODEL_OVERRIDE"
+elif [ "$PROFILE" = "local" ] \
+    && [ -z "$CONFIG_OVERRIDE" ] \
+    && [ "$CONFIG_PATH" = "qa_config.yaml" ]; then
+    # The tracked base profile targets hosted OpenAI by default. Preserve the
+    # documented no-edit local route when no local overlay or explicit config
+    # selected another model.
+    SELECTED_MODEL="$LOCAL_MODEL_FALLBACK"
+else
+    SELECTED_MODEL="$CONFIG_MODEL"
+fi
 if [ ! -f "$REGISTRY" ]; then
     echo "ERROR: No repo registry found at $REGISTRY"
     echo ""
@@ -165,10 +178,8 @@ echo "────────────────────────�
 echo ""
 
 export CODENIB_DEMO_CONFIG="$CONFIG_PATH"
+export CODENIB_DEMO_MODEL="$SELECTED_MODEL"
 export CODENIB_DEMO_PORT="$BACKEND_PORT"
-if [ -n "$MODEL_OVERRIDE" ]; then
-    export CODENIB_DEMO_MODEL="$MODEL_OVERRIDE"
-fi
 
 if [ "$PROFILE" = "local" ]; then
     export OPENAI_API_KEY="fake"

--- a/scripts/start_web.sh
+++ b/scripts/start_web.sh
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Start the CodeNib FastAPI backend pointed at a local LLM server.
-# Run this in Terminal 2 (on your main machine).
+# Start the CodeNib FastAPI backend with either a local LLM or a hosted API
+# profile. Run this in Terminal 2 (on your main machine).
 # See docs/running-locally.md for the full setup guide.
 
 set -e
@@ -12,11 +12,22 @@ CONDA_ENV="${CONDA_ENV:-codenib}"
 BACKEND_PORT="${CODENIB_DEMO_PORT:-8000}"
 LLM_PORT="${LLM_PORT:-8080}"
 DEFAULT_GPU_HOST="vscode-dsmlp-l40s"
-LOCAL_MODEL="${CODENIB_DEMO_MODEL:-openai/qwen2.5-coder}"
+PROFILE="${CODENIB_DEMO_PROFILE:-local}"
+MODEL_OVERRIDE="${CODENIB_DEMO_MODEL:-}"
 CONFIG_PATH="${CODENIB_DEMO_CONFIG:-}"
 
+case "$PROFILE" in
+    local|api) ;;
+    *)
+        echo "ERROR: CODENIB_DEMO_PROFILE must be 'local' or 'api'."
+        exit 1
+        ;;
+esac
+
 if [ -z "$CONFIG_PATH" ]; then
-    if [ -f "qa_config.local.yaml" ]; then
+    if [ "$PROFILE" = "api" ]; then
+        CONFIG_PATH="qa_config.api.yaml"
+    elif [ -f "qa_config.local.yaml" ]; then
         CONFIG_PATH="qa_config.local.yaml"
     else
         CONFIG_PATH="qa_config.yaml"
@@ -26,6 +37,7 @@ fi
 # ── Prerequisites ────────────────────────────────────────────────────────────
 
 echo "=== CodeNib Backend ==="
+echo "Profile: $PROFILE"
 echo ""
 
 # Must run from repo root
@@ -35,7 +47,13 @@ if [ ! -f "$CONFIG_PATH" ]; then
     echo "  cd ~/projects/CodeNib/CodeNib"
     echo "  bash scripts/start_web.sh"
     echo ""
-    echo "For local overrides, copy qa_config.local.yaml.example to qa_config.local.yaml."
+    if [ "$PROFILE" = "api" ]; then
+        echo "Create the layered API profile:"
+        echo "  cp qa_config.local.yaml.example qa_config.local.yaml"
+        echo "  cp qa_config.api.yaml.example qa_config.api.yaml"
+    else
+        echo "For local overrides, copy qa_config.local.yaml.example to qa_config.local.yaml."
+    fi
     exit 1
 fi
 
@@ -47,14 +65,23 @@ if ! conda run -n "$CONDA_ENV" python -c "import codenib" &>/dev/null; then
 fi
 
 # Check qa_registry.json
-REGISTRY=$(CODENIB_DEMO_CONFIG="$CONFIG_PATH" python3 -c "
-import os, yaml
-path = os.environ['CODENIB_DEMO_CONFIG']
-with open(path) as f:
-    data = yaml.safe_load(f) or {}
-data_dir = os.environ.get('CODENIB_DEMO_DATA_DIR') or data.get('data_dir', '.codenib_qa')
-print(os.path.join(os.path.abspath(data_dir), 'qa_registry.json'))
-" 2>/dev/null || echo ".codenib_qa/qa_registry.json")
+CONFIG_DETAILS=$(CODENIB_DEMO_CONFIG="$CONFIG_PATH" \
+    conda run -n "$CONDA_ENV" python -c "
+from codenib.web.config import load_config
+config = load_config()
+print(config.registry_path)
+print(config.model)
+print(config.model_api_base or '')
+print('1' if config.model_api_key else '0')
+" 2>/dev/null) || {
+    echo "ERROR: Could not load layered config: $CONFIG_PATH"
+    exit 1
+}
+REGISTRY=$(printf '%s\n' "$CONFIG_DETAILS" | sed -n '1p')
+CONFIG_MODEL=$(printf '%s\n' "$CONFIG_DETAILS" | sed -n '2p')
+CONFIG_API_BASE=$(printf '%s\n' "$CONFIG_DETAILS" | sed -n '3p')
+CONFIG_HAS_API_KEY=$(printf '%s\n' "$CONFIG_DETAILS" | sed -n '4p')
+SELECTED_MODEL="${MODEL_OVERRIDE:-$CONFIG_MODEL}"
 if [ ! -f "$REGISTRY" ]; then
     echo "ERROR: No repo registry found at $REGISTRY"
     echo ""
@@ -72,47 +99,59 @@ REPO_COUNT=$(python3 -c "import json; print(len(json.load(open('$REGISTRY'))))" 
 echo "Found $REPO_COUNT repo(s) in registry."
 echo ""
 
-# ── GPU node hostname ─────────────────────────────────────────────────────────
+# ── Model backend ─────────────────────────────────────────────────────────────
 
-GPU_HOST="${LLM_HOST:-}"
+if [ "$PROFILE" = "local" ]; then
+    GPU_HOST="${LLM_HOST:-}"
 
-if [ -z "$GPU_HOST" ]; then
-    echo "Enter the hostname of the node running scripts/start_llm.sh."
-    read -rp "GPU node hostname [${DEFAULT_GPU_HOST}]: " GPU_HOST
-    GPU_HOST="${GPU_HOST:-$DEFAULT_GPU_HOST}"
-fi
+    if [ -z "$GPU_HOST" ]; then
+        echo "Enter the hostname of the node running scripts/start_llm.sh."
+        read -rp "GPU node hostname [${DEFAULT_GPU_HOST}]: " GPU_HOST
+        GPU_HOST="${GPU_HOST:-$DEFAULT_GPU_HOST}"
+    fi
 
-LLM_BASE="http://${GPU_HOST}:${LLM_PORT}/v1"
+    MODEL_ENDPOINT="http://${GPU_HOST}:${LLM_PORT}/v1"
 
-# Check LLM server is reachable
-echo ""
-echo "Checking LLM server at $LLM_BASE ..."
-if curl -sf --max-time 5 "${LLM_BASE}/models" > /dev/null 2>&1; then
-    echo "  LLM server: OK"
+    # Check LLM server is reachable.
+    echo ""
+    echo "Checking LLM server at $MODEL_ENDPOINT ..."
+    if curl -sf --max-time 5 "${MODEL_ENDPOINT}/models" > /dev/null 2>&1; then
+        echo "  LLM server: OK"
+    else
+        echo "  WARNING: Cannot reach LLM server at $MODEL_ENDPOINT"
+        echo ""
+        echo "  Make sure scripts/start_llm.sh is running on $GPU_HOST."
+        echo "  If the hostname is wrong, re-run and enter the correct hostname."
+        echo ""
+        read -rp "  Continue anyway? [y/N]: " CONT
+        [[ "$CONT" =~ ^[Yy]$ ]] || exit 1
+    fi
 else
-    echo "  WARNING: Cannot reach LLM server at $LLM_BASE"
-    echo ""
-    echo "  Make sure scripts/start_llm.sh is running on $GPU_HOST."
-    echo "  If the hostname is wrong, re-run and enter the correct hostname."
-    echo ""
-    read -rp "  Continue anyway? [y/N]: " CONT
-    [[ "$CONT" =~ ^[Yy]$ ]] || exit 1
+    MODEL_ENDPOINT="${CONFIG_API_BASE:-provider default}"
+    if [ "$CONFIG_HAS_API_KEY" != "1" ] \
+        && [ -z "${CODENIB_DEMO_API_KEY:-}" ] \
+        && [ -z "${DEEPSEEK_API_KEY:-}" ] \
+        && [ -z "${OPENAI_API_KEY:-}" ]; then
+        echo "WARNING: No hosted-model credential was found."
+        echo "Set CODENIB_DEMO_API_KEY or the provider's standard key variable."
+    fi
 fi
 
-# ── Local model override ─────────────────────────────────────────────────────
+# ── Selected profile ─────────────────────────────────────────────────────────
 
 echo ""
-echo "Using local LLM model: $LOCAL_MODEL"
+echo "Using $PROFILE model profile: $SELECTED_MODEL"
 echo "  Config: $CONFIG_PATH"
-echo "  Override with CODENIB_DEMO_MODEL or CODENIB_DEMO_CONFIG if needed."
+echo "  Endpoint: $MODEL_ENDPOINT"
+echo "  Override with CODENIB_DEMO_MODEL, CODENIB_DEMO_CONFIG, or CODENIB_DEMO_PROFILE."
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 
 echo ""
 echo "Starting CodeNib backend..."
 echo "  Backend:  http://localhost:$BACKEND_PORT"
-echo "  LLM:      $LLM_BASE"
-echo "  Model:    $LOCAL_MODEL"
+echo "  Model:    $SELECTED_MODEL"
+echo "  Endpoint: $MODEL_ENDPOINT"
 echo "  Config:   $CONFIG_PATH"
 echo ""
 echo "─────────────────────────────────────────────"
@@ -125,14 +164,18 @@ echo "Then open: http://localhost:3000"
 echo "─────────────────────────────────────────────"
 echo ""
 
-export OPENAI_API_KEY="fake"
-export OPENAI_API_BASE="$LLM_BASE"
 export CODENIB_DEMO_CONFIG="$CONFIG_PATH"
-export CODENIB_DEMO_MODEL="$LOCAL_MODEL"
 export CODENIB_DEMO_PORT="$BACKEND_PORT"
+if [ -n "$MODEL_OVERRIDE" ]; then
+    export CODENIB_DEMO_MODEL="$MODEL_OVERRIDE"
+fi
+
+if [ "$PROFILE" = "local" ]; then
+    export OPENAI_API_KEY="fake"
+    export OPENAI_API_BASE="$MODEL_ENDPOINT"
+    export CODENIB_DEMO_API_BASE="$MODEL_ENDPOINT"
+    export CODENIB_DEMO_API_KEY="fake"
+fi
 
 conda run -n "$CONDA_ENV" --no-capture-output \
-    env OPENAI_API_KEY=fake OPENAI_API_BASE="$LLM_BASE" \
-    CODENIB_DEMO_CONFIG="$CONFIG_PATH" \
-    CODENIB_DEMO_MODEL="$LOCAL_MODEL" \
     python -m codenib.web.app

--- a/test/agent/test_runner.py
+++ b/test/agent/test_runner.py
@@ -249,6 +249,11 @@ class TestAgentRunner:
         forced_kwargs = llm._call_raw.call_args.kwargs
         assert forced_kwargs.get("tool_choice") == "none"
         assert forced_kwargs.get("usage_turn") == 3
+        forced_history = llm._call_raw.call_args.args[0]
+        assert any(
+            "directly supported by retrieved evidence" in (message.get("content") or "")
+            for message in forced_history
+        )
 
     def test_force_final_answer_empty_result_raises(self, echo_registry):
         """An empty forced answer is an error, not a silent fallback."""

--- a/test/chunker/test_base_chunker.py
+++ b/test/chunker/test_base_chunker.py
@@ -119,6 +119,19 @@ def test_chunk_file_replaces_invalid_utf8_bytes(monkeypatch, tmp_path):
     assert "\ufffd" in chunks[0].content
 
 
+def test_tree_walkers_handle_deeper_trees_than_python_recursion_limit():
+    target = SimpleNamespace(type="target", children=[])
+    branch = target
+    for _ in range(1500):
+        branch = SimpleNamespace(type="nested", children=[branch])
+    later_target = SimpleNamespace(type="target", children=[])
+    root = SimpleNamespace(type="root", children=[branch, later_target])
+    chunker = object.__new__(StubCodeChunker)
+
+    assert chunker._find_first_child(root, ("target",)) is target
+    assert chunker._find_nodes_by_type(root, "target") == [target, later_target]
+
+
 @pytest.mark.parametrize(
     ("configured_limit", "expected_limit"),
     [(None, DEFAULT_L0_RAW_FALLBACK_MAX_LINES), (100, 100)],

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -1032,7 +1032,7 @@ class TestVectorIndexBuilder:
 
         identity = builder.artifact_identity()
         assert identity == {
-            "builder_schema": 6,
+            "builder_schema": 7,
             "embedding_model": "test-model",
             "embedding_provider": "huggingface",
             "embedding_dimension": 384,

--- a/test/compiler/test_manifest_storage.py
+++ b/test/compiler/test_manifest_storage.py
@@ -528,6 +528,73 @@ def test_every_profile_axis_participates_in_profile_identity(view_type: str) -> 
         assert altered.profile_id != intent.profile_id, axis
 
 
+@pytest.mark.parametrize("view_type", ["bm25", "vector"])
+def test_optional_ignore_directories_participate_in_profile_identity(
+    view_type: str,
+) -> None:
+    manifest = _manifest()
+    baseline = _profile_id(manifest, view_type)
+    _set_entry_field(
+        manifest.indexes[view_type],
+        "additional_ignore_dirs",
+        ["vendored-source"],
+    )
+
+    plan = plan_repo_manifest_import(manifest, views=[view_type])
+    compatibility = plan.view_map[view_type].profile.config["compatibility"]
+
+    assert compatibility["additional_ignore_dirs"] == ["vendored-source"]
+    assert plan.view_map[view_type].profile_id != baseline
+
+
+def test_remote_vector_profile_binds_document_input_limit() -> None:
+    manifest = _manifest()
+    entry = manifest.indexes["vector"]
+    remote_identity = VectorIndexBuilder(
+        languages=["python", "typescript"],
+        embedding_model="test/model",
+        embedding_provider="openai",
+        embedding_dimension=4,
+        embedding_endpoint="https://embedding.example/v1",
+        embedding_credential_env="TEST_EMBEDDING_API_KEY",
+        build_levels=["l0", "l2"],
+        max_lines_per_chunk=240,
+        embedding_document_max_chars=12_000,
+    ).artifact_identity()
+    _set_entry_fields(entry, remote_identity)
+
+    first = plan_repo_manifest_import(manifest, views=["vector"])
+    assert (
+        first.view_map["vector"].profile.config["compatibility"][
+            "embedding_document_max_chars"
+        ]
+        == 12_000
+    )
+
+    _set_entry_field(entry, "embedding_document_max_chars", 8_000)
+    second = plan_repo_manifest_import(manifest, views=["vector"])
+    assert second.view_map["vector"].profile_id != first.view_map["vector"].profile_id
+
+
+def test_remote_vector_profile_requires_document_input_limit() -> None:
+    manifest = _manifest()
+    entry = manifest.indexes["vector"]
+    remote_identity = VectorIndexBuilder(
+        languages=["python", "typescript"],
+        embedding_model="test/model",
+        embedding_provider="openai",
+        embedding_dimension=4,
+        embedding_endpoint="https://embedding.example/v1",
+        build_levels=["l0", "l2"],
+        max_lines_per_chunk=240,
+    ).artifact_identity()
+    remote_identity.pop("embedding_document_max_chars")
+    _set_entry_fields(entry, remote_identity)
+
+    with pytest.raises(StorageValidationError, match="document bound is missing"):
+        plan_repo_manifest_import(manifest, views=["vector"])
+
+
 def test_vector_profile_binds_resolved_artifact_model_policy() -> None:
     manifest = _manifest()
     baseline = _profile_id(manifest, "vector")

--- a/test/compiler/test_manifest_storage.py
+++ b/test/compiler/test_manifest_storage.py
@@ -547,6 +547,29 @@ def test_optional_ignore_directories_participate_in_profile_identity(
     assert plan.view_map[view_type].profile_id != baseline
 
 
+@pytest.mark.parametrize(
+    ("axis", "value"),
+    [
+        ("additional_ignore_dirs", ["vendored-source"]),
+        ("embedding_document_max_chars", 12_000),
+    ],
+)
+def test_metadata_only_optional_vector_axes_are_incomplete_profiles(
+    axis: str,
+    value: object,
+) -> None:
+    manifest = _manifest()
+    entry = manifest.indexes["vector"]
+    entry.config.pop(axis, None)
+    entry.metadata[axis] = value
+
+    optional = plan_repo_manifest_import(manifest)
+    assert optional.selection.skipped_views == {"vector": "incomplete_profile"}
+
+    with pytest.raises(StorageValidationError, match="incomplete profile.*missing"):
+        plan_repo_manifest_import(manifest, views=["vector"])
+
+
 def test_remote_vector_profile_binds_document_input_limit() -> None:
     manifest = _manifest()
     entry = manifest.indexes["vector"]

--- a/test/graph/test_graph_persistence.py
+++ b/test/graph/test_graph_persistence.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pickle
+
+from codenib.graph.code_graph import (
+    CodeGraph,
+    current_graph_schema_version,
+    persisted_graph_schema_version,
+)
+
+
+def test_persisted_graph_schema_version_reads_current_graph_without_loading(tmp_path):
+    path = tmp_path / "graph.pkl"
+    CodeGraph().save_graph(path)
+
+    assert persisted_graph_schema_version(path) == current_graph_schema_version()
+
+
+def test_persisted_graph_schema_version_reports_old_and_invalid_pickles(tmp_path):
+    old_path = tmp_path / "old.pkl"
+    with old_path.open("wb") as handle:
+        pickle.dump({"schema_version": 4, "graph": "not loaded"}, handle)
+    invalid_path = tmp_path / "invalid.pkl"
+    invalid_path.write_bytes(b"not a pickle")
+
+    assert persisted_graph_schema_version(old_path) == 4
+    assert persisted_graph_schema_version(invalid_path) is None

--- a/test/graph/test_graph_persistence.py
+++ b/test/graph/test_graph_persistence.py
@@ -24,6 +24,9 @@ def test_persisted_graph_schema_version_reports_old_and_invalid_pickles(tmp_path
         pickle.dump({"schema_version": 4, "graph": "not loaded"}, handle)
     invalid_path = tmp_path / "invalid.pkl"
     invalid_path.write_bytes(b"not a pickle")
+    invalid_unicode_path = tmp_path / "invalid-unicode.pkl"
+    invalid_unicode_path.write_bytes(b"\x8c\x01\xff.")
 
     assert persisted_graph_schema_version(old_path) == 4
     assert persisted_graph_schema_version(invalid_path) is None
+    assert persisted_graph_schema_version(invalid_unicode_path) is None

--- a/test/index/test_vector_artifact_identity.py
+++ b/test/index/test_vector_artifact_identity.py
@@ -666,3 +666,80 @@ def test_openai_wrapper_sends_vector_options_on_embedding_requests() -> None:
         model="text-embedding-3-small",
         dimensions=2,
     )
+
+
+def test_openai_wrapper_batches_document_embeddings_in_order() -> None:
+    client = MagicMock()
+    client.embeddings.create.side_effect = [
+        SimpleNamespace(
+            data=[
+                SimpleNamespace(index=1, embedding=[2.0]),
+                SimpleNamespace(index=0, embedding=[1.0]),
+            ]
+        ),
+        SimpleNamespace(
+            data=[
+                SimpleNamespace(index=1, embedding=[4.0]),
+                SimpleNamespace(index=0, embedding=[3.0]),
+            ]
+        ),
+        SimpleNamespace(data=[SimpleNamespace(index=0, embedding=[5.0])]),
+    ]
+    with patch("openai.OpenAI", return_value=client):
+        embedding = _OpenAIEmbeddingWrapper("served", batch_size=2)
+
+    assert embedding.embed_documents(["a", "b", "c", "d", "e"]) == [
+        [1.0],
+        [2.0],
+        [3.0],
+        [4.0],
+        [5.0],
+    ]
+    assert [
+        call.kwargs["input"] for call in client.embeddings.create.call_args_list
+    ] == [
+        ["a", "b"],
+        ["c", "d"],
+        ["e"],
+    ]
+
+
+def test_openai_wrapper_splits_only_context_limit_failures() -> None:
+    class ContextLimitError(Exception):
+        status_code = 400
+
+    client = MagicMock()
+
+    def create(*, input, **_kwargs):
+        if len(input) > 1:
+            raise ContextLimitError("maximum context length; input_tokens")
+        return SimpleNamespace(
+            data=[SimpleNamespace(index=0, embedding=[float(ord(input[0]))])]
+        )
+
+    client.embeddings.create.side_effect = create
+    with patch("openai.OpenAI", return_value=client):
+        embedding = _OpenAIEmbeddingWrapper("served", batch_size=4)
+
+    assert embedding.embed_documents(["a", "b", "c"]) == [
+        [97.0],
+        [98.0],
+        [99.0],
+    ]
+
+
+def test_openai_wrapper_bounds_one_oversized_document_deterministically() -> None:
+    client = MagicMock()
+
+    def create(*, input, **_kwargs):
+        assert len(input) == 1
+        assert len(input[0]) == 80
+        assert input[0].startswith("a" * 20)
+        assert input[0].endswith("z" * 5)
+        return SimpleNamespace(data=[SimpleNamespace(index=0, embedding=[1.0])])
+
+    client.embeddings.create.side_effect = create
+    with patch("openai.OpenAI", return_value=client):
+        embedding = _OpenAIEmbeddingWrapper("served", max_input_chars=80)
+
+    assert embedding.embed_documents(["a" * 100 + "z" * 100]) == [[1.0]]

--- a/test/scip/test_rust_analyzer_command.py
+++ b/test/scip/test_rust_analyzer_command.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from codenib.scip_interface.rust_analyzer import rust_analyzer_command
+
+
+def test_explicit_rust_analyzer_executable_wins_over_rustup(monkeypatch):
+    monkeypatch.setenv("CODENIB_RUST_ANALYZER", "/opt/rust/bin/rust-analyzer")
+    monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/rustup")
+
+    assert rust_analyzer_command("scip", "/repo") == [
+        "/opt/rust/bin/rust-analyzer",
+        "scip",
+        "/repo",
+    ]
+
+
+def test_rust_analyzer_uses_selected_rustup_toolchain(monkeypatch):
+    monkeypatch.delenv("CODENIB_RUST_ANALYZER", raising=False)
+    monkeypatch.setenv("CODENIB_RUST_TOOLCHAIN", "stable")
+    monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/rustup")
+
+    assert rust_analyzer_command("--version") == [
+        "rustup",
+        "run",
+        "stable",
+        "rust-analyzer",
+        "--version",
+    ]

--- a/test/scip/test_scip_typescript_runtime.py
+++ b/test/scip/test_scip_typescript_runtime.py
@@ -100,8 +100,15 @@ def test_read_only_pipeline_skips_all_project_preparation(tmp_path, monkeypatch)
 def test_read_only_pipeline_uses_external_config_for_jsconfig(tmp_path, monkeypatch):
     project = tmp_path / "repo"
     project.mkdir()
-    (project / "jsconfig.json").write_text("{}\n", encoding="utf-8")
-    indexer = SCIPTypeScriptIndexer(project, output_dir=tmp_path / "index")
+    (project / "jsconfig.json").write_text(
+        json.dumps({"exclude": ["custom/**"]}) + "\n",
+        encoding="utf-8",
+    )
+    indexer = SCIPTypeScriptIndexer(
+        project,
+        output_dir=tmp_path / "index",
+        exclude_patterns=["dist/**"],
+    )
     observed: dict[str, object] = {}
 
     def run_pipeline(_self, **kwargs):
@@ -124,7 +131,40 @@ def test_read_only_pipeline_uses_external_config_for_jsconfig(tmp_path, monkeypa
     assert isinstance(config, dict)
     assert config["extends"] == str((project / "jsconfig.json").resolve())
     assert f"{project.resolve()}/**/*.js" in config["include"]
+    root = project.resolve().as_posix()
+    assert config["exclude"] == [f"{root}/custom/**", f"{root}/dist/**"]
     assert not (project / "tsconfig.json").exists()
+    assert not (tmp_path / "index" / ".tsconfig.scip.readonly.json").exists()
+
+
+def test_read_only_pipeline_anchors_repository_excludes_to_the_checkout(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "repo"
+    project.mkdir()
+    indexer = SCIPTypeScriptIndexer(
+        project,
+        output_dir=tmp_path / "index",
+        exclude_patterns=["dist/**", "**/vendor/**"],
+    )
+    observed: dict[str, object] = {}
+
+    def run_pipeline(_self, **kwargs):
+        observed["config"] = json.loads(
+            Path(kwargs["patched_tsconfig"]).read_text(encoding="utf-8")
+        )
+        return "graph"
+
+    monkeypatch.setattr(SCIPIndexerBase, "run_pipeline", run_pipeline)
+
+    assert (
+        indexer.run_pipeline(allow_project_preparation=False, report_profile=False)
+        == "graph"
+    )
+    config = observed["config"]
+    assert isinstance(config, dict)
+    root = project.resolve().as_posix()
+    assert config["exclude"] == [f"{root}/dist/**", f"{root}/**/vendor/**"]
     assert not (tmp_path / "index" / ".tsconfig.scip.readonly.json").exists()
 
 

--- a/test/scip/test_scip_typescript_runtime.py
+++ b/test/scip/test_scip_typescript_runtime.py
@@ -5,12 +5,16 @@
 """Fast tests for TypeScript repository filtering before SCIP generation."""
 
 import json
+from pathlib import Path
 
 import pytest
 
 from codenib.repository_filters import default_exclude_patterns
 from codenib.scip_interface.scip_indexer_base import SCIPIndexerBase
 from codenib.scip_interface.scip_indexer_ts import SCIPTypeScriptIndexer
+from codenib.scip_interface.typescript_semantics import (
+    typescript_static_module_fingerprint,
+)
 
 
 def test_default_excludes_cover_root_and_nested_generated_trees():
@@ -84,5 +88,113 @@ def test_read_only_pipeline_skips_all_project_preparation(tmp_path, monkeypatch)
         indexer.run_pipeline(allow_project_preparation=False, report_profile=False)
         == "graph"
     )
-    assert observed["infer_tsconfig"] is True
+    assert observed["infer_tsconfig"] is False
+    patched = observed["patched_tsconfig"]
+    assert isinstance(patched, str)
+    assert patched.startswith(str(tmp_path / "index"))
+    assert not (project / "tsconfig.json").exists()
+    assert not (tmp_path / "index" / ".tsconfig.scip.readonly.json").exists()
     assert existing_patch.read_text(encoding="utf-8") == '{"owned": "by-user"}\n'
+
+
+def test_read_only_pipeline_uses_external_config_for_jsconfig(tmp_path, monkeypatch):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "jsconfig.json").write_text("{}\n", encoding="utf-8")
+    indexer = SCIPTypeScriptIndexer(project, output_dir=tmp_path / "index")
+    observed: dict[str, object] = {}
+
+    def run_pipeline(_self, **kwargs):
+        observed.update(kwargs)
+        observed["config"] = json.loads(
+            Path(kwargs["patched_tsconfig"]).read_text(encoding="utf-8")
+        )
+        return "graph"
+
+    monkeypatch.setattr(SCIPIndexerBase, "run_pipeline", run_pipeline)
+
+    assert (
+        indexer.run_pipeline(allow_project_preparation=False, report_profile=False)
+        == "graph"
+    )
+    assert observed["infer_tsconfig"] is False
+    patched_path = observed["patched_tsconfig"]
+    assert isinstance(patched_path, str)
+    config = observed["config"]
+    assert isinstance(config, dict)
+    assert config["extends"] == str((project / "jsconfig.json").resolve())
+    assert f"{project.resolve()}/**/*.js" in config["include"]
+    assert not (project / "tsconfig.json").exists()
+    assert not (tmp_path / "index" / ".tsconfig.scip.readonly.json").exists()
+
+
+def test_read_only_pipeline_uses_existing_tsconfig_without_wrapper(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "tsconfig.json").write_text("{}\n", encoding="utf-8")
+    indexer = SCIPTypeScriptIndexer(project, output_dir=tmp_path / "index")
+    observed: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        SCIPIndexerBase,
+        "run_pipeline",
+        lambda _self, **kwargs: observed.update(kwargs) or "graph",
+    )
+
+    assert (
+        indexer.run_pipeline(allow_project_preparation=False, report_profile=False)
+        == "graph"
+    )
+    assert observed["infer_tsconfig"] is False
+    assert "patched_tsconfig" not in observed
+
+
+def test_root_tsconfig_takes_precedence_over_auto_workspace_mode(tmp_path, monkeypatch):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "tsconfig.json").write_text(
+        json.dumps({"include": ["packages/*/src"]}) + "\n",
+        encoding="utf-8",
+    )
+    (project / "pnpm-workspace.yaml").write_text(
+        "packages:\n  - packages/*\n",
+        encoding="utf-8",
+    )
+    indexer = SCIPTypeScriptIndexer(project, output_dir=tmp_path / "index")
+    observed: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        SCIPIndexerBase,
+        "run_pipeline",
+        lambda _self, **kwargs: observed.update(kwargs) or "graph",
+    )
+    monkeypatch.setattr(
+        "codenib.scip_interface.scip_indexer_ts.shutil.which",
+        lambda _command: "/managed/bin/tool",
+    )
+
+    assert (
+        indexer.run_pipeline(allow_project_preparation=False, report_profile=False)
+        == "graph"
+    )
+    assert observed["infer_tsconfig"] is False
+    assert not any(
+        observed.get(flag)
+        for flag in ("yarn_workspaces", "pnpm_workspaces", "npm_workspaces")
+    )
+
+
+def test_static_module_parser_safely_reuses_mixed_language_grammars():
+    typescript = b'import type { Runner } from "./types";\n'
+    javascript = b'import value from "./value.js";\nexport { value };\n'
+
+    for _ in range(32):
+        ts_fingerprint = typescript_static_module_fingerprint(typescript, ".ts")
+        js_fingerprint = typescript_static_module_fingerprint(javascript, ".js")
+
+    assert len(ts_fingerprint) == 1
+    assert len(js_fingerprint) == 1
+    assert ts_fingerprint[0][0] == "import_statement"
+    assert js_fingerprint[0][0] == "import_statement"

--- a/test/scripts/test_benchmark_demo_ask.py
+++ b/test/scripts/test_benchmark_demo_ask.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from scripts.benchmark_demo_ask import evaluate_response
+
+
+def test_evaluate_response_reports_source_and_term_coverage():
+    case = {
+        "expected_files": ["src/core.py", "src/runtime.py"],
+        "expected_terms": ["queueJob", "flushJobs"],
+    }
+    response = {
+        "answer": "queueJob schedules work before flushJobs drains it.",
+        "citations": [
+            {
+                "file": "src/core.py",
+                "start_line": 10,
+                "end_line": 20,
+            }
+        ],
+        "tool_calls": [{"skill_id": "repository_search"}],
+        "total_turns": 2,
+        "total_duration_ms": 42.0,
+    }
+
+    result = evaluate_response(case, response)
+
+    assert result["citation_locations_valid"] is True
+    assert result["expected_file_recall"] == 0.5
+    assert result["expected_term_coverage"] == 1.0
+    assert result["tool_call_count"] == 1
+
+
+def test_evaluate_response_rejects_missing_or_reversed_citation_ranges():
+    result = evaluate_response(
+        {"expected_files": [], "expected_terms": []},
+        {
+            "answer": "answer",
+            "citations": [{"file": "src/core.py", "start_line": 20, "end_line": 10}],
+        },
+    )
+
+    assert result["citation_locations_valid"] is False

--- a/test/scripts/test_benchmark_demo_ask.py
+++ b/test/scripts/test_benchmark_demo_ask.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+
+from scripts import benchmark_demo_ask
 from scripts.benchmark_demo_ask import _parser, evaluate_response
 
 
@@ -48,3 +51,96 @@ def test_evaluate_response_rejects_missing_or_reversed_citation_ranges():
     )
 
     assert result["citation_locations_valid"] is False
+
+
+def test_main_fails_when_a_successful_response_is_not_grounded(
+    tmp_path, monkeypatch, capsys
+):
+    cases = [
+        {
+            "id": "runtime",
+            "repo": "owner__repo",
+            "question": "How does it run?",
+            "expected_files": ["src/runtime.py"],
+            "expected_terms": ["dispatch"],
+        }
+    ]
+    case_file = tmp_path / "cases.json"
+    case_file.write_text(json.dumps(cases), encoding="utf-8")
+    monkeypatch.setattr(
+        benchmark_demo_ask,
+        "_request",
+        lambda *_args, **_kwargs: (
+            {"answer": "No source evidence.", "citations": []},
+            12.0,
+            None,
+        ),
+    )
+
+    result = benchmark_demo_ask.main(
+        ["--candidate", "test", "--case-file", str(case_file), "--compact"]
+    )
+    report = json.loads(capsys.readouterr().out)
+
+    assert result == 1
+    assert report["summary"]["successful"] == 0
+    assert report["summary"]["grounding_failed"] == 1
+    assert report["runs"][0]["status"] == "grounding_failed"
+    assert report["runs"][0]["grounding_failures"] == [
+        "citation_locations_invalid",
+        "expected_file_recall_below_threshold",
+        "expected_term_coverage_below_threshold",
+    ]
+
+
+def test_main_accepts_a_response_that_meets_explicit_grounding_thresholds(
+    tmp_path, monkeypatch, capsys
+):
+    case_file = tmp_path / "cases.json"
+    case_file.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "runtime",
+                    "repo": "owner__repo",
+                    "question": "How does it run?",
+                    "expected_files": ["src/runtime.py", "src/router.py"],
+                    "expected_terms": ["dispatch", "queue"],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        benchmark_demo_ask,
+        "_request",
+        lambda *_args, **_kwargs: (
+            {
+                "answer": "dispatch handles the request",
+                "citations": [
+                    {"file": "src/runtime.py", "start_line": 1, "end_line": 4}
+                ],
+            },
+            12.0,
+            None,
+        ),
+    )
+
+    result = benchmark_demo_ask.main(
+        [
+            "--candidate",
+            "test",
+            "--case-file",
+            str(case_file),
+            "--min-file-recall",
+            "0.5",
+            "--min-term-coverage",
+            "0.5",
+            "--compact",
+        ]
+    )
+    report = json.loads(capsys.readouterr().out)
+
+    assert result == 0
+    assert report["runs"][0]["grounding_passed"] is True
+    assert report["summary"]["successful"] == 1

--- a/test/scripts/test_benchmark_demo_ask.py
+++ b/test/scripts/test_benchmark_demo_ask.py
@@ -2,7 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from scripts.benchmark_demo_ask import evaluate_response
+from scripts.benchmark_demo_ask import _parser, evaluate_response
+
+
+def test_default_endpoint_matches_the_demo_backend():
+    args = _parser().parse_args(["--candidate", "test-model"])
+
+    assert args.endpoint == "http://127.0.0.1:8000"
 
 
 def test_evaluate_response_reports_source_and_term_coverage():

--- a/test/scripts/test_benchmark_demo_ask.py
+++ b/test/scripts/test_benchmark_demo_ask.py
@@ -4,6 +4,8 @@
 
 import json
 
+import pytest
+
 from scripts import benchmark_demo_ask
 from scripts.benchmark_demo_ask import _parser, evaluate_response
 
@@ -12,6 +14,23 @@ def test_default_endpoint_matches_the_demo_backend():
     args = _parser().parse_args(["--candidate", "test-model"])
 
     assert args.endpoint == "http://127.0.0.1:8000"
+
+
+def test_main_rejects_an_empty_case_file_before_requesting_the_candidate(
+    tmp_path, monkeypatch
+):
+    case_file = tmp_path / "cases.json"
+    case_file.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(
+        benchmark_demo_ask,
+        "_request",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("empty gate must not call the candidate")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="non-empty JSON list"):
+        benchmark_demo_ask.main(["--candidate", "test", "--case-file", str(case_file)])
 
 
 def test_evaluate_response_reports_source_and_term_coverage():

--- a/test/scripts/test_benchmark_demo_wiki.py
+++ b/test/scripts/test_benchmark_demo_wiki.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from scripts.benchmark_demo_wiki import _summary, evaluate_page
+
+
+def test_evaluate_page_reports_quality_without_retaining_prose():
+    result = evaluate_page(
+        {
+            "markdown": "Readable explanation.",
+            "citations": [{"file": "src/main.py"}],
+            "generation": {
+                "mode": "generated",
+                "fallback": None,
+                "metrics": {"model_calls": 1},
+            },
+            "quality": {"valid": True},
+            "grounding": {
+                "valid": True,
+                "citation_coverage": 1.0,
+                "evidence_count": 4,
+                "relation_count": 2,
+            },
+        }
+    )
+
+    assert result["quality_valid"] is True
+    assert result["generation_mode"] == "generated"
+    assert result["citation_count"] == 1
+    assert result["markdown_chars"] == 21
+    assert "markdown" not in result
+
+
+def test_wiki_benchmark_summary_counts_degraded_runs():
+    summary = _summary(
+        [
+            {
+                "status": "ok",
+                "wall_ms": 10.0,
+                "quality_valid": True,
+                "generation_mode": "generated",
+            },
+            {
+                "status": "ok",
+                "wall_ms": 30.0,
+                "quality_valid": False,
+                "generation_mode": "degraded",
+            },
+            {"status": "error", "wall_ms": 5.0},
+        ]
+    )
+
+    assert summary == {
+        "successful": 2,
+        "failed": 1,
+        "quality_valid": 1,
+        "degraded": 1,
+        "wall_ms": {"p50": 20.0, "p95": 30.0, "max": 30.0},
+    }

--- a/test/scripts/test_check_public_docs.py
+++ b/test/scripts/test_check_public_docs.py
@@ -32,6 +32,7 @@ def test_mkdocs_navigation_tabs_contract():
     titles = [item if isinstance(item, str) else next(iter(item)) for item in nav]
     assert titles == [
         "Home",
+        "Blog",
         "Get Started",
         "Guides",
         "Concepts",
@@ -44,6 +45,7 @@ def test_mkdocs_navigation_tabs_contract():
         for item in nav
         if isinstance(item, dict)
     }
+    assert sections["Blog"][0] == "blog/index.md"
     assert sections["Get Started"][0] == "get-started/index.md"
     assert sections["Guides"][0] == "guides/index.md"
     assert sections["Concepts"][0] == "concepts/index.md"

--- a/test/scripts/test_start_web.py
+++ b/test/scripts/test_start_web.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "start_web.sh"
+
+
+def _run_start_web(
+    tmp_path: Path,
+    *,
+    config_model: str,
+    config_override: str | None = None,
+    model_override: str | None = None,
+    local_overlay: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    (tmp_path / "qa_config.yaml").write_text("model: gpt-4o\n", encoding="utf-8")
+    if local_overlay:
+        (tmp_path / "qa_config.local.yaml").write_text(
+            "extends: qa_config.yaml\nmodel: local-profile\n",
+            encoding="utf-8",
+        )
+    if config_override:
+        (tmp_path / config_override).write_text(
+            f"model: {config_model}\n",
+            encoding="utf-8",
+        )
+    registry = tmp_path / "qa_registry.json"
+    registry.write_text("{}\n", encoding="utf-8")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    conda = fake_bin / "conda"
+    conda.write_text(
+        """#!/usr/bin/env bash
+case "$*" in
+  *"import codenib"*) exit 0 ;;
+  *"from codenib.web.config import load_config"*)
+    printf '%s\\n%s\\n\\n0\\n' "$FAKE_REGISTRY" "$FAKE_CONFIG_MODEL"
+    exit 0
+    ;;
+  *"python -m codenib.web.app"*)
+    printf 'LAUNCHED_MODEL=%s\\n' "${CODENIB_DEMO_MODEL:-}"
+    exit 0
+    ;;
+esac
+exit 99
+""",
+        encoding="utf-8",
+    )
+    conda.chmod(0o755)
+    curl = fake_bin / "curl"
+    curl.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    curl.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "FAKE_REGISTRY": str(registry),
+            "FAKE_CONFIG_MODEL": config_model,
+            "LLM_HOST": "127.0.0.1",
+            "CODENIB_DEMO_PROFILE": "local",
+        }
+    )
+    env.pop("CODENIB_DEMO_CONFIG", None)
+    env.pop("CODENIB_DEMO_MODEL", None)
+    if config_override:
+        env["CODENIB_DEMO_CONFIG"] = config_override
+    if model_override:
+        env["CODENIB_DEMO_MODEL"] = model_override
+
+    return subprocess.run(
+        ["bash", str(_SCRIPT)],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({"config_model": "gpt-4o"}, "openai/qwen2.5-coder"),
+        (
+            {"config_model": "local-profile", "local_overlay": True},
+            "local-profile",
+        ),
+        (
+            {"config_model": "custom-profile", "config_override": "custom.yaml"},
+            "custom-profile",
+        ),
+        (
+            {"config_model": "gpt-4o", "model_override": "explicit-model"},
+            "explicit-model",
+        ),
+    ],
+)
+def test_start_web_selects_the_documented_local_model(tmp_path, kwargs, expected):
+    result = _run_start_web(tmp_path, **kwargs)
+
+    assert result.returncode == 0, result.stderr
+    assert f"Using local model profile: {expected}" in result.stdout
+    assert f"LAUNCHED_MODEL={expected}" in result.stdout

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -233,6 +233,11 @@ def test_registry_publishers_use_separate_workflows() -> None:
     )
     assert "docs/releases/**" in production["on"]["pull_request"]["paths"]
 
+    release_tag_push = (
+        "github.event_name == 'push' && github.ref_type == 'tag' && "
+        "startsWith(github.ref_name, 'v')"
+    )
+
     assert set(production["jobs"]) == {
         "verify",
         "registry-auth-preflight",
@@ -243,7 +248,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
     }
     registry_preflight = production["jobs"]["registry-auth-preflight"]
     assert registry_preflight["if"] == (
-        "github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'"
+        "github.ref_type == 'tag' && startsWith(github.ref_name, 'v')"
     )
     assert registry_preflight["needs"] == "verify"
     assert registry_preflight["runs-on"] == "ubuntu-latest"
@@ -254,12 +259,14 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert "--connect-timeout 10 --max-time 90" in preflight_download
     assert "login dns" in preflight_steps["Verify branded namespace ownership"]["run"]
     production_publisher = production["jobs"]["publish-pypi"]
+    assert production_publisher["if"] == release_tag_push
     assert production_publisher["needs"] == "registry-auth-preflight"
     assert production_publisher["environment"]["name"] == "pypi"
     assert production_publisher["permissions"] == {"id-token": "write"}
     assert "password" not in publisher_step(production_publisher).get("with", {})
     assert "PYPI_API_TOKEN" not in str(production_publisher)
     pypi_install = production["jobs"]["verify-pypi-install"]
+    assert pypi_install["if"] == release_tag_push
     assert pypi_install["needs"] == "publish-pypi"
     assert pypi_install["runs-on"] == "ubuntu-latest"
     pypi_install_steps = {step["name"]: step for step in pypi_install["steps"]}
@@ -273,6 +280,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
         in pypi_install_steps["Exercise public Wiki and MCP services"]["run"]
     )
     registry_publisher = production["jobs"]["publish-mcp-registry"]
+    assert registry_publisher["if"] == release_tag_push
     assert registry_publisher["needs"] == "verify-pypi-install"
     assert registry_publisher["runs-on"] == "ubuntu-latest"
     assert registry_publisher["environment"]["name"] == "mcp-registry-publish"
@@ -294,6 +302,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "publish-pypi",
         "publish-mcp-registry",
     ]
+    assert production["jobs"]["github-release"]["if"] == release_tag_push
     release_steps = {
         step["name"]: step for step in production["jobs"]["github-release"]["steps"]
     }

--- a/test/test_toolchains.py
+++ b/test/test_toolchains.py
@@ -52,6 +52,20 @@ def test_packaged_tool_versions_match_source_bootstrap(
     assert match.group(1) == packaged_value
 
 
+def test_go_bootstrap_binds_cached_tool_to_detected_platform() -> None:
+    makefile = (Path(__file__).resolve().parents[1] / "Makefile").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "GO_ARCH ?= $(if $(filter aarch64 arm64,$(shell uname -m)),arm64,amd64)"
+        in makefile
+    )
+    assert "GO_TOOL_ID = $(GO_VERSION)-$(GO_OS)-$(GO_ARCH)" in makefile
+    assert 'grep -qx "$(GO_TOOL_ID)"' in makefile
+    assert 'echo "$(GO_TOOL_ID)"' in makefile
+
+
 def test_toolchain_dir_is_durable_and_supports_explicit_override(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -77,6 +91,7 @@ def test_activate_managed_toolchain_prepends_all_provider_bins(
     assert root == tmp_path / "tools"
     assert path[0] == str(root)
     assert str(root / "node-tools" / "node_modules" / ".bin") in path
+    assert str(root / "go" / "bin") in path
     assert str(root / "go-tools" / "bin") in path
     assert path[-1] == "/usr/bin"
 

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 
 import codenib.web.app as web_app
 import codenib.wiki.media_generation as media_generation
+from codenib.web.schemas import ChatRequest, ChatResponse
 
 
 def test_request_timing_header_and_slow_log_exclude_query(monkeypatch, caplog):
@@ -97,6 +98,52 @@ def test_oversized_chat_request_is_rejected_before_runtime_lookup(monkeypatch):
     )
 
     assert response.status_code == 422
+
+
+def test_chat_maps_citations_off_loop_from_the_served_checkout(monkeypatch):
+    calls = []
+    runner_result = object()
+
+    class Runner:
+        def run(self, query, *, chat_history):
+            assert query == "Where is runtime?"
+            assert chat_history == []
+            return runner_result
+
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir="/served/checkout"),
+        runner=Runner(),
+        ensure_runtime=lambda: None,
+    )
+
+    class Registry:
+        def get(self, repo_id):
+            return bundle if repo_id == "repo" else None
+
+    def fake_mapping(result, *, repo_path):
+        assert result is runner_result
+        assert repo_path == "/served/checkout"
+        return ChatResponse(answer="answer")
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append(func)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(web_app, "_registry", Registry)
+    monkeypatch.setattr(web_app, "agent_result_to_response", fake_mapping)
+    monkeypatch.setattr(web_app.asyncio, "to_thread", fake_to_thread)
+
+    response = asyncio.run(
+        web_app.chat(
+            ChatRequest(
+                repo_id="repo",
+                messages=[{"role": "user", "content": "Where is runtime?"}],
+            )
+        )
+    )
+
+    assert response.answer == "answer"
+    assert calls == [bundle.ensure_runtime, bundle.runner.run, fake_mapping]
 
 
 def test_wiki_generation_runs_off_event_loop(monkeypatch):

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -280,6 +280,37 @@ def test_wiki_page_materializes_local_svg_media(tmp_path, monkeypatch):
     assert "sandbox" in asset_response.headers["content-security-policy"]
 
 
+def test_wiki_page_can_skip_media_materialization_for_preload(monkeypatch):
+    slot = {
+        "id": "overview-concept-illustration",
+        "kind": "image",
+        "prompt": "Draw the runtime.",
+    }
+
+    class Builder:
+        def page(self, page_id):
+            return {
+                "id": page_id,
+                "title": "Overview",
+                "markdown": "# Overview",
+                "citations": [],
+                "diagram": "",
+                "media_slots": [slot],
+            }
+
+    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id: Builder())
+    monkeypatch.setattr(
+        web_app,
+        "_materialize_wiki_media",
+        lambda *_args: pytest.fail("read-only preload must not generate media"),
+    )
+
+    page = asyncio.run(web_app.wiki_page("demo", "overview", materialize_media=False))
+
+    assert page["media_slots"] == [slot]
+    assert "asset" not in page["media_slots"][0]
+
+
 def test_wiki_media_storage_keys_cannot_traverse_data_root(tmp_path):
     config = SimpleNamespace(data_dir=str(tmp_path))
     root = tmp_path / "wiki_media"

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -14,6 +15,23 @@ from fastapi.testclient import TestClient
 
 import codenib.web.app as web_app
 import codenib.wiki.media_generation as media_generation
+
+
+def test_request_timing_header_and_slow_log_exclude_query(monkeypatch, caplog):
+    ticks = iter((10.0, 12.5))
+    monkeypatch.setattr(web_app, "perf_counter", lambda: next(ticks))
+
+    with caplog.at_level(logging.INFO, logger=web_app.logger.name):
+        response = TestClient(web_app.app).get("/api/health?secret=query")
+
+    assert response.headers["server-timing"] == "codenib;dur=2500.0"
+    app_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == web_app.logger.name
+    ]
+    assert "Slow API request: GET /api/health 2500.0 ms" in app_messages
+    assert all("secret=query" not in message for message in app_messages)
 
 
 def test_lifespan_injects_local_native_authority_resolver(monkeypatch):
@@ -59,6 +77,7 @@ def test_lifespan_injects_local_native_authority_resolver(monkeypatch):
     assert captured == {
         "config": config,
         "native_index_authorization_resolver": resolver,
+        "allow_missing_native_index_authorization": True,
         "loaded": True,
     }
 
@@ -243,6 +262,34 @@ def test_wiki_media_materialization_does_not_swallow_memory_error(
         web_app._materialize_wiki_media(
             "demo", "overview", {"media_slots": [{"id": "asset"}]}
         )
+
+
+def test_wiki_page_graph_reports_why_the_graph_is_unavailable(monkeypatch):
+    class Builder:
+        def page_citations(self, page_id):
+            return []
+
+        def page(self, page_id):
+            raise AssertionError("page graph must not generate prose")
+
+    bundle = SimpleNamespace(
+        code_graph=lambda: None,
+        graph_unavailable_note=lambda: (
+            "Dependency graph uses schema 4, but this server requires schema 5."
+        ),
+    )
+    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id: Builder())
+    monkeypatch.setattr(web_app, "_bundle", lambda _repo_id: bundle)
+
+    result = asyncio.run(web_app.wiki_page_graph("repo", "overview"))
+
+    assert result == {
+        "available": False,
+        "nodes": [],
+        "edges": [],
+        "mermaid": "",
+        "note": "Dependency graph uses schema 4, but this server requires schema 5.",
+    }
 
 
 def test_template_wiki_disables_narrator(tmp_path):

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -196,6 +196,30 @@ def test_wiki_generation_runs_off_event_loop(monkeypatch):
     assert calls == [("page_tree", ()), ("page", ("overview",))]
 
 
+def test_cached_wiki_tree_does_not_generate_a_missing_outline(monkeypatch):
+    calls = []
+
+    class Builder:
+        def cached_page_tree(self):
+            calls.append("cached_page_tree")
+            return None
+
+        def page_tree(self):
+            raise AssertionError("cached-only Wiki lookup must not generate")
+
+    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id: Builder())
+    monkeypatch.setattr(
+        web_app,
+        "_bundle",
+        lambda _repo_id: SimpleNamespace(entry=SimpleNamespace(repo="org/repo")),
+    )
+
+    tree = asyncio.run(web_app.wiki_tree("repo", cached_only=True))
+
+    assert tree == {"repo": "org/repo", "pages": []}
+    assert calls == ["cached_page_tree"]
+
+
 def test_wiki_page_materializes_local_svg_media(tmp_path, monkeypatch):
     class Builder:
         def page(self, page_id):

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -111,7 +111,10 @@ def test_chat_maps_citations_off_loop_from_the_served_checkout(monkeypatch):
             return runner_result
 
     bundle = SimpleNamespace(
-        entry=SimpleNamespace(repo_dir="/served/checkout"),
+        entry=SimpleNamespace(
+            repo_dir="/served/checkout",
+            base_commit="a" * 40,
+        ),
         runner=Runner(),
         ensure_runtime=lambda: None,
     )
@@ -120,9 +123,10 @@ def test_chat_maps_citations_off_loop_from_the_served_checkout(monkeypatch):
         def get(self, repo_id):
             return bundle if repo_id == "repo" else None
 
-    def fake_mapping(result, *, repo_path):
+    def fake_mapping(result, *, repo_path, repo_commit):
         assert result is runner_result
         assert repo_path == "/served/checkout"
+        assert repo_commit == "a" * 40
         return ChatResponse(answer="answer")
 
     async def fake_to_thread(func, *args, **kwargs):

--- a/test/web/test_build_qa_index_config.py
+++ b/test/web/test_build_qa_index_config.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from scripts.build_qa_index import _vector_builder
+from scripts.rebuild_demo_indexes import (
+    _builders,
+    _parse_repo_ignore_dirs,
+    _validated_graph_node_count,
+)
+
+
+def test_demo_index_builder_uses_configured_remote_embedding_route():
+    builder = _vector_builder(
+        SimpleNamespace(
+            embedding_model="Qwen/Qwen3-Embedding-0.6B",
+            embedding_provider="openai",
+            embedding_dimension=1024,
+            embedding_base_url="http://127.0.0.1:8081/v1",
+            embedding_api_key="secret-runtime-only",
+        ),
+        ["rust"],
+    )
+
+    identity = builder.artifact_identity()
+
+    assert identity["embedding_provider"] == "openai"
+    assert identity["embedding_endpoint"] == "http://127.0.0.1:8081/v1"
+    assert identity["embedding_dimension"] == 1024
+    assert builder.embedding_runtime_kwargs == {"api_key": "secret-runtime-only"}
+    assert "secret-runtime-only" not in str(identity)
+
+
+def test_demo_rebuild_uses_same_secret_free_embedding_identity():
+    config = SimpleNamespace(
+        embedding_model="Qwen/Qwen3-Embedding-0.6B",
+        embedding_provider="openai",
+        embedding_dimension=1024,
+        embedding_base_url="http://127.0.0.1:8081/v1",
+        embedding_api_key="secret-runtime-only",
+    )
+    manifest = RepoManifest(languages=["rust"])
+    manifest.indexes["vector"] = IndexEntry(
+        index_type="vector",
+        path="/old/vector",
+        built_at="",
+        built_at_epoch=0.0,
+        status="fresh",
+    )
+    manifest.indexes["symbol_graph"] = IndexEntry(
+        index_type="symbol_graph",
+        path="/old/graph",
+        built_at="",
+        built_at_epoch=0.0,
+        status="fresh",
+        config={"language": "rust", "languages": ["rust"]},
+    )
+
+    builder = _builders(config, manifest).get("vector")
+    identity = builder.artifact_identity()
+
+    assert identity["embedding_provider"] == "openai"
+    assert identity["embedding_endpoint"] == "http://127.0.0.1:8081/v1"
+    assert builder.embedding_runtime_kwargs == {"api_key": "secret-runtime-only"}
+    assert "secret-runtime-only" not in str(identity)
+    graph_builder = _builders(config, manifest).get("symbol_graph")
+    assert graph_builder.languages == ["rust"]
+    assert graph_builder.allow_project_preparation is False
+
+
+def test_demo_rebuild_rejects_successful_but_pathologically_small_graph(
+    tmp_path, monkeypatch
+):
+    loaded = SimpleNamespace(
+        get_graph=lambda: SimpleNamespace(vcount=lambda: 12),
+    )
+    monkeypatch.setattr(
+        "codenib.graph.code_graph.CodeGraph.load_graph",
+        lambda _path: loaded,
+    )
+
+    with pytest.raises(RuntimeError, match="only 12 nodes.*requires 25"):
+        _validated_graph_node_count(str(tmp_path), 25)
+
+    assert _validated_graph_node_count(str(tmp_path), 0) == 12
+
+
+def test_demo_rebuild_records_explicit_repository_dependency_exclusions():
+    config = SimpleNamespace(
+        embedding_model="Qwen/Qwen3-Embedding-0.6B",
+        embedding_provider="openai",
+        embedding_dimension=1024,
+        embedding_base_url="http://127.0.0.1:8081/v1",
+        embedding_api_key="runtime-only",
+    )
+    manifest = RepoManifest(languages=["cpp"])
+
+    builders = _builders(
+        config,
+        manifest,
+        additional_chunk_ignore_dirs=["lib"],
+    )
+
+    assert builders.get("bm25").artifact_identity()["additional_ignore_dirs"] == ["lib"]
+    assert builders.get("vector").artifact_identity()["additional_ignore_dirs"] == [
+        "lib"
+    ]
+    assert _parse_repo_ignore_dirs(
+        ["micropython__micropython:lib", "micropython__micropython:lib"]
+    ) == {"micropython__micropython": ["lib"]}
+
+
+@pytest.mark.parametrize("value", ["missing-separator", "repo:../lib", "repo:"])
+def test_demo_rebuild_rejects_ambiguous_dependency_exclusions(value):
+    with pytest.raises(ValueError, match="REPO_ID:DIR_NAME"):
+        _parse_repo_ignore_dirs([value])

--- a/test/web/test_build_qa_index_config.py
+++ b/test/web/test_build_qa_index_config.py
@@ -11,6 +11,7 @@ from scripts.build_qa_index import _vector_builder
 from scripts.rebuild_demo_indexes import (
     _builders,
     _parse_repo_ignore_dirs,
+    _select_registry_bundles,
     _validated_graph_node_count,
 )
 
@@ -119,3 +120,28 @@ def test_demo_rebuild_records_explicit_repository_dependency_exclusions():
 def test_demo_rebuild_rejects_ambiguous_dependency_exclusions(value):
     with pytest.raises(ValueError, match="REPO_ID:DIR_NAME"):
         _parse_repo_ignore_dirs([value])
+
+
+def test_demo_rebuild_validates_selectors_before_applying_the_limit():
+    bundles = {
+        "owner__a": SimpleNamespace(entry=SimpleNamespace(instance_id="owner__a")),
+        "owner__b": SimpleNamespace(entry=SimpleNamespace(instance_id="owner__b")),
+    }
+    registry = SimpleNamespace(
+        list_infos=lambda: [SimpleNamespace(id=repo_id) for repo_id in bundles],
+        get=bundles.get,
+    )
+
+    selected = _select_registry_bundles(
+        registry,
+        ["owner__a", "owner__b"],
+        max_repos=1,
+    )
+
+    assert [bundle.entry.instance_id for bundle in selected] == ["owner__a"]
+    with pytest.raises(ValueError, match="Unknown repository ids.*owner__missing"):
+        _select_registry_bundles(
+            registry,
+            ["owner__a", "owner__missing"],
+            max_repos=1,
+        )

--- a/test/web/test_build_qa_index_config.py
+++ b/test/web/test_build_qa_index_config.py
@@ -12,6 +12,7 @@ from scripts.rebuild_demo_indexes import (
     _builders,
     _parse_repo_ignore_dirs,
     _select_registry_bundles,
+    _validate_repo_ignore_dirs,
     _validated_graph_node_count,
 )
 
@@ -120,6 +121,17 @@ def test_demo_rebuild_records_explicit_repository_dependency_exclusions():
 def test_demo_rebuild_rejects_ambiguous_dependency_exclusions(value):
     with pytest.raises(ValueError, match="REPO_ID:DIR_NAME"):
         _parse_repo_ignore_dirs([value])
+
+
+def test_demo_rebuild_rejects_dependency_exclusions_for_unknown_repositories():
+    with pytest.raises(
+        ValueError,
+        match="Unknown repository ids in --ignore-dir: owner__missing",
+    ):
+        _validate_repo_ignore_dirs(
+            {"owner__known": ["vendor"], "owner__missing": ["generated"]},
+            {"owner__known"},
+        )
 
 
 def test_demo_rebuild_validates_selectors_before_applying_the_limit():

--- a/test/web/test_build_qa_index_config.py
+++ b/test/web/test_build_qa_index_config.py
@@ -2,15 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-from codenib.compiler.manifest import IndexEntry, RepoManifest
+import scripts.rebuild_demo_indexes as rebuild_demo_indexes
+from codenib.compiler.manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
 from scripts.build_qa_index import _vector_builder
 from scripts.rebuild_demo_indexes import (
     _builders,
     _parse_repo_ignore_dirs,
+    _rebuild_one,
     _select_registry_bundles,
     _validate_repo_ignore_dirs,
     _validated_graph_node_count,
@@ -157,3 +160,81 @@ def test_demo_rebuild_validates_selectors_before_applying_the_limit():
             ["owner__a", "owner__missing"],
             max_repos=1,
         )
+
+
+def test_demo_rebuild_resets_staging_manifest_from_current_target(
+    tmp_path,
+    monkeypatch,
+):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    target = tmp_path / "published" / MANIFEST_FILENAME
+    source_fingerprint = "sha256-v2:" + ("a" * 64)
+    current = RepoManifest(
+        repo_path=str(repo_root),
+        commit="current-commit",
+        source_fingerprint=source_fingerprint,
+        languages=["python"],
+        capabilities={"sparse_search": True},
+    )
+    current.indexes["bm25"] = IndexEntry(
+        index_type="bm25",
+        path="/published/bm25",
+        built_at="",
+        built_at_epoch=0.0,
+        status="fresh",
+        commit=current.commit,
+        source_fingerprint=source_fingerprint,
+    )
+    current.save(target)
+
+    output_root = tmp_path / "staging"
+    stage_manifest = output_root / "owner__repo" / MANIFEST_FILENAME
+    stale = RepoManifest.from_dict(current.to_dict())
+    stale.languages.append("rust")
+    stale.capabilities["dense_search"] = True
+    stale.indexes["vector"] = IndexEntry(
+        index_type="vector",
+        path="/stale/vector",
+        built_at="",
+        built_at_epoch=0.0,
+        status="fresh",
+        commit=stale.commit,
+        source_fingerprint=source_fingerprint,
+    )
+    stale.save(stage_manifest)
+    observed = []
+
+    class StopAfterStageCheck(RuntimeError):
+        pass
+
+    class FakeCompiler:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def compile_repo(self, _repo_path, *, cache_dir, **_kwargs):
+            observed.append(RepoManifest.load(Path(cache_dir) / MANIFEST_FILENAME))
+            raise StopAfterStageCheck
+
+    monkeypatch.setattr(rebuild_demo_indexes, "IndexCompiler", FakeCompiler)
+    monkeypatch.setattr(rebuild_demo_indexes, "_builders", lambda *_a, **_k: object())
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            instance_id="owner__repo",
+            manifest_path=str(target),
+            repo_dir=str(repo_root),
+            base_commit=current.commit,
+        )
+    )
+
+    with pytest.raises(StopAfterStageCheck):
+        _rebuild_one(
+            config=SimpleNamespace(),
+            bundle=bundle,
+            output_root=output_root,
+            dry_run=False,
+            min_graph_nodes=0,
+            additional_chunk_ignore_dirs=[],
+        )
+
+    assert observed[0].to_dict() == current.to_dict()

--- a/test/web/test_codemap.py
+++ b/test/web/test_codemap.py
@@ -131,6 +131,23 @@ def test_page_subgraph_bounds_repeated_anchor_collection():
     assert edge["hidden_anchors"] == 88
 
 
+def test_page_subgraph_explains_missing_or_mismatched_graph_seeds():
+    graph = CodeGraph()
+
+    no_evidence = build_page_subgraph(graph, [])
+    unresolved = build_page_subgraph(
+        graph,
+        [{"file": "src/missing.py", "start_line": 1, "node_name": "missing"}],
+    )
+
+    assert no_evidence["note"] == "This page has no source citations to map yet."
+    assert unresolved["note"] == (
+        "This page cites 1 source location, but none match symbols in the active "
+        "graph snapshot. Rebuild the symbol graph from the same repository "
+        "snapshot as the Wiki indexes."
+    )
+
+
 def test_page_subgraph_ranks_bridges_by_exact_anchor_count():
     graph = CodeGraph()
     vertices = {

--- a/test/web/test_config.py
+++ b/test/web/test_config.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from codenib.web.config import load_config
 
 
@@ -26,14 +28,12 @@ def test_wiki_media_config_enables_local_renderer_without_endpoint(
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "config.yaml"
-    config_path.write_text(
-        """
+    config_path.write_text("""
 wiki_media_model: local/svg
 wiki_media_options:
   provider: local
   width: 1024
-""".lstrip()
-    )
+""".lstrip())
 
     config = load_config(str(config_path))
 
@@ -47,13 +47,11 @@ def test_wiki_media_environment_overrides_file_config(
     monkeypatch,
 ) -> None:
     config_path = tmp_path / "config.yaml"
-    config_path.write_text(
-        """
+    config_path.write_text("""
 wiki_media_model: local/svg
 wiki_media_options:
   provider: local
-""".lstrip()
-    )
+""".lstrip())
     monkeypatch.setenv("CODENIB_WIKI_MEDIA_MODEL", "openai/image-1")
     monkeypatch.setenv("CODENIB_WIKI_MEDIA_API_BASE", "https://images.example/v1")
     monkeypatch.setenv("CODENIB_WIKI_MEDIA_API_KEY", "secret")
@@ -72,3 +70,96 @@ wiki_media_options:
         "provider": "openai",
         "timeout": 30,
     }
+
+
+def test_config_profile_extends_relative_base_and_merges_options(
+    tmp_path: Path,
+) -> None:
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        "model: openai/local\n"
+        "model_api_base: http://127.0.0.1:8080/v1\n"
+        "model_api_key: local-placeholder\n"
+        "mode: hybrid\n"
+        "model_options:\n"
+        "  timeout: 90\n"
+        "  extra_body:\n"
+        "    reasoning:\n"
+        "      enabled: true\n"
+    )
+    profile_dir = tmp_path / "profiles"
+    profile_dir.mkdir()
+    api = profile_dir / "api.yaml"
+    api.write_text(
+        "extends: ../base.yaml\n"
+        "model: deepseek/deepseek-v4-flash\n"
+        "model_api_base: https://api.deepseek.com\n"
+        "model_api_key: null\n"
+        "model_options:\n"
+        "  timeout: 30\n"
+        "  extra_body:\n"
+        "    thinking:\n"
+        "      type: disabled\n"
+    )
+
+    config = load_config(str(api))
+
+    assert config.model == "deepseek/deepseek-v4-flash"
+    assert config.model_api_base == "https://api.deepseek.com"
+    assert config.model_api_key is None
+    assert config.mode == "hybrid"
+    assert config.model_options == {
+        "timeout": 30,
+        "extra_body": {
+            "reasoning": {"enabled": True},
+            "thinking": {"type": "disabled"},
+        },
+    }
+
+
+def test_config_profile_supports_ordered_parent_layers(tmp_path: Path) -> None:
+    base = tmp_path / "base.yaml"
+    base.write_text("model: base\nmax_tokens: 1024\n")
+    service = tmp_path / "service.yaml"
+    service.write_text("max_tokens: 2048\nmode: hybrid\n")
+    profile = tmp_path / "profile.yaml"
+    profile.write_text(
+        "extends:\n" "  - base.yaml\n" "  - service.yaml\n" "model: api\n"
+    )
+
+    config = load_config(str(profile))
+
+    assert config.model == "api"
+    assert config.max_tokens == 2048
+    assert config.mode == "hybrid"
+
+
+def test_config_profile_environment_still_has_highest_precedence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base = tmp_path / "base.yaml"
+    base.write_text("model: base\n")
+    profile = tmp_path / "profile.yaml"
+    profile.write_text("extends: base.yaml\nmodel: profile\n")
+    monkeypatch.setenv("CODENIB_DEMO_MODEL", "environment")
+
+    assert load_config(str(profile)).model == "environment"
+
+
+def test_config_profile_rejects_extends_cycle(tmp_path: Path) -> None:
+    first = tmp_path / "first.yaml"
+    second = tmp_path / "second.yaml"
+    first.write_text("extends: second.yaml\n")
+    second.write_text("extends: first.yaml\n")
+
+    with pytest.raises(ValueError, match="extends cycle"):
+        load_config(str(first))
+
+
+def test_config_profile_reports_missing_parent(tmp_path: Path) -> None:
+    profile = tmp_path / "profile.yaml"
+    profile.write_text("extends: missing.yaml\n")
+
+    with pytest.raises(FileNotFoundError, match="parent does not exist"):
+        load_config(str(profile))

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -5,6 +5,8 @@
 """Tests for per-repo skill-registry isolation, config, and the QA registry."""
 
 import pickle
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
 from types import SimpleNamespace
 
 import pytest
@@ -859,6 +861,67 @@ def test_vector_store_uses_provider_config_and_reuses_client(
     assert first.kwargs["api_key"] == "secret"
     assert first.kwargs["dimension"] == 768
     assert second.kwargs["embedding"] is first.embedding
+
+
+def test_concurrent_vector_loads_initialize_shared_embedding_once(
+    monkeypatch,
+    native_authorization,
+):
+    first_load_started = Event()
+    allow_first_load = Event()
+    duplicate_construction = Event()
+    construction_lock = Lock()
+    cold_embeddings = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs):
+            embedding = kwargs.get("embedding")
+            if embedding is None:
+                embedding = object()
+                with construction_lock:
+                    cold_embeddings.append(embedding)
+                    if len(cold_embeddings) > 1:
+                        duplicate_construction.set()
+            self.embedding = embedding
+
+        def load(self, _path, **_kwargs):
+            if not first_load_started.is_set():
+                first_load_started.set()
+                assert allow_first_load.wait(timeout=2)
+
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: FakeVectorStore,
+    )
+    registry = RepoRegistry(QAConfig(embedding_provider="huggingface"))
+    entry = SimpleNamespace(
+        path="/tmp/vector",
+        config={
+            "embedding_model": "vendor/model",
+            "embedding_provider": "huggingface",
+            "embedding_dimension": 384,
+        },
+    )
+
+    def load():
+        return registry._load_vector_store(
+            entry,
+            native_index_authorization=native_authorization,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_future = executor.submit(load)
+        assert first_load_started.wait(timeout=2)
+        second_future = executor.submit(load)
+        try:
+            assert not duplicate_construction.wait(timeout=0.2)
+        finally:
+            allow_first_load.set()
+        first = first_future.result(timeout=2)
+        second = second_future.result(timeout=2)
+
+    assert cold_embeddings == [first.embedding]
+    assert second.embedding is first.embedding
 
 
 def test_vector_load_failure_does_not_publish_embedding_and_retains_cleanup_owner(

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -4,6 +4,7 @@
 
 """Tests for per-repo skill-registry isolation, config, and the QA registry."""
 
+import pickle
 from types import SimpleNamespace
 
 import pytest
@@ -63,6 +64,8 @@ def test_ask_prompt_requires_resolving_discovered_identifiers():
     assert "targeted search" in _DEMO_SYSTEM_PROMPT
     assert "exact identifier and defining file" in _DEMO_SYSTEM_PROMPT
     assert "unresolved candidate identifier" in _DEMO_SYSTEM_PROMPT
+    assert "combine every unresolved identifier" in _DEMO_SYSTEM_PROMPT
+    assert "under 500 words" in _DEMO_SYSTEM_PROMPT
 
 
 def test_bundle_loads_views_without_constructing_agent_runtime():
@@ -84,6 +87,35 @@ def test_bundle_loads_views_without_constructing_agent_runtime():
     bundle.ensure_runtime()
 
     assert calls == [("views", bundle), ("runtime", bundle)]
+
+
+def test_bundle_can_release_and_reload_maintenance_views():
+    calls = []
+
+    class Vector:
+        def close(self):
+            calls.append("closed")
+
+    def load_views(target):
+        calls.append("loaded")
+        target.vector_store = Vector()
+        target.bm25 = object()
+
+    bundle = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(),
+        view_loader=load_views,
+        runtime_loader=lambda _target: None,
+    )
+
+    bundle.ensure_views()
+    assert bundle.release_views() is True
+    assert bundle.vector_store is None
+    assert bundle.bm25 is None
+
+    bundle.ensure_views()
+
+    assert calls == ["loaded", "closed", "loaded"]
 
 
 def test_bundle_reports_indexed_source_files_instead_of_repository_files():
@@ -231,6 +263,63 @@ def test_bundle_accepts_legacy_graph_beside_current_vector_view(tmp_path):
     assert bundle._graph_path() == str(graph_path)
 
 
+def test_bundle_explains_schema_mismatch_without_advertising_codemap(
+    tmp_path, monkeypatch
+):
+    graph_dir = tmp_path / "symbol_graph"
+    graph_dir.mkdir()
+    with (graph_dir / "graph.pkl").open("wb") as handle:
+        pickle.dump({"schema_version": 4}, handle)
+    bundle = RepoBundle(
+        entry=SimpleNamespace(
+            instance_id="org__repo",
+            repo="org/repo",
+            commit_short="abc12345",
+            base_commit="abc123456789",
+            language="python",
+            problem_statement="",
+            repo_dir=str(tmp_path),
+        ),
+        manifest=SimpleNamespace(
+            capabilities={"symbol_navigation": True},
+            languages=["python"],
+            file_count=1,
+            source_fingerprint="",
+            indexes={
+                "symbol_graph": SimpleNamespace(
+                    status="fresh",
+                    commit="abc123456789",
+                    path=str(graph_dir),
+                    metadata={},
+                )
+            },
+            commit="abc123456789",
+        ),
+    )
+
+    def reject_old_graph(_path):
+        raise ValueError(
+            "graph.pkl at /private/index has schema_version=4, expected 5. Rebuild."
+        )
+
+    monkeypatch.setattr(
+        "codenib.graph.code_graph.CodeGraph.load_graph", reject_old_graph
+    )
+    monkeypatch.setattr("codenib.web.repo_registry.find_spec", lambda _name: object())
+
+    assert bundle.info().capabilities["codemap"] is False
+    assert bundle.graph_unavailable_note() == (
+        "Dependency graph uses schema 4, but this server requires schema 5. "
+        "Rebuild symbol_graph for this repository."
+    )
+    assert bundle.code_graph() is None
+    assert bundle.graph_unavailable_note() == (
+        "Dependency graph uses schema 4, but this server requires schema 5. "
+        "Rebuild symbol_graph for this repository."
+    )
+    assert bundle.info().capabilities["codemap"] is False
+
+
 def test_config_index_types_for_mode():
     assert QAConfig(mode="sparse").index_types() == ["bm25"]
     assert QAConfig(mode="hybrid").index_types() == ["bm25", "vector"]
@@ -328,6 +417,56 @@ def test_repo_views_keep_bm25_only_for_explicit_optional_authority_policy(
     assert bundle.vector_store is None
 
 
+@pytest.mark.parametrize(
+    "source_fingerprint",
+    ["", f"sha256:{'a' * 64}"],
+)
+def test_repo_views_keep_bm25_only_for_legacy_source_fingerprint(
+    monkeypatch,
+    source_fingerprint,
+):
+    class FakeBM25:
+        def load_index(self, path):
+            self.path = path
+
+    monkeypatch.setattr(
+        "codenib.index.sparse_idx.bm25_index.BM25CodeIndexer",
+        FakeBM25,
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.require_bm25_manifest_artifact",
+        lambda _entry: None,
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail(
+            "legacy vector must be skipped before model initialization"
+        ),
+    )
+
+    def unexpected_resolver(_repo_entry, _manifest, _vector_entry):
+        pytest.fail("legacy vector must be skipped before authorization")
+
+    bm25_entry = SimpleNamespace(path="/idx/bm25", config={})
+    vector_entry = SimpleNamespace(path="/idx/vector", config={})
+    manifest = SimpleNamespace(
+        source_fingerprint=source_fingerprint,
+        indexes={"bm25": bm25_entry, "vector": vector_entry},
+        index_is_current=lambda _index_type: True,
+    )
+    bundle = SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
+    registry = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=unexpected_resolver,
+        allow_missing_native_index_authorization=True,
+    )
+
+    registry._load_repo_views(bundle)
+
+    assert bundle.bm25.path == "/idx/bm25"
+    assert bundle.vector_store is None
+
+
 @pytest.mark.parametrize("resolver_kind", ["missing", "declines"])
 def test_repo_views_fail_closed_when_required_authority_is_missing(
     monkeypatch,
@@ -385,6 +524,7 @@ def test_repo_views_propagate_resolver_rejection_before_model_initialization(
 
     vector_entry = SimpleNamespace(path="/idx/vector", config={})
     manifest = SimpleNamespace(
+        source_fingerprint=f"sha256-v2:{'a' * 64}",
         indexes={"vector": vector_entry},
         index_is_current=lambda _index_type: True,
     )
@@ -405,6 +545,7 @@ def test_repo_views_propagate_vector_integrity_failures(
 ):
     vector_entry = SimpleNamespace(path="/idx/vector", config={})
     manifest = SimpleNamespace(
+        source_fingerprint=f"sha256-v2:{'b' * 64}",
         indexes={"vector": vector_entry},
         index_is_current=lambda _index_type: True,
     )

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -320,6 +320,22 @@ def test_bundle_explains_schema_mismatch_without_advertising_codemap(
     assert bundle.info().capabilities["codemap"] is False
 
 
+def test_bundle_graph_diagnostic_does_not_import_optional_igraph(monkeypatch):
+    bundle = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(indexes={}),
+    )
+    monkeypatch.setattr(
+        "codenib.web.repo_registry.find_spec",
+        lambda name: None if name == "igraph" else object(),
+    )
+
+    assert bundle.graph_unavailable_note() == (
+        "Dependency graph support is unavailable. Install CodeNib with the "
+        "graph extra to inspect symbol_graph artifacts."
+    )
+
+
 def test_config_index_types_for_mode():
     assert QAConfig(mode="sparse").index_types() == ["bm25"]
     assert QAConfig(mode="hybrid").index_types() == ["bm25", "vector"]

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -336,6 +336,63 @@ def test_citations_embed_exact_live_source_and_drop_empty_tabs(tmp_path):
     )
 
 
+def test_citations_read_from_the_indexed_commit_instead_of_live_source(
+    monkeypatch,
+):
+    commit = "a" * 40
+    calls = []
+
+    def snapshot_slice(repo_path, repo_commit, file, start, end):
+        calls.append((repo_path, repo_commit, file, start, end))
+        return {
+            "file": file,
+            "start_line": start,
+            "end_line": end,
+            "content": "def indexed_runtime():\n    return 'snapshot'\n",
+        }
+
+    def reject_live_read(*_args, **_kwargs):
+        raise AssertionError("chat citation read from the mutable checkout")
+
+    monkeypatch.setattr(
+        "codenib.web.schemas.git_source_slice",
+        snapshot_slice,
+    )
+    monkeypatch.setattr(
+        "codenib.web.schemas.live_source_slice",
+        reject_live_read,
+    )
+    result = AgentResult(
+        answer="`indexed_runtime()` is implemented in `src/runtime.py`.",
+        tool_calls=[
+            ToolCallRecord(
+                "1",
+                "repository_search",
+                {},
+                result=[
+                    _node(
+                        "src/runtime.py",
+                        1,
+                        2,
+                        "src/runtime.py:indexed_runtime()",
+                    )
+                ],
+            )
+        ],
+    )
+
+    response = agent_result_to_response(
+        result,
+        repo_path="/served/checkout",
+        repo_commit=commit,
+    )
+
+    assert calls == [("/served/checkout", commit, "src/runtime.py", 2, 3)]
+    assert response.citations[0].content == (
+        "def indexed_runtime():\n    return 'snapshot'\n"
+    )
+
+
 def test_plain_prose_does_not_match_a_generic_main_symbol():
     result = AgentResult(
         answer="The main entry point delegates to `index_repository()`.",

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -290,6 +290,52 @@ def test_citations_fall_back_to_five_retrieval_results():
     ]
 
 
+def test_citations_embed_exact_live_source_and_drop_empty_tabs(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "runtime.py").write_text(
+        "# heading\ndef load_runtime():\n    return 'ready'\n",
+        encoding="utf-8",
+    )
+    result = AgentResult(
+        answer=(
+            "`load_runtime()` is implemented in `src/runtime.py`; "
+            "`missing_runtime()` is not in this checkout."
+        ),
+        tool_calls=[
+            ToolCallRecord(
+                "1",
+                "repository_search",
+                {},
+                result=[
+                    _node(
+                        "src/runtime.py",
+                        1,
+                        2,
+                        "src/runtime.py:load_runtime()",
+                    ),
+                    _node(
+                        "src/missing.py",
+                        1,
+                        2,
+                        "src/missing.py:missing_runtime()",
+                    ),
+                ],
+            )
+        ],
+    )
+
+    response = agent_result_to_response(result, repo_path=str(tmp_path))
+
+    assert len(response.citations) == 1
+    assert response.citations[0].file == "src/runtime.py"
+    assert response.citations[0].start_line == 2
+    assert response.citations[0].end_line == 3
+    assert response.citations[0].content == (
+        "def load_runtime():\n    return 'ready'\n"
+    )
+
+
 def test_plain_prose_does_not_match_a_generic_main_symbol():
     result = AgentResult(
         answer="The main entry point delegates to `index_repository()`.",

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -6655,6 +6655,58 @@ def test_agent_wiki_adopts_legacy_timestamp_cache_into_stable_key(tmp_path):
         assert json.load(handle)["model"] == "old-model"
 
 
+def test_agent_wiki_cached_page_tree_reads_without_generating_or_migrating(
+    tmp_path, monkeypatch
+):
+    view = SimpleNamespace(
+        status="fresh",
+        commit="abc123",
+        source_fingerprint="",
+        built_at_epoch=1.0,
+        config={},
+        metadata={},
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={"bm25": view}),
+    )
+    cache_dir = tmp_path / "wiki-cache"
+    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+    stable, legacy = wiki._cache_candidate_paths("outline")
+    wiki._atomic_write_cache(
+        legacy,
+        {
+            "model": "old-model",
+            "data": {"pages": [{"id": "runtime", "title": "Runtime", "children": []}]},
+        },
+    )
+    monkeypatch.setattr(
+        wiki,
+        "outline",
+        lambda: (_ for _ in ()).throw(AssertionError("must not generate outline")),
+    )
+
+    tree = wiki.cached_page_tree()
+
+    assert tree == [
+        {
+            "id": "runtime",
+            "title": "Runtime",
+            "cache_state": "cold",
+            "children": [],
+        }
+    ]
+    assert not os.path.exists(stable)
+
+
 def test_agent_wiki_atomic_cache_write_preserves_previous_entry_on_failure(
     tmp_path, monkeypatch
 ):

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -5,6 +5,9 @@
 """Fast unit tests for the agent wiki retrieval guardrails."""
 
 import json
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 from codenib.graph.code_graph import CodeGraph
@@ -12,6 +15,7 @@ from codenib.wiki.agent_wiki import (
     AgentWiki,
     _candidate_score,
     _clean_markdown,
+    _compact_dense_plan,
     _condense_relation_free_overview,
     _ensure_cited_intro,
     _fact_plan_markdown,
@@ -22,6 +26,7 @@ from codenib.wiki.agent_wiki import (
     _page_quality_report,
     _plan_evidence_constraints,
     _plan_quality_warnings,
+    _plan_repair_limit,
     _plan_repair_score,
     _prepare_evidence_content,
     _prune_uncited_blocks,
@@ -174,6 +179,13 @@ def test_plan_repair_score_never_trades_a_required_topic_for_style_progress():
         plan,
         missing_topic,
     )
+
+
+def test_plan_repair_limit_distinguishes_truth_from_composition_feedback():
+    assert _plan_repair_limit(["claim cites evidence that does not exist"]) == 3
+    assert _plan_repair_limit(["section 'Flow' reads as a callable catalog"]) == 1
+    assert _plan_repair_limit(["section 'A' substantially repeats section 'B'"]) == 1
+    assert _plan_repair_limit([]) == 0
 
 
 def test_relation_free_overview_keeps_one_explanatory_fact_per_topic():
@@ -1277,6 +1289,96 @@ def test_renderable_plan_aligns_intro_deduplication_with_quality_gate():
     assert quality["planned_sections"] == quality["rendered_sections"] == 1
     assert quality["planned_claims"] == quality["covered_claims"] == 1
     assert quality["valid"] is True
+
+
+def test_renderable_plan_deduplicates_claims_across_overview_sections():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="src/client.py",
+            start_line=1,
+            end_line=12,
+            symbol="Client.send",
+            kind="method",
+            content=(
+                "def send(self, request):\n"
+                "    prepared = self.prepare(request)\n"
+                "    return self.adapter.dispatch(prepared)"
+            ),
+        ),
+        EvidenceItem(
+            id="E2",
+            file="src/client.py",
+            start_line=1,
+            end_line=12,
+            symbol="Client.send",
+            kind="method",
+            content=(
+                "def send(self, request):\n"
+                "    prepared = self.prepare(request)\n"
+                "    return self.adapter.dispatch(prepared)"
+            ),
+        ),
+    ]
+    repeated = (
+        "`Client.send()` prepares an incoming request and dispatches the "
+        "prepared request through its configured adapter"
+    )
+    plan = {
+        "thesis": {
+            "statement": "The client coordinates HTTP request execution",
+            "evidence": ["E1"],
+        },
+        "sections": [
+            {
+                "title": "Client requests",
+                "claims": [
+                    {
+                        "role": "responsibility",
+                        "statement": repeated,
+                        "evidence": ["E1"],
+                    }
+                ],
+            },
+            {
+                "title": "Adapter dispatch",
+                "claims": [
+                    {
+                        "role": "responsibility",
+                        "statement": repeated,
+                        "evidence": ["E2"],
+                    }
+                ],
+            },
+        ],
+    }
+
+    rendered = _renderable_plan(plan, evidence, [])
+
+    assert [section["title"] for section in rendered["sections"]] == ["Client requests"]
+
+
+def test_dense_plan_compaction_drops_thin_sections_but_keeps_three_areas():
+    plan = {
+        "sections": [
+            {"title": "Core", "claims": [{"evidence": ["E1"]}]},
+            {"title": "Compute", "claims": [{"evidence": ["E2"]}]},
+            {"title": "Grouping", "claims": [{"evidence": ["E3"]}]},
+            {"title": "Parallel", "claims": [{"evidence": ["E4"]}]},
+        ]
+    }
+
+    compacted = _compact_dense_plan(
+        plan,
+        {"thin_sections": ["Parallel"], "redundant_sections": []},
+    )
+
+    assert [section["title"] for section in compacted["sections"]] == [
+        "Core",
+        "Compute",
+        "Grouping",
+    ]
+    assert len(plan["sections"]) == 4
 
 
 def test_renderable_plan_keeps_specific_claims_for_distinct_named_scripts():
@@ -3669,6 +3771,73 @@ def test_overview_plan_rejects_filename_as_subsystem_name():
     assert "section 'Subsystems' names a source file as a subsystem" in warnings
 
 
+def test_fact_plan_caps_total_model_calls_when_repairs_never_improve(monkeypatch):
+    response = json.dumps(
+        {
+            "thesis": {
+                "statement": "`Router.run()` returns `dispatch(request)`",
+                "evidence": ["E1"],
+            },
+            "sections": [
+                {
+                    "title": "Routing",
+                    "claims": [
+                        {
+                            "role": "contract",
+                            "statement": "`Router.run()` returns `dispatch(request)`",
+                            "evidence": ["E1"],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    class LLM:
+        cache_identity = "fake"
+
+        def __init__(self):
+            self.calls = 0
+
+        def complete(self, _messages, **_kwargs):
+            self.calls += 1
+            return response
+
+    llm = LLM()
+    wiki = AgentWiki(
+        SimpleNamespace(entry=SimpleNamespace(repo="owner/repo", language="python")),
+        model="fake-model",
+        llm=llm,
+    )
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="src/router.py",
+            start_line=1,
+            end_line=2,
+            symbol="Router.run",
+            kind="method",
+            content="def run(request):\n    return dispatch(request)",
+        )
+    ]
+    monkeypatch.setattr(
+        "codenib.wiki.agent_wiki._plan_quality_warnings",
+        lambda *_args, **_kwargs: ["claim cites evidence that does not exist"],
+    )
+    metrics = {}
+
+    wiki._fact_plan(
+        {"id": "routing", "title": "Routing", "summary": "Request routing"},
+        evidence,
+        [],
+        metrics=metrics,
+    )
+
+    assert llm.calls == 3
+    assert metrics["model_calls"] == 3
+    assert metrics["fresh_replans"] + metrics["repair_attempts"] == 2
+
+
 def test_overview_fact_plan_repairs_sparse_plan():
     sparse = {
         "thesis": "indexed source",
@@ -4174,6 +4343,72 @@ def test_overview_uses_canonical_readme_intro():
     )
     assert "This document provides" not in rendered
     assert "## Workflow" in rendered
+
+
+def test_overview_keeps_supported_thesis_when_canonical_intro_is_a_fragment():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="README.md",
+            start_line=1,
+            end_line=20,
+            symbol="README.md",
+            kind="file",
+            content=("jq is a lightweight and flexible command-line JSON processor."),
+        )
+    ]
+    draft = (
+        "`jq` parses JSON input, compiles a filter, and executes the compiled "
+        "program against each value. [E1]\n\n"
+        "## Execution\n\n"
+        "The runtime evaluates compiled filters against JSON values. [E1]"
+    )
+
+    rendered = _ensure_cited_intro(
+        draft,
+        evidence,
+        canonical_readme=True,
+        repository_name="jq",
+    )
+
+    assert rendered == draft
+    assert not rendered.startswith("jq is a lightweight.")
+
+
+def test_overview_drops_purpose_that_repeats_canonical_intro():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="README.md",
+            start_line=1,
+            end_line=20,
+            symbol="README.md",
+            kind="file",
+            content=(
+                "Axios is a promise-based HTTP client that sends requests from "
+                "browsers and Node.js applications."
+            ),
+        )
+    ]
+    draft = (
+        "A supported planning thesis that will be replaced. [E1]\n\n"
+        "## Purpose and scope\n\n"
+        "Axios is a promise-based HTTP client for sending requests from browser "
+        "and Node.js applications. [E1]\n\n"
+        "## Request pipeline\n\n"
+        "The request pipeline normalizes configuration before dispatch. [E1]"
+    )
+
+    rendered = _ensure_cited_intro(
+        draft,
+        evidence,
+        canonical_readme=True,
+        repository_name="Axios",
+    )
+
+    assert rendered.startswith("Axios is a promise-based HTTP client")
+    assert "## Purpose and scope" not in rendered
+    assert "## Request pipeline" in rendered
 
 
 def test_overview_truncates_promotional_readme_tail_at_complete_clause():
@@ -5607,8 +5842,98 @@ def test_generated_page_uses_fact_plan_and_reports_grounding(tmp_path):
     assert page["quality"]["valid"] is True
     assert page["generation"]["mode"] == "generated"
     assert page["generation"]["renderer"] == "fact_plan"
+    assert page["generation"]["metrics"]["model_calls"] == 1
+    assert page["generation"]["metrics"]["repair_attempts"] == 0
+    assert page["generation"]["metrics"]["total_ms"] >= 0
     assert page["citations"][0]["start_line"] == 1
     assert page["evidence"]["items"][0]["routes"] == ("outline", "dense")
+
+
+def test_empty_fact_plan_replans_from_original_evidence(tmp_path):
+    valid_plan = json.dumps(
+        {
+            "thesis": {
+                "statement": "The `Router` owns repository request dispatch",
+                "evidence": ["E1"],
+            },
+            "sections": [
+                {
+                    "title": "Flow",
+                    "claims": [
+                        {
+                            "role": "responsibility",
+                            "statement": (
+                                "`dispatch` invokes `handle` for source-backed "
+                                "repository requests"
+                            ),
+                            "evidence": ["E1"],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    class LLM:
+        cache_identity = "fake"
+
+        def __init__(self):
+            self.prompts = []
+
+        def complete(self, messages, **_kwargs):
+            prompt = messages[0]["content"]
+            self.prompts.append(prompt)
+            if len(self.prompts) == 1:
+                return '{"thesis": {}, "sections": []}'
+            # An empty admitted plan must start over from the original source
+            # prompt instead of trying to revise the poisoned plan.
+            assert prompt.startswith("You are planning one source-grounded page")
+            return valid_plan
+
+    node = {
+        "file": "src/core.py",
+        "node_name": "Router",
+        "type": "class",
+        "start_line": 0,
+        "end_line": 6,
+        "content": (
+            "class Router:\n"
+            "    def dispatch(self, repository_request):\n"
+            "        return handle(repository_request)"
+        ),
+    }
+    llm = LLM()
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=_FakeVectorStore([node]),
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+        code_graph=lambda: None,
+    )
+
+    page = AgentWiki(bundle, model="fake-model", llm=llm)._generate_page(
+        {
+            "id": "routing",
+            "title": "Request Routing",
+            "summary": "How requests move through the repository",
+            "keywords": ["dispatch"],
+            "files": ["src/core.py"],
+        }
+    )
+
+    assert len(llm.prompts) == 2
+    assert page["generation"]["mode"] == "generated"
+    assert page["generation"]["fallback"] is None
+    assert page["generation"]["metrics"]["model_calls"] == 2
+    assert page["generation"]["metrics"]["fresh_replans"] == 1
+    assert page["generation"]["metrics"]["repair_attempts"] == 0
+    assert "is indexed from" not in page["markdown"]
 
 
 def test_structured_page_deduplicates_without_free_form_markdown_repair(tmp_path):
@@ -5943,6 +6268,8 @@ def test_page_reports_model_unavailable_when_fact_planning_falls_back(tmp_path):
     assert page["generation"]["renderer"] == "fact_plan"
     assert page["generation"]["fallback"] == "fact_plan"
     assert page["grounding"]["valid"] is True
+    assert page["generation"]["metrics"]["model_calls"] == 1
+    assert page["generation"]["metrics"]["model_failures"] == 1
     assert llm.calls == 1
 
 
@@ -5969,6 +6296,72 @@ def test_agent_wiki_cache_key_tracks_view_rebuild_identity(tmp_path):
     before = wiki._key("outline")
     view.built_at_epoch = 2.0
     view.config = {"builder_schema": 2}
+
+    assert wiki._key("outline") != before
+
+
+def test_agent_wiki_cache_key_ignores_equivalent_rebuild_timestamp(tmp_path):
+    view = SimpleNamespace(
+        status="fresh",
+        commit="abc123",
+        source_fingerprint="sha256:source",
+        built_at_epoch=1.0,
+        config={"builder_schema": 1},
+        metadata={"artifact_digest": "sha256:artifact"},
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(
+            languages=["python"],
+            indexes={"bm25": view},
+            source_fingerprint="sha256:source",
+        ),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+    before = wiki._key("outline")
+
+    view.built_at_epoch = 2.0
+
+    assert wiki._key("outline") == before
+
+
+def test_agent_wiki_cache_key_tracks_artifact_receipt(tmp_path):
+    view = SimpleNamespace(
+        status="fresh",
+        commit="abc123",
+        source_fingerprint="sha256:source",
+        built_at_epoch=1.0,
+        config={"builder_schema": 1},
+        metadata={"artifact_digest": "sha256:first"},
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(
+            languages=["python"],
+            indexes={"bm25": view},
+            source_fingerprint="sha256:source",
+        ),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+    before = wiki._key("outline")
+
+    view.metadata["artifact_digest"] = "sha256:second"
 
     assert wiki._key("outline") != before
 
@@ -6020,6 +6413,73 @@ def test_agent_wiki_cache_key_is_stable_across_lazy_client_creation(tmp_path):
     assert wiki._key("outline") == before
 
 
+def test_agent_wiki_adopts_legacy_timestamp_cache_into_stable_key(tmp_path):
+    view = SimpleNamespace(
+        status="fresh",
+        commit="abc123",
+        source_fingerprint="",
+        built_at_epoch=1.0,
+        config={"builder_schema": 1},
+        metadata={},
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={"bm25": view}),
+    )
+    cache_dir = tmp_path / "wiki-cache"
+    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+    stable, legacy = wiki._cache_candidate_paths("outline")
+    payload = {"pages": [{"id": "overview", "title": "Overview"}]}
+    wiki._atomic_write_cache(
+        legacy,
+        {"model": "old-model", "data": payload},
+    )
+
+    assert not os.path.exists(stable)
+    assert wiki._read_cache("outline") == payload
+    assert os.path.isfile(stable)
+    with open(stable, encoding="utf-8") as handle:
+        assert json.load(handle)["model"] == "old-model"
+
+
+def test_agent_wiki_atomic_cache_write_preserves_previous_entry_on_failure(
+    tmp_path, monkeypatch
+):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    cache_dir = tmp_path / "wiki-cache"
+    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+    wiki._write_cache("outline", {"pages": [{"id": "original"}]})
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            "codenib.wiki.agent_wiki.json.dump",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        wiki._write_cache("outline", {"pages": [{"id": "replacement"}]})
+
+    assert wiki._read_cache("outline") == {"pages": [{"id": "original"}]}
+    assert not list(cache_dir.glob("*.tmp"))
+
+
 def test_agent_wiki_page_cache_key_tracks_outline_metadata():
     original = {
         "id": "runtime",
@@ -6038,6 +6498,322 @@ def test_agent_wiki_page_cache_key_tracks_outline_metadata():
     assert AgentWiki._page_cache_suffix(original) != AgentWiki._page_cache_suffix(
         revised
     )
+
+
+def test_agent_wiki_page_tree_reports_ready_cold_and_degraded_cache_states(tmp_path):
+    runtime = {
+        "id": "runtime",
+        "title": "Runtime",
+        "children": [
+            {"id": "routing", "title": "Routing", "children": []},
+        ],
+    }
+    broken = {"id": "broken", "title": "Broken", "children": []}
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+        vector_store=None,
+        bm25=None,
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+    wiki._outline = {"pages": [runtime, broken]}
+    cached = {
+        wiki._page_cache_suffix(runtime): {
+            "generation": {"mode": "generated"},
+            "quality": {"valid": True},
+        },
+        wiki._page_cache_suffix(broken): {
+            "generation": {
+                "mode": "degraded",
+                "retry": {"attempts": 2},
+            },
+            "quality": {"valid": False},
+        },
+    }
+    wiki._read_cache = lambda suffix: cached.get(suffix)
+
+    tree = wiki.page_tree()
+
+    assert tree[0]["cache_state"] == "ready"
+    assert tree[0]["children"][0]["cache_state"] == "cold"
+    assert tree[1]["cache_state"] == "degraded"
+
+
+def test_agent_wiki_page_citations_never_generate_prose_and_are_cached(tmp_path):
+    node = {
+        "file": "src/router.py",
+        "node_name": "Router.run",
+        "type": "method",
+        "start_line": 0,
+        "end_line": 2,
+        "content": "def run(request):\n    return dispatch(request)",
+    }
+    store = _FakeVectorStore([node])
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=store,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    outline = {
+        "pages": [
+            {
+                "id": "runtime",
+                "title": "Runtime",
+                "summary": "Request routing",
+                "files": ["src/router.py"],
+                "children": [],
+            }
+        ]
+    }
+    cache_dir = tmp_path / "wiki-cache"
+    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+    wiki._outline = outline
+    wiki._generate_page = lambda _meta: (_ for _ in ()).throw(
+        AssertionError("graph evidence must not generate prose")
+    )
+
+    citations = wiki.page_citations("runtime")
+
+    assert citations == [
+        {
+            "file": "src/router.py",
+            "start_line": 1,
+            "end_line": 3,
+            "node_name": "Router.run",
+            "type": "method",
+            "score": None,
+            "content": None,
+        }
+    ]
+    assert len(store.calls) == 1
+    assert wiki._pages == {}
+
+    store.calls.clear()
+    reloaded = AgentWiki(bundle, model="other-model", cache_dir=str(cache_dir))
+    reloaded._outline = outline
+    assert reloaded.page_citations("runtime") == citations
+    assert store.calls == []
+
+
+def test_agent_wiki_regenerates_cached_diagnostic_fallback(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+    meta = {"id": "runtime", "title": "Runtime", "children": []}
+    cached = {
+        "id": "runtime",
+        "markdown": "`Router` is indexed from `src/router.py`.",
+        "generation": {
+            "mode": "degraded",
+            "fallback": "fact_plan",
+            "reason": "quality_guard",
+        },
+    }
+    generated = {
+        "id": "runtime",
+        "markdown": "Readable source-linked explanation.",
+        "generation": {"mode": "generated", "fallback": None},
+    }
+    writes = []
+    wiki._find = lambda _page_id: meta
+    wiki._read_cache = lambda _suffix: cached
+    wiki._generate_page = lambda _meta: generated
+    wiki._write_cache = lambda suffix, page: writes.append((suffix, page))
+
+    assert wiki.page("runtime") is generated
+    assert writes == [(wiki._page_cache_suffix(meta), generated)]
+
+
+def test_agent_wiki_retries_quality_invalid_cache_with_a_cooldown():
+    legacy_invalid = {
+        "generation": {"mode": "degraded", "fallback": None},
+        "quality": {"valid": False},
+    }
+
+    assert AgentWiki._cached_page_needs_regeneration(legacy_invalid) is True
+
+    AgentWiki._record_page_retry(legacy_invalid, now_epoch=10_000_000_000.0)
+    retry = legacy_invalid["generation"]["retry"]
+    assert retry["state"] == "scheduled"
+    assert retry["attempts"] == 0
+    assert retry["next_attempt_epoch"] > 10_000_000_000.0
+    assert AgentWiki._cached_page_needs_regeneration(legacy_invalid) is False
+
+
+def test_agent_wiki_stops_retrying_after_bounded_failed_attempts():
+    previous = {
+        "generation": {
+            "mode": "degraded",
+            "fallback": None,
+            "retry": {"attempts": 1},
+        },
+        "quality": {"valid": False},
+    }
+    still_invalid = {
+        "generation": {"mode": "degraded", "fallback": None},
+        "quality": {"valid": False},
+    }
+
+    AgentWiki._record_page_retry(
+        still_invalid,
+        previous=previous,
+        now_epoch=100.0,
+    )
+
+    assert still_invalid["generation"]["retry"] == {
+        "state": "exhausted",
+        "attempts": 2,
+        "max_attempts": 2,
+        "last_attempt_epoch": 100.0,
+        "next_attempt_epoch": None,
+    }
+    assert AgentWiki._cached_page_needs_regeneration(still_invalid) is False
+
+
+def test_agent_wiki_records_recovery_from_a_bad_cached_page():
+    previous = {
+        "generation": {"mode": "degraded", "fallback": "fact_plan"},
+        "quality": {"valid": False},
+    }
+    recovered = {
+        "generation": {"mode": "generated", "fallback": None},
+        "quality": {"valid": True},
+    }
+
+    AgentWiki._record_page_retry(recovered, previous=previous, now_epoch=100.0)
+
+    assert recovered["generation"]["retry"]["state"] == "recovered"
+    assert recovered["generation"]["retry"]["attempts"] == 1
+
+
+def test_agent_wiki_coalesces_concurrent_page_generation(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+    meta = {"id": "runtime", "title": "Runtime", "children": []}
+    generation_started = threading.Event()
+    second_lookup_started = threading.Event()
+    release_generation = threading.Event()
+    lookup_calls = 0
+    generation_calls = 0
+    calls_guard = threading.Lock()
+
+    def find(_page_id):
+        nonlocal lookup_calls
+        with calls_guard:
+            lookup_calls += 1
+            if lookup_calls == 2:
+                second_lookup_started.set()
+        return meta
+
+    def generate(_meta):
+        nonlocal generation_calls
+        with calls_guard:
+            generation_calls += 1
+        generation_started.set()
+        assert release_generation.wait(timeout=2)
+        return {"id": "runtime", "markdown": "generated once"}
+
+    wiki._find = find
+    wiki._generate_page = generate
+    wiki._read_cache = lambda _suffix: None
+    wiki._write_cache = lambda _suffix, _page: None
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(wiki.page, "runtime")
+        assert generation_started.wait(timeout=2)
+        second = executor.submit(wiki.page, "runtime")
+        assert second_lookup_started.wait(timeout=2)
+        release_generation.set()
+
+        assert first.result(timeout=2) == second.result(timeout=2)
+
+    assert generation_calls == 1
+
+
+def test_agent_wiki_coalesces_generation_across_builder_instances(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    meta = {"id": "runtime", "title": "Runtime", "children": []}
+    outline = {"pages": [meta]}
+    cache_dir = tmp_path / "wiki-cache"
+    builders = [
+        AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+        for _ in range(2)
+    ]
+    for wiki in builders:
+        wiki._outline = outline
+    generation_started = threading.Event()
+    release_generation = threading.Event()
+    calls_guard = threading.Lock()
+    generation_calls = 0
+
+    def generate(_meta):
+        nonlocal generation_calls
+        with calls_guard:
+            generation_calls += 1
+        generation_started.set()
+        assert release_generation.wait(timeout=2)
+        return {
+            "id": "runtime",
+            "markdown": "generated once across processes",
+            "generation": {"mode": "generated"},
+            "quality": {"valid": True},
+        }
+
+    for wiki in builders:
+        wiki._generate_page = generate
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = [executor.submit(wiki.page, "runtime") for wiki in builders]
+        assert generation_started.wait(timeout=2)
+        release_generation.set()
+        assert results[0].result(timeout=2) == results[1].result(timeout=2)
+
+    assert generation_calls == 1
 
 
 def test_flow_step_naming_an_unsupported_symbol_is_dropped():

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -3364,6 +3364,52 @@ def test_plan_support_downgrades_a_mislabeled_local_state_claim():
     )
 
 
+def test_plan_support_promotes_a_grounded_section_lead_to_thesis():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="tokio/src/sync/barrier.rs",
+            start_line=139,
+            end_line=198,
+            symbol="Barrier.wait_internal",
+            kind="method",
+            content=(
+                "The count and generation are stored behind a synchronous "
+                "mutex. A watch channel carries the generation number to "
+                "waiting tasks."
+            ),
+        )
+    ]
+    lead = (
+        "The count and generation are stored behind a synchronous mutex, and "
+        "a watch channel carries the generation number to waiting tasks"
+    )
+    plan = {
+        "sections": [
+            {
+                "title": "Barrier generation counting and release",
+                "lead": {"statements": [lead], "evidence": ["E1"]},
+                "claims": [
+                    {
+                        "statement": (
+                            "`Barrier.wait_internal()` increments the arrival "
+                            "count. `Barrier.wait()` waits for its result"
+                        ),
+                        "evidence": ["E1"],
+                    }
+                ],
+            }
+        ]
+    }
+
+    normalized = _normalize_plan_support(plan, evidence, [])
+
+    assert normalized["thesis"] == {
+        "statement": lead,
+        "evidence": ["E1"],
+    }
+
+
 def test_plan_support_drops_method_to_owner_generalization():
     evidence = [
         EvidenceItem(

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -6904,6 +6904,46 @@ def test_agent_wiki_regenerates_cached_diagnostic_fallback(tmp_path):
     assert writes == [(wiki._page_cache_suffix(meta), generated)]
 
 
+def test_agent_wiki_rechecks_in_memory_degraded_page_after_cooldown(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+    meta = {"id": "runtime", "title": "Runtime", "children": []}
+    degraded = {
+        "id": "runtime",
+        "generation": {
+            "mode": "degraded",
+            "fallback": "fact_plan",
+            "retry": {"attempts": 0, "next_attempt_epoch": 0.0},
+        },
+        "quality": {"valid": False},
+    }
+    generated = {
+        "id": "runtime",
+        "markdown": "Recovered source-linked explanation.",
+        "generation": {"mode": "generated", "fallback": None},
+        "quality": {"valid": True},
+    }
+    wiki._pages["runtime"] = degraded
+    wiki._find = lambda _page_id: meta
+    wiki._read_cache = lambda _suffix: degraded
+    wiki._generate_page = lambda _meta: generated
+    wiki._write_cache = lambda _suffix, _page: None
+
+    assert wiki.page("runtime") is generated
+    assert wiki._pages["runtime"] is generated
+
+
 def test_agent_wiki_retries_quality_invalid_cache_with_a_cooldown():
     legacy_invalid = {
         "generation": {"mode": "degraded", "fallback": None},

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -31,6 +31,7 @@ from codenib.wiki.agent_wiki import (
     _prepare_evidence_content,
     _prune_uncited_blocks,
     _readme_intro,
+    _relation_backed_recovery_plan,
     _remove_orphan_headings,
     _renderable_plan,
     _supplement_topic_relation_flows,
@@ -3202,6 +3203,20 @@ def test_page_plan_rejects_labeling_a_function_as_a_method():
         "records function" in warnings
     )
 
+    normalized = _normalize_plan_support(plan, evidence, [])
+    normalized_statement = normalized["sections"][0]["claims"][0]["statement"]
+    assert normalized_statement == (
+        "The `register_default_builders` function registers builders"
+    )
+    assert (
+        _plan_quality_warnings(
+            {"id": "indexing", "title": "Indexing"},
+            normalized,
+            evidence,
+        )
+        == []
+    )
+
 
 def test_plan_support_drops_an_unrelated_relation_when_source_proves_flow():
     evidence = [
@@ -3408,6 +3423,60 @@ def test_plan_support_promotes_a_grounded_section_lead_to_thesis():
         "statement": lead,
         "evidence": ["E1"],
     }
+
+
+def test_relation_recovery_plan_uses_verified_call_endpoints():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="include/fmt/format.h",
+            start_line=2590,
+            end_line=2626,
+            symbol="include/fmt/format.h:do_write_float()",
+            kind="function",
+            content="do_write_float(...) { return write_fixed(...); }",
+        ),
+        EvidenceItem(
+            id="E2",
+            file="include/fmt/format.h",
+            start_line=2524,
+            end_line=2586,
+            symbol="write_fixed",
+            kind="function",
+            content="write_fixed(...) { /* write fixed-point digits */ }",
+        ),
+    ]
+    relations = [
+        RelationItem(
+            id="R1",
+            source="include/fmt/format.h:fmt.detail.do_write_float()",
+            target="include/fmt/format.h:fmt.detail.write_fixed()",
+        )
+    ]
+
+    plan = _relation_backed_recovery_plan(
+        {
+            "id": "type-dispatch-and-writing",
+            "summary": "Routes formatted values to specialized write functions",
+        },
+        evidence,
+        relations,
+    )
+    markdown = _fact_plan_markdown(plan, evidence, relations)
+
+    assert (
+        _plan_quality_warnings(
+            {"id": "type-dispatch-and-writing"},
+            plan,
+            evidence,
+            relations,
+        )
+        == []
+    )
+    assert "## Verified call path" in markdown
+    assert "`fmt.detail.do_write_float()` calls `fmt.detail.write_fixed()`" in markdown
+    assert "Source-backed components" not in markdown
+    assert "is indexed from" not in markdown
 
 
 def test_plan_support_drops_method_to_owner_generalization():

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -2690,6 +2690,45 @@ def test_page_plan_rejects_private_helper_as_public_entrypoint():
     ]
 
 
+def test_page_plan_allows_private_work_in_a_mixed_entry_section():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="core/resample.py",
+            start_line=10,
+            end_line=20,
+            symbol="DataWithCoords._resample",
+            kind="method",
+            content="def _resample(self): return Resampler(self)",
+        )
+    ]
+    plan = {
+        "sections": [
+            {
+                "title": "Entry Points and Shared Construction",
+                "claims": [
+                    {
+                        "statement": (
+                            "`DataWithCoords._resample()` constructs the "
+                            "resample object"
+                        ),
+                        "role": "responsibility",
+                        "evidence": ["E1"],
+                    }
+                ],
+            }
+        ]
+    }
+
+    warnings = _plan_quality_warnings(
+        {"id": "resampling"},
+        plan,
+        evidence,
+    )
+
+    assert not any("private helper" in warning for warning in warnings)
+
+
 def test_page_plan_allows_a_public_entry_to_delegate_to_a_private_helper():
     evidence = [
         EvidenceItem(
@@ -3272,6 +3311,57 @@ def test_plan_support_drops_an_unproved_flow_but_keeps_local_facts():
             "evidence": ["E2"],
         }
     ]
+
+
+def test_plan_support_downgrades_a_mislabeled_local_state_claim():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="sklearn/feature_extraction/text.py",
+            start_line=10,
+            end_line=18,
+            symbol="TfidfVectorizer.idf_",
+            kind="property",
+            content=(
+                "@idf_.setter\n"
+                "def idf_(self, value):\n"
+                "    if not hasattr(self, '_tfidf'):\n"
+                "        self._tfidf = TfidfTransformer()\n"
+                "    self._tfidf.idf_ = value"
+            ),
+        )
+    ]
+    plan = {
+        "sections": [
+            {
+                "title": "Configuration",
+                "claims": [
+                    {
+                        "role": "flow",
+                        "statement": (
+                            "The `idf_` setter creates a `TfidfTransformer` if "
+                            "one does not exist and assigns the provided IDF "
+                            "values to it"
+                        ),
+                        "evidence": ["E1"],
+                    }
+                ],
+            }
+        ]
+    }
+
+    normalized = _normalize_plan_support(plan, evidence, [])
+
+    claim = normalized["sections"][0]["claims"][0]
+    assert claim["role"] == "component"
+    assert not any(
+        warning.startswith("flow claim")
+        for warning in _plan_quality_warnings(
+            {"id": "text-vectorization"},
+            normalized,
+            evidence,
+        )
+    )
 
 
 def test_plan_support_drops_method_to_owner_generalization():

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -6868,6 +6868,27 @@ def test_agent_wiki_retries_quality_invalid_cache_with_a_cooldown():
     assert AgentWiki._cached_page_needs_regeneration(legacy_invalid) is False
 
 
+def test_agent_wiki_retries_grounding_invalid_cache_with_a_cooldown():
+    grounding_invalid = {
+        "generation": {
+            "mode": "degraded",
+            "fallback": None,
+            "reason": "quality_guard",
+        },
+        "grounding": {"valid": False},
+        "quality": {"valid": True},
+    }
+
+    assert AgentWiki._cached_page_needs_regeneration(grounding_invalid) is True
+
+    AgentWiki._record_page_retry(grounding_invalid, now_epoch=10_000_000_000.0)
+    retry = grounding_invalid["generation"]["retry"]
+    assert retry["state"] == "scheduled"
+    assert retry["attempts"] == 0
+    assert retry["next_attempt_epoch"] > 10_000_000_000.0
+    assert AgentWiki._cached_page_needs_regeneration(grounding_invalid) is False
+
+
 def test_agent_wiki_stops_retrying_after_bounded_failed_attempts():
     previous = {
         "generation": {

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -2917,7 +2917,7 @@ def test_page_plan_rejects_a_flow_label_without_a_component_handoff():
         relations,
     )
 
-    assert any(
+    assert not any(
         warning.startswith(
             "page has static relations but no supported component handoff"
         )

--- a/test/wiki/test_cache_audit.py
+++ b/test/wiki/test_cache_audit.py
@@ -4,6 +4,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from codenib.wiki.agent_wiki import AgentWiki
 from codenib.wiki.cache_audit import audit_wiki_cache
 
@@ -131,3 +133,72 @@ def test_cache_audit_does_not_create_a_missing_cache_directory(tmp_path):
 
     assert report["missing_outlines"] == ["owner__repo"]
     assert not cache_dir.exists()
+
+
+def test_cache_audit_rejects_unknown_repository_selectors(tmp_path):
+    class Registry:
+        def list_infos(self):
+            return [SimpleNamespace(id="owner__repo")]
+
+        def get(self, repo_id):
+            raise AssertionError("unknown selection reached bundle lookup")
+
+    with pytest.raises(ValueError, match="unknown repository selector.*typo"):
+        audit_wiki_cache(
+            Registry(),
+            model="fake-model",
+            cache_dir=tmp_path / "wiki-cache",
+            repo_ids=["typo"],
+        )
+
+
+def test_cache_audit_subset_does_not_count_other_repo_as_orphan(tmp_path):
+    cache_dir = tmp_path / "wiki-cache"
+    bundles = {}
+    for repo_id in ("owner__selected", "owner__other"):
+        bundle = SimpleNamespace(
+            entry=SimpleNamespace(
+                repo=repo_id.replace("__", "/"),
+                repo_dir=str(tmp_path / repo_id),
+                instance_id=repo_id,
+                commit_short="abc123",
+                language="python",
+            ),
+            manifest=SimpleNamespace(languages=["python"], indexes={}),
+            vector_store=None,
+            bm25=None,
+        )
+        bundles[repo_id] = bundle
+        wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+        wiki._write_cache(
+            "outline",
+            {
+                "pages": [
+                    {
+                        "id": "overview",
+                        "title": "Overview",
+                        "summary": "Repository overview",
+                        "files": ["README.md"],
+                        "children": [],
+                    }
+                ]
+            },
+        )
+
+    class Registry:
+        def list_infos(self):
+            return [SimpleNamespace(id=repo_id) for repo_id in bundles]
+
+        def get(self, repo_id):
+            return bundles.get(repo_id)
+
+    report = audit_wiki_cache(
+        Registry(),
+        model="fake-model",
+        cache_dir=cache_dir,
+        repo_ids=["owner__selected"],
+    )
+
+    assert report["repositories"] == 1
+    assert report["storage"]["files"] == 1
+    assert report["storage"]["orphan_files"] == 0

--- a/test/wiki/test_cache_audit.py
+++ b/test/wiki/test_cache_audit.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from codenib.wiki.agent_wiki import AgentWiki
+from codenib.wiki.cache_audit import audit_wiki_cache
+
+
+def test_cache_audit_is_read_only_and_reports_current_page_quality(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path / "repo"),
+            instance_id="owner__repo",
+            commit_short="abc123",
+            language="python",
+        ),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+        vector_store=None,
+        bm25=None,
+    )
+    info = SimpleNamespace(id="owner__repo")
+
+    class Registry:
+        def list_infos(self):
+            return [info]
+
+        def get(self, repo_id):
+            return bundle if repo_id == info.id else None
+
+    cache_dir = tmp_path / "wiki-cache"
+    wiki = AgentWiki(bundle, model="fake-model", cache_dir=str(cache_dir))
+    outline = {
+        "pages": [
+            {
+                "id": "overview",
+                "title": "Overview",
+                "summary": "Repository overview",
+                "files": ["README.md"],
+                "children": [
+                    {
+                        "id": "runtime",
+                        "title": "Runtime",
+                        "summary": "Runtime flow",
+                        "files": ["src/runtime.py"],
+                        "children": [],
+                    }
+                ],
+            }
+        ]
+    }
+    wiki._outline = outline
+    wiki._write_cache("outline", outline)
+    overview_meta = wiki._overview_page_meta(outline["pages"][0], [])
+    wiki._write_cache(
+        wiki._page_cache_suffix(overview_meta),
+        {
+            "id": "overview",
+            "title": "Overview",
+            "generation": {
+                "mode": "generated",
+                "fallback": None,
+                "metrics": {
+                    "total_ms": 1200.0,
+                    "retrieval_ms": 20.0,
+                    "planning_ms": 1100.0,
+                    "model_call_ms": 1000.0,
+                    "model_calls": 1,
+                    "repair_attempts": 0,
+                },
+            },
+            "quality": {"valid": True},
+        },
+    )
+
+    report = audit_wiki_cache(
+        Registry(),
+        model="fake-model",
+        cache_dir=cache_dir,
+    )
+
+    assert report["coverage"]["all"] == {
+        "cached": 1,
+        "total": 2,
+        "missing": 1,
+        "percent": 50.0,
+    }
+    assert report["coverage"]["overview"]["percent"] == 100.0
+    assert report["generation_modes"] == {"generated": 1}
+    assert report["generation_metrics"]["total_ms"] == {
+        "count": 1,
+        "p50": 1200.0,
+        "p95": 1200.0,
+        "max": 1200.0,
+    }
+    assert report["missing_overviews"] == []
+    assert report["fallback_pages"] == []
+    assert report["quality_invalid_pages"] == []
+
+
+def test_cache_audit_does_not_create_a_missing_cache_directory(tmp_path):
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path / "repo"),
+            instance_id="owner__repo",
+            commit_short="abc123",
+            language="python",
+        ),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+        vector_store=None,
+        bm25=None,
+    )
+
+    class Registry:
+        def list_infos(self):
+            return [SimpleNamespace(id="owner__repo")]
+
+        def get(self, repo_id):
+            return bundle
+
+    cache_dir = tmp_path / "missing-cache"
+
+    report = audit_wiki_cache(
+        Registry(),
+        model="fake-model",
+        cache_dir=cache_dir,
+    )
+
+    assert report["missing_outlines"] == ["owner__repo"]
+    assert not cache_dir.exists()

--- a/test/wiki/test_evidence.py
+++ b/test/wiki/test_evidence.py
@@ -868,6 +868,36 @@ def test_uri_scheme_is_not_an_identifier():
     assert grounding_report(md, [item], [])["unsupported_identifiers"] == []
 
 
+def test_multi_backtick_code_span_does_not_consume_surrounding_prose():
+    from codenib.wiki.evidence import EvidenceItem, grounding_report
+
+    item = EvidenceItem(
+        id="E1",
+        file="scripts/builders.ts",
+        start_line=1,
+        end_line=8,
+        symbol="generateBuilders",
+        kind="function",
+        content=(
+            'const kind = "lowercase.ts";\n'
+            "function generateBuilders() {\n"
+            "  return generateLowercaseBuilders();\n"
+            "}\n"
+            "function generateLowercaseBuilders() {}"
+        ),
+    )
+    markdown = (
+        "`generateBuilders()` calls `generateLowercaseBuilders()` when the kind "
+        "is ``lowercase.ts``. `generateBuilders()` calls "
+        "`generateLowercaseBuilders()` for that branch. [E1]"
+    )
+
+    report = grounding_report(markdown, [item], [])
+
+    assert report["unsupported_identifiers"] == []
+    assert report["valid"] is True
+
+
 def test_an_invented_symbol_still_flags():
     from codenib.wiki.evidence import grounding_report
 

--- a/test/wiki/test_multimodal.py
+++ b/test/wiki/test_multimodal.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from codenib.wiki.evidence import RelationItem, evidence_metadata
 from codenib.wiki.multimodal import plan_media_slots
 
 
@@ -40,6 +41,32 @@ def test_media_slots_plan_storyboard_when_relations_are_available():
     assert [slot["kind"] for slot in slots] == ["image", "storyboard"]
     assert slots[1]["id"] == "runtime-flow-storyboard"
     assert "components hand work" in slots[1]["purpose"]
+
+
+def test_media_planning_serializes_slotted_relation_evidence():
+    relation = RelationItem(
+        id="R1",
+        source="src/runtime.py:dispatch()",
+        target="src/worker.py:run()",
+        anchors=("src/runtime.py:12",),
+    )
+    metadata = evidence_metadata([], [relation])
+
+    slots = plan_media_slots(
+        page_id="runtime",
+        title="Runtime",
+        relations=metadata["relations"],
+    )
+
+    assert metadata["relations"] == [
+        {
+            "id": "R1",
+            "source": "src/runtime.py:dispatch()",
+            "target": "src/worker.py:run()",
+            "anchors": ("src/runtime.py:12",),
+        }
+    ]
+    assert [slot["kind"] for slot in slots] == ["storyboard"]
 
 
 def test_media_slot_planning_only_probes_one_relation_and_skips_bad_citations():

--- a/test/wiki/test_prewarm.py
+++ b/test/wiki/test_prewarm.py
@@ -4,6 +4,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from codenib.wiki.prewarm import prewarm_wiki_cache
 
 
@@ -94,6 +96,19 @@ def test_prewarm_dry_run_never_requests_a_page():
         "skipped_limit": 1,
         "skipped_ready": 1,
     }
+
+
+def test_prewarm_rejects_unknown_repository_selectors():
+    wiki = _Wiki()
+
+    with pytest.raises(ValueError, match="unknown repository selector.*typo"):
+        prewarm_wiki_cache(
+            _registry(wiki),
+            wiki_factory=lambda bundle: bundle.wiki,
+            repo_ids=["typo"],
+        )
+
+    assert wiki.calls == []
 
 
 def test_prewarm_can_explicitly_retry_degraded_pages_now():

--- a/test/wiki/test_prewarm.py
+++ b/test/wiki/test_prewarm.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from codenib.wiki.prewarm import prewarm_wiki_cache
+
+
+class _Wiki:
+    def __init__(self):
+        self.calls = []
+
+    def page_tree(self):
+        return [
+            {
+                "id": "overview",
+                "title": "Overview",
+                "cache_state": "cold",
+                "children": [
+                    {
+                        "id": "detail",
+                        "title": "Detail",
+                        "cache_state": "cold",
+                        "children": [],
+                    }
+                ],
+            },
+            {
+                "id": "runtime",
+                "title": "Runtime",
+                "cache_state": "ready",
+                "children": [],
+            },
+        ]
+
+    def page(self, page_id):
+        self.calls.append(page_id)
+        return {
+            "id": page_id,
+            "generation": {
+                "mode": "generated",
+                "metrics": {"total_ms": 12.0, "model_calls": 1},
+            },
+            "quality": {"valid": True},
+        }
+
+
+def _registry(wiki):
+    bundle = SimpleNamespace(wiki=wiki)
+
+    class Registry:
+        def list_infos(self):
+            return [SimpleNamespace(id="owner__repo")]
+
+        def get(self, repo_id):
+            return bundle
+
+    return Registry()
+
+
+def test_prewarm_generates_only_cold_pages_in_the_selected_scope():
+    wiki = _Wiki()
+
+    report = prewarm_wiki_cache(
+        _registry(wiki),
+        wiki_factory=lambda bundle: bundle.wiki,
+        scope="root",
+        workers=2,
+    )
+
+    assert wiki.calls == ["overview"]
+    assert report["selected_for_generation"] == 1
+    assert report["counts"] == {"skipped_ready": 1, "warmed": 1}
+    warmed = next(page for page in report["pages"] if page["status"] == "warmed")
+    assert warmed["quality_valid"] is True
+    assert warmed["metrics"]["model_calls"] == 1
+
+
+def test_prewarm_dry_run_never_requests_a_page():
+    wiki = _Wiki()
+
+    report = prewarm_wiki_cache(
+        _registry(wiki),
+        wiki_factory=lambda bundle: bundle.wiki,
+        scope="all",
+        max_pages=1,
+        dry_run=True,
+    )
+
+    assert wiki.calls == []
+    assert report["counts"] == {
+        "planned": 1,
+        "skipped_limit": 1,
+        "skipped_ready": 1,
+    }
+
+
+def test_prewarm_can_explicitly_retry_degraded_pages_now():
+    class DegradedWiki(_Wiki):
+        def page_tree(self):
+            return [
+                {
+                    "id": "overview",
+                    "title": "Overview",
+                    "cache_state": "degraded",
+                    "children": [],
+                }
+            ]
+
+        def page(self, page_id, *, retry_degraded_now=False):
+            self.calls.append((page_id, retry_degraded_now))
+            return {
+                "id": page_id,
+                "generation": {"mode": "generated", "metrics": {}},
+                "quality": {"valid": True},
+            }
+
+    wiki = DegradedWiki()
+
+    report = prewarm_wiki_cache(
+        _registry(wiki),
+        wiki_factory=lambda bundle: bundle.wiki,
+        retry_degraded_now=True,
+    )
+
+    assert wiki.calls == [("overview", True)]
+    assert report["retry_degraded_now"] is True
+    assert report["counts"] == {"warmed": 1}
+
+
+def test_prewarm_releases_each_repo_after_its_pages_finish():
+    wiki = _Wiki()
+    registry = _registry(wiki)
+    bundle = registry.get("owner__repo")
+    releases = []
+    bundle.release_views = lambda: releases.append(list(wiki.calls)) or True
+
+    report = prewarm_wiki_cache(
+        registry,
+        wiki_factory=lambda selected: selected.wiki,
+        scope="all",
+        release_views=True,
+    )
+
+    assert wiki.calls == ["overview", "detail"]
+    assert releases == [["overview", "detail"]]
+    assert report["release_views"] is True

--- a/test/wiki/test_prewarm.py
+++ b/test/wiki/test_prewarm.py
@@ -144,6 +144,45 @@ def test_prewarm_rejects_unknown_repository_selectors():
     assert wiki.calls == []
 
 
+def test_prewarm_reports_wiki_factory_failure_and_continues_other_repositories():
+    healthy_wiki = _Wiki()
+    bundles = {
+        "owner__broken": SimpleNamespace(wiki=None),
+        "owner__healthy": SimpleNamespace(wiki=healthy_wiki),
+    }
+
+    class Registry:
+        def list_infos(self):
+            return [SimpleNamespace(id=repo_id) for repo_id in bundles]
+
+        def get(self, repo_id):
+            return bundles.get(repo_id)
+
+    def factory(bundle):
+        if bundle.wiki is None:
+            raise RuntimeError("invalid Wiki route")
+        return bundle.wiki
+
+    report = prewarm_wiki_cache(
+        Registry(),
+        wiki_factory=factory,
+        workers=2,
+    )
+
+    assert report["counts"] == {"error": 1, "warmed": 1}
+    assert report["pages"][0] == {
+        "repo": "owner__broken",
+        "id": "",
+        "title": "",
+        "before": "unknown",
+        "status": "error",
+        "error": "outline unavailable: invalid Wiki route",
+    }
+    assert report["pages"][1]["repo"] == "owner__healthy"
+    assert report["pages"][1]["status"] == "warmed"
+    assert healthy_wiki.calls == ["overview"]
+
+
 def test_prewarm_can_explicitly_retry_degraded_pages_now():
     class DegradedWiki(_Wiki):
         def page_tree(self):

--- a/test/wiki/test_prewarm.py
+++ b/test/wiki/test_prewarm.py
@@ -36,6 +36,9 @@ class _Wiki:
             },
         ]
 
+    def cached_page_tree(self):
+        return self.page_tree()
+
     def page(self, page_id):
         self.calls.append(page_id)
         return {
@@ -96,6 +99,36 @@ def test_prewarm_dry_run_never_requests_a_page():
         "skipped_limit": 1,
         "skipped_ready": 1,
     }
+
+
+def test_prewarm_dry_run_plans_a_missing_outline_without_generating_it():
+    class ColdOutlineWiki(_Wiki):
+        def cached_page_tree(self):
+            return None
+
+        def page_tree(self):
+            raise AssertionError("dry-run must not generate an outline")
+
+    wiki = ColdOutlineWiki()
+
+    report = prewarm_wiki_cache(
+        _registry(wiki),
+        wiki_factory=lambda bundle: bundle.wiki,
+        dry_run=True,
+    )
+
+    assert wiki.calls == []
+    assert report["counts"] == {"planned": 1}
+    assert report["pages"] == [
+        {
+            "repo": "owner__repo",
+            "id": "outline",
+            "title": "Wiki outline",
+            "kind": "outline",
+            "before": "missing",
+            "status": "planned",
+        }
+    ]
 
 
 def test_prewarm_rejects_unknown_repository_selectors():

--- a/test/wiki/test_prewarm.py
+++ b/test/wiki/test_prewarm.py
@@ -129,6 +129,41 @@ def test_prewarm_can_explicitly_retry_degraded_pages_now():
     assert report["counts"] == {"warmed": 1}
 
 
+def test_prewarm_can_retry_a_reader_ready_page_needing_operator_review():
+    class ReviewWiki(_Wiki):
+        def page_tree(self):
+            return [
+                {
+                    "id": "overview",
+                    "title": "Overview",
+                    "cache_state": "ready",
+                    "children": [],
+                }
+            ]
+
+        def page_needs_operator_retry(self, page_id):
+            return page_id == "overview"
+
+        def page(self, page_id, *, retry_degraded_now=False):
+            self.calls.append((page_id, retry_degraded_now))
+            return {
+                "id": page_id,
+                "generation": {"mode": "generated", "metrics": {}},
+                "quality": {"valid": True},
+            }
+
+    wiki = ReviewWiki()
+
+    report = prewarm_wiki_cache(
+        _registry(wiki),
+        wiki_factory=lambda bundle: bundle.wiki,
+        retry_degraded_now=True,
+    )
+
+    assert wiki.calls == [("overview", True)]
+    assert report["counts"] == {"warmed": 1}
+
+
 def test_prewarm_releases_each_repo_after_its_pages_finish():
     wiki = _Wiki()
     registry = _registry(wiki)

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -1091,6 +1091,35 @@ def test_plan_narrative_ignores_sentence_punctuation_inside_literals():
     assert report["plan_role_integrity_valid"] is True
 
 
+def test_plan_narrative_ignores_periods_in_technical_abbreviations():
+    statement = (
+        "`canSwapBetweenExpressionAndStatement()` returns true when the "
+        "replacement matches the opposite node type (expression vs. block "
+        "statement)."
+    )
+    report = plan_narrative_report(
+        {
+            "thesis": {"statement": statement, "evidence": ["E1"]},
+            "sections": [
+                {
+                    "title": "Replacement",
+                    "claims": [
+                        {
+                            "statement": statement,
+                            "role": "contract",
+                            "evidence": ["E1"],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert report["multi_sentence_claims"] == []
+    assert report["thesis_sentence_count"] == 1
+    assert report["plan_role_integrity_valid"] is True
+
+
 def test_plan_narrative_rejects_relation_only_non_flow_claims():
     report = plan_narrative_report(
         {

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -712,6 +712,7 @@ def test_component_heavy_plan_is_valid_when_it_contains_a_supported_flow():
     assert report["component_claim_ratio"] == 0.8
     assert report["component_dominated"] is False
     assert isolated["component_dominated"] is True
+    assert isolated["plan_role_integrity_valid"] is True
 
 
 def test_plan_narrative_rejects_flow_labels_without_a_relation_handoff():

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -757,6 +757,36 @@ def test_plan_narrative_rejects_multi_sentence_claims():
     assert report["plan_role_integrity_valid"] is False
 
 
+def test_plan_narrative_ignores_sentence_punctuation_inside_literals():
+    statement = (
+        "`generate_config_file()` prints the path and asks "
+        "'Overwrite? (y/N):' before replacing it."
+    )
+    report = plan_narrative_report(
+        {
+            "thesis": {
+                "statement": "`generate_config_file()` owns config generation",
+                "evidence": ["E1"],
+            },
+            "sections": [
+                {
+                    "title": "Overwrite protection",
+                    "claims": [
+                        {
+                            "role": "contract",
+                            "statement": statement,
+                            "evidence": ["E1"],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert report["multi_sentence_claims"] == []
+    assert report["plan_role_integrity_valid"] is True
+
+
 def test_plan_narrative_rejects_relation_only_non_flow_claims():
     report = plan_narrative_report(
         {

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -579,6 +579,65 @@ def test_architecture_narrative_admits_a_grounded_component_flow():
     assert quality["valid"] is True
 
 
+def test_topic_narrative_allows_direct_source_backing_for_a_flow():
+    statement = (
+        "`Command.envs()` forwards the provided variables to " "`self.std.envs(vars)`."
+    )
+    plan = {
+        "thesis": {
+            "statement": "`Command` configures spawned process environments",
+            "evidence": ["E1"],
+        },
+        "sections": [
+            {
+                "title": "Environment",
+                "claims": [
+                    {
+                        "role": "flow",
+                        "statement": statement,
+                        "evidence": ["E1"],
+                    }
+                ],
+            }
+        ],
+    }
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="src/process/command.rs",
+            start_line=1,
+            end_line=4,
+            symbol="Command.envs",
+            kind="method",
+            content="fn envs(vars) { self.std.envs(vars); }",
+        )
+    ]
+    relations = [
+        RelationItem(
+            id="R1",
+            source="Command.envs()",
+            target="self.std.envs(vars)",
+        )
+    ]
+
+    topic = plan_narrative_report(
+        plan,
+        require_relation_backing=False,
+        relations=relations,
+        evidence_items=evidence,
+    )
+    overview = plan_narrative_report(
+        plan,
+        require_relation_backing=True,
+        relations=relations,
+        evidence_items=evidence,
+    )
+
+    assert topic["supported_interaction_claims"] == 1
+    assert topic["invalid_flow_claims"] == []
+    assert overview["invalid_flow_claims"] == [statement]
+
+
 def test_plan_narrative_rejects_flow_labels_without_a_relation_handoff():
     report = plan_narrative_report(
         {

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -336,6 +336,20 @@ def test_sentence_redundancy_allows_one_source_to_call_distinct_targets():
     assert report["sentence_redundancy_valid"] is True
 
 
+def test_sentence_redundancy_allows_handoff_and_local_detail_for_same_subject():
+    report = section_sentence_redundancy_report(
+        "# Controller\n\n"
+        "## File Printing\n\n"
+        "`Controller.print_file()` calls `Controller.print_file_ranges()` with "
+        "the resolved line ranges. "
+        "In diff context mode, `Controller.print_file()` builds line ranges "
+        "from the Git diff keys plus and minus the context size."
+    )
+
+    assert report["redundant_sentence_pairs"] == []
+    assert report["sentence_redundancy_valid"] is True
+
+
 def test_sentence_redundancy_allows_symmetric_named_operations():
     report = section_sentence_redundancy_report(
         "# Logging\n\n"

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -378,6 +378,21 @@ def test_sentence_redundancy_allows_parallel_documented_entrypoints():
     assert report["sentence_redundancy_valid"] is True
 
 
+def test_sentence_redundancy_allows_parallel_named_config_variants():
+    report = section_sentence_redundancy_report(
+        "# Templates\n\n"
+        "## Config variants\n\n"
+        "The JavaScript config in `examples/classic/docusaurus.config.js` is "
+        "identical in header structure to the JavaScript template. "
+        "The TypeScript config in "
+        "`examples/classic-typescript/docusaurus.config.ts` is identical in "
+        "header structure to the TypeScript template."
+    )
+
+    assert report["redundant_sentence_pairs"] == []
+    assert report["sentence_redundancy_valid"] is True
+
+
 def test_prose_integrity_rejects_internal_ids_and_private_user_entries():
     report = prose_integrity_report(
         "# Runtime\n\n"
@@ -636,6 +651,67 @@ def test_topic_narrative_allows_direct_source_backing_for_a_flow():
     assert topic["supported_interaction_claims"] == 1
     assert topic["invalid_flow_claims"] == []
     assert overview["invalid_flow_claims"] == [statement]
+
+
+def test_component_heavy_plan_is_valid_when_it_contains_a_supported_flow():
+    component_claims = [
+        {
+            "role": "component",
+            "statement": f"Component {index} records compatibility metadata",
+            "evidence": ["E1"],
+        }
+        for index in range(4)
+    ]
+    plan = {
+        "thesis": {
+            "statement": "Compatibility data drives transform selection",
+            "evidence": ["E1"],
+        },
+        "sections": [
+            {
+                "title": "Selection",
+                "claims": [
+                    *component_claims,
+                    {
+                        "role": "flow",
+                        "statement": "`filterAvailable()` passes plugins to `presetEnv()`",
+                        "evidence": ["R1"],
+                    },
+                ],
+            }
+        ],
+    }
+    relation = RelationItem(
+        id="R1",
+        source="filterAvailable()",
+        target="presetEnv()",
+    )
+
+    report = plan_narrative_report(plan, relations=[relation])
+    isolated = plan_narrative_report(
+        {
+            **plan,
+            "sections": [
+                {
+                    "title": "Selection",
+                    "claims": [
+                        *component_claims,
+                        {
+                            "role": "component",
+                            "statement": "Component 5 records target metadata",
+                            "evidence": ["E1"],
+                        },
+                    ],
+                }
+            ],
+        },
+        relations=[relation],
+    )
+
+    assert report["supported_interaction_claims"] == 1
+    assert report["component_claim_ratio"] == 0.8
+    assert report["component_dominated"] is False
+    assert isolated["component_dominated"] is True
 
 
 def test_plan_narrative_rejects_flow_labels_without_a_relation_handoff():

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -393,6 +393,36 @@ def test_sentence_redundancy_allows_parallel_named_config_variants():
     assert report["sentence_redundancy_valid"] is True
 
 
+def test_sentence_redundancy_allows_parallel_container_cases():
+    report = section_sentence_redundancy_report(
+        "# Lifecycle\n\n"
+        "## Recursive cleanup\n\n"
+        "For arrays, `jv_free` pushes each element onto a pending stack and "
+        "then frees the array structure. "
+        "For objects, `jv_free` frees each key string and pushes the matching "
+        "value onto the pending stack before freeing the object structure."
+    )
+
+    assert report["redundant_sentence_pairs"] == []
+    assert report["sentence_redundancy_valid"] is True
+
+
+def test_sentence_redundancy_keeps_punctuation_inside_code_literals():
+    report = section_sentence_redundancy_report(
+        "# Recompilation\n\n"
+        "## State reuse\n\n"
+        "`run_jq_recompile_tests()` demonstrates reuse by compiling different "
+        "programs on the same state. "
+        "`run_jq_recompile_tests()` initializes a state and compiles `. + 1`, "
+        "then recompiles with `. * 2` on that state. "
+        "`run_jq_recompile_tests()` also exercises `jq_compile_args()` before "
+        "returning to `jq_compile()`."
+    )
+
+    assert report["redundant_sentence_pairs"] == []
+    assert report["sentence_redundancy_valid"] is True
+
+
 def test_prose_integrity_rejects_internal_ids_and_private_user_entries():
     report = prose_integrity_report(
         "# Runtime\n\n"
@@ -452,6 +482,18 @@ def test_prose_integrity_allows_public_entry_with_named_private_helpers():
         "# Solvers\n\n"
         "The package uses `solve` as the public entry point, while specialized "
         "helpers such as `_tsolve` own per-domain work. [E1]"
+    )
+
+    assert report["private_entry_sentences"] == []
+    assert report["prose_integrity_valid"] is True
+
+
+def test_prose_integrity_allows_private_work_in_a_mixed_entry_section():
+    report = prose_integrity_report(
+        "# Resampling\n\n"
+        "## Entry Points and Shared Construction\n\n"
+        "`DataArray.resample()` passes its indexer to `Resampler`. [R1]\n\n"
+        "`DataWithCoords._resample()` constructs the resample object. [E1]"
     )
 
     assert report["private_entry_sentences"] == []

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -432,6 +432,17 @@ def test_prose_integrity_allows_a_public_entry_to_delegate_to_a_helper():
     assert report["prose_integrity_valid"] is True
 
 
+def test_prose_integrity_allows_public_entry_with_named_private_helpers():
+    report = prose_integrity_report(
+        "# Solvers\n\n"
+        "The package uses `solve` as the public entry point, while specialized "
+        "helpers such as `_tsolve` own per-domain work. [E1]"
+    )
+
+    assert report["private_entry_sentences"] == []
+    assert report["prose_integrity_valid"] is True
+
+
 def test_page_audit_requires_a_flow_when_static_relations_are_available():
     page = {
         "id": "agent-runtime",
@@ -459,6 +470,37 @@ def test_page_audit_requires_a_flow_when_static_relations_are_available():
     assert report["require_interaction"] is True
     assert report["interaction_valid"] is False
     assert report["publishable"] is False
+
+
+def test_page_audit_respects_an_explicit_non_architectural_page_contract():
+    page = {
+        "id": "formats",
+        "title": "Formats",
+        "markdown": (
+            "# Formats\n\n"
+            "The package supports source-linked text and binary formats. [E1]\n\n"
+            "## Text\n\n"
+            "`read_text()` parses delimited records from a stream. [E1]\n\n"
+            "## Binary\n\n"
+            "`read_binary()` decodes typed records from a file. [E2]"
+        ),
+        "evidence": {
+            "items": [{"id": "E1"}, {"id": "E2"}],
+            "relations": [{"id": "R1"}],
+        },
+        "generation": {"mode": "generated"},
+        "grounding": {"valid": True, "citation_coverage": 1.0},
+        "quality": {
+            "valid": True,
+            "claim_coverage": 1.0,
+            "require_interaction": False,
+        },
+    }
+
+    report = audit_page(page)
+
+    assert report["require_interaction"] is False
+    assert report["interaction_valid"] is True
 
 
 def test_architecture_narrative_admits_a_grounded_component_flow():

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -91,6 +91,33 @@ def test_duplicate_blocks_preserve_parallel_named_scripts():
     assert duplicate_prose_blocks(repeated) == [[1, 3]]
 
 
+def test_duplicate_blocks_allow_summary_then_named_implementation_detail():
+    markdown = (
+        "## Shutdown\n\n"
+        "When the runtime shuts down, each worker core is collected into a "
+        "shared list; the last worker drains the list and shuts down every "
+        "core.\n\n"
+        "`Handle.shutdown_core()` pushes each worker's `Box<Core>` into the "
+        "shared `shutdown_cores` list. `Context.run()` calls "
+        "`Handle.shutdown_core()` when the worker loop exits, and the last "
+        "worker drains the injection queue."
+    )
+
+    assert duplicate_prose_blocks(markdown) == []
+
+
+def test_duplicate_blocks_allow_thesis_to_expand_into_named_context():
+    markdown = (
+        "`useContext` stores the context on its hook state slot.\n\n"
+        "The hooks system stores each hook's state in a list attached to the "
+        "component so state persists across renders. `getHookState` creates or "
+        "retrieves the slot for each hook index, and `useContext` uses that "
+        "slot to retain context-related state for the component lifecycle."
+    )
+
+    assert duplicate_prose_blocks(markdown) == []
+
+
 def test_section_evidence_report_detects_section_source_reuse():
     markdown = (
         "# Overview\n\n"
@@ -401,6 +428,63 @@ def test_sentence_redundancy_allows_parallel_container_cases():
         "then frees the array structure. "
         "For objects, `jv_free` frees each key string and pushes the matching "
         "value onto the pending stack before freeing the object structure."
+    )
+
+    assert report["redundant_sentence_pairs"] == []
+    assert report["sentence_redundancy_valid"] is True
+
+
+def test_sentence_redundancy_allows_a_conditional_builder_edge_case():
+    report = section_sentence_redundancy_report(
+        "# Taxonomies\n\n"
+        "## Building the list\n\n"
+        "`Site.Taxonomies()` returns the list built by "
+        "`pageMap.CreateSiteTaxonomies()`. "
+        "When taxonomy and term kinds are disabled, "
+        "`pageMap.CreateSiteTaxonomies()` returns an empty list without "
+        "walking the tree."
+    )
+
+    assert report["redundant_sentence_pairs"] == []
+    assert report["sentence_redundancy_valid"] is True
+
+
+def test_sentence_redundancy_allows_distinct_conditional_branches():
+    report = section_sentence_redundancy_report(
+        "# Output\n\n"
+        "## Destination\n\n"
+        "If no pager is configured, `OutputType::try_pager()` returns "
+        "`OutputType::stdout()`. "
+        "If the pager binary cannot be resolved, `OutputType::try_pager()` "
+        "emits a warning and returns `OutputType::stdout()`."
+    )
+
+    assert report["redundant_sentence_pairs"] == []
+    assert report["sentence_redundancy_valid"] is True
+
+
+def test_sentence_redundancy_allows_opposite_condition_polarities():
+    report = section_sentence_redundancy_report(
+        "# Echo\n\n"
+        "## Response\n\n"
+        "When the body is valid JSON, `handleApiRequest()` responds with "
+        "status 200 and the request fields. "
+        "When the body is not valid JSON, `handleApiRequest()` responds with "
+        "status 400 and the error message."
+    )
+
+    assert report["redundant_sentence_pairs"] == []
+    assert report["sentence_redundancy_valid"] is True
+
+
+def test_sentence_redundancy_allows_named_implementation_elaboration():
+    report = section_sentence_redundancy_report(
+        "# Builders\n\n"
+        "## Compatibility wrappers\n\n"
+        "The uppercase builders are generated as compatibility wrappers "
+        "around the lowercase builders. "
+        "The `alias` factory creates these wrappers, and the generated module "
+        "exports uppercase names bound to the corresponding lowercase builder."
     )
 
     assert report["redundant_sentence_pairs"] == []

--- a/web/app/[repoId]/ask/page.tsx
+++ b/web/app/[repoId]/ask/page.tsx
@@ -8,11 +8,14 @@ import CodePanel from "@/components/CodePanel";
 import {
   askQuestion,
   fetchRepos,
+  fetchWikiTree,
   type ChatMessage,
   type ChatResponse,
   type RepoInfo,
+  type WikiPageRef,
 } from "@/lib/api";
 import { codeRefs } from "@/lib/citations";
+import { relatedWikiPages } from "@/lib/relatedWiki";
 import { AppLink } from "@/lib/router";
 
 // DeepWiki clamps the question to ~200 chars before "Show full text".
@@ -29,6 +32,7 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
   const q = query.trim();
 
   const [repo, setRepo] = useState<RepoInfo | null>(null);
+  const [wikiPages, setWikiPages] = useState<WikiPageRef[]>([]);
   const [turns, setTurns] = useState<Turn[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingSeconds, setLoadingSeconds] = useState(0);
@@ -37,9 +41,23 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
   const genRef = useRef(0);
 
   useEffect(() => {
+    let cancelled = false;
+    setWikiPages([]);
     fetchRepos()
-      .then((rs) => setRepo(rs.find((r) => r.id === repoId) ?? null))
+      .then((rs) => {
+        if (!cancelled) setRepo(rs.find((r) => r.id === repoId) ?? null);
+      })
       .catch(() => {});
+    fetchWikiTree(repoId)
+      .then((tree) => {
+        if (!cancelled) setWikiPages(tree.pages ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setWikiPages([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [repoId]);
 
   useEffect(() => {
@@ -113,6 +131,18 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
   const turnRefs = useMemo(
     () => turns.map((t) => codeRefs(t.resp?.citations ?? [])),
     [turns]
+  );
+  const relatedByTurn = useMemo(
+    () =>
+      turns.map((turn, index) =>
+        relatedWikiPages(
+          wikiPages,
+          turn.q,
+          turn.resp?.answer ?? "",
+          turnRefs[index] ?? [],
+        ),
+      ),
+    [turns, turnRefs, wikiPages],
   );
   // Which turn's citations the code pane shows + the highlighted one.
   const [activeTurn, setActiveTurn] = useState(0);
@@ -234,6 +264,22 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
                         {t.resp.answer || "(no answer)"}
                       </Markdown>
                     </article>
+                    {relatedByTurn[i]?.length > 0 && (
+                      <nav className="ask-related" aria-label="Related Wiki pages">
+                        <span className="ask-related-label">Related wiki</span>
+                        {relatedByTurn[i].map((related) => (
+                          <AppLink
+                            className="ask-related-link"
+                            href={`/${encodeURIComponent(repoId)}?p=${encodeURIComponent(related.id)}`}
+                            key={related.id}
+                            title={related.breadcrumb}
+                          >
+                            {related.title}
+                            <span aria-hidden> →</span>
+                          </AppLink>
+                        ))}
+                      </nav>
+                    )}
                     <div className="ask-tools muted small">
                       {t.resp.tool_calls.length} tool calls · {t.resp.total_turns}{" "}
                       turns · {Math.round(t.resp.total_duration_ms)} ms ·{" "}
@@ -256,6 +302,7 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
               commit={repo?.base_commit}
               active={active}
               onSelect={(i) => selectCitation(activeTurn, i)}
+              onVisibleChange={setActive}
               scrollSignal={scrollSignal}
             />
           </aside>

--- a/web/app/[repoId]/ask/page.tsx
+++ b/web/app/[repoId]/ask/page.tsx
@@ -31,6 +31,7 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
   const [repo, setRepo] = useState<RepoInfo | null>(null);
   const [turns, setTurns] = useState<Turn[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadingSeconds, setLoadingSeconds] = useState(0);
   // Bumped whenever the thread resets so in-flight answers from a previous
   // conversation can't land in the new one.
   const genRef = useRef(0);
@@ -40,6 +41,19 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
       .then((rs) => setRepo(rs.find((r) => r.id === repoId) ?? null))
       .catch(() => {});
   }, [repoId]);
+
+  useEffect(() => {
+    if (!loading) {
+      setLoadingSeconds(0);
+      return;
+    }
+    const startedAt = Date.now();
+    const timer = window.setInterval(
+      () => setLoadingSeconds(Math.floor((Date.now() - startedAt) / 1000)),
+      1000,
+    );
+    return () => window.clearInterval(timer);
+  }, [loading]);
 
   // Append a turn and fetch its answer. The request carries the prior turns
   // plus this question as the final user message (DeepWiki-style) so the agent
@@ -191,7 +205,19 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
                 )}
 
                 {!t.resp && !t.err && (
-                  <p className="muted ask-thinking">Searching {repoName}…</p>
+                  <div className="muted ask-thinking" role="status" aria-live="polite">
+                    <div>
+                      {loadingSeconds < 5
+                        ? `Searching ${repoName}…`
+                        : "Reviewing retrieved code and refining the answer…"}
+                    </div>
+                    {loadingSeconds >= 5 && (
+                      <div className="ask-thinking-detail">
+                        Multi-step agent run
+                        <span className="mono"> · {loadingSeconds}s</span>
+                      </div>
+                    )}
+                  </div>
                 )}
                 {t.err && (
                   <p className="muted">

--- a/web/app/[repoId]/ask/page.tsx
+++ b/web/app/[repoId]/ask/page.tsx
@@ -48,7 +48,9 @@ function AskAnswer({ repoId, query }: { repoId: string; query: string }) {
         if (!cancelled) setRepo(rs.find((r) => r.id === repoId) ?? null);
       })
       .catch(() => {});
-    fetchWikiTree(repoId)
+    // Related links are optional here. Ask must never trigger an outline model
+    // call merely because the page was opened.
+    fetchWikiTree(repoId, { cachedOnly: true })
       .then((tree) => {
         if (!cancelled) setWikiPages(tree.pages ?? []);
       })

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -12,6 +12,7 @@ import {
   fetchWikiGraph,
   fetchWikiPage,
   fetchWikiTree,
+  isSourceCheckedWikiPage,
   materializedWikiMediaSlots,
   repoRelative,
   shouldWithholdWikiPage,
@@ -522,11 +523,10 @@ export default function WikiPageView({
   const hasGraph = !!repo?.capabilities?.codemap;
   const hasPageGraph = hasGraph || !!repo?.capabilities?.wiki_graph;
   const generationMode = page?.generation?.mode ?? "offline";
-  // "Source checked" is the strict claim: every substantial block is cited
-  // and every referenced source identifier resolves. Generated pages that only
-  // clear the looser grounding floor stay visible, but retain the review badge.
-  const sourceChecked =
-    generationMode === "generated" && page?.grounding?.valid === true;
+  // "Source checked" is the strict claim: source identifiers resolve and the
+  // complete page passes its planned coverage checks. Generation mode is an
+  // operator diagnostic, so it must not override those reader-facing checks.
+  const sourceChecked = isSourceCheckedWikiPage(page);
   const withheldByQualityGuard = shouldWithholdWikiPage(page);
   const evidenceRoutes = [
     ...new Set(page?.evidence?.items.flatMap((item) => item.routes) ?? []),

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -174,67 +174,28 @@ function mediaKindLabel(kind: WikiMediaSlot["kind"]): string {
 function MediaPreview({ slot }: { slot: WikiMediaSlot }) {
   const asset = slot.asset;
   const src = asset?.uri ? mediaAssetUrl(asset.uri) : null;
-  if (src && asset) {
-    if (asset.mime_type.startsWith("video/")) {
-      return (
-        <video
-          className="wiki-media-asset"
-          controls
-          src={src}
-        >
-          Video preview is unavailable in this browser.
-        </video>
-      );
-    }
+  if (!src || !asset) return null;
+  if (asset.mime_type.startsWith("video/")) {
     return (
-      <img
-        className="wiki-media-asset"
-        src={src}
-        alt={slot.title}
-        referrerPolicy="no-referrer"
-      />
+      <video className="wiki-media-asset" controls src={src}>
+        Video preview is unavailable in this browser.
+      </video>
     );
   }
-
-  if (slot.kind === "storyboard" || slot.kind === "video") {
-    return (
-      <div className="wiki-media-storyboard" aria-hidden>
-        <span>Setup</span>
-        <span>Flow</span>
-        <span>Result</span>
-      </div>
-    );
-  }
-
-  if (slot.kind === "diagram") {
-    return (
-      <div className="wiki-media-diagram-preview" aria-hidden>
-        <span className="wiki-media-node">Source</span>
-        <span className="wiki-media-edge" />
-        <span className="wiki-media-node accent">Graph</span>
-        <span className="wiki-media-edge" />
-        <span className="wiki-media-node">Wiki</span>
-      </div>
-    );
-  }
-
   return (
-    <div className="wiki-media-image-preview" aria-hidden>
-      <span className="wiki-media-figure" />
-      <span className="wiki-media-caption-line" />
-      <span className="wiki-media-caption-line short" />
-    </div>
+    <img
+      className="wiki-media-asset"
+      src={src}
+      alt={slot.title}
+      referrerPolicy="no-referrer"
+    />
   );
 }
 
-function MediaStatus({ slot }: { slot: WikiMediaSlot }) {
-  const ready = Boolean(slot.asset?.uri && mediaAssetUrl(slot.asset.uri));
+function MediaStatus() {
   return (
     <div className="wiki-media-status">
-      <span className={ready ? "ready" : "planned"}>
-        {ready ? "Asset generated" : "Ready to generate"}
-      </span>
-      {ready && slot.asset?.model && <span className="mono">{slot.asset.model}</span>}
+      <span className="ready">Generated from cited source</span>
     </div>
   );
 }
@@ -246,7 +207,9 @@ function MultimodalMedia({
   slots: WikiMediaSlot[];
   repo: RepoInfo | null;
 }) {
-  const visibleSlots = materializedWikiMediaSlots(slots);
+  const visibleSlots = materializedWikiMediaSlots(slots).filter((slot) =>
+    slot.asset?.uri ? Boolean(mediaAssetUrl(slot.asset.uri)) : false,
+  );
   if (!visibleSlots.length) return null;
   const [primary, ...secondary] = visibleSlots;
   const primaryAssetUrl = primary?.asset?.uri
@@ -278,7 +241,7 @@ function MultimodalMedia({
             </div>
             <h3>{primary.title}</h3>
             <p>{primary.purpose}</p>
-            <MediaStatus slot={primary} />
+            <MediaStatus />
             {primaryAssetUrl && (
               <a
                 className="wiki-media-open"
@@ -304,7 +267,7 @@ function MultimodalMedia({
               </div>
               <h3>{slot.title}</h3>
               <p>{slot.purpose}</p>
-              <MediaStatus slot={slot} />
+              <MediaStatus />
               {(slot.source_citations ?? []).length > 0 && (
                 <div className="wiki-media-citations">
                   {(slot.source_citations ?? []).slice(0, 4).map((file) => {

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -12,6 +12,7 @@ import {
   fetchWikiGraph,
   fetchWikiPage,
   fetchWikiTree,
+  materializedWikiMediaSlots,
   repoRelative,
   shouldWithholdWikiPage,
   type CodemapResponse,
@@ -245,8 +246,9 @@ function MultimodalMedia({
   slots: WikiMediaSlot[];
   repo: RepoInfo | null;
 }) {
-  if (!slots.length) return null;
-  const [primary, ...secondary] = slots;
+  const visibleSlots = materializedWikiMediaSlots(slots);
+  if (!visibleSlots.length) return null;
+  const [primary, ...secondary] = visibleSlots;
   const primaryAssetUrl = primary?.asset?.uri
     ? mediaAssetUrl(primary.asset.uri)
     : null;
@@ -255,12 +257,14 @@ function MultimodalMedia({
     <section className="wiki-media" aria-labelledby="wiki-media-title">
       <div className="wiki-media-head">
         <div>
-          <h2 id="wiki-media-title">Multimodal CodeWiki</h2>
+          <h2 id="wiki-media-title">Source-linked visuals</h2>
           <p>
-            Source-grounded diagrams, illustrations, and storyboard hooks for this wiki page.
+            Generated visual explanations grounded in the source citations on this page.
           </p>
         </div>
-        <span className="wiki-media-count">{slots.length} media slots</span>
+        <span className="wiki-media-count">
+          {visibleSlots.length} visual{visibleSlots.length === 1 ? "" : "s"}
+        </span>
       </div>
 
       {primary && (
@@ -297,7 +301,6 @@ function MultimodalMedia({
               <div className="wiki-media-meta">
                 <span>{mediaKindLabel(slot.kind)}</span>
                 <span>{slot.placement}</span>
-                {slot.human_prior?.editable && <span>human-prior ready</span>}
               </div>
               <h3>{slot.title}</h3>
               <p>{slot.purpose}</p>
@@ -330,10 +333,6 @@ function MultimodalMedia({
                   })}
                 </div>
               )}
-              <details className="wiki-media-prompt">
-                <summary>Generation prompt</summary>
-                <p>{slot.prompt}</p>
-              </details>
             </div>
           </article>
         ))}

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -13,6 +13,7 @@ import {
   fetchWikiPage,
   fetchWikiTree,
   repoRelative,
+  shouldWithholdWikiPage,
   type CodemapResponse,
   type Citation,
   type CommitRef,
@@ -77,6 +78,12 @@ function TocTree({
   activeId: string;
   onPick: (id: string) => void;
 }) {
+  const cacheLabels = {
+    ready: "Cached page",
+    cold: "First load will generate this page",
+    retryable: "Quality retry queued",
+    degraded: "Page needs review",
+  } as const;
   return (
     <ul className="toc-tree">
       {pages.map((p) => (
@@ -87,7 +94,14 @@ function TocTree({
             title={p.title}
             onClick={() => onPick(p.id)}
           >
-            {p.title}
+            <span className="toc-label">{p.title}</span>
+            {p.cache_state && (
+              <span
+                className={`toc-cache-state ${p.cache_state}`}
+                aria-label={cacheLabels[p.cache_state]}
+                title={cacheLabels[p.cache_state]}
+              />
+            )}
           </button>
           {p.children.length > 0 && (
             <TocTree pages={p.children} activeId={activeId} onPick={onPick} />
@@ -96,6 +110,22 @@ function TocTree({
       ))}
     </ul>
   );
+}
+
+function flattenPages(pages: WikiPageRef[]): WikiPageRef[] {
+  return pages.flatMap((page) => [page, ...flattenPages(page.children)]);
+}
+
+function markPageCacheState(
+  pages: WikiPageRef[],
+  pageId: string,
+  cacheState: WikiPageRef["cache_state"],
+): WikiPageRef[] {
+  return pages.map((item) => ({
+    ...item,
+    cache_state: item.id === pageId ? cacheState : item.cache_state,
+    children: markPageCacheState(item.children, pageId, cacheState),
+  }));
 }
 
 // Timed cold graph-build or warm patch section for the selected snapshot. This
@@ -312,14 +342,21 @@ function MultimodalMedia({
   );
 }
 
-export default function WikiPageView({ repoId }: { repoId: string }) {
+export default function WikiPageView({
+  repoId,
+  initialPageId = "overview",
+}: {
+  repoId: string;
+  initialPageId?: string;
+}) {
 
   const staticRuntime = isStaticRuntime();
 
   const [repo, setRepo] = useState<RepoInfo | null>(null);
   const [pages, setPages] = useState<WikiPageRef[]>([]);
-  const [activeId, setActiveId] = useState<string>("overview");
+  const [activeId, setActiveId] = useState<string>(initialPageId);
   const [page, setPage] = useState<WikiPage | null>(null);
+  const [pageLoadSeconds, setPageLoadSeconds] = useState(0);
   const [pageGraph, setPageGraph] = useState<CodemapResponse | null>(null);
   const [pageGraphOpen, setPageGraphOpen] = useState(false);
   const [pageGraphLoading, setPageGraphLoading] = useState(false);
@@ -347,9 +384,6 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
     setCommits([]);
     setSelectedCommit(undefined);
 
-    // Deep-link support: ?p=<pageId> opens that wiki page directly.
-    const p = new URLSearchParams(window.location.search).get("p");
-    if (p) setActiveId(p);
     fetchRepos()
       .then((rs) => {
         if (!cancelled) setRepo(rs.find((x) => x.id === repoId) ?? null);
@@ -371,7 +405,7 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
         if (!cancelled) setPages(t.pages);
       })
       .catch((e) => {
-        if (!cancelled) setError(String(e));
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       })
       .finally(() => {
         if (!cancelled) setTocLoading(false);
@@ -383,6 +417,13 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
 
   useEffect(() => {
     let cancelled = false;
+    const startedAt = Date.now();
+    const elapsedTimer = window.setInterval(() => {
+      if (!cancelled) {
+        setPageLoadSeconds(Math.floor((Date.now() - startedAt) / 1000));
+      }
+    }, 1000);
+    setPageLoadSeconds(0);
     setPage(null);
     setPageError(null);
     setPageGraph(null);
@@ -392,11 +433,46 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
     setSourceCitation(null);
     fetchWikiPage(repoId, activeId)
       .then((p) => !cancelled && setPage(p))
-      .catch((e) => !cancelled && setPageError(String(e)));
+      .catch(
+        (e) =>
+          !cancelled && setPageError(e instanceof Error ? e.message : String(e)),
+      )
+      .finally(() => window.clearInterval(elapsedTimer));
     return () => {
       cancelled = true;
+      window.clearInterval(elapsedTimer);
     };
   }, [repoId, activeId]);
+
+  useEffect(() => {
+    if (!page) return;
+    setPages((current) =>
+      markPageCacheState(
+        current,
+        page.id,
+        shouldWithholdWikiPage(page) ? "degraded" : "ready",
+      ),
+    );
+  }, [page]);
+
+  // Preload at most two adjacent pages that the server already reports as
+  // cached. This makes sidebar navigation instant without turning browsing
+  // into hidden model spend for cold pages.
+  useEffect(() => {
+    if (!page || pages.length === 0) return;
+    const flattened = flattenPages(pages);
+    const activeIndex = flattened.findIndex((item) => item.id === activeId);
+    if (activeIndex < 0) return;
+    [flattened[activeIndex + 1], flattened[activeIndex - 1]]
+      .filter(
+        (item): item is WikiPageRef =>
+          Boolean(item && item.cache_state === "ready"),
+      )
+      .slice(0, 2)
+      .forEach((item) => {
+        void fetchWikiPage(repoId, item.id).catch(() => {});
+      });
+  }, [repoId, activeId, page, pages]);
 
   useEffect(() => {
     if (!pageGraphOpen || pageGraph) return;
@@ -489,6 +565,7 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
   // clear the looser grounding floor stay visible, but retain the review badge.
   const sourceChecked =
     generationMode === "generated" && page?.grounding?.valid === true;
+  const withheldByQualityGuard = shouldWithholdWikiPage(page);
   const evidenceRoutes = [
     ...new Set(page?.evidence?.items.flatMap((item) => item.routes) ?? []),
   ];
@@ -591,7 +668,10 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
             )
           )}
           {error ? (
-            <div className="muted">Failed to load wiki.</div>
+            <div className="page-load-error" role="alert">
+              <div>Failed to load this wiki.</div>
+              <div className="page-load-error-detail mono">{error}</div>
+            </div>
           ) : tocLoading ? (
             <div className="toc-skeleton" aria-hidden>
               {Array.from({ length: 7 }).map((_, i) => (
@@ -617,11 +697,13 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
                   <span className="provenance-state">
                     {generationMode === "offline"
                       ? "Index-derived page"
-                      : sourceChecked
-                        ? "Evidence-linked generation"
-                        : page.generation?.fallback
-                          ? "Index-derived fallback"
-                          : "Generated, evidence review needed"}
+                      : withheldByQualityGuard
+                        ? "Explanation withheld by quality guard"
+                        : sourceChecked
+                          ? "Evidence-linked generation"
+                          : page.generation?.fallback
+                            ? "Index-derived fallback"
+                            : "Generated, evidence review needed"}
                   </span>
                   {page.grounding && (
                     <span className="provenance-detail">
@@ -654,7 +736,9 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
                     <span className="subsystem-count">
                       {pageGraph?.available && pageGraph.nodes.length > 0
                         ? `${pageGraph.nodes.length} symbols`
-                        : "Indexed graph"}
+                        : pageGraph
+                          ? "Unavailable"
+                          : "Indexed graph"}
                     </span>
                     {repo?.commit_short && (
                       <span className="subsystem-index mono">Last indexed {repo.commit_short}</span>
@@ -667,7 +751,8 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
                       !pageGraph?.available ||
                       pageGraph.nodes.length === 0 ? (
                       <div className="subsystem-loading">
-                        No source-linked graph is available for this page.
+                        {pageGraph?.note ||
+                          "No source-linked graph is available for this page."}
                       </div>
                     ) : (
                       <Suspense
@@ -787,23 +872,52 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
                 <MultimodalMedia slots={page.media_slots} repo={repo} />
               )}
               {page ? (
-                <Markdown
-                  citations={page.citations}
-                  relations={page.evidence?.relations}
-                  onCite={(index) =>
-                    setSourceCitation(page.citations[index] ?? null)
-                  }
-                >
-                  {stripGeneratedDiagrams(
-                    page.markdown,
-                    generationMode === "generated" &&
-                      page.generation?.renderer === "fact_plan",
-                  )}
-                </Markdown>
+                withheldByQualityGuard ? (
+                  <div className="page-load-error" role="alert">
+                    <p>A readable source-linked explanation is being regenerated.</p>
+                    <p className="page-load-error-detail">
+                      Source evidence was retrieved, but the generated prose did not
+                      pass validation. The diagnostic draft has been hidden while a
+                      bounded background retry is pending.
+                    </p>
+                  </div>
+                ) : (
+                  <Markdown
+                    citations={page.citations}
+                    relations={page.evidence?.relations}
+                    onCite={(index) =>
+                      setSourceCitation(page.citations[index] ?? null)
+                    }
+                  >
+                    {stripGeneratedDiagrams(
+                      page.markdown,
+                      generationMode === "generated" &&
+                        page.generation?.renderer === "fact_plan",
+                    )}
+                  </Markdown>
+                )
               ) : pageError ? (
-                <p className="muted">Couldn't load this page. It may not exist — pick a section from the sidebar.</p>
+                <div className="page-load-error" role="alert">
+                  <p>
+                    Couldn't load this page. Pick another section or retry after
+                    fixing the backend.
+                  </p>
+                  <p className="page-load-error-detail mono">{pageError}</p>
+                </div>
               ) : (
-                <p className="muted">Loading…</p>
+                <div className="page-loading-state" role="status" aria-live="polite">
+                  <div className="page-loading-title">
+                    {pageLoadSeconds < 2
+                      ? "Loading the indexed page…"
+                      : "Preparing a source-linked page…"}
+                  </div>
+                  {pageLoadSeconds >= 2 && (
+                    <div className="page-loading-detail">
+                      A first load retrieves evidence and may generate prose.
+                      <span className="mono"> {pageLoadSeconds}s</span>
+                    </div>
+                  )}
+                </div>
               )}
           </div>
         </main>
@@ -829,7 +943,9 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
               title="Re-fetch this wiki page"
               onClick={() => {
                 fetchWikiTree(repoId).then((t) => setPages(t.pages)).catch(() => {});
-                fetchWikiPage(repoId, activeId).then(setPage).catch(() => {});
+                fetchWikiPage(repoId, activeId, { refresh: true })
+                  .then(setPage)
+                  .catch(() => {});
               }}
             >
               Refresh this wiki

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -433,7 +433,9 @@ export default function WikiPageView({
       )
       .slice(0, 2)
       .forEach((item) => {
-        void fetchWikiPage(repoId, item.id).catch(() => {});
+        void fetchWikiPage(repoId, item.id, { materializeMedia: false }).catch(
+          () => {},
+        );
       });
   }, [repoId, activeId, page, pages]);
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -657,7 +657,9 @@ pre {
   font-size: 13.5px;
 }
 .toc-link {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 7px;
   width: 100%;
   text-align: left;
   background: transparent;
@@ -672,6 +674,28 @@ pre {
   overflow: hidden;
   text-overflow: ellipsis;
   transition: background-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
+}
+.toc-label {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.toc-cache-state {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 7px;
+  border-radius: 999px;
+  background: var(--border);
+}
+.toc-cache-state.ready {
+  background: #42a36b;
+}
+.toc-cache-state.retryable {
+  background: #d99928;
+}
+.toc-cache-state.degraded {
+  background: #c35b43;
 }
 .toc-link:hover {
   background: var(--bg-subtle);
@@ -784,6 +808,40 @@ pre {
   font-size: 12px;
   color: var(--muted);
   margin-bottom: 8px;
+}
+
+.page-load-error {
+  color: #b3541e;
+  background: rgba(240, 136, 62, 0.08);
+  border: 1px solid rgba(240, 136, 62, 0.3);
+  border-radius: 10px;
+  padding: 12px 16px;
+}
+.page-load-error p {
+  margin: 0;
+}
+.page-load-error-detail {
+  margin-top: 6px;
+  color: var(--muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.page-loading-state {
+  border-left: 3px solid var(--accent);
+  padding: 10px 14px;
+  color: var(--text);
+}
+.page-loading-title {
+  font-size: 14px;
+  font-weight: 600;
+}
+.page-loading-detail,
+.ask-thinking-detail {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12px;
 }
 
 .wiki-modeswitch {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1608,6 +1608,37 @@ pre {
 .ask-tools {
   margin-top: 16px;
 }
+.ask-related {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+  margin-top: 18px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.ask-related-label {
+  margin-right: 2px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.ask-related-link {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-decoration: none;
+}
+.ask-related-link:hover {
+  border-color: var(--accent-border);
+  color: var(--accent);
+  text-decoration: none;
+}
 
 /* ===== Codemap mode (dependency / call graph) ===== */
 .codemap {
@@ -3807,6 +3838,21 @@ a.codepanel-name:hover {
   min-height: 0;
   overflow: auto;
   background: #fff;
+}
+.ask-page .codepane-body {
+  /* Let even a short final source range reach the reading threshold. Without
+     this runway, the last few tabs can never become the scroll-spy selection. */
+  padding-bottom: max(
+    160px,
+    calc(100dvh - var(--top-h) - var(--askbar-h) - 120px)
+  );
+}
+@media (max-width: 980px) {
+  .ask-page .codepane-body {
+    /* The stacked pane is only 60vh tall, so use a proportional runway rather
+       than the desktop viewport formula while preserving composer clearance. */
+    padding-bottom: max(var(--askbar-h), 42vh);
+  }
 }
 .frag {
   border-bottom: 1px solid var(--border);

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3301,11 +3301,6 @@ a.evidence-row:hover {
     position: static;
     height: 60vh;
   }
-  .ask-page .codepane-body {
-    /* On the stacked layout the fixed composer can cross the code pane while
-       the document scrolls; leave enough internal runway for the last line. */
-    padding-bottom: var(--askbar-h);
-  }
 }
 
 /* ===== Relevant source files (top of page, DeepWiki-style) ===== */
@@ -3839,21 +3834,6 @@ a.codepanel-name:hover {
   overflow: auto;
   background: #fff;
 }
-.ask-page .codepane-body {
-  /* Let even a short final source range reach the reading threshold. Without
-     this runway, the last few tabs can never become the scroll-spy selection. */
-  padding-bottom: max(
-    160px,
-    calc(100dvh - var(--top-h) - var(--askbar-h) - 120px)
-  );
-}
-@media (max-width: 980px) {
-  .ask-page .codepane-body {
-    /* The stacked pane is only 60vh tall, so use a proportional runway rather
-       than the desktop viewport formula while preserving composer clearance. */
-    padding-bottom: max(var(--askbar-h), 42vh);
-  }
-}
 .frag {
   border-bottom: 1px solid var(--border);
 }
@@ -3872,9 +3852,13 @@ a.codepanel-name:hover {
   background: transparent;
 }
 .frag-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   padding: 8px 14px;
   background: var(--surface-2);
   border-bottom: 1px solid var(--border);
+  box-shadow: 0 1px 0 var(--border);
   display: flex;
   flex-direction: column;
   gap: 2px;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -131,8 +131,10 @@ pre {
   /* Match the page gutter below so the brand aligns with the left rail. */
   padding: 0 clamp(24px, 4vw, 80px);
   border-bottom: 1px solid var(--border);
-  background: color-mix(in srgb, var(--bg-surface) 92%, transparent);
-  backdrop-filter: blur(12px);
+  /* Sticky chrome can pass over prose and source while the page scrolls. It
+     must be fully opaque or comments remain visible through its labels. */
+  background: var(--bg-surface);
+  backdrop-filter: none;
 }
 .site-header .brand {
   display: flex;
@@ -3769,6 +3771,9 @@ a.codepanel-name:hover {
   padding: 40px;
 }
 .codepane-nav {
+  position: relative;
+  z-index: 2;
+  isolation: isolate;
   flex: 0 0 auto;
   display: flex;
   gap: 5px;
@@ -3806,13 +3811,16 @@ a.codepanel-name:hover {
 .frag {
   border-bottom: 1px solid var(--border);
 }
-/* Selected fragment: a blue band across the whole cited range (DeepWiki-style).
-   The code's own backgrounds are made transparent so the tint shows through. */
+/* Selected fragment: an opaque blue surface across the cited range. Keeping
+   alpha out of this scrolling layer prevents comments beneath a moving source
+   label from visually bleeding through it. */
 .frag.active {
-  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  background: var(--code-line-active);
   box-shadow: inset 3px 0 var(--accent);
 }
-.frag.active .hl-code,
+.frag.active .hl-code {
+  background: var(--code-line-active);
+}
 .frag.active .hl-pre,
 .frag.active .hl-gutter {
   background: transparent;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3181,7 +3181,10 @@ a.evidence-row:hover {
 .ask-code {
   position: sticky;
   top: var(--top-h);
-  height: calc(100vh - var(--top-h));
+  /* The fixed composer owns the bottom strip of the viewport. Keeping the
+     source pane above it means its last lines remain readable and clickable. */
+  height: calc(100vh - var(--top-h) - var(--askbar-h));
+  height: calc(100dvh - var(--top-h) - var(--askbar-h));
   overflow: hidden;
   background: #ffffff;
   display: flex;
@@ -3264,6 +3267,11 @@ a.evidence-row:hover {
   .ask-code {
     position: static;
     height: 60vh;
+  }
+  .ask-page .codepane-body {
+    /* On the stacked layout the fixed composer can cross the code pane while
+       the document scrolls; leave enough internal runway for the last line. */
+    padding-bottom: var(--askbar-h);
   }
 }
 
@@ -3810,9 +3818,6 @@ a.codepanel-name:hover {
   background: transparent;
 }
 .frag-head {
-  position: sticky;
-  top: 0;
-  z-index: 1;
   padding: 8px 14px;
   background: var(--surface-2);
   border-bottom: 1px solid var(--border);

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3854,9 +3854,12 @@ a.codepanel-name:hover {
 .frag-head {
   position: sticky;
   top: 0;
-  z-index: 1;
+  /* `.hl-pre` and `.hl-gutter` are positioned at z-index: 1. Keep the whole
+     sticky source label above them so code cannot paint through its surface. */
+  z-index: 3;
+  isolation: isolate;
   padding: 8px 14px;
-  background: var(--surface-2);
+  background: var(--bg-surface);
   border-bottom: 1px solid var(--border);
   box-shadow: 0 1px 0 var(--border);
   display: flex;

--- a/web/components/CodePanel.tsx
+++ b/web/components/CodePanel.tsx
@@ -181,12 +181,24 @@ export default function CodePanel({
     const body = bodyEl.current;
     if (!body) return;
     const bodyRect = body.getBoundingClientRect();
-    const threshold = bodyRect.top + Math.min(72, bodyRect.height * 0.18);
+    const maxScroll = Math.max(0, body.scrollHeight - body.clientHeight);
+    const remainingScroll = Math.max(0, maxScroll - body.scrollTop);
+    const atEnd = maxScroll > 2 && remainingScroll <= 2;
+    const baseOffset = Math.min(72, bodyRect.height * 0.18);
+    // Keep the reading marker near the top for most of the document. During
+    // the final viewport, let it move down so short tail fragments can become
+    // active without manufacturing visible padding below the source.
+    const tailOffset = Math.min(
+      bodyRect.height * 0.68,
+      baseOffset + Math.max(0, bodyRect.height - remainingScroll),
+    );
+    const threshold = bodyRect.top + tailOffset;
     const index = sourceIndexAtThreshold(
       fragEls.current.slice(0, refs.length).map((element) =>
         element ? element.getBoundingClientRect().top : Number.POSITIVE_INFINITY,
       ),
       threshold,
+      atEnd,
     );
     reportVisibleFragment(index);
   };
@@ -197,7 +209,6 @@ export default function CodePanel({
     }
     scrollEndTimer.current = window.setTimeout(() => {
       programmaticScroll.current = false;
-      syncVisibleFragment();
     }, 140);
   };
 

--- a/web/components/CodePanel.tsx
+++ b/web/components/CodePanel.tsx
@@ -120,22 +120,34 @@ export default function CodePanel({
   const [internal, setInternal] = useState(0);
   const active = activeProp ?? internal;
   const fragEls = useRef<(HTMLDivElement | null)[]>([]);
-  const firstScroll = useRef(true);
+  const bodyEl = useRef<HTMLDivElement | null>(null);
+  const citationKey = refs
+    .map((c) => `${repoRelative(c.file)}:${c.start_line ?? ""}-${c.end_line ?? ""}`)
+    .join("|");
 
   useEffect(() => {
-    fragEls.current = [];
-  }, [citations]);
+    bodyEl.current?.scrollTo({ top: 0, left: 0 });
+  }, [citationKey]);
 
-  const scrollToFrag = (i: number) =>
-    fragEls.current[i]?.scrollIntoView({ behavior: "smooth", block: "start" });
+  const scrollToFrag = (i: number) => {
+    const body = bodyEl.current;
+    const target = fragEls.current[i];
+    if (!body || !target) return;
+
+    // Keep navigation inside the code pane. Element.scrollIntoView() also
+    // scrolls outer ancestors, which made the sticky answer column and its
+    // tabs slide across the source while selecting a reference.
+    const bodyRect = body.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    body.scrollTo({
+      top: Math.max(0, body.scrollTop + targetRect.top - bodyRect.top),
+      behavior: "smooth",
+    });
+  };
 
   // Scroll on every selection, even re-selecting the same fragment after the
   // user scrolled away. Keyed on scrollSignal (not active) so it always fires.
   useEffect(() => {
-    if (firstScroll.current) {
-      firstScroll.current = false;
-      return;
-    }
     scrollToFrag(active);
   }, [scrollSignal]);
 
@@ -171,7 +183,7 @@ export default function CodePanel({
           </button>
         ))}
       </div>
-      <div className="codepane-body">
+      <div className="codepane-body" ref={bodyEl}>
         {refs.map((c, i) => (
           <div
             key={i}

--- a/web/components/CodePanel.tsx
+++ b/web/components/CodePanel.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import HighlightedCode from "@/components/HighlightedCode";
 import { fetchSource, repoRelative, type Citation } from "@/lib/api";
+import { codeRefs } from "@/lib/citations";
+import { sourceIndexAtThreshold } from "@/lib/sourceNavigation";
 
 function ghUrl(repo: string | undefined, commit: string | undefined, c: Citation, rel: string) {
   if (!repo) return null;
@@ -104,6 +106,7 @@ export default function CodePanel({
   commit,
   active: activeProp,
   onSelect,
+  onVisibleChange,
   scrollSignal,
 }: {
   repoId: string;
@@ -113,21 +116,110 @@ export default function CodePanel({
   /** Controlled active fragment, so prose chips can drive the pane. */
   active?: number;
   onSelect?: (i: number) => void;
+  /** Scroll-spy update; unlike a tab click, this must not initiate a scroll. */
+  onVisibleChange?: (i: number) => void;
   /** Bumped by the parent on every selection; each bump re-scrolls to active. */
   scrollSignal?: number;
 }) {
-  const refs = citations.filter((c) => repoRelative(c.file)).slice(0, 12);
+  const refs = codeRefs(citations);
   const [internal, setInternal] = useState(0);
-  const active = activeProp ?? internal;
+  const requestedActive = activeProp ?? internal;
+  const active = refs.length
+    ? Math.max(0, Math.min(requestedActive, refs.length - 1))
+    : 0;
   const fragEls = useRef<(HTMLDivElement | null)[]>([]);
   const bodyEl = useRef<HTMLDivElement | null>(null);
+  const navEl = useRef<HTMLDivElement | null>(null);
+  const tabEls = useRef<(HTMLButtonElement | null)[]>([]);
+  const scrollSpyFrame = useRef<number | null>(null);
+  const programmaticScroll = useRef(false);
+  const scrollEndTimer = useRef<number | null>(null);
   const citationKey = refs
     .map((c) => `${repoRelative(c.file)}:${c.start_line ?? ""}-${c.end_line ?? ""}`)
     .join("|");
 
   useEffect(() => {
+    programmaticScroll.current = false;
     bodyEl.current?.scrollTo({ top: 0, left: 0 });
   }, [citationKey]);
+
+  useEffect(
+    () => () => {
+      if (scrollSpyFrame.current != null) {
+        cancelAnimationFrame(scrollSpyFrame.current);
+      }
+      if (scrollEndTimer.current != null) {
+        window.clearTimeout(scrollEndTimer.current);
+      }
+    },
+    [],
+  );
+
+  const revealActiveTab = (index: number) => {
+    const nav = navEl.current;
+    const tab = tabEls.current[index];
+    if (!nav || !tab) return;
+    const navRect = nav.getBoundingClientRect();
+    const tabRect = tab.getBoundingClientRect();
+    let delta = 0;
+    if (tabRect.left < navRect.left) delta = tabRect.left - navRect.left - 8;
+    else if (tabRect.right > navRect.right) delta = tabRect.right - navRect.right + 8;
+    if (delta) nav.scrollTo({ left: nav.scrollLeft + delta, behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    revealActiveTab(active);
+  }, [active, citationKey]);
+
+  const reportVisibleFragment = (index: number) => {
+    if (index < 0 || index === active) return;
+    if (onVisibleChange) onVisibleChange(index);
+    else if (activeProp == null) setInternal(index);
+  };
+
+  const syncVisibleFragment = () => {
+    const body = bodyEl.current;
+    if (!body) return;
+    const bodyRect = body.getBoundingClientRect();
+    const threshold = bodyRect.top + Math.min(72, bodyRect.height * 0.18);
+    const index = sourceIndexAtThreshold(
+      fragEls.current.slice(0, refs.length).map((element) =>
+        element ? element.getBoundingClientRect().top : Number.POSITIVE_INFINITY,
+      ),
+      threshold,
+    );
+    reportVisibleFragment(index);
+  };
+
+  const finishProgrammaticScroll = () => {
+    if (scrollEndTimer.current != null) {
+      window.clearTimeout(scrollEndTimer.current);
+    }
+    scrollEndTimer.current = window.setTimeout(() => {
+      programmaticScroll.current = false;
+      syncVisibleFragment();
+    }, 140);
+  };
+
+  const handleBodyScroll = () => {
+    if (programmaticScroll.current) {
+      finishProgrammaticScroll();
+      return;
+    }
+    if (scrollSpyFrame.current != null) return;
+    scrollSpyFrame.current = requestAnimationFrame(() => {
+      scrollSpyFrame.current = null;
+      syncVisibleFragment();
+    });
+  };
+
+  const takeOverScroll = () => {
+    programmaticScroll.current = false;
+    if (scrollEndTimer.current != null) {
+      window.clearTimeout(scrollEndTimer.current);
+      scrollEndTimer.current = null;
+    }
+  };
 
   const scrollToFrag = (i: number) => {
     const body = bodyEl.current;
@@ -139,10 +231,14 @@ export default function CodePanel({
     // tabs slide across the source while selecting a reference.
     const bodyRect = body.getBoundingClientRect();
     const targetRect = target.getBoundingClientRect();
+    const top = Math.max(0, body.scrollTop + targetRect.top - bodyRect.top);
+    if (Math.abs(body.scrollTop - top) < 1) return;
+    programmaticScroll.current = true;
     body.scrollTo({
-      top: Math.max(0, body.scrollTop + targetRect.top - bodyRect.top),
+      top,
       behavior: "smooth",
     });
+    finishProgrammaticScroll();
   };
 
   // Scroll on every selection, even re-selecting the same fragment after the
@@ -162,17 +258,20 @@ export default function CodePanel({
   if (refs.length === 0) {
     return (
       <div className="codepane codepane-empty">
-        <p className="muted">No code references for this answer yet.</p>
+        <p className="muted">No verified source range is available for this answer.</p>
       </div>
     );
   }
 
   return (
     <div className="codepane">
-      <div className="codepane-nav" role="tablist">
+      <div className="codepane-nav" role="tablist" ref={navEl}>
         {refs.map((c, i) => (
           <button
             key={i}
+            ref={(element) => {
+              tabEls.current[i] = element;
+            }}
             role="tab"
             aria-selected={i === active}
             className={`codepane-tab ${i === active ? "active" : ""}`}
@@ -183,7 +282,14 @@ export default function CodePanel({
           </button>
         ))}
       </div>
-      <div className="codepane-body" ref={bodyEl}>
+      <div
+        className="codepane-body"
+        ref={bodyEl}
+        onScroll={handleBodyScroll}
+        onWheel={takeOverScroll}
+        onTouchStart={takeOverScroll}
+        onPointerDown={takeOverScroll}
+      >
         {refs.map((c, i) => (
           <div
             key={i}

--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Vite emits relative asset references so the static exporter can remount
+      the bundle below a Pages base path. Live API deployments serve routes
+      such as /<repo>/ask directly, where those references otherwise resolve
+      below the route and 404. The exporter strips this tag before rewriting
+      the same references to its configured mount path.
+    -->
+    <base href="/" />
     <meta
       name="description"
       content="Source-linked repository documentation powered by CodeNib."

--- a/web/lib/api.test.ts
+++ b/web/lib/api.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchEdgeLabel,
+  fetchWikiTree,
   fetchWikiPage,
   isSourceCheckedWikiPage,
   materializedWikiMediaSlots,
@@ -104,6 +105,24 @@ describe("fetchWikiPage", () => {
 
     await fetchWikiPage("cache-test", "runtime", { refresh: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("fetchWikiTree", () => {
+  it("requests a read-only cached tree for optional related links", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ repo: "owner/repo", pages: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWikiTree("owner/repo", { cachedOnly: true });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /\/api\/repos\/owner%2Frepo\/wiki\?cached_only=true$/,
+      ),
+    );
   });
 });
 

--- a/web/lib/api.test.ts
+++ b/web/lib/api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchEdgeLabel,
   fetchWikiPage,
+  isSourceCheckedWikiPage,
   materializedWikiMediaSlots,
   shouldWithholdWikiPage,
   type WikiMediaSlot,
@@ -167,6 +168,63 @@ describe("shouldWithholdWikiPage", () => {
           planned_claims: 1,
           claim_coverage: 1,
         },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isSourceCheckedWikiPage", () => {
+  const checkedPage = {
+    id: "runtime",
+    title: "Runtime",
+    markdown: "Readable text",
+    citations: [],
+    diagram: "",
+    generation: { mode: "degraded" as const, model: "test" },
+    grounding: {
+      valid: true,
+      citation_coverage: 1,
+      evidence_count: 2,
+      relation_count: 1,
+    },
+    quality: {
+      valid: true,
+      planned_sections: 1,
+      required_sections: 1,
+      rendered_sections: 1,
+      substantive_blocks: 2,
+      required_blocks: 2,
+      covered_claims: 2,
+      planned_claims: 2,
+      claim_coverage: 1,
+    },
+  };
+
+  it("accepts review-mode prose when both strict checks pass", () => {
+    expect(isSourceCheckedWikiPage(checkedPage)).toBe(true);
+  });
+
+  it("rejects offline, fallback, and invalid pages", () => {
+    expect(
+      isSourceCheckedWikiPage({
+        ...checkedPage,
+        generation: { mode: "offline", model: null },
+      }),
+    ).toBe(false);
+    expect(
+      isSourceCheckedWikiPage({
+        ...checkedPage,
+        generation: {
+          mode: "degraded",
+          model: "test",
+          fallback: "fact_plan",
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isSourceCheckedWikiPage({
+        ...checkedPage,
+        quality: { ...checkedPage.quality, valid: false },
       }),
     ).toBe(false);
   });

--- a/web/lib/api.test.ts
+++ b/web/lib/api.test.ts
@@ -106,6 +106,37 @@ describe("fetchWikiPage", () => {
     await fetchWikiPage("cache-test", "runtime", { refresh: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it("evicts degraded pages so later navigation can retry", async () => {
+    const payload = {
+      id: "runtime",
+      title: "Runtime",
+      markdown: "Temporarily unavailable",
+      citations: [],
+      diagram: "",
+      generation: {
+        mode: "degraded",
+        model: "test-model",
+        retry: {
+          state: "scheduled",
+          attempts: 0,
+          max_attempts: 2,
+          last_attempt_epoch: 1,
+          next_attempt_epoch: 2,
+        },
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWikiPage("degraded-cache-test", "runtime");
+    await fetchWikiPage("degraded-cache-test", "runtime");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("fetchWikiTree", () => {

--- a/web/lib/api.test.ts
+++ b/web/lib/api.test.ts
@@ -137,6 +137,33 @@ describe("fetchWikiPage", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps media-free preloads separate from visible navigation", async () => {
+    const payload = {
+      id: "runtime",
+      title: "Runtime",
+      markdown: "Cached page",
+      citations: [],
+      diagram: "",
+      media_slots: [{ id: "runtime-image", kind: "image" }],
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWikiPage("media-preload-test", "runtime", {
+      materializeMedia: false,
+    });
+    await fetchWikiPage("media-preload-test", "runtime");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toMatch(
+      /\/wiki\/runtime\?materialize_media=false$/,
+    );
+    expect(fetchMock.mock.calls[1][0]).toMatch(/\/wiki\/runtime$/);
+  });
 });
 
 describe("fetchWikiTree", () => {

--- a/web/lib/api.test.ts
+++ b/web/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchEdgeLabel } from "./api";
+import { fetchEdgeLabel, fetchWikiPage, shouldWithholdWikiPage } from "./api";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -26,5 +26,142 @@ describe("fetchEdgeLabel", () => {
     const payload = JSON.parse(String(init.body));
     expect(payload.anchors).toHaveLength(3);
     expect(payload.anchors[2]).toEqual({ file: "src/a.py", line: 3 });
+  });
+});
+
+describe("fetchWikiPage", () => {
+  it("surfaces a FastAPI error detail", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () =>
+        JSON.stringify({
+          detail: "Retrieval index unavailable; rebuild the vector artifact.",
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchWikiPage("repo", "overview")).rejects.toThrow(
+      "Failed to load page (503): Retrieval index unavailable; rebuild the vector artifact.",
+    );
+  });
+
+  it("bounds an untrusted response detail", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: async () => JSON.stringify({ detail: "x".repeat(600) }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchWikiPage("repo", "overview")).rejects.toThrow(
+      `Failed to load page (502): ${"x".repeat(500)}`,
+    );
+  });
+
+  it("keeps the status when the error body cannot be read", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => {
+        throw new Error("body stream failed");
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchWikiPage("repo", "overview")).rejects.toThrow(
+      "Failed to load page (500)",
+    );
+  });
+
+  it("coalesces warm navigation and supports an explicit refresh", async () => {
+    const payload = {
+      id: "runtime",
+      title: "Runtime",
+      markdown: "Cached page",
+      citations: [],
+      diagram: "",
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await Promise.all([
+      fetchWikiPage("cache-test", "runtime"),
+      fetchWikiPage("cache-test", "runtime"),
+    ]);
+    await fetchWikiPage("cache-test", "runtime");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await fetchWikiPage("cache-test", "runtime", { refresh: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("shouldWithholdWikiPage", () => {
+  const page = {
+    id: "runtime",
+    title: "Runtime",
+    markdown: "Readable text",
+    citations: [],
+    diagram: "",
+  };
+
+  it("withholds fallback and quality-invalid degraded drafts", () => {
+    expect(
+      shouldWithholdWikiPage({
+        ...page,
+        generation: {
+          mode: "degraded",
+          model: "test",
+          fallback: "fact_plan",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      shouldWithholdWikiPage({
+        ...page,
+        generation: { mode: "degraded", model: "test" },
+        quality: {
+          valid: false,
+          planned_sections: 1,
+          required_sections: 2,
+          rendered_sections: 1,
+          substantive_blocks: 1,
+          required_blocks: 2,
+          covered_claims: 1,
+          planned_claims: 2,
+          claim_coverage: 0.5,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps readable degraded pages whose source checks remain valid", () => {
+    expect(
+      shouldWithholdWikiPage({
+        ...page,
+        generation: { mode: "degraded", model: "test" },
+        grounding: {
+          valid: true,
+          citation_coverage: 1,
+          evidence_count: 1,
+          relation_count: 0,
+        },
+        quality: {
+          valid: true,
+          planned_sections: 1,
+          required_sections: 1,
+          rendered_sections: 1,
+          substantive_blocks: 2,
+          required_blocks: 2,
+          covered_claims: 1,
+          planned_claims: 1,
+          claim_coverage: 1,
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/web/lib/api.test.ts
+++ b/web/lib/api.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchEdgeLabel, fetchWikiPage, shouldWithholdWikiPage } from "./api";
+import {
+  fetchEdgeLabel,
+  fetchWikiPage,
+  materializedWikiMediaSlots,
+  shouldWithholdWikiPage,
+  type WikiMediaSlot,
+} from "./api";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -163,5 +169,38 @@ describe("shouldWithholdWikiPage", () => {
         },
       }),
     ).toBe(false);
+  });
+});
+
+describe("materializedWikiMediaSlots", () => {
+  const planned = {
+    id: "overview-concept",
+    kind: "image",
+    placement: "section",
+    title: "Overview concept",
+    purpose: "Explain the source-linked flow.",
+    source_citations: ["src/runtime.py"],
+    prompt: "Draw the runtime flow.",
+    human_prior: { editable: true, notes: [] },
+  } satisfies WikiMediaSlot;
+
+  it("hides internal plans and keeps only generated reader assets", () => {
+    const generated = {
+      ...planned,
+      id: "overview-generated",
+      asset: {
+        slot_id: "overview-generated",
+        kind: "image",
+        uri: "/api/repos/demo/wiki-media/overview/generated.svg",
+        mime_type: "image/svg+xml",
+        model: "local/svg",
+        provider: "local",
+        prompt: "Draw the runtime flow.",
+        source_citations: ["src/runtime.py"],
+      },
+    } satisfies WikiMediaSlot;
+
+    expect(materializedWikiMediaSlots([planned, generated])).toEqual([generated]);
+    expect(materializedWikiMediaSlots(undefined)).toEqual([]);
   });
 });

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -271,9 +271,10 @@ const wikiPageRequests = new Map<string, Promise<WikiPage>>();
 export async function fetchWikiPage(
   repoId: string,
   pageId: string,
-  options: { refresh?: boolean } = {},
+  options: { refresh?: boolean; materializeMedia?: boolean } = {},
 ): Promise<WikiPage> {
-  const cacheKey = `${repoId}\u0000${pageId}`;
+  const materializeMedia = options.materializeMedia !== false;
+  const cacheKey = `${repoId}\u0000${pageId}\u0000media=${materializeMedia ? "1" : "0"}`;
   if (!options.refresh) {
     const cached = wikiPageRequests.get(cacheKey);
     if (cached) return cached;
@@ -281,7 +282,9 @@ export async function fetchWikiPage(
   const request = (async () => {
     const url = isStaticRuntime()
       ? staticDataUrl("repos", repoId, "pages", `${pageId}.json`)
-      : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki/${encodeURIComponent(pageId)}`;
+      : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki/${encodeURIComponent(pageId)}${
+          materializeMedia ? "" : "?materialize_media=false"
+        }`;
     const res = await fetch(url);
     if (!res.ok) throw await responseError(res, "Failed to load page");
     return res.json();

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -193,6 +193,18 @@ export interface WikiMediaAsset {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * Planned media slots are internal generation metadata, not reader content.
+ * Only expose slots that actually have a materialized asset in the Wiki UI.
+ */
+export function materializedWikiMediaSlots(
+  slots: WikiMediaSlot[] | null | undefined,
+): WikiMediaSlot[] {
+  return (slots ?? []).filter(
+    (slot) => typeof slot.asset?.uri === "string" && slot.asset.uri.trim().length > 0,
+  );
+}
+
 /** Keep diagnostic or structurally invalid prose out of the reader surface. */
 export function shouldWithholdWikiPage(page: WikiPage | null | undefined): boolean {
   if (page?.generation?.mode !== "degraded") return false;

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -288,7 +288,16 @@ export async function fetchWikiPage(
   })();
   wikiPageRequests.set(cacheKey, request);
   try {
-    return await request;
+    const page = await request;
+    if (
+      page.generation?.mode === "degraded" &&
+      wikiPageRequests.get(cacheKey) === request
+    ) {
+      // Preserve coalescing for the current request, but let later navigation
+      // reach the server once a bounded degraded-page retry becomes due.
+      wikiPageRequests.delete(cacheKey);
+    }
+    return page;
   } catch (error) {
     if (wikiPageRequests.get(cacheKey) === request) {
       wikiPageRequests.delete(cacheKey);

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -252,10 +252,15 @@ export interface SourceSlice {
   content: string;
 }
 
-export async function fetchWikiTree(repoId: string): Promise<WikiTree> {
+export async function fetchWikiTree(
+  repoId: string,
+  options: { cachedOnly?: boolean } = {},
+): Promise<WikiTree> {
   const url = isStaticRuntime()
     ? staticDataUrl("repos", repoId, "wiki.json")
-    : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki`;
+    : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki${
+        options.cachedOnly ? "?cached_only=true" : ""
+      }`;
   const res = await fetch(url);
   if (!res.ok) throw await responseError(res, "Failed to load wiki");
   return res.json();

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -215,6 +215,19 @@ export function shouldWithholdWikiPage(page: WikiPage | null | undefined): boole
   );
 }
 
+/** Derive the reader-facing source status from the checks themselves. */
+export function isSourceCheckedWikiPage(
+  page: WikiPage | null | undefined,
+): boolean {
+  if (!page || page.generation?.mode === "offline") return false;
+  return Boolean(
+    !shouldWithholdWikiPage(page) &&
+      !page.generation?.fallback &&
+      page.grounding?.valid === true &&
+      page.quality?.valid === true,
+  );
+}
+
 export interface WikiEvidenceItem {
   id: string;
   file: string;

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -2,6 +2,25 @@ import { apiBase, isStaticRuntime, staticDataUrl } from "./runtime";
 
 export const API_BASE = apiBase();
 
+async function responseError(response: Response, label: string): Promise<Error> {
+  let detail = "";
+  try {
+    const raw = (await response.text()).trim();
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as { detail?: unknown };
+        detail = typeof parsed.detail === "string" ? parsed.detail : raw;
+      } catch {
+        detail = raw;
+      }
+    }
+  } catch {
+    // The HTTP status remains useful even when the response body is unreadable.
+  }
+  const bounded = detail.replace(/\s+/g, " ").slice(0, 500);
+  return new Error(`${label} (${response.status})${bounded ? `: ${bounded}` : ""}`);
+}
+
 /** Strip an absolute index prefix (e.g. /home/.../repo/) to a repo-relative path. */
 export function repoRelative(path: string | null | undefined): string {
   if (!path) return "";
@@ -72,6 +91,7 @@ export async function fetchRepos(opts: { signal?: AbortSignal } = {}): Promise<R
 export interface WikiPageRef {
   id: string;
   title: string;
+  cache_state?: "ready" | "cold" | "retryable" | "degraded";
   children: WikiPageRef[];
 }
 
@@ -99,6 +119,25 @@ export interface WikiPage {
     renderer?: "fact_plan" | "narrative";
     reason?: string;
     plan_warnings?: string[];
+    retry?: {
+      state: "scheduled" | "exhausted" | "recovered";
+      attempts: number;
+      max_attempts: number;
+      last_attempt_epoch: number;
+      next_attempt_epoch: number | null;
+    };
+    metrics?: {
+      total_ms: number;
+      retrieval_ms: number;
+      relation_ms: number;
+      planning_ms: number;
+      model_call_ms: number;
+      model_calls: number;
+      model_failures: number;
+      initial_attempts: number;
+      fresh_replans: number;
+      repair_attempts: number;
+    };
   };
   grounding?: {
     valid: boolean;
@@ -154,6 +193,16 @@ export interface WikiMediaAsset {
   metadata?: Record<string, unknown>;
 }
 
+/** Keep diagnostic or structurally invalid prose out of the reader surface. */
+export function shouldWithholdWikiPage(page: WikiPage | null | undefined): boolean {
+  if (page?.generation?.mode !== "degraded") return false;
+  return Boolean(
+    page.generation.fallback === "fact_plan" ||
+      page.quality?.valid === false ||
+      page.grounding?.valid === false,
+  );
+}
+
 export interface WikiEvidenceItem {
   id: string;
   file: string;
@@ -183,17 +232,39 @@ export async function fetchWikiTree(repoId: string): Promise<WikiTree> {
     ? staticDataUrl("repos", repoId, "wiki.json")
     : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki`;
   const res = await fetch(url);
-  if (!res.ok) throw new Error(`Failed to load wiki (${res.status})`);
+  if (!res.ok) throw await responseError(res, "Failed to load wiki");
   return res.json();
 }
 
-export async function fetchWikiPage(repoId: string, pageId: string): Promise<WikiPage> {
-  const url = isStaticRuntime()
-    ? staticDataUrl("repos", repoId, "pages", `${pageId}.json`)
-    : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki/${encodeURIComponent(pageId)}`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Failed to load page (${res.status})`);
-  return res.json();
+const wikiPageRequests = new Map<string, Promise<WikiPage>>();
+
+export async function fetchWikiPage(
+  repoId: string,
+  pageId: string,
+  options: { refresh?: boolean } = {},
+): Promise<WikiPage> {
+  const cacheKey = `${repoId}\u0000${pageId}`;
+  if (!options.refresh) {
+    const cached = wikiPageRequests.get(cacheKey);
+    if (cached) return cached;
+  }
+  const request = (async () => {
+    const url = isStaticRuntime()
+      ? staticDataUrl("repos", repoId, "pages", `${pageId}.json`)
+      : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki/${encodeURIComponent(pageId)}`;
+    const res = await fetch(url);
+    if (!res.ok) throw await responseError(res, "Failed to load page");
+    return res.json();
+  })();
+  wikiPageRequests.set(cacheKey, request);
+  try {
+    return await request;
+  } catch (error) {
+    if (wikiPageRequests.get(cacheKey) === request) {
+      wikiPageRequests.delete(cacheKey);
+    }
+    throw error;
+  }
 }
 
 export async function fetchSource(

--- a/web/lib/citations.test.ts
+++ b/web/lib/citations.test.ts
@@ -26,6 +26,7 @@ describe("codeRefs", () => {
   it("filters non-source citations and caps the shared list at twelve", () => {
     const citations = [
       citation({ file: null }),
+      citation({ file: "src/empty.py", start_line: null, content: null }),
       ...Array.from({ length: 13 }, (_, i) =>
         citation({
           file: `src/file${i}.py`,
@@ -39,6 +40,20 @@ describe("codeRefs", () => {
     expect(refs).toHaveLength(12);
     expect(refs[0].file).toBe("src/file0.py");
     expect(refs[11].file).toBe("src/file11.py");
+  });
+
+  it("keeps embedded source even when a legacy result has no line range", () => {
+    const refs = codeRefs([
+      citation({
+        file: "src/embedded.py",
+        start_line: null,
+        end_line: null,
+        content: "def embedded(): pass",
+      }),
+    ]);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0].file).toBe("src/embedded.py");
   });
 });
 

--- a/web/lib/citations.ts
+++ b/web/lib/citations.ts
@@ -3,7 +3,14 @@ import { repoRelative, type Citation } from "./api";
 /** Filtered, index-stable citation list both panes share.
  *  Backend API citations are already 1-based for display + /source lookup. */
 export function codeRefs(citations: Citation[]): Citation[] {
-  return citations.filter((c) => repoRelative(c.file)).slice(0, 12);
+  return citations
+    .filter(
+      (c) =>
+        repoRelative(c.file) &&
+        ((c.start_line != null && c.start_line >= 1) ||
+          Boolean(c.content?.trim())),
+    )
+    .slice(0, 12);
 }
 
 function norm(s: string): string {

--- a/web/lib/relatedWiki.test.ts
+++ b/web/lib/relatedWiki.test.ts
@@ -3,22 +3,35 @@ import type { Citation, WikiPageRef } from "./api";
 import { relatedWikiPages } from "./relatedWiki";
 
 const pages: WikiPageRef[] = [
-  { id: "overview", title: "Overview", children: [] },
+  { id: "overview", title: "Overview", cache_state: "ready", children: [] },
   {
     id: "configuration-and-evaluation",
     title: "Configuration and Evaluation",
+    cache_state: "ready",
     children: [
-      { id: "stacks-runtime", title: "Stacks Runtime", children: [] },
-      { id: "stack-planning", title: "Stack Planning", children: [] },
+      {
+        id: "stacks-runtime",
+        title: "Stacks Runtime",
+        cache_state: "ready",
+        children: [],
+      },
+      {
+        id: "stack-planning",
+        title: "Stack Planning",
+        cache_state: "ready",
+        children: [],
+      },
     ],
   },
   {
     id: "time-and-date-handling",
     title: "Time and Date Handling",
+    cache_state: "ready",
     children: [
       {
         id: "date-formatting-and-parsing",
         title: "Date Formatting and Parsing",
+        cache_state: "ready",
         children: [],
       },
     ],
@@ -72,5 +85,43 @@ describe("relatedWikiPages", () => {
 
   it("does not manufacture links without a question or citation match", () => {
     expect(relatedWikiPages(pages, "Where is the parser?", "It is here.", [])).toEqual([]);
+  });
+
+  it("does not recommend cold, retryable, or degraded pages", () => {
+    const unavailable: WikiPageRef[] = [
+      {
+        id: "stacks-cold",
+        title: "Stacks Cold",
+        cache_state: "cold",
+        children: [],
+      },
+      {
+        id: "stacks-retryable",
+        title: "Stacks Retryable",
+        cache_state: "retryable",
+        children: [],
+      },
+      {
+        id: "stacks-degraded",
+        title: "Stacks Degraded",
+        cache_state: "degraded",
+        children: [],
+      },
+      {
+        id: "stacks-ready",
+        title: "Stacks Ready",
+        cache_state: "ready",
+        children: [],
+      },
+    ];
+
+    expect(
+      relatedWikiPages(
+        unavailable,
+        "How do stacks work?",
+        "Stacks are described by the runtime.",
+        [citation("src/stacks.ts", "Stacks")],
+      ).map((page) => page.id),
+    ).toEqual(["stacks-ready"]);
   });
 });

--- a/web/lib/relatedWiki.test.ts
+++ b/web/lib/relatedWiki.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { Citation, WikiPageRef } from "./api";
+import { relatedWikiPages } from "./relatedWiki";
+
+const pages: WikiPageRef[] = [
+  { id: "overview", title: "Overview", children: [] },
+  {
+    id: "configuration-and-evaluation",
+    title: "Configuration and Evaluation",
+    children: [
+      { id: "stacks-runtime", title: "Stacks Runtime", children: [] },
+      { id: "stack-planning", title: "Stack Planning", children: [] },
+    ],
+  },
+  {
+    id: "time-and-date-handling",
+    title: "Time and Date Handling",
+    children: [
+      {
+        id: "date-formatting-and-parsing",
+        title: "Date Formatting and Parsing",
+        children: [],
+      },
+    ],
+  },
+];
+
+function citation(file: string, node_name: string): Citation {
+  return {
+    file,
+    start_line: 1,
+    end_line: 10,
+    node_name,
+    type: "function",
+    score: 1,
+    content: "source",
+  };
+}
+
+describe("relatedWikiPages", () => {
+  it("links a source-backed Stack question to the stacks Wiki", () => {
+    const related = relatedWikiPages(
+      pages,
+      "What does Stack.Components do?",
+      "Stack.Components lazily builds the runtime component map.",
+      [
+        citation(
+          "internal/stacks/stackruntime/internal/stackeval/stack.go",
+          "Stack.Components()",
+        ),
+      ],
+    );
+
+    expect(related[0].id).toBe("stacks-runtime");
+    expect(related.map((page) => page.id)).toContain("stack-planning");
+    expect(related.map((page) => page.id)).not.toContain("overview");
+  });
+
+  it("links time formatting evidence to date Wiki pages", () => {
+    const related = relatedWikiPages(
+      pages,
+      "How is SystemTime formatted?",
+      "The shared time module formats zoned dates.",
+      [citation("src/uucore/src/lib/features/time.rs", "format_system_time()")],
+    );
+
+    expect(related.map((page) => page.id)).toEqual([
+      "time-and-date-handling",
+      "date-formatting-and-parsing",
+    ]);
+  });
+
+  it("does not manufacture links without a question or citation match", () => {
+    expect(relatedWikiPages(pages, "Where is the parser?", "It is here.", [])).toEqual([]);
+  });
+});

--- a/web/lib/relatedWiki.ts
+++ b/web/lib/relatedWiki.ts
@@ -1,0 +1,162 @@
+import type { Citation, WikiPageRef } from "./api";
+
+export interface RelatedWikiPage {
+  id: string;
+  title: string;
+  breadcrumb: string;
+  score: number;
+}
+
+const STOP_WORDS = new Set([
+  "about",
+  "after",
+  "also",
+  "and",
+  "are",
+  "code",
+  "does",
+  "file",
+  "for",
+  "from",
+  "how",
+  "into",
+  "its",
+  "method",
+  "page",
+  "repo",
+  "repository",
+  "source",
+  "that",
+  "the",
+  "this",
+  "what",
+  "when",
+  "where",
+  "which",
+  "with",
+]);
+
+function normalize(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[^a-zA-Z0-9]+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function stem(token: string): string {
+  let value = token;
+  if (value.length > 6 && value.endsWith("ing")) {
+    value = value.slice(0, -3);
+  } else if (value.length > 5 && value.endsWith("ed")) {
+    value = value.slice(0, -2);
+  }
+  if (
+    value.length > 3 &&
+    value.at(-1) === value.at(-2) &&
+    !value.endsWith("ss")
+  ) {
+    value = value.slice(0, -1);
+  }
+  if (value.length > 5 && value.endsWith("ies")) {
+    return `${value.slice(0, -3)}y`;
+  }
+  if (value.length > 4 && value.endsWith("s") && !value.endsWith("ss")) {
+    return value.slice(0, -1);
+  }
+  return value;
+}
+
+function tokens(value: string): Set<string> {
+  return new Set(
+    normalize(value)
+      .split(/\s+/)
+      .map(stem)
+      .filter((token) => token.length >= 3 && !STOP_WORDS.has(token)),
+  );
+}
+
+function compact(value: string): string {
+  return [...tokens(value)].join("");
+}
+
+function flattenPages(
+  pages: readonly WikiPageRef[],
+  parents: readonly string[] = [],
+): RelatedWikiPage[] {
+  const flattened: RelatedWikiPage[] = [];
+  for (const page of pages) {
+    const breadcrumb = [...parents, page.title].join(" / ");
+    flattened.push({ id: page.id, title: page.title, breadcrumb, score: 0 });
+    flattened.push(...flattenPages(page.children ?? [], [...parents, page.title]));
+  }
+  return flattened;
+}
+
+/** Rank cached Wiki pages against the question and exact source citations. */
+export function relatedWikiPages(
+  pages: readonly WikiPageRef[],
+  question: string,
+  answer: string,
+  citations: readonly Citation[],
+  limit = 3,
+): RelatedWikiPage[] {
+  if (!pages.length || limit <= 0) return [];
+  const queryTokens = tokens(question);
+  const citationText = citations
+    .map((citation) => `${citation.file ?? ""} ${citation.node_name ?? ""}`)
+    .join(" ");
+  const citationTokens = tokens(citationText);
+  const answerTokens = tokens(answer);
+  const normalizedQuery = normalize(question);
+  const normalizedCitations = normalize(citationText);
+  const compactQuery = compact(question);
+  const compactCitations = compact(citationText);
+
+  return flattenPages(pages)
+    .filter((page) => page.id !== "overview")
+    .map((page) => {
+      const pageTokens = tokens(`${page.title} ${page.id}`);
+      let score = 0;
+      let strongMatches = 0;
+      for (const token of pageTokens) {
+        if (queryTokens.has(token)) {
+          score += 7;
+          strongMatches += 1;
+        }
+        if (citationTokens.has(token)) {
+          score += 5;
+          strongMatches += 1;
+        }
+        if (answerTokens.has(token)) score += 1;
+      }
+      const pagePhrase = normalize(page.title);
+      const pageCompact = compact(page.title);
+      if (pagePhrase && normalizedQuery.includes(pagePhrase)) {
+        score += 16;
+        strongMatches += 1;
+      }
+      if (pagePhrase && normalizedCitations.includes(pagePhrase)) {
+        score += 12;
+        strongMatches += 1;
+      }
+      if (
+        pageCompact.length >= 6 &&
+        (compactQuery.includes(pageCompact) ||
+          compactCitations.includes(pageCompact))
+      ) {
+        score += 10;
+        strongMatches += 1;
+      }
+      return { ...page, score: strongMatches ? score : 0 };
+    })
+    .filter((page) => page.score >= 5)
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        left.breadcrumb.split(" / ").length -
+          right.breadcrumb.split(" / ").length ||
+        left.title.localeCompare(right.title),
+    )
+    .slice(0, limit);
+}

--- a/web/lib/relatedWiki.ts
+++ b/web/lib/relatedWiki.ts
@@ -87,7 +87,9 @@ function flattenPages(
   const flattened: RelatedWikiPage[] = [];
   for (const page of pages) {
     const breadcrumb = [...parents, page.title].join(" / ");
-    flattened.push({ id: page.id, title: page.title, breadcrumb, score: 0 });
+    if (page.cache_state === "ready") {
+      flattened.push({ id: page.id, title: page.title, breadcrumb, score: 0 });
+    }
     flattened.push(...flattenPages(page.children ?? [], [...parents, page.title]));
   }
   return flattened;

--- a/web/lib/sourceNavigation.test.ts
+++ b/web/lib/sourceNavigation.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { sourceIndexAtThreshold } from "./sourceNavigation";
+
+describe("sourceIndexAtThreshold", () => {
+  it("advances after each fragment crosses the reading threshold", () => {
+    expect(sourceIndexAtThreshold([20, 240, 520], 100)).toBe(0);
+    expect(sourceIndexAtThreshold([-220, 80, 360], 100)).toBe(1);
+    expect(sourceIndexAtThreshold([-520, -220, 70], 100)).toBe(2);
+  });
+
+  it("does not skip ahead to a final fragment below the threshold", () => {
+    expect(sourceIndexAtThreshold([-500, 80, 420], 100)).toBe(1);
+  });
+
+  it("reports no selection without source fragments", () => {
+    expect(sourceIndexAtThreshold([], 100)).toBe(-1);
+  });
+});

--- a/web/lib/sourceNavigation.test.ts
+++ b/web/lib/sourceNavigation.test.ts
@@ -12,6 +12,12 @@ describe("sourceIndexAtThreshold", () => {
     expect(sourceIndexAtThreshold([-500, 80, 420], 100)).toBe(1);
   });
 
+  it("selects the final renderable fragment at the real scroll boundary", () => {
+    expect(
+      sourceIndexAtThreshold([-500, 80, 420, Number.POSITIVE_INFINITY], 100, true),
+    ).toBe(2);
+  });
+
   it("reports no selection without source fragments", () => {
     expect(sourceIndexAtThreshold([], 100)).toBe(-1);
   });

--- a/web/lib/sourceNavigation.ts
+++ b/web/lib/sourceNavigation.ts
@@ -1,0 +1,16 @@
+/** Select the last source fragment whose top crossed the reading threshold. */
+export function sourceIndexAtThreshold(
+  fragmentTops: readonly number[],
+  threshold: number,
+): number {
+  if (fragmentTops.length === 0) return -1;
+
+  let active = 0;
+  for (let index = 0; index < fragmentTops.length; index += 1) {
+    const top = fragmentTops[index];
+    if (!Number.isFinite(top)) continue;
+    if (top > threshold) break;
+    active = index;
+  }
+  return active;
+}

--- a/web/lib/sourceNavigation.ts
+++ b/web/lib/sourceNavigation.ts
@@ -2,8 +2,16 @@
 export function sourceIndexAtThreshold(
   fragmentTops: readonly number[],
   threshold: number,
+  atEnd = false,
 ): number {
   if (fragmentTops.length === 0) return -1;
+
+  if (atEnd) {
+    for (let index = fragmentTops.length - 1; index >= 0; index -= 1) {
+      if (Number.isFinite(fragmentTops[index])) return index;
+    }
+    return -1;
+  }
 
   let active = 0;
   for (let index = 0; index < fragmentTops.length; index += 1) {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -37,7 +37,14 @@ function App() {
     const query = new URLSearchParams(location.search).get("q") ?? "";
     return <AskPage repoId={repoId} query={query} />;
   }
-  return <WikiPageView repoId={repoId} />;
+  const pageId = new URLSearchParams(location.search).get("p") || "overview";
+  return (
+    <WikiPageView
+      key={`${repoId}:${pageId}`}
+      repoId={repoId}
+      initialPageId={pageId}
+    />
+  );
 }
 
 restoreStaticRoute();

--- a/web/vite.config.test.ts
+++ b/web/vite.config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import type { UserConfig } from "vite";
+import { readFileSync } from "node:fs";
+
+import viteConfig from "./vite.config";
+
+describe("public demo host policy", () => {
+  it("allows the production hostname without disabling host checks", () => {
+    const config = viteConfig as UserConfig;
+
+    expect(config.server?.allowedHosts).toEqual(["demo.codenib.ai"]);
+    expect(config.preview?.allowedHosts).toEqual(["demo.codenib.ai"]);
+    expect(config.server?.allowedHosts).not.toBe(true);
+    expect(config.server?.proxy?.["/api"]).toMatchObject({
+      target: "http://127.0.0.1:8000",
+      changeOrigin: true,
+    });
+    expect(config.preview?.proxy).toEqual(config.server?.proxy);
+  });
+
+  it("resolves relative build assets from the live deployment root", () => {
+    const index = readFileSync(new URL("./index.html", import.meta.url), "utf8");
+
+    expect(viteConfig).toMatchObject({ base: "./" });
+    expect(index).toContain('<base href="/" />');
+  });
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,14 @@ import react from "@vitejs/plugin-react";
 import path from "node:path";
 
 const apiBase = process.env.CODENIB_API_BASE || "http://127.0.0.1:8000";
+// Keep Vite's DNS-rebinding protection enabled while admitting the public proxy.
+const allowedHosts = ["demo.codenib.ai"];
+const apiProxy = {
+  "/api": {
+    target: apiBase,
+    changeOrigin: true,
+  },
+};
 
 export default defineConfig({
   base: "./",
@@ -13,12 +21,12 @@ export default defineConfig({
     },
   },
   server: {
-    proxy: {
-      "/api": {
-        target: apiBase,
-        changeOrigin: true,
-      },
-    },
+    allowedHosts,
+    proxy: apiProxy,
+  },
+  preview: {
+    allowedHosts,
+    proxy: apiProxy,
   },
   build: {
     outDir: "dist",


### PR DESCRIPTION
## Summary

Stabilize and accelerate the local/public CodeNib demo while keeping generated Wiki prose and Ask answers strictly tied to reviewable source evidence.

## Changes

- Add layered local/API model profiles, safe vector-artifact fallbacks, multilingual artifact hardening, and demo benchmark/rebuild tooling.
- Improve Wiki planning, grounding, quality checks, cache auditing, bounded regeneration, and source-backed narrative recovery.
- Return only renderable Ask citations, add related Wiki navigation, and synchronize the source tab bar with manual code scrolling.
- Fix Vite host access, route/source loading states, opaque sticky source chrome, mobile behavior, and empty bottom scroll space.
- Expand unit coverage and local documentation for the updated demo, indexing, Wiki, and frontend paths.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` — 6062 passed, 71 skipped, 190 deselected
- `pytest -q test/wiki` — 325 passed
- `npm test -- --run` — 47 passed
- `npm run build`
- Desktop and 390px mobile Playwright checks against `demo.codenib.ai` for Ask citations, source scroll-spy, opaque sticky labels, Related Wiki links, and recovered Wiki pages

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
