### PR TITLE
fix(web): read indexed sources from shared checkouts

### DIFF
--- a/codenib/web/repository_files.py
+++ b/codenib/web/repository_files.py
@@ -38,6 +38,20 @@ def has_git_metadata(repo_dir: str) -> bool:
     return os.path.lexists(os.path.join(os.path.realpath(repo_dir), ".git"))
 
 
+def _git_command(repo_dir: str, *args: str) -> list[str]:
+    """Build a Git command that trusts only the requested repository root.
+
+    Published indexes are often served from a checkout owned by a build or
+    storage account rather than the runtime user.  Git otherwise rejects that
+    checkout as dubious before it can read the immutable indexed commit.  A
+    command-scoped ``safe.directory`` keeps the exception local to this exact,
+    canonical path instead of mutating the user's global Git configuration.
+    """
+
+    root = os.path.realpath(repo_dir)
+    return ["git", "-c", f"safe.directory={root}", "-C", root, *args]
+
+
 def safe_repo_relative_path(repo_dir: str, file_path: str) -> Optional[str]:
     """Return a repo-relative POSIX path without permitting an outside read.
 
@@ -85,7 +99,7 @@ def _git_blob(
     process: Optional[subprocess.Popen[bytes]] = None
     try:
         process = subprocess.Popen(
-            ["git", "-C", repo_dir, "show", f"{commit}:{relative}"],
+            _git_command(repo_dir, "show", f"{commit}:{relative}"),
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
         )
@@ -122,9 +136,7 @@ def git_grep_paths(repo_dir: str, commit: str, pattern: str) -> frozenset[str]:
         return frozenset()
     try:
         result = subprocess.run(
-            [
-                "git",
-                "-C",
+            _git_command(
                 repo_dir,
                 "grep",
                 "-I",
@@ -134,7 +146,7 @@ def git_grep_paths(repo_dir: str, commit: str, pattern: str) -> frozenset[str]:
                 pattern,
                 commit,
                 "--",
-            ],
+            ),
             check=False,
             capture_output=True,
             text=True,
@@ -159,7 +171,7 @@ def git_tree_paths(repo_dir: str, commit: str) -> Optional[frozenset[str]]:
         return None
     try:
         result = subprocess.run(
-            ["git", "-C", repo_dir, "ls-tree", "-r", "-z", "--name-only", commit],
+            _git_command(repo_dir, "ls-tree", "-r", "-z", "--name-only", commit),
             check=False,
             capture_output=True,
             timeout=20,

--- a/test/web/test_repository_files.py
+++ b/test/web/test_repository_files.py
@@ -13,6 +13,7 @@ import pytest
 
 from codenib.web.repository_files import (
     git_grep_paths,
+    git_source_slice,
     git_tree_paths,
     live_source_slice,
 )
@@ -67,6 +68,31 @@ def test_git_snapshot_caches_evict_old_commits(tmp_path: Path) -> None:
     git_grep_paths(str(tmp_path), commits[0], "generated")
     assert git_tree_paths.cache_info().misses == tree_misses + 1
     assert git_grep_paths.cache_info().misses == grep_misses + 1
+
+
+def test_git_snapshot_reads_shared_owner_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    (tmp_path / "source.py").write_text("VALUE = 'indexed'\n", encoding="utf-8")
+    _git(tmp_path, "add", "source.py")
+    _git(tmp_path, "commit", "-qm", "indexed source")
+    commit = _git(tmp_path, "rev-parse", "HEAD")
+
+    # Git's own test hook reproduces a checkout owned by another account.
+    monkeypatch.setenv("GIT_TEST_ASSUME_DIFFERENT_OWNER", "1")
+
+    assert git_tree_paths(str(tmp_path), commit) == frozenset({"source.py"})
+    assert git_grep_paths(str(tmp_path), commit, "indexed") == frozenset({"source.py"})
+    assert git_source_slice(str(tmp_path), commit, "source.py", 1, 1) == {
+        "file": "source.py",
+        "start_line": 1,
+        "end_line": 1,
+        "content": "VALUE = 'indexed'\n",
+    }
 
 
 def test_live_source_slice_bounds_explicit_line_ranges(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Restore source-linked Ask citations when a published index checkout belongs to a build or storage account. Git ownership protection previously made immutable indexed files appear unavailable, so otherwise valid citations were discarded.

## Changes
- Build read-only Git commands with a command-scoped `safe.directory` for the exact canonical repository root.
- Use the scoped command for indexed blob reads, grep path lookup, and tree path lookup.
- Add a regression test that reproduces different checkout ownership with the Git test hook and verifies tree, grep, and source-slice reads.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/web -q --tb=short` — 307 passed

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` — 6098 passed, 71 skipped, 190 deselected

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published