### PR TITLE
fix(web): close post-merge demo review gaps

### DIFF
--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -680,6 +680,13 @@ class RepoRegistry:
         vector_store: Optional["CodeVectorStore"] = None
         index_types = set(self._config.index_types())
 
+        def use_bm25_fallback(reason: str) -> None:
+            if bm25_index is None:
+                raise ValueError(f"{reason}; no current BM25 fallback is available")
+            logger.warning("%s; BM25 remains available", reason)
+            bundle.vector_store = None
+            bundle.bm25 = bm25_index
+
         bm25_entry = manifest.indexes.get("bm25")
         if (
             "bm25" in index_types
@@ -694,16 +701,11 @@ class RepoRegistry:
         if "vector" in index_types:
             if vec_entry is None or not manifest.index_is_current("vector"):
                 if self._allow_missing_native_index_authorization:
-                    logger.warning(
-                        "Skipping missing or stale optional vector view; "
-                        "BM25 remains available"
-                    )
+                    use_bm25_fallback("Skipping missing or stale optional vector view")
                 else:
                     raise ValueError(
                         "hybrid mode requires a current vector manifest entry"
                     )
-                bundle.vector_store = None
-                bundle.bm25 = bm25_index
                 return
 
             if (
@@ -712,15 +714,12 @@ class RepoRegistry:
                     getattr(manifest, "source_fingerprint", None)
                 )
             ):
-                logger.warning(
-                    "Skipping legacy native vector view at %s without source "
-                    "fingerprint v2; BM25 remains available. Rebuild the "
-                    "repository manifest and vector artifact to restore hybrid "
-                    "retrieval.",
-                    vec_entry.path,
+                use_bm25_fallback(
+                    "Skipping legacy native vector view at "
+                    f"{vec_entry.path} without source fingerprint v2; rebuild "
+                    "the repository manifest and vector artifact to restore "
+                    "hybrid retrieval"
                 )
-                bundle.vector_store = None
-                bundle.bm25 = bm25_index
                 return
 
             authorization = None
@@ -729,11 +728,11 @@ class RepoRegistry:
                 authorization = resolver(bundle.entry, manifest, vec_entry)
             if authorization is None:
                 if self._allow_missing_native_index_authorization:
-                    logger.warning(
-                        "Skipping optional native vector view at %s without "
-                        "external authorization; BM25 remains available",
-                        vec_entry.path,
+                    use_bm25_fallback(
+                        "Skipping optional native vector view at "
+                        f"{vec_entry.path} without external authorization"
                     )
+                    return
                 else:
                     from ..native_index_authorization import (
                         MissingNativeIndexAuthorizationError,

--- a/codenib/web/repository_files.py
+++ b/codenib/web/repository_files.py
@@ -27,6 +27,17 @@ def valid_commit(commit: object) -> bool:
     return isinstance(commit, str) and _COMMIT_RE.fullmatch(commit) is not None
 
 
+def has_git_metadata(repo_dir: str) -> bool:
+    """Return whether *repo_dir* declares its own Git metadata boundary.
+
+    A read-only prebuilt source snapshot intentionally has no ``.git`` entry.
+    Broken or inaccessible metadata still counts as present so callers fail
+    closed instead of treating a Git error as permission to use stale content.
+    """
+
+    return os.path.lexists(os.path.join(os.path.realpath(repo_dir), ".git"))
+
+
 def safe_repo_relative_path(repo_dir: str, file_path: str) -> Optional[str]:
     """Return a repo-relative POSIX path without permitting an outside read.
 

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from codenib.agent.boundary import to_agent_repr
 
-from .repository_files import git_source_slice, live_source_slice
+from .repository_files import git_source_slice, has_git_metadata, live_source_slice
 
 _MAX_REPO_ID_CHARS = 512
 _MAX_PATH_CHARS = 4096
@@ -334,6 +334,8 @@ def _select_answer_citations(
                     # retrieval result is the authenticated snapshot payload;
                     # retain it instead of reading the mutable live path or
                     # dropping the citation altogether.
+                    if has_git_metadata(repo_path):
+                        continue
                     if (
                         not isinstance(citation.content, str)
                         or not citation.content.strip()

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -328,6 +328,21 @@ def _select_answer_citations(
                     citation.start_line,
                     citation.end_line or citation.start_line,
                 )
+                if source is None:
+                    # Read-only prebuilt layouts carry an indexed commit but do
+                    # not necessarily include Git metadata.  In that case the
+                    # retrieval result is the authenticated snapshot payload;
+                    # retain it instead of reading the mutable live path or
+                    # dropping the citation altogether.
+                    if (
+                        not isinstance(citation.content, str)
+                        or not citation.content.strip()
+                    ):
+                        continue
+                    renderable.append(citation)
+                    if len(renderable) >= limit:
+                        break
+                    continue
             else:
                 source = live_source_slice(
                     repo_path,

--- a/codenib/wiki/prewarm.py
+++ b/codenib/wiki/prewarm.py
@@ -85,13 +85,42 @@ def prewarm_wiki_cache(
 
     def process_repo(repo_id: str, bundle: Any) -> list[dict[str, Any]]:
         repo_results: list[dict[str, Any]] = []
+        outline_limited = False
         try:
             wiki = wiki_factory(bundle)
-            if dry_run:
-                cached_page_tree = getattr(wiki, "cached_page_tree", None)
-                tree = cached_page_tree() if callable(cached_page_tree) else None
-            else:
-                tree = wiki.page_tree()
+            cached_page_tree = getattr(wiki, "cached_page_tree", None)
+            tree = cached_page_tree() if callable(cached_page_tree) else None
+            if not dry_run and tree is None:
+                if not reserve_generation():
+                    outline_limited = True
+                    repo_results.append(
+                        {
+                            "repo": repo_id,
+                            "id": "outline",
+                            "title": "Wiki outline",
+                            "kind": "outline",
+                            "before": "missing",
+                            "status": "skipped_limit",
+                        }
+                    )
+                else:
+                    outline_started = perf_counter()
+                    tree = wiki.page_tree()
+                    repo_results.append(
+                        {
+                            "repo": repo_id,
+                            "id": "outline",
+                            "title": "Wiki outline",
+                            "kind": "outline",
+                            "before": "missing",
+                            "status": "warmed",
+                            "duration_ms": round(
+                                (perf_counter() - outline_started) * 1000,
+                                1,
+                            ),
+                            "generation_mode": "outline",
+                        }
+                    )
         except Exception as exc:  # noqa: BLE001 - report one repo, keep the batch
             repo_results.append(
                 {
@@ -104,7 +133,9 @@ def prewarm_wiki_cache(
                 }
             )
         else:
-            if dry_run and tree is None:
+            if outline_limited:
+                scoped = []
+            elif dry_run and tree is None:
                 repo_results.append(
                     {
                         "repo": repo_id,
@@ -119,7 +150,7 @@ def prewarm_wiki_cache(
             else:
                 scoped = _scope_pages(tree or [], scope)
             if scope == "overview" and not scoped:
-                if not (dry_run and tree is None):
+                if not (outline_limited or (dry_run and tree is None)):
                     repo_results.append(
                         {
                             "repo": repo_id,

--- a/codenib/wiki/prewarm.py
+++ b/codenib/wiki/prewarm.py
@@ -86,11 +86,12 @@ def prewarm_wiki_cache(
     def process_repo(repo_id: str, bundle: Any) -> list[dict[str, Any]]:
         repo_results: list[dict[str, Any]] = []
         outline_limited = False
+        outline_planned = False
         try:
             wiki = wiki_factory(bundle)
             cached_page_tree = getattr(wiki, "cached_page_tree", None)
             tree = cached_page_tree() if callable(cached_page_tree) else None
-            if not dry_run and tree is None:
+            if tree is None:
                 if not reserve_generation():
                     outline_limited = True
                     repo_results.append(
@@ -101,6 +102,18 @@ def prewarm_wiki_cache(
                             "kind": "outline",
                             "before": "missing",
                             "status": "skipped_limit",
+                        }
+                    )
+                elif dry_run:
+                    outline_planned = True
+                    repo_results.append(
+                        {
+                            "repo": repo_id,
+                            "id": "outline",
+                            "title": "Wiki outline",
+                            "kind": "outline",
+                            "before": "missing",
+                            "status": "planned",
                         }
                     )
                 else:
@@ -133,24 +146,12 @@ def prewarm_wiki_cache(
                 }
             )
         else:
-            if outline_limited:
-                scoped = []
-            elif dry_run and tree is None:
-                repo_results.append(
-                    {
-                        "repo": repo_id,
-                        "id": "outline",
-                        "title": "Wiki outline",
-                        "kind": "outline",
-                        "before": "missing",
-                        "status": "planned",
-                    }
-                )
+            if outline_limited or outline_planned:
                 scoped = []
             else:
                 scoped = _scope_pages(tree or [], scope)
             if scope == "overview" and not scoped:
-                if not (outline_limited or (dry_run and tree is None)):
+                if not (outline_limited or outline_planned):
                     repo_results.append(
                         {
                             "repo": repo_id,

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -485,6 +485,30 @@ def test_repo_views_keep_bm25_only_for_legacy_source_fingerprint(
     assert bundle.vector_store is None
 
 
+def test_repo_views_reject_legacy_vector_without_current_bm25(monkeypatch):
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail("legacy vector must not be opened"),
+    )
+    vector_entry = SimpleNamespace(path="/idx/vector", config={})
+    manifest = SimpleNamespace(
+        source_fingerprint="",
+        indexes={"vector": vector_entry},
+        index_is_current=lambda index_type: index_type == "vector",
+    )
+    bundle = SimpleNamespace(entry=SimpleNamespace(), manifest=manifest)
+    registry = RepoRegistry(
+        QAConfig(mode="hybrid"),
+        native_index_authorization_resolver=lambda *_args: pytest.fail(
+            "legacy vector must be skipped before authorization"
+        ),
+        allow_missing_native_index_authorization=True,
+    )
+
+    with pytest.raises(ValueError, match="no current BM25 fallback is available"):
+        registry._load_repo_views(bundle)
+
+
 @pytest.mark.parametrize("resolver_kind", ["missing", "declines"])
 def test_repo_views_fail_closed_when_required_authority_is_missing(
     monkeypatch,
@@ -588,7 +612,7 @@ def test_repo_views_propagate_vector_integrity_failures(
         )
 
 
-def test_hybrid_requires_a_current_vector_unless_explicitly_optional(monkeypatch):
+def test_hybrid_requires_a_current_vector_or_current_bm25_fallback(monkeypatch):
     manifest = SimpleNamespace(
         indexes={},
         index_is_current=lambda _index_type: False,
@@ -606,8 +630,8 @@ def test_hybrid_requires_a_current_vector_unless_explicitly_optional(monkeypatch
         QAConfig(mode="hybrid"),
         allow_missing_native_index_authorization=True,
     )
-    optional._load_repo_views(bundle)
-    assert bundle.vector_store is None
+    with pytest.raises(ValueError, match="no current BM25 fallback is available"):
+        optional._load_repo_views(bundle)
 
 
 def test_vector_authority_is_preflighted_before_model_initialization(monkeypatch):

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -433,6 +433,50 @@ def test_citations_keep_indexed_content_for_non_git_prebuilt_snapshot(tmp_path):
     assert "mutable_runtime" not in response.citations[0].content
 
 
+def test_citations_drop_unresolved_content_for_git_backed_snapshot(
+    monkeypatch,
+    tmp_path,
+):
+    (tmp_path / ".git").mkdir()
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "runtime.py").write_text(
+        "def mutable_runtime():\n    return 'live'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "codenib.web.schemas.git_source_slice",
+        lambda *_args, **_kwargs: None,
+    )
+    result = AgentResult(
+        answer="`indexed_runtime()` is implemented in `src/runtime.py`.",
+        tool_calls=[
+            ToolCallRecord(
+                "1",
+                "repository_search",
+                {},
+                result=[
+                    _node(
+                        "src/runtime.py",
+                        1,
+                        2,
+                        "src/runtime.py:indexed_runtime()",
+                        content="def stale_runtime():\n    return 'index'\n",
+                    )
+                ],
+            )
+        ],
+    )
+
+    response = agent_result_to_response(
+        result,
+        repo_path=str(tmp_path),
+        repo_commit="a" * 40,
+    )
+
+    assert response.citations == []
+
+
 def test_plain_prose_does_not_match_a_generic_main_symbol():
     result = AgentResult(
         answer="The main entry point delegates to `index_repository()`.",

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -90,7 +90,7 @@ def test_edge_label_request_bounds_text_fields() -> None:
         )
 
 
-def _node(file, start, end, name="fn", score=1.0):
+def _node(file, start, end, name="fn", score=1.0, content="def fn(): ..."):
     return QueriedNode(
         node_name=name,
         type="function",
@@ -98,7 +98,7 @@ def _node(file, start, end, name="fn", score=1.0):
         start_line=start,
         end_line=end,
         score=score,
-        content="def fn(): ...",
+        content=content,
     )
 
 
@@ -391,6 +391,46 @@ def test_citations_read_from_the_indexed_commit_instead_of_live_source(
     assert response.citations[0].content == (
         "def indexed_runtime():\n    return 'snapshot'\n"
     )
+
+
+def test_citations_keep_indexed_content_for_non_git_prebuilt_snapshot(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "runtime.py").write_text(
+        "def mutable_runtime():\n    return 'live'\n",
+        encoding="utf-8",
+    )
+    result = AgentResult(
+        answer="`indexed_runtime()` is implemented in `src/runtime.py`.",
+        tool_calls=[
+            ToolCallRecord(
+                "1",
+                "repository_search",
+                {},
+                result=[
+                    _node(
+                        "src/runtime.py",
+                        1,
+                        2,
+                        "src/runtime.py:indexed_runtime()",
+                        content="def indexed_runtime():\n    return 'snapshot'\n",
+                    )
+                ],
+            )
+        ],
+    )
+
+    response = agent_result_to_response(
+        result,
+        repo_path=str(tmp_path),
+        repo_commit="a" * 40,
+    )
+
+    assert len(response.citations) == 1
+    assert response.citations[0].content == (
+        "def indexed_runtime():\n    return 'snapshot'\n"
+    )
+    assert "mutable_runtime" not in response.citations[0].content
 
 
 def test_plain_prose_does_not_match_a_generic_main_symbol():

--- a/test/wiki/test_prewarm.py
+++ b/test/wiki/test_prewarm.py
@@ -132,6 +132,37 @@ def test_prewarm_dry_run_plans_a_missing_outline_without_generating_it():
 
 
 @pytest.mark.parametrize(
+    ("max_pages", "status", "selected"),
+    [(0, "skipped_limit", 0), (1, "planned", 1)],
+)
+def test_prewarm_dry_run_applies_limit_to_missing_outline(
+    max_pages,
+    status,
+    selected,
+):
+    class ColdOutlineWiki(_Wiki):
+        def cached_page_tree(self):
+            return None
+
+        def page_tree(self):
+            raise AssertionError("dry-run must not generate an outline")
+
+    wiki = ColdOutlineWiki()
+
+    report = prewarm_wiki_cache(
+        _registry(wiki),
+        wiki_factory=lambda bundle: bundle.wiki,
+        max_pages=max_pages,
+        dry_run=True,
+    )
+
+    assert wiki.calls == []
+    assert report["selected_for_generation"] == selected
+    assert report["counts"] == {status: 1}
+    assert report["pages"][0]["status"] == status
+
+
+@pytest.mark.parametrize(
     ("max_pages", "expected_tree_calls", "expected_page_calls", "counts"),
     [
         (0, 0, [], {"skipped_limit": 1}),

--- a/test/wiki/test_prewarm.py
+++ b/test/wiki/test_prewarm.py
@@ -131,6 +131,48 @@ def test_prewarm_dry_run_plans_a_missing_outline_without_generating_it():
     ]
 
 
+@pytest.mark.parametrize(
+    ("max_pages", "expected_tree_calls", "expected_page_calls", "counts"),
+    [
+        (0, 0, [], {"skipped_limit": 1}),
+        (1, 1, [], {"skipped_limit": 1, "warmed": 1}),
+    ],
+)
+def test_prewarm_counts_cold_outline_against_page_limit(
+    max_pages,
+    expected_tree_calls,
+    expected_page_calls,
+    counts,
+):
+    class ColdOutlineWiki(_Wiki):
+        def __init__(self):
+            super().__init__()
+            self.tree_calls = 0
+
+        def cached_page_tree(self):
+            return None
+
+        def page_tree(self):
+            self.tree_calls += 1
+            return super().page_tree()
+
+    wiki = ColdOutlineWiki()
+
+    report = prewarm_wiki_cache(
+        _registry(wiki),
+        wiki_factory=lambda bundle: bundle.wiki,
+        max_pages=max_pages,
+    )
+
+    assert wiki.tree_calls == expected_tree_calls
+    assert wiki.calls == expected_page_calls
+    assert report["selected_for_generation"] == max_pages
+    assert report["counts"] == counts
+    assert next(page for page in report["pages"] if page["id"] == "outline")[
+        "status"
+    ] == ("warmed" if max_pages else "skipped_limit")
+
+
 def test_prewarm_rejects_unknown_repository_selectors():
     wiki = _Wiki()
 


### PR DESCRIPTION
## Summary

Close the three review findings that arrived immediately after #632 merged.

## Changes

- Preserve authenticated indexed citation content when a read-only prebuilt source tree has no Git metadata.
- Count cold Wiki outline generation against the global `--max-pages` prewarm budget.
- Permit optional vector fallback only when a current BM25 view actually loaded.
- Add focused regressions for all three boundaries.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/web/test_schemas.py test/wiki/test_prewarm.py test/web/test_repo_registry.py --tb=short` (86 passed)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` with two independently reproduced local-environment baseline deselections (6092 passed, 71 skipped)
- changed-file pre-commit hooks

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Follow-up to #632.