### PR TITLE
feat(storage): export retained manifest snapshots

### DIFF
--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -82,8 +82,8 @@ _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
 _PICKLE_SUFFIXES = frozenset({".pkl", ".pickle"})
 _WINDOWS_REPARSE_POINT = 0x400
 _MAX_CONFIG_JSON_BYTES = 16 * 1024 * 1024
-_MAX_DOCUMENTS_JSON_BYTES = 256 * 1024 * 1024
-_MAX_FAISS_INDEX_BYTES = 8 * 1024 * 1024 * 1024
+MAX_PORTABLE_DOCUMENTS_JSON_BYTES = 256 * 1024 * 1024
+MAX_PORTABLE_FAISS_INDEX_BYTES = 8 * 1024 * 1024 * 1024
 _JSON_READ_CHUNK_BYTES = 1024 * 1024
 _MAX_SOURCE_PATH_BYTES = 4_096
 _MAX_SOURCE_PATH_COMPONENTS = 256
@@ -1242,7 +1242,10 @@ def _normalize_pickle_documents(
     """Load documents from an explicitly trusted, machine-local pickle."""
 
     try:
-        payload = reader.read_bytes(path, max_bytes=_MAX_DOCUMENTS_JSON_BYTES)
+        payload = reader.read_bytes(
+            path,
+            max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+        )
         with io.BytesIO(payload) as handle:
             documents = compat_pickle.load(handle)
     except Exception as exc:
@@ -1352,7 +1355,7 @@ def _normalize_json_documents(
     documents = _load_json(
         path,
         label="portable vector documents",
-        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
         reader=reader,
     )
     if not isinstance(documents, list):
@@ -1410,7 +1413,10 @@ def _iter_content_bound_documents(
     authenticated_source_files: frozenset[str],
 ) -> Iterable[dict[str, Any]]:
     relative = PurePosixPath(path.relative_to(reader.root).as_posix())
-    with reader.open_file(relative, max_bytes=_MAX_DOCUMENTS_JSON_BYTES) as source:
+    with reader.open_file(
+        relative,
+        max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+    ) as source:
         documents = iter_bounded_json_array(
             source,
             label=f"portable {view_type} documents",
@@ -1490,7 +1496,7 @@ def _require_content_bound_canonical_documents(
 
     for chunk in canonical_json_array_chunks(values()):
         size += len(chunk)
-        if size > _MAX_DOCUMENTS_JSON_BYTES:
+        if size > MAX_PORTABLE_DOCUMENTS_JSON_BYTES:
             raise ValueError(f"portable {view_type} documents exceed their byte limit")
         digest.update(chunk)
     record = reader.record(path)
@@ -1508,7 +1514,7 @@ def _normalize_bm25_documents(
     documents = _load_json(
         path,
         label="portable BM25 documents",
-        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
         reader=reader,
     )
     if not isinstance(documents, list):
@@ -2031,7 +2037,7 @@ def _validate_vector_layout(
                 root,
                 ownership,
                 path,
-                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+                max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
                 cache_bytes=True,
             )
             payload = _normalize_pickle_documents(path, repo_path, reader=reader)
@@ -2071,7 +2077,7 @@ def _validate_vector_layout(
             root,
             ownership,
             index_path,
-            max_bytes=_MAX_FAISS_INDEX_BYTES,
+            max_bytes=MAX_PORTABLE_FAISS_INDEX_BYTES,
             keep_descriptor=native_authorized,
         )
         derived_counts[level] = count
@@ -2230,7 +2236,7 @@ def _refresh_vector_persistence_records(
             index_record["file"] = index_path.name
             documents_record = reader.fingerprint(
                 documents_path,
-                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+                max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
             )
             documents_record["file"] = documents_path.name
             level_artifacts[level] = {
@@ -2573,7 +2579,7 @@ def _normalize_bm25_view(
         fingerprints = {
             "documents.json": fingerprint_reader.fingerprint(
                 documents_path,
-                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+                max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
             ),
             "bm25_metadata.json": fingerprint_reader.fingerprint(
                 metadata_path,
@@ -2720,7 +2726,7 @@ def _validate_normalized_document_sources(
     documents = _load_json(
         path,
         label=f"portable {view_type} documents",
-        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
         require_canonical=True,
         reader=reader,
     )
@@ -2843,7 +2849,7 @@ def _authenticate_vector_generation(
                 root / level / str(documents_record["file"]),
                 documents_record,
                 cache_bytes=True,
-                max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+                max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
             )
         except ValueError as exc:
             raise ValueError(
@@ -2853,7 +2859,7 @@ def _authenticate_vector_generation(
             root / level / index_name,
             index_record,
             cache_bytes=False,
-            max_bytes=_MAX_FAISS_INDEX_BYTES,
+            max_bytes=MAX_PORTABLE_FAISS_INDEX_BYTES,
             keep_descriptor=True,
         )
     return config
@@ -2893,7 +2899,7 @@ def _validate_portable_bm25_view(
         root / "documents.json",
         fingerprints["documents.json"],
         cache_bytes=True,
-        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+        max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
     )
     reader.authenticate(
         root / "bm25_metadata.json",
@@ -3273,6 +3279,8 @@ def validate_portable_query_view(
 
 
 __all__ = [
+    "MAX_PORTABLE_DOCUMENTS_JSON_BYTES",
+    "MAX_PORTABLE_FAISS_INDEX_BYTES",
     "SourceTrust",
     "normalize_owned_query_view",
     "validate_content_bound_portable_query_view_reader",

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -58,6 +58,8 @@ from ..source_fingerprint import (
     RepositorySourceBinding,
     RepositorySourceIdentitySnapshot,
 )
+from ..storage.models import StorageIntegrityError
+from ..storage.protocols import snapshot_retained_import_response
 from .security import assert_publishable_json_value
 
 _VECTOR_LEVELS = ("l0", "l2")
@@ -1770,6 +1772,50 @@ def _validate_vector_semantics(
     )
 
 
+def validate_portable_vector_persistence_semantics(
+    config: Mapping[str, Any],
+    view_config: Mapping[str, Any],
+) -> tuple[str, int, str | None, str, str]:
+    """Validate persisted vector identity using artifact-only route policy.
+
+    This source-free helper never discovers credentials or interprets an
+    embedding model as a local filesystem locator. Document/source membership
+    and directory ownership remain the responsibility of the caller's
+    retained-artifact validation layer.
+    """
+
+    try:
+        config_value = snapshot_retained_import_response(
+            config,
+            label="portable vector persistence config",
+        )
+        view_config_value = snapshot_retained_import_response(
+            view_config,
+            label="portable vector view config",
+        )
+    except StorageIntegrityError as exc:
+        raise ValueError(
+            "portable vector persistence inputs must be bounded exact JSON objects"
+        ) from exc
+    if type(config_value) is not dict or type(view_config_value) is not dict:
+        raise ValueError(
+            "portable vector persistence inputs must be bounded exact JSON objects"
+        )
+    config_snapshot = _bounded_json_object_snapshot(
+        config_value,
+        label="portable vector persistence config",
+    )
+    view_config_snapshot = _bounded_json_object_snapshot(
+        view_config_value,
+        label="portable vector view config",
+    )
+    return _validate_vector_semantics(
+        config_snapshot,
+        view_config_snapshot,
+        portable_artifact_policy=True,
+    )
+
+
 def _faiss_contract(
     path: Path,
     *,
@@ -2887,6 +2933,14 @@ def _validate_portable_bm25_view(
         or len(metadata["language"]) > 256
     ):
         raise ValueError("portable BM25 metadata is invalid")
+    configured_max_k = view_config.get("max_k")
+    if configured_max_k is not None and (
+        isinstance(configured_max_k, bool)
+        or not isinstance(configured_max_k, int)
+        or configured_max_k <= 0
+        or metadata["max_k"] != configured_max_k
+    ):
+        raise ValueError("portable BM25 metadata max_k does not match its view config")
     _validate_normalized_document_sources(
         root / "documents.json",
         repository,
@@ -3223,4 +3277,5 @@ __all__ = [
     "normalize_owned_query_view",
     "validate_content_bound_portable_query_view_reader",
     "validate_portable_query_view",
+    "validate_portable_vector_persistence_semantics",
 ]

--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -29,6 +29,13 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     from codenib.compiler.index_builders import IndexBuilderRegistry
     from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
     from codenib.compiler.manifest import ManifestIndexStateStore, RepoManifest
+    from codenib.compiler.manifest_export import (
+        RepoManifestExportReceipt,
+        RepoManifestExportResult,
+        RepoManifestViewExportReceipt,
+        export_retained_repo_manifest_ref,
+        export_retained_repo_manifest_snapshot,
+    )
     from codenib.compiler.manifest_import import (
         RepoManifestImportResult,
         import_retained_repo_manifest,
@@ -69,6 +76,18 @@ _EXPORTS = {
         "codenib.compiler.manifest",
         "ManifestIndexStateStore",
     ),
+    "RepoManifestExportReceipt": (
+        "codenib.compiler.manifest_export",
+        "RepoManifestExportReceipt",
+    ),
+    "RepoManifestExportResult": (
+        "codenib.compiler.manifest_export",
+        "RepoManifestExportResult",
+    ),
+    "RepoManifestViewExportReceipt": (
+        "codenib.compiler.manifest_export",
+        "RepoManifestViewExportReceipt",
+    ),
     "RepoManifestImportResult": (
         "codenib.compiler.manifest_import",
         "RepoManifestImportResult",
@@ -94,6 +113,14 @@ _EXPORTS = {
     "import_retained_repo_manifest": (
         "codenib.compiler.manifest_import",
         "import_retained_repo_manifest",
+    ),
+    "export_retained_repo_manifest_ref": (
+        "codenib.compiler.manifest_export",
+        "export_retained_repo_manifest_ref",
+    ),
+    "export_retained_repo_manifest_snapshot": (
+        "codenib.compiler.manifest_export",
+        "export_retained_repo_manifest_snapshot",
     ),
     "ResourceResolver": ("codenib.compiler.resources", "ResourceResolver"),
     "ResourcePlan": ("codenib.compiler.resources", "ResourcePlan"),
@@ -124,6 +151,9 @@ __all__ = [
     # Manifest
     "RepoManifest",
     "ManifestIndexStateStore",
+    "RepoManifestExportReceipt",
+    "RepoManifestExportResult",
+    "RepoManifestViewExportReceipt",
     "RepoManifestImportResult",
     "RepoManifestImportPlan",
     "SourceIntent",
@@ -132,6 +162,8 @@ __all__ = [
     "plan_repo_manifest_import",
     "plan_repo_manifest_import_bytes",
     "import_retained_repo_manifest",
+    "export_retained_repo_manifest_ref",
+    "export_retained_repo_manifest_snapshot",
     # Resources
     "ResourceResolver",
     "ResourcePlan",

--- a/codenib/compiler/manifest_export.py
+++ b/codenib/compiler/manifest_export.py
@@ -1,0 +1,1888 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export retained catalog snapshots as canonical portable RepoManifest bytes.
+
+The export result is deliberately data-only.  It does not materialize a
+directory, authorize native index loading, or pin CAS objects against future
+garbage collection.  Every receipt records a point-in-time observation made
+while this call ran.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import re
+import zipfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from types import MappingProxyType
+from typing import Any, BinaryIO, Callable
+
+from .._atomic_directory import _annotate_secondary_error
+from .._bounded_json import canonical_json_array_chunks, iter_bounded_json_array
+from .._secret_fields import SecretFieldError, assert_no_secret_fields
+from ..artifacts.portable_views import validate_portable_vector_persistence_semantics
+from ..index.embedding.artifact_integrity import VECTOR_PERSISTENCE_SCHEMA
+from ..provider_routes import normalize_provider, resolve_embedding_artifact_route
+from ..storage.cas import BlobInfo
+from ..storage.models import (
+    VIEW_GENERATION_MEMBERS_METADATA_KEY,
+    ArtifactMember,
+    ObjectRecord,
+    PublishConflict,
+    StorageIntegrityError,
+    StorageValidationError,
+    canonical_json,
+    canonical_utc_timestamp,
+)
+from ..storage.protocols import (
+    RETAINED_IMPORT_CATALOG_CONTRACT,
+    ReceiptVerifyingObjectStore,
+    RetainedSnapshotCatalog,
+    snapshot_retained_import_response,
+)
+from ..storage.view_bundle import (
+    DEFAULT_MAX_BUNDLE_BYTES,
+    DEFAULT_MAX_BUNDLE_FILES,
+    DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    VIEW_BUNDLE_MEDIA_TYPE,
+    VIEW_BUNDLE_PAYLOAD,
+    VIEW_BUNDLE_SCHEMA,
+    ViewBundleRecord,
+    consume_verified_view_bundle_stream,
+    validate_view_bundle_physical_size,
+)
+from .manifest import MANIFEST_VERSION, RepoManifest
+from .manifest_import import DEFAULT_MAX_PROJECTION_BYTES
+from .manifest_storage import (
+    DEFAULT_MAX_MANIFEST_BYTES,
+    PORTABLE_STORAGE_VIEWS,
+    REPO_MANIFEST_IMPORT_PLAN_SCHEMA,
+    RepoManifestImportPlan,
+    ViewImportIntent,
+    plan_repo_manifest_import_bytes,
+)
+from .retained_manifest_contract import (
+    REPO_MANIFEST_PROJECTION_MEDIA_TYPE,
+    REPO_MANIFEST_PROJECTION_SCHEMA,
+    REPO_MANIFEST_PROJECTION_VIEW,
+    repo_manifest_generation_metadata,
+    repo_manifest_projection_profile,
+)
+from .retained_snapshot import (
+    _RetainedSnapshot,
+    _RetainedSnapshotView,
+    attest_detached_retained_snapshot,
+    same_exact_json,
+)
+
+DEFAULT_REF_NAME = "main"
+
+_INT64_MAX = 9_223_372_036_854_775_807
+_MAX_TEXT = 32_768
+_READ_CHUNK_BYTES = 1024 * 1024
+_MEMBER_MEDIA_TYPE = "application/octet-stream"
+_MAX_CONFIG_BYTES = 16 * 1024 * 1024
+_VECTOR_LEVELS = ("l0", "l2")
+_VECTOR_LEVEL_CONFIG_FIELDS = {
+    "embedding_model",
+    "embedding_provider",
+    "embedding_revision",
+    "dimension",
+    "index_type",
+    "index_metric",
+    "level",
+    "num_documents",
+}
+_DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+_WORKSPACE_PLAN_DIGEST_RE = _DIGEST_RE
+_CATALOG_METHODS = (
+    "retained_import_contract",
+    "resolve_ref",
+    "get_manifest_summary",
+)
+_OBJECT_STORE_METHODS = (
+    "open",
+    "verify_receipt",
+)
+_MISSING = object()
+
+
+@dataclass(frozen=True, slots=True)
+class RepoManifestViewExportReceipt:
+    """Point-in-time receipts for one exported portable view."""
+
+    view_type: str
+    view_generation_id: str
+    bundle_receipt: BlobInfo
+    member_receipt_items: tuple[tuple[str, BlobInfo], ...]
+
+    def __post_init__(self) -> None:
+        if type(self) is not RepoManifestViewExportReceipt:
+            raise StorageValidationError(
+                "manifest view export receipt must use the exact receipt type"
+            )
+        view_type = _exact_text(
+            self.view_type,
+            "exported view type",
+            max_length=128,
+        )
+        if view_type not in PORTABLE_STORAGE_VIEWS:
+            raise StorageValidationError("exported view type is unsupported")
+        _exact_text(self.view_generation_id, "exported view generation ID")
+        _require_exact_blob(self.bundle_receipt, label="exported view bundle receipt")
+        if type(self.member_receipt_items) is not tuple:
+            raise StorageValidationError(
+                "exported view member receipts must be an exact tuple"
+            )
+        previous = ""
+        seen: set[str] = set()
+        for item in self.member_receipt_items:
+            if type(item) is not tuple or len(item) != 2 or type(item[0]) is not str:
+                raise StorageValidationError(
+                    "exported view member receipt entries are invalid"
+                )
+            path = _exact_text(item[0], "exported view member path", max_length=4096)
+            blob = _require_exact_blob(
+                item[1],
+                label="exported view member receipt",
+            )
+            try:
+                ArtifactMember(path, blob.digest, blob.byte_size)
+            except StorageValidationError as exc:
+                raise StorageValidationError(
+                    "exported view member receipt path is not canonical"
+                ) from exc
+            if path <= previous or path in seen:
+                raise StorageValidationError(
+                    "exported view member receipt paths are not canonical"
+                )
+            previous = path
+            seen.add(path)
+
+    @property
+    def member_receipts(self) -> Mapping[str, BlobInfo]:
+        return MappingProxyType(dict(self.member_receipt_items))
+
+
+@dataclass(frozen=True, slots=True)
+class RepoManifestExportReceipt:
+    """Point-in-time observations supporting one manifest byte export.
+
+    This is not a GC pin, retention lease, directory ownership token, or
+    materialization authority.
+    """
+
+    repository_id: str
+    source_revision_id: str
+    snapshot_id: str
+    snapshot_published_at: str
+    ref_name: str | None
+    ref_generation: int | None
+    ref_updated_at: str | None
+    manifest_digest: str
+    manifest_byte_size: int
+    projection_generation_id: str
+    projection_receipt: BlobInfo
+    view_receipts: tuple[RepoManifestViewExportReceipt, ...]
+    skipped_items: tuple[tuple[str, str], ...]
+
+    def __post_init__(self) -> None:
+        if type(self) is not RepoManifestExportReceipt:
+            raise StorageValidationError(
+                "manifest export receipt must use the exact receipt type"
+            )
+        for value, label in (
+            (self.repository_id, "export repository ID"),
+            (self.source_revision_id, "export source revision ID"),
+            (self.snapshot_id, "export snapshot ID"),
+            (self.projection_generation_id, "export projection generation ID"),
+        ):
+            _exact_text(value, label)
+        if (
+            type(self.manifest_digest) is not str
+            or _DIGEST_RE.fullmatch(self.manifest_digest) is None
+        ):
+            raise StorageValidationError("export manifest digest is invalid")
+        if (
+            type(self.manifest_byte_size) is not int
+            or not 0 < self.manifest_byte_size <= _INT64_MAX
+        ):
+            raise StorageValidationError("export manifest byte size is invalid")
+        try:
+            canonical_utc_timestamp(
+                self.snapshot_published_at,
+                "export snapshot published_at",
+            )
+        except StorageValidationError:
+            raise
+        if self.ref_name is None:
+            if self.ref_generation is not None or self.ref_updated_at is not None:
+                raise StorageValidationError(
+                    "snapshot export receipt must not claim a ref generation"
+                )
+        else:
+            _exact_text(self.ref_name, "export ref name")
+            if (
+                type(self.ref_generation) is not int
+                or not 0 < self.ref_generation <= _INT64_MAX
+                or type(self.ref_updated_at) is not str
+            ):
+                raise StorageValidationError("export ref observation is invalid")
+            canonical_utc_timestamp(self.ref_updated_at, "export ref updated_at")
+        _require_exact_blob(
+            self.projection_receipt,
+            label="export projection receipt",
+        )
+        if type(self.view_receipts) is not tuple or not self.view_receipts:
+            raise StorageValidationError(
+                "exported view receipts must be a nonempty exact tuple"
+            )
+        if any(
+            type(value) is not RepoManifestViewExportReceipt
+            for value in self.view_receipts
+        ):
+            raise StorageValidationError("exported view receipt entries are invalid")
+        view_names = tuple(value.view_type for value in self.view_receipts)
+        if view_names != tuple(sorted(set(view_names))):
+            raise StorageValidationError("exported view receipts are not canonical")
+        if type(self.skipped_items) is not tuple:
+            raise StorageValidationError(
+                "export skipped decisions must be an exact tuple"
+            )
+        previous_skipped = ""
+        for item in self.skipped_items:
+            if (
+                type(item) is not tuple
+                or len(item) != 2
+                or type(item[0]) is not str
+                or type(item[1]) is not str
+            ):
+                raise StorageValidationError("export skipped decisions are invalid")
+            view_type = _exact_text(
+                item[0],
+                "export skipped view",
+                max_length=128,
+            )
+            _exact_text(item[1], "export skip reason", max_length=256)
+            if (
+                view_type not in PORTABLE_STORAGE_VIEWS
+                or view_type <= previous_skipped
+                or view_type in view_names
+            ):
+                raise StorageValidationError(
+                    "export skipped decisions are not canonical"
+                )
+            previous_skipped = view_type
+
+    @property
+    def views(self) -> tuple[str, ...]:
+        return tuple(value.view_type for value in self.view_receipts)
+
+    @property
+    def skipped_views(self) -> Mapping[str, str]:
+        return MappingProxyType(dict(self.skipped_items))
+
+
+@dataclass(frozen=True, slots=True)
+class RepoManifestExportResult:
+    """Canonical portable ``RepoManifest`` bytes and their export receipt."""
+
+    canonical_manifest_bytes: bytes
+    receipt: RepoManifestExportReceipt
+
+    def __post_init__(self) -> None:
+        if type(self) is not RepoManifestExportResult:
+            raise StorageValidationError(
+                "manifest export result must use the exact result type"
+            )
+        if type(self.canonical_manifest_bytes) is not bytes:
+            raise StorageValidationError("exported manifest bytes must be exact bytes")
+        if type(self.receipt) is not RepoManifestExportReceipt:
+            raise StorageValidationError("exported manifest receipt is invalid")
+        if (
+            len(self.canonical_manifest_bytes) != self.receipt.manifest_byte_size
+            or hashlib.sha256(self.canonical_manifest_bytes).hexdigest()
+            != self.receipt.manifest_digest
+        ):
+            raise StorageValidationError(
+                "exported manifest bytes differ from their receipt"
+            )
+
+    @property
+    def manifest_bytes(self) -> bytes:
+        return self.canonical_manifest_bytes
+
+    @property
+    def manifest(self) -> RepoManifest:
+        plan = plan_repo_manifest_import_bytes(
+            self.canonical_manifest_bytes,
+            required_views=self.receipt.views,
+            max_manifest_bytes=max(
+                DEFAULT_MAX_MANIFEST_BYTES,
+                len(self.canonical_manifest_bytes),
+            ),
+        )
+        return plan.manifest
+
+    @property
+    def repository_id(self) -> str:
+        return self.receipt.repository_id
+
+    @property
+    def source_revision_id(self) -> str:
+        return self.receipt.source_revision_id
+
+    @property
+    def snapshot_id(self) -> str:
+        return self.receipt.snapshot_id
+
+    @property
+    def views(self) -> tuple[str, ...]:
+        return self.receipt.views
+
+
+@dataclass(frozen=True, slots=True)
+class _ProjectedView:
+    intent: ViewImportIntent
+    catalog_view: _RetainedSnapshotView
+    members: tuple[ArtifactMember, ...]
+    member_receipt_items: tuple[tuple[str, BlobInfo], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _ValidatedProjection:
+    manifest_bytes: bytes
+    plan: RepoManifestImportPlan
+    skipped_items: tuple[tuple[str, str], ...]
+    projection_receipt: BlobInfo
+    projection_view: _RetainedSnapshotView
+    view_items: tuple[tuple[str, _ProjectedView], ...]
+
+    @property
+    def views(self) -> Mapping[str, _ProjectedView]:
+        return MappingProxyType(dict(self.view_items))
+
+
+def _exact_text(value: object, label: str, *, max_length: int = _MAX_TEXT) -> str:
+    if type(value) is not str:
+        raise StorageValidationError(f"{label} must be exact text")
+    if len(value) > max_length:
+        raise StorageValidationError(f"{label} exceeds {max_length} characters")
+    if not value or value != value.strip() or "\x00" in value:
+        raise StorageValidationError(f"{label} is not canonical")
+    return value
+
+
+def _positive_limit(value: object, label: str) -> int:
+    if type(value) is not int or not 0 < value <= (64 * 1024 * 1024 * 1024):
+        raise StorageValidationError(
+            f"{label} must be a positive integer no larger than 64 GiB"
+        )
+    return value
+
+
+def _optional_generation(value: object) -> int | None:
+    if value is None:
+        return None
+    if type(value) is not int or not 0 < value <= _INT64_MAX:
+        raise StorageValidationError(
+            "expected ref generation must be a positive signed 64-bit integer"
+        )
+    return value
+
+
+def _require_static_methods(value: object, *, label: str, names: Sequence[str]) -> None:
+    if value is None:
+        raise TypeError(f"{label} is required")
+    for name in names:
+        candidate = inspect.getattr_static(value, name, _MISSING)
+        if candidate is _MISSING or not callable(candidate):
+            raise TypeError(f"{label} must provide {name}()")
+
+
+def _require_exact_blob(value: object, *, label: str) -> BlobInfo:
+    if type(value) is not BlobInfo:
+        raise StorageIntegrityError(f"{label} must be an exact BlobInfo")
+    if (
+        type(value.digest) is not str
+        or _DIGEST_RE.fullmatch(value.digest) is None
+        or type(value.byte_size) is not int
+        or not 0 <= value.byte_size <= _INT64_MAX
+        or type(value.storage_key) is not str
+        or not value.storage_key
+        or value.storage_key != value.storage_key.strip()
+        or "\x00" in value.storage_key
+    ):
+        raise StorageIntegrityError(f"{label} is not canonical")
+    return value
+
+
+def _receipt(record: ObjectRecord) -> BlobInfo:
+    return BlobInfo(
+        digest=record.digest,
+        byte_size=record.byte_size,
+        storage_key=record.storage_key,
+    )
+
+
+def _same_record(left: ObjectRecord, right: ObjectRecord) -> bool:
+    return (
+        left.digest == right.digest
+        and left.byte_size == right.byte_size
+        and left.storage_key == right.storage_key
+        and left.media_type == right.media_type
+    )
+
+
+def _verify_receipt(
+    object_store: ReceiptVerifyingObjectStore,
+    record: ObjectRecord,
+) -> BlobInfo:
+    expected = _receipt(record)
+    observed = object_store.verify_receipt(expected)
+    observed = _require_exact_blob(observed, label="object-store receipt verification")
+    if (
+        observed.digest != expected.digest
+        or observed.byte_size != expected.byte_size
+        or observed.storage_key != expected.storage_key
+    ):
+        raise StorageIntegrityError("object-store receipt identity changed")
+    return observed
+
+
+def _run_open_object(
+    object_store: ReceiptVerifyingObjectStore,
+    record: ObjectRecord,
+    operation: Callable[[BinaryIO], Any],
+) -> Any:
+    _verify_receipt(object_store, record)
+    try:
+        source = object_store.open(record.digest)
+    except StorageIntegrityError:
+        raise
+    except BaseException as error:  # noqa: B036 - backend boundary
+        if isinstance(error, (GeneratorExit, KeyboardInterrupt, SystemExit)):
+            raise
+        raise StorageIntegrityError("object-store read could not be opened") from error
+    primary: BaseException | None = None
+    try:
+        return operation(source)
+    except BaseException as error:  # noqa: B036 - preserve primary
+        primary = error
+        raise
+    finally:
+        try:
+            close = source.close
+            close()
+        except BaseException as close_error:  # noqa: B036 - backend cleanup
+            if primary is None:
+                if isinstance(
+                    close_error,
+                    (GeneratorExit, KeyboardInterrupt, SystemExit),
+                ):
+                    raise
+                raise StorageIntegrityError(
+                    "object-store reader close failed"
+                ) from close_error
+            _annotate_secondary_error(
+                primary,
+                "object-store reader close also failed",
+                close_error,
+            )
+
+
+def _read_exact_bytes(source: BinaryIO, record: ObjectRecord) -> bytes:
+    try:
+        read = source.read
+    except Exception as exc:
+        raise StorageIntegrityError("object-store reader is invalid") from exc
+    if not callable(read):
+        raise StorageIntegrityError("object-store reader is invalid")
+    result = bytearray()
+    observed = hashlib.sha256()
+    remaining = record.byte_size
+    while remaining:
+        try:
+            block = read(min(_READ_CHUNK_BYTES, remaining))
+        except BaseException as error:  # noqa: B036 - backend boundary
+            if isinstance(error, (GeneratorExit, KeyboardInterrupt, SystemExit)):
+                raise
+            raise StorageIntegrityError("object-store read failed") from error
+        if type(block) is not bytes or not block:
+            raise StorageIntegrityError("object-store read was truncated")
+        if len(block) > remaining:
+            raise StorageIntegrityError("object-store read exceeded its receipt")
+        observed.update(block)
+        result.extend(block)
+        remaining -= len(block)
+    try:
+        extra = read(1)
+    except BaseException as error:  # noqa: B036 - backend boundary
+        if isinstance(error, (GeneratorExit, KeyboardInterrupt, SystemExit)):
+            raise
+        raise StorageIntegrityError("object-store read failed") from error
+    if type(extra) is not bytes or extra:
+        raise StorageIntegrityError("object-store read exceeded its receipt")
+    if observed.hexdigest() != record.digest:
+        raise StorageIntegrityError("object-store bytes do not match their receipt")
+    return bytes(result)
+
+
+def _strict_json_bytes(payload: bytes, *, label: str) -> dict[str, Any]:
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate key: {key}")
+            result[key] = value
+        return result
+
+    try:
+        text = payload.decode("ascii", errors="strict")
+        raw = json.loads(
+            text,
+            object_pairs_hook=object_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ValueError(f"non-finite number: {value}")
+            ),
+        )
+        value = snapshot_retained_import_response(raw, label=label)
+        if type(value) is not dict or canonical_json(value).encode("ascii") != payload:
+            raise StorageIntegrityError(f"{label} is not canonical JSON")
+        return value
+    except StorageIntegrityError:
+        raise
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise StorageIntegrityError(f"{label} is invalid") from exc
+
+
+def _semantic_object(record: ObjectRecord) -> dict[str, Any]:
+    return {
+        "digest": record.digest,
+        "byte_size": record.byte_size,
+        "media_type": record.media_type,
+    }
+
+
+def _artifact_member(
+    value: object,
+    *,
+    view_type: str,
+) -> ArtifactMember:
+    if type(value) is not dict or set(value) != {
+        "path",
+        "digest",
+        "byte_size",
+        "mode",
+        "object",
+    }:
+        raise StorageIntegrityError(f"projected {view_type!r} member shape is invalid")
+    try:
+        member = ArtifactMember(
+            path=value["path"],
+            digest=value["digest"],
+            byte_size=value["byte_size"],
+            mode=value["mode"],
+        )
+    except StorageValidationError as exc:
+        raise StorageIntegrityError(
+            f"projected {view_type!r} member is invalid"
+        ) from exc
+    semantic = value["object"]
+    if (
+        type(semantic) is not dict
+        or set(semantic) != {"digest", "byte_size", "media_type"}
+        or not same_exact_json(
+            semantic,
+            {
+                "digest": member.digest,
+                "byte_size": member.byte_size,
+                "media_type": _MEMBER_MEDIA_TYPE,
+            },
+        )
+        or not same_exact_json(
+            value,
+            {
+                "path": member.path,
+                "digest": member.digest,
+                "byte_size": member.byte_size,
+                "mode": member.mode,
+                "object": semantic,
+            },
+        )
+    ):
+        raise StorageIntegrityError(
+            f"projected {view_type!r} member identity is inconsistent"
+        )
+    return member
+
+
+def _require_fingerprint(
+    value: object,
+    member: ArtifactMember | None,
+    *,
+    expected_file: str,
+    label: str,
+    keyed_by_path: bool = False,
+) -> None:
+    expected_fields = (
+        {"size", "sha256"} if keyed_by_path else {"file", "size", "sha256"}
+    )
+    if (
+        type(value) is not dict
+        or set(value) != expected_fields
+        or member is None
+        or (not keyed_by_path and value["file"] != expected_file)
+        or type(value["size"]) is not int
+        or value["size"] != member.byte_size
+        or value["sha256"] != member.digest
+    ):
+        raise StorageIntegrityError(f"{label} differs from its projected member")
+
+
+def _cross_bind_generation_record(
+    intent: ViewImportIntent,
+    members: tuple[ArtifactMember, ...],
+) -> None:
+    by_path = {member.path: member for member in members}
+    record = intent.generation_record
+    if intent.view_type == "bm25":
+        if set(by_path) != {"bm25_metadata.json", "documents.json"}:
+            raise StorageIntegrityError(
+                "projected BM25 bundle contains an undeclared artifact"
+            )
+        fingerprints = record.get("files")
+        if type(fingerprints) is not dict or set(fingerprints) != set(by_path):
+            raise StorageIntegrityError("projected BM25 generation files are invalid")
+        for path in sorted(by_path):
+            _require_fingerprint(
+                fingerprints[path],
+                by_path[path],
+                expected_file=path,
+                label=f"projected BM25 {path}",
+                keyed_by_path=True,
+            )
+        return
+    if intent.view_type != "vector":
+        raise StorageIntegrityError("projected view type is unsupported")
+    fingerprint = record.get("persistence_config")
+    if type(fingerprint) is not dict:
+        raise StorageIntegrityError("projected vector generation config is invalid")
+    path = fingerprint.get("file")
+    if type(path) is not str:
+        raise StorageIntegrityError(
+            "projected vector generation config path is invalid"
+        )
+    _require_fingerprint(
+        fingerprint,
+        by_path.get(path),
+        expected_file=path,
+        label="projected vector root config",
+    )
+
+
+def _read_zip_json(
+    archive: zipfile.ZipFile,
+    member_by_path: Mapping[str, ArtifactMember],
+    path: str,
+    *,
+    label: str,
+) -> dict[str, Any]:
+    member = member_by_path.get(path)
+    if member is None or member.byte_size > _MAX_CONFIG_BYTES:
+        raise StorageIntegrityError(f"{label} is missing or exceeds its byte limit")
+    try:
+        source = archive.open(f"{VIEW_BUNDLE_PAYLOAD}/{path}", mode="r")
+    except (KeyError, OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise StorageIntegrityError(f"{label} cannot be opened") from exc
+
+    primary: BaseException | None = None
+    try:
+        payload = source.read(_MAX_CONFIG_BYTES + 1)
+        if type(payload) is not bytes or len(payload) > _MAX_CONFIG_BYTES:
+            raise StorageIntegrityError(f"{label} exceeds its byte limit")
+        value = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=lambda pairs: _strict_object_pairs(pairs, label=label),
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ValueError(f"non-finite number: {value}")
+            ),
+        )
+        value = snapshot_retained_import_response(value, label=label)
+        if (
+            type(value) is not dict
+            or _portable_json_bytes(value) != payload
+            or hashlib.sha256(payload).hexdigest() != member.digest
+            or len(payload) != member.byte_size
+        ):
+            raise StorageIntegrityError(f"{label} is not canonical JSON")
+        assert_no_secret_fields(value, source=label)
+        return value
+    except BaseException as error:  # noqa: B036 - preserve semantic primary
+        if isinstance(
+            error,
+            (StorageIntegrityError, GeneratorExit, KeyboardInterrupt, SystemExit),
+        ):
+            primary = error
+            raise
+        if isinstance(
+            error,
+            (
+                KeyError,
+                OSError,
+                RecursionError,
+                SecretFieldError,
+                TypeError,
+                UnicodeError,
+                ValueError,
+                zipfile.BadZipFile,
+            ),
+        ):
+            wrapped = StorageIntegrityError(f"{label} is invalid")
+            primary = wrapped
+            raise wrapped from error
+        primary = error
+        raise
+    finally:
+        try:
+            source.close()
+        except BaseException as close_error:  # noqa: B036 - cleanup boundary
+            if primary is None:
+                if isinstance(
+                    close_error,
+                    (GeneratorExit, KeyboardInterrupt, SystemExit),
+                ):
+                    raise
+                raise StorageIntegrityError(f"{label} close failed") from close_error
+            _annotate_secondary_error(
+                primary,
+                f"{label} close also failed",
+                close_error,
+            )
+
+
+def _run_zip_archive(
+    archive_handle: BinaryIO,
+    *,
+    label: str,
+    operation: Callable[[zipfile.ZipFile], Any],
+) -> Any:
+    try:
+        archive = zipfile.ZipFile(archive_handle, mode="r")
+    except (OSError, RuntimeError, ValueError, zipfile.BadZipFile) as exc:
+        raise StorageIntegrityError(f"{label} cannot be opened") from exc
+
+    primary: BaseException | None = None
+    try:
+        return operation(archive)
+    except BaseException as error:  # noqa: B036 - preserve semantic primary
+        primary = error
+        raise
+    finally:
+        try:
+            archive.close()
+        except BaseException as close_error:  # noqa: B036 - cleanup boundary
+            if primary is None:
+                if isinstance(
+                    close_error,
+                    (GeneratorExit, KeyboardInterrupt, SystemExit),
+                ):
+                    raise
+                raise StorageIntegrityError(f"{label} close failed") from close_error
+            _annotate_secondary_error(
+                primary,
+                f"{label} close also failed",
+                close_error,
+            )
+
+
+def _strict_object_pairs(
+    pairs: list[tuple[str, Any]],
+    *,
+    label: str,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise StorageIntegrityError(f"{label} repeats a JSON key")
+        result[key] = value
+    return result
+
+
+def _portable_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return (
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _read_canonical_documents(
+    archive: zipfile.ZipFile,
+    member: ArtifactMember,
+    path: str,
+    *,
+    label: str,
+    require_source_field: bool,
+) -> int:
+    try:
+        source = archive.open(f"{VIEW_BUNDLE_PAYLOAD}/{path}", mode="r")
+    except (KeyError, OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise StorageIntegrityError(f"{label} cannot be opened") from exc
+    primary: BaseException | None = None
+    count = 0
+    size = 0
+    digest = hashlib.sha256()
+
+    def documents():
+        nonlocal count
+        for index, document in enumerate(iter_bounded_json_array(source, label=label)):
+            if (
+                type(document) is not dict
+                or set(document) != {"page_content", "metadata"}
+                or type(document["page_content"]) is not str
+                or type(document["metadata"]) is not dict
+            ):
+                raise StorageIntegrityError(
+                    f"{label} document {index} has an invalid shape"
+                )
+            try:
+                assert_no_secret_fields(
+                    document["metadata"],
+                    source=f"{label} document {index} metadata",
+                )
+            except SecretFieldError as exc:
+                raise StorageIntegrityError(
+                    f"{label} document {index} metadata is not publishable"
+                ) from exc
+            raw_file = document["metadata"].get("file")
+            if require_source_field and "file" not in document["metadata"]:
+                raise StorageIntegrityError(
+                    f"{label} document {index} has no source path"
+                )
+            if raw_file is not None:
+                _require_portable_source_path(
+                    raw_file,
+                    label=f"{label} document {index} source path",
+                )
+            count += 1
+            yield document
+
+    try:
+        for chunk in canonical_json_array_chunks(documents()):
+            size += len(chunk)
+            digest.update(chunk)
+        if size != member.byte_size or digest.hexdigest() != member.digest:
+            raise StorageIntegrityError(f"{label} is not canonical JSON")
+    except BaseException as error:  # noqa: B036 - preserve semantic primary
+        primary = error
+        if isinstance(
+            error,
+            (StorageIntegrityError, GeneratorExit, KeyboardInterrupt, SystemExit),
+        ):
+            raise
+        raise StorageIntegrityError(f"{label} is invalid") from error
+    finally:
+        try:
+            source.close()
+        except BaseException as close_error:  # noqa: B036 - cleanup boundary
+            if primary is None:
+                if isinstance(
+                    close_error, (GeneratorExit, KeyboardInterrupt, SystemExit)
+                ):
+                    raise
+                raise StorageIntegrityError(f"{label} close failed") from close_error
+            _annotate_secondary_error(
+                primary, f"{label} close also failed", close_error
+            )
+    return count
+
+
+def _require_portable_source_path(value: object, *, label: str) -> str:
+    if type(value) is not str:
+        raise StorageIntegrityError(f"{label} is invalid")
+    # Content-bound portable validation preserves an exact empty source path
+    # for documents that intentionally carry no repository-file attribution.
+    if not value:
+        return value
+    try:
+        encoded = value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise StorageIntegrityError(f"{label} is invalid") from exc
+    parts = value.split("/")
+    normalized = PurePosixPath(value)
+    if (
+        len(encoded) > 4_096
+        or len(parts) > 256
+        or value.startswith(("/", "~"))
+        or "\\" in value
+        or _WINDOWS_DRIVE_RE.match(value) is not None
+        or normalized.is_absolute()
+        or any(part in {"", ".", "..", "~"} for part in parts)
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+        or value != normalized.as_posix()
+    ):
+        raise StorageIntegrityError(f"{label} is not portable-relative")
+    return value
+
+
+def _require_vector_record(
+    value: object,
+    member_by_path: Mapping[str, ArtifactMember],
+    *,
+    relative_path: str,
+    expected_file: str,
+    label: str,
+) -> None:
+    _require_fingerprint(
+        value,
+        member_by_path.get(relative_path),
+        expected_file=expected_file,
+        label=label,
+    )
+
+
+def _require_level_config(
+    value: Mapping[str, Any],
+    *,
+    root: Mapping[str, Any],
+    level: str,
+    count: int,
+    provider: str,
+    revision: str | None,
+    dimension: int,
+    metric: str,
+    index_type: str,
+) -> None:
+    if set(value) != _VECTOR_LEVEL_CONFIG_FIELDS:
+        raise StorageIntegrityError(
+            f"snapshot vector {level} config has an invalid shape"
+        )
+    try:
+        observed_provider = normalize_provider(value["embedding_provider"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise StorageIntegrityError(
+            f"snapshot vector {level} config has an invalid provider"
+        ) from exc
+    expected = {
+        "embedding_model": root.get("embedding_model"),
+        "embedding_revision": revision,
+        "dimension": dimension,
+        "index_type": index_type,
+        "index_metric": metric,
+        "level": level,
+        "num_documents": count,
+    }
+    if observed_provider != provider or any(
+        type(value.get(field)) is not type(expected_value)
+        or not same_exact_json(value.get(field), expected_value)
+        for field, expected_value in expected.items()
+    ):
+        raise StorageIntegrityError(
+            f"snapshot vector {level} config conflicts with its root config"
+        )
+
+
+def _require_bundle_semantics(
+    archive_handle: BinaryIO,
+    view: _ProjectedView,
+) -> None:
+    member_by_path = {member.path: member for member in view.members}
+    if view.intent.view_type == "bm25":
+        # Exact inventory was already checked; parsing both canonical JSON
+        # objects prevents a coherently reclosed arbitrary byte bundle.
+        def validate_bm25(archive: zipfile.ZipFile) -> None:
+            metadata = _read_zip_json(
+                archive,
+                member_by_path,
+                "bm25_metadata.json",
+                label="snapshot BM25 metadata",
+            )
+            view_config = view.intent.manifest_entry.get("config")
+            if (
+                set(metadata) != {"project_root", "max_k", "language"}
+                or metadata.get("project_root") != "source"
+                or type(metadata.get("max_k")) is not int
+                or metadata["max_k"] <= 0
+                or type(view_config) is not dict
+                or type(view_config.get("max_k")) is not int
+                or metadata["max_k"] != view_config["max_k"]
+                or type(metadata.get("language")) is not str
+                or not metadata["language"].strip()
+                or "\x00" in metadata["language"]
+                or len(metadata["language"]) > 256
+            ):
+                raise StorageIntegrityError(
+                    "snapshot BM25 metadata conflicts with its manifest"
+                )
+            member = member_by_path["documents.json"]
+            _read_canonical_documents(
+                archive,
+                member,
+                "documents.json",
+                label="snapshot BM25 documents",
+                require_source_field=False,
+            )
+
+        archive_handle.seek(0)
+        _run_zip_archive(
+            archive_handle,
+            label="snapshot BM25 bundle",
+            operation=validate_bm25,
+        )
+        return
+
+    record = view.intent.generation_record["persistence_config"]
+    root_path = record["file"]
+    if (
+        type(root_path) is not str
+        or len(root_path) <= len("config_.json")
+        or not root_path.startswith("config_")
+        or not root_path.endswith(".json")
+        or "/" in root_path
+    ):
+        raise StorageIntegrityError("snapshot vector root config path is invalid")
+    model_suffix = root_path[len("config_") : -len(".json")]
+    manifest_entry = view.intent.manifest_entry
+    view_config = manifest_entry.get("config")
+    if type(view_config) is not dict:
+        raise StorageIntegrityError(
+            "snapshot vector manifest entry has an invalid config"
+        )
+
+    def validate_vector(
+        archive: zipfile.ZipFile,
+    ) -> tuple[dict[str, int], set[str]]:
+        root = _read_zip_json(
+            archive,
+            member_by_path,
+            root_path,
+            label="snapshot vector root config",
+        )
+        try:
+            suffix, dimension, revision, metric, index_type = (
+                validate_portable_vector_persistence_semantics(
+                    root,
+                    view_config,
+                )
+            )
+            provider = resolve_embedding_artifact_route(
+                view_config,
+                environ={},
+            ).provider
+        except (RuntimeError, TypeError, ValueError) as exc:
+            raise StorageIntegrityError(
+                "snapshot vector root config conflicts with its profile"
+            ) from exc
+        if (
+            suffix != model_suffix
+            or type(root.get("persistence_schema")) is not int
+            or root["persistence_schema"] != VECTOR_PERSISTENCE_SCHEMA
+        ):
+            raise StorageIntegrityError(
+                "snapshot vector root config has an invalid schema or suffix"
+            )
+        committed = root.get("level_artifacts")
+        if type(committed) is not dict or not set(committed) <= set(_VECTOR_LEVELS):
+            raise StorageIntegrityError(
+                "snapshot vector root config has invalid committed levels"
+            )
+        counts: dict[str, int] = {}
+        expected_paths = {root_path}
+        for level in _VECTOR_LEVELS:
+            count = root.get(f"{level}_documents")
+            if type(count) is not int or count < 0:
+                raise StorageIntegrityError(
+                    f"snapshot vector root config has an invalid {level} count"
+                )
+            counts[level] = count
+            artifacts = committed.get(level)
+            if count == 0:
+                if level in committed:
+                    raise StorageIntegrityError(
+                        f"snapshot vector root config commits empty {level} artifacts"
+                    )
+                continue
+            if type(artifacts) is not dict or set(artifacts) != {
+                "documents",
+                "index",
+            }:
+                raise StorageIntegrityError(
+                    f"snapshot vector root config has invalid {level} artifacts"
+                )
+            documents_name = f"documents_{model_suffix}.json"
+            index_name = f"index_{model_suffix}.faiss"
+            documents_path = f"{level}/{documents_name}"
+            index_path = f"{level}/{index_name}"
+            _require_vector_record(
+                artifacts["documents"],
+                member_by_path,
+                relative_path=documents_path,
+                expected_file=documents_name,
+                label=f"snapshot vector {level} documents",
+            )
+            _require_vector_record(
+                artifacts["index"],
+                member_by_path,
+                relative_path=index_path,
+                expected_file=index_name,
+                label=f"snapshot vector {level} index",
+            )
+            observed_count = _read_canonical_documents(
+                archive,
+                member_by_path[documents_path],
+                documents_path,
+                label=f"snapshot vector {level} documents",
+                require_source_field=True,
+            )
+            if observed_count != count:
+                raise StorageIntegrityError(
+                    f"snapshot vector {level} document count conflicts"
+                )
+            expected_paths.update({documents_path, index_path})
+            config_path = f"{level}/config_{model_suffix}.json"
+            if config_path in member_by_path:
+                level_config = _read_zip_json(
+                    archive,
+                    member_by_path,
+                    config_path,
+                    label=f"snapshot vector {level} config",
+                )
+                _require_level_config(
+                    level_config,
+                    root=root,
+                    level=level,
+                    count=count,
+                    provider=provider,
+                    revision=revision,
+                    dimension=dimension,
+                    metric=metric,
+                    index_type=index_type,
+                )
+                expected_paths.add(config_path)
+        return counts, expected_paths
+
+    archive_handle.seek(0)
+    counts, expected_paths = _run_zip_archive(
+        archive_handle,
+        label="snapshot vector bundle",
+        operation=validate_vector,
+    )
+    observed_counts = view_config.get("document_count")
+    positive_counts = {level: count for level, count in counts.items() if count > 0}
+    if (
+        not positive_counts
+        or (
+            observed_counts is not None
+            and (
+                type(observed_counts) is not dict
+                or set(observed_counts) != set(positive_counts)
+                or any(
+                    type(observed_counts[level]) is not int
+                    or observed_counts[level] != expected
+                    for level, expected in positive_counts.items()
+                )
+            )
+        )
+        or set(member_by_path) != expected_paths
+    ):
+        raise StorageIntegrityError("snapshot vector semantic inventory conflicts")
+
+
+def _validate_projection(
+    projection: dict[str, Any],
+    *,
+    retained: _RetainedSnapshot,
+    max_manifest_bytes: int,
+    max_bundle_files: int,
+) -> _ValidatedProjection:
+    if (
+        set(projection)
+        != {
+            "schema",
+            "repository_id",
+            "source",
+            "artifact",
+            "plan",
+            "selection",
+            "manifest",
+            "views",
+        }
+        or projection["schema"] != REPO_MANIFEST_PROJECTION_SCHEMA
+    ):
+        raise StorageIntegrityError("repository manifest projection shape is invalid")
+    if projection["repository_id"] != retained.repository.repository_id:
+        raise StorageIntegrityError("repository manifest projection identity conflicts")
+    projected_source = projection["source"]
+    if type(projected_source) is not dict or set(projected_source) != {
+        "source_revision_id",
+        "kind",
+        "source_fingerprint",
+        "file_count",
+        "display_commit",
+        "verification_scope",
+        "source_verified",
+        "commit_verified",
+        "checkout_state",
+    }:
+        raise StorageIntegrityError("projected source shape is invalid")
+    source = retained.source
+    if (
+        source.source_kind != "dirty"
+        or source.commit_sha is not None
+        or source.tree_sha is not None
+        or projected_source["source_revision_id"] != source.source_revision_id
+        or projected_source["kind"] != "dirty"
+        or projected_source["source_fingerprint"] != source.source_fingerprint
+        or type(projected_source["file_count"]) is not int
+        or projected_source["file_count"] < 0
+        or type(projected_source["display_commit"]) is not str
+        or projected_source["verification_scope"] != "content-bytes"
+        or projected_source["source_verified"] is not True
+        or projected_source["commit_verified"] is not False
+        or projected_source["checkout_state"] != "not-attested"
+    ):
+        raise StorageIntegrityError("projected source authority claims are invalid")
+    artifact = projection["artifact"]
+    if (
+        type(artifact) is not dict
+        or set(artifact) != {"workspace_plan_digest", "postflight"}
+        or type(artifact["workspace_plan_digest"]) is not str
+        or _WORKSPACE_PLAN_DIGEST_RE.fullmatch(artifact["workspace_plan_digest"])
+        is None
+        or artifact["postflight"] != "completed-before-catalog"
+    ):
+        raise StorageIntegrityError("projected artifact postflight is invalid")
+    selection = projection["selection"]
+    if type(selection) is not dict or set(selection) != {
+        "required_views",
+        "optional_views",
+        "selected_views",
+        "skipped_views",
+    }:
+        raise StorageIntegrityError("projected view selection shape is invalid")
+    for field in ("required_views", "optional_views", "selected_views"):
+        values = selection[field]
+        if (
+            type(values) is not list
+            or any(type(item) is not str for item in values)
+            or tuple(values) != tuple(sorted(set(values)))
+            or any(item not in PORTABLE_STORAGE_VIEWS for item in values)
+        ):
+            raise StorageIntegrityError(f"projected {field} is invalid")
+    if type(selection["skipped_views"]) is not dict:
+        raise StorageIntegrityError("projected skipped views are invalid")
+    manifest_value = projection["manifest"]
+    if type(manifest_value) is not dict:
+        raise StorageIntegrityError("projected repository manifest is invalid")
+    full_manifest_bytes = canonical_json(manifest_value).encode("ascii")
+    if len(full_manifest_bytes) > max_manifest_bytes:
+        raise StorageIntegrityError(
+            f"projected repository manifest exceeds {max_manifest_bytes} bytes"
+        )
+    try:
+        plan = plan_repo_manifest_import_bytes(
+            full_manifest_bytes,
+            required_views=tuple(selection["required_views"]),
+            optional_views=tuple(selection["optional_views"]),
+            max_manifest_bytes=max_manifest_bytes,
+        )
+    except StorageValidationError as exc:
+        raise StorageIntegrityError(
+            "projected repository manifest cannot be replanned"
+        ) from exc
+    expected_plan = {**plan.to_dict(), "digest": plan.plan_digest}
+    if (
+        not same_exact_json(projection["plan"], expected_plan)
+        or not same_exact_json(selection, plan.selection.to_dict())
+        or plan.schema != REPO_MANIFEST_IMPORT_PLAN_SCHEMA
+        or plan.source.fingerprint != source.source_fingerprint
+        or plan.source.file_count != projected_source["file_count"]
+        or plan.source.display_commit != projected_source["display_commit"]
+        or plan.source.fingerprint_version != 2
+        or plan.manifest.repo_path != "source"
+    ):
+        raise StorageIntegrityError("projected import plan identity conflicts")
+    selected = plan.selection.selected_views
+    projected_views = projection["views"]
+    if type(projected_views) is not dict or set(projected_views) != set(selected):
+        raise StorageIntegrityError("projected view closure is invalid")
+    if set(retained.views) != set(selected) | {REPO_MANIFEST_PROJECTION_VIEW}:
+        raise StorageIntegrityError("snapshot retained view closure is invalid")
+
+    projected_items: list[tuple[str, _ProjectedView]] = []
+    for intent in plan.views:
+        view_type = intent.view_type
+        value = projected_views[view_type]
+        if type(value) is not dict or set(value) != {
+            "generation",
+            "generation_record",
+            "members",
+        }:
+            raise StorageIntegrityError(
+                f"projected {view_type!r} view shape is invalid"
+            )
+        catalog_view = retained.views[view_type]
+        generation_value = value["generation"]
+        expected_generation = {
+            "view_generation_id": catalog_view.generation.view_generation_id,
+            "schema_version": catalog_view.generation.schema_version,
+            "metadata": json.loads(catalog_view.generation.metadata_json),
+            "profile": {
+                "profile_id": catalog_view.profile.profile_id,
+                "name": catalog_view.profile.name,
+                "config": catalog_view.profile.config,
+            },
+            "object": _semantic_object(catalog_view.primary),
+        }
+        if (
+            type(generation_value) is not dict
+            or set(generation_value) != set(expected_generation)
+            or not same_exact_json(generation_value, expected_generation)
+            or catalog_view.generation.schema_version != VIEW_BUNDLE_SCHEMA
+            or catalog_view.primary.media_type != VIEW_BUNDLE_MEDIA_TYPE
+            or not same_exact_json(value["generation_record"], intent.generation_record)
+            or catalog_view.profile.profile_id != intent.profile_id
+            or catalog_view.profile.name != intent.profile.name
+            or not same_exact_json(catalog_view.profile.config, intent.profile.config)
+        ):
+            raise StorageIntegrityError(
+                f"projected {view_type!r} generation conflicts with the snapshot"
+            )
+        metadata = json.loads(catalog_view.generation.metadata_json)
+        metadata.pop(VIEW_GENERATION_MEMBERS_METADATA_KEY, None)
+        if not same_exact_json(metadata, repo_manifest_generation_metadata(intent)):
+            raise StorageIntegrityError(
+                f"projected {view_type!r} generation metadata conflicts"
+            )
+        raw_members = value["members"]
+        if (
+            type(raw_members) is not list
+            or not raw_members
+            or len(raw_members) > max_bundle_files
+        ):
+            raise StorageIntegrityError(
+                f"projected {view_type!r} member inventory is invalid"
+            )
+        members: list[ArtifactMember] = []
+        member_receipts: list[tuple[str, BlobInfo]] = []
+        catalog_members = {record.digest: record for record in catalog_view.members}
+        if len(catalog_members) != len(catalog_view.members):
+            raise StorageIntegrityError(
+                f"catalog {view_type!r} member objects repeat a digest"
+            )
+        previous = ""
+        for raw_member in raw_members:
+            member = _artifact_member(
+                raw_member,
+                view_type=view_type,
+            )
+            if member.path <= previous:
+                raise StorageIntegrityError(
+                    f"projected {view_type!r} members are not canonical"
+                )
+            stored = catalog_members.get(member.digest)
+            if (
+                stored is None
+                or stored.digest != member.digest
+                or stored.byte_size != member.byte_size
+                or stored.media_type != _MEMBER_MEDIA_TYPE
+            ):
+                raise StorageIntegrityError(
+                    f"projected {view_type!r} member differs from its catalog object"
+                )
+            members.append(member)
+            member_receipts.append((member.path, _receipt(stored)))
+            previous = member.path
+        member_tuple = tuple(members)
+        if tuple(sorted({member.digest for member in member_tuple})) != tuple(
+            record.digest for record in catalog_view.members
+        ):
+            raise StorageIntegrityError(
+                f"projected {view_type!r} member reachability conflicts"
+            )
+        _cross_bind_generation_record(intent, member_tuple)
+        projected_items.append(
+            (
+                view_type,
+                _ProjectedView(
+                    intent=intent,
+                    catalog_view=catalog_view,
+                    members=member_tuple,
+                    member_receipt_items=tuple(member_receipts),
+                ),
+            )
+        )
+
+    export_manifest = json.loads(plan.manifest_json)
+    export_manifest["indexes"] = {
+        view_type: export_manifest["indexes"][view_type] for view_type in selected
+    }
+    capabilities = dict(export_manifest["capabilities"])
+    capabilities.update(
+        {
+            "sparse_search": "bm25" in selected,
+            "dense_search": "vector" in selected,
+            "hybrid_search": {"bm25", "vector"} <= set(selected),
+            "symbol_navigation": "symbol_graph" in selected,
+        }
+    )
+    export_manifest["capabilities"] = capabilities
+    manifest_bytes = canonical_json(export_manifest).encode("ascii")
+    if len(manifest_bytes) > max_manifest_bytes:
+        raise StorageIntegrityError(
+            f"exported repository manifest exceeds {max_manifest_bytes} bytes"
+        )
+    try:
+        emitted = plan_repo_manifest_import_bytes(
+            manifest_bytes,
+            required_views=selected,
+            max_manifest_bytes=max_manifest_bytes,
+        )
+    except StorageValidationError as exc:
+        raise StorageIntegrityError(
+            "exported repository manifest cannot be replanned"
+        ) from exc
+    if emitted.selection.selected_views != selected:
+        raise StorageIntegrityError("exported repository manifest changed its views")
+    return _ValidatedProjection(
+        manifest_bytes=manifest_bytes,
+        plan=plan,
+        skipped_items=plan.selection.skipped_items,
+        projection_receipt=BlobInfo("0" * 64, 0, "placeholder"),
+        projection_view=retained.views[REPO_MANIFEST_PROJECTION_VIEW],
+        view_items=tuple(projected_items),
+    )
+
+
+def _read_and_validate_projection(
+    retained: _RetainedSnapshot,
+    *,
+    object_store: ReceiptVerifyingObjectStore,
+    max_manifest_bytes: int,
+    max_projection_bytes: int,
+    max_bundle_files: int,
+) -> _ValidatedProjection:
+    projection_view = retained.views.get(REPO_MANIFEST_PROJECTION_VIEW)
+    expected_profile = repo_manifest_projection_profile()
+    if (
+        projection_view is None
+        or projection_view.generation.schema_version != REPO_MANIFEST_PROJECTION_SCHEMA
+        or projection_view.profile.profile_id != expected_profile.profile_id
+        or projection_view.profile.name != expected_profile.name
+        or not same_exact_json(projection_view.profile.config, expected_profile.config)
+        or projection_view.primary.media_type != REPO_MANIFEST_PROJECTION_MEDIA_TYPE
+        or projection_view.primary.byte_size > max_projection_bytes
+    ):
+        raise StorageIntegrityError(
+            "snapshot repository manifest projection generation is invalid"
+        )
+    payload = _run_open_object(
+        object_store,
+        projection_view.primary,
+        lambda source: _read_exact_bytes(source, projection_view.primary),
+    )
+    projection = _strict_json_bytes(
+        payload,
+        label="repository manifest projection",
+    )
+    validated = _validate_projection(
+        projection,
+        retained=retained,
+        max_manifest_bytes=max_manifest_bytes,
+        max_bundle_files=max_bundle_files,
+    )
+    plan_identity = projection["plan"]["manifest"]
+    metadata = json.loads(projection_view.generation.metadata_json)
+    metadata.pop(VIEW_GENERATION_MEMBERS_METADATA_KEY, None)
+    expected_metadata = {
+        "contract": REPO_MANIFEST_PROJECTION_SCHEMA,
+        "manifest_version": MANIFEST_VERSION,
+        "manifest_digest": plan_identity["digest"],
+        "plan_digest": validated.plan.plan_digest,
+        "projected_views": list(validated.plan.selection.selected_views),
+    }
+    dependency_records: dict[str, ObjectRecord] = {}
+    for _view_type, view in validated.view_items:
+        for record in (view.catalog_view.primary, *view.catalog_view.members):
+            existing = dependency_records.get(record.digest)
+            if existing is None:
+                dependency_records[record.digest] = record
+            elif not _same_record(existing, record):
+                raise StorageIntegrityError(
+                    "snapshot dependency object metadata conflicts"
+                )
+    dependencies = tuple(sorted(dependency_records))
+    projection_dependencies = {
+        record.digest: record for record in projection_view.members
+    }
+    if (
+        not same_exact_json(metadata, expected_metadata)
+        or projection_view.generation.member_object_digests != dependencies
+        or tuple(record.digest for record in projection_view.members) != dependencies
+        or set(projection_dependencies) != set(dependency_records)
+        or any(
+            not _same_record(projection_dependencies[digest], record)
+            for digest, record in dependency_records.items()
+        )
+    ):
+        raise StorageIntegrityError(
+            "snapshot repository manifest projection reachability conflicts"
+        )
+    return _ValidatedProjection(
+        manifest_bytes=validated.manifest_bytes,
+        plan=validated.plan,
+        skipped_items=validated.skipped_items,
+        projection_receipt=_receipt(projection_view.primary),
+        projection_view=projection_view,
+        view_items=validated.view_items,
+    )
+
+
+def _verify_bundle(
+    object_store: ReceiptVerifyingObjectStore,
+    view: _ProjectedView,
+    *,
+    max_files: int,
+    max_bytes: int,
+    max_metadata_bytes: int,
+) -> BlobInfo:
+    record = view.catalog_view.primary
+    try:
+        validate_view_bundle_physical_size(
+            record.byte_size,
+            max_files=max_files,
+            max_bytes=max_bytes,
+            max_metadata_bytes=max_metadata_bytes,
+        )
+    except StorageValidationError as exc:
+        raise StorageIntegrityError(
+            f"snapshot {view.intent.view_type!r} bundle exceeds its limits"
+        ) from exc
+
+    def consume(source: BinaryIO) -> None:
+        def compare(_archive: BinaryIO, observed: ViewBundleRecord) -> None:
+            if observed.members != view.members:
+                raise StorageIntegrityError(
+                    f"snapshot {view.intent.view_type!r} bundle inventory conflicts"
+                )
+            _require_bundle_semantics(_archive, view)
+
+        consume_verified_view_bundle_stream(
+            source,
+            compare,
+            expected_view_type=view.intent.view_type,
+            expected_digest=record.digest,
+            expected_size=record.byte_size,
+            max_files=max_files,
+            max_bytes=max_bytes,
+            max_metadata_bytes=max_metadata_bytes,
+        )
+
+    _run_open_object(object_store, record, consume)
+    return _receipt(record)
+
+
+def _unique_records(values: Sequence[ObjectRecord]) -> tuple[ObjectRecord, ...]:
+    result: dict[str, ObjectRecord] = {}
+    for record in values:
+        existing = result.get(record.digest)
+        if existing is None:
+            result[record.digest] = record
+        elif not _same_record(existing, record):
+            raise StorageIntegrityError(
+                "one object digest has conflicting retained metadata"
+            )
+    return tuple(result[digest] for digest in sorted(result))
+
+
+def _export_snapshot(
+    retained: _RetainedSnapshot,
+    *,
+    object_store: ReceiptVerifyingObjectStore,
+    ref_name: str | None,
+    ref_generation: int | None,
+    ref_updated_at: str | None,
+    max_manifest_bytes: int,
+    max_projection_bytes: int,
+    max_bundle_files: int,
+    max_bundle_bytes: int,
+    max_bundle_metadata_bytes: int,
+) -> RepoManifestExportResult:
+    validated = _read_and_validate_projection(
+        retained,
+        object_store=object_store,
+        max_manifest_bytes=max_manifest_bytes,
+        max_projection_bytes=max_projection_bytes,
+        max_bundle_files=max_bundle_files,
+    )
+    receipts: list[RepoManifestViewExportReceipt] = []
+    all_records: list[ObjectRecord] = [validated.projection_view.primary]
+    all_records.extend(validated.projection_view.members)
+    for view_type, view in validated.view_items:
+        bundle_receipt = _verify_bundle(
+            object_store,
+            view,
+            max_files=max_bundle_files,
+            max_bytes=max_bundle_bytes,
+            max_metadata_bytes=max_bundle_metadata_bytes,
+        )
+        for record in view.catalog_view.members:
+            _verify_receipt(object_store, record)
+        all_records.append(view.catalog_view.primary)
+        all_records.extend(view.catalog_view.members)
+        receipts.append(
+            RepoManifestViewExportReceipt(
+                view_type=view_type,
+                view_generation_id=view.catalog_view.generation.view_generation_id,
+                bundle_receipt=bundle_receipt,
+                member_receipt_items=view.member_receipt_items,
+            )
+        )
+    # Receipts are observations rather than pins. Recheck every unique object
+    # at the final boundary immediately before returning the data-only result.
+    for record in _unique_records(all_records):
+        _verify_receipt(object_store, record)
+    manifest_digest = hashlib.sha256(validated.manifest_bytes).hexdigest()
+    receipt = RepoManifestExportReceipt(
+        repository_id=retained.repository.repository_id,
+        source_revision_id=retained.source.source_revision_id,
+        snapshot_id=retained.snapshot.snapshot_id,
+        snapshot_published_at=retained.published_at,
+        ref_name=ref_name,
+        ref_generation=ref_generation,
+        ref_updated_at=ref_updated_at,
+        manifest_digest=manifest_digest,
+        manifest_byte_size=len(validated.manifest_bytes),
+        projection_generation_id=validated.projection_view.generation.view_generation_id,
+        projection_receipt=validated.projection_receipt,
+        view_receipts=tuple(receipts),
+        skipped_items=validated.skipped_items,
+    )
+    return RepoManifestExportResult(validated.manifest_bytes, receipt)
+
+
+def _preflight(
+    *,
+    catalog: object,
+    object_store: object,
+    max_manifest_bytes: object,
+    max_projection_bytes: object,
+    max_bundle_files: object,
+    max_bundle_bytes: object,
+    max_bundle_metadata_bytes: object,
+) -> tuple[int, int, int, int, int]:
+    if not isinstance(catalog, RetainedSnapshotCatalog):
+        raise TypeError("retained manifest export catalog lacks required capabilities")
+    if not isinstance(object_store, ReceiptVerifyingObjectStore):
+        raise TypeError(
+            "retained manifest export object store lacks required capabilities"
+        )
+    _require_static_methods(
+        catalog,
+        label="retained manifest export catalog",
+        names=_CATALOG_METHODS,
+    )
+    _require_static_methods(
+        object_store,
+        label="retained manifest export object store",
+        names=_OBJECT_STORE_METHODS,
+    )
+    limits = (
+        _positive_limit(max_manifest_bytes, "manifest byte limit"),
+        _positive_limit(max_projection_bytes, "projection byte limit"),
+        _positive_limit(max_bundle_files, "bundle file limit"),
+        _positive_limit(max_bundle_bytes, "bundle byte limit"),
+        _positive_limit(max_bundle_metadata_bytes, "bundle metadata byte limit"),
+    )
+    contract = catalog.retained_import_contract()  # type: ignore[union-attr]
+    if type(contract) is not str or contract != RETAINED_IMPORT_CATALOG_CONTRACT:
+        raise TypeError("retained manifest export catalog contract is incompatible")
+    return limits
+
+
+def export_retained_repo_manifest_ref(
+    repository_id: str,
+    *,
+    catalog: RetainedSnapshotCatalog,
+    object_store: ReceiptVerifyingObjectStore,
+    ref_name: str = DEFAULT_REF_NAME,
+    expected_generation: int | None = None,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+) -> RepoManifestExportResult:
+    """Resolve one ref once and export its immutable snapshot as v1.1 bytes."""
+
+    repository_id = _exact_text(repository_id, "export repository ID")
+    ref_name = _exact_text(ref_name, "export ref name")
+    expected_generation = _optional_generation(expected_generation)
+    (
+        manifest_limit,
+        projection_limit,
+        bundle_files,
+        bundle_bytes,
+        bundle_metadata,
+    ) = _preflight(
+        catalog=catalog,
+        object_store=object_store,
+        max_manifest_bytes=max_manifest_bytes,
+        max_projection_bytes=max_projection_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+    )
+    raw = catalog.resolve_ref(repository_id, ref_name)
+    # An expected-generation mismatch is a caller-visible optimistic-lock
+    # conflict, not a request to authenticate or read the resolved snapshot.
+    # Inspect only the exact outer built-in mapping before detaching its
+    # potentially large manifest so this precondition cannot trigger CAS I/O.
+    if type(raw) is not dict:
+        raise StorageIntegrityError("resolved retained manifest ref shape is invalid")
+    raw_generation = raw.get("generation")
+    raw_repository_id = raw.get("repository_id")
+    raw_ref_name = raw.get("ref_name")
+    if (
+        type(raw_generation) is not int
+        or not 0 < raw_generation <= _INT64_MAX
+        or type(raw_repository_id) is not str
+        or raw_repository_id != repository_id
+        or type(raw_ref_name) is not str
+        or raw_ref_name != ref_name
+    ):
+        raise StorageIntegrityError("resolved retained manifest ref is invalid")
+    if expected_generation is not None and raw_generation != expected_generation:
+        raise PublishConflict(
+            "resolved repository ref generation differs from expected_generation"
+        )
+    resolution = snapshot_retained_import_response(
+        raw,
+        label="resolved retained manifest ref",
+    )
+    required = {
+        "repository_id",
+        "ref_name",
+        "snapshot_id",
+        "generation",
+        "updated_at",
+        "manifest",
+    }
+    if type(resolution) is not dict or not required <= set(resolution):
+        raise StorageIntegrityError("resolved retained manifest ref shape is invalid")
+    generation = resolution["generation"]
+    if (
+        type(generation) is not int
+        or not 0 < generation <= _INT64_MAX
+        or generation != raw_generation
+        or resolution["repository_id"] != repository_id
+        or resolution["ref_name"] != ref_name
+        or type(resolution["snapshot_id"]) is not str
+    ):
+        raise StorageIntegrityError("resolved retained manifest ref is invalid")
+    try:
+        updated_at = canonical_utc_timestamp(
+            resolution["updated_at"],
+            "resolved retained manifest ref updated_at",
+        )
+    except StorageValidationError as exc:
+        raise StorageIntegrityError(
+            "resolved retained manifest ref is invalid"
+        ) from exc
+    retained = attest_detached_retained_snapshot(
+        resolution["manifest"],
+        label="resolved retained manifest snapshot",
+        expected_repository_id=repository_id,
+        expected_snapshot_id=resolution["snapshot_id"],
+    )
+    return _export_snapshot(
+        retained,
+        object_store=object_store,
+        ref_name=ref_name,
+        ref_generation=generation,
+        ref_updated_at=updated_at,
+        max_manifest_bytes=manifest_limit,
+        max_projection_bytes=projection_limit,
+        max_bundle_files=bundle_files,
+        max_bundle_bytes=bundle_bytes,
+        max_bundle_metadata_bytes=bundle_metadata,
+    )
+
+
+def export_retained_repo_manifest_snapshot(
+    repository_id: str,
+    snapshot_id: str,
+    *,
+    catalog: RetainedSnapshotCatalog,
+    object_store: ReceiptVerifyingObjectStore,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+) -> RepoManifestExportResult:
+    """Export one explicit immutable snapshot without resolving a ref."""
+
+    repository_id = _exact_text(repository_id, "export repository ID")
+    snapshot_id = _exact_text(snapshot_id, "export snapshot ID")
+    (
+        manifest_limit,
+        projection_limit,
+        bundle_files,
+        bundle_bytes,
+        bundle_metadata,
+    ) = _preflight(
+        catalog=catalog,
+        object_store=object_store,
+        max_manifest_bytes=max_manifest_bytes,
+        max_projection_bytes=max_projection_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+    )
+    raw = catalog.get_manifest_summary(snapshot_id)
+    summary = snapshot_retained_import_response(
+        raw,
+        label="retained manifest snapshot summary",
+    )
+    retained = attest_detached_retained_snapshot(
+        summary,
+        label="retained manifest snapshot summary",
+        expected_repository_id=repository_id,
+        expected_snapshot_id=snapshot_id,
+    )
+    return _export_snapshot(
+        retained,
+        object_store=object_store,
+        ref_name=None,
+        ref_generation=None,
+        ref_updated_at=None,
+        max_manifest_bytes=manifest_limit,
+        max_projection_bytes=projection_limit,
+        max_bundle_files=bundle_files,
+        max_bundle_bytes=bundle_bytes,
+        max_bundle_metadata_bytes=bundle_metadata,
+    )
+
+
+__all__ = [
+    "RepoManifestExportReceipt",
+    "RepoManifestExportResult",
+    "RepoManifestViewExportReceipt",
+    "export_retained_repo_manifest_ref",
+    "export_retained_repo_manifest_snapshot",
+]

--- a/codenib/compiler/manifest_export.py
+++ b/codenib/compiler/manifest_export.py
@@ -23,10 +23,18 @@ from pathlib import PurePosixPath
 from types import MappingProxyType
 from typing import Any, BinaryIO, Callable
 
-from .._atomic_directory import _annotate_secondary_error
+from .._atomic_directory import (
+    _attach_publication_cleanup_owner,
+    _OrderedAction,
+    _run_context_with_cleanup_actions,
+)
 from .._bounded_json import canonical_json_array_chunks, iter_bounded_json_array
 from .._secret_fields import SecretFieldError, assert_no_secret_fields
-from ..artifacts.portable_views import validate_portable_vector_persistence_semantics
+from ..artifacts.portable_views import (
+    MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+    MAX_PORTABLE_FAISS_INDEX_BYTES,
+    validate_portable_vector_persistence_semantics,
+)
 from ..index.embedding.artifact_integrity import VECTOR_PERSISTENCE_SCHEMA
 from ..provider_routes import normalize_provider, resolve_embedding_artifact_route
 from ..storage.cas import BlobInfo
@@ -35,6 +43,7 @@ from ..storage.models import (
     ArtifactMember,
     ObjectRecord,
     PublishConflict,
+    RepositoryIdentity,
     StorageIntegrityError,
     StorageValidationError,
     canonical_json,
@@ -179,7 +188,9 @@ class RepoManifestExportReceipt:
     materialization authority.
     """
 
+    namespace_id: str
     repository_id: str
+    repository_key: str
     source_revision_id: str
     snapshot_id: str
     snapshot_published_at: str
@@ -199,12 +210,25 @@ class RepoManifestExportReceipt:
                 "manifest export receipt must use the exact receipt type"
             )
         for value, label in (
+            (self.namespace_id, "export namespace ID"),
             (self.repository_id, "export repository ID"),
+            (self.repository_key, "export repository key"),
             (self.source_revision_id, "export source revision ID"),
             (self.snapshot_id, "export snapshot ID"),
             (self.projection_generation_id, "export projection generation ID"),
         ):
             _exact_text(value, label)
+        try:
+            repository = RepositoryIdentity(
+                namespace_id=self.namespace_id,
+                repository_key=self.repository_key,
+            )
+        except StorageValidationError as exc:
+            raise StorageValidationError(
+                "export repository identity is invalid"
+            ) from exc
+        if repository.repository_id != self.repository_id:
+            raise StorageValidationError("export repository identity is inconsistent")
         if (
             type(self.manifest_digest) is not str
             or _DIGEST_RE.fullmatch(self.manifest_digest) is None
@@ -370,6 +394,85 @@ class _ValidatedProjection:
         return MappingProxyType(dict(self.view_items))
 
 
+class _CloseableResourceOwner:
+    """Own one callback-acquired closeable across interruption boundaries."""
+
+    __slots__ = ("_complete", "_first_close_error", "_resource")
+
+    def __init__(self, complete: Callable[[Any], bool]) -> None:
+        self._complete = complete
+        self._first_close_error: BaseException | None = None
+        self._resource: Any = _MISSING
+
+    @property
+    def closed(self) -> bool:
+        resource = self._resource
+        if resource is _MISSING:
+            return True
+        return self._complete(resource) is True
+
+    @property
+    def first_close_error(self) -> BaseException | None:
+        return self._first_close_error
+
+    def acquire(self, callback: Callable[[], Any]) -> Any:
+        if self._resource is not _MISSING:
+            raise RuntimeError("closeable resource is already acquired")
+        # The owner and its cleanup action exist before this call.  As with the
+        # repository's descriptor owners, only the native-return-to-STORE_ATTR
+        # edge remains outside Python's control.
+        self._resource = callback()
+        return self._resource
+
+    def close(self) -> None:
+        resource = self._resource
+        if resource is _MISSING:
+            return
+        try:
+            resource.close()
+        except BaseException as error:  # noqa: B036 - preserve exact close primary
+            if self._first_close_error is None:
+                self._first_close_error = error
+            raise
+
+
+def _run_with_owned_close(
+    acquire: Callable[[], Any],
+    operation: Callable[[Any], Any],
+    *,
+    complete: Callable[[Any], bool],
+    cleanup_label: str,
+    close_failure: str,
+) -> Any:
+    """Acquire and close one resource under the shared ordered-cleanup fence."""
+
+    owner = _CloseableResourceOwner(complete)
+    close_action = _OrderedAction(
+        label=cleanup_label,
+        action=owner.close,
+        complete=lambda: owner.closed,
+        retry_incomplete="cancellation",
+        incomplete_owner=owner,
+    )
+    operation_succeeded = False
+    try:
+        with _run_context_with_cleanup_actions((close_action,)):
+            resource = owner.acquire(acquire)
+            result = operation(resource)
+            operation_succeeded = True
+            return result
+    except BaseException as error:  # noqa: B036 - preserve operation primary
+        if (
+            operation_succeeded
+            and error is owner.first_close_error
+            and isinstance(error, Exception)
+        ):
+            wrapped = StorageIntegrityError(close_failure)
+            _attach_publication_cleanup_owner(wrapped, owner)
+            raise wrapped from error
+        raise
+
+
 def _exact_text(value: object, label: str, *, max_length: int = _MAX_TEXT) -> str:
     if type(value) is not str:
         raise StorageValidationError(f"{label} must be exact text")
@@ -463,39 +566,26 @@ def _run_open_object(
     operation: Callable[[BinaryIO], Any],
 ) -> Any:
     _verify_receipt(object_store, record)
-    try:
-        source = object_store.open(record.digest)
-    except StorageIntegrityError:
-        raise
-    except BaseException as error:  # noqa: B036 - backend boundary
-        if isinstance(error, (GeneratorExit, KeyboardInterrupt, SystemExit)):
-            raise
-        raise StorageIntegrityError("object-store read could not be opened") from error
-    primary: BaseException | None = None
-    try:
-        return operation(source)
-    except BaseException as error:  # noqa: B036 - preserve primary
-        primary = error
-        raise
-    finally:
+
+    def acquire() -> BinaryIO:
         try:
-            close = source.close
-            close()
-        except BaseException as close_error:  # noqa: B036 - backend cleanup
-            if primary is None:
-                if isinstance(
-                    close_error,
-                    (GeneratorExit, KeyboardInterrupt, SystemExit),
-                ):
-                    raise
-                raise StorageIntegrityError(
-                    "object-store reader close failed"
-                ) from close_error
-            _annotate_secondary_error(
-                primary,
-                "object-store reader close also failed",
-                close_error,
-            )
+            return object_store.open(record.digest)
+        except StorageIntegrityError:
+            raise
+        except BaseException as error:  # noqa: B036 - backend boundary
+            if isinstance(error, (GeneratorExit, KeyboardInterrupt, SystemExit)):
+                raise
+            raise StorageIntegrityError(
+                "object-store read could not be opened"
+            ) from error
+
+    return _run_with_owned_close(
+        acquire,
+        operation,
+        complete=lambda source: source.closed is True,
+        cleanup_label="object-store reader close also failed",
+        close_failure="object-store reader close failed",
+    )
 
 
 def _read_exact_bytes(source: BinaryIO, record: ObjectRecord) -> bytes:
@@ -698,74 +788,72 @@ def _read_zip_json(
     member = member_by_path.get(path)
     if member is None or member.byte_size > _MAX_CONFIG_BYTES:
         raise StorageIntegrityError(f"{label} is missing or exceeds its byte limit")
-    try:
-        source = archive.open(f"{VIEW_BUNDLE_PAYLOAD}/{path}", mode="r")
-    except (KeyError, OSError, RuntimeError, zipfile.BadZipFile) as exc:
-        raise StorageIntegrityError(f"{label} cannot be opened") from exc
 
-    primary: BaseException | None = None
-    try:
-        payload = source.read(_MAX_CONFIG_BYTES + 1)
-        if type(payload) is not bytes or len(payload) > _MAX_CONFIG_BYTES:
-            raise StorageIntegrityError(f"{label} exceeds its byte limit")
-        value = json.loads(
-            payload.decode("utf-8", errors="strict"),
-            object_pairs_hook=lambda pairs: _strict_object_pairs(pairs, label=label),
-            parse_constant=lambda value: (_ for _ in ()).throw(
-                ValueError(f"non-finite number: {value}")
-            ),
-        )
-        value = snapshot_retained_import_response(value, label=label)
-        if (
-            type(value) is not dict
-            or _portable_json_bytes(value) != payload
-            or hashlib.sha256(payload).hexdigest() != member.digest
-            or len(payload) != member.byte_size
-        ):
-            raise StorageIntegrityError(f"{label} is not canonical JSON")
-        assert_no_secret_fields(value, source=label)
-        return value
-    except BaseException as error:  # noqa: B036 - preserve semantic primary
-        if isinstance(
-            error,
-            (StorageIntegrityError, GeneratorExit, KeyboardInterrupt, SystemExit),
-        ):
-            primary = error
-            raise
-        if isinstance(
-            error,
-            (
-                KeyError,
-                OSError,
-                RecursionError,
-                SecretFieldError,
-                TypeError,
-                UnicodeError,
-                ValueError,
-                zipfile.BadZipFile,
-            ),
-        ):
-            wrapped = StorageIntegrityError(f"{label} is invalid")
-            primary = wrapped
-            raise wrapped from error
-        primary = error
-        raise
-    finally:
+    def acquire() -> BinaryIO:
         try:
-            source.close()
-        except BaseException as close_error:  # noqa: B036 - cleanup boundary
-            if primary is None:
-                if isinstance(
-                    close_error,
-                    (GeneratorExit, KeyboardInterrupt, SystemExit),
-                ):
-                    raise
-                raise StorageIntegrityError(f"{label} close failed") from close_error
-            _annotate_secondary_error(
-                primary,
-                f"{label} close also failed",
-                close_error,
+            return archive.open(f"{VIEW_BUNDLE_PAYLOAD}/{path}", mode="r")
+        except (KeyError, OSError, RuntimeError, zipfile.BadZipFile) as exc:
+            raise StorageIntegrityError(f"{label} cannot be opened") from exc
+
+    def read(source: BinaryIO) -> dict[str, Any]:
+        try:
+            payload = source.read(_MAX_CONFIG_BYTES + 1)
+            if type(payload) is not bytes or len(payload) > _MAX_CONFIG_BYTES:
+                raise StorageIntegrityError(f"{label} exceeds its byte limit")
+            value = json.loads(
+                payload.decode("utf-8", errors="strict"),
+                object_pairs_hook=lambda pairs: _strict_object_pairs(
+                    pairs,
+                    label=label,
+                ),
+                parse_constant=lambda value: (_ for _ in ()).throw(
+                    ValueError(f"non-finite number: {value}")
+                ),
             )
+            value = snapshot_retained_import_response(value, label=label)
+            if (
+                type(value) is not dict
+                or _portable_json_bytes(value) != payload
+                or hashlib.sha256(payload).hexdigest() != member.digest
+                or len(payload) != member.byte_size
+            ):
+                raise StorageIntegrityError(f"{label} is not canonical JSON")
+            assert_no_secret_fields(value, source=label)
+            return value
+        except BaseException as error:  # noqa: B036 - preserve semantic primary
+            if isinstance(
+                error,
+                (
+                    StorageIntegrityError,
+                    GeneratorExit,
+                    KeyboardInterrupt,
+                    SystemExit,
+                ),
+            ):
+                raise
+            if isinstance(
+                error,
+                (
+                    KeyError,
+                    OSError,
+                    RecursionError,
+                    SecretFieldError,
+                    TypeError,
+                    UnicodeError,
+                    ValueError,
+                    zipfile.BadZipFile,
+                ),
+            ):
+                raise StorageIntegrityError(f"{label} is invalid") from error
+            raise
+
+    return _run_with_owned_close(
+        acquire,
+        read,
+        complete=lambda source: source.closed is True,
+        cleanup_label=f"{label} close also failed",
+        close_failure=f"{label} close failed",
+    )
 
 
 def _run_zip_archive(
@@ -774,33 +862,19 @@ def _run_zip_archive(
     label: str,
     operation: Callable[[zipfile.ZipFile], Any],
 ) -> Any:
-    try:
-        archive = zipfile.ZipFile(archive_handle, mode="r")
-    except (OSError, RuntimeError, ValueError, zipfile.BadZipFile) as exc:
-        raise StorageIntegrityError(f"{label} cannot be opened") from exc
-
-    primary: BaseException | None = None
-    try:
-        return operation(archive)
-    except BaseException as error:  # noqa: B036 - preserve semantic primary
-        primary = error
-        raise
-    finally:
+    def acquire() -> zipfile.ZipFile:
         try:
-            archive.close()
-        except BaseException as close_error:  # noqa: B036 - cleanup boundary
-            if primary is None:
-                if isinstance(
-                    close_error,
-                    (GeneratorExit, KeyboardInterrupt, SystemExit),
-                ):
-                    raise
-                raise StorageIntegrityError(f"{label} close failed") from close_error
-            _annotate_secondary_error(
-                primary,
-                f"{label} close also failed",
-                close_error,
-            )
+            return zipfile.ZipFile(archive_handle, mode="r")
+        except (OSError, RuntimeError, ValueError, zipfile.BadZipFile) as exc:
+            raise StorageIntegrityError(f"{label} cannot be opened") from exc
+
+    return _run_with_owned_close(
+        acquire,
+        operation,
+        complete=lambda archive: archive.fp is None,
+        cleanup_label=f"{label} close also failed",
+        close_failure=f"{label} close failed",
+    )
 
 
 def _strict_object_pairs(
@@ -838,77 +912,85 @@ def _read_canonical_documents(
     label: str,
     require_source_field: bool,
 ) -> int:
-    try:
-        source = archive.open(f"{VIEW_BUNDLE_PAYLOAD}/{path}", mode="r")
-    except (KeyError, OSError, RuntimeError, zipfile.BadZipFile) as exc:
-        raise StorageIntegrityError(f"{label} cannot be opened") from exc
-    primary: BaseException | None = None
-    count = 0
-    size = 0
-    digest = hashlib.sha256()
+    if member.byte_size > MAX_PORTABLE_DOCUMENTS_JSON_BYTES:
+        raise StorageIntegrityError(f"{label} exceeds its byte limit")
 
-    def documents():
-        nonlocal count
-        for index, document in enumerate(iter_bounded_json_array(source, label=label)):
-            if (
-                type(document) is not dict
-                or set(document) != {"page_content", "metadata"}
-                or type(document["page_content"]) is not str
-                or type(document["metadata"]) is not dict
-            ):
-                raise StorageIntegrityError(
-                    f"{label} document {index} has an invalid shape"
-                )
-            try:
-                assert_no_secret_fields(
-                    document["metadata"],
-                    source=f"{label} document {index} metadata",
-                )
-            except SecretFieldError as exc:
-                raise StorageIntegrityError(
-                    f"{label} document {index} metadata is not publishable"
-                ) from exc
-            raw_file = document["metadata"].get("file")
-            if require_source_field and "file" not in document["metadata"]:
-                raise StorageIntegrityError(
-                    f"{label} document {index} has no source path"
-                )
-            if raw_file is not None:
-                _require_portable_source_path(
-                    raw_file,
-                    label=f"{label} document {index} source path",
-                )
-            count += 1
-            yield document
-
-    try:
-        for chunk in canonical_json_array_chunks(documents()):
-            size += len(chunk)
-            digest.update(chunk)
-        if size != member.byte_size or digest.hexdigest() != member.digest:
-            raise StorageIntegrityError(f"{label} is not canonical JSON")
-    except BaseException as error:  # noqa: B036 - preserve semantic primary
-        primary = error
-        if isinstance(
-            error,
-            (StorageIntegrityError, GeneratorExit, KeyboardInterrupt, SystemExit),
-        ):
-            raise
-        raise StorageIntegrityError(f"{label} is invalid") from error
-    finally:
+    def acquire() -> BinaryIO:
         try:
-            source.close()
-        except BaseException as close_error:  # noqa: B036 - cleanup boundary
-            if primary is None:
-                if isinstance(
-                    close_error, (GeneratorExit, KeyboardInterrupt, SystemExit)
+            return archive.open(f"{VIEW_BUNDLE_PAYLOAD}/{path}", mode="r")
+        except (KeyError, OSError, RuntimeError, zipfile.BadZipFile) as exc:
+            raise StorageIntegrityError(f"{label} cannot be opened") from exc
+
+    def read(source: BinaryIO) -> int:
+        count = 0
+        size = 0
+        digest = hashlib.sha256()
+
+        def documents():
+            nonlocal count
+            for index, document in enumerate(
+                iter_bounded_json_array(source, label=label)
+            ):
+                if (
+                    type(document) is not dict
+                    or set(document) != {"page_content", "metadata"}
+                    or type(document["page_content"]) is not str
+                    or type(document["metadata"]) is not dict
                 ):
-                    raise
-                raise StorageIntegrityError(f"{label} close failed") from close_error
-            _annotate_secondary_error(
-                primary, f"{label} close also failed", close_error
-            )
-    return count
+                    raise StorageIntegrityError(
+                        f"{label} document {index} has an invalid shape"
+                    )
+                try:
+                    assert_no_secret_fields(
+                        document,
+                        source=f"{label} document {index}",
+                    )
+                except SecretFieldError as exc:
+                    raise StorageIntegrityError(
+                        f"{label} document {index} is not publishable"
+                    ) from exc
+                raw_file = document["metadata"].get("file")
+                if require_source_field and "file" not in document["metadata"]:
+                    raise StorageIntegrityError(
+                        f"{label} document {index} has no source path"
+                    )
+                if raw_file is not None:
+                    _require_portable_source_path(
+                        raw_file,
+                        label=f"{label} document {index} source path",
+                    )
+                count += 1
+                yield document
+
+        try:
+            for chunk in canonical_json_array_chunks(documents()):
+                size += len(chunk)
+                if size > MAX_PORTABLE_DOCUMENTS_JSON_BYTES:
+                    raise StorageIntegrityError(f"{label} exceeds its byte limit")
+                digest.update(chunk)
+            if size != member.byte_size or digest.hexdigest() != member.digest:
+                raise StorageIntegrityError(f"{label} is not canonical JSON")
+        except BaseException as error:  # noqa: B036 - preserve semantic primary
+            if isinstance(
+                error,
+                (
+                    StorageIntegrityError,
+                    GeneratorExit,
+                    KeyboardInterrupt,
+                    SystemExit,
+                ),
+            ):
+                raise
+            raise StorageIntegrityError(f"{label} is invalid") from error
+        return count
+
+    return _run_with_owned_close(
+        acquire,
+        read,
+        complete=lambda source: source.closed is True,
+        cleanup_label=f"{label} close also failed",
+        close_failure=f"{label} close failed",
+    )
 
 
 def _require_portable_source_path(value: object, *, label: str) -> str:
@@ -946,13 +1028,17 @@ def _require_vector_record(
     relative_path: str,
     expected_file: str,
     label: str,
+    max_bytes: int,
 ) -> None:
+    member = member_by_path.get(relative_path)
     _require_fingerprint(
         value,
-        member_by_path.get(relative_path),
+        member,
         expected_file=expected_file,
         label=label,
     )
+    if member is None or member.byte_size > max_bytes:
+        raise StorageIntegrityError(f"{label} exceeds its byte limit")
 
 
 def _require_level_config(
@@ -1133,6 +1219,7 @@ def _require_bundle_semantics(
                 relative_path=documents_path,
                 expected_file=documents_name,
                 label=f"snapshot vector {level} documents",
+                max_bytes=MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
             )
             _require_vector_record(
                 artifacts["index"],
@@ -1140,6 +1227,7 @@ def _require_bundle_semantics(
                 relative_path=index_path,
                 expected_file=index_name,
                 label=f"snapshot vector {level} index",
+                max_bytes=MAX_PORTABLE_FAISS_INDEX_BYTES,
             )
             observed_count = _read_canonical_documents(
                 archive,
@@ -1658,7 +1746,9 @@ def _export_snapshot(
         _verify_receipt(object_store, record)
     manifest_digest = hashlib.sha256(validated.manifest_bytes).hexdigest()
     receipt = RepoManifestExportReceipt(
+        namespace_id=retained.namespace.namespace_id,
         repository_id=retained.repository.repository_id,
+        repository_key=retained.repository.repository_key,
         source_revision_id=retained.source.source_revision_id,
         snapshot_id=retained.snapshot.snapshot_id,
         snapshot_published_at=retained.published_at,

--- a/codenib/compiler/manifest_import.py
+++ b/codenib/compiler/manifest_import.py
@@ -25,7 +25,6 @@ import inspect
 import json
 import os
 import re
-import struct
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -84,14 +83,24 @@ from .manifest_storage import (
     ViewImportIntent,
     ViewSelection,
 )
-
-REPO_MANIFEST_IMPORT_GENERATION_CONTRACT = "codenib.repo-manifest-import-generation.v2"
-REPO_MANIFEST_PROJECTION_VIEW = "codenib.internal.repo-manifest"
-REPO_MANIFEST_PROJECTION_SCHEMA = "codenib.internal.repo-manifest.v2"
-REPO_MANIFEST_PROJECTION_MEDIA_TYPE = (
-    "application/vnd.codenib.repo-manifest-projection.v2+json"
+from .retained_manifest_contract import (
+    REPO_MANIFEST_IMPORT_GENERATION_CONTRACT,
+    REPO_MANIFEST_PROJECTION_MEDIA_TYPE,
+    REPO_MANIFEST_PROJECTION_PROFILE_NAME,
+    REPO_MANIFEST_PROJECTION_SCHEMA,
+    REPO_MANIFEST_PROJECTION_VIEW,
 )
-REPO_MANIFEST_PROJECTION_PROFILE_NAME = "canonical"
+from .retained_manifest_contract import (
+    repo_manifest_generation_metadata as _generation_metadata,
+)
+from .retained_manifest_contract import (
+    repo_manifest_projection_profile as _projection_profile,
+)
+from .retained_snapshot import (
+    attest_detached_retained_snapshot as _attest_detached_retained_snapshot,
+)
+from .retained_snapshot import has_exact_json_core as _has_exact_json_core
+from .retained_snapshot import same_exact_json as _same_exact_json
 
 DEFAULT_REF_NAME = "main"
 DEFAULT_MAX_CONTEXT_FILES = 100_000
@@ -253,57 +262,6 @@ def _exact_backend_id(value: object, expected: str, label: str) -> None:
 def _snapshot_backend_json(value: object, *, label: str) -> Any:
     """Detach one bounded exact-JSON backend response without virtual equality."""
     return snapshot_retained_import_response(value, label=label)
-
-
-def _same_exact_json(left: object, right: object) -> bool:
-    """Compare detached JSON without Python's bool/int/float coercions."""
-
-    if type(left) is not type(right):
-        return False
-    if type(left) is dict:
-        if left.keys() != right.keys():  # type: ignore[union-attr]
-            return False
-        return all(
-            _same_exact_json(value, right[key])  # type: ignore[index]
-            for key, value in left.items()  # type: ignore[union-attr]
-        )
-    if type(left) is list:
-        if len(left) != len(right):  # type: ignore[arg-type]
-            return False
-        return all(
-            _same_exact_json(left_value, right_value)
-            for left_value, right_value in zip(  # type: ignore[arg-type]
-                left, right, strict=True
-            )
-        )
-    if type(left) is float:
-        return struct.pack(">d", left) == struct.pack(">d", right)  # type: ignore[arg-type]
-    return left == right
-
-
-def _has_exact_json_core(observed: object, expected: object) -> bool:
-    """Match identity fields exactly while allowing additive object fields."""
-
-    if type(observed) is not type(expected):
-        return False
-    if type(expected) is dict:
-        return all(
-            key in observed  # type: ignore[operator]
-            and _has_exact_json_core(observed[key], value)  # type: ignore[index]
-            for key, value in expected.items()  # type: ignore[union-attr]
-        )
-    if type(expected) is list:
-        if len(observed) != len(expected):  # type: ignore[arg-type]
-            return False
-        return all(
-            _has_exact_json_core(observed_value, expected_value)
-            for observed_value, expected_value in zip(  # type: ignore[arg-type]
-                observed,
-                expected,
-                strict=True,
-            )
-        )
-    return _same_exact_json(observed, expected)
 
 
 def _positive_limit(value: object, label: str) -> int:
@@ -508,30 +466,6 @@ def _snapshot_workspace_plan_digest(receipt: PublishedWorkspaceReceipt) -> str:
 
 def _expected_namespace_id(name: str) -> str:
     return NamespaceIdentity(name).namespace_id
-
-
-def _projection_profile() -> ViewProfile:
-    return ViewProfile.create(
-        REPO_MANIFEST_PROJECTION_VIEW,
-        {
-            "contract": REPO_MANIFEST_PROJECTION_SCHEMA,
-            "builder_schema": REPO_MANIFEST_PROJECTION_SCHEMA,
-            "artifact_schema": REPO_MANIFEST_PROJECTION_SCHEMA,
-        },
-        name=REPO_MANIFEST_PROJECTION_PROFILE_NAME,
-    )
-
-
-def _generation_metadata(intent: ViewImportIntent) -> dict[str, Any]:
-    return {
-        "contract": REPO_MANIFEST_IMPORT_GENERATION_CONTRACT,
-        "manifest_version": MANIFEST_VERSION,
-        "generation_record_digest": intent.generation_record_digest,
-        "verification_scope": "content-bytes",
-        "native_execution": (
-            "inert" if intent.view_type == "vector" else "not-required"
-        ),
-    }
 
 
 def _exact_blob_object(
@@ -1005,182 +939,13 @@ def _validate_catalog_publication(
     return generation, changed, updated_at
 
 
-def _identity_closed_object(value: object, *, label: str) -> ObjectRecord:
-    required = {"digest", "storage_key", "byte_size", "media_type"}
-    if type(value) is not dict or not required <= set(value):
-        raise StorageIntegrityError(f"{label} shape is invalid")
-    try:
-        record = ObjectRecord(
-            digest=value["digest"],
-            storage_key=value["storage_key"],
-            byte_size=value["byte_size"],
-            media_type=value["media_type"],
-        )
-    except StorageValidationError as exc:
-        raise StorageIntegrityError(f"{label} identity is invalid") from exc
-    if not _same_exact_json(
-        value,
-        {
-            **value,
-            "digest": record.digest,
-            "storage_key": record.storage_key,
-            "byte_size": record.byte_size,
-            "media_type": record.media_type,
-        },
-    ):
-        raise StorageIntegrityError(f"{label} identity is not canonical")
-    return record
-
-
 def _validate_identity_closed_summary(summary: object) -> str:
     """Rebuild every backend-neutral identity in one ready summary."""
 
-    required = {
-        "snapshot_id",
-        "repository_id",
-        "namespace",
-        "repository",
-        "status",
-        "published_at",
-        "source",
-        "views",
-    }
-    if type(summary) is not dict or not required <= set(summary):
-        raise StorageIntegrityError("published ref manifest shape is invalid")
-    namespace_value = summary["namespace"]
-    repository_value = summary["repository"]
-    source_value = summary["source"]
-    views_value = summary["views"]
-    if (
-        type(namespace_value) is not dict
-        or not {"namespace_id", "name"} <= set(namespace_value)
-        or type(repository_value) is not dict
-        or not {"namespace_id", "repository_key"} <= set(repository_value)
-        or type(source_value) is not dict
-        or not {
-            "source_revision_id",
-            "kind",
-            "commit_sha",
-            "tree_sha",
-            "source_fingerprint",
-        }
-        <= set(source_value)
-        or type(views_value) is not dict
-        or not views_value
-        or summary["status"] != "ready"
-    ):
-        raise StorageIntegrityError("published ref manifest core is invalid")
-    try:
-        namespace = NamespaceIdentity(namespace_value["name"])
-        repository = RepositoryIdentity(
-            namespace_id=namespace_value["namespace_id"],
-            repository_key=repository_value["repository_key"],
-        )
-        source = SourceRevision(
-            repository_id=summary["repository_id"],
-            source_kind=source_value["kind"],
-            commit_sha=source_value["commit_sha"],
-            tree_sha=source_value["tree_sha"],
-            source_fingerprint=source_value["source_fingerprint"],
-        )
-        published_at = canonical_utc_timestamp(
-            summary["published_at"],
-            "published ref manifest published_at",
-        )
-    except StorageValidationError as exc:
-        raise StorageIntegrityError(
-            "published ref manifest identity is invalid"
-        ) from exc
-    if (
-        namespace_value["name"] != namespace.name
-        or namespace_value["namespace_id"] != namespace.namespace_id
-        or repository_value["namespace_id"] != namespace.namespace_id
-        or repository_value["repository_key"] != repository.repository_key
-        or summary["repository_id"] != repository.repository_id
-        or source.repository_id != repository.repository_id
-        or source_value["source_revision_id"] != source.source_revision_id
-        or source_value["kind"] != source.source_kind
-        or source_value["commit_sha"] != source.commit_sha
-        or source_value["tree_sha"] != source.tree_sha
-        or source_value["source_fingerprint"] != source.source_fingerprint
-    ):
-        raise StorageIntegrityError("published ref manifest identity is inconsistent")
-
-    snapshot_views: list[SnapshotView] = []
-    for view_type, value in views_value.items():
-        view_required = {
-            "view_generation_id",
-            "schema_version",
-            "metadata",
-            "profile",
-            "object",
-            "member_objects",
-        }
-        if (
-            type(view_type) is not str
-            or type(value) is not dict
-            or not view_required <= set(value)
-            or type(value["metadata"]) is not dict
-            or type(value["profile"]) is not dict
-            or not {"profile_id", "name", "config"} <= set(value["profile"])
-            or type(value["profile"]["config"]) is not dict
-            or type(value["member_objects"]) is not list
-        ):
-            raise StorageIntegrityError("published ref view shape is invalid")
-        try:
-            profile = ViewProfile.create(
-                view_type,
-                value["profile"]["config"],
-                name=value["profile"]["name"],
-            )
-            primary = _identity_closed_object(
-                value["object"],
-                label=f"published {view_type!r} primary object",
-            )
-            generation = ViewGeneration(
-                repository_id=repository.repository_id,
-                source_revision_id=source.source_revision_id,
-                profile=profile,
-                object_digest=primary.digest,
-                schema_version=value["schema_version"],
-                metadata_json=canonical_json(value["metadata"]),
-            )
-            members = tuple(
-                _identity_closed_object(
-                    member,
-                    label=f"published {view_type!r} member object",
-                )
-                for member in value["member_objects"]
-            )
-        except StorageValidationError as exc:
-            raise StorageIntegrityError(
-                f"published {view_type!r} identity is invalid"
-            ) from exc
-        if (
-            profile.view_type != view_type
-            or value["profile"]["name"] != profile.name
-            or value["profile"]["profile_id"] != profile.profile_id
-            or not _same_exact_json(value["profile"]["config"], profile.config)
-            or value["schema_version"] != generation.schema_version
-            or value["view_generation_id"] != generation.view_generation_id
-            or tuple(member.digest for member in members)
-            != generation.member_object_digests
-        ):
-            raise StorageIntegrityError(
-                f"published {view_type!r} identity is inconsistent"
-            )
-        snapshot_views.append(SnapshotView(generation))
-    try:
-        snapshot = PublishedSnapshot(
-            repository.repository_id,
-            source.source_revision_id,
-            tuple(snapshot_views),
-        )
-    except StorageValidationError as exc:
-        raise StorageIntegrityError("published ref snapshot is invalid") from exc
-    if summary["snapshot_id"] != snapshot.snapshot_id:
-        raise StorageIntegrityError("published ref snapshot identity is inconsistent")
-    return published_at
+    return _attest_detached_retained_snapshot(
+        summary,
+        label="published ref manifest",
+    ).published_at
 
 
 def _validate_ref_resolution(

--- a/codenib/compiler/retained_manifest_contract.py
+++ b/codenib/compiler/retained_manifest_contract.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared immutable contracts for retained RepoManifest projections."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..storage.models import ViewProfile
+from .manifest import MANIFEST_VERSION
+from .manifest_storage import ViewImportIntent
+
+REPO_MANIFEST_IMPORT_GENERATION_CONTRACT = "codenib.repo-manifest-import-generation.v2"
+REPO_MANIFEST_PROJECTION_VIEW = "codenib.internal.repo-manifest"
+REPO_MANIFEST_PROJECTION_SCHEMA = "codenib.internal.repo-manifest.v2"
+REPO_MANIFEST_PROJECTION_MEDIA_TYPE = (
+    "application/vnd.codenib.repo-manifest-projection.v2+json"
+)
+REPO_MANIFEST_PROJECTION_PROFILE_NAME = "canonical"
+
+
+def repo_manifest_projection_profile() -> ViewProfile:
+    return ViewProfile.create(
+        REPO_MANIFEST_PROJECTION_VIEW,
+        {
+            "contract": REPO_MANIFEST_PROJECTION_SCHEMA,
+            "builder_schema": REPO_MANIFEST_PROJECTION_SCHEMA,
+            "artifact_schema": REPO_MANIFEST_PROJECTION_SCHEMA,
+        },
+        name=REPO_MANIFEST_PROJECTION_PROFILE_NAME,
+    )
+
+
+def repo_manifest_generation_metadata(intent: ViewImportIntent) -> dict[str, Any]:
+    return {
+        "contract": REPO_MANIFEST_IMPORT_GENERATION_CONTRACT,
+        "manifest_version": MANIFEST_VERSION,
+        "generation_record_digest": intent.generation_record_digest,
+        "verification_scope": "content-bytes",
+        "native_execution": (
+            "inert" if intent.view_type == "vector" else "not-required"
+        ),
+    }
+
+
+__all__ = [
+    "REPO_MANIFEST_IMPORT_GENERATION_CONTRACT",
+    "REPO_MANIFEST_PROJECTION_MEDIA_TYPE",
+    "REPO_MANIFEST_PROJECTION_PROFILE_NAME",
+    "REPO_MANIFEST_PROJECTION_SCHEMA",
+    "REPO_MANIFEST_PROJECTION_VIEW",
+    "repo_manifest_generation_metadata",
+    "repo_manifest_projection_profile",
+]

--- a/codenib/compiler/retained_snapshot.py
+++ b/codenib/compiler/retained_snapshot.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared read-only attestation for retained catalog snapshots.
+
+The values returned here are internal, point-in-time observations.  They are
+not object-store pins, leases, filesystem ownership tokens, or publication
+authority.  Callers that read object bytes must still authenticate those bytes
+inside the read and revalidate receipts at their final metadata boundary.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from ..storage.models import (
+    NamespaceIdentity,
+    ObjectRecord,
+    PublishedSnapshot,
+    RepositoryIdentity,
+    SnapshotView,
+    SourceRevision,
+    StorageIntegrityError,
+    StorageValidationError,
+    ViewGeneration,
+    ViewProfile,
+    canonical_json,
+    canonical_utc_timestamp,
+)
+from ..storage.protocols import snapshot_retained_import_response
+
+
+@dataclass(frozen=True, slots=True)
+class _RetainedSnapshotView:
+    view_type: str
+    summary: dict[str, Any]
+    profile: ViewProfile
+    generation: ViewGeneration
+    primary: ObjectRecord
+    members: tuple[ObjectRecord, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _RetainedSnapshot:
+    summary: dict[str, Any]
+    namespace: NamespaceIdentity
+    repository: RepositoryIdentity
+    source: SourceRevision
+    snapshot: PublishedSnapshot
+    published_at: str
+    view_items: tuple[tuple[str, _RetainedSnapshotView], ...]
+
+    @property
+    def views(self) -> Mapping[str, _RetainedSnapshotView]:
+        return MappingProxyType(dict(self.view_items))
+
+
+def same_exact_json(left: object, right: object) -> bool:
+    """Compare detached JSON without bool/int/float coercions."""
+
+    if type(left) is not type(right):
+        return False
+    if type(left) is dict:
+        if left.keys() != right.keys():  # type: ignore[union-attr]
+            return False
+        return all(
+            same_exact_json(value, right[key])  # type: ignore[index]
+            for key, value in left.items()  # type: ignore[union-attr]
+        )
+    if type(left) is list:
+        if len(left) != len(right):  # type: ignore[arg-type]
+            return False
+        return all(
+            same_exact_json(left_value, right_value)
+            for left_value, right_value in zip(  # type: ignore[arg-type]
+                left,
+                right,
+                strict=True,
+            )
+        )
+    if type(left) is float:
+        return struct.pack(">d", left) == struct.pack(  # type: ignore[arg-type]
+            ">d", right
+        )
+    return left == right
+
+
+def has_exact_json_core(observed: object, expected: object) -> bool:
+    """Match identity fields exactly while allowing additive object fields."""
+
+    if type(observed) is not type(expected):
+        return False
+    if type(expected) is dict:
+        return all(
+            key in observed  # type: ignore[operator]
+            and has_exact_json_core(observed[key], value)  # type: ignore[index]
+            for key, value in expected.items()  # type: ignore[union-attr]
+        )
+    if type(expected) is list:
+        if len(observed) != len(expected):  # type: ignore[arg-type]
+            return False
+        return all(
+            has_exact_json_core(observed_value, expected_value)
+            for observed_value, expected_value in zip(  # type: ignore[arg-type]
+                observed,
+                expected,
+                strict=True,
+            )
+        )
+    return same_exact_json(observed, expected)
+
+
+def identity_closed_object(value: object, *, label: str) -> ObjectRecord:
+    """Rebuild one canonical object identity while permitting extensions."""
+
+    required = {"digest", "storage_key", "byte_size", "media_type"}
+    if type(value) is not dict or not required <= set(value):
+        raise StorageIntegrityError(f"{label} shape is invalid")
+    try:
+        record = ObjectRecord(
+            digest=value["digest"],
+            storage_key=value["storage_key"],
+            byte_size=value["byte_size"],
+            media_type=value["media_type"],
+        )
+    except StorageValidationError as exc:
+        raise StorageIntegrityError(f"{label} identity is invalid") from exc
+    if not same_exact_json(
+        value,
+        {
+            **value,
+            "digest": record.digest,
+            "storage_key": record.storage_key,
+            "byte_size": record.byte_size,
+            "media_type": record.media_type,
+        },
+    ):
+        raise StorageIntegrityError(f"{label} identity is not canonical")
+    return record
+
+
+def attest_retained_snapshot(
+    value: object,
+    *,
+    label: str,
+    expected_repository_id: str | None = None,
+    expected_snapshot_id: str | None = None,
+) -> _RetainedSnapshot:
+    """Detach one bounded response and rebuild its complete identity closure."""
+
+    summary = snapshot_retained_import_response(value, label=label)
+    return attest_detached_retained_snapshot(
+        summary,
+        label=label,
+        expected_repository_id=expected_repository_id,
+        expected_snapshot_id=expected_snapshot_id,
+    )
+
+
+def attest_detached_retained_snapshot(
+    summary: object,
+    *,
+    label: str,
+    expected_repository_id: str | None = None,
+    expected_snapshot_id: str | None = None,
+) -> _RetainedSnapshot:
+    """Rebuild an already detached exact-JSON snapshot summary."""
+
+    required = {
+        "snapshot_id",
+        "repository_id",
+        "namespace",
+        "repository",
+        "status",
+        "published_at",
+        "source",
+        "views",
+    }
+    if type(summary) is not dict or not required <= set(summary):
+        raise StorageIntegrityError(f"{label} shape is invalid")
+    namespace_value = summary["namespace"]
+    repository_value = summary["repository"]
+    source_value = summary["source"]
+    views_value = summary["views"]
+    if (
+        type(namespace_value) is not dict
+        or not {"namespace_id", "name"} <= set(namespace_value)
+        or type(repository_value) is not dict
+        or not {"namespace_id", "repository_key"} <= set(repository_value)
+        or type(source_value) is not dict
+        or not {
+            "source_revision_id",
+            "kind",
+            "commit_sha",
+            "tree_sha",
+            "source_fingerprint",
+        }
+        <= set(source_value)
+        or type(views_value) is not dict
+        or not views_value
+        or summary["status"] != "ready"
+    ):
+        raise StorageIntegrityError(f"{label} core is invalid")
+    try:
+        namespace = NamespaceIdentity(namespace_value["name"])
+        repository = RepositoryIdentity(
+            namespace_id=namespace_value["namespace_id"],
+            repository_key=repository_value["repository_key"],
+        )
+        source = SourceRevision(
+            repository_id=summary["repository_id"],
+            source_kind=source_value["kind"],
+            commit_sha=source_value["commit_sha"],
+            tree_sha=source_value["tree_sha"],
+            source_fingerprint=source_value["source_fingerprint"],
+        )
+        published_at = canonical_utc_timestamp(
+            summary["published_at"],
+            f"{label} published_at",
+        )
+    except StorageValidationError as exc:
+        raise StorageIntegrityError(f"{label} identity is invalid") from exc
+    if (
+        namespace_value["name"] != namespace.name
+        or namespace_value["namespace_id"] != namespace.namespace_id
+        or repository_value["namespace_id"] != namespace.namespace_id
+        or repository_value["repository_key"] != repository.repository_key
+        or summary["repository_id"] != repository.repository_id
+        or source.repository_id != repository.repository_id
+        or source_value["source_revision_id"] != source.source_revision_id
+        or source_value["kind"] != source.source_kind
+        or source_value["commit_sha"] != source.commit_sha
+        or source_value["tree_sha"] != source.tree_sha
+        or source_value["source_fingerprint"] != source.source_fingerprint
+        or (
+            expected_repository_id is not None
+            and repository.repository_id != expected_repository_id
+        )
+    ):
+        raise StorageIntegrityError(f"{label} identity is inconsistent")
+
+    snapshot_views: list[SnapshotView] = []
+    view_items: list[tuple[str, _RetainedSnapshotView]] = []
+    for view_type, view_value in views_value.items():
+        view_required = {
+            "view_generation_id",
+            "schema_version",
+            "metadata",
+            "profile",
+            "object",
+            "member_objects",
+        }
+        if (
+            type(view_type) is not str
+            or type(view_value) is not dict
+            or not view_required <= set(view_value)
+            or type(view_value["metadata"]) is not dict
+            or type(view_value["profile"]) is not dict
+            or not {"profile_id", "name", "config"} <= set(view_value["profile"])
+            or type(view_value["profile"]["config"]) is not dict
+            or type(view_value["member_objects"]) is not list
+        ):
+            raise StorageIntegrityError(f"{label} view shape is invalid")
+        try:
+            profile = ViewProfile.create(
+                view_type,
+                view_value["profile"]["config"],
+                name=view_value["profile"]["name"],
+            )
+            primary = identity_closed_object(
+                view_value["object"],
+                label=f"{label} {view_type!r} primary object",
+            )
+            generation = ViewGeneration(
+                repository_id=repository.repository_id,
+                source_revision_id=source.source_revision_id,
+                profile=profile,
+                object_digest=primary.digest,
+                schema_version=view_value["schema_version"],
+                metadata_json=canonical_json(view_value["metadata"]),
+            )
+            members = tuple(
+                identity_closed_object(
+                    member,
+                    label=f"{label} {view_type!r} member object",
+                )
+                for member in view_value["member_objects"]
+            )
+        except StorageValidationError as exc:
+            raise StorageIntegrityError(
+                f"{label} {view_type!r} identity is invalid"
+            ) from exc
+        if (
+            profile.view_type != view_type
+            or view_value["profile"]["name"] != profile.name
+            or view_value["profile"]["profile_id"] != profile.profile_id
+            or not same_exact_json(view_value["profile"]["config"], profile.config)
+            or view_value["schema_version"] != generation.schema_version
+            or view_value["view_generation_id"] != generation.view_generation_id
+            or tuple(member.digest for member in members)
+            != generation.member_object_digests
+        ):
+            raise StorageIntegrityError(
+                f"{label} {view_type!r} identity is inconsistent"
+            )
+        snapshot_views.append(SnapshotView(generation))
+        view_items.append(
+            (
+                view_type,
+                _RetainedSnapshotView(
+                    view_type=view_type,
+                    summary=view_value,
+                    profile=profile,
+                    generation=generation,
+                    primary=primary,
+                    members=members,
+                ),
+            )
+        )
+    try:
+        snapshot = PublishedSnapshot(
+            repository.repository_id,
+            source.source_revision_id,
+            tuple(snapshot_views),
+        )
+    except StorageValidationError as exc:
+        raise StorageIntegrityError(f"{label} snapshot is invalid") from exc
+    if summary["snapshot_id"] != snapshot.snapshot_id or (
+        expected_snapshot_id is not None
+        and snapshot.snapshot_id != expected_snapshot_id
+    ):
+        raise StorageIntegrityError(f"{label} snapshot identity is inconsistent")
+    return _RetainedSnapshot(
+        summary=summary,
+        namespace=namespace,
+        repository=repository,
+        source=source,
+        snapshot=snapshot,
+        published_at=published_at,
+        view_items=tuple(sorted(view_items)),
+    )
+
+
+__all__ = [
+    "attest_retained_snapshot",
+    "has_exact_json_core",
+    "identity_closed_object",
+    "same_exact_json",
+]

--- a/codenib/storage/__init__.py
+++ b/codenib/storage/__init__.py
@@ -49,6 +49,7 @@ from .protocols import (
     ReceiptVerifyingObjectStore,
     RetainedImportCatalog,
     RetainedImportObjectStore,
+    RetainedSnapshotCatalog,
     StreamingObjectStore,
 )
 from .sqlite_catalog import (
@@ -71,8 +72,10 @@ from .view_bundle import (
     ViewBundleRecord,
     build_view_bundle,
     consume_planned_view_bundle,
+    consume_verified_view_bundle_stream,
     materialize_view_bundle,
     plan_view_bundle_reader,
+    retry_retained_verified_bundle_stream_cleanup,
     validate_view_bundle_physical_size,
     verify_view_bundle,
 )
@@ -117,6 +120,7 @@ __all__ = [
     "RETAINED_IMPORT_RESPONSE_MAX_TEXT_CHARS",
     "RetainedImportCatalog",
     "RetainedImportObjectStore",
+    "RetainedSnapshotCatalog",
     "RepositoryIdentity",
     "SQLiteCatalog",
     "SnapshotView",
@@ -137,9 +141,11 @@ __all__ = [
     "build_view_bundle",
     "canonical_utc_timestamp",
     "consume_planned_view_bundle",
+    "consume_verified_view_bundle_stream",
     "materialize_view_bundle",
     "normalize_view_generation_metadata",
     "plan_view_bundle_reader",
+    "retry_retained_verified_bundle_stream_cleanup",
     "view_generation_member_digests",
     "validate_view_bundle_physical_size",
     "verify_view_bundle",

--- a/codenib/storage/protocols.py
+++ b/codenib/storage/protocols.py
@@ -331,8 +331,8 @@ class IndexCatalog(Protocol):
 
 
 @runtime_checkable
-class RetainedImportCatalog(IndexCatalog, Protocol):
-    """Catalog response contract required by retained import attestation.
+class RetainedSnapshotCatalog(Protocol):
+    """Read-only catalog surface for retained snapshot attestation.
 
     Every response uses exact built-in JSON values with finite floats and
     signed 64-bit integers. Keys are nonempty, NUL-free text no longer than
@@ -344,13 +344,9 @@ class RetainedImportCatalog(IndexCatalog, Protocol):
     consumers ignore extensions only after authenticating exact core types and
     identities.
 
-    ``publish_snapshot`` returns ``snapshot_id``, ``repository_id``,
-    ``ref_name``, positive ``generation``, exact ``changed`` boolean, and
-    ``updated_at`` accepted by :func:`codenib.storage.canonical_utc_timestamp`.
-    ``resolve_ref`` repeats repository/ref/snapshot/generation/updated_at and
-    has a ``manifest`` with the summary shape below. For one repository/ref,
-    publish and resolve are linearizable: a later resolve sees that generation
-    or a strictly newer, valid identity-closed ref.
+    ``resolve_ref`` returns repository/ref/snapshot/generation/updated_at and
+    has a ``manifest`` with the summary shape below. Ref generations are
+    positive, monotonic signed 64-bit integers.
 
     A manifest summary contains ``snapshot_id``, ``repository_id``, ``status``
     (``ready``), canonical ``published_at``, ``namespace``
@@ -372,6 +368,29 @@ class RetainedImportCatalog(IndexCatalog, Protocol):
         """Opt in to the exact retained-import response contract above."""
 
         ...
+
+    def resolve_ref(
+        self,
+        repository_id: str,
+        ref_name: str = "main",
+    ) -> dict[str, Any]: ...
+
+    def get_manifest_summary(self, snapshot_id: str) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class RetainedImportCatalog(IndexCatalog, RetainedSnapshotCatalog, Protocol):
+    """Mutation-capable retained import catalog.
+
+    In addition to the read-only retained snapshot contract, publication
+    results use exact ``snapshot_id``, ``repository_id``, ``ref_name``,
+    positive ``generation``, exact ``changed`` boolean, and canonical
+    ``updated_at``. For one repository/ref, ``publish_snapshot`` and
+    ``resolve_ref`` are linearizable: a later resolve sees that publication or
+    a strictly newer valid identity-closed ref.
+    """
+
+    pass
 
 
 @runtime_checkable
@@ -437,6 +456,7 @@ __all__ = [
     "RETAINED_IMPORT_RESPONSE_MAX_TEXT_CHARS",
     "RetainedImportCatalog",
     "RetainedImportObjectStore",
+    "RetainedSnapshotCatalog",
     "snapshot_retained_import_response",
     "StreamingObjectStore",
 ]

--- a/codenib/storage/view_bundle.py
+++ b/codenib/storage/view_bundle.py
@@ -28,6 +28,7 @@ from threading import RLock
 from typing import Any, BinaryIO, Callable, Iterable, Iterator, Mapping, TypeVar
 
 from .._atomic_directory import (
+    _MAX_ORDERED_ACTION_CANCELLATION_RETRIES,
     DirectoryOrphan,
     PublicationDirectoryReader,
     TreeFileRecord,
@@ -100,6 +101,9 @@ _ZIP64_LIMIT = (1 << 31) - 1
 _ZIP_FILECOUNT_LIMIT = (1 << 16) - 1
 _BUNDLE_STREAM_CLOSE_RECOVERY_LIMIT = 64
 _BUNDLE_STREAM_REVOKE_RECOVERY_LIMIT = 64
+_VERIFIED_BUNDLE_STREAM_CLOSE_RECOVERY_LIMIT = (
+    _MAX_ORDERED_ACTION_CANCELLATION_RETRIES + 1
+)
 _FIXED_ZIP_TIME = (1980, 1, 1, 0, 0, 0)
 _VIEW_TYPE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z", re.ASCII)
 _WINDOWS_RESERVED_NAMES = frozenset(
@@ -779,7 +783,7 @@ class _CallbackScopedVerifiedBundleFile:
         "_primary_error",
     )
 
-    def __init__(self, archive: BinaryIO) -> None:
+    def __init__(self, archive: BinaryIO | None = None) -> None:
         self._archive = archive
         self._cleanup_attempts = 0
         self._first_cleanup_error: BaseException | None = None
@@ -799,18 +803,34 @@ class _CallbackScopedVerifiedBundleFile:
         # completion boundary for its arbitrary ``close`` implementation.  Do
         # not close a captured integer fd behind a still-open Python file: a
         # later file-object close could otherwise target a reused descriptor.
-        return self._archive.closed is True
+        archive = self._archive
+        return archive is None or archive.closed is True
+
+    def _acquire_archive(self, callback: Callable[[], BinaryIO]) -> BinaryIO:
+        if self._archive is not None:
+            raise RuntimeError("temporary view-bundle stream is already acquired")
+        # The revocable facade and its ordered cleanup action exist before the
+        # native temporary-file call.  Only the native return-to-STORE_ATTR edge
+        # remains outside Python's ownership boundary.
+        self._archive = callback()
+        return self._archive
 
     def _cleanup_complete(self) -> bool:
         return not self._lifetime.active and self._archive_is_closed()
 
     def _require_active(self) -> None:
-        if self._lifetime.process_id != os.getpid() or not self._lifetime.active:
+        if (
+            self._lifetime.process_id != os.getpid()
+            or not self._lifetime.active
+            or self._archive is None
+        ):
             raise ValueError("I/O operation on closed file.")
 
     def _invoke(self, name: str, *args: Any, **kwargs: Any) -> Any:
         self._require_active()
-        method = getattr(self._archive, name)
+        archive = self._archive
+        assert archive is not None
+        method = getattr(archive, name)
         result = method(*args, **kwargs)
         self._require_active()
         return result
@@ -932,8 +952,12 @@ class _CallbackScopedVerifiedBundleFile:
         # code.  Even a persistent close failure then leaves only this private
         # cleanup owner with access to the real tempfile.
         self._lifetime.active = False
+        archive = self._archive
+        if archive is None:
+            _forget_verified_bundle_stream_cleanup_owner(self)
+            return
         try:
-            self._archive.close()
+            archive.close()
         except BaseException as error:  # noqa: B036 - cleanup boundary
             try:
                 physically_closed = self._archive_is_closed()
@@ -978,7 +1002,7 @@ class _CallbackScopedVerifiedBundleFile:
             self._first_cleanup_error = error
         if self._cleanup_complete():
             return False
-        if self._cleanup_attempts < _BUNDLE_STREAM_CLOSE_RECOVERY_LIMIT:
+        if self._cleanup_attempts < _VERIFIED_BUNDLE_STREAM_CLOSE_RECOVERY_LIMIT:
             return True
         primary = (
             self._primary_error
@@ -997,10 +1021,28 @@ class _CallbackScopedVerifiedBundleFile:
             return
         self._prepare_cleanup()
         action = _verified_bundle_stream_close_action(self)
-        with _run_context_with_cleanup_actions(lambda: (action,)):
+        with _run_context_with_cleanup_actions((action,)):
             pass
         if self._cleanup_complete():
             _forget_verified_bundle_stream_cleanup_owner(self)
+
+
+class _CallbackScopedVerifiedBundleCleanupOwner:
+    """Retry physical stream cleanup after callback authority is revoked."""
+
+    __slots__ = ("_stream",)
+
+    def __init__(self, stream: _CallbackScopedVerifiedBundleFile) -> None:
+        self._stream = stream
+
+    @property
+    def closed(self) -> bool:
+        if _verified_bundle_stream_cleanup_owner_is_retained(self._stream):
+            return True
+        return self._stream._cleanup_complete()
+
+    def close(self) -> None:
+        self._stream._close_for_cleanup()
 
 
 _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS: list[
@@ -1030,6 +1072,17 @@ def _register_verified_bundle_stream_cleanup_owner(
             for owner in _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
         ):
             _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS.append(cleanup_owner)
+
+
+def _verified_bundle_stream_cleanup_owner_is_retained(
+    cleanup_owner: _CallbackScopedVerifiedBundleFile,
+) -> bool:
+    _synchronize_verified_bundle_stream_cleanup_process()
+    with _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_LOCK:
+        return any(
+            owner is cleanup_owner
+            for owner in _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+        )
 
 
 def _forget_verified_bundle_stream_cleanup_owner(
@@ -1081,6 +1134,7 @@ def _verified_bundle_stream_close_action(
         action=stream._close_for_cleanup,
         complete=stream._cleanup_complete,
         retry_incomplete=stream._retry_incomplete_cleanup,
+        incomplete_owner=_CallbackScopedVerifiedBundleCleanupOwner(stream),
     )
 
 
@@ -1136,17 +1190,19 @@ def consume_verified_view_bundle_stream(
     if not callable(read):
         raise StorageIntegrityError("view bundle stream cannot be read")
 
-    try:
-        archive = tempfile.TemporaryFile(mode="w+b")
-    except Exception as exc:
-        raise StorageIntegrityError(
-            "view bundle temporary copy could not be opened"
-        ) from exc
-    callback_file = _CallbackScopedVerifiedBundleFile(archive)
+    callback_file = _CallbackScopedVerifiedBundleFile()
     callback_file._prepare_cleanup()
     close_action = _verified_bundle_stream_close_action(callback_file)
-    with _run_context_with_cleanup_actions(lambda: (close_action,)):
+    with _run_context_with_cleanup_actions((close_action,)):
         try:
+            try:
+                archive = callback_file._acquire_archive(
+                    lambda: tempfile.TemporaryFile(mode="w+b")
+                )
+            except Exception as exc:
+                raise StorageIntegrityError(
+                    "view bundle temporary copy could not be opened"
+                ) from exc
             observed = hashlib.sha256()
             remaining = byte_size
             while remaining:

--- a/codenib/storage/view_bundle.py
+++ b/codenib/storage/view_bundle.py
@@ -935,6 +935,24 @@ class _CallbackScopedVerifiedBundleFile:
         try:
             self._archive.close()
         except BaseException as error:  # noqa: B036 - cleanup boundary
+            try:
+                physically_closed = self._archive_is_closed()
+            except BaseException as completion_error:  # noqa: B036 - keep first
+                _annotate_secondary_error(
+                    error,
+                    "temporary view-bundle stream close observation also failed",
+                    completion_error,
+                )
+            else:
+                if physically_closed:
+                    try:
+                        _forget_verified_bundle_stream_cleanup_owner(self)
+                    except BaseException as retention_error:  # noqa: B036
+                        _annotate_secondary_error(
+                            error,
+                            "verified view-bundle cleanup registry release also failed",
+                            retention_error,
+                        )
             if isinstance(error, (GeneratorExit, KeyboardInterrupt, SystemExit)):
                 raise
             raise StorageIntegrityError(
@@ -974,10 +992,15 @@ class _CallbackScopedVerifiedBundleFile:
     def retry_cleanup(self) -> None:
         """Retry a retained physical tempfile close after failure recovery."""
 
+        if self._cleanup_complete():
+            _forget_verified_bundle_stream_cleanup_owner(self)
+            return
         self._prepare_cleanup()
         action = _verified_bundle_stream_close_action(self)
         with _run_context_with_cleanup_actions(lambda: (action,)):
             pass
+        if self._cleanup_complete():
+            _forget_verified_bundle_stream_cleanup_owner(self)
 
 
 _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS: list[
@@ -1027,19 +1050,19 @@ def retry_retained_verified_bundle_stream_cleanup() -> None:
     _synchronize_verified_bundle_stream_cleanup_process()
     with _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_LOCK:
         owners = tuple(_RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS)
-    primary: BaseException | None = None
-    for owner in owners:
-        try:
-            owner.retry_cleanup()
-        except BaseException as error:  # noqa: B036 - keep trying later owners
-            if primary is None:
-                primary = error
-            else:
-                _annotate_secondary_error(
-                    primary,
-                    "additional retained verified stream cleanup failed",
-                    error,
-                )
+        primary: BaseException | None = None
+        for owner in owners:
+            try:
+                owner.retry_cleanup()
+            except BaseException as error:  # noqa: B036 - keep trying later owners
+                if primary is None:
+                    primary = error
+                else:
+                    _annotate_secondary_error(
+                        primary,
+                        "additional retained verified stream cleanup failed",
+                        error,
+                    )
     if primary is not None:
         raise primary
 

--- a/codenib/storage/view_bundle.py
+++ b/codenib/storage/view_bundle.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import io
 import json
 import logging
 import os
@@ -23,6 +24,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from pathlib import Path, PurePosixPath
+from threading import RLock
 from typing import Any, BinaryIO, Callable, Iterable, Iterator, Mapping, TypeVar
 
 from .._atomic_directory import (
@@ -752,6 +754,449 @@ def verify_view_bundle(
             max_metadata_bytes=max_metadata_bytes,
         )
         return record
+
+
+@dataclass(slots=True)
+class _CallbackScopedVerifiedBundleLifetime:
+    active: bool = True
+    process_id: int = dataclass_field(default_factory=os.getpid)
+
+
+class _CallbackScopedVerifiedBundleFile:
+    """Revocable callback facade over one owned anonymous temporary file.
+
+    The facade deliberately delegates operations through methods that re-check
+    its lease instead of exposing bound methods from the underlying file.  A
+    failed physical close can therefore retain the real file for an explicit
+    retry without leaving a callback-retained facade usable.
+    """
+
+    __slots__ = (
+        "_archive",
+        "_cleanup_attempts",
+        "_first_cleanup_error",
+        "_lifetime",
+        "_primary_error",
+    )
+
+    def __init__(self, archive: BinaryIO) -> None:
+        self._archive = archive
+        self._cleanup_attempts = 0
+        self._first_cleanup_error: BaseException | None = None
+        self._lifetime = _CallbackScopedVerifiedBundleLifetime()
+        self._primary_error: BaseException | None = None
+
+    @property
+    def closed(self) -> bool:
+        return (
+            self._lifetime.process_id != os.getpid()
+            or not self._lifetime.active
+            or self._archive_is_closed()
+        )
+
+    def _archive_is_closed(self) -> bool:
+        # ``closed`` belongs to the actual tempfile object and is the safe
+        # completion boundary for its arbitrary ``close`` implementation.  Do
+        # not close a captured integer fd behind a still-open Python file: a
+        # later file-object close could otherwise target a reused descriptor.
+        return self._archive.closed is True
+
+    def _cleanup_complete(self) -> bool:
+        return not self._lifetime.active and self._archive_is_closed()
+
+    def _require_active(self) -> None:
+        if self._lifetime.process_id != os.getpid() or not self._lifetime.active:
+            raise ValueError("I/O operation on closed file.")
+
+    def _invoke(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        self._require_active()
+        method = getattr(self._archive, name)
+        result = method(*args, **kwargs)
+        self._require_active()
+        return result
+
+    @staticmethod
+    def _exact_integer(value: object, *, label: str) -> int:
+        if type(value) is not int:
+            raise TypeError(f"verified view-bundle {label} must be an exact integer")
+        return value
+
+    def read(self, size: int = -1) -> bytes:
+        return self._invoke("read", self._exact_integer(size, label="read size"))
+
+    def read1(self, size: int = -1) -> bytes:
+        return self._invoke("read1", self._exact_integer(size, label="read1 size"))
+
+    def readinto(self, buffer: Any) -> int | None:
+        del buffer
+        raise io.UnsupportedOperation(
+            "verified view-bundle stream does not expose mutable read buffers"
+        )
+
+    def readinto1(self, buffer: Any) -> int | None:
+        del buffer
+        raise io.UnsupportedOperation(
+            "verified view-bundle stream does not expose mutable read buffers"
+        )
+
+    def readline(self, size: int = -1) -> bytes:
+        return self._invoke("readline", self._exact_integer(size, label="line size"))
+
+    def readlines(self, hint: int = -1) -> list[bytes]:
+        return self._invoke("readlines", self._exact_integer(hint, label="line hint"))
+
+    def write(self, data: bytes) -> int:
+        del data
+        raise io.UnsupportedOperation("verified view-bundle stream is read-only")
+
+    def writelines(self, lines: Iterable[bytes]) -> None:
+        del lines
+        raise io.UnsupportedOperation("verified view-bundle stream is read-only")
+
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        return self._invoke(
+            "seek",
+            self._exact_integer(offset, label="seek offset"),
+            self._exact_integer(whence, label="seek whence"),
+        )
+
+    def tell(self) -> int:
+        return self._invoke("tell")
+
+    def truncate(self, size: int | None = None) -> int:
+        del size
+        raise io.UnsupportedOperation("verified view-bundle stream is read-only")
+
+    def flush(self) -> None:
+        self._invoke("flush")
+
+    def fileno(self) -> int:
+        raise io.UnsupportedOperation(
+            "verified view-bundle stream does not expose a descriptor"
+        )
+
+    def isatty(self) -> bool:
+        return self._invoke("isatty")
+
+    def readable(self) -> bool:
+        return self._invoke("readable")
+
+    def writable(self) -> bool:
+        self._require_active()
+        return False
+
+    def seekable(self) -> bool:
+        return self._invoke("seekable")
+
+    def __iter__(self) -> _CallbackScopedVerifiedBundleFile:
+        self._require_active()
+        return self
+
+    def __next__(self) -> bytes:
+        return self._invoke("__next__")
+
+    def __enter__(self) -> _CallbackScopedVerifiedBundleFile:
+        self._require_active()
+        return self
+
+    def __copy__(self) -> _CallbackScopedVerifiedBundleFile:
+        return self
+
+    def __deepcopy__(self, _memo: dict[int, Any]) -> _CallbackScopedVerifiedBundleFile:
+        return self
+
+    def __reduce_ex__(self, _protocol: int) -> object:
+        raise TypeError("verified view-bundle streams cannot be serialized")
+
+    def __reduce__(self) -> object:
+        raise TypeError("verified view-bundle streams cannot be serialized")
+
+    def __getstate__(self) -> object:
+        raise TypeError("verified view-bundle stream state is private")
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if not self._lifetime.active:
+            return
+        self._close_for_cleanup()
+
+    def _close_for_cleanup(self) -> None:
+        # Revoke callback authority before entering arbitrary file-object close
+        # code.  Even a persistent close failure then leaves only this private
+        # cleanup owner with access to the real tempfile.
+        self._lifetime.active = False
+        try:
+            self._archive.close()
+        except BaseException as error:  # noqa: B036 - cleanup boundary
+            if isinstance(error, (GeneratorExit, KeyboardInterrupt, SystemExit)):
+                raise
+            raise StorageIntegrityError(
+                "temporary view-bundle stream close failed"
+            ) from error
+        if not self._archive_is_closed():
+            raise StorageIntegrityError(
+                "temporary view-bundle stream close did not complete"
+            )
+        _forget_verified_bundle_stream_cleanup_owner(self)
+
+    def _prepare_cleanup(self) -> None:
+        self._cleanup_attempts = 0
+        self._first_cleanup_error = None
+
+    def _remember_primary(self, error: BaseException) -> None:
+        if self._primary_error is None:
+            self._primary_error = error
+
+    def _retry_incomplete_cleanup(self, error: BaseException | None) -> bool:
+        self._cleanup_attempts += 1
+        if error is not None and self._first_cleanup_error is None:
+            self._first_cleanup_error = error
+        if self._cleanup_complete():
+            return False
+        if self._cleanup_attempts < _BUNDLE_STREAM_CLOSE_RECOVERY_LIMIT:
+            return True
+        primary = (
+            self._primary_error
+            if self._primary_error is not None
+            else self._first_cleanup_error
+        )
+        if primary is not None:
+            _register_verified_bundle_stream_cleanup_owner(self)
+        return False
+
+    def retry_cleanup(self) -> None:
+        """Retry a retained physical tempfile close after failure recovery."""
+
+        self._prepare_cleanup()
+        action = _verified_bundle_stream_close_action(self)
+        with _run_context_with_cleanup_actions(lambda: (action,)):
+            pass
+
+
+_RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS: list[
+    _CallbackScopedVerifiedBundleFile
+] = []
+_RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_LOCK = RLock()
+_RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_PID = os.getpid()
+
+
+def _synchronize_verified_bundle_stream_cleanup_process() -> None:
+    global _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_LOCK
+    global _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_PID
+    process_id = os.getpid()
+    if process_id == _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_PID:
+        return
+    _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_LOCK = RLock()
+    _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_PID = process_id
+
+
+def _register_verified_bundle_stream_cleanup_owner(
+    cleanup_owner: _CallbackScopedVerifiedBundleFile,
+) -> None:
+    _synchronize_verified_bundle_stream_cleanup_process()
+    with _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_LOCK:
+        if not any(
+            owner is cleanup_owner
+            for owner in _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+        ):
+            _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS.append(cleanup_owner)
+
+
+def _forget_verified_bundle_stream_cleanup_owner(
+    cleanup_owner: _CallbackScopedVerifiedBundleFile,
+) -> None:
+    _synchronize_verified_bundle_stream_cleanup_process()
+    with _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_LOCK:
+        _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS[:] = [
+            owner
+            for owner in _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+            if owner is not cleanup_owner
+        ]
+
+
+def retry_retained_verified_bundle_stream_cleanup() -> None:
+    """Retry physical closes retained after verified callback-stream failure."""
+
+    _synchronize_verified_bundle_stream_cleanup_process()
+    with _RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_LOCK:
+        owners = tuple(_RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS)
+    primary: BaseException | None = None
+    for owner in owners:
+        try:
+            owner.retry_cleanup()
+        except BaseException as error:  # noqa: B036 - keep trying later owners
+            if primary is None:
+                primary = error
+            else:
+                _annotate_secondary_error(
+                    primary,
+                    "additional retained verified stream cleanup failed",
+                    error,
+                )
+    if primary is not None:
+        raise primary
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(
+        after_in_child=_synchronize_verified_bundle_stream_cleanup_process
+    )
+
+
+def _verified_bundle_stream_close_action(
+    stream: _CallbackScopedVerifiedBundleFile,
+) -> _OrderedAction:
+    return _OrderedAction(
+        label="temporary view-bundle stream close also failed",
+        action=stream._close_for_cleanup,
+        complete=stream._cleanup_complete,
+        retry_incomplete=stream._retry_incomplete_cleanup,
+    )
+
+
+def consume_verified_view_bundle_stream(
+    source: BinaryIO,
+    operation: Callable[[BinaryIO, ViewBundleRecord], _T],
+    *,
+    expected_view_type: str,
+    expected_digest: str,
+    expected_size: int,
+    max_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+) -> _T:
+    """Authenticate one stream and synchronously consume its canonical bundle.
+
+    ``source`` remains caller-owned and is never closed here. The callback gets
+    a callback-scoped seekable facade only after the expected byte count,
+    SHA-256 identity, canonical ZIP layout, and member inventory have all been
+    verified. The facade is revoked before physical tempfile cleanup begins,
+    so a callback cannot retain working byte authority through the public stream
+    API, including when physical close needs an explicit retained retry.
+    """
+
+    if (
+        type(expected_view_type) is not str
+        or type(expected_digest) is not str
+        or type(expected_size) is not int
+        or type(max_files) is not int
+        or type(max_bytes) is not int
+        or type(max_metadata_bytes) is not int
+    ):
+        raise StorageValidationError(
+            "view bundle stream identity and limits must use exact scalar types"
+        )
+    _validate_limits(max_files, max_bytes, max_metadata_bytes)
+    view_type = _validate_view_type(expected_view_type)
+    digest = normalize_digest(expected_digest)
+    byte_size = _validate_expected_size(expected_size)
+    assert byte_size is not None
+    validate_view_bundle_physical_size(
+        byte_size,
+        max_files=max_files,
+        max_bytes=max_bytes,
+        max_metadata_bytes=max_metadata_bytes,
+    )
+    if not callable(operation):
+        raise TypeError("view bundle stream operation must be callable")
+    try:
+        read = source.read
+    except Exception as exc:
+        raise StorageIntegrityError("view bundle stream cannot be read") from exc
+    if not callable(read):
+        raise StorageIntegrityError("view bundle stream cannot be read")
+
+    try:
+        archive = tempfile.TemporaryFile(mode="w+b")
+    except Exception as exc:
+        raise StorageIntegrityError(
+            "view bundle temporary copy could not be opened"
+        ) from exc
+    callback_file = _CallbackScopedVerifiedBundleFile(archive)
+    callback_file._prepare_cleanup()
+    close_action = _verified_bundle_stream_close_action(callback_file)
+    with _run_context_with_cleanup_actions(lambda: (close_action,)):
+        try:
+            observed = hashlib.sha256()
+            remaining = byte_size
+            while remaining:
+                try:
+                    block = read(min(_COPY_CHUNK_BYTES, remaining))
+                except BaseException as error:  # noqa: B036 - stream boundary
+                    if isinstance(
+                        error,
+                        (GeneratorExit, KeyboardInterrupt, SystemExit),
+                    ):
+                        raise
+                    raise StorageIntegrityError(
+                        "view bundle stream read failed"
+                    ) from error
+                if type(block) is not bytes or not block:
+                    raise StorageIntegrityError("view bundle stream was truncated")
+                if len(block) > remaining:
+                    raise StorageIntegrityError(
+                        "view bundle stream exceeded its receipt"
+                    )
+                observed.update(block)
+                try:
+                    written = archive.write(block)
+                except Exception as exc:
+                    raise StorageIntegrityError(
+                        "view bundle temporary copy write failed"
+                    ) from exc
+                if written != len(block):
+                    raise StorageIntegrityError(
+                        "view bundle temporary copy was truncated"
+                    )
+                remaining -= len(block)
+            try:
+                extra = read(1)
+            except BaseException as error:  # noqa: B036 - stream boundary
+                if isinstance(
+                    error,
+                    (GeneratorExit, KeyboardInterrupt, SystemExit),
+                ):
+                    raise
+                raise StorageIntegrityError("view bundle stream read failed") from error
+            if type(extra) is not bytes or extra:
+                raise StorageIntegrityError("view bundle stream exceeded its receipt")
+            if observed.hexdigest() != digest:
+                raise StorageIntegrityError("view bundle stream digest does not match")
+            try:
+                archive.flush()
+                archive.seek(0)
+                record, _manifest = _verify_archive_handle(
+                    archive,
+                    Path("<authenticated-view-bundle-stream>"),
+                    expected_view_type=view_type,
+                    archive_digest=digest,
+                    archive_size=byte_size,
+                    max_files=max_files,
+                    max_bytes=max_bytes,
+                    max_metadata_bytes=max_metadata_bytes,
+                )
+                archive.seek(0)
+            except StorageIntegrityError:
+                raise
+            except StorageValidationError as exc:
+                raise StorageIntegrityError(
+                    "view bundle stream is not a canonical archive"
+                ) from exc
+            except Exception as exc:
+                raise StorageIntegrityError(
+                    "view bundle temporary verification failed"
+                ) from exc
+            return operation(callback_file, record)
+        except BaseException as error:  # noqa: B036 - preserve first primary
+            callback_file._remember_primary(error)
+            raise
 
 
 def materialize_view_bundle(
@@ -4337,8 +4782,10 @@ __all__ = [
     "ViewBundleRecord",
     "build_view_bundle",
     "consume_planned_view_bundle",
+    "consume_verified_view_bundle_stream",
     "materialize_view_bundle",
     "plan_view_bundle_reader",
+    "retry_retained_verified_bundle_stream_cleanup",
     "validate_view_bundle_physical_size",
     "verify_view_bundle",
 ]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -238,8 +238,8 @@ closed in staging, binding, BM25 reads, and MCP reads.  The shared credential
 classifier lives outside both artifacts and storage so the artifact layer does
 not depend on the catalog implementation.  These gates close the current
 portable context publication surface; they are a prerequisite for, but do not
-complete, the remaining legacy manifest import/export adapter or a future
-streaming payload revision.
+complete, retained filesystem materialization, production compiler/runtime
+wiring, or a future streaming payload revision.
 
 Local filesystem publication now has an explicit strict-authority gate. Regular
 files are written through caller-owned staged descriptors, installed with
@@ -453,9 +453,9 @@ publication cannot move the old ref. If cancellation lands after SQLite commits
 but before the caller observes the result, the direct M1 call is at-least-once:
 an exact retry idempotently resolves to the already-published snapshot without
 advancing the ref again. This is the direct M1 bootstrap path, not the M2 fenced
-job-success transaction. Retained
-materialization/export, production compiler/runtime wiring, and a production
-GC implementation and policy remain outstanding, so M1 remains in progress.
+job-success transaction. Retained materialization, production compiler/runtime
+wiring, and a production GC implementation and policy remain outstanding, so
+M1 remains in progress.
 
 The first read-only retained `RepoManifest` exporter now closes the data-only
 round trip without introducing path authority. It accepts the additive
@@ -470,9 +470,11 @@ are checked source-free while native vector indexes remain inert. Unselected
 entries are omitted from the emitted manifest, unknown capability extensions
 are preserved, and the built-in sparse/dense/hybrid/symbol capabilities are
 recomputed from the retained selection. A final receipt sweep precedes return
-of canonical `RepoManifest` v1.1 bytes and a point-in-time observation receipt.
-That receipt is neither a GC pin nor a materialization/native-load authority;
-filesystem output and runtime activation remain separate future boundaries.
+of canonical `RepoManifest` v1.1 bytes and a point-in-time observation receipt
+that carries the attested namespace ID, canonical repository key, and derived
+repository ID. It is neither a GC pin nor a materialization/native-load
+authority; filesystem output and runtime activation remain separate future
+boundaries.
 
 Schema v2 now adds
 canonical idempotent job requests, immutable

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -393,8 +393,9 @@ and Git commit text remains display provenance rather than source authority.
 Planning performs no source or artifact reads, native parsing, CAS/catalog
 operation, receipt minting, or ref publication. Execution is a separate
 authority-bearing API, so inspecting or serializing a plan cannot publish it.
-Equivalent v1.1 export and runtime wiring remain outstanding, so M1 and M2
-remain in progress.
+The retained exporter described below now supplies equivalent canonical v1.1
+bytes. Retained filesystem materialization and production runtime wiring remain
+outstanding, so M1 and M2 remain in progress.
 
 The retained-import foundation now also exposes schema-v4 compound-generation
 identity as one backend-neutral model rule, including the canonical member
@@ -456,6 +457,23 @@ job-success transaction. Retained
 materialization/export, production compiler/runtime wiring, and a production
 GC implementation and policy remain outstanding, so M1 remains in progress.
 
+The first read-only retained `RepoManifest` exporter now closes the data-only
+round trip without introducing path authority. It accepts the additive
+`RetainedSnapshotCatalog` capability plus a receipt-verifying object store,
+either resolves one ref exactly once or reads one explicit immutable snapshot,
+and rebuilds the complete namespace, repository, source, profile, generation,
+member, and snapshot identity closure before object access. It authenticates
+the internal v2 projection, re-plans the complete portable manifest and its
+selection, cross-binds every schema-v4 dependency envelope, and verifies each
+canonical bundle plus every per-file receipt. BM25 and vector payload semantics
+are checked source-free while native vector indexes remain inert. Unselected
+entries are omitted from the emitted manifest, unknown capability extensions
+are preserved, and the built-in sparse/dense/hybrid/symbol capabilities are
+recomputed from the retained selection. A final receipt sweep precedes return
+of canonical `RepoManifest` v1.1 bytes and a point-in-time observation receipt.
+That receipt is neither a GC pin nor a materialization/native-load authority;
+filesystem output and runtime activation remain separate future boundaries.
+
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced
@@ -463,9 +481,9 @@ per-ref leases.  Catalog reads revalidate the normalized view rows against the
 canonical request; the M2 publication transaction must repeat that gate before
 associating outputs.  An explicit acquire may atomically retire an expired
 holder while taking over its slot; this slice adds no background reaper and is
-not wired to the compiler or Web workers. Retained equivalent export and
-production runtime wiring remain the outstanding M1 deliverables; fenced job
-publication remains M2 work.
+not wired to the compiler or Web workers. Retained materialization and
+production compiler/runtime wiring remain the outstanding M1 deliverables;
+fenced job publication remains M2 work.
 
 The shared compiler-cache lock is a cooperative serialization boundary for
 compiler and importer processes using a cache namespace private to one OS

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -799,7 +799,7 @@ def test_portable_documents_contract_has_a_fixed_nonconfigurable_cap(
         view_config={},
     )
     monkeypatch.setattr(
-        "codenib.artifacts.portable_views._MAX_DOCUMENTS_JSON_BYTES",
+        "codenib.artifacts.portable_views.MAX_PORTABLE_DOCUMENTS_JSON_BYTES",
         1,
     )
 

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -619,6 +619,53 @@ def test_portable_bm25_requires_complete_file_fingerprints(tmp_path: Path) -> No
             )
 
 
+def test_portable_bm25_rejects_metadata_max_k_mismatched_with_view_config(
+    tmp_path: Path,
+) -> None:
+    repo, bm25 = _bm25_view(
+        tmp_path,
+        documents=[
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": "sample.py"},
+            }
+        ],
+        metadata={"project_root": "source", "max_k": 99, "language": "english"},
+    )
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+
+    with pytest.raises(ValueError, match="max_k does not match"):
+        validate_portable_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={**adjustments, "max_k": 17},
+        )
+
+
+def test_vector_persistence_semantics_rejects_nonexact_json_without_traversal() -> None:
+    class TrapDict(dict[str, object]):
+        calls = 0
+
+        def items(self):  # type: ignore[no-untyped-def]
+            type(self).calls += 1
+            raise AssertionError("hostile mapping was traversed")
+
+    for config in (TrapDict(), {"nested": TrapDict()}):
+        TrapDict.calls = 0
+        with pytest.raises(ValueError, match="bounded exact JSON objects"):
+            portable_views_module.validate_portable_vector_persistence_semantics(
+                config,
+                {},
+            )
+        assert TrapDict.calls == 0
+
+
 def test_portable_bm25_rejects_documents_replaced_after_authentication(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/test/compiler/test_manifest_export.py
+++ b/test/compiler/test_manifest_export.py
@@ -1,0 +1,715 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import codenib.compiler.manifest_export as manifest_export_module
+from codenib._captured_directory import PublishedWorkspaceReceiptOwner
+from codenib.artifacts import stage_context_artifact_strict
+from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
+from codenib.compiler.manifest import RepoManifest
+from codenib.compiler.manifest_export import (
+    RepoManifestExportReceipt,
+    RepoManifestExportResult,
+    RepoManifestViewExportReceipt,
+    export_retained_repo_manifest_ref,
+    export_retained_repo_manifest_snapshot,
+)
+from codenib.compiler.manifest_import import (
+    REPO_MANIFEST_PROJECTION_VIEW,
+    import_retained_repo_manifest,
+)
+from codenib.compiler.manifest_storage import (
+    plan_repo_manifest_import,
+    plan_repo_manifest_import_bytes,
+)
+from codenib.compiler.retained_snapshot import attest_detached_retained_snapshot
+from codenib.source_fingerprint import capture_repository_source
+from codenib.storage import (
+    RETAINED_IMPORT_CATALOG_CONTRACT,
+    ArtifactMember,
+    BlobInfo,
+    LocalCAS,
+    PublishConflict,
+    SQLiteCatalog,
+    StorageIntegrityError,
+    StorageValidationError,
+    build_view_bundle,
+)
+
+from .test_manifest_import import (
+    _COMMIT,
+    _context_fixture,
+    _ContextFixture,
+    _entry,
+    _json_bytes,
+    _publish_generation,
+    _TestWorkspaceProvider,
+    _vector_files,
+)
+
+_REPOSITORY_KEY = "owner/repo"
+
+
+def _exception_notes(error: BaseException) -> tuple[str, ...]:
+    return (
+        *tuple(getattr(error, "__notes__", ())),
+        *tuple(getattr(error, "_codenib_cleanup_notes", ())),
+    )
+
+
+def _vector_context_fixture(
+    root: Path,
+    *,
+    document_count: dict[str, int] | None,
+) -> _ContextFixture:
+    source_text = "VALUE = 1\n"
+    repository = root / "repo"
+    repository.mkdir(parents=True)
+    (repository / "sample.py").write_text(source_text, encoding="utf-8")
+    repository_source = capture_repository_source(repository)
+    generation_owner = _publish_generation(
+        root / "state" / "vector",
+        _vector_files(source_text),
+    )
+    context_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        entry = _entry(
+            "vector",
+            source_fingerprint=repository_source.fingerprint,
+        )
+        if document_count is None:
+            entry.config.pop("document_count", None)
+            entry.metadata.pop("document_count", None)
+        else:
+            entry.config["document_count"] = dict(document_count)
+            entry.metadata["document_count"] = dict(document_count)
+        manifest = RepoManifest(
+            repo_path=str(repository),
+            commit=_COMMIT,
+            last_indexed_commit=_COMMIT,
+            source_fingerprint=repository_source.fingerprint,
+            last_indexed_source_fingerprint=repository_source.fingerprint,
+            languages=["python"],
+            file_count=repository_source.file_count,
+            indexes={"vector": entry},
+            compiled_at="2026-01-01T00:00:00Z",
+            compiled_at_epoch=1.0,
+        )
+        manifest.derive_capabilities()
+        context = root / "published" / "context"
+        stage_context_artifact_strict(
+            context,
+            manifest=manifest,
+            repository=_REPOSITORY_KEY,
+            repository_source=repository_source,
+            view_generations={"vector": generation_owner},
+            workspace_provider=_TestWorkspaceProvider(),
+            output_receipt_owner=context_owner,
+            environ={},
+        )
+        return _ContextFixture(
+            repository=repository,
+            repository_source=repository_source,
+            context=context,
+            context_owner=context_owner,
+            generation_owners=(generation_owner,),
+        )
+    except BaseException:
+        if context_owner.active:
+            context_owner.close()
+        generation_owner.close()
+        repository_source.close()
+        raise
+
+
+@contextmanager
+def _retained_fixture(
+    root: Path,
+    views: tuple[str, ...] = ("bm25", "vector"),
+    *,
+    selected_views: tuple[str, ...] | None = None,
+    source_text: str = "VALUE = 1\n",
+    ref_name: str = "main",
+) -> Iterator[tuple[_ContextFixture, Any, LocalCAS, SQLiteCatalog]]:
+    fixture = _context_fixture(root / "fixture", views, source_text=source_text)
+    plan = fixture.plan(selected_views)
+    object_store = LocalCAS(root / "cas")
+    catalog = SQLiteCatalog(root / "catalog.sqlite")
+    try:
+        imported = import_retained_repo_manifest(
+            plan,
+            artifact_owner=fixture.context_owner,
+            repository_source=fixture.repository_source,
+            repository_key=_REPOSITORY_KEY,
+            catalog=catalog,
+            object_store=object_store,
+            ref_name=ref_name,
+            environ={},
+        )
+        yield fixture, imported, object_store, catalog
+    finally:
+        catalog.close()
+        fixture.close()
+
+
+def test_real_import_round_trips_ref_and_snapshot_as_canonical_v11_bytes(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(tmp_path / "roundtrip") as (
+        fixture,
+        imported,
+        object_store,
+        catalog,
+    ):
+        expected = fixture.plan().canonical_manifest_bytes
+        ref_export = export_retained_repo_manifest_ref(
+            imported.repository_id,
+            catalog=catalog,
+            object_store=object_store,
+            expected_generation=1,
+        )
+
+        assert isinstance(ref_export, RepoManifestExportResult)
+        assert ref_export.canonical_manifest_bytes == expected
+        assert ref_export.receipt.snapshot_id == imported.snapshot_id
+        assert ref_export.receipt.ref_name == "main"
+        assert ref_export.receipt.ref_generation == 1
+        assert (
+            ref_export.receipt.manifest_digest == hashlib.sha256(expected).hexdigest()
+        )
+        assert ref_export.receipt.manifest_byte_size == len(expected)
+        assert tuple(
+            receipt.view_type for receipt in ref_export.receipt.view_receipts
+        ) == (
+            "bm25",
+            "vector",
+        )
+        assert all(
+            receipt.member_receipt_items for receipt in ref_export.receipt.view_receipts
+        )
+
+        replanned = plan_repo_manifest_import_bytes(ref_export.canonical_manifest_bytes)
+        assert replanned.canonical_manifest_bytes == expected
+        assert replanned.selection.selected_views == ("bm25", "vector")
+
+        snapshot_export = export_retained_repo_manifest_snapshot(
+            imported.repository_id,
+            imported.snapshot_id,
+            catalog=catalog,
+            object_store=object_store,
+        )
+        assert snapshot_export.canonical_manifest_bytes == expected
+        assert snapshot_export.receipt.ref_name is None
+        assert snapshot_export.receipt.ref_generation is None
+        assert snapshot_export.receipt.ref_updated_at is None
+        assert snapshot_export.receipt.snapshot_published_at == (
+            ref_export.receipt.snapshot_published_at
+        )
+
+
+def test_subset_export_removes_unretained_view_and_keeps_capability_extensions(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "subset",
+        selected_views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        exported = export_retained_repo_manifest_snapshot(
+            imported.repository_id,
+            imported.snapshot_id,
+            catalog=catalog,
+            object_store=object_store,
+        )
+
+        manifest = json.loads(exported.canonical_manifest_bytes)
+        assert set(manifest["indexes"]) == {"bm25"}
+        assert manifest["capabilities"] == {
+            "dense_search": False,
+            "future_query": True,
+            "hybrid_search": False,
+            "sparse_search": True,
+            "symbol_navigation": False,
+        }
+        assert tuple(
+            receipt.view_type for receipt in exported.receipt.view_receipts
+        ) == ("bm25",)
+        assert exported.receipt.skipped_items == ()
+
+
+def test_export_receipts_close_projection_bundle_and_member_inventory(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(tmp_path / "receipt-closure") as (
+        _fixture,
+        imported,
+        object_store,
+        catalog,
+    ):
+        exported = export_retained_repo_manifest_snapshot(
+            imported.repository_id,
+            imported.snapshot_id,
+            catalog=catalog,
+            object_store=object_store,
+        )
+        summary = catalog.get_manifest_summary(imported.snapshot_id)
+        projection = summary["views"][REPO_MANIFEST_PROJECTION_VIEW]
+        projection_payload = json.loads(
+            object_store.read_bytes(projection["object"]["digest"])
+        )
+
+        assert exported.receipt.projection_generation_id == (
+            projection["view_generation_id"]
+        )
+        assert exported.receipt.projection_receipt == BlobInfo(
+            digest=projection["object"]["digest"],
+            byte_size=projection["object"]["byte_size"],
+            storage_key=projection["object"]["storage_key"],
+        )
+        for view_receipt in exported.receipt.view_receipts:
+            view = summary["views"][view_receipt.view_type]
+            assert view_receipt.view_generation_id == view["view_generation_id"]
+            assert view_receipt.bundle_receipt == BlobInfo(
+                digest=view["object"]["digest"],
+                byte_size=view["object"]["byte_size"],
+                storage_key=view["object"]["storage_key"],
+            )
+            observed_members = dict(view_receipt.member_receipt_items)
+            expected_members = {
+                member["path"]: member["object"]
+                for member in projection_payload["views"][view_receipt.view_type][
+                    "members"
+                ]
+            }
+            assert tuple(observed_members) == tuple(sorted(expected_members))
+            assert {receipt.digest for receipt in observed_members.values()} == {
+                member["digest"] for member in view["member_objects"]
+            }
+            for path, receipt in observed_members.items():
+                assert receipt == BlobInfo(
+                    digest=expected_members[path]["digest"],
+                    byte_size=expected_members[path]["byte_size"],
+                    storage_key=next(
+                        member["storage_key"]
+                        for member in view["member_objects"]
+                        if member["digest"] == expected_members[path]["digest"]
+                    ),
+                )
+
+
+def test_ref_export_resolves_once_and_stays_on_resolved_snapshot_when_ref_moves(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "moving-ref"
+    with _retained_fixture(root / "first", views=("bm25",)) as (
+        first_fixture,
+        first,
+        first_store,
+        first_catalog,
+    ):
+        second_fixture = _context_fixture(
+            root / "second-fixture",
+            ("bm25",),
+            source_text="VALUE = 2\n",
+        )
+        try:
+            second = import_retained_repo_manifest(
+                second_fixture.plan(),
+                artifact_owner=second_fixture.context_owner,
+                repository_source=second_fixture.repository_source,
+                repository_key=_REPOSITORY_KEY,
+                catalog=first_catalog,
+                object_store=first_store,
+                ref_name="next",
+                environ={},
+            )
+
+            class MovingCatalog:
+                calls = 0
+
+                @staticmethod
+                def retained_import_contract() -> str:
+                    return RETAINED_IMPORT_CATALOG_CONTRACT
+
+                def resolve_ref(
+                    self,
+                    repository_id: str,
+                    ref_name: str = "main",
+                ) -> dict[str, Any]:
+                    self.calls += 1
+                    resolved = first_catalog.resolve_ref(repository_id, ref_name)
+                    first_catalog.publish_snapshot(
+                        second.repository_id,
+                        second.source_revision_id,
+                        tuple(dict(second.view_generation_items).values()),
+                        ref_name="main",
+                        expected_generation=1,
+                    )
+                    return resolved
+
+                def get_manifest_summary(self, _snapshot_id: str) -> dict[str, Any]:
+                    raise AssertionError("resolved ref summary must not be reread")
+
+            moving_catalog = MovingCatalog()
+            exported = export_retained_repo_manifest_ref(
+                first.repository_id,
+                catalog=moving_catalog,
+                object_store=first_store,
+            )
+
+            assert moving_catalog.calls == 1
+            assert exported.receipt.snapshot_id == first.snapshot_id
+            assert exported.canonical_manifest_bytes == (
+                first_fixture.plan().canonical_manifest_bytes
+            )
+            assert first_catalog.resolve_ref(first.repository_id)["snapshot_id"] == (
+                second.snapshot_id
+            )
+        finally:
+            second_fixture.close()
+
+
+def test_expected_ref_generation_conflicts_before_snapshot_or_object_access() -> None:
+    repository_id = "repo_" + "0" * 64
+
+    class ConflictCatalog:
+        @staticmethod
+        def retained_import_contract() -> str:
+            return RETAINED_IMPORT_CATALOG_CONTRACT
+
+        @staticmethod
+        def resolve_ref(
+            observed_repository_id: str,
+            ref_name: str = "main",
+        ) -> dict[str, Any]:
+            return {
+                "repository_id": observed_repository_id,
+                "ref_name": ref_name,
+                "snapshot_id": "snapshot_unread",
+                "generation": 2,
+                "updated_at": "2026-08-10T00:00:00+00:00",
+                "manifest": object(),
+            }
+
+        @staticmethod
+        def get_manifest_summary(_snapshot_id: str) -> dict[str, Any]:
+            raise AssertionError("generation conflict reread a snapshot")
+
+    class ForbiddenStore:
+        @staticmethod
+        def _forbidden() -> None:
+            raise AssertionError("generation conflict reached object storage")
+
+        def put_bytes(self, _data: bytes) -> BlobInfo:
+            self._forbidden()
+
+        def put_file(self, _source: str | Path) -> BlobInfo:
+            self._forbidden()
+
+        def has(self, _digest: str) -> bool:
+            self._forbidden()
+
+        def open(self, _digest: str) -> Any:
+            self._forbidden()
+
+        def read_bytes(self, _digest: str) -> bytes:
+            self._forbidden()
+
+        def verify(self, _digest: str) -> BlobInfo:
+            self._forbidden()
+
+        def materialize(self, _digest: str, _destination: str | Path) -> Path:
+            self._forbidden()
+
+        def verify_receipt(self, _expected: BlobInfo) -> BlobInfo:
+            self._forbidden()
+
+    with pytest.raises(PublishConflict, match="expected_generation"):
+        export_retained_repo_manifest_ref(
+            repository_id,
+            catalog=ConflictCatalog(),
+            object_store=ForbiddenStore(),
+            expected_generation=1,
+        )
+
+
+def test_zip_json_entry_close_failure_preserves_read_cancellation() -> None:
+    primary = KeyboardInterrupt("cancelled while reading ZIP entry")
+
+    class FailingEntry:
+        @staticmethod
+        def read(_limit: int) -> bytes:
+            raise primary
+
+        @staticmethod
+        def close() -> None:
+            raise OSError("ZIP entry close failed")
+
+    class Archive:
+        @staticmethod
+        def open(_path: str, *, mode: str) -> FailingEntry:
+            assert mode == "r"
+            return FailingEntry()
+
+    member = ArtifactMember(
+        path="config.json",
+        digest="0" * 64,
+        byte_size=1,
+    )
+
+    with pytest.raises(BaseException) as caught:
+        manifest_export_module._read_zip_json(
+            Archive(),  # type: ignore[arg-type]
+            {member.path: member},
+            member.path,
+            label="snapshot test config",
+        )
+
+    assert caught.value is primary
+    assert any(
+        "snapshot test config close also failed" in note
+        and "ZIP entry close failed" in note
+        for note in _exception_notes(primary)
+    )
+
+
+@pytest.mark.parametrize(
+    ("metadata", "documents"),
+    (
+        (
+            {
+                "project_root": "../../outside",
+                "max_k": 17,
+                "language": "english",
+            },
+            [
+                {
+                    "page_content": "VALUE = 1",
+                    "metadata": {"file": "sample.py", "node_id": "sample.VALUE"},
+                }
+            ],
+        ),
+        (
+            {"project_root": "source", "max_k": 17, "language": "english"},
+            [
+                {
+                    "page_content": "VALUE = 1",
+                    "metadata": {"file": "../escape.py", "node_id": "escape"},
+                }
+            ],
+        ),
+    ),
+    ids=("metadata-conflict", "document-traversal"),
+)
+def test_coherently_reclosed_bm25_bundle_rejects_bad_portable_semantics(
+    tmp_path: Path,
+    metadata: dict[str, object],
+    documents: list[dict[str, object]],
+) -> None:
+    fixture = _context_fixture(tmp_path / "fixture", ("bm25",))
+    try:
+        view_root = tmp_path / "malicious-bm25"
+        view_root.mkdir()
+        (view_root / "bm25_metadata.json").write_bytes(_json_bytes(metadata))
+        (view_root / "documents.json").write_bytes(_json_bytes(documents))
+
+        manifest = copy.deepcopy(fixture.plan().manifest)
+        fingerprints = bm25_artifact_file_fingerprints(view_root)
+        entry = manifest.indexes["bm25"]
+        entry.config["artifact_file_fingerprints"] = copy.deepcopy(fingerprints)
+        entry.metadata["artifact_file_fingerprints"] = copy.deepcopy(fingerprints)
+        plan = plan_repo_manifest_import(manifest, views=("bm25",))
+        bundle = build_view_bundle(
+            view_root,
+            tmp_path / "malicious-bm25.zip",
+            view_type="bm25",
+        )
+        projected = manifest_export_module._ProjectedView(
+            intent=plan.views[0],
+            catalog_view=None,  # type: ignore[arg-type]
+            members=bundle.members,
+            member_receipt_items=(),
+        )
+
+        with bundle.path.open("rb") as archive_handle:
+            with pytest.raises(StorageIntegrityError):
+                manifest_export_module._require_bundle_semantics(
+                    archive_handle,
+                    projected,
+                )
+    finally:
+        fixture.close()
+
+
+def test_real_vector_import_and_export_allow_missing_document_count(
+    tmp_path: Path,
+) -> None:
+    fixture = _vector_context_fixture(
+        tmp_path / "missing-vector-count",
+        document_count=None,
+    )
+    object_store = LocalCAS(tmp_path / "cas")
+    catalog = SQLiteCatalog(tmp_path / "catalog.sqlite")
+    try:
+        plan = fixture.plan()
+        assert "document_count" not in plan.manifest.indexes["vector"].config
+        assert "document_count" not in plan.manifest.indexes["vector"].metadata
+        imported = import_retained_repo_manifest(
+            plan,
+            artifact_owner=fixture.context_owner,
+            repository_source=fixture.repository_source,
+            repository_key=_REPOSITORY_KEY,
+            catalog=catalog,
+            object_store=object_store,
+            environ={},
+        )
+
+        exported = export_retained_repo_manifest_snapshot(
+            imported.repository_id,
+            imported.snapshot_id,
+            catalog=catalog,
+            object_store=object_store,
+        )
+
+        exported_manifest = json.loads(exported.canonical_manifest_bytes)
+        assert "document_count" not in exported_manifest["indexes"]["vector"]["config"]
+        assert exported.receipt.views == ("vector",)
+    finally:
+        catalog.close()
+        fixture.close()
+
+
+def test_vector_export_semantics_reject_present_mismatched_document_count(
+    tmp_path: Path,
+) -> None:
+    fixture = _vector_context_fixture(
+        tmp_path / "mismatched-vector-count",
+        document_count={"l2": 1},
+    )
+    try:
+        manifest = copy.deepcopy(fixture.plan().manifest)
+        entry = manifest.indexes["vector"]
+        entry.config["document_count"] = {"l2": 2}
+        entry.metadata["document_count"] = {"l2": 2}
+        plan = plan_repo_manifest_import(manifest, views=("vector",))
+        bundle = build_view_bundle(
+            fixture.context / "views" / "vector",
+            tmp_path / "mismatched-vector-count.zip",
+            view_type="vector",
+        )
+        projected = manifest_export_module._ProjectedView(
+            intent=plan.views[0],
+            catalog_view=None,  # type: ignore[arg-type]
+            members=bundle.members,
+            member_receipt_items=(),
+        )
+
+        with bundle.path.open("rb") as archive_handle:
+            with pytest.raises(StorageIntegrityError, match="semantic inventory"):
+                manifest_export_module._require_bundle_semantics(
+                    archive_handle,
+                    projected,
+                )
+    finally:
+        fixture.close()
+
+
+def test_projection_member_object_envelope_conflict_is_rejected(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(tmp_path / "member-envelope", views=("bm25",)) as (
+        _fixture,
+        imported,
+        object_store,
+        catalog,
+    ):
+        summary = catalog.get_manifest_summary(imported.snapshot_id)
+        retained = attest_detached_retained_snapshot(
+            summary,
+            label="test retained snapshot",
+            expected_repository_id=imported.repository_id,
+            expected_snapshot_id=imported.snapshot_id,
+        )
+        projection_record = summary["views"][REPO_MANIFEST_PROJECTION_VIEW]["object"]
+        projection = json.loads(object_store.read_bytes(projection_record["digest"]))
+        projection["views"]["bm25"]["members"][0]["object"][
+            "media_type"
+        ] = "application/json"
+
+        with pytest.raises(StorageIntegrityError, match="identity is inconsistent"):
+            manifest_export_module._validate_projection(
+                projection,
+                retained=retained,
+                max_manifest_bytes=manifest_export_module.DEFAULT_MAX_MANIFEST_BYTES,
+                max_bundle_files=manifest_export_module.DEFAULT_MAX_BUNDLE_FILES,
+            )
+
+
+def _receipt_fixture() -> tuple[BlobInfo, RepoManifestViewExportReceipt]:
+    blob = BlobInfo(
+        digest="0" * 64,
+        byte_size=1,
+        storage_key="objects/00/receipt",
+    )
+    view = RepoManifestViewExportReceipt(
+        view_type="bm25",
+        view_generation_id="view_generation",
+        bundle_receipt=blob,
+        member_receipt_items=(("documents.json", blob),),
+    )
+    return blob, view
+
+
+@pytest.mark.parametrize("path", ("../escape", "/absolute"))
+def test_view_export_receipt_rejects_noncanonical_member_paths(path: str) -> None:
+    blob, _view = _receipt_fixture()
+
+    with pytest.raises(StorageValidationError, match="path is not canonical"):
+        RepoManifestViewExportReceipt(
+            view_type="bm25",
+            view_generation_id="view_generation",
+            bundle_receipt=blob,
+            member_receipt_items=((path, blob),),
+        )
+
+
+@pytest.mark.parametrize(
+    "skipped_items",
+    (
+        (("vector", "not retained"), ("vector", "not retained")),
+        (("bm25", "not retained"),),
+    ),
+    ids=("duplicate", "overlaps-exported-view"),
+)
+def test_export_receipt_rejects_noncanonical_skipped_view_closure(
+    skipped_items: tuple[tuple[str, str], ...],
+) -> None:
+    blob, view = _receipt_fixture()
+
+    with pytest.raises(StorageValidationError, match="not canonical"):
+        RepoManifestExportReceipt(
+            repository_id="repository",
+            source_revision_id="source_revision",
+            snapshot_id="snapshot",
+            snapshot_published_at="2026-08-10T00:00:00+00:00",
+            ref_name=None,
+            ref_generation=None,
+            ref_updated_at=None,
+            manifest_digest="1" * 64,
+            manifest_byte_size=1,
+            projection_generation_id="projection_generation",
+            projection_receipt=blob,
+            view_receipts=(view,),
+            skipped_items=skipped_items,
+        )

--- a/test/compiler/test_manifest_export.py
+++ b/test/compiler/test_manifest_export.py
@@ -5,8 +5,10 @@
 from __future__ import annotations
 
 import copy
+import dis
 import hashlib
 import json
+import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -17,6 +19,10 @@ import pytest
 import codenib.compiler.manifest_export as manifest_export_module
 from codenib._captured_directory import PublishedWorkspaceReceiptOwner
 from codenib.artifacts import stage_context_artifact_strict
+from codenib.artifacts.portable_views import (
+    MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+    MAX_PORTABLE_FAISS_INDEX_BYTES,
+)
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import RepoManifest
 from codenib.compiler.manifest_export import (
@@ -41,7 +47,10 @@ from codenib.storage import (
     ArtifactMember,
     BlobInfo,
     LocalCAS,
+    NamespaceIdentity,
+    ObjectRecord,
     PublishConflict,
+    RepositoryIdentity,
     SQLiteCatalog,
     StorageIntegrityError,
     StorageValidationError,
@@ -67,6 +76,123 @@ def _exception_notes(error: BaseException) -> tuple[str, ...]:
         *tuple(getattr(error, "__notes__", ())),
         *tuple(getattr(error, "_codenib_cleanup_notes", ())),
     )
+
+
+def _interrupt_after_owned_acquire(
+    callback: Any,
+    *,
+    error: BaseException,
+) -> None:
+    function = manifest_export_module._CloseableResourceOwner.acquire
+    code = function.__code__
+    instructions = tuple(dis.get_instructions(function))
+    store_indexes = {
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_ATTR" and instruction.argval == "_resource"
+    }
+    opcode_offsets_after_store = {
+        instructions[index + 1].offset for index in store_indexes
+    }
+    store_offsets = {instructions[index].offset for index in store_indexes}
+    line_offsets_after_store = {
+        instruction.offset
+        for instruction in instructions
+        if instruction.starts_line is not None
+        and any(instruction.offset > store_offset for store_offset in store_offsets)
+    }
+    assert len(store_indexes) == 1
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: Any, event: str, _arg: object) -> Any:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is code
+            and (
+                (event == "opcode" and frame.f_lasti in opcode_offsets_after_store)
+                or (event == "line" and frame.f_lasti in line_offsets_after_store)
+            )
+            and frame.f_locals["self"]._resource is not manifest_export_module._MISSING
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, "failed to interrupt after owned resource result store"
+
+
+def _interrupt_after_owned_operation(
+    callback: Any,
+    *,
+    error: BaseException,
+) -> None:
+    function = manifest_export_module._run_with_owned_close
+    code = function.__code__
+    instructions = tuple(dis.get_instructions(function))
+    store_indexes = {
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_FAST"
+        and instruction.argval == "operation_succeeded"
+        and instructions[index - 1].opname == "LOAD_CONST"
+        and instructions[index - 1].argval is True
+    }
+    opcode_offsets_after_store = {
+        instructions[index + 1].offset for index in store_indexes
+    }
+    store_offsets = {instructions[index].offset for index in store_indexes}
+    line_offsets_after_store = {
+        instruction.offset
+        for instruction in instructions
+        if instruction.starts_line is not None
+        and any(instruction.offset > store_offset for store_offset in store_offsets)
+    }
+    assert len(store_indexes) == 1
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: Any, event: str, _arg: object) -> Any:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is code
+            and (
+                (event == "opcode" and frame.f_lasti in opcode_offsets_after_store)
+                or (event == "line" and frame.f_lasti in line_offsets_after_store)
+            )
+            and frame.f_locals["operation_succeeded"] is True
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, "failed to interrupt after owned operation result store"
+
+
+def _publication_cleanup_owners(error: BaseException) -> tuple[Any, ...]:
+    return BaseException.__getattribute__(error, "publication_cleanup_owners")
 
 
 def _vector_context_fixture(
@@ -183,6 +309,10 @@ def test_real_import_round_trips_ref_and_snapshot_as_canonical_v11_bytes(
 
         assert isinstance(ref_export, RepoManifestExportResult)
         assert ref_export.canonical_manifest_bytes == expected
+        summary = catalog.get_manifest_summary(imported.snapshot_id)
+        assert ref_export.receipt.namespace_id == summary["namespace"]["namespace_id"]
+        assert ref_export.receipt.repository_id == imported.repository_id
+        assert ref_export.receipt.repository_key == _REPOSITORY_KEY
         assert ref_export.receipt.snapshot_id == imported.snapshot_id
         assert ref_export.receipt.ref_name == "main"
         assert ref_export.receipt.ref_generation == 1
@@ -444,23 +574,511 @@ def test_expected_ref_generation_conflicts_before_snapshot_or_object_access() ->
         )
 
 
+def test_open_object_acquisition_interruption_closes_owned_reader() -> None:
+    interruption = KeyboardInterrupt("object reader acquisition interrupted")
+
+    class Reader:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class Store:
+        def __init__(self) -> None:
+            self.reader = Reader()
+
+        @staticmethod
+        def verify_receipt(expected: BlobInfo) -> BlobInfo:
+            return expected
+
+        def open(self, _digest: str) -> Reader:
+            return self.reader
+
+    store = Store()
+    record = ObjectRecord(
+        digest="0" * 64,
+        byte_size=0,
+        storage_key="objects/00/acquisition",
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_after_owned_acquire(
+            lambda: manifest_export_module._run_open_object(
+                store,  # type: ignore[arg-type]
+                record,
+                lambda _reader: None,
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert store.reader.closed
+
+
+def test_zip_entry_acquisition_interruption_closes_owned_reader() -> None:
+    interruption = SystemExit("ZIP entry acquisition interrupted")
+
+    class Entry:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class Archive:
+        def __init__(self) -> None:
+            self.entry = Entry()
+
+        def open(self, _path: str, *, mode: str) -> Entry:
+            assert mode == "r"
+            return self.entry
+
+    archive = Archive()
+    member = ArtifactMember(
+        path="config.json",
+        digest="0" * 64,
+        byte_size=1,
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        _interrupt_after_owned_acquire(
+            lambda: manifest_export_module._read_zip_json(
+                archive,  # type: ignore[arg-type]
+                {member.path: member},
+                member.path,
+                label="snapshot test config",
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert archive.entry.closed
+
+
+@pytest.mark.parametrize(
+    ("path", "label", "require_source_field"),
+    (
+        ("documents.json", "snapshot BM25 documents", False),
+        (
+            "root/documents_root.json",
+            "snapshot vector root documents",
+            True,
+        ),
+    ),
+    ids=("bm25", "vector"),
+)
+def test_canonical_documents_acquisition_interruption_closes_owned_reader(
+    path: str,
+    label: str,
+    require_source_field: bool,
+) -> None:
+    interruption = KeyboardInterrupt(f"{label} acquisition interrupted")
+
+    class Entry:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class Archive:
+        def __init__(self) -> None:
+            self.entry = Entry()
+
+        def open(self, observed_path: str, *, mode: str) -> Entry:
+            assert observed_path == f"payload/{path}"
+            assert mode == "r"
+            return self.entry
+
+    archive = Archive()
+    member = ArtifactMember(path=path, digest="0" * 64, byte_size=1)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_after_owned_acquire(
+            lambda: manifest_export_module._read_canonical_documents(
+                archive,  # type: ignore[arg-type]
+                member,
+                path,
+                label=label,
+                require_source_field=require_source_field,
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert archive.entry.closed
+
+
+def test_canonical_documents_rejects_oversized_member_before_open() -> None:
+    class Archive:
+        @staticmethod
+        def open(_path: str, *, mode: str) -> None:
+            raise AssertionError(f"oversized member was opened in {mode!r} mode")
+
+    member = ArtifactMember(
+        path="documents.json",
+        digest="0" * 64,
+        byte_size=MAX_PORTABLE_DOCUMENTS_JSON_BYTES + 1,
+    )
+
+    with pytest.raises(StorageIntegrityError, match="exceeds its byte limit"):
+        manifest_export_module._read_canonical_documents(
+            Archive(),  # type: ignore[arg-type]
+            member,
+            member.path,
+            label="snapshot test documents",
+            require_source_field=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected_file", "max_bytes"),
+    (
+        (
+            "l2/documents_test__model.json",
+            "documents_test__model.json",
+            MAX_PORTABLE_DOCUMENTS_JSON_BYTES,
+        ),
+        (
+            "l2/index_test__model.faiss",
+            "index_test__model.faiss",
+            MAX_PORTABLE_FAISS_INDEX_BYTES,
+        ),
+    ),
+    ids=("documents", "faiss-index"),
+)
+def test_vector_record_rejects_member_above_portable_limit(
+    relative_path: str,
+    expected_file: str,
+    max_bytes: int,
+) -> None:
+    digest = "0" * 64
+    byte_size = max_bytes + 1
+    member = ArtifactMember(
+        path=relative_path,
+        digest=digest,
+        byte_size=byte_size,
+    )
+    record = {
+        "file": expected_file,
+        "size": byte_size,
+        "sha256": digest,
+    }
+
+    with pytest.raises(StorageIntegrityError, match="exceeds its byte limit"):
+        manifest_export_module._require_vector_record(
+            record,
+            {relative_path: member},
+            relative_path=relative_path,
+            expected_file=expected_file,
+            label="snapshot vector l2 artifact",
+            max_bytes=max_bytes,
+        )
+
+
+def test_zip_archive_acquisition_interruption_closes_owned_archive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    interruption = KeyboardInterrupt("ZIP archive acquisition interrupted")
+
+    class Archive:
+        def __init__(self) -> None:
+            self.fp: object | None = object()
+
+        def close(self) -> None:
+            self.fp = None
+
+    archive = Archive()
+    monkeypatch.setattr(
+        manifest_export_module.zipfile,
+        "ZipFile",
+        lambda _handle, mode: archive,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        _interrupt_after_owned_acquire(
+            lambda: manifest_export_module._run_zip_archive(
+                object(),  # type: ignore[arg-type]
+                label="snapshot test archive",
+                operation=lambda _archive: None,
+            ),
+            error=interruption,
+        )
+
+    assert caught.value is interruption
+    assert archive.fp is None
+
+
+def test_owned_close_preserves_post_operation_ordinary_interruption() -> None:
+    primary = LookupError("post-operation ordinary interruption")
+
+    class Reader:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    reader = Reader()
+    with pytest.raises(LookupError) as caught:
+        _interrupt_after_owned_operation(
+            lambda: manifest_export_module._run_with_owned_close(
+                lambda: reader,
+                lambda _reader: "result",
+                complete=lambda resource: resource.closed is True,
+                cleanup_label="test reader close also failed",
+                close_failure="test reader close failed",
+            ),
+            error=primary,
+        )
+
+    assert caught.value is primary
+    assert reader.closed
+
+
+def test_owned_close_preserves_unrelated_finalizer_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = RuntimeError("unrelated cleanup finalizer failure")
+
+    class Reader:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    reader = Reader()
+    real_context = manifest_export_module._run_context_with_cleanup_actions
+
+    @contextmanager
+    def fail_after_cleanup(actions: Any) -> Iterator[None]:
+        with real_context(actions):
+            yield
+        raise primary
+
+    monkeypatch.setattr(
+        manifest_export_module,
+        "_run_context_with_cleanup_actions",
+        fail_after_cleanup,
+    )
+    with pytest.raises(RuntimeError) as caught:
+        manifest_export_module._run_with_owned_close(
+            lambda: reader,
+            lambda _reader: "result",
+            complete=lambda resource: resource.closed is True,
+            cleanup_label="test reader close also failed",
+            close_failure="test reader close failed",
+        )
+
+    assert caught.value is primary
+    assert reader.closed
+
+
+def test_owned_close_preserves_completion_observer_cancellation() -> None:
+    primary = KeyboardInterrupt("one-shot close observation cancellation")
+
+    class Reader:
+        physically_closed = False
+        observations = 0
+
+        @property
+        def closed(self) -> bool:
+            self.observations += 1
+            if self.observations == 1:
+                raise primary
+            return self.physically_closed
+
+        def close(self) -> None:
+            self.physically_closed = True
+
+    reader = Reader()
+    with pytest.raises(KeyboardInterrupt) as caught:
+        manifest_export_module._run_with_owned_close(
+            lambda: reader,
+            lambda _reader: "result",
+            complete=lambda resource: resource.closed is True,
+            cleanup_label="test reader close also failed",
+            close_failure="test reader close failed",
+        )
+
+    assert caught.value is primary
+    assert reader.physically_closed
+    assert reader.observations >= 2
+
+
+def test_owned_close_persistent_observer_failure_exposes_retry_owner() -> None:
+    primary = OSError("persistent close observation failure")
+    close_error = OSError("persistent physical close failure")
+
+    class Reader:
+        physically_closed = False
+        allow_close = False
+        allow_observation = False
+
+        @property
+        def closed(self) -> bool:
+            if not self.allow_observation:
+                raise primary
+            return self.physically_closed
+
+        def close(self) -> None:
+            if not self.allow_close:
+                raise close_error
+            self.physically_closed = True
+
+    reader = Reader()
+    with pytest.raises(OSError) as caught:
+        manifest_export_module._run_with_owned_close(
+            lambda: reader,
+            lambda _reader: "result",
+            complete=lambda resource: resource.closed is True,
+            cleanup_label="test reader close also failed",
+            close_failure="test reader close failed",
+        )
+
+    assert caught.value is primary
+    owners = _publication_cleanup_owners(primary)
+    assert len(owners) == 1
+    with pytest.raises(OSError) as retry:
+        owners[0].close()
+    assert retry.value is close_error
+    reader.allow_close = True
+    reader.allow_observation = True
+    owners[0].close()
+    assert owners[0].closed
+    assert reader.physically_closed
+
+
+def test_owned_close_does_not_wrap_shared_operation_primary() -> None:
+    primary = OSError("shared operation and close failure")
+
+    class Reader:
+        closed = False
+        allow_close = False
+
+        def close(self) -> None:
+            if not self.allow_close:
+                raise primary
+            self.closed = True
+
+    reader = Reader()
+    with pytest.raises(OSError) as caught:
+        manifest_export_module._run_with_owned_close(
+            lambda: reader,
+            lambda _reader: (_ for _ in ()).throw(primary),
+            complete=lambda resource: resource.closed is True,
+            cleanup_label="test reader close also failed",
+            close_failure="test reader close failed",
+        )
+
+    assert caught.value is primary
+    owners = _publication_cleanup_owners(primary)
+    assert len(owners) == 1
+    reader.allow_close = True
+    owners[0].close()
+    assert reader.closed
+
+
+def test_open_object_persistent_close_exposes_retry_owner() -> None:
+    class Reader:
+        closed = False
+        allow_close = False
+
+        def close(self) -> None:
+            if not self.allow_close:
+                raise OSError("persistent object reader close failure")
+            self.closed = True
+
+    class Store:
+        def __init__(self) -> None:
+            self.reader = Reader()
+
+        @staticmethod
+        def verify_receipt(expected: BlobInfo) -> BlobInfo:
+            return expected
+
+        def open(self, _digest: str) -> Reader:
+            return self.reader
+
+    store = Store()
+    record = ObjectRecord(
+        digest="0" * 64,
+        byte_size=0,
+        storage_key="objects/00/persistent-close",
+    )
+
+    with pytest.raises(StorageIntegrityError, match="reader close failed") as caught:
+        manifest_export_module._run_open_object(
+            store,  # type: ignore[arg-type]
+            record,
+            lambda _reader: None,
+        )
+
+    owners = _publication_cleanup_owners(caught.value)
+    assert len(owners) == 1
+    assert not owners[0].closed
+    store.reader.allow_close = True
+    owners[0].close()
+    assert owners[0].closed
+    assert store.reader.closed
+
+
+def test_zip_archive_persistent_close_exposes_retry_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Archive:
+        def __init__(self) -> None:
+            self.fp: object | None = object()
+            self.allow_close = False
+
+        def close(self) -> None:
+            if not self.allow_close:
+                raise OSError("persistent ZIP archive close failure")
+            self.fp = None
+
+    archive = Archive()
+    monkeypatch.setattr(
+        manifest_export_module.zipfile,
+        "ZipFile",
+        lambda _handle, mode: archive,
+    )
+
+    with pytest.raises(StorageIntegrityError, match="archive close failed") as caught:
+        manifest_export_module._run_zip_archive(
+            object(),  # type: ignore[arg-type]
+            label="snapshot test archive",
+            operation=lambda _archive: None,
+        )
+
+    owners = _publication_cleanup_owners(caught.value)
+    assert len(owners) == 1
+    assert not owners[0].closed
+    archive.allow_close = True
+    owners[0].close()
+    assert owners[0].closed
+    assert archive.fp is None
+
+
 def test_zip_json_entry_close_failure_preserves_read_cancellation() -> None:
     primary = KeyboardInterrupt("cancelled while reading ZIP entry")
 
     class FailingEntry:
+        closed = False
+        allow_close = False
+
         @staticmethod
         def read(_limit: int) -> bytes:
             raise primary
 
-        @staticmethod
-        def close() -> None:
-            raise OSError("ZIP entry close failed")
+        def close(self) -> None:
+            if not self.allow_close:
+                raise OSError("ZIP entry close failed")
+            self.closed = True
 
     class Archive:
-        @staticmethod
-        def open(_path: str, *, mode: str) -> FailingEntry:
+        def __init__(self) -> None:
+            self.entry = FailingEntry()
+
+        def open(self, _path: str, *, mode: str) -> FailingEntry:
             assert mode == "r"
-            return FailingEntry()
+            return self.entry
 
     member = ArtifactMember(
         path="config.json",
@@ -468,9 +1086,10 @@ def test_zip_json_entry_close_failure_preserves_read_cancellation() -> None:
         byte_size=1,
     )
 
+    archive = Archive()
     with pytest.raises(BaseException) as caught:
         manifest_export_module._read_zip_json(
-            Archive(),  # type: ignore[arg-type]
+            archive,  # type: ignore[arg-type]
             {member.path: member},
             member.path,
             label="snapshot test config",
@@ -482,6 +1101,13 @@ def test_zip_json_entry_close_failure_preserves_read_cancellation() -> None:
         and "ZIP entry close failed" in note
         for note in _exception_notes(primary)
     )
+    owners = _publication_cleanup_owners(primary)
+    assert len(owners) == 1
+    assert not owners[0].closed
+    archive.entry.allow_close = True
+    owners[0].close()
+    assert owners[0].closed
+    assert archive.entry.closed
 
 
 @pytest.mark.parametrize(
@@ -509,8 +1135,17 @@ def test_zip_json_entry_close_failure_preserves_read_cancellation() -> None:
                 }
             ],
         ),
+        (
+            {"project_root": "source", "max_k": 17, "language": "english"},
+            [
+                {
+                    "page_content": "Bearer audit-secret-value",
+                    "metadata": {"file": "sample.py", "node_id": "sample.VALUE"},
+                }
+            ],
+        ),
     ),
-    ids=("metadata-conflict", "document-traversal"),
+    ids=("metadata-conflict", "document-traversal", "document-secret"),
 )
 def test_coherently_reclosed_bm25_bundle_rejects_bad_portable_semantics(
     tmp_path: Path,
@@ -696,10 +1331,14 @@ def test_export_receipt_rejects_noncanonical_skipped_view_closure(
     skipped_items: tuple[tuple[str, str], ...],
 ) -> None:
     blob, view = _receipt_fixture()
+    namespace = NamespaceIdentity("default")
+    repository = RepositoryIdentity(namespace.namespace_id, _REPOSITORY_KEY)
 
     with pytest.raises(StorageValidationError, match="not canonical"):
         RepoManifestExportReceipt(
-            repository_id="repository",
+            namespace_id=namespace.namespace_id,
+            repository_id=repository.repository_id,
+            repository_key=repository.repository_key,
             source_revision_id="source_revision",
             snapshot_id="snapshot",
             snapshot_published_at="2026-08-10T00:00:00+00:00",
@@ -712,4 +1351,28 @@ def test_export_receipt_rejects_noncanonical_skipped_view_closure(
             projection_receipt=blob,
             view_receipts=(view,),
             skipped_items=skipped_items,
+        )
+
+
+def test_export_receipt_rejects_inconsistent_repository_identity() -> None:
+    blob, view = _receipt_fixture()
+    namespace = NamespaceIdentity("default")
+
+    with pytest.raises(StorageValidationError, match="identity is inconsistent"):
+        RepoManifestExportReceipt(
+            namespace_id=namespace.namespace_id,
+            repository_id="repo_" + "0" * 64,
+            repository_key=_REPOSITORY_KEY,
+            source_revision_id="source_revision",
+            snapshot_id="snapshot",
+            snapshot_published_at="2026-08-10T00:00:00+00:00",
+            ref_name=None,
+            ref_generation=None,
+            ref_updated_at=None,
+            manifest_digest="1" * 64,
+            manifest_byte_size=1,
+            projection_generation_id="projection_generation",
+            projection_receipt=blob,
+            view_receipts=(view,),
+            skipped_items=(),
         )

--- a/test/storage/test_view_bundle.py
+++ b/test/storage/test_view_bundle.py
@@ -15,6 +15,7 @@ import shutil
 import stat
 import struct
 import sys
+import threading
 import tracemalloc
 import warnings
 import zipfile
@@ -3288,6 +3289,7 @@ def test_verified_stream_persistent_close_failure_is_fail_closed_and_retained(
         def __init__(self) -> None:
             self._handle = real_temporary_file(mode="w+b")
             self.allow_close = False
+            self.raise_after_close = False
             self.close_attempts = 0
 
         def __getattr__(self, name: str) -> object:
@@ -3298,6 +3300,8 @@ def test_verified_stream_persistent_close_failure_is_fail_closed_and_retained(
             if not self.allow_close:
                 raise OSError(errno.EIO, "persistent stream close failure")
             self._handle.close()
+            if self.raise_after_close:
+                raise OSError(errno.EIO, "post-close stream failure")
 
     created: list[PersistentCloseFailure] = []
 
@@ -3351,9 +3355,109 @@ def test_verified_stream_persistent_close_failure_is_fail_closed_and_retained(
         ]
 
         created[0].allow_close = True
-        retry_retained_verified_bundle_stream_cleanup()
+        created[0].raise_after_close = True
+        with pytest.raises(StorageIntegrityError, match="stream close failed"):
+            retry_retained_verified_bundle_stream_cleanup()
         assert created[0]._handle.closed
         assert not bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+        retry_retained_verified_bundle_stream_cleanup()
     finally:
         created[0].allow_close = True
         created[0]._handle.close()
+
+
+def test_retained_verified_stream_cleanup_serializes_concurrent_retries() -> None:
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+    errors: list[BaseException] = []
+
+    class Owner:
+        calls = 0
+
+        def retry_cleanup(self) -> None:
+            self.calls += 1
+            if self.calls == 1:
+                first_entered.set()
+                assert release_first.wait(5)
+            else:
+                second_entered.set()
+            bundle_module._forget_verified_bundle_stream_cleanup_owner(self)
+
+    owner = Owner()
+    with bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_LOCK:
+        assert not bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+        bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS.append(owner)
+
+    def retry() -> None:
+        try:
+            retry_retained_verified_bundle_stream_cleanup()
+        except BaseException as error:  # noqa: B036 - thread result capture
+            errors.append(error)
+
+    first = threading.Thread(target=retry)
+    second = threading.Thread(target=retry)
+    try:
+        first.start()
+        assert first_entered.wait(5)
+        second.start()
+        assert not second_entered.wait(0.1)
+        release_first.set()
+        first.join(5)
+        second.join(5)
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert owner.calls == 1
+        assert not errors
+        assert not bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+    finally:
+        release_first.set()
+        first.join(5)
+        second.join(5)
+        with bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_LOCK:
+            bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS.clear()
+
+
+def test_retained_verified_stream_cleanup_preserves_close_primary_when_forget_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = KeyboardInterrupt("physical close primary")
+    secondary = SystemExit("registry release interruption")
+
+    class CloseThenInterrupt:
+        closed = False
+        calls = 0
+
+        def close(self) -> None:
+            self.calls += 1
+            self.closed = True
+            raise primary
+
+    archive = CloseThenInterrupt()
+    owner = bundle_module._CallbackScopedVerifiedBundleFile(archive)
+    bundle_module._register_verified_bundle_stream_cleanup_owner(owner)
+    real_forget = bundle_module._forget_verified_bundle_stream_cleanup_owner
+
+    def interrupt_forget(_owner: object) -> None:
+        raise secondary
+
+    monkeypatch.setattr(
+        bundle_module,
+        "_forget_verified_bundle_stream_cleanup_owner",
+        interrupt_forget,
+    )
+    with pytest.raises(KeyboardInterrupt) as captured:
+        owner.retry_cleanup()
+
+    assert captured.value is primary
+    assert archive.calls == 1
+    assert owner in bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+    assert "registry release" in "\n".join(_exception_notes(primary))
+
+    monkeypatch.setattr(
+        bundle_module,
+        "_forget_verified_bundle_stream_cleanup_owner",
+        real_forget,
+    )
+    retry_retained_verified_bundle_stream_cleanup()
+    assert not bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS

--- a/test/storage/test_view_bundle.py
+++ b/test/storage/test_view_bundle.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import copy
+import dis
 import errno
 import hashlib
 import inspect
@@ -21,7 +22,7 @@ import warnings
 import zipfile
 from dataclasses import fields, replace
 from pathlib import Path
-from typing import BinaryIO, Callable, Iterable
+from typing import Any, BinaryIO, Callable, Iterable
 
 import pytest
 
@@ -53,6 +54,13 @@ def _exception_notes(error: BaseException) -> tuple[str, ...]:
         *tuple(getattr(error, "__notes__", ())),
         *tuple(getattr(error, "_codenib_cleanup_notes", ())),
     )
+
+
+def _publication_cleanup_owners(error: BaseException) -> tuple[Any, ...]:
+    try:
+        return BaseException.__getattribute__(error, "publication_cleanup_owners")
+    except AttributeError:
+        return ()
 
 
 def _source(root: Path) -> Path:
@@ -284,6 +292,61 @@ def _call_with_interrupt_at_ordered_action_call(
     finally:
         sys.settrace(previous_trace)
         assert injected, "failed to inject at the ordered bundle action call"
+
+
+def _call_with_interrupt_after_temporary_file_acquire(
+    callback: Callable[[], object],
+    *,
+    error: BaseException,
+) -> None:
+    function = bundle_module._CallbackScopedVerifiedBundleFile._acquire_archive
+    code = function.__code__
+    instructions = tuple(dis.get_instructions(function))
+    store_indexes = {
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_ATTR" and instruction.argval == "_archive"
+    }
+    opcode_offsets_after_store = {
+        instructions[index + 1].offset for index in store_indexes
+    }
+    store_offsets = {instructions[index].offset for index in store_indexes}
+    line_offsets_after_store = {
+        instruction.offset
+        for instruction in instructions
+        if instruction.starts_line is not None
+        and any(instruction.offset > store_offset for store_offset in store_offsets)
+    }
+    assert len(store_indexes) == 1
+    previous_trace = sys.gettrace()
+    injected = False
+
+    def trace(frame: Any, event: str, _arg: object) -> Any:
+        nonlocal injected
+        if event == "call" and frame.f_code is code:
+            frame.f_trace_opcodes = True
+            frame.f_trace_lines = True
+            return trace
+        if (
+            not injected
+            and frame.f_code is code
+            and (
+                (event == "opcode" and frame.f_lasti in opcode_offsets_after_store)
+                or (event == "line" and frame.f_lasti in line_offsets_after_store)
+            )
+            and frame.f_locals["self"]._archive is not None
+        ):
+            injected = True
+            sys.settrace(None)
+            raise error
+        return trace
+
+    sys.settrace(trace)
+    try:
+        callback()
+    finally:
+        sys.settrace(previous_trace)
+        assert injected, "failed to interrupt after temporary-file result store"
 
 
 def test_reader_plan_matches_canonical_builder_without_path_or_temp_reopen(
@@ -3096,6 +3159,80 @@ def test_verified_stream_rejects_reentrant_integer_arguments(
     assert TrapInt.calls == 0
 
 
+def test_verified_stream_temporary_file_acquisition_interruption_closes_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = b"result-store interruption"
+    temporary_files: list[BinaryIO] = []
+    real_temporary_file = bundle_module.tempfile.TemporaryFile
+
+    def capture_temporary_file(**kwargs: object) -> BinaryIO:
+        handle = real_temporary_file(**kwargs)
+        temporary_files.append(handle)
+        return handle
+
+    monkeypatch.setattr(
+        bundle_module.tempfile,
+        "TemporaryFile",
+        capture_temporary_file,
+    )
+    interruption = KeyboardInterrupt(
+        "injected temporary-file result-store interruption"
+    )
+
+    with pytest.raises(KeyboardInterrupt) as captured:
+        _call_with_interrupt_after_temporary_file_acquire(
+            lambda: consume_verified_view_bundle_stream(
+                io.BytesIO(payload),
+                lambda _archive, _record: None,
+                expected_view_type="bm25",
+                expected_digest=hashlib.sha256(payload).hexdigest(),
+                expected_size=len(payload),
+            ),
+            error=interruption,
+        )
+
+    assert captured.value is interruption
+    assert len(temporary_files) == 1
+    assert temporary_files[0].closed
+
+
+def test_verified_stream_temporary_file_acquisition_failure_has_no_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    acquisition_error = OSError(errno.EIO, "temporary-file acquisition failed")
+    operation_calls = 0
+
+    def fail_temporary_file(**_kwargs: object) -> BinaryIO:
+        raise acquisition_error
+
+    def operation(_archive: BinaryIO, _record: object) -> None:
+        nonlocal operation_calls
+        operation_calls += 1
+
+    monkeypatch.setattr(
+        bundle_module.tempfile,
+        "TemporaryFile",
+        fail_temporary_file,
+    )
+    with pytest.raises(
+        StorageIntegrityError,
+        match="temporary copy could not be opened",
+    ) as caught:
+        consume_verified_view_bundle_stream(
+            io.BytesIO(b""),
+            operation,
+            expected_view_type="bm25",
+            expected_digest=hashlib.sha256(b"").hexdigest(),
+            expected_size=0,
+        )
+
+    assert caught.value.__cause__ is acquisition_error
+    assert operation_calls == 0
+    assert not _publication_cleanup_owners(caught.value)
+    assert not bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+
+
 @pytest.mark.parametrize(
     "interruption",
     [
@@ -3146,6 +3283,141 @@ def test_verified_stream_close_retries_pre_call_failure_and_revokes_handle(
     assert escaped[0].closed
     with pytest.raises(ValueError, match="closed file"):
         escaped[0].read(1)
+
+
+def test_verified_stream_permanent_pre_call_failure_exposes_stable_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(tmp_path / "source-root")
+    built = build_view_bundle(source, tmp_path / "bundle.zip", view_type="bm25")
+    payload = built.path.read_bytes()
+    real_temporary_file = bundle_module.tempfile.TemporaryFile
+
+    class PersistentCloseFailure:
+        def __init__(self) -> None:
+            self._handle = real_temporary_file(mode="w+b")
+            self.allow_close = False
+            self.close_attempts = 0
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._handle, name)
+
+        def close(self) -> None:
+            self.close_attempts += 1
+            if not self.allow_close:
+                raise OSError(errno.EIO, "persistent external close failure")
+            self._handle.close()
+
+    created: list[PersistentCloseFailure] = []
+
+    def open_persistent_failure(**_kwargs: object) -> PersistentCloseFailure:
+        archive = PersistentCloseFailure()
+        created.append(archive)
+        return archive
+
+    monkeypatch.setattr(
+        bundle_module.tempfile,
+        "TemporaryFile",
+        open_persistent_failure,
+    )
+    real_attempt = atomic_module._attempt_ordered_action
+    primary = KeyboardInterrupt("permanent pre-call stream close cancellation")
+    attempts = 0
+
+    def interrupt_close_action(
+        state: object,
+        ordered: object,
+    ) -> BaseException | None:
+        nonlocal attempts
+        if (
+            getattr(ordered, "label", None)
+            == "temporary view-bundle stream close also failed"
+        ):
+            attempts += 1
+            raise primary
+        return real_attempt(state, ordered)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_attempt_ordered_action",
+        interrupt_close_action,
+    )
+    escaped: list[BinaryIO] = []
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            consume_verified_view_bundle_stream(
+                io.BytesIO(payload),
+                lambda archive, _record: escaped.append(archive),
+                expected_view_type="bm25",
+                expected_digest=hashlib.sha256(payload).hexdigest(),
+                expected_size=len(payload),
+            )
+
+        assert caught.value is primary
+        assert attempts == atomic_module._MAX_ORDERED_ACTION_CANCELLATION_RETRIES + 1
+        assert len(created) == len(escaped) == 1
+        assert created[0].close_attempts == 0
+        assert not created[0]._handle.closed
+        assert not escaped[0].closed
+        owners = _publication_cleanup_owners(primary)
+        assert len(owners) == 1
+        assert not owners[0].closed
+        assert not bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+
+        with pytest.raises(StorageIntegrityError, match="stream close failed"):
+            owners[0].close()
+        assert created[0].close_attempts == 1
+        assert not created[0]._handle.closed
+        assert escaped[0].closed
+        assert not owners[0].closed
+
+        created[0].allow_close = True
+        owners[0].close()
+        assert created[0].close_attempts == 2
+        assert created[0]._handle.closed
+        assert owners[0].closed
+        assert not bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+    finally:
+        created[0].allow_close = True
+        created[0]._handle.close()
+        bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS.clear()
+
+
+def test_verified_stream_runner_failure_exposes_physical_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Archive:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    archive = Archive()
+    stream = bundle_module._CallbackScopedVerifiedBundleFile(archive)
+    stream._prepare_cleanup()
+    action = bundle_module._verified_bundle_stream_close_action(stream)
+    primary = RuntimeError("cleanup runner failed before stream close")
+    monkeypatch.setattr(
+        atomic_module,
+        "_run_ordered_actions",
+        lambda _state: (_ for _ in ()).throw(primary),
+    )
+
+    with pytest.raises(RuntimeError) as caught:
+        with bundle_module._run_context_with_cleanup_actions((action,)):
+            pass
+
+    assert caught.value is primary
+    assert not archive.closed
+    assert not stream.closed
+    owners = _publication_cleanup_owners(primary)
+    assert len(owners) == 1
+    assert not owners[0].closed
+    owners[0].close()
+    assert archive.closed
+    assert stream.closed
+    assert owners[0].closed
 
 
 @pytest.mark.parametrize(
@@ -3342,7 +3614,7 @@ def test_verified_stream_persistent_close_failure_is_fail_closed_and_retained(
         assert not created[0]._handle.closed
         assert (
             created[0].close_attempts
-            == bundle_module._BUNDLE_STREAM_CLOSE_RECOVERY_LIMIT
+            == bundle_module._VERIFIED_BUNDLE_STREAM_CLOSE_RECOVERY_LIMIT
         )
         assert escaped[0].closed
         with pytest.raises(ValueError, match="closed file"):
@@ -3353,6 +3625,7 @@ def test_verified_stream_persistent_close_failure_is_fail_closed_and_retained(
         assert bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS == [
             escaped[0]
         ]
+        assert not _publication_cleanup_owners(primary)
 
         created[0].allow_close = True
         created[0].raise_after_close = True
@@ -3364,6 +3637,94 @@ def test_verified_stream_persistent_close_failure_is_fail_closed_and_retained(
     finally:
         created[0].allow_close = True
         created[0]._handle.close()
+
+
+def test_verified_stream_persistent_close_observer_failure_exposes_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(tmp_path / "source-root")
+    built = build_view_bundle(source, tmp_path / "bundle.zip", view_type="bm25")
+    payload = built.path.read_bytes()
+    real_temporary_file = bundle_module.tempfile.TemporaryFile
+    primary = KeyboardInterrupt("persistent physical close observation failure")
+
+    class PersistentObserverFailure:
+        def __init__(self) -> None:
+            self._handle = real_temporary_file(mode="w+b")
+            self.allow_close = False
+            self.fail_observation = False
+            self.close_attempts = 0
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._handle, name)
+
+        @property
+        def closed(self) -> bool:
+            if self.fail_observation:
+                raise primary
+            return self._handle.closed
+
+        def close(self) -> None:
+            self.close_attempts += 1
+            if not self.allow_close:
+                raise OSError(errno.EIO, "persistent physical close failure")
+            self._handle.close()
+
+    created: list[PersistentObserverFailure] = []
+
+    def open_persistent_failure(**_kwargs: object) -> PersistentObserverFailure:
+        archive = PersistentObserverFailure()
+        created.append(archive)
+        return archive
+
+    monkeypatch.setattr(
+        bundle_module.tempfile,
+        "TemporaryFile",
+        open_persistent_failure,
+    )
+    escaped: list[BinaryIO] = []
+
+    def enable_observer_failure(archive: BinaryIO, _record: object) -> None:
+        escaped.append(archive)
+        created[0].fail_observation = True
+
+    try:
+        with pytest.raises(KeyboardInterrupt) as caught:
+            consume_verified_view_bundle_stream(
+                io.BytesIO(payload),
+                enable_observer_failure,
+                expected_view_type="bm25",
+                expected_digest=hashlib.sha256(payload).hexdigest(),
+                expected_size=len(payload),
+            )
+
+        assert caught.value is primary
+        assert len(created) == len(escaped) == 1
+        assert (
+            created[0].close_attempts
+            == atomic_module._MAX_ORDERED_ACTION_CANCELLATION_RETRIES + 1
+        )
+        assert not created[0]._handle.closed
+        assert escaped[0].closed
+        assert not bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+        owners = _publication_cleanup_owners(primary)
+        assert len(owners) == 1
+
+        with pytest.raises(StorageIntegrityError, match="stream close failed"):
+            owners[0].close()
+        assert not created[0]._handle.closed
+        created[0].allow_close = True
+        created[0].fail_observation = False
+        owners[0].close()
+        assert created[0]._handle.closed
+        assert owners[0].closed
+        assert not bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+    finally:
+        created[0].allow_close = True
+        created[0].fail_observation = False
+        created[0]._handle.close()
+        bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS.clear()
 
 
 def test_retained_verified_stream_cleanup_serializes_concurrent_retries() -> None:

--- a/test/storage/test_view_bundle.py
+++ b/test/storage/test_view_bundle.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import copy
 import errno
 import hashlib
 import inspect
@@ -19,7 +20,7 @@ import warnings
 import zipfile
 from dataclasses import fields, replace
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import BinaryIO, Callable, Iterable
 
 import pytest
 
@@ -33,7 +34,9 @@ from codenib.storage import (
     StorageIntegrityError,
     StorageValidationError,
     build_view_bundle,
+    consume_verified_view_bundle_stream,
     materialize_view_bundle,
+    retry_retained_verified_bundle_stream_cleanup,
     validate_view_bundle_physical_size,
     verify_view_bundle,
 )
@@ -2952,3 +2955,405 @@ def test_invalid_limits_fail_closed(
     archive = tmp_path / "missing.zip"
     with pytest.raises(StorageValidationError, match=message):
         verify_view_bundle(archive, **kwargs)
+
+
+def test_verified_stream_is_exact_and_callback_handle_cannot_escape(
+    tmp_path: Path,
+) -> None:
+    source = _source(tmp_path / "source-root")
+    built = build_view_bundle(source, tmp_path / "bundle.zip", view_type="bm25")
+    payload = built.path.read_bytes()
+    escaped: list[BinaryIO] = []
+
+    def consume(
+        archive: BinaryIO,
+        record: bundle_module.ViewBundleRecord,
+    ) -> tuple[str, bytes]:
+        escaped.append(archive)
+        assert copy.copy(archive) is archive
+        assert copy.deepcopy(archive) is archive
+        with pytest.raises(TypeError, match="state is private"):
+            archive.__getstate__()  # type: ignore[attr-defined]
+        assert archive.readable()
+        assert archive.seekable()
+        assert not archive.writable()
+        with pytest.raises(io.UnsupportedOperation, match="descriptor"):
+            archive.fileno()
+        with pytest.raises(io.UnsupportedOperation, match="read-only"):
+            archive.write(b"mutation")
+        with pytest.raises(io.UnsupportedOperation, match="read-only"):
+            archive.truncate(0)
+        with pytest.raises(io.UnsupportedOperation, match="mutable read buffers"):
+            archive.readinto(bytearray(4))
+        return record.view_type, archive.read()
+
+    result = consume_verified_view_bundle_stream(
+        io.BytesIO(payload),
+        consume,
+        expected_view_type="bm25",
+        expected_digest=hashlib.sha256(payload).hexdigest(),
+        expected_size=len(payload),
+    )
+
+    assert result == ("bm25", payload)
+    assert len(escaped) == 1
+    assert escaped[0].closed
+    with pytest.raises(ValueError, match="closed file"):
+        escaped[0].read(1)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires process forking")
+def test_verified_stream_facade_fails_closed_across_fork(
+    tmp_path: Path,
+) -> None:
+    source = _source(tmp_path / "source-root")
+    built = build_view_bundle(source, tmp_path / "bundle.zip", view_type="bm25")
+    payload = built.path.read_bytes()
+    gate_read, gate_write = os.pipe()
+    result_read, result_write = os.pipe()
+    child_pid = -1
+
+    def consume(archive: BinaryIO, _record: object) -> bytes:
+        nonlocal child_pid
+        child_pid = os.fork()
+        if child_pid == 0:
+            os.close(gate_write)
+            os.close(result_read)
+            try:
+                if os.read(gate_read, 1) != b"x":
+                    os._exit(2)
+                try:
+                    archive.seek(0)
+                    archive.read(4)
+                except ValueError:
+                    os.write(result_write, b"closed")
+                    os._exit(0)
+                os.write(result_write, b"open")
+                os._exit(1)
+            except Exception:
+                os._exit(3)
+        os.close(gate_read)
+        os.close(result_write)
+        return b"parent"
+
+    try:
+        assert (
+            consume_verified_view_bundle_stream(
+                io.BytesIO(payload),
+                consume,
+                expected_view_type="bm25",
+                expected_digest=hashlib.sha256(payload).hexdigest(),
+                expected_size=len(payload),
+            )
+            == b"parent"
+        )
+        os.write(gate_write, b"x")
+        assert os.read(result_read, 16) == b"closed"
+        waited, status = os.waitpid(child_pid, 0)
+        child_pid = -1
+        assert waited > 0
+        assert os.waitstatus_to_exitcode(status) == 0
+    finally:
+        for descriptor in (gate_read, gate_write, result_read, result_write):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        if child_pid > 0:
+            try:
+                os.write(gate_write, b"x")
+            except OSError:
+                pass
+            os.waitpid(child_pid, 0)
+
+
+def test_verified_stream_rejects_reentrant_integer_arguments(
+    tmp_path: Path,
+) -> None:
+    source = _source(tmp_path / "source-root")
+    built = build_view_bundle(source, tmp_path / "bundle.zip", view_type="bm25")
+    payload = built.path.read_bytes()
+
+    class TrapInt:
+        calls = 0
+
+        def __index__(self) -> int:
+            type(self).calls += 1
+            raise AssertionError("stream must not coerce callback-controlled integers")
+
+    def consume(archive: BinaryIO, _record: object) -> None:
+        with pytest.raises(TypeError, match="exact integer"):
+            archive.read(TrapInt())  # type: ignore[arg-type]
+
+    consume_verified_view_bundle_stream(
+        io.BytesIO(payload),
+        consume,
+        expected_view_type="bm25",
+        expected_digest=hashlib.sha256(payload).hexdigest(),
+        expected_size=len(payload),
+    )
+    assert TrapInt.calls == 0
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [
+        KeyboardInterrupt("injected pre-call stream close cancellation"),
+        SystemExit("injected pre-call stream close exit"),
+        OSError(errno.EIO, "injected pre-call stream close failure"),
+    ],
+)
+def test_verified_stream_close_retries_pre_call_failure_and_revokes_handle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interruption: BaseException,
+) -> None:
+    source = _source(tmp_path / "source-root")
+    built = build_view_bundle(source, tmp_path / "bundle.zip", view_type="bm25")
+    payload = built.path.read_bytes()
+    escaped: list[BinaryIO] = []
+    temporary_files: list[BinaryIO] = []
+    real_temporary_file = bundle_module.tempfile.TemporaryFile
+
+    def capture_temporary_file(**kwargs: object) -> BinaryIO:
+        handle = real_temporary_file(**kwargs)
+        temporary_files.append(handle)
+        return handle
+
+    monkeypatch.setattr(
+        bundle_module.tempfile,
+        "TemporaryFile",
+        capture_temporary_file,
+    )
+
+    with pytest.raises(interruption.__class__) as captured:
+        _call_with_interrupt_at_ordered_action_call(
+            lambda: consume_verified_view_bundle_stream(
+                io.BytesIO(payload),
+                lambda archive, _record: escaped.append(archive),
+                expected_view_type="bm25",
+                expected_digest=hashlib.sha256(payload).hexdigest(),
+                expected_size=len(payload),
+            ),
+            label="temporary view-bundle stream close also failed",
+            error=interruption,
+        )
+
+    assert captured.value is interruption
+    assert len(temporary_files) == len(escaped) == 1
+    assert temporary_files[0].closed
+    assert escaped[0].closed
+    with pytest.raises(ValueError, match="closed file"):
+        escaped[0].read(1)
+
+
+@pytest.mark.parametrize(
+    "mutation, message",
+    [
+        (lambda payload: payload[:-1], "truncated"),
+        (lambda payload: payload + b"x", "exceeded"),
+    ],
+)
+def test_verified_stream_rejects_receipt_length_mismatch(
+    tmp_path: Path,
+    mutation: Callable[[bytes], bytes],
+    message: str,
+) -> None:
+    source = _source(tmp_path / "source-root")
+    built = build_view_bundle(source, tmp_path / "bundle.zip", view_type="bm25")
+    payload = built.path.read_bytes()
+
+    with pytest.raises(StorageIntegrityError, match=message):
+        consume_verified_view_bundle_stream(
+            io.BytesIO(mutation(payload)),
+            lambda _archive, _record: None,
+            expected_view_type="bm25",
+            expected_digest=hashlib.sha256(payload).hexdigest(),
+            expected_size=len(payload),
+        )
+
+
+def test_verified_stream_rejects_digest_valid_noncanonical_archive(
+    tmp_path: Path,
+) -> None:
+    source = _source(tmp_path / "source-root")
+    built = build_view_bundle(source, tmp_path / "bundle.zip", view_type="bm25")
+    payload = bytearray(built.path.read_bytes())
+    payload[0:4] = b"nope"
+    corrupt = bytes(payload)
+
+    with pytest.raises(
+        (StorageIntegrityError, StorageValidationError),
+        match="ZIP|zip|canonical|archive",
+    ):
+        consume_verified_view_bundle_stream(
+            io.BytesIO(corrupt),
+            lambda _archive, _record: None,
+            expected_view_type="bm25",
+            expected_digest=hashlib.sha256(corrupt).hexdigest(),
+            expected_size=len(corrupt),
+        )
+
+
+def test_verified_stream_close_failure_is_primary_without_callback_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(tmp_path / "source-root")
+    built = build_view_bundle(source, tmp_path / "bundle.zip", view_type="bm25")
+    payload = built.path.read_bytes()
+    real_temporary_file = bundle_module.tempfile.TemporaryFile
+    escaped: list[BinaryIO] = []
+
+    class CloseFailure:
+        def __init__(self) -> None:
+            self._handle = real_temporary_file(mode="w+b")
+            self.close_attempts = 0
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._handle, name)
+
+        def close(self) -> None:
+            self.close_attempts += 1
+            self._handle.close()
+            raise OSError("injected stream close failure")
+
+    created: list[CloseFailure] = []
+
+    def open_close_failure(**_kwargs: object) -> CloseFailure:
+        failure = CloseFailure()
+        created.append(failure)
+        return failure
+
+    monkeypatch.setattr(
+        bundle_module.tempfile,
+        "TemporaryFile",
+        open_close_failure,
+    )
+
+    with pytest.raises(
+        StorageIntegrityError,
+        match="temporary view-bundle stream close failed",
+    ):
+        consume_verified_view_bundle_stream(
+            io.BytesIO(payload),
+            lambda archive, _record: escaped.append(archive),
+            expected_view_type="bm25",
+            expected_digest=hashlib.sha256(payload).hexdigest(),
+            expected_size=len(payload),
+        )
+
+    assert len(created) == len(escaped) == 1
+    assert created[0].close_attempts == 1
+    assert created[0]._handle.closed
+    assert escaped[0].closed
+    with pytest.raises(ValueError, match="closed file"):
+        escaped[0].read(1)
+
+
+def test_verified_stream_persistent_close_failure_is_fail_closed_and_retained(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class CallbackFailure(RuntimeError):
+        def __init__(self, message: str) -> None:
+            super().__init__(message)
+            self.bool_calls = 0
+            self.owner_attr_calls = 0
+
+        def __bool__(self) -> bool:
+            self.bool_calls += 1
+            raise AssertionError("cleanup must not truth-test the primary error")
+
+        @property
+        def _codenib_verified_bundle_stream_cleanup_owners(self) -> tuple[object, ...]:
+            self.owner_attr_calls += 1
+            raise AssertionError("cleanup must not inspect callback exception state")
+
+        @_codenib_verified_bundle_stream_cleanup_owners.setter
+        def _codenib_verified_bundle_stream_cleanup_owners(
+            self,
+            _value: tuple[object, ...],
+        ) -> None:
+            self.owner_attr_calls += 1
+            raise AssertionError("cleanup must not mutate callback exception state")
+
+    source = _source(tmp_path / "source-root")
+    built = build_view_bundle(source, tmp_path / "bundle.zip", view_type="bm25")
+    payload = built.path.read_bytes()
+    real_temporary_file = bundle_module.tempfile.TemporaryFile
+    escaped: list[BinaryIO] = []
+
+    class PersistentCloseFailure:
+        def __init__(self) -> None:
+            self._handle = real_temporary_file(mode="w+b")
+            self.allow_close = False
+            self.close_attempts = 0
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._handle, name)
+
+        def close(self) -> None:
+            self.close_attempts += 1
+            if not self.allow_close:
+                raise OSError(errno.EIO, "persistent stream close failure")
+            self._handle.close()
+
+    created: list[PersistentCloseFailure] = []
+
+    def open_persistent_failure(**_kwargs: object) -> PersistentCloseFailure:
+        failure = PersistentCloseFailure()
+        created.append(failure)
+        return failure
+
+    monkeypatch.setattr(
+        bundle_module.tempfile,
+        "TemporaryFile",
+        open_persistent_failure,
+    )
+    primary = CallbackFailure("callback primary")
+
+    copied: list[BinaryIO] = []
+
+    def fail_callback(archive: BinaryIO, _record: object) -> None:
+        escaped.append(archive)
+        copied.append(copy.copy(archive))
+        raise primary
+
+    try:
+        with pytest.raises(CallbackFailure) as captured:
+            consume_verified_view_bundle_stream(
+                io.BytesIO(payload),
+                fail_callback,
+                expected_view_type="bm25",
+                expected_digest=hashlib.sha256(payload).hexdigest(),
+                expected_size=len(payload),
+            )
+
+        assert captured.value is primary
+        assert primary.bool_calls == 0
+        assert primary.owner_attr_calls == 0
+        assert len(created) == len(escaped) == len(copied) == 1
+        assert copied[0] is escaped[0]
+        assert not created[0]._handle.closed
+        assert (
+            created[0].close_attempts
+            == bundle_module._BUNDLE_STREAM_CLOSE_RECOVERY_LIMIT
+        )
+        assert escaped[0].closed
+        with pytest.raises(ValueError, match="closed file"):
+            escaped[0].read(1)
+        with pytest.raises(ValueError, match="closed file"):
+            copied[0].read(1)
+        assert "close also failed" in "\n".join(_exception_notes(primary))
+        assert bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS == [
+            escaped[0]
+        ]
+
+        created[0].allow_close = True
+        retry_retained_verified_bundle_stream_cleanup()
+        assert created[0]._handle.closed
+        assert not bundle_module._RETAINED_VERIFIED_BUNDLE_STREAM_CLEANUP_OWNERS
+    finally:
+        created[0].allow_close = True
+        created[0]._handle.close()


### PR DESCRIPTION
## Summary

Add the first read-only retained RepoManifest exporter, closing the data-only import/export round trip for canonical v1.1 manifests without introducing filesystem, native-load, or GC authority. M1 remains in progress: retained filesystem materialization, production compiler/runtime wiring, and production GC are still outstanding.

## Changes

- add shared retained snapshot and manifest-contract attestation used by import and export
- add ref and immutable-snapshot export APIs with exact ref resolution, identity closure, final receipt sweeps, and attested namespace/repository receipt fields
- verify retained view-bundle streams without path reopen and preserve retryable cleanup ownership across cancellation and close failures
- validate source-free BM25/vector semantics, fixed portable payload limits, and full-document secret rejection while keeping vector native bytes inert
- expose the additive retained snapshot catalog contract and lazy compiler exports
- document the completed data-only export boundary and remaining M1 work
- add adversarial tests for identity, semantic, receipt, acquisition, cleanup, cancellation, and ref-movement boundaries

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/compiler/test_manifest_export.py test/storage/test_view_bundle.py test/artifacts/test_portable_views.py --tb=short` — 290 passed
- `pytest -q test/compiler/test_manifest_export.py test/compiler/test_manifest_import.py test/compiler/test_manifest_storage.py test/storage/test_view_bundle.py test/storage/test_contracts.py test/storage/test_sqlite_catalog.py test/artifacts/test_portable_views.py --tb=short` — 639 passed
- unit marker tier excluding `test/sandbox/test_docker.py` — 6113 passed, 71 skipped, 190 deselected; the file was excluded because this host has no `/usr/bin/docker`
- unexcluded unit run reached 3339 passed and 49 skipped before the Docker provider raised `SandboxUnavailableError` for the missing client
- pinned Black 24.8.0, isort 5.13.2 with the Black profile, flake8, py_compile, and `git diff --check` passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published