### PR TITLE
feat(storage): add Linux local workspace provider

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -110,20 +110,18 @@ jobs:
           import os
           from pathlib import Path
 
-          built = list(Path("dist").glob("*.whl"))
-          fetched = list(Path(os.environ["FETCH_DIR"]).glob("*.whl"))
-          if len(built) != 1 or len(fetched) != 1:
-              raise SystemExit(
-                  f"expected one built and fetched wheel, got {built!r}, {fetched!r}"
-              )
+          from scripts.verify_release_artifacts import select_compatible_wheel
+
+          built = select_compatible_wheel(Path("dist"))
+          fetched = select_compatible_wheel(Path(os.environ["FETCH_DIR"]))
 
           def digest(path: Path) -> str:
               return hashlib.sha256(path.read_bytes()).hexdigest()
 
-          if digest(built[0]) != digest(fetched[0]):
+          if digest(built) != digest(fetched):
               raise SystemExit("TestPyPI wheel does not match the verified build")
           with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as handle:
-              handle.write(f"TESTPYPI_WHEEL={fetched[0].resolve()}\n")
+              handle.write(f"TESTPYPI_WHEEL={fetched.resolve()}\n")
           PY
 
       - name: Install the registry wheel

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -16,8 +16,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build and inspect distributions
+  build-sdist:
+    name: Build source distribution
     # This job executes package and frontend build code from pull requests.
     # Keep it off the persistent self-hosted runner.
     runs-on: ubuntu-latest
@@ -45,20 +45,162 @@ jobs:
           npm test
           npm run build
 
-      - name: Build Python distributions
+      - name: Build source distribution
         run: |
-          BUILD_VENV="$RUNNER_TEMP/codenib-release-build-${{ github.run_id }}-${{ github.run_attempt }}"
+          BUILD_VENV="$RUNNER_TEMP/codenib-release-sdist-${{ github.run_id }}-${{ github.run_attempt }}"
+          python -m venv "$BUILD_VENV"
+          "$BUILD_VENV/bin/python" -m pip install --upgrade pip build
+          "$BUILD_VENV/bin/python" -m build --sdist
+
+      - name: Upload source distribution
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: python-build-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  build-wheel:
+    name: Build ${{ matrix.arch }} wheel
+    needs: build-sdist
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - x86_64
+          - aarch64
+    steps:
+      - name: Download source distribution
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: python-build-sdist
+          path: source-dist
+
+      - name: Resolve source distribution
+        id: sdist
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          sources = list(Path("source-dist").glob("*.tar.gz"))
+          if len(sources) != 1:
+              raise SystemExit(f"expected one source distribution, found {sources!r}")
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+              handle.write(f"path={sources[0]}\n")
+          PY
+
+      - name: Set up QEMU for aarch64
+        if: matrix.arch == 'aarch64'
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
+
+      - name: Build and smoke-test wheel
+        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
+        with:
+          package-dir: ${{ steps.sdist.outputs.path }}
+          output-dir: wheelhouse
+        env:
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_BUILD: cp310-manylinux_${{ matrix.arch }}
+          CIBW_CONTAINER_ENGINE: "docker; create_args: --cap-add SYS_PTRACE"
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+            auditwheel repair --plat manylinux_2_28_${{ matrix.arch }}
+            -w {dest_dir} {wheel}
+          CIBW_TEST_COMMAND: >-
+            python -c "import platform;
+            import codenib._workspace_owner_impl as implementation;
+            from codenib import _workspace_owner;
+            assert platform.machine() == '${{ matrix.arch }}';
+            assert implementation.workspace_owner_protocol_version == 2;
+            assert implementation.require_support() is None;
+            _workspace_owner.require_support()"
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: python-build-wheel-${{ matrix.arch }}
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+          retention-days: 1
+
+  limited-abi-compile:
+    name: Strict CPython 3.10 limited-ABI compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.10"
+
+      - name: Compile the native extension against the limited API
+        run: |
+          INCLUDE_DIR="$(python - <<'PY'
+          import sysconfig
+
+          print(sysconfig.get_config_var("INCLUDEPY"))
+          PY
+          )"
+          cc \
+            -std=c11 \
+            -D_GNU_SOURCE=1 \
+            -DPy_LIMITED_API=0x030A0000 \
+            -Wall \
+            -Wextra \
+            -Werror \
+            -fPIC \
+            -I"$INCLUDE_DIR" \
+            -c native/workspace_owner.c \
+            -o "$RUNNER_TEMP/workspace-owner-limited-api.o"
+          test -s "$RUNNER_TEMP/workspace-owner-limited-api.o"
+
+  build:
+    name: Inspect production distributions
+    needs:
+      - build-sdist
+      - build-wheel
+      - limited-abi-compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Download distributions
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          pattern: python-build-*
+          path: dist
+          merge-multiple: true
+
+      - name: Inspect Python distributions
+        run: |
+          BUILD_VENV="$RUNNER_TEMP/codenib-release-inspect-${{ github.run_id }}-${{ github.run_attempt }}"
           python -m venv "$BUILD_VENV"
           "$BUILD_VENV/bin/python" -m pip install \
-            --upgrade pip build "jsonschema>=4,<5" twine
-          "$BUILD_VENV/bin/python" -m build
+            --upgrade pip "jsonschema>=4,<5" twine
           "$BUILD_VENV/bin/python" -m twine check dist/*
-          "$BUILD_VENV/bin/python" \
-            scripts/verify_release_artifacts.py dist
+          "$BUILD_VENV/bin/python" scripts/verify_release_artifacts.py dist
 
       - name: Validate MCP Registry metadata
         run: |
-          BUILD_VENV="$RUNNER_TEMP/codenib-release-build-${{ github.run_id }}-${{ github.run_attempt }}"
+          BUILD_VENV="$RUNNER_TEMP/codenib-release-inspect-${{ github.run_id }}-${{ github.run_attempt }}"
           curl --fail --location --retry 3 --retry-all-errors \
             --connect-timeout 10 --max-time 90 \
             --output "$RUNNER_TEMP/mcp-server.schema.json" \
@@ -93,6 +235,191 @@ jobs:
             dist/*.tar.gz
           if-no-files-found: error
           retention-days: 14
+
+  source-smoke:
+    name: Source install without native extension
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout smoke harness
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Download distributions
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Install source distribution without a compiler
+        env:
+          CC: /bin/false
+        run: |
+          SOURCE_VENV="$RUNNER_TEMP/codenib-release-source-${{ github.run_id }}-${{ github.run_attempt }}"
+          python -m venv "$SOURCE_VENV"
+          echo "$SOURCE_VENV/bin" >> "$GITHUB_PATH"
+          "$SOURCE_VENV/bin/python" -m pip install --upgrade pip
+          "$SOURCE_VENV/bin/python" -m pip install --no-cache-dir dist/*.tar.gz
+
+      - name: Exercise core and fail-closed workspace support
+        working-directory: ${{ runner.temp }}
+        run: |
+          codenib --version
+          codenib doctor --require core
+          python "$GITHUB_WORKSPACE/scripts/smoke_release_install.py"
+          python - <<'PY'
+          import importlib.util
+          from pathlib import Path
+          from tempfile import TemporaryDirectory
+
+          if importlib.util.find_spec("codenib._workspace_owner_impl") is not None:
+              raise SystemExit("source install unexpectedly built the native extension")
+
+          from codenib import LocalWorkspaceProvider
+          from codenib import _workspace_owner
+          from codenib._captured_directory import UnsupportedWorkspaceCreation
+
+          try:
+              _workspace_owner.require_support()
+          except RuntimeError:
+              pass
+          else:
+              raise SystemExit("workspace support did not fail closed")
+
+          with TemporaryDirectory() as root:
+              provider = LocalWorkspaceProvider(Path(root))
+              try:
+                  provider.require_support()
+              except UnsupportedWorkspaceCreation:
+                  pass
+              else:
+                  raise SystemExit("local workspace provider did not fail closed")
+          PY
+
+  abi3-smoke:
+    name: Native ABI3 smoke (Python ${{ matrix.python-version }})
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+    steps:
+      - name: Checkout smoke harness
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download distributions
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Install the compatible ABI3 wheel
+        run: |
+          ABI3_VENV="$RUNNER_TEMP/codenib-release-abi3-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          python -m venv "$ABI3_VENV"
+          echo "$ABI3_VENV/bin" >> "$GITHUB_PATH"
+          "$ABI3_VENV/bin/python" -m pip install --upgrade pip
+          WHEEL="$(python scripts/verify_release_artifacts.py \
+            dist --print-compatible-wheel)"
+          "$ABI3_VENV/bin/python" -m pip install --no-deps "$WHEEL"
+
+      - name: Exercise native ABI and local workspace lifecycle
+        working-directory: ${{ runner.temp }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import stat
+          from pathlib import Path
+          from tempfile import TemporaryDirectory
+
+          import codenib._workspace_owner_impl as implementation
+          from codenib import LocalWorkspaceProvider, PublishedWorkspaceReceiptOwner
+          from codenib import _workspace_owner
+          from codenib._captured_directory import (
+              WorkspaceDirectory,
+              WorkspaceFile,
+              WorkspacePlan,
+          )
+          from codenib._workspace_provider import (
+              StrictWorkspaceRequest,
+              run_strict_workspace,
+          )
+
+          assert Path(implementation.__file__).name == "_workspace_owner_impl.abi3.so"
+          assert implementation.workspace_owner_protocol_version == 2
+          assert implementation.require_support() is None
+          assert _workspace_owner.require_support() is None
+
+          payload = b'{"release-smoke":"ok"}'
+          with TemporaryDirectory() as temporary:
+              root = Path(temporary) / "authority"
+              root.mkdir(mode=0o700)
+              root.chmod(0o700)
+              assert stat.S_IMODE(root.stat().st_mode) == 0o700
+              destination = root / "published"
+              provider = LocalWorkspaceProvider(root)
+              provider.require_support()
+              receipt_owner = PublishedWorkspaceReceiptOwner()
+              plan = WorkspacePlan(
+                  subject_digest=hashlib.sha256(b"release-smoke").hexdigest(),
+                  directories=(WorkspaceDirectory(Path("data")),),
+                  files=(
+                      WorkspaceFile(
+                          Path("data/result.json"),
+                          mode=0o600,
+                          max_bytes=1 << 20,
+                      ),
+                  ),
+              )
+              request = StrictWorkspaceRequest(
+                  purpose="release-smoke",
+                  destination=destination,
+                  plan=plan,
+              )
+
+              def write_and_publish(session):
+                  record = session.write_file("data/result.json", (payload,))
+                  return session.publish_validated(
+                      lambda reader: (
+                          record,
+                          reader.capture_ownership(allow_empty_root=True),
+                      )
+                  )
+
+              record, ownership = run_strict_workspace(
+                  provider,
+                  request,
+                  receipt_owner=receipt_owner,
+                  operation=write_and_publish,
+              )
+              output = destination / "data/result.json"
+              assert record.sha256 == hashlib.sha256(payload).hexdigest()
+              assert ownership.file_records == (record,)
+              assert receipt_owner.active
+              assert output.read_bytes() == payload
+
+              receipt_owner.close()
+
+              assert receipt_owner.closed
+              assert output.read_bytes() == payload
+          PY
 
   install-smoke:
     name: Install smoke (Python ${{ matrix.python-version }})
@@ -130,7 +457,9 @@ jobs:
           python -m venv "$SMOKE_VENV"
           echo "$SMOKE_VENV/bin" >> "$GITHUB_PATH"
           "$SMOKE_VENV/bin/python" -m pip install --upgrade pip
-          "$SMOKE_VENV/bin/python" -m pip install dist/*.whl
+          WHEEL="$(python scripts/verify_release_artifacts.py \
+            dist --print-compatible-wheel)"
+          "$SMOKE_VENV/bin/python" -m pip install "$WHEEL"
 
       - name: Exercise installed CLI
         working-directory: ${{ runner.temp }}
@@ -170,8 +499,8 @@ jobs:
               print(tomllib.load(handle)["project"]["version"])
           PY
           )"
-          WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
-          test -n "$WHEEL"
+          WHEEL="$(python scripts/verify_release_artifacts.py \
+            dist --print-compatible-wheel)"
           python scripts/smoke_release_upgrade.py \
             --wheel "$WHEEL" \
             --expected-version "$VERSION"
@@ -203,8 +532,8 @@ jobs:
           python -m venv "$SERVICE_VENV"
           echo "$SERVICE_VENV/bin" >> "$GITHUB_PATH"
           "$SERVICE_VENV/bin/python" -m pip install --upgrade pip
-          WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
-          test -n "$WHEEL"
+          WHEEL="$(python scripts/verify_release_artifacts.py \
+            dist --print-compatible-wheel)"
           "$SERVICE_VENV/bin/python" -m pip install "${WHEEL}[mcp]"
 
       - name: Verify optional runtime boundary
@@ -264,8 +593,8 @@ jobs:
           python -m venv "$AGENT_VENV"
           echo "$AGENT_VENV/bin" >> "$GITHUB_PATH"
           "$AGENT_VENV/bin/python" -m pip install --upgrade pip
-          WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
-          test -n "$WHEEL"
+          WHEEL="$(python scripts/verify_release_artifacts.py \
+            dist --print-compatible-wheel)"
           "$AGENT_VENV/bin/python" -m pip install "${WHEEL}[agent]"
 
       - name: Verify sparse agent dependency boundary
@@ -321,8 +650,8 @@ jobs:
           python -m venv "$GRAPH_VENV"
           echo "$GRAPH_VENV/bin" >> "$GITHUB_PATH"
           "$GRAPH_VENV/bin/python" -m pip install --upgrade pip
-          WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
-          test -n "$WHEEL"
+          WHEEL="$(python scripts/verify_release_artifacts.py \
+            dist --print-compatible-wheel)"
           "$GRAPH_VENV/bin/python" -m pip install "${WHEEL}[graph,mcp]"
 
       - name: Provision the Python SCIP provider

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
       - ".github/workflows/release-test.yml"
       - ".github/workflows/release-verify.yml"
       - "codenib/**"
+      - "native/**"
       - "scripts/smoke_release_install.py"
       - "scripts/smoke_release_services.py"
       - "scripts/smoke_release_upgrade.py"
@@ -218,10 +219,10 @@ jobs:
           done
           test "$FOUND" = 1
 
-          BUILT_WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
-          PYPI_WHEEL="$(find "$FETCH_DIR" -maxdepth 1 -name '*.whl' -print -quit)"
-          test -n "$BUILT_WHEEL"
-          test -n "$PYPI_WHEEL"
+          BUILT_WHEEL="$(python scripts/verify_release_artifacts.py \
+            dist --print-compatible-wheel)"
+          PYPI_WHEEL="$(python scripts/verify_release_artifacts.py \
+            "$FETCH_DIR" --print-compatible-wheel)"
           test "$(sha256sum "$BUILT_WHEEL" | cut -d' ' -f1)" = \
             "$(sha256sum "$PYPI_WHEEL" | cut -d' ' -f1)"
           echo "CODENIB_VERSION=$VERSION" >> "$GITHUB_ENV"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ logs/
 hf_dataset/
 site/
 .venv/
+/codenib/_workspace_owner_impl*.so
+/codenib/_workspace_owner_impl*.pyd
 .cursor/
 *.bak
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 graft web
+include native/workspace_owner.c
 include CHANGELOG.md
 include CONTRIBUTING.md
 include server.json

--- a/codenib/__init__.py
+++ b/codenib/__init__.py
@@ -16,6 +16,8 @@ from ._lazy import exported_dir, load_export
 from ._version import __version__
 
 if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
+    from codenib._captured_directory import PublishedWorkspaceReceiptOwner
+    from codenib._local_workspace_provider import LocalWorkspaceProvider
     from codenib.agent.extract_agent import KeywordExtractor
     from codenib.agent.rerank_agent import RerankAgent
     from codenib.code_chunker import CodeChunker, RepoChunkingConfig
@@ -30,6 +32,14 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     from codenib.search import CodeSearchEngine
 
 _EXPORTS = {
+    "PublishedWorkspaceReceiptOwner": (
+        "codenib._captured_directory",
+        "PublishedWorkspaceReceiptOwner",
+    ),
+    "LocalWorkspaceProvider": (
+        "codenib._local_workspace_provider",
+        "LocalWorkspaceProvider",
+    ),
     "LSIndexer": ("codenib.ls_router", "LSIndexer"),
     "CodeGraph": ("codenib.graph.code_graph", "CodeGraph"),
     "BM25CodeIndexer": (
@@ -54,6 +64,8 @@ _EXPORTS = {
 
 __all__ = [
     "__version__",
+    "PublishedWorkspaceReceiptOwner",
+    "LocalWorkspaceProvider",
     "LSIndexer",
     "CodeGraph",
     "BM25CodeIndexer",

--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -31,6 +31,7 @@ from typing import (
 )
 
 from . import _windows_fs_authority as _windows_fs
+from . import _workspace_owner as _native_workspace_owner
 
 _WINDOWS_DELETE = _windows_fs.DELETE
 _WINDOWS_FILE_ATTRIBUTE_DIRECTORY = _windows_fs.FILE_ATTRIBUTE_DIRECTORY
@@ -64,7 +65,9 @@ _RENAME_NOREPLACE = 1
 _RENAME_EXCL = 0x4
 _MAX_ORPHAN_NAME_ATTEMPTS = 128
 _MAX_ORDERED_ACTION_CANCELLATION_RETRIES = 8
-_DURABLE_PUBLICATION_FSYNC_BACKENDS = frozenset({"linux-renameat2"})
+_DURABLE_PUBLICATION_FSYNC_BACKENDS = frozenset(
+    {"linux-native-workspace-owner", "linux-renameat2"}
+)
 _WINDOWS_RESERVED_BASENAMES = frozenset(
     {"CON", "PRN", "AUX", "NUL"}
     | {f"COM{number}" for number in range(1, 10)}
@@ -2616,6 +2619,7 @@ class _PublicationAuthority:
         "_metadata_callback",
         "_reader_callback",
         "_rename_callback",
+        "_sync_callback",
         "_verify_callback",
         "_close_complete_callback",
         "_close_state",
@@ -2641,9 +2645,10 @@ class _PublicationAuthority:
             ],
             _T,
         ],
-        rename_callback: Callable[[str, str], None],
+        rename_callback: Callable[[str, str], object | None],
         verify_callback: Callable[[], None],
         close_complete_callback: Callable[[], bool],
+        sync_callback: Callable[[], None] | None = None,
     ) -> None:
         self.display_parent = display_parent
         self.identity = identity
@@ -2653,6 +2658,9 @@ class _PublicationAuthority:
         self._metadata_callback = metadata_callback
         self._reader_callback = reader_callback
         self._rename_callback = rename_callback
+        self._sync_callback = (
+            sync_callback if sync_callback is not None else lambda: os.fsync(resource)
+        )
         self._verify_callback = verify_callback
         self._close_complete_callback = close_complete_callback
         self._close_state = False
@@ -2738,11 +2746,11 @@ class _PublicationAuthority:
             ),
         )
 
-    def rename_noreplace(self, source: str, destination: str) -> None:
+    def rename_noreplace(self, source: str, destination: str) -> object | None:
         self._require_process()
         if self._closed:
             raise RuntimeError("publication authority is closed")
-        self._rename_callback(
+        return self._rename_callback(
             _simple_child_name(source, label="rename source"),
             _simple_child_name(destination, label="rename destination"),
         )
@@ -2752,6 +2760,14 @@ class _PublicationAuthority:
         if self._closed:
             raise RuntimeError("publication authority is closed")
         self._verify_callback()
+
+    def sync_parent(self) -> None:
+        """Durably synchronize the authenticated parent authority."""
+
+        self._require_process()
+        if self._closed:
+            raise RuntimeError("publication authority is closed")
+        self._sync_callback()
 
     def close(self) -> None:
         if self._close_state:
@@ -3139,6 +3155,7 @@ def _open_posix_publication_authority(
             metadata_callback=metadata_callback,
             reader_callback=reader_callback,
             rename_callback=rename_callback,
+            sync_callback=lambda: os.fsync(owned_descriptor),
             verify_callback=verify_callback,
             close_complete_callback=lambda: resources.closed,
         )
@@ -3188,6 +3205,159 @@ def _open_publication_authority(
             authority_owner=authority_owner,
         )
     raise RuntimeError("atomic directory publication is unsupported on this host")
+
+
+def _adopt_native_posix_publication_authority(
+    path: Path,
+    *,
+    native_owner: object,
+    publication_permit: object,
+    authority_owner: _PublicationAuthorityOwner,
+) -> _PublicationAuthority:
+    """Borrow publication callbacks from one exact native aggregate owner.
+
+    The native aggregate remains the sole descriptor owner.  Borrowing these
+    integers creates no Python close authority and performs no ``open`` or
+    ``dup`` operation during adoption.
+    """
+
+    if not sys.platform.startswith("linux"):
+        raise RuntimeError("native workspace adoption requires Linux")
+    if authority_owner.authority is not None:
+        raise RuntimeError("publication authority owner is already active")
+    owner = _native_workspace_owner.require_exact_owner(native_owner)
+    rename_with_permit = _native_workspace_owner._bind_owner_publish_permit(
+        publication_permit
+    )
+    parent_descriptor = _native_workspace_owner.borrow_owner_parent_descriptor(owner)
+    root_descriptor = _native_workspace_owner.borrow_owner_root_descriptor(owner)
+    identity = publication_parent_identity(parent_descriptor)
+    root_identity = _directory_inode_identity(os.fstat(root_descriptor))
+
+    def verify_callback() -> None:
+        _native_workspace_owner.verify_owner_authority(owner)
+        if publication_parent_identity(parent_descriptor) != identity:
+            raise RuntimeError("native workspace parent authority changed")
+        if _directory_inode_identity(os.fstat(root_descriptor)) != root_identity:
+            raise RuntimeError("native workspace root authority changed")
+
+    def metadata_callback(
+        name: str,
+        display_path: Path,
+        label: str,
+    ) -> os.stat_result | None:
+        try:
+            metadata = os.stat(
+                name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            return None
+        if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError(f"{label} is not a directory or is a link: {display_path}")
+        return metadata
+
+    def reader_callback(
+        name: str,
+        display_path: Path,
+        label: str,
+        expected_ownership: _TreeOwnership | None,
+        callback: Callable[[_PublicationTreeReader], _T],
+    ) -> _T:
+        metadata = metadata_callback(name, display_path, label)
+        if metadata is None:
+            raise RuntimeError(f"{label} disappeared: {display_path}")
+        if _directory_inode_identity(metadata) != root_identity:
+            raise RuntimeError(f"{label} differs from the native workspace root")
+        verify_callback()
+        reader: _PublicationTreeReader | None = None
+
+        def deactivate_reader() -> None:
+            if reader is not None:
+                reader._deactivate()
+
+        cleanup_actions = (
+            _OrderedAction(
+                label="publication reader deactivation also failed",
+                action=deactivate_reader,
+                complete=lambda: reader is None or not reader._lifetime.active,
+                retry_incomplete="cancellation",
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            reader = _PublicationTreeReader(
+                display_path,
+                root_identity,
+                lambda required_root_file, allow_empty_root, entry_policy: (
+                    _capture_posix_directory_descriptor(
+                        root_descriptor,
+                        display_path,
+                        required_root_file=required_root_file,
+                        allow_empty_root=allow_empty_root,
+                        entry_policy=entry_policy,
+                    )
+                ),
+                lambda relative, max_bytes, expected: (
+                    _open_posix_authenticated_file(
+                        root_descriptor,
+                        display_path,
+                        relative,
+                        max_bytes=max_bytes,
+                        expected=expected,
+                    )
+                ),
+                expected_ownership,
+            )
+
+            def validate_child_binding() -> None:
+                observed = metadata_callback(name, display_path, label)
+                if (
+                    observed is None
+                    or _directory_inode_identity(observed) != root_identity
+                ):
+                    raise RuntimeError(f"{label} namespace binding changed")
+                verify_callback()
+
+            return _run_publication_reader_callback(
+                reader,
+                callback,
+                validate_child_binding,
+            )
+
+    def rename_callback(source: str, destination: str) -> object | None:
+        return rename_with_permit(
+            os.fsencode(source),
+            os.fsencode(destination),
+        )
+
+    facade_closed = False
+
+    def close_callback(_resource: int) -> None:
+        nonlocal facade_closed
+        facade_closed = True
+
+    authority = _PublicationAuthority(
+        display_parent=path,
+        identity=identity,
+        backend_tag="linux-native-workspace-owner",
+        resource=parent_descriptor,
+        close_callback=close_callback,
+        metadata_callback=metadata_callback,
+        reader_callback=reader_callback,
+        rename_callback=rename_callback,
+        verify_callback=verify_callback,
+        close_complete_callback=lambda: facade_closed,
+        sync_callback=lambda: _native_workspace_owner.sync_owner_parent(owner),
+    )
+    try:
+        verify_callback()
+        authority_owner.install(authority)
+    except BaseException as primary_error:  # noqa: B036 - facade-only cleanup
+        if authority_owner.authority is authority:
+            authority_owner.close_after_error(primary_error)
+        raise
+    return authority
 
 
 def _require_publication_parent_path(
@@ -4379,6 +4549,7 @@ def _open_windows_publication_authority(
             metadata_callback=metadata_callback,
             reader_callback=reader_callback,
             rename_callback=rename_callback,
+            sync_callback=lambda: None,
             verify_callback=verify_callback,
             close_complete_callback=resources_closed,
         )
@@ -5986,7 +6157,7 @@ def _fsync_publication_parent_for_commit(
 ) -> None:
     """Durably order a supported strict commit before its ownership handoff."""
 
-    os.fsync(publication_authority.resource)
+    publication_authority.sync_parent()
 
 
 def _publish_staged_directory_with_authority(
@@ -6012,7 +6183,16 @@ def _publish_staged_directory_with_authority(
         Callable[[PublicationDirectoryReader], None] | None
     ) = None,
     commit_callback: (
-        Callable[[_TreeOwnership, _TreeOwnership, DirectoryOrphan | None], None] | None
+        Callable[
+            [
+                _TreeOwnership,
+                _TreeOwnership,
+                DirectoryOrphan | None,
+                object | None,
+            ],
+            None,
+        ]
+        | None
     ) = None,
 ) -> DirectoryOrphan | None:
     """Publish a complete stage through a caller-owned parent authority.
@@ -6024,10 +6204,13 @@ def _publish_staged_directory_with_authority(
 
     This helper borrows ``publication_authority``.  It never acquires, closes,
     or transfers that authority.  ``commit_callback`` receives the sealed
-    pre-rename token, a fresh post-rename token, and the previous orphan.  It is
-    the final fallible action after publication is fully authenticated and the
-    supported parent namespace has been durably synchronized; once the callback
-    starts, its failures propagate without rolling the publication back.
+    pre-rename token, a fresh post-rename token, the previous orphan, and an
+    optional backend-private receipt capability.  The capability is held only
+    in this protected publication frame until every validator has succeeded.
+    The callback is the final fallible action after publication is fully
+    authenticated and the supported parent namespace has been durably
+    synchronized; once it starts, its failures propagate without rolling the
+    publication back.
 
     Parent fsync orders only the namespace publication.  Strict callers must
     durably seal every staged file and directory before invoking this helper;
@@ -6108,6 +6291,13 @@ def _publish_staged_directory_with_authority(
             path=destination_display,
             label="destination",
         )
+        native_candidate_cleanup = (
+            publication_authority.backend_tag == "linux-native-workspace-owner"
+        )
+        if native_candidate_cleanup and destination_metadata is not None:
+            raise FileExistsError(
+                "native workspace publication requires a missing destination"
+            )
         observed_destination_ownership = (
             None
             if destination_metadata is None
@@ -6249,11 +6439,17 @@ def _publish_staged_directory_with_authority(
             raise
 
         try:
-            publication_authority.rename_noreplace(
+            publication_token = publication_authority.rename_noreplace(
                 stage_display.name,
                 destination_display.name,
             )
         except BaseException:
+            if native_candidate_cleanup:
+                # The aggregate owner still holds the exact candidate and its
+                # original stage/destination binding.  The outer receipt
+                # reconciliation aborts and quarantines it without exposing a
+                # second arbitrary rename capability here.
+                raise
             # If the kernel completed the rename before an asynchronous error,
             # isolate only a tree that still matches the complete stage token.
             try:
@@ -6315,6 +6511,11 @@ def _publish_staged_directory_with_authority(
                     allow_root_rename=True,
                 )
         except BaseException as boundary_error:  # noqa: B036 - safe rollback
+            if native_candidate_cleanup:
+                # Preserve the exact validator/observation error.  The caller
+                # has not installed a receipt yet, so its reserved transfer
+                # deterministically invokes the native owner's abort path.
+                raise
             quarantine = _quarantine_destination(
                 destination_display,
                 parent_authority=publication_authority,
@@ -6415,7 +6616,12 @@ def _publish_staged_directory_with_authority(
         publication_authority.verify_path_binding()
         if commit_callback is not None:
             _fsync_publication_parent_for_commit(publication_authority)
-            commit_callback(stage_ownership, published_ownership, previous_orphan)
+            commit_callback(
+                stage_ownership,
+                published_ownership,
+                previous_orphan,
+                publication_token,
+            )
         return previous_orphan
 
     return perform_publication()

--- a/codenib/_captured_directory.py
+++ b/codenib/_captured_directory.py
@@ -25,12 +25,14 @@ except ImportError:  # pragma: no cover - Windows fails closed when requested
     _fcntl = None  # type: ignore[assignment]
 
 from . import _windows_fs_authority as _windows_fs
+from . import _workspace_owner as _native_workspace_owner
 from ._atomic_directory import (
     _MAX_OWNERSHIP_COMPONENT_BYTES,
     _SAFE_OWNERSHIP_DIRECTORY_FDS,
     DirectoryOrphan,
     PublicationDirectoryReader,
     TreeFileRecord,
+    _adopt_native_posix_publication_authority,
     _annotate_secondary_error,
     _open_publication_authority,
     _PosixResourceOwner,
@@ -641,6 +643,8 @@ class _WorkspaceReservation:
 @dataclass(slots=True)
 class _WorkspaceCleanup:
     transfer: _WorkspacePublicationTransfer
+    abort_unreceipted: bool
+    native_receipt_token: object | None = None
     attempted: bool = False
 
 
@@ -656,6 +660,7 @@ class PublishedWorkspaceReceipt:
         "orphan",
         "durable",
         "_transfer",
+        "_native_receipt_token",
         "_owner_pid",
     )
 
@@ -669,6 +674,7 @@ class PublishedWorkspaceReceipt:
         published_ownership: object,
         parent_identity: tuple[int, ...],
         orphan: DirectoryOrphan | None,
+        native_receipt_token: object | None,
     ) -> None:
         # Store the shared aggregate first.  A constructor interruption can
         # therefore be reconciled against the same transfer held by the owner.
@@ -680,6 +686,7 @@ class PublishedWorkspaceReceipt:
         self.parent_identity = parent_identity
         self.orphan = orphan
         self.durable = True
+        self._native_receipt_token = native_receipt_token
         self._owner_pid = os.getpid()
 
     @property
@@ -721,7 +728,18 @@ class PublishedWorkspaceReceipt:
     def _close_from_owner(self, close_authority: object) -> None:
         if close_authority is not _WORKSPACE_RECEIPT_CLOSE:
             raise RuntimeError("published workspace receipt close authority is invalid")
-        self._transfer.workspace._close_publication_transfer(self._transfer)
+        self._transfer.workspace._close_publication_transfer(
+            self._transfer,
+            abort_unreceipted=False,
+            native_receipt_token=self._native_receipt_token,
+        )
+
+
+# Keep the runtime receipt discriminator independent from the public module
+# attribute. Publication validators run between the native rename and the
+# caller-owned slot store; replacing that public name during the callback must
+# not change owner-state reconciliation after the callback returns.
+_PUBLISHED_WORKSPACE_RECEIPT_TYPE = PublishedWorkspaceReceipt
 
 
 class PublishedWorkspaceReceiptOwner:
@@ -759,7 +777,7 @@ class PublishedWorkspaceReceiptOwner:
 
         def borrow() -> PublishedWorkspaceReceipt:
             self._normalize_closed_locked()
-            if not isinstance(self._slot, PublishedWorkspaceReceipt):
+            if not isinstance(self._slot, _PUBLISHED_WORKSPACE_RECEIPT_TYPE):
                 raise RuntimeError(
                     "published workspace receipt owner is "
                     f"{self._state_locked()}, expected active"
@@ -785,7 +803,7 @@ class PublishedWorkspaceReceiptOwner:
 
         def consume_locked() -> _WorkspaceResult:
             self._normalize_closed_locked()
-            if not isinstance(self._slot, PublishedWorkspaceReceipt):
+            if not isinstance(self._slot, _PUBLISHED_WORKSPACE_RECEIPT_TYPE):
                 raise RuntimeError(
                     "published workspace receipt owner is "
                     f"{self._state_locked()}, expected active"
@@ -842,11 +860,20 @@ class PublishedWorkspaceReceiptOwner:
             # cannot wait for or affect the parent's in-flight publication,
             # so revoke the child copy and run the transfer's raw inherited-fd
             # cleanup before reporting the PID boundary.
-            cleanup = _WorkspaceCleanup(self._slot.transfer, attempted=True)
+            cleanup = _WorkspaceCleanup(
+                self._slot.transfer,
+                abort_unreceipted=True,
+                attempted=True,
+            )
             self._slot = cleanup
-        if isinstance(self._slot, PublishedWorkspaceReceipt):
+        if isinstance(self._slot, _PUBLISHED_WORKSPACE_RECEIPT_TYPE):
             receipt = self._slot
-            cleanup = _WorkspaceCleanup(receipt._transfer, attempted=True)
+            cleanup = _WorkspaceCleanup(
+                receipt._transfer,
+                abort_unreceipted=False,
+                native_receipt_token=receipt._native_receipt_token,
+                attempted=True,
+            )
             self._slot = cleanup
         elif isinstance(self._slot, _WorkspaceCleanup):
             cleanup = self._slot
@@ -856,7 +883,11 @@ class PublishedWorkspaceReceiptOwner:
 
         primary_error: BaseException | None = None
         try:
-            cleanup.transfer.workspace._close_publication_transfer(cleanup.transfer)
+            cleanup.transfer.workspace._close_publication_transfer(
+                cleanup.transfer,
+                abort_unreceipted=cleanup.abort_unreceipted,
+                native_receipt_token=cleanup.native_receipt_token,
+            )
         except BaseException as close_error:  # noqa: B036 - settle aggregate
             primary_error = close_error
         try:
@@ -924,21 +955,42 @@ class PublishedWorkspaceReceiptOwner:
     def _has_active_transfer(self, transfer: _WorkspacePublicationTransfer) -> bool:
         def active() -> bool:
             return (
-                isinstance(self._slot, PublishedWorkspaceReceipt)
+                isinstance(self._slot, _PUBLISHED_WORKSPACE_RECEIPT_TYPE)
                 and self._slot._transfer is transfer
             )
 
         return self._lock.run(active)
 
     def _transfer_state(self, transfer: _WorkspacePublicationTransfer) -> str:
-        def observe() -> str:
-            if isinstance(self._slot, PublishedWorkspaceReceipt):
-                return "active" if self._slot._transfer is transfer else "absent"
+        return self._transfer_state_and_receipt_token(transfer)[0]
+
+    def _transfer_state_and_receipt_token(
+        self,
+        transfer: _WorkspacePublicationTransfer,
+    ) -> tuple[str, object | None]:
+        def observe() -> tuple[str, object | None]:
+            if isinstance(self._slot, _PUBLISHED_WORKSPACE_RECEIPT_TYPE):
+                if self._slot._transfer is transfer:
+                    return "active", self._slot._native_receipt_token
+                return "absent", None
             if isinstance(self._slot, _WorkspaceReservation):
-                return "reserved" if self._slot.transfer is transfer else "absent"
+                return (
+                    ("reserved", None)
+                    if self._slot.transfer is transfer
+                    else ("absent", None)
+                )
             if isinstance(self._slot, _WorkspaceCleanup):
-                return "cleanup" if self._slot.transfer is transfer else "absent"
-            return "absent"
+                if self._slot.transfer is not transfer:
+                    return "absent", None
+                return (
+                    (
+                        "cleanup-abort"
+                        if self._slot.abort_unreceipted
+                        else "cleanup-retain"
+                    ),
+                    self._slot.native_receipt_token,
+                )
+            return "absent", None
 
         return self._lock.run(observe)
 
@@ -972,7 +1024,10 @@ class PublishedWorkspaceReceiptOwner:
         reservation: _WorkspaceReservation,
     ) -> bool:
         if self._slot is reservation:
-            self._slot = _WorkspaceCleanup(reservation.transfer)
+            self._slot = _WorkspaceCleanup(
+                reservation.transfer,
+                abort_unreceipted=True,
+            )
         return self._slot is not reservation
 
     def _normalize_closed_locked(self) -> None:
@@ -989,7 +1044,7 @@ class PublishedWorkspaceReceiptOwner:
             return self._slot.transfer
         if isinstance(self._slot, _WorkspaceCleanup):
             return self._slot.transfer
-        if isinstance(self._slot, PublishedWorkspaceReceipt):
+        if isinstance(self._slot, _PUBLISHED_WORKSPACE_RECEIPT_TYPE):
             return self._slot._transfer
         return None
 
@@ -1000,7 +1055,7 @@ class PublishedWorkspaceReceiptOwner:
             return "closed"
         if isinstance(self._slot, _WorkspaceReservation):
             return "reserved"
-        if isinstance(self._slot, PublishedWorkspaceReceipt):
+        if isinstance(self._slot, _PUBLISHED_WORKSPACE_RECEIPT_TYPE):
             return "active"
         if isinstance(self._slot, _WorkspaceCleanup):
             return "close-failed" if self._slot.attempted else "cleanup"
@@ -2035,6 +2090,7 @@ class OwnedWorkspaceAuthority:
         self._sealed_ownership: object | None = None
         self._publication_transfer: _WorkspacePublicationTransfer | None = None
         self._resources_transferred = False
+        self._native_owner: object | None = None
 
     @property
     def state(self) -> str:
@@ -2120,6 +2176,105 @@ class OwnedWorkspaceAuthority:
             )
         )
 
+    def adopt_provisioned(
+        self,
+        *,
+        destination: Path,
+        stage_name: str,
+        provisioned_owner: object,
+        publication_permit: object,
+        plan: WorkspacePlan,
+        expected_destination: object | None,
+    ) -> None:
+        """Adopt a native-owned skeleton without duplicating its descriptors."""
+
+        self._require_owner_pid()
+        if not sys.platform.startswith("linux"):
+            raise UnsupportedWorkspaceCreation(
+                "native provisioned workspace adoption requires Linux"
+            )
+        self._reject_reentrant("adopt provisioned workspace")
+        self._lock.run(
+            lambda: self._adopt_provisioned_locked(
+                destination=destination,
+                stage_name=stage_name,
+                provisioned_owner=provisioned_owner,
+                publication_permit=publication_permit,
+                plan=plan,
+                expected_destination=expected_destination,
+            )
+        )
+
+    def _adopt_provisioned_locked(
+        self,
+        *,
+        destination: Path,
+        stage_name: str,
+        provisioned_owner: object,
+        publication_permit: object,
+        plan: WorkspacePlan,
+        expected_destination: object | None,
+    ) -> None:
+        self._require_owner_pid()
+        if self._state != "empty" or self._native_owner is not None:
+            raise RuntimeError("owned workspace authority is not empty")
+        if expected_destination is not None:
+            raise UnsupportedWorkspaceCreation(
+                "native local workspaces currently require a missing destination"
+            )
+        detached_plan = _snapshot_workspace_plan(plan)
+        destination_path = lexical_directory_path(destination)
+        stage_relative = _relative_path(stage_name)
+        if len(stage_relative.parts) != 1:
+            raise ValueError("workspace stage name must be one bounded file name")
+        owner = _native_workspace_owner.require_exact_owner(provisioned_owner)
+        _native_workspace_owner.verify_owner_adoption_binding(
+            owner,
+            os.fsencode(destination_path),
+            os.fsencode(stage_relative.name),
+            detached_plan.digest.encode("ascii"),
+        )
+        try:
+            # This is the native ownership handoff.  It precedes every
+            # borrowed-descriptor read and remains inside failure settlement.
+            self._native_owner = owner
+            directory_descriptors = {
+                item.path.as_posix(): (
+                    _native_workspace_owner.borrow_owner_directory_descriptor(
+                        owner,
+                        os.fsencode(item.path.as_posix()),
+                    )
+                )
+                for item in detached_plan.directories
+            }
+            self._adopt_locked(
+                destination=destination_path,
+                stage_name=stage_relative.name,
+                parent_descriptor=(
+                    _native_workspace_owner.borrow_owner_parent_descriptor(owner)
+                ),
+                root_descriptor=(
+                    _native_workspace_owner.borrow_owner_root_descriptor(owner)
+                ),
+                directory_descriptors=directory_descriptors,
+                plan=detached_plan,
+                expected_destination=None,
+                native_publication_permit=publication_permit,
+            )
+        except BaseException as adoption_error:  # noqa: B036 - settle owner
+            if self._state == "empty":
+                self._state = "failed"
+                try:
+                    _native_workspace_owner.abort_owner(owner)
+                except BaseException as cleanup_error:  # noqa: B036
+                    _attach_cleanup_owner(adoption_error, owner)
+                    _annotate_secondary_error(
+                        adoption_error,
+                        "native workspace adoption cleanup also failed",
+                        cleanup_error,
+                    )
+            raise
+
     def _adopt_locked(
         self,
         *,
@@ -2133,6 +2288,7 @@ class OwnedWorkspaceAuthority:
         ],
         plan: WorkspacePlan,
         expected_destination: object | None,
+        native_publication_permit: object | None = None,
     ) -> None:
         self._require_owner_pid()
         if self._state != "empty":
@@ -2188,12 +2344,26 @@ class OwnedWorkspaceAuthority:
         self._expected_destination = expected_destination
         self._file_specs = {item.path.as_posix(): item for item in plan.files}
         try:
-            _open_publication_authority(
-                destination_path.parent,
-                parent_resource=parent_descriptor,
-                expected_parent_identity=publication_parent_identity(parent_descriptor),
-                authority_owner=self._parent_owner,
-            )
+            if self._native_owner is None:
+                _open_publication_authority(
+                    destination_path.parent,
+                    parent_resource=parent_descriptor,
+                    expected_parent_identity=publication_parent_identity(
+                        parent_descriptor
+                    ),
+                    authority_owner=self._parent_owner,
+                )
+            else:
+                if native_publication_permit is None:
+                    raise RuntimeError(
+                        "native workspace publication capability is missing"
+                    )
+                _adopt_native_posix_publication_authority(
+                    destination_path.parent,
+                    native_owner=self._native_owner,
+                    publication_permit=native_publication_permit,
+                    authority_owner=self._parent_owner,
+                )
             authority = self._require_parent_authority()
             flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
             flags |= getattr(os, "O_CLOEXEC", 0) | getattr(
@@ -2201,11 +2371,14 @@ class OwnedWorkspaceAuthority:
                 "O_NONBLOCK",
                 0,
             )
-            self._root_descriptor = self._resources.open(
-                ".",
-                flags,
-                dir_fd=root_descriptor,
-            )
+            if self._native_owner is None:
+                self._root_descriptor = self._resources.open(
+                    ".",
+                    flags,
+                    dir_fd=root_descriptor,
+                )
+            else:
+                self._root_descriptor = root_descriptor
             root_metadata = os.fstat(self._root_descriptor)
             if not stat.S_ISDIR(root_metadata.st_mode):
                 raise ValueError("workspace root descriptor is not a directory")
@@ -2271,11 +2444,14 @@ class OwnedWorkspaceAuthority:
             self._directory_identities = {"": self._root_identity}
             for item in plan.directories:
                 path = item.path.as_posix()
-                descriptor = self._resources.open(
-                    ".",
-                    flags,
-                    dir_fd=normalized_descriptors[path],
-                )
+                if self._native_owner is None:
+                    descriptor = self._resources.open(
+                        ".",
+                        flags,
+                        dir_fd=normalized_descriptors[path],
+                    )
+                else:
+                    descriptor = normalized_descriptors[path]
                 metadata = os.fstat(descriptor)
                 identity = _root_identity(metadata)
                 if (
@@ -2330,9 +2506,21 @@ class OwnedWorkspaceAuthority:
                     raise RuntimeError("owned workspace destination changed")
             authority.verify_path_binding()
             self._refresh_locked(require_complete=False)
+            if self._native_owner is not None:
+                _native_workspace_owner.mark_owner_adopted(self._native_owner)
             self._state = "adopted"
         except BaseException as refresh_error:
             self._state = "failed"
+            if self._native_owner is not None:
+                try:
+                    _native_workspace_owner.abort_owner(self._native_owner)
+                except BaseException as cleanup_error:  # noqa: B036
+                    _attach_cleanup_owner(refresh_error, self._native_owner)
+                    _annotate_secondary_error(
+                        refresh_error,
+                        "native workspace adoption cleanup also failed",
+                        cleanup_error,
+                    )
             self._close_resources_after_error_locked(refresh_error)
             raise
 
@@ -2360,6 +2548,8 @@ class OwnedWorkspaceAuthority:
             raise ValueError(f"workspace file is absent from its plan: {path}")
         if path in self._written_files:
             raise ValueError(f"workspace file was already written: {path}")
+        if self._native_owner is not None:
+            return self._write_native_file_locked(normalized, path, spec, chunks)
 
         descriptor = -1
         descriptor_record = _WorkspaceFileOwner(_DescriptorOwner())
@@ -2492,6 +2682,140 @@ class OwnedWorkspaceAuthority:
             raise
         return public_record
 
+    def _write_native_file_locked(
+        self,
+        normalized: PurePosixPath,
+        path: str,
+        spec: WorkspaceFile,
+        chunks: Iterable[bytes],
+    ) -> TreeFileRecord:
+        owner = self._native_owner
+        if owner is None:  # pragma: no cover - caller selects this branch
+            raise RuntimeError("native workspace owner is unavailable")
+        iterator = None
+        primary_error: BaseException | None = None
+        record: tuple[tuple[int, ...], int, int, str] | None = None
+        try:
+            self._refresh_locked(require_complete=False)
+            iterator = iter(chunks)
+            parent_path = normalized.parent.as_posix()
+            if parent_path == ".":
+                parent_path = ""
+            _native_workspace_owner.begin_owner_file(
+                owner,
+                os.fsencode(parent_path),
+                os.fsencode(normalized.name),
+                0o600,
+            )
+            byte_count = 0
+            digest = hashlib.sha256()
+            for chunk in iterator:
+                if not isinstance(chunk, bytes):
+                    raise TypeError("owned workspace file chunks must be bytes")
+                byte_count += len(chunk)
+                if byte_count > spec.max_bytes:
+                    raise ValueError(
+                        f"workspace file exceeds its {spec.max_bytes}-byte limit: "
+                        f"{path}"
+                    )
+                digest.update(chunk)
+                for offset in range(0, len(chunk), _COPY_BYTES):
+                    _native_workspace_owner.write_owner_file(
+                        owner,
+                        chunk[offset : offset + _COPY_BYTES],
+                    )
+            metadata = _native_workspace_owner.finish_owner_file(owner, spec.mode)
+            identity = (
+                metadata[0],
+                metadata[1],
+                stat.S_IFMT(metadata[2]),
+                metadata[7],
+            )
+            if (
+                not stat.S_ISREG(metadata[2])
+                or stat.S_IMODE(metadata[2]) != spec.mode
+                or metadata[3] != byte_count
+                or metadata[6] != 1
+                or self._root_identity is None
+                or identity[0] != self._root_identity[0]
+            ):
+                raise RuntimeError(f"owned workspace file changed: {path}")
+            record = (identity, spec.mode, byte_count, digest.hexdigest())
+        except BaseException as exc:  # noqa: B036 - settle native owner
+            primary_error = exc
+        finally:
+            try:
+                close_iterator = getattr(iterator, "close", None)
+            except BaseException as close_error:  # noqa: B036
+                if primary_error is None:
+                    primary_error = close_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "workspace producer cleanup lookup also failed",
+                        close_error,
+                    )
+            else:
+                if callable(close_iterator):
+                    try:
+                        close_iterator()
+                    except BaseException as close_error:  # noqa: B036
+                        if primary_error is None:
+                            primary_error = close_error
+                        else:
+                            _annotate_secondary_error(
+                                primary_error,
+                                "workspace producer cleanup also failed",
+                                close_error,
+                            )
+            if primary_error is not None:
+                try:
+                    _native_workspace_owner.abort_owner_file(owner)
+                except BaseException as cleanup_error:  # noqa: B036
+                    _annotate_secondary_error(
+                        primary_error,
+                        "native workspace file cleanup also failed",
+                        cleanup_error,
+                    )
+
+        if primary_error is not None:
+            self._state = "failed"
+            self._abort_native_after_error_locked(primary_error)
+            raise primary_error.with_traceback(primary_error.__traceback__)
+        assert record is not None
+        try:
+            self._written_files[path] = record
+            public_record = TreeFileRecord(
+                path=path,
+                mode=record[1],
+                size=record[2],
+                sha256=record[3],
+            )
+            self._refresh_locked(require_complete=False)
+            self._state = "writing"
+        except BaseException as transition_error:
+            self._state = "failed"
+            self._abort_native_after_error_locked(transition_error)
+            raise
+        return public_record
+
+    def _abort_native_after_error_locked(
+        self,
+        primary_error: BaseException,
+    ) -> None:
+        owner = self._native_owner
+        if owner is not None:
+            try:
+                _native_workspace_owner.abort_owner(owner)
+            except BaseException as cleanup_error:  # noqa: B036
+                _attach_cleanup_owner(primary_error, owner)
+                _annotate_secondary_error(
+                    primary_error,
+                    "native workspace abort also failed",
+                    cleanup_error,
+                )
+        self._close_resources_after_error_locked(primary_error)
+
     def seal(self) -> object:
         self._require_owner_pid()
         self._reject_reentrant("seal")
@@ -2508,7 +2832,10 @@ class OwnedWorkspaceAuthority:
                 ownership = self._refresh_locked(require_complete=True)
             except BaseException as primary_error:
                 self._state = "failed"
-                self._close_resources_after_error_locked(primary_error)
+                if self._native_owner is None:
+                    self._close_resources_after_error_locked(primary_error)
+                else:
+                    self._abort_native_after_error_locked(primary_error)
                 raise
             self._sealed_ownership = ownership
             self._state = "sealed"
@@ -2518,6 +2845,10 @@ class OwnedWorkspaceAuthority:
 
     def _fsync_directories_locked(self) -> None:
         """Persist the complete pre-opened skeleton from leaves to its root."""
+
+        if self._native_owner is not None:
+            _native_workspace_owner.seal_owner_directories(self._native_owner)
+            return
 
         ordered_paths = sorted(
             self._directory_descriptors,
@@ -2602,11 +2933,20 @@ class OwnedWorkspaceAuthority:
         destination = self._destination
         plan = self._plan
         authority = self._require_parent_authority()
+        # Freeze every token-receiving Python callable before either validator
+        # runs.  Fault-injection may replace these before publish_into enters,
+        # but validator-time module/class mutation cannot intercept the private
+        # capability between the native rename and the caller-owned slot store.
+        receipt_type = _PUBLISHED_WORKSPACE_RECEIPT_TYPE
+        receipt_new = receipt_type.__new__
+        receipt_init = receipt_type.__init__
+        install_receipt_exact = PublishedWorkspaceReceiptOwner._install
 
         def install_receipt(
             committed_sealed: object,
             published_ownership: object,
             previous_orphan: DirectoryOrphan | None,
+            native_receipt_token: object | None,
         ) -> None:
             if committed_sealed != sealed_ownership:
                 raise RuntimeError("published workspace sealed token changed")
@@ -2616,7 +2956,9 @@ class OwnedWorkspaceAuthority:
                 label="published workspace",
                 allow_root_rename=True,
             )
-            receipt = PublishedWorkspaceReceipt(
+            receipt = receipt_new(receipt_type)
+            receipt_init(
+                receipt,
                 transfer=transfer,
                 path=destination,
                 plan=_snapshot_workspace_plan(plan),
@@ -2624,12 +2966,14 @@ class OwnedWorkspaceAuthority:
                 published_ownership=published_ownership,
                 parent_identity=authority.identity,
                 orphan=previous_orphan,
+                native_receipt_token=native_receipt_token,
             )
-            # State is written before install.  If install is interrupted
-            # before its slot store, the outer reconciliation demotes this to
-            # failed; after the store no later state write is required.
+            # This slot store is the unique authority linearization point.
+            # Before it, reconciliation aborts a native candidate; after it,
+            # every active/retain path idempotently commits that candidate.
+            install_receipt_exact(receipt_owner, reservation, receipt)
+            self._ensure_native_receipted_locked(native_receipt_token)
             self._state = "published"
-            receipt_owner._install(reservation, receipt)
 
         _publish_staged_directory_with_authority(
             authority,
@@ -2714,7 +3058,7 @@ class OwnedWorkspaceAuthority:
         if not publication_started:
             return True
 
-        transfer_state = self._receipt_transfer_state_after_error(
+        transfer_state, native_receipt_token = self._receipt_transfer_state_after_error(
             receipt_owner,
             transfer,
             primary_error,
@@ -2723,7 +3067,10 @@ class OwnedWorkspaceAuthority:
             raise RuntimeError("workspace receipt ownership is unknown")
         if transfer_state == "reserved":
             receipt_owner._cancel_reservation(reservation)
-            transfer_state = self._receipt_transfer_state_after_error(
+            (
+                transfer_state,
+                native_receipt_token,
+            ) = self._receipt_transfer_state_after_error(
                 receipt_owner,
                 transfer,
                 primary_error,
@@ -2739,11 +3086,13 @@ class OwnedWorkspaceAuthority:
             # checked again before touching workspace state.
             if self._publication_transfer is not transfer:
                 return
-            if transfer_state == "active":
+            if transfer_state in {"active", "cleanup-retain"}:
+                self._ensure_native_receipted_locked(native_receipt_token)
                 self._state = "published"
                 return
-            if transfer_state == "cleanup":
+            if transfer_state == "cleanup-abort":
                 self._state = "failed"
+                self._abort_native_owner_locked()
                 return
             if transfer_state != "absent":
                 raise RuntimeError(
@@ -2754,6 +3103,7 @@ class OwnedWorkspaceAuthority:
             # the transfer marker last so an interrupted settle can resume.
             self._resources_transferred = False
             self._state = "failed"
+            self._abort_native_owner_locked()
             self._close_resources_after_error_locked(primary_error)
             self._publication_transfer = None
 
@@ -2765,11 +3115,11 @@ class OwnedWorkspaceAuthority:
         receipt_owner: PublishedWorkspaceReceiptOwner,
         transfer: _WorkspacePublicationTransfer,
         primary_error: BaseException,
-    ) -> str:
+    ) -> tuple[str, object | None]:
         deferred: BaseException | None = None
         for _attempt in range(_WORKSPACE_OWNER_RECOVERY_LIMIT):
             try:
-                state = receipt_owner._transfer_state(transfer)
+                state = receipt_owner._transfer_state_and_receipt_token(transfer)
             except BaseException as state_error:  # noqa: B036 - bounded recovery
                 if deferred is None:
                     deferred = state_error
@@ -2802,7 +3152,7 @@ class OwnedWorkspaceAuthority:
             recovery_error,
         )
         # Unknown ownership must never trigger a competing resource close.
-        return "unknown"
+        return "unknown", None
 
     def _consume_published_workspace(
         self,
@@ -2823,6 +3173,7 @@ class OwnedWorkspaceAuthority:
                 or self._plan != receipt._plan
             ):
                 raise RuntimeError("published workspace receipt is not active")
+            self._ensure_native_receipted_locked(receipt._native_receipt_token)
             authority = self._require_parent_authority()
             if authority.identity != receipt.parent_identity:
                 raise RuntimeError("published workspace parent authority changed")
@@ -2873,6 +3224,9 @@ class OwnedWorkspaceAuthority:
     def _close_publication_transfer(
         self,
         transfer: _WorkspacePublicationTransfer,
+        *,
+        abort_unreceipted: bool,
+        native_receipt_token: object | None,
     ) -> None:
         current_pid = os.getpid()
         if current_pid != self._owner_pid:
@@ -2905,7 +3259,10 @@ class OwnedWorkspaceAuthority:
             self._require_publication_transfer_locked(transfer)
             primary_error: BaseException | None = None
             try:
-                self._close_resources_locked()
+                self._close_resources_locked(
+                    abort_unreceipted=abort_unreceipted,
+                    native_receipt_token=native_receipt_token,
+                )
             except BaseException as close_error:  # noqa: B036 - reconcile transfer
                 primary_error = close_error
             try:
@@ -2957,6 +3314,36 @@ class OwnedWorkspaceAuthority:
         self._require_publication_transfer_locked(transfer)
         self._resources_transferred = False
         self._publication_transfer = None
+
+    def _ensure_native_receipted_locked(
+        self,
+        native_receipt_token: object | None,
+    ) -> None:
+        owner = self._native_owner
+        if owner is None:
+            return
+        if _native_workspace_owner.owner_closed(owner):
+            if self._state != "closed":
+                raise RuntimeError(
+                    "native workspace owner closed before receipt settlement"
+                )
+            return
+        if _native_workspace_owner.owner_state(owner) != "receipted":
+            if native_receipt_token is None:
+                raise RuntimeError("native workspace receipt capability is missing")
+            _native_workspace_owner.commit_owner_receipt(native_receipt_token)
+        if _native_workspace_owner.owner_state(owner) != "receipted":
+            raise RuntimeError("native workspace receipt did not commit")
+
+    def _abort_native_owner_locked(self) -> None:
+        owner = self._native_owner
+        if owner is None or _native_workspace_owner.owner_closed(owner):
+            return
+        if _native_workspace_owner.owner_state(owner) == "receipted":
+            raise RuntimeError("receipted native workspace cannot be aborted")
+        _native_workspace_owner.abort_owner(owner)
+        if not _native_workspace_owner.owner_closed(owner):
+            raise RuntimeError("native workspace abort did not close its owner")
 
     def _refresh_locked(self, *, require_complete: bool) -> object:
         authority = self._require_parent_authority()
@@ -3137,12 +3524,86 @@ class OwnedWorkspaceAuthority:
         if close_error is not None:
             raise close_error
 
+    def _settle_provider_owner(self, native_owner: object) -> None:
+        """Abort pre-transfer resources or defer to the caller receipt."""
+
+        current_pid = os.getpid()
+        if current_pid != self._owner_pid:
+            child_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+
+            def settle_inherited() -> None:
+                exact_owner = _native_workspace_owner.require_exact_owner(native_owner)
+                if self._native_owner is None:
+                    _native_workspace_owner.close_owner_exact(exact_owner)
+                    return
+                if self._native_owner is not exact_owner:
+                    raise RuntimeError("workspace provider native owner changed")
+                self._close_inherited_resources_locked()
+
+            child_lock.run(settle_inherited)
+            return
+        self._require_owner_pid()
+
+        def settle() -> None:
+            if self._resources_transferred:
+                return
+            exact_owner = _native_workspace_owner.require_exact_owner(native_owner)
+            if self._native_owner is None:
+                if not _native_workspace_owner.owner_closed(exact_owner):
+                    _native_workspace_owner.abort_owner(exact_owner)
+            elif self._native_owner is not exact_owner:
+                raise RuntimeError("workspace provider native owner changed")
+            self._close_resources_locked(abort_unreceipted=True)
+
+        self._lock.run(settle)
+
+    def _provider_owner_settled(self, native_owner: object) -> bool:
+        """Return whether provider cleanup is terminal or receipt-transferred."""
+
+        current_pid = os.getpid()
+        if current_pid != self._owner_pid:
+            child_lock = self._process_locks.setdefault(
+                current_pid,
+                _CancellationSafeRLock(),
+            )
+
+            def inherited_settled() -> bool:
+                exact_owner = _native_workspace_owner.require_exact_owner(native_owner)
+                if self._native_owner is None:
+                    return _native_workspace_owner.owner_closed(exact_owner)
+                if self._native_owner is not exact_owner:
+                    raise RuntimeError("workspace provider native owner changed")
+                return self._state == "closed" and _native_workspace_owner.owner_closed(
+                    exact_owner
+                )
+
+            return child_lock.run(inherited_settled)
+        self._require_owner_pid()
+
+        def settled() -> bool:
+            exact_owner = _native_workspace_owner.require_exact_owner(native_owner)
+            if self._resources_transferred:
+                return True
+            return self._state == "closed" and _native_workspace_owner.owner_closed(
+                exact_owner
+            )
+
+        return self._lock.run(settled)
+
     def _close_inherited_resources_locked(self) -> None:
         """Close only this fork child's inherited descriptor references."""
 
         if self._state == "closed":
             return
         primary_error: BaseException | None = None
+        if self._native_owner is not None:
+            try:
+                _native_workspace_owner.close_owner_exact(self._native_owner)
+            except BaseException as close_error:  # noqa: B036 - child cleanup
+                primary_error = close_error
         for record in reversed(tuple(self._file_owners)):
             descriptor = record.owner.descriptor
             if descriptor < 0:
@@ -3187,6 +3648,10 @@ class OwnedWorkspaceAuthority:
                 all(record.owner.descriptor < 0 for record in self._file_owners)
                 and self._resources.closed
                 and self._parent_owner.authority is None
+                and (
+                    self._native_owner is None
+                    or _native_workspace_owner.owner_closed(self._native_owner)
+                )
             )
         except BaseException as reconciliation_error:  # noqa: B036
             if primary_error is None:
@@ -3264,10 +3729,24 @@ class OwnedWorkspaceAuthority:
         record.owner._identity = None
         record.owner._close_cookie = None
 
-    def _close_resources_locked(self) -> None:
+    def _close_resources_locked(
+        self,
+        *,
+        abort_unreceipted: bool = True,
+        native_receipt_token: object | None = None,
+    ) -> None:
         if self._state == "closed":
             return
         primary_error: BaseException | None = None
+        if self._native_owner is not None:
+            try:
+                if abort_unreceipted:
+                    self._abort_native_owner_locked()
+                else:
+                    self._ensure_native_receipted_locked(native_receipt_token)
+                    _native_workspace_owner.close_owner_exact(self._native_owner)
+            except BaseException as close_error:  # noqa: B036 - cleanup all
+                primary_error = close_error
         for record in reversed(tuple(self._file_owners)):
             descriptor = record.owner.descriptor
             if descriptor < 0:
@@ -3318,6 +3797,10 @@ class OwnedWorkspaceAuthority:
                 all(record.owner.descriptor < 0 for record in self._file_owners)
                 and self._resources.closed
                 and self._parent_owner.authority is None
+                and (
+                    self._native_owner is None
+                    or _native_workspace_owner.owner_closed(self._native_owner)
+                )
             )
         except BaseException as reconciliation_error:  # noqa: B036
             if primary_error is None:

--- a/codenib/_local_workspace_provider.py
+++ b/codenib/_local_workspace_provider.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Linux missing-destination provider for strict local workspaces.
+
+The configured root is an authority boundary, not a sandbox.  It must be a
+private, quiescent directory controlled by the current process owner.  The
+native aggregate pins every namespace component and owns all mutating file
+descriptors; Python only borrows those handles through the existing strict
+workspace lifecycle.  This is not an in-process Python sandbox: callbacks share
+the interpreter and must not reflectively mutate CodeNib's private internals.
+If a process later blocks both native OFD-comparison mechanisms, cleanup fails
+closed and the raised exception retains the explicit cleanup owner for retry.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, TypeVar
+
+from . import _workspace_owner
+from ._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
+from ._captured_directory import (
+    OwnedWorkspaceAuthority,
+    PublishedWorkspaceReceiptOwner,
+    UnsupportedWorkspaceCreation,
+    _snapshot_workspace_plan,
+    require_owned_workspace_publication_support,
+)
+from ._workspace_provider import (
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_adopted_workspace_operation,
+)
+
+_OperationResult = TypeVar("_OperationResult")
+_DEFAULT_PROVISION_TIMEOUT_NS = 30_000_000_000
+_MAX_PROVISION_TIMEOUT_NS = 300_000_000_000
+_STAGE_PREFIX = ".codenib-workspace-stage-"
+
+
+@dataclass(slots=True)
+class _ProviderWorkspaceCleanupOwner:
+    workspace: OwnedWorkspaceAuthority
+    native_owner: object
+
+    @property
+    def closed(self) -> bool:
+        return self.workspace._provider_owner_settled(self.native_owner)
+
+    def close(self) -> None:
+        self.workspace._settle_provider_owner(self.native_owner)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalWorkspaceProvider:
+    """Provision strict workspaces below one private Linux authority root."""
+
+    allowed_root: Path
+    provision_timeout_ns: int = _DEFAULT_PROVISION_TIMEOUT_NS
+    _owner_pid: int = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if type(self) is not LocalWorkspaceProvider:
+            raise TypeError("LocalWorkspaceProvider cannot be subclassed")
+        if not isinstance(self.allowed_root, Path):
+            raise TypeError("local workspace allowed_root must be a Path")
+        root = Path(os.path.abspath(os.fspath(self.allowed_root.expanduser())))
+        if root == root.parent:
+            raise ValueError("local workspace allowed_root cannot be a filesystem root")
+        timeout = self.provision_timeout_ns
+        if type(timeout) is not int:
+            raise TypeError("local workspace provision timeout must be an integer")
+        if timeout <= 0 or timeout > _MAX_PROVISION_TIMEOUT_NS:
+            raise ValueError("local workspace provision timeout is out of bounds")
+        object.__setattr__(self, "allowed_root", root)
+        object.__setattr__(self, "_owner_pid", os.getpid())
+
+    def _require_owner_pid(self) -> None:
+        if os.getpid() != self._owner_pid:
+            raise RuntimeError("local workspace provider cannot cross a PID boundary")
+
+    def _require_private_root(self) -> None:
+        try:
+            metadata = self.allowed_root.lstat()
+        except OSError as error:
+            raise UnsupportedWorkspaceCreation(
+                "local workspace allowed_root is unavailable"
+            ) from error
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) & 0o077
+            or stat.S_IMODE(metadata.st_mode) & 0o700 != 0o700
+        ):
+            raise UnsupportedWorkspaceCreation(
+                "local workspace allowed_root must be a private owner-only directory"
+            )
+
+    def require_support(self) -> None:
+        self._require_owner_pid()
+        require_owned_workspace_publication_support()
+        try:
+            _workspace_owner.require_support()
+        except (OSError, RuntimeError) as error:
+            raise UnsupportedWorkspaceCreation(
+                "native local workspace ownership is unavailable"
+            ) from error
+        self._require_private_root()
+
+    def _relative_destination(self, destination: Path) -> bytes:
+        try:
+            relative = destination.relative_to(self.allowed_root)
+        except ValueError as error:
+            raise ValueError(
+                "strict workspace destination is outside the provider root"
+            ) from error
+        if not relative.parts:
+            raise ValueError("strict workspace destination must be below provider root")
+        return os.fsencode(relative.as_posix())
+
+    def run_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        *,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], _OperationResult],
+    ) -> _OperationResult:
+        self._require_owner_pid()
+        if type(request) is not StrictWorkspaceRequest:
+            raise TypeError("strict workspace request has an invalid type")
+        if type(receipt_owner) is not PublishedWorkspaceReceiptOwner:
+            raise TypeError("strict workspace receipt owner has an invalid type")
+        if request.destination_expectation != "missing":
+            raise UnsupportedWorkspaceCreation(
+                "local workspace provider currently requires a missing destination"
+            )
+        detached_plan = _snapshot_workspace_plan(request.plan)
+        relative_destination = self._relative_destination(request.destination)
+        self.require_support()
+        stage_name = _STAGE_PREFIX + secrets.token_hex(16)
+        deadline_ns = time.monotonic_ns() + self.provision_timeout_ns
+        workspace = OwnedWorkspaceAuthority()
+        native_owner = _workspace_owner.create_owner()
+        publication_permit = _workspace_owner.claim_owner_publish_permit(native_owner)
+        cleanup_owner = _ProviderWorkspaceCleanupOwner(workspace, native_owner)
+        cleanup_actions = (
+            _OrderedAction(
+                label="local workspace provider cleanup also failed",
+                action=cleanup_owner.close,
+                complete=lambda: cleanup_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=cleanup_owner,
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            # Recheck mutable external policy immediately before the native
+            # call that can perform the first namespace mutation.
+            self._require_private_root()
+            _workspace_owner.provision_owner(
+                native_owner,
+                os.fsencode(self.allowed_root),
+                relative_destination,
+                os.fsencode(stage_name),
+                detached_plan.digest.encode("ascii"),
+                detached_plan.root_mode,
+                tuple(
+                    (os.fsencode(item.path.as_posix()), item.mode)
+                    for item in detached_plan.directories
+                ),
+                deadline_ns,
+            )
+            workspace.adopt_provisioned(
+                destination=request.destination,
+                stage_name=stage_name,
+                provisioned_owner=native_owner,
+                publication_permit=publication_permit,
+                plan=detached_plan,
+                expected_destination=None,
+            )
+            return run_adopted_workspace_operation(
+                request,
+                workspace=workspace,
+                receipt_owner=receipt_owner,
+                operation=operation,
+            )
+
+
+__all__ = ["LocalWorkspaceProvider"]

--- a/codenib/_workspace_owner.py
+++ b/codenib/_workspace_owner.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed facade for the optional strict-workspace native owner.
+
+The owner ABI is deliberately independent from every optional cleanup or
+retrieval extension.  Source installs may omit the extension, but a production
+local workspace provider must call :func:`require_support` before its first
+filesystem mutation and must never select a path-based fallback.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+_EXPECTED_WORKSPACE_OWNER_PROTOCOL_VERSION = 2
+_IMPORT_ERROR: BaseException | None = None
+
+try:
+    from . import _workspace_owner_impl as _implementation
+except (ImportError, OSError) as error:
+    _implementation = None
+    _IMPORT_ERROR = error
+
+
+def _implementation_attribute(name: str) -> Any:
+    if _implementation is None:
+        return None
+    return getattr(_implementation, name, None)
+
+
+_protocol_version = _implementation_attribute("workspace_owner_protocol_version")
+_require_support_exact = _implementation_attribute("require_support")
+_create_owner_exact = _implementation_attribute("create_owner_exact")
+_claim_owner_publish_permit_exact = _implementation_attribute(
+    "claim_owner_publish_permit_exact"
+)
+_require_owner_exact = _implementation_attribute("require_owner_exact")
+_close_owner_exact = _implementation_attribute("close_owner_exact")
+_provision_owner_exact = _implementation_attribute("provision_owner_exact")
+_verify_owner_authority_exact = _implementation_attribute(
+    "verify_owner_authority_exact"
+)
+_verify_owner_adoption_binding_exact = _implementation_attribute(
+    "verify_owner_adoption_binding_exact"
+)
+_borrow_owner_parent_descriptor_exact = _implementation_attribute(
+    "borrow_owner_parent_descriptor_exact"
+)
+_borrow_owner_root_descriptor_exact = _implementation_attribute(
+    "borrow_owner_root_descriptor_exact"
+)
+_borrow_owner_directory_descriptor_exact = _implementation_attribute(
+    "borrow_owner_directory_descriptor_exact"
+)
+_begin_owner_file_exact = _implementation_attribute("begin_owner_file_exact")
+_write_owner_file_exact = _implementation_attribute("write_owner_file_exact")
+_finish_owner_file_exact = _implementation_attribute("finish_owner_file_exact")
+_abort_owner_file_exact = _implementation_attribute("abort_owner_file_exact")
+_seal_owner_directories_exact = _implementation_attribute(
+    "seal_owner_directories_exact"
+)
+_sync_owner_parent_exact = _implementation_attribute("sync_owner_parent_exact")
+_mark_owner_adopted_exact = _implementation_attribute("mark_owner_adopted_exact")
+_rename_owner_child_noreplace_exact = _implementation_attribute(
+    "rename_owner_child_noreplace_exact"
+)
+_commit_owner_receipt_exact = _implementation_attribute("commit_owner_receipt_exact")
+_abort_owner_exact = _implementation_attribute("abort_owner_exact")
+_quarantine_owner_exact = _implementation_attribute("quarantine_owner_exact")
+_owner_state_exact = _implementation_attribute("owner_state_exact")
+_owner_closed_exact = _implementation_attribute("owner_closed_exact")
+
+_workspace_owner_protocol_available = (
+    type(_protocol_version) is int
+    and _protocol_version == _EXPECTED_WORKSPACE_OWNER_PROTOCOL_VERSION
+    and all(
+        callable(symbol)
+        for symbol in (
+            _require_support_exact,
+            _create_owner_exact,
+            _claim_owner_publish_permit_exact,
+            _require_owner_exact,
+            _close_owner_exact,
+            _provision_owner_exact,
+            _verify_owner_authority_exact,
+            _verify_owner_adoption_binding_exact,
+            _borrow_owner_parent_descriptor_exact,
+            _borrow_owner_root_descriptor_exact,
+            _borrow_owner_directory_descriptor_exact,
+            _begin_owner_file_exact,
+            _write_owner_file_exact,
+            _finish_owner_file_exact,
+            _abort_owner_file_exact,
+            _seal_owner_directories_exact,
+            _sync_owner_parent_exact,
+            _mark_owner_adopted_exact,
+            _rename_owner_child_noreplace_exact,
+            _commit_owner_receipt_exact,
+            _abort_owner_exact,
+            _quarantine_owner_exact,
+            _owner_state_exact,
+            _owner_closed_exact,
+        )
+    )
+)
+
+if not _workspace_owner_protocol_available:
+    _require_support_exact = None
+    _create_owner_exact = None
+    _claim_owner_publish_permit_exact = None
+    _require_owner_exact = None
+    _close_owner_exact = None
+    _provision_owner_exact = None
+    _verify_owner_authority_exact = None
+    _verify_owner_adoption_binding_exact = None
+    _borrow_owner_parent_descriptor_exact = None
+    _borrow_owner_root_descriptor_exact = None
+    _borrow_owner_directory_descriptor_exact = None
+    _begin_owner_file_exact = None
+    _write_owner_file_exact = None
+    _finish_owner_file_exact = None
+    _abort_owner_file_exact = None
+    _seal_owner_directories_exact = None
+    _sync_owner_parent_exact = None
+    _mark_owner_adopted_exact = None
+    _rename_owner_child_noreplace_exact = None
+    _commit_owner_receipt_exact = None
+    _abort_owner_exact = None
+    _quarantine_owner_exact = None
+    _owner_state_exact = None
+    _owner_closed_exact = None
+
+
+def require_support() -> None:
+    """Require the complete owner ABI without choosing a fallback."""
+
+    _require_protocol()
+    assert _require_support_exact is not None
+    result = _require_support_exact()
+    if result is not None:
+        raise RuntimeError("native workspace support result changed")
+
+
+def _require_protocol() -> None:
+    """Require only the immutable ABI, without a fallible support probe."""
+
+    if not _workspace_owner_protocol_available:
+        raise RuntimeError(
+            "strict local workspaces require the CodeNib workspace-owner " "extension"
+        ) from _IMPORT_ERROR
+
+
+def create_owner() -> Any:
+    """Create one exact empty native aggregate owner."""
+
+    require_support()
+    assert _create_owner_exact is not None
+    return _create_owner_exact()
+
+
+def claim_owner_publish_permit(owner: object) -> object:
+    """Claim the owner's one private, one-shot publication capability."""
+
+    _require_protocol()
+    assert _claim_owner_publish_permit_exact is not None
+    return _claim_owner_publish_permit_exact(owner)
+
+
+def _bind_owner_publish_permit(
+    publication_permit: object,
+) -> Callable[[bytes, bytes], object | None]:
+    """Bind one permit to the exact ABI callable before user callbacks run."""
+
+    _require_protocol()
+    exact_rename = _rename_owner_child_noreplace_exact
+    assert exact_rename is not None
+
+    def rename(source: bytes, destination: bytes) -> object | None:
+        return exact_rename(publication_permit, source, destination)
+
+    return rename
+
+
+def require_exact_owner(candidate: object) -> Any:
+    """Authenticate and return one exact native owner."""
+
+    _require_protocol()
+    assert _require_owner_exact is not None
+    owner = _require_owner_exact(candidate)
+    if owner is not candidate:
+        raise RuntimeError("native workspace owner identity changed")
+    return owner
+
+
+def close_owner_exact(candidate: object) -> None:
+    """Close an exact owner without consulting mutable instance dispatch."""
+
+    _require_protocol()
+    assert _close_owner_exact is not None
+    result = _close_owner_exact(candidate)
+    if result is not None:
+        raise RuntimeError("native workspace close result changed")
+
+
+def _require_none_result(result: object, label: str) -> None:
+    if result is not None:
+        raise RuntimeError(f"native workspace {label} result changed")
+
+
+def provision_owner(
+    owner: object,
+    allowed_root: bytes,
+    destination_name: bytes,
+    stage_name: bytes,
+    plan_digest: bytes,
+    root_mode: int,
+    directories: tuple[tuple[bytes, int], ...],
+    deadline_ns: int,
+) -> None:
+    """Provision one exact missing-destination skeleton."""
+
+    _require_protocol()
+    assert _provision_owner_exact is not None
+    _require_none_result(
+        _provision_owner_exact(
+            owner,
+            allowed_root,
+            destination_name,
+            stage_name,
+            plan_digest,
+            root_mode,
+            directories,
+            deadline_ns,
+        ),
+        "provision",
+    )
+
+
+def verify_owner_authority(owner: object) -> None:
+    _require_protocol()
+    assert _verify_owner_authority_exact is not None
+    _require_none_result(_verify_owner_authority_exact(owner), "verify")
+
+
+def verify_owner_adoption_binding(
+    owner: object,
+    destination: bytes,
+    stage_name: bytes,
+    plan_digest: bytes,
+) -> None:
+    _require_protocol()
+    assert _verify_owner_adoption_binding_exact is not None
+    _require_none_result(
+        _verify_owner_adoption_binding_exact(
+            owner,
+            destination,
+            stage_name,
+            plan_digest,
+        ),
+        "adoption-binding verification",
+    )
+
+
+def _require_descriptor(result: object, label: str) -> int:
+    if type(result) is not int or result < 0:
+        raise RuntimeError(f"native workspace {label} result changed")
+    return result
+
+
+def borrow_owner_parent_descriptor(owner: object) -> int:
+    _require_protocol()
+    assert _borrow_owner_parent_descriptor_exact is not None
+    return _require_descriptor(
+        _borrow_owner_parent_descriptor_exact(owner),
+        "parent-descriptor",
+    )
+
+
+def borrow_owner_root_descriptor(owner: object) -> int:
+    _require_protocol()
+    assert _borrow_owner_root_descriptor_exact is not None
+    return _require_descriptor(
+        _borrow_owner_root_descriptor_exact(owner),
+        "root-descriptor",
+    )
+
+
+def borrow_owner_directory_descriptor(owner: object, path: bytes) -> int:
+    _require_protocol()
+    assert _borrow_owner_directory_descriptor_exact is not None
+    return _require_descriptor(
+        _borrow_owner_directory_descriptor_exact(owner, path),
+        "directory-descriptor",
+    )
+
+
+def begin_owner_file(
+    owner: object,
+    parent: bytes,
+    name: bytes,
+    create_mode: int,
+) -> None:
+    _require_protocol()
+    assert _begin_owner_file_exact is not None
+    _require_none_result(
+        _begin_owner_file_exact(owner, parent, name, create_mode),
+        "file-begin",
+    )
+
+
+def write_owner_file(owner: object, data: bytes) -> None:
+    _require_protocol()
+    assert _write_owner_file_exact is not None
+    _require_none_result(_write_owner_file_exact(owner, data), "file-write")
+
+
+def finish_owner_file(owner: object, final_mode: int) -> tuple[int, ...]:
+    _require_protocol()
+    assert _finish_owner_file_exact is not None
+    result = _finish_owner_file_exact(owner, final_mode)
+    if (
+        type(result) is not tuple
+        or len(result) != 8
+        or any(type(value) is not int for value in result)
+    ):
+        raise RuntimeError("native workspace file-finish result changed")
+    return result
+
+
+def abort_owner_file(owner: object) -> None:
+    _require_protocol()
+    assert _abort_owner_file_exact is not None
+    _require_none_result(_abort_owner_file_exact(owner), "file-abort")
+
+
+def seal_owner_directories(owner: object) -> None:
+    _require_protocol()
+    assert _seal_owner_directories_exact is not None
+    _require_none_result(_seal_owner_directories_exact(owner), "directory-seal")
+
+
+def sync_owner_parent(owner: object) -> None:
+    _require_protocol()
+    assert _sync_owner_parent_exact is not None
+    _require_none_result(_sync_owner_parent_exact(owner), "parent-sync")
+
+
+def mark_owner_adopted(owner: object) -> None:
+    _require_protocol()
+    assert _mark_owner_adopted_exact is not None
+    _require_none_result(_mark_owner_adopted_exact(owner), "adoption")
+
+
+def rename_owner_child_noreplace(
+    owner: object,
+    source: bytes,
+    destination: bytes,
+) -> object | None:
+    _require_protocol()
+    assert _rename_owner_child_noreplace_exact is not None
+    return _rename_owner_child_noreplace_exact(owner, source, destination)
+
+
+def commit_owner_receipt(receipt_token: object) -> None:
+    _require_protocol()
+    assert _commit_owner_receipt_exact is not None
+    _require_none_result(
+        _commit_owner_receipt_exact(receipt_token),
+        "receipt-commit",
+    )
+
+
+def abort_owner(owner: object) -> None:
+    _require_protocol()
+    assert _abort_owner_exact is not None
+    _require_none_result(_abort_owner_exact(owner), "abort")
+
+
+def quarantine_owner(owner: object) -> str | None:
+    _require_protocol()
+    assert _quarantine_owner_exact is not None
+    result = _quarantine_owner_exact(owner)
+    if result is not None and type(result) is not str:
+        raise RuntimeError("native workspace quarantine result changed")
+    return result
+
+
+def owner_state(owner: object) -> str:
+    _require_protocol()
+    assert _owner_state_exact is not None
+    result = _owner_state_exact(owner)
+    if type(result) is not str:
+        raise RuntimeError("native workspace state result changed")
+    return result
+
+
+def owner_closed(owner: object) -> bool:
+    _require_protocol()
+    assert _owner_closed_exact is not None
+    result = _owner_closed_exact(owner)
+    if type(result) is not bool:
+        raise RuntimeError("native workspace closed result changed")
+    return result
+
+
+__all__ = [
+    "abort_owner",
+    "abort_owner_file",
+    "begin_owner_file",
+    "borrow_owner_directory_descriptor",
+    "borrow_owner_parent_descriptor",
+    "borrow_owner_root_descriptor",
+    "claim_owner_publish_permit",
+    "close_owner_exact",
+    "commit_owner_receipt",
+    "create_owner",
+    "finish_owner_file",
+    "mark_owner_adopted",
+    "owner_closed",
+    "owner_state",
+    "provision_owner",
+    "quarantine_owner",
+    "rename_owner_child_noreplace",
+    "require_exact_owner",
+    "require_support",
+    "seal_owner_directories",
+    "sync_owner_parent",
+    "verify_owner_adoption_binding",
+    "verify_owner_authority",
+    "write_owner_file",
+]

--- a/codenib/_workspace_provider.py
+++ b/codenib/_workspace_provider.py
@@ -28,6 +28,7 @@ from ._captured_directory import (
     OwnedWorkspaceAuthority,
     PublishedWorkspaceReceiptOwner,
     WorkspacePlan,
+    _snapshot_workspace_plan,
     require_owned_workspace_publication_support,
 )
 from ._owned_file_publication import _CancellationSafeRLock
@@ -137,11 +138,11 @@ class StrictWorkspaceRequest:
         if requested_destination.name in {"", ".", ".."}:
             raise ValueError("strict workspace destination must name one directory")
         destination = Path(os.path.abspath(os.fspath(requested_destination)))
-        if not isinstance(self.plan, WorkspacePlan):
-            raise TypeError("strict workspace request plan must be WorkspacePlan")
+        plan = _snapshot_workspace_plan(self.plan)
         if self.destination_expectation not in {"missing", "provider-bound-exact"}:
             raise ValueError("strict workspace destination expectation is invalid")
         object.__setattr__(self, "destination", destination)
+        object.__setattr__(self, "plan", plan)
 
 
 class StrictWorkspaceSession(Protocol):

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -48,6 +48,15 @@ surface at the right test tier, and keep evaluation artifacts reproducible.
 
     [Prepare a release →](../releasing.md)
 
+-   <span class="codenib-card-eyebrow">Storage</span>
+
+    **Local workspace provider**
+
+    Publish a validated missing-directory generation through the Linux native
+    ownership boundary and manage its caller-owned receipt lifecycle.
+
+    [Use the local provider →](local-workspace-provider.md)
+
 -   <span class="codenib-card-eyebrow">Measure</span>
 
     **Evaluation workflows**

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -1,0 +1,110 @@
+---
+title: Local Workspace Provider
+---
+
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Local Workspace Provider
+
+`LocalWorkspaceProvider` is CodeNib's production Linux implementation of the
+strict workspace contract. It publishes one fully validated directory into a
+missing destination and transfers the generation to a caller-owned
+`PublishedWorkspaceReceiptOwner`.
+
+The provider is currently a library boundary. CodeNib's compiler and runtime do
+not construct one automatically, and the strict BM25 replacement path still
+requires the unsupported `provider-bound-exact` destination mode. The portable
+whole-context producer can use the provider when its destination is missing.
+
+## Lifecycle
+
+Create one private authority root and one empty receipt owner before calling a
+strict producer:
+
+```python
+from pathlib import Path
+
+from codenib import LocalWorkspaceProvider, PublishedWorkspaceReceiptOwner
+from codenib.artifacts import stage_context_artifact_strict
+
+root = Path("/var/lib/codenib/workspaces")
+root.mkdir(mode=0o700, parents=True, exist_ok=True)
+root.chmod(0o700)
+
+provider = LocalWorkspaceProvider(root)
+output_owner = PublishedWorkspaceReceiptOwner()
+try:
+    result = stage_context_artifact_strict(
+        root / "repository-context-v1",
+        manifest=manifest,
+        repository="owner/repository",
+        repository_source=repository_source,
+        view_generations=view_generations,
+        workspace_provider=provider,
+        output_receipt_owner=output_owner,
+        environ={},
+    )
+    assert output_owner.active
+    use(result)
+finally:
+    output_owner.close()
+```
+
+The owner must begin empty and cannot cross a PID boundary. A successful
+publication leaves it active even if a later caller callback is interrupted.
+Close it in `finally` (or use it as a context manager) to release the retained
+native handles. Closing the receipt owner does not delete the published output.
+
+## Support boundary
+
+The provider deliberately has a narrow first release:
+
+- Linux only, with `cp310-abi3-manylinux_2_28` wheels for x86-64 and AArch64.
+- Missing destinations only; it never replaces an existing file, directory, or
+  symlink.
+- One absolute authority root owned by the current effective UID, with exact
+  mode `0700`. The root must be a private, quiescent namespace rather than a
+  directory another same-UID process actively mutates.
+- A complete protocol-v2 native extension and a successful Linux ownership
+  support probe before the first namespace mutation.
+- A plan small enough for the process descriptor limit. The format permits up
+  to 100,000 directories, but the native `RLIMIT_NOFILE` preflight may reject a
+  much smaller plan.
+
+macOS, Windows, and installations without a compatible native extension keep
+the rest of CodeNib usable, but `LocalWorkspaceProvider.require_support()`
+fails closed before provisioning. CodeNib does not publish a prebuilt musllinux
+wheel; a source build on Linux may provide the extension when a compatible C
+toolchain is available. Container and seccomp policies must permit the
+ownership probe, including `kcmp`; the release smoke container grants the
+required ptrace capability.
+
+This is an authority boundary for trusted CodeNib callbacks, not a Python
+sandbox. Callbacks share the interpreter and must not reflectively mutate
+CodeNib's private implementation state. If a process tightens seccomp after
+acquisition and blocks both `kcmp` and the native `F_SETFL` OFD comparison,
+cleanup preserves the exact unresolved descriptor pair and attaches a retryable
+cleanup owner to the raised primary error. Retain and retry that owner after the
+policy permits cleanup; discarding it forfeits recoverability.
+
+## Publication guarantees
+
+The protocol-v2 native aggregate owns the namespace and file descriptors for
+the whole operation. It creates and writes files without returning raw file
+descriptors to Python, pins the root and planned directory identities, and
+performs one no-replace forward rename under a one-shot permit. The caller's
+receipt-slot store is the authority linearization point:
+
+- before the store, failure quarantines the exact candidate;
+- after the store, recovery commits the same native receipt token
+  idempotently;
+- a fork child only authenticates and closes its inherited descriptor pairs and
+  cannot rename, quarantine, or commit the parent generation.
+
+Staged and published validators run inside that transaction. The returned
+receipt therefore names one exact, durably published generation rather than a
+path checked after the fact.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,39 +13,65 @@ installed distribution metadata generated from it.
 ## Automated Gates
 
 The reusable Release verification workflow runs from both publishing
-workflows. Pull requests build and inspect the distribution once. Pushes to
-`main`, version tags, and explicit TestPyPI dispatches run the complete gate:
+workflows. Pull requests build and inspect the complete distribution contract,
+including the native ABI smoke. Pushes to `main`, version tags, and explicit
+TestPyPI dispatches additionally run the heavier installed-service gates:
 
 1. Tests and production-builds the packaged Wiki frontend.
-2. Builds one sdist and one universal wheel.
-3. Runs `twine check` and validates package contents and metadata.
-4. Installs the wheel on every supported Python minor version.
-5. Builds a real BM25 index through the installed `codenib` command.
-6. Installs the public 0.1.0 package, upgrades it to the candidate wheel,
+2. Builds one source-only sdist and two `cp310-abi3-manylinux_2_28` wheels, one
+   each for x86-64 and AArch64.
+3. Compiles the C extension against CPython 3.10's limited API with
+   `-Wall -Wextra -Werror`, then runs `twine check` and validates artifact
+   contents, metadata, and tags.
+4. Installs the sdist with compilation deliberately disabled, proving that the
+   core remains usable and local workspace support fails closed.
+5. Installs the native wheel on Python 3.10 through 3.14 and publishes, retains,
+   and closes one real `LocalWorkspaceProvider` generation.
+6. Builds a real BM25 index through the installed `codenib` command.
+7. Installs the public 0.1.0 package, upgrades it to the candidate wheel,
    verifies that an incompatible BM25 view rebuilds once, and then verifies
    that the rebuilt view is reused.
-7. Exercises the installed Wiki and MCP services end to end.
-8. Runs sparse Ask through a local OpenAI-compatible endpoint, including a
+8. Exercises the installed Wiki and MCP services end to end.
+9. Runs sparse Ask through a local OpenAI-compatible endpoint, including a
    real BM25 tool call, final answer, and source citation, without installing
    semantic or graph extras.
-9. Installs the graph extra and a pinned Python SCIP provider, then verifies
+10. Installs the graph extra and a pinned Python SCIP provider, then verifies
    repository-aware diagnostics, a real caller-to-callee graph edge, source
    anchors, and the installed Dependency Map API.
 
 Manually dispatching the TestPyPI Release workflow from `main` runs these gates,
 publishes to TestPyPI, then downloads that exact version from TestPyPI's public
-simple index. The workflow byte-compares the downloaded wheel with the verified
-build before installing it in a fresh environment and exercising a real BM25
-index build. Production publishing remains in the separate Release workflow
+simple index. The workflow selects the current host's compatible wheel and
+byte-compares it with the corresponding verified build before installing it in
+a fresh environment and exercising a real BM25 index build. Production
+publishing remains in the separate Release workflow
 and requires a `v<version>` tag that exactly matches `project.version`. Before
 any upload, the production workflow proves MCP DNS ownership so a missing
 record cannot leave a partial release. It then publishes to PyPI,
-downloads and byte-compares the exact public wheel, exercises its installed
-Wiki and MCP services, publishes `ai.codenib/codenib` to the official MCP
-Registry, and verifies Registry discovery. The final GitHub Release contains
-the distributions and `SHA256SUMS`; stable versions are marked latest and PEP
-440 prereleases remain prereleases. TestPyPI does not feed the MCP Registry
-because the Registry accepts only official PyPI packages.
+downloads and byte-compares the compatible public wheel, exercises its
+installed Wiki and MCP services, publishes `ai.codenib/codenib` to the official
+MCP Registry, and verifies Registry discovery. The final GitHub Release
+contains both Linux wheels, the sdist, and `SHA256SUMS`; stable versions are
+marked latest and PEP 440 prereleases remain prereleases. TestPyPI does not feed
+the MCP Registry because the Registry accepts only official PyPI packages.
+
+## Native Artifact Contract
+
+The production artifact set is exact:
+
+- `codenib-<version>-cp310-abi3-manylinux_2_28_x86_64.whl`
+- `codenib-<version>-cp310-abi3-manylinux_2_28_aarch64.whl`
+- `codenib-<version>.tar.gz`
+
+Each wheel contains exactly one `_workspace_owner_impl.abi3.so`. The sdist
+contains `native/workspace_owner.c` and no compiled extension. This lets
+compiler-less, macOS, Windows, and other environments without a compatible
+native extension install the Python core from source; the local workspace
+provider then remains unavailable and fails before mutation. CodeNib does not
+publish a prebuilt musllinux wheel, although a Linux source build can provide
+the extension when a compatible C toolchain is available. Do not replace this
+set with a universal wheel: its tag would falsely claim that the native
+ownership boundary works on every platform.
 
 ## Trusted Publisher Setup
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -260,8 +260,19 @@ to exact, scanner-bounded directory plans. Its side-effect-free capability
 probe fails before provisioning on unsupported hosts; descriptor-bound writes
 return the authenticated file record, and staged and published validators run
 inside the same atomic publication boundary. The caller-owned receipt keeps its
-authenticated reader pinned through synchronous consumption. This remains a
-provider-neutral foundation: no compiler or context producer is wired to it.
+authenticated reader pinned through synchronous consumption. The contract
+remains provider-neutral, and a concrete `LocalWorkspaceProvider` now supplies
+it on Linux for missing destinations below one private, quiescent root owned by
+the current effective UID with exact mode `0700`. Native workspace-owner
+protocol v2 pins the namespace
+and owns every file descriptor, acquires and writes files without exposing raw
+file descriptors to Python, and gates the only forward rename with a one-shot
+publish permit. The caller-owned receipt slot is the publication-authority
+linearization point: unreceipted same-process failures quarantine the exact
+candidate, while a fork child authenticates and closes only its inherited
+descriptor pairs. The provider is an authority boundary for trusted callbacks,
+not an in-process Python sandbox. No compiler or runtime route constructs it by
+default yet.
 
 Callback-scoped directory results are likewise provisional until ordered
 reader-validity, exact-ownership, child-namespace, and parent-authority
@@ -275,19 +286,22 @@ idempotent owner on the primary exception for explicit retry. Later independent
 cleanup actions still run. An identity-reused foreign resource is diagnosed and
 never closed when its immutable identity observably differs from the owned
 resource. An exact same-inode descriptor ABA or same-FILE_ID HANDLE reuse is not
-distinguishable in Python and remains a native-owner promotion gate. One
-C-level trampoline gives runner entry, re-entry, planning, action, and loop
-failures the same per-action retry state while keeping Python stack and
-diagnostic space constant. Exhausting the nine-attempt window retains an
-incomplete idempotent owner on the primary and continues later actions. The
-first local callback, postflight, or cleanup failure stays primary; later
-failures are diagnostic only. Pure Python cannot guarantee execution when
-repeated interruption lands before the trampoline itself starts. A known
-primary therefore protects pending owners before that handoff, and the first
-outer-entry failure becomes the primary and protects them when no earlier
-failure exists. Closing that remaining arbitrary call-entry gap, the raw
-resource-return gap, and exact-identity ABA requires native ownership. This
-does not complete M1 producer wiring.
+distinguishable in Python and remains a native-owner promotion gate for the
+generic POSIX and Windows publishers. The Linux workspace owner closes the
+equivalent workspace-file return and OFD-identity gaps for
+`LocalWorkspaceProvider` by acquiring, writing, authenticating, and closing the
+file inside the native aggregate. One C-level trampoline gives runner entry,
+re-entry, planning, action, and loop failures the same per-action retry state
+while keeping Python stack and diagnostic space constant. Exhausting the
+nine-attempt window retains an incomplete idempotent owner on the primary and
+continues later actions. The first local callback, postflight, or cleanup
+failure stays primary; later failures are diagnostic only. Pure Python cannot
+guarantee execution when repeated interruption lands before the trampoline
+itself starts. A known primary therefore protects pending owners before that
+handoff, and the first outer-entry failure becomes the primary and protects
+them when no earlier failure exists. Closing those remaining gaps outside the
+Linux local provider still requires native promotion. This does not complete
+M1 producer wiring.
 
 Native vector parsing is now a separate local-authority boundary. Portable
 validation and normalization remain inert: they authenticate the declared
@@ -339,8 +353,11 @@ repository fingerprint, and caller configuration into an exact workspace plan.
 It then replays and validates the same bytes through that contract before and
 after replacement without consulting mutable public source projections. Its
 `PlannedBm25View` is a short-lived in-process replay subject, not a catalog
-profile or durable job payload. No production provider, compiler integration,
-or whole-context producer is wired to the strict contract yet, so M1 remains in
+profile or durable job payload. The Linux local provider deliberately accepts
+only missing destinations, while strict BM25 requests
+`provider-bound-exact`; BM25 therefore still lacks a concrete production
+provider. Whole-context publication can use the local provider explicitly, but
+no compiler or runtime route constructs either producer yet. M1 remains in
 progress and the M2 BM25 profile adapter is still outstanding.
 
 Strict whole-context publication can now aggregate already-normalized BM25 and
@@ -354,11 +371,12 @@ context-manifest, and exact-tree checks before the caller receives a durable
 output receipt. Large canonical documents remain element-streamed, and vector
 indexes stay authenticated but native-inert throughout context assembly.
 Planning and publication never consult mutable public source projections after
-that identity is captured. This slice does not normalize native vector state,
-provision a production workspace provider, or route compiler output. Its
-retained receipt is now accepted by the direct M1 importer below, but it is not
-yet an M2 fenced job output and is not wired into production compiler/runtime
-paths.
+that identity is captured. The producer can now use a caller-supplied
+`LocalWorkspaceProvider` for a missing destination, but no compiler/runtime
+route constructs the provider or manages the output receipt lifetime by
+default. This slice does not normalize native vector state or route compiler
+output. Its retained receipt is now accepted by the direct M1 importer below,
+but it is not yet an M2 fenced job output.
 
 Retained manifest import now has additional backend-neutral prerequisite
 gates. `BlobInfo` is an exact point-in-time CAS receipt, and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -207,6 +207,7 @@ nav:
           - CI/CD: ci_cd.md
       - Project Maintenance:
           - Releasing: releasing.md
+          - Local Workspace Provider: development/local-workspace-provider.md
           - Naming: branding.md
       - Benchmarks & Evaluation:
           - evaluation/index.md

--- a/native/workspace_owner.c
+++ b/native/workspace_owner.c
@@ -1,0 +1,3881 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifdef __linux__
+#include <sys/random.h>
+#include <sys/syscall.h>
+#endif
+
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+#ifndef O_DIRECTORY
+#define O_DIRECTORY 0
+#endif
+#ifndef O_NOFOLLOW
+#define O_NOFOLLOW 0
+#endif
+#ifndef O_NONBLOCK
+#define O_NONBLOCK 0
+#endif
+#ifndef AT_SYMLINK_NOFOLLOW
+#define AT_SYMLINK_NOFOLLOW 0x100
+#endif
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+#ifndef RENAME_NOREPLACE
+#define RENAME_NOREPLACE (1U << 0)
+#endif
+#ifndef KCMP_FILE
+#define KCMP_FILE 0
+#endif
+
+#define CODENIB_MAX_PATH_BYTES 4096
+#define CODENIB_MAX_ADOPTION_PATH_BYTES ((CODENIB_MAX_PATH_BYTES * 2) + 1)
+#define CODENIB_MAX_COMPONENT_BYTES 255
+#define CODENIB_MAX_DIRECTORIES 100000
+#define CODENIB_MAX_COMPONENTS 256
+#define CODENIB_MAX_SCRATCH_FDS ((CODENIB_MAX_COMPONENTS * 2) + 8)
+#define CODENIB_ORPHAN_ATTEMPTS 64
+#define CODENIB_MAX_FILE_WRITE_BYTES (8 * 1024 * 1024)
+#define CODENIB_FD_SAFETY_MARGIN 64
+
+enum workspace_namespace_state {
+  WORKSPACE_EMPTY = 0,
+  WORKSPACE_PROVISIONING = 1,
+  WORKSPACE_PROVISIONED = 2,
+  WORKSPACE_ADOPTED = 3,
+  WORKSPACE_PUBLISHED_UNRECEIPTED = 4,
+  WORKSPACE_RECEIPTED = 5,
+  WORKSPACE_QUARANTINED = 6,
+};
+
+typedef struct {
+  char *path;
+  int fd;
+  int guard_fd;
+  int exposed;
+  mode_t mode;
+  dev_t device;
+  ino_t inode;
+  int identity_known;
+} WorkspaceDirectoryRecord;
+
+typedef struct WorkspaceOwner {
+  PyObject_HEAD pid_t owner_pid;
+  uid_t allowed_root_euid;
+  int allowed_root_policy_known;
+  int closed;
+  int provision_started;
+  int namespace_created;
+  int namespace_sync_pending;
+  enum workspace_namespace_state namespace_state;
+  int anchor_fd;
+  int anchor_guard_fd;
+  int parent_fd;
+  int parent_guard_fd;
+  int parent_exposed;
+  int root_fd;
+  int root_guard_fd;
+  int root_exposed;
+  dev_t anchor_device;
+  ino_t anchor_inode;
+  int anchor_identity_known;
+  dev_t parent_device;
+  ino_t parent_inode;
+  int parent_identity_known;
+  dev_t root_device;
+  ino_t root_inode;
+  int root_identity_known;
+  char *destination_name;
+  char *destination_path;
+  char *initial_stage_name;
+  char *stage_name;
+  char *plan_digest;
+  char *orphan_name;
+  WorkspaceDirectoryRecord *directories;
+  Py_ssize_t directory_count;
+  WorkspaceDirectoryRecord scratch[CODENIB_MAX_SCRATCH_FDS];
+  Py_ssize_t scratch_count;
+  Py_ssize_t absolute_chain_count;
+  Py_ssize_t relative_chain_start;
+  Py_ssize_t relative_chain_count;
+  int file_fd;
+  int file_guard_fd;
+  Py_ssize_t file_parent_index;
+  char *file_name;
+  dev_t file_device;
+  ino_t file_inode;
+  int file_identity_known;
+  int file_active;
+  int file_failed;
+  off_t file_offset;
+  int publish_permit_claimed;
+  int publish_permit_active;
+  uint64_t receipt_generation;
+} WorkspaceOwner;
+
+typedef struct {
+  PyObject_HEAD WorkspaceOwner *owner;
+  pid_t owner_pid;
+  int consumed;
+} WorkspacePublishPermit;
+
+typedef struct {
+  PyObject_HEAD WorkspaceOwner *owner;
+  pid_t owner_pid;
+  uint64_t generation;
+  int consumed;
+} WorkspaceReceiptToken;
+
+static PyObject *WorkspacePublishPermitTypeObject = NULL;
+static PyObject *WorkspaceReceiptTokenTypeObject = NULL;
+
+static PyObject *new_workspace_publish_permit(WorkspaceOwner *owner);
+static PyObject *new_workspace_receipt_token(WorkspaceOwner *owner);
+
+static int set_errno_error(int error) {
+  errno = error;
+  PyErr_SetFromErrno(PyExc_OSError);
+  return -1;
+}
+
+static int require_linux(void) {
+#ifdef __linux__
+  return 0;
+#else
+  PyErr_SetString(PyExc_RuntimeError,
+                  "native strict workspace provisioning requires Linux");
+  return -1;
+#endif
+}
+
+static int require_owner_pid(WorkspaceOwner *self) {
+  if (getpid() == self->owner_pid) {
+    return 0;
+  }
+  PyErr_SetString(PyExc_RuntimeError,
+                  "native workspace owner cannot cross a PID boundary");
+  return -1;
+}
+
+static int check_deadline(long long deadline_ns) {
+  struct timespec now;
+  long long current;
+
+  if (deadline_ns <= 0) {
+    return 0;
+  }
+  if (clock_gettime(CLOCK_MONOTONIC, &now) < 0) {
+    return set_errno_error(errno);
+  }
+  current = ((long long)now.tv_sec * 1000000000LL) + now.tv_nsec;
+  if (current >= deadline_ns) {
+    PyErr_SetString(PyExc_TimeoutError,
+                    "native workspace provisioning deadline expired");
+    return -1;
+  }
+  return 0;
+}
+
+static int verify_parent_binding(WorkspaceOwner *self);
+static int verify_owner_authority(WorkspaceOwner *self);
+static int verify_hidden_directory(int descriptor, dev_t device, ino_t inode);
+static int quarantine_namespace_internal(WorkspaceOwner *self);
+
+static int native_fsync_retry(int descriptor) {
+  int attempts;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    if (fsync(descriptor) == 0) {
+      return 0;
+    }
+    if (errno != EINTR) {
+      return -1;
+    }
+  }
+  errno = EINTR;
+  return -1;
+}
+
+static int native_fchmod_retry(int descriptor, mode_t mode) {
+  int attempts;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    if (fchmod(descriptor, mode) == 0) {
+      return 0;
+    }
+    if (errno != EINTR) {
+      return -1;
+    }
+  }
+  errno = EINTR;
+  return -1;
+}
+
+static int native_open_file_retry(int parent, const char *name, mode_t mode) {
+  int attempts;
+  int descriptor;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    descriptor =
+        openat(parent, name,
+               O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, mode);
+    if (descriptor >= 0 || errno != EINTR) {
+      return descriptor;
+    }
+  }
+  errno = EINTR;
+  return -1;
+}
+
+static int native_fcntl_getfd_retry(int descriptor) {
+  int attempts;
+  int result;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    result = fcntl(descriptor, F_GETFD);
+    if (result >= 0 || errno != EINTR) {
+      return result;
+    }
+  }
+  errno = EINTR;
+  return -1;
+}
+
+static int native_fcntl_getfl_retry(int descriptor) {
+  int attempts;
+  int result;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    result = fcntl(descriptor, F_GETFL);
+    if (result >= 0 || errno != EINTR) {
+      return result;
+    }
+  }
+  errno = EINTR;
+  return -1;
+}
+
+static int native_fcntl_setfl_retry(int descriptor, int flags) {
+  int attempts;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    if (fcntl(descriptor, F_SETFL, flags) == 0) {
+      return 0;
+    }
+    if (errno != EINTR) {
+      return -1;
+    }
+  }
+  errno = EINTR;
+  return -1;
+}
+
+#ifndef F_DUPFD_CLOEXEC
+static int native_fcntl_setfd_retry(int descriptor, int flags) {
+  int attempts;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    if (fcntl(descriptor, F_SETFD, flags) == 0) {
+      return 0;
+    }
+    if (errno != EINTR) {
+      return -1;
+    }
+  }
+  errno = EINTR;
+  return -1;
+}
+#endif
+
+#ifdef F_DUPFD_CLOEXEC
+static int native_fcntl_dupfd_cloexec_retry(int descriptor) {
+  int attempts;
+  int result;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    result = fcntl(descriptor, F_DUPFD_CLOEXEC, 0);
+    if (result >= 0 || errno != EINTR) {
+      return result;
+    }
+  }
+  errno = EINTR;
+  return -1;
+}
+#endif
+
+static int sync_parent(WorkspaceOwner *self) {
+  if (!self->parent_identity_known ||
+      verify_hidden_directory(self->parent_guard_fd, self->parent_device,
+                              self->parent_inode) < 0) {
+    return -1;
+  }
+  return native_fsync_retry(self->parent_guard_fd);
+}
+
+static int native_fstat_once(int descriptor, struct stat *metadata) {
+#ifdef SYS_fstat
+  return (int)syscall(SYS_fstat, descriptor, metadata);
+#else
+  (void)descriptor;
+  (void)metadata;
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+
+static int native_fstat_retry(int descriptor, struct stat *metadata) {
+  int attempts;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    if (native_fstat_once(descriptor, metadata) == 0) {
+      return 0;
+    }
+    if (errno != EINTR) {
+      return -1;
+    }
+  }
+  errno = EINTR;
+  return -1;
+}
+
+static int native_fstatat(int parent, const char *name, struct stat *metadata,
+                          int flags) {
+#ifdef SYS_newfstatat
+  return (int)syscall(SYS_newfstatat, parent, name, metadata, flags);
+#else
+  (void)parent;
+  (void)name;
+  (void)metadata;
+  (void)flags;
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+
+static int native_fstatat_retry(int parent, const char *name,
+                                struct stat *metadata, int flags) {
+  int attempts;
+  for (attempts = 0; attempts < 64; ++attempts) {
+    if (native_fstatat(parent, name, metadata, flags) == 0) {
+      return 0;
+    }
+    if (errno != EINTR) {
+      return -1;
+    }
+  }
+  errno = EINTR;
+  return -1;
+}
+
+enum ofd_comparison {
+  OFD_COMPARISON_ERROR = -1,
+  OFD_DIFFERENT = 0,
+  OFD_SAME = 1,
+};
+
+static int compare_open_file_description(int descriptor, int guard) {
+#if defined(__linux__) && defined(SYS_kcmp)
+  long result;
+  int attempts;
+  if (descriptor < 0 || guard < 0) {
+    errno = EBADF;
+    return OFD_COMPARISON_ERROR;
+  }
+  for (attempts = 0; attempts < 64; ++attempts) {
+    result =
+        syscall(SYS_kcmp, getpid(), getpid(), KCMP_FILE, descriptor, guard);
+    if (result == 0) {
+      return OFD_SAME;
+    }
+    if (result > 0) {
+      return OFD_DIFFERENT;
+    }
+    if (errno != EINTR) {
+      return OFD_COMPARISON_ERROR;
+    }
+  }
+  errno = EINTR;
+  return OFD_COMPARISON_ERROR;
+#else
+  (void)descriptor;
+  (void)guard;
+  errno = ENOSYS;
+  return OFD_COMPARISON_ERROR;
+#endif
+}
+
+static int compare_open_file_description_by_status_flags(int descriptor,
+                                                         int guard) {
+  int descriptor_initial;
+  int guard_initial;
+  int toggled_flags;
+  int descriptor_toggled;
+  int guard_toggled;
+  int descriptor_restored;
+  int guard_restored;
+  int comparison = OFD_COMPARISON_ERROR;
+  int error = 0;
+  int guard_changed = 0;
+
+  descriptor_initial = native_fcntl_getfl_retry(descriptor);
+  guard_initial = native_fcntl_getfl_retry(guard);
+  if (descriptor_initial < 0 || guard_initial < 0) {
+    return OFD_COMPARISON_ERROR;
+  }
+  if (descriptor_initial != guard_initial) {
+    return OFD_DIFFERENT;
+  }
+
+  /* File status flags belong to the open file description.  Toggling the
+     otherwise inert O_NONBLOCK bit on the hidden directory guard gives
+     cleanup a callback-free OFD challenge when a later seccomp policy denies
+     kcmp.  A same-inode reopen has independent status flags and cannot pass.
+     The GIL remains held throughout the challenge and the original flags are
+     restored and re-read before the result is trusted. */
+  toggled_flags = guard_initial ^ O_NONBLOCK;
+  if (native_fcntl_setfl_retry(guard, toggled_flags) < 0) {
+    return OFD_COMPARISON_ERROR;
+  }
+  guard_changed = 1;
+  guard_toggled = native_fcntl_getfl_retry(guard);
+  descriptor_toggled = native_fcntl_getfl_retry(descriptor);
+  if (guard_toggled < 0 || descriptor_toggled < 0) {
+    error = errno == 0 ? EIO : errno;
+    goto restore;
+  }
+  if (guard_toggled != toggled_flags) {
+    error = EOPNOTSUPP;
+    goto restore;
+  }
+  comparison = descriptor_toggled == guard_toggled ? OFD_SAME : OFD_DIFFERENT;
+
+restore:
+  if (guard_changed && native_fcntl_setfl_retry(guard, guard_initial) < 0) {
+    error = errno == 0 ? EIO : errno;
+    comparison = OFD_COMPARISON_ERROR;
+  }
+  guard_restored = native_fcntl_getfl_retry(guard);
+  descriptor_restored = native_fcntl_getfl_retry(descriptor);
+  if (guard_restored != guard_initial || descriptor_restored < 0 ||
+      (comparison == OFD_SAME && descriptor_restored != descriptor_initial)) {
+    if (error == 0) {
+      error = errno == 0 ? ESTALE : errno;
+    }
+    comparison = OFD_COMPARISON_ERROR;
+  }
+  if (comparison == OFD_COMPARISON_ERROR) {
+    errno = error == 0 ? EIO : error;
+  }
+  return comparison;
+}
+
+static int compare_open_file_description_for_cleanup(int descriptor,
+                                                     int guard) {
+  int comparison = compare_open_file_description(descriptor, guard);
+  int kcmp_error;
+
+  if (comparison != OFD_COMPARISON_ERROR) {
+    return comparison;
+  }
+  kcmp_error = errno == 0 ? EIO : errno;
+  comparison = compare_open_file_description_by_status_flags(descriptor, guard);
+  if (comparison == OFD_COMPARISON_ERROR && errno == 0) {
+    errno = kcmp_error;
+  }
+  return comparison;
+}
+
+static int duplicate_cloexec(int descriptor);
+
+static int raw_close_terminal(int descriptor) {
+#if defined(__linux__) && defined(SYS_close)
+  int result;
+  if (descriptor < 0) {
+    return 0;
+  }
+  result = (int)syscall(SYS_close, descriptor);
+  return result == 0 ? 0 : (errno == 0 ? EIO : errno);
+#else
+  (void)descriptor;
+  return ENOSYS;
+#endif
+}
+
+static void discard_uncommitted_pair(int *descriptor_slot, int *guard_slot,
+                                     int error) {
+  if (*guard_slot >= 0) {
+    (void)raw_close_terminal(*guard_slot);
+    *guard_slot = -1;
+  }
+  if (*descriptor_slot >= 0) {
+    (void)raw_close_terminal(*descriptor_slot);
+    *descriptor_slot = -1;
+  }
+  errno = error == 0 ? EIO : error;
+}
+
+static int close_inflight_file(WorkspaceOwner *self) {
+  int first_error = 0;
+  int error;
+
+  if (self->file_fd >= 0) {
+    first_error = raw_close_terminal(self->file_fd);
+    self->file_fd = -1;
+  }
+  if (self->file_guard_fd >= 0) {
+    error = raw_close_terminal(self->file_guard_fd);
+    self->file_guard_fd = -1;
+    if (first_error == 0) {
+      first_error = error;
+    }
+  }
+  self->file_active = 0;
+  self->file_identity_known = 0;
+  self->file_parent_index = -2;
+  self->file_offset = 0;
+  free(self->file_name);
+  self->file_name = NULL;
+  return first_error;
+}
+
+static int probe_kcmp_support(void) {
+#if defined(__linux__) && defined(SYS_kcmp) && defined(SYS_close)
+  int original = -1;
+  int duplicate = -1;
+  int independent = -1;
+  int error = 0;
+  int same_result;
+  int independent_result;
+
+  original =
+      open("/", O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK);
+  if (original < 0) {
+    return -1;
+  }
+  duplicate = duplicate_cloexec(original);
+  independent =
+      open("/", O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK);
+  if (duplicate < 0 || independent < 0) {
+    error = errno == 0 ? EIO : errno;
+    goto done;
+  }
+  same_result = compare_open_file_description(original, duplicate);
+  if (same_result != OFD_SAME) {
+    error = same_result == OFD_COMPARISON_ERROR ? (errno == 0 ? EPERM : errno)
+                                                : ESTALE;
+    goto done;
+  }
+  independent_result = compare_open_file_description(original, independent);
+  if (independent_result != OFD_DIFFERENT) {
+    error = independent_result == OFD_COMPARISON_ERROR
+                ? (errno == 0 ? EPERM : errno)
+                : ESTALE;
+    goto done;
+  }
+
+done:
+  if (independent >= 0 && raw_close_terminal(independent) != 0 && error == 0) {
+    error = EIO;
+  }
+  if (duplicate >= 0 && raw_close_terminal(duplicate) != 0 && error == 0) {
+    error = EIO;
+  }
+  if (raw_close_terminal(original) != 0 && error == 0) {
+    error = EIO;
+  }
+  if (error != 0) {
+    errno = error;
+    return -1;
+  }
+  return 0;
+#else
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+
+static int close_one(WorkspaceOwner *self, int *slot, int *guard_slot,
+                     dev_t *expected_device, ino_t *expected_inode,
+                     int *identity_known, int exposed) {
+  int fd = *slot;
+  int guard = *guard_slot;
+  int public_error = 0;
+  int guard_error = 0;
+  int verification_error = 0;
+  struct stat metadata;
+
+  (void)self;
+
+  if (fd < 0) {
+    if (guard >= 0) {
+      guard_error = raw_close_terminal(guard);
+      *guard_slot = -1;
+    }
+    return guard_error;
+  }
+  if (guard >= 0 && exposed) {
+    int comparison = compare_open_file_description_for_cleanup(fd, guard);
+    if (comparison == OFD_COMPARISON_ERROR) {
+      int comparison_error = errno == 0 ? EIO : errno;
+      int guard_flags;
+      if (comparison_error == EBADF &&
+          native_fstat_retry(guard, &metadata) == 0 &&
+          S_ISDIR(metadata.st_mode) && metadata.st_dev == *expected_device &&
+          metadata.st_ino == *expected_inode &&
+          (guard_flags = native_fcntl_getfd_retry(guard)) >= 0 &&
+          (guard_flags & FD_CLOEXEC) != 0) {
+        /* The guarded original remains exact and the public number is gone. */
+        *slot = -1;
+        guard_error = raw_close_terminal(guard);
+        *guard_slot = -1;
+        return guard_error != 0 ? guard_error : ESTALE;
+      }
+      /* A comparison error proves neither ownership nor replacement.  Keep
+         the complete pair so an explicit cleanup retry can authenticate it;
+         dropping the guard here would make the exposed number permanently
+         uncloseable.  The kcmp-denied case normally resolves through the
+         status-flag challenge before reaching this branch. */
+      return comparison_error;
+    }
+    if (comparison == OFD_DIFFERENT) {
+      /* The caller-visible number no longer denotes our OFD.  Revoke it without
+         touching the foreign replacement, then close only the hidden original.
+       */
+      *slot = -1;
+      guard_error = raw_close_terminal(guard);
+      *guard_slot = -1;
+      return guard_error != 0 ? guard_error : ESTALE;
+    }
+  }
+  if (guard < 0 && exposed) {
+    /* A guardless exposed number cannot be authenticated safely.  All partial
+       acquisition paths close their unexposed number immediately, so this is
+       only reachable after a failed cleanup comparison retained the number. */
+    return ESTALE;
+  }
+  if (!*identity_known) {
+    if (native_fstat_retry(fd, &metadata) < 0) {
+      verification_error = errno == 0 ? EIO : errno;
+    } else if (!S_ISDIR(metadata.st_mode) || metadata.st_dev == 0 ||
+               metadata.st_ino == 0) {
+      verification_error = ESTALE;
+    } else {
+      *expected_device = metadata.st_dev;
+      *expected_inode = metadata.st_ino;
+      *identity_known = 1;
+    }
+  } else if (native_fstat_retry(fd, &metadata) < 0 ||
+             !S_ISDIR(metadata.st_mode) ||
+             metadata.st_dev != *expected_device ||
+             metadata.st_ino != *expected_inode) {
+    verification_error = errno == 0 ? ESTALE : errno;
+  }
+
+  /* Either the number was never exposed or its OFD matched the hidden guard.
+     It is safe to close both even when the final metadata attestation reports
+     corruption; retaining an authenticated pair on that error would leak it. */
+  public_error = raw_close_terminal(fd);
+  *slot = -1;
+  if (guard >= 0) {
+    guard_error = raw_close_terminal(guard);
+    *guard_slot = -1;
+  }
+  if (verification_error != 0) {
+    return verification_error;
+  }
+  if (public_error != 0) {
+    return public_error;
+  }
+  if (guard_error != 0) {
+    return guard_error;
+  }
+  /* Linux releases the descriptor number before reporting late close errors.
+     Raw close is therefore terminal and is never retried through a reused
+     integer slot. */
+  return 0;
+}
+
+static int close_inherited_descriptors(WorkspaceOwner *self) {
+  Py_ssize_t index;
+  int first_error = close_inflight_file(self);
+  int error;
+
+  /* A child must not mutate or sync the inherited namespace.  Public
+     descriptor numbers can nevertheless have been closed and reused in the
+     child before this call, so authenticate exposed pairs exactly as normal
+     cleanup does rather than raw-closing a possible foreign replacement. */
+  for (index = self->directory_count; index > 0; --index) {
+    error = close_one(self, &self->directories[index - 1].fd,
+                      &self->directories[index - 1].guard_fd,
+                      &self->directories[index - 1].device,
+                      &self->directories[index - 1].inode,
+                      &self->directories[index - 1].identity_known,
+                      self->directories[index - 1].exposed);
+    if (first_error == 0 && error != 0) {
+      first_error = error;
+    }
+  }
+  error = close_one(self, &self->root_fd, &self->root_guard_fd,
+                    &self->root_device, &self->root_inode,
+                    &self->root_identity_known, self->root_exposed);
+  if (first_error == 0 && error != 0) {
+    first_error = error;
+  }
+  error = close_one(self, &self->parent_fd, &self->parent_guard_fd,
+                    &self->parent_device, &self->parent_inode,
+                    &self->parent_identity_known, self->parent_exposed);
+  if (first_error == 0 && error != 0) {
+    first_error = error;
+  }
+  error = close_one(self, &self->anchor_fd, &self->anchor_guard_fd,
+                    &self->anchor_device, &self->anchor_inode,
+                    &self->anchor_identity_known, 0);
+  if (first_error == 0 && error != 0) {
+    first_error = error;
+  }
+  for (index = self->scratch_count; index > 0; --index) {
+    error = close_one(
+        self, &self->scratch[index - 1].fd, &self->scratch[index - 1].guard_fd,
+        &self->scratch[index - 1].device, &self->scratch[index - 1].inode,
+        &self->scratch[index - 1].identity_known, 0);
+    if (first_error == 0 && error != 0) {
+      first_error = error;
+    }
+  }
+  self->closed = self->root_fd < 0 && self->root_guard_fd < 0 &&
+                 self->parent_fd < 0 && self->parent_guard_fd < 0 &&
+                 self->anchor_fd < 0 && self->anchor_guard_fd < 0;
+  for (index = 0; index < self->directory_count; ++index) {
+    if (self->directories[index].fd >= 0 ||
+        self->directories[index].guard_fd >= 0) {
+      self->closed = 0;
+    }
+  }
+  for (index = 0; index < self->scratch_count; ++index) {
+    if (self->scratch[index].fd >= 0 || self->scratch[index].guard_fd >= 0) {
+      self->closed = 0;
+    }
+  }
+  return first_error;
+}
+
+static int close_all(WorkspaceOwner *self) {
+  Py_ssize_t index;
+  int first_error = 0;
+  int error;
+
+  if (getpid() != self->owner_pid) {
+    return close_inherited_descriptors(self);
+  }
+  error = close_inflight_file(self);
+  if (error != 0) {
+    first_error = error;
+  }
+  if (self->namespace_sync_pending) {
+    if (self->parent_fd < 0 || sync_parent(self) < 0) {
+      if (first_error == 0) {
+        first_error = errno == 0 ? EIO : errno;
+      }
+    } else {
+      self->namespace_sync_pending = 0;
+    }
+  }
+
+  for (index = self->directory_count; index > 0; --index) {
+    error = close_one(self, &self->directories[index - 1].fd,
+                      &self->directories[index - 1].guard_fd,
+                      &self->directories[index - 1].device,
+                      &self->directories[index - 1].inode,
+                      &self->directories[index - 1].identity_known,
+                      self->directories[index - 1].exposed);
+    if (first_error == 0 && error != 0) {
+      first_error = error;
+    }
+  }
+  error = close_one(self, &self->root_fd, &self->root_guard_fd,
+                    &self->root_device, &self->root_inode,
+                    &self->root_identity_known, self->root_exposed);
+  if (first_error == 0 && error != 0) {
+    first_error = error;
+  }
+  error = close_one(self, &self->parent_fd, &self->parent_guard_fd,
+                    &self->parent_device, &self->parent_inode,
+                    &self->parent_identity_known, self->parent_exposed);
+  if (first_error == 0 && error != 0) {
+    first_error = error;
+  }
+  error = close_one(self, &self->anchor_fd, &self->anchor_guard_fd,
+                    &self->anchor_device, &self->anchor_inode,
+                    &self->anchor_identity_known, 0);
+  if (first_error == 0 && error != 0) {
+    first_error = error;
+  }
+  for (index = self->scratch_count; index > 0; --index) {
+    error = close_one(
+        self, &self->scratch[index - 1].fd, &self->scratch[index - 1].guard_fd,
+        &self->scratch[index - 1].device, &self->scratch[index - 1].inode,
+        &self->scratch[index - 1].identity_known, 0);
+    if (first_error == 0 && error != 0) {
+      first_error = error;
+    }
+  }
+  self->closed = self->root_fd < 0 && self->root_guard_fd < 0 &&
+                 self->parent_fd < 0 && self->parent_guard_fd < 0 &&
+                 self->anchor_fd < 0 && self->anchor_guard_fd < 0;
+  for (index = 0; index < self->directory_count; ++index) {
+    if (self->directories[index].fd >= 0 ||
+        self->directories[index].guard_fd >= 0) {
+      self->closed = 0;
+    }
+  }
+  for (index = 0; index < self->scratch_count; ++index) {
+    if (self->scratch[index].fd >= 0 || self->scratch[index].guard_fd >= 0) {
+      self->closed = 0;
+    }
+  }
+  return first_error;
+}
+
+static void free_configuration(WorkspaceOwner *self) {
+  Py_ssize_t index;
+
+  for (index = 0; index < self->directory_count; ++index) {
+    free(self->directories[index].path);
+    self->directories[index].path = NULL;
+  }
+  free(self->directories);
+  self->directories = NULL;
+  self->directory_count = 0;
+  for (index = 0; index < self->scratch_count; ++index) {
+    free(self->scratch[index].path);
+    self->scratch[index].path = NULL;
+  }
+  free(self->destination_name);
+  self->destination_name = NULL;
+  free(self->destination_path);
+  self->destination_path = NULL;
+  free(self->initial_stage_name);
+  self->initial_stage_name = NULL;
+  free(self->stage_name);
+  self->stage_name = NULL;
+  free(self->plan_digest);
+  self->plan_digest = NULL;
+  free(self->orphan_name);
+  self->orphan_name = NULL;
+  free(self->file_name);
+  self->file_name = NULL;
+}
+
+static char *copy_exact_bytes(PyObject *value, const char *label,
+                              Py_ssize_t max_bytes) {
+  char *source;
+  char *copy;
+  Py_ssize_t size;
+
+  if (!PyBytes_CheckExact(value)) {
+    PyErr_Format(PyExc_TypeError, "%s must be exact bytes", label);
+    return NULL;
+  }
+  if (PyBytes_AsStringAndSize(value, &source, &size) < 0) {
+    return NULL;
+  }
+  if (size <= 0 || size > max_bytes ||
+      memchr(source, '\0', (size_t)size) != NULL) {
+    PyErr_Format(PyExc_ValueError, "%s is empty, unbounded, or contains NUL",
+                 label);
+    return NULL;
+  }
+  copy = malloc((size_t)size + 1);
+  if (copy == NULL) {
+    PyErr_NoMemory();
+    return NULL;
+  }
+  memcpy(copy, source, (size_t)size);
+  copy[size] = '\0';
+  return copy;
+}
+
+static int valid_component(const char *value) {
+  size_t length = strlen(value);
+  return length > 0 && length <= CODENIB_MAX_COMPONENT_BYTES &&
+         strcmp(value, ".") != 0 && strcmp(value, "..") != 0 &&
+         strchr(value, '/') == NULL;
+}
+
+static int valid_relative_path(const char *value) {
+  const char *start = value;
+  const char *cursor = value;
+  size_t component_length;
+  size_t components = 0;
+
+  if (*value == '\0' || *value == '/' ||
+      strlen(value) > CODENIB_MAX_PATH_BYTES) {
+    return 0;
+  }
+  for (;;) {
+    if (*cursor == '/' || *cursor == '\0') {
+      ++components;
+      component_length = (size_t)(cursor - start);
+      if (components > CODENIB_MAX_COMPONENTS || component_length == 0 ||
+          component_length > CODENIB_MAX_COMPONENT_BYTES ||
+          (component_length == 1 && start[0] == '.') ||
+          (component_length == 2 && start[0] == '.' && start[1] == '.')) {
+        return 0;
+      }
+      if (*cursor == '\0') {
+        return 1;
+      }
+      start = cursor + 1;
+    }
+    ++cursor;
+  }
+}
+
+static char *join_destination_path(const char *allowed_root,
+                                   const char *relative) {
+  size_t root_length = strlen(allowed_root);
+  size_t relative_length = strlen(relative);
+  int needs_separator =
+      root_length == 0 || allowed_root[root_length - 1] != '/';
+  size_t total = root_length + (size_t)needs_separator + relative_length;
+  char *joined;
+
+  if (total == 0 || total > CODENIB_MAX_ADOPTION_PATH_BYTES) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace absolute destination is unbounded");
+    return NULL;
+  }
+  joined = malloc(total + 1);
+  if (joined == NULL) {
+    PyErr_NoMemory();
+    return NULL;
+  }
+  memcpy(joined, allowed_root, root_length);
+  if (needs_separator) {
+    joined[root_length] = '/';
+  }
+  memcpy(joined + root_length + (size_t)needs_separator, relative,
+         relative_length);
+  joined[total] = '\0';
+  return joined;
+}
+
+static int open_directory_at(int parent, const char *name) {
+  return openat(parent, name,
+                O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK);
+}
+
+static int duplicate_cloexec(int descriptor) {
+#ifdef F_DUPFD_CLOEXEC
+  return native_fcntl_dupfd_cloexec_retry(descriptor);
+#else
+  int duplicate = dup(descriptor);
+  if (duplicate >= 0 && native_fcntl_setfd_retry(duplicate, FD_CLOEXEC) < 0) {
+    int error = errno;
+    close(duplicate);
+    errno = error;
+    return -1;
+  }
+  return duplicate;
+#endif
+}
+
+static int record_identity(int descriptor, dev_t *device, ino_t *inode,
+                           mode_t expected_type);
+
+static int retain_scratch_descriptor(WorkspaceOwner *self, int descriptor,
+                                     const char *component) {
+  WorkspaceDirectoryRecord *record;
+  if (self->scratch_count >= CODENIB_MAX_SCRATCH_FDS) {
+    errno = EMFILE;
+    return -1;
+  }
+  record = &self->scratch[self->scratch_count++];
+  record->path = NULL;
+  record->fd = descriptor;
+  record->guard_fd = -1;
+  record->exposed = 0;
+  record->identity_known = 0;
+  if (component != NULL) {
+    record->path = strdup(component);
+    if (record->path == NULL) {
+      discard_uncommitted_pair(&record->fd, &record->guard_fd, ENOMEM);
+      return -1;
+    }
+  }
+  record->guard_fd = duplicate_cloexec(descriptor);
+  if (record->guard_fd < 0) {
+    int error = errno;
+    discard_uncommitted_pair(&record->fd, &record->guard_fd, error);
+    return -1;
+  }
+  if (record_identity(descriptor, &record->device, &record->inode, S_IFDIR) <
+      0) {
+    int error = errno;
+    discard_uncommitted_pair(&record->fd, &record->guard_fd, error);
+    return -1;
+  }
+  record->identity_known = 1;
+  return 0;
+}
+
+static int transfer_scratch_descriptor(WorkspaceOwner *self, int descriptor,
+                                       int *guard, dev_t *device,
+                                       ino_t *inode) {
+  Py_ssize_t index;
+  for (index = self->scratch_count; index > 0; --index) {
+    if (self->scratch[index - 1].fd == descriptor) {
+      if (!self->scratch[index - 1].identity_known) {
+        errno = ESTALE;
+        return -1;
+      }
+      *device = self->scratch[index - 1].device;
+      *inode = self->scratch[index - 1].inode;
+      *guard = self->scratch[index - 1].guard_fd;
+      self->scratch[index - 1].fd = -1;
+      self->scratch[index - 1].guard_fd = -1;
+      return descriptor;
+    }
+  }
+  errno = EBADF;
+  return -1;
+}
+
+static int open_absolute_directory(WorkspaceOwner *self, const char *path) {
+  int current = -1;
+  int child = -1;
+  const char *start;
+  const char *cursor;
+  char component[CODENIB_MAX_COMPONENT_BYTES + 1];
+  size_t length;
+  size_t components = 0;
+
+  if (path[0] != '/' || strlen(path) > CODENIB_MAX_PATH_BYTES) {
+    errno = EINVAL;
+    return -1;
+  }
+  for (cursor = path + 1; *cursor != '\0'; ++cursor) {
+    if (*cursor == '/') {
+      ++components;
+    }
+  }
+  if (path[1] != '\0' && ++components > CODENIB_MAX_COMPONENTS) {
+    errno = EINVAL;
+    return -1;
+  }
+  current =
+      open("/", O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK);
+  if (current < 0) {
+    return -1;
+  }
+  if (retain_scratch_descriptor(self, current, "/") < 0) {
+    return -1;
+  }
+  start = path + 1;
+  if (*start == '\0') {
+    return current;
+  }
+  for (cursor = start;; ++cursor) {
+    if (*cursor != '/' && *cursor != '\0') {
+      continue;
+    }
+    length = (size_t)(cursor - start);
+    if (length == 0 || length > CODENIB_MAX_COMPONENT_BYTES) {
+      errno = EINVAL;
+      return -1;
+    }
+    memcpy(component, start, length);
+    component[length] = '\0';
+    if (!valid_component(component)) {
+      errno = EINVAL;
+      return -1;
+    }
+    child = open_directory_at(current, component);
+    if (child < 0) {
+      return -1;
+    }
+    if (retain_scratch_descriptor(self, child, component) < 0) {
+      return -1;
+    }
+    current = child;
+    if (*cursor == '\0') {
+      return current;
+    }
+    start = cursor + 1;
+  }
+}
+
+static int split_destination(const char *relative, char **parent_path,
+                             char **name) {
+  const char *slash = strrchr(relative, '/');
+  size_t parent_length;
+
+  if (!valid_relative_path(relative)) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace destination must be normalized relative POSIX");
+    return -1;
+  }
+  if (slash == NULL) {
+    *parent_path = strdup("");
+    *name = strdup(relative);
+  } else {
+    parent_length = (size_t)(slash - relative);
+    *parent_path = malloc(parent_length + 1);
+    *name = strdup(slash + 1);
+    if (*parent_path != NULL) {
+      memcpy(*parent_path, relative, parent_length);
+      (*parent_path)[parent_length] = '\0';
+    }
+  }
+  if (*parent_path == NULL || *name == NULL) {
+    free(*parent_path);
+    free(*name);
+    *parent_path = NULL;
+    *name = NULL;
+    PyErr_NoMemory();
+    return -1;
+  }
+  return 0;
+}
+
+static int walk_relative_directory(WorkspaceOwner *self, int anchor,
+                                   const char *relative) {
+  int current = duplicate_cloexec(anchor);
+  int child;
+  char *copy = NULL;
+  char *cursor;
+  char *slash;
+
+  if (current < 0) {
+    return -1;
+  }
+  if (retain_scratch_descriptor(self, current, NULL) < 0) {
+    return -1;
+  }
+  if (relative[0] == '\0') {
+    return current;
+  }
+  copy = strdup(relative);
+  if (copy == NULL) {
+    errno = ENOMEM;
+    return -1;
+  }
+  cursor = copy;
+  for (;;) {
+    slash = strchr(cursor, '/');
+    if (slash != NULL) {
+      *slash = '\0';
+    }
+    child = open_directory_at(current, cursor);
+    if (child < 0) {
+      free(copy);
+      return -1;
+    }
+    if (retain_scratch_descriptor(self, child, cursor) < 0) {
+      free(copy);
+      return -1;
+    }
+    current = child;
+    if (slash == NULL) {
+      break;
+    }
+    cursor = slash + 1;
+  }
+  free(copy);
+  return current;
+}
+
+static int record_identity(int descriptor, dev_t *device, ino_t *inode,
+                           mode_t expected_type) {
+  struct stat metadata;
+  if (native_fstat_retry(descriptor, &metadata) < 0) {
+    return -1;
+  }
+  if ((metadata.st_mode & S_IFMT) != expected_type || metadata.st_dev == 0 ||
+      metadata.st_ino == 0) {
+    errno = EINVAL;
+    return -1;
+  }
+  *device = metadata.st_dev;
+  *inode = metadata.st_ino;
+  return 0;
+}
+
+static int same_identity_at(int parent, const char *name, dev_t device,
+                            ino_t inode) {
+  struct stat metadata;
+  if (native_fstatat_retry(parent, name, &metadata, AT_SYMLINK_NOFOLLOW) < 0) {
+    return -1;
+  }
+  if (!S_ISDIR(metadata.st_mode) || metadata.st_dev != device ||
+      metadata.st_ino != inode) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
+static int identify_created_root(WorkspaceOwner *self) {
+  struct stat metadata;
+  if (!self->namespace_created || self->parent_guard_fd < 0 ||
+      self->stage_name == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (native_fstatat_retry(self->parent_guard_fd, self->stage_name, &metadata,
+                           AT_SYMLINK_NOFOLLOW) < 0) {
+    return -1;
+  }
+  if (!S_ISDIR(metadata.st_mode) || metadata.st_dev == 0 ||
+      metadata.st_ino == 0 ||
+      (self->root_device != 0 && self->root_device != metadata.st_dev) ||
+      (self->root_inode != 0 && self->root_inode != metadata.st_ino)) {
+    errno = ESTALE;
+    return -1;
+  }
+  self->root_device = metadata.st_dev;
+  self->root_inode = metadata.st_ino;
+  return 0;
+}
+
+static int compare_path_to_prefix(const char *candidate, const char *path,
+                                  size_t path_length) {
+  size_t candidate_length = strlen(candidate);
+  size_t shared =
+      candidate_length < path_length ? candidate_length : path_length;
+  int comparison = memcmp(candidate, path, shared);
+
+  if (comparison != 0) {
+    return comparison;
+  }
+  if (candidate_length < path_length) {
+    return -1;
+  }
+  if (candidate_length > path_length) {
+    return 1;
+  }
+  return 0;
+}
+
+static Py_ssize_t find_directory_index(WorkspaceOwner *self, const char *path,
+                                       size_t path_length,
+                                       Py_ssize_t upper_bound) {
+  Py_ssize_t lower = 0;
+  Py_ssize_t upper = upper_bound;
+
+  while (lower < upper) {
+    Py_ssize_t middle = lower + ((upper - lower) / 2);
+    int comparison = compare_path_to_prefix(self->directories[middle].path,
+                                            path, path_length);
+    if (comparison < 0) {
+      lower = middle + 1;
+    } else if (comparison > 0) {
+      upper = middle;
+    } else {
+      return middle;
+    }
+  }
+  return -1;
+}
+
+static int find_parent_descriptor(WorkspaceOwner *self, const char *path) {
+  const char *slash = strrchr(path, '/');
+  Py_ssize_t index;
+
+  if (slash == NULL) {
+    return self->root_guard_fd;
+  }
+  index = find_directory_index(self, path, (size_t)(slash - path),
+                               self->directory_count);
+  if (index >= 0) {
+    return self->directories[index].guard_fd;
+  }
+  errno = EINVAL;
+  return -1;
+}
+
+static const char *path_basename(const char *path) {
+  const char *slash = strrchr(path, '/');
+  return slash == NULL ? path : slash + 1;
+}
+
+static int parse_directories(WorkspaceOwner *self, PyObject *directories,
+                             long long deadline_ns) {
+  Py_ssize_t count;
+  Py_ssize_t index;
+  PyObject *item;
+  PyObject *path_object;
+  PyObject *mode_object;
+  long mode;
+
+  if (!PyTuple_CheckExact(directories)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "workspace directories must be an exact tuple");
+    return -1;
+  }
+  count = PyTuple_Size(directories);
+  if (count < 0 || count > CODENIB_MAX_DIRECTORIES) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace directory count exceeds native owner budget");
+    return -1;
+  }
+  if (count == 0) {
+    return 0;
+  }
+  self->directories = calloc((size_t)count, sizeof(*self->directories));
+  if (self->directories == NULL) {
+    PyErr_NoMemory();
+    return -1;
+  }
+  self->directory_count = count;
+  for (index = 0; index < count; ++index) {
+    if ((index & 63) == 0 && check_deadline(deadline_ns) < 0) {
+      return -1;
+    }
+    self->directories[index].fd = -1;
+    self->directories[index].guard_fd = -1;
+    self->directories[index].exposed = 0;
+  }
+  for (index = 0; index < count; ++index) {
+    item = PyTuple_GetItem(directories, index);
+    if (item == NULL || !PyTuple_CheckExact(item) || PyTuple_Size(item) != 2) {
+      PyErr_SetString(PyExc_TypeError,
+                      "workspace directory records must be exact 2-tuples");
+      return -1;
+    }
+    path_object = PyTuple_GetItem(item, 0);
+    mode_object = PyTuple_GetItem(item, 1);
+    self->directories[index].path = copy_exact_bytes(
+        path_object, "workspace directory path", CODENIB_MAX_PATH_BYTES);
+    if (self->directories[index].path == NULL) {
+      return -1;
+    }
+    if (!valid_relative_path(self->directories[index].path)) {
+      PyErr_SetString(
+          PyExc_ValueError,
+          "workspace directory path must be normalized relative POSIX");
+      return -1;
+    }
+    if (!PyLong_CheckExact(mode_object)) {
+      PyErr_SetString(PyExc_TypeError,
+                      "workspace directory mode must be an exact integer");
+      return -1;
+    }
+    mode = PyLong_AsLong(mode_object);
+    if (mode == -1 && PyErr_Occurred()) {
+      return -1;
+    }
+    if (mode < 0 || mode > 0777) {
+      PyErr_SetString(PyExc_ValueError,
+                      "workspace directory mode is outside 0000..0777");
+      return -1;
+    }
+    self->directories[index].mode = (mode_t)mode;
+  }
+  return 0;
+}
+
+static int validate_directory_plan(WorkspaceOwner *self,
+                                   long long deadline_ns) {
+  Py_ssize_t index;
+  const char *path;
+  const char *slash;
+
+  for (index = 0; index < self->directory_count; ++index) {
+    if ((index & 63) == 0 && check_deadline(deadline_ns) < 0) {
+      return -1;
+    }
+    path = self->directories[index].path;
+    if (index > 0) {
+      int comparison = strcmp(self->directories[index - 1].path, path);
+      if (comparison == 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "workspace directory plan contains a duplicate path");
+        return -1;
+      }
+      if (comparison > 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "workspace directory plan is not in canonical order");
+        return -1;
+      }
+    }
+    slash = strrchr(path, '/');
+    if (slash != NULL &&
+        find_directory_index(self, path, (size_t)(slash - path), index) < 0) {
+      PyErr_SetString(PyExc_ValueError,
+                      "workspace directory parent is absent from its plan");
+      return -1;
+    }
+  }
+  return 0;
+}
+
+static size_t relative_component_count(const char *path) {
+  const char *cursor;
+  size_t count = 0;
+
+  if (*path == '\0') {
+    return 0;
+  }
+  count = 1;
+  for (cursor = path; *cursor != '\0'; ++cursor) {
+    if (*cursor == '/') {
+      ++count;
+    }
+  }
+  return count;
+}
+
+static int count_open_descriptors(uintmax_t *count) {
+  DIR *directory;
+  struct dirent *entry;
+  uintmax_t observed = 0;
+  int scan_error = 0;
+
+  directory = opendir("/proc/self/fd");
+  if (directory == NULL) {
+    return -1;
+  }
+  errno = 0;
+  while ((entry = readdir(directory)) != NULL) {
+    const char *cursor = entry->d_name;
+    if (*cursor == '\0') {
+      continue;
+    }
+    while (*cursor >= '0' && *cursor <= '9') {
+      ++cursor;
+    }
+    if (*cursor == '\0') {
+      ++observed;
+    }
+  }
+  if (errno != 0) {
+    scan_error = errno;
+  }
+  if (closedir(directory) < 0 && scan_error == 0) {
+    scan_error = errno == 0 ? EIO : errno;
+  }
+  if (scan_error != 0) {
+    errno = scan_error;
+    return -1;
+  }
+  if (observed == 0) {
+    errno = EIO;
+    return -1;
+  }
+  /* The scan observes its own directory descriptor, which closedir released. */
+  *count = observed - 1;
+  return 0;
+}
+
+static int preflight_descriptor_budget(WorkspaceOwner *self,
+                                       const char *allowed_root,
+                                       const char *parent_path) {
+  struct rlimit limit;
+  size_t absolute_records;
+  size_t relative_records;
+  size_t owner_pairs;
+  size_t required;
+  uintmax_t open_descriptors;
+
+  absolute_records = 1 + relative_component_count(allowed_root + 1);
+  relative_records = 1 + relative_component_count(parent_path);
+  if (absolute_records > SIZE_MAX - relative_records - 1 ||
+      absolute_records + relative_records + 1 >
+          SIZE_MAX - (size_t)self->directory_count) {
+    PyErr_SetString(PyExc_OverflowError,
+                    "workspace descriptor budget overflowed");
+    return -1;
+  }
+  owner_pairs =
+      absolute_records + relative_records + 1 + (size_t)self->directory_count;
+  if (owner_pairs > (SIZE_MAX - 2 - CODENIB_FD_SAFETY_MARGIN) / (size_t)2) {
+    PyErr_SetString(PyExc_OverflowError,
+                    "workspace descriptor budget overflowed");
+    return -1;
+  }
+  required = (owner_pairs * 2) + 2 + CODENIB_FD_SAFETY_MARGIN;
+  if (getrlimit(RLIMIT_NOFILE, &limit) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    return -1;
+  }
+  if (count_open_descriptors(&open_descriptors) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    return -1;
+  }
+  if (limit.rlim_cur != RLIM_INFINITY &&
+      (open_descriptors > (uintmax_t)limit.rlim_cur ||
+       (uintmax_t)required > (uintmax_t)limit.rlim_cur - open_descriptors)) {
+    errno = EMFILE;
+    PyErr_SetFromErrno(PyExc_OSError);
+    return -1;
+  }
+  return 0;
+}
+
+static int verify_allowed_root_policy(WorkspaceOwner *self) {
+  struct stat metadata;
+  int flags;
+  uid_t current_euid;
+
+  if (!self->allowed_root_policy_known || !self->anchor_identity_known ||
+      self->anchor_guard_fd < 0 ||
+      native_fstat_retry(self->anchor_guard_fd, &metadata) < 0) {
+    return -1;
+  }
+  flags = native_fcntl_getfd_retry(self->anchor_guard_fd);
+  current_euid = geteuid();
+  if (!S_ISDIR(metadata.st_mode) || metadata.st_dev != self->anchor_device ||
+      metadata.st_ino != self->anchor_inode || flags < 0 ||
+      (flags & FD_CLOEXEC) == 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  if (current_euid != self->allowed_root_euid ||
+      metadata.st_uid != current_euid ||
+      (metadata.st_mode & (mode_t)07777) != (mode_t)0700) {
+    errno = EPERM;
+    return -1;
+  }
+  return 0;
+}
+
+static PyObject *WorkspaceOwner_new(PyTypeObject *type, PyObject *args,
+                                    PyObject *keywords) {
+  allocfunc allocate;
+  WorkspaceOwner *self;
+
+  if (PyTuple_Size(args) != 0 ||
+      (keywords != NULL && PyDict_Size(keywords) != 0)) {
+    PyErr_SetString(PyExc_TypeError, "WorkspaceOwner accepts no arguments");
+    return NULL;
+  }
+  allocate = (allocfunc)PyType_GetSlot(type, Py_tp_alloc);
+  if (allocate == NULL) {
+    return NULL;
+  }
+  self = (WorkspaceOwner *)allocate(type, 0);
+  if (self == NULL) {
+    return NULL;
+  }
+  self->owner_pid = getpid();
+  self->allowed_root_euid = (uid_t)-1;
+  self->allowed_root_policy_known = 0;
+  self->closed = 0;
+  self->provision_started = 0;
+  self->namespace_created = 0;
+  self->namespace_sync_pending = 0;
+  self->namespace_state = WORKSPACE_EMPTY;
+  self->anchor_fd = -1;
+  self->anchor_guard_fd = -1;
+  self->parent_fd = -1;
+  self->parent_guard_fd = -1;
+  self->parent_exposed = 0;
+  self->root_fd = -1;
+  self->root_guard_fd = -1;
+  self->root_exposed = 0;
+  self->anchor_identity_known = 0;
+  self->parent_identity_known = 0;
+  self->root_identity_known = 0;
+  self->destination_name = NULL;
+  self->destination_path = NULL;
+  self->initial_stage_name = NULL;
+  self->stage_name = NULL;
+  self->plan_digest = NULL;
+  self->orphan_name = NULL;
+  self->directories = NULL;
+  self->directory_count = 0;
+  self->scratch_count = 0;
+  self->absolute_chain_count = 0;
+  self->relative_chain_start = 0;
+  self->relative_chain_count = 0;
+  self->file_fd = -1;
+  self->file_guard_fd = -1;
+  self->file_parent_index = -2;
+  self->file_name = NULL;
+  self->file_identity_known = 0;
+  self->file_active = 0;
+  self->file_failed = 0;
+  self->file_offset = 0;
+  self->publish_permit_claimed = 0;
+  self->publish_permit_active = 0;
+  self->receipt_generation = 0;
+  for (Py_ssize_t index = 0; index < CODENIB_MAX_SCRATCH_FDS; ++index) {
+    self->scratch[index].path = NULL;
+    self->scratch[index].fd = -1;
+    self->scratch[index].guard_fd = -1;
+    self->scratch[index].exposed = 0;
+    self->scratch[index].identity_known = 0;
+  }
+  return (PyObject *)self;
+}
+
+static void WorkspaceOwner_dealloc(WorkspaceOwner *self) {
+  freefunc release;
+  if (!self->closed && getpid() == self->owner_pid && self->namespace_created &&
+      self->namespace_state != WORKSPACE_RECEIPTED) {
+    (void)quarantine_namespace_internal(self);
+  }
+  close_all(self);
+  free_configuration(self);
+  release = (freefunc)PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+  if (release != NULL) {
+    release((PyObject *)self);
+  }
+}
+
+static PyObject *
+WorkspaceOwner_claim_publish_permit(WorkspaceOwner *self,
+                                    PyObject *Py_UNUSED(ignored)) {
+  PyObject *permit;
+
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (self->closed || self->publish_permit_claimed || self->provision_started ||
+      self->namespace_state != WORKSPACE_EMPTY || self->namespace_created ||
+      self->anchor_fd >= 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace publish permit is not claimable");
+    return NULL;
+  }
+  permit = new_workspace_publish_permit(self);
+  if (permit == NULL) {
+    return NULL;
+  }
+  self->publish_permit_claimed = 1;
+  self->publish_permit_active = 1;
+  return permit;
+}
+
+static PyObject *WorkspaceOwner_provision(WorkspaceOwner *self,
+                                          PyObject *args) {
+  PyObject *allowed_root_object;
+  PyObject *destination_object;
+  PyObject *stage_object;
+  PyObject *digest_object;
+  PyObject *root_mode_object;
+  PyObject *directories_object;
+  PyObject *deadline_object;
+  char *allowed_root = NULL;
+  char *destination = NULL;
+  char *parent_path = NULL;
+  char *destination_name = NULL;
+  char *destination_path = NULL;
+  char *stage_name = NULL;
+  char *plan_digest = NULL;
+  long root_mode;
+  long long deadline_ns;
+  struct stat metadata;
+  dev_t opened_device;
+  ino_t opened_inode;
+  Py_ssize_t index;
+  int parent;
+  int acquisition_started = 0;
+  const char *name;
+
+  if (require_linux() < 0 || require_owner_pid(self) < 0) {
+    return NULL;
+  }
+#if !defined(SYS_renameat2) || !defined(SYS_fstat) ||                          \
+    !defined(SYS_newfstatat) || !defined(SYS_kcmp) || !defined(SYS_close)
+  PyErr_SetString(PyExc_RuntimeError,
+                  "native strict workspace provisioning requires Linux "
+                  "descriptor and OFD-comparison syscalls");
+  return NULL;
+#else
+  if (probe_kcmp_support() < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native strict workspace provisioning requires permitted "
+                    "same-process kcmp OFD comparison");
+    return NULL;
+  }
+#endif
+  if (!self->publish_permit_claimed || !self->publish_permit_active) {
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        "native workspace provision requires its claimed publish permit");
+    return NULL;
+  }
+  if (self->namespace_state != WORKSPACE_EMPTY || self->closed ||
+      self->provision_started || self->anchor_fd >= 0) {
+    PyErr_SetString(PyExc_RuntimeError, "native workspace owner is not empty");
+    return NULL;
+  }
+  if (!PyArg_UnpackTuple(args, "provision", 7, 7, &allowed_root_object,
+                         &destination_object, &stage_object, &digest_object,
+                         &root_mode_object, &directories_object,
+                         &deadline_object)) {
+    return NULL;
+  }
+  if (!PyLong_CheckExact(deadline_object)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "workspace deadline must be an exact integer");
+    return NULL;
+  }
+  deadline_ns = PyLong_AsLongLong(deadline_object);
+  if (deadline_ns == -1 && PyErr_Occurred()) {
+    return NULL;
+  }
+  if (deadline_ns <= 0) {
+    PyErr_SetString(PyExc_ValueError, "workspace deadline is invalid");
+    return NULL;
+  }
+  if (check_deadline(deadline_ns) < 0) {
+    return NULL;
+  }
+  allowed_root = copy_exact_bytes(allowed_root_object, "allowed root",
+                                  CODENIB_MAX_PATH_BYTES);
+  destination = copy_exact_bytes(destination_object, "workspace destination",
+                                 CODENIB_MAX_PATH_BYTES);
+  stage_name = copy_exact_bytes(stage_object, "workspace stage name",
+                                CODENIB_MAX_COMPONENT_BYTES);
+  plan_digest = copy_exact_bytes(digest_object, "workspace plan digest", 128);
+  if (allowed_root == NULL || destination == NULL || stage_name == NULL ||
+      plan_digest == NULL) {
+    goto error;
+  }
+  if (allowed_root[0] != '/' || !valid_component(stage_name) ||
+      strlen(plan_digest) != 64) {
+    PyErr_SetString(PyExc_ValueError,
+                    "native workspace provision arguments are invalid");
+    goto error;
+  }
+  for (index = 0; index < 64; ++index) {
+    if (!((plan_digest[index] >= '0' && plan_digest[index] <= '9') ||
+          (plan_digest[index] >= 'a' && plan_digest[index] <= 'f'))) {
+      PyErr_SetString(PyExc_ValueError,
+                      "workspace plan digest must be lowercase hexadecimal");
+      goto error;
+    }
+  }
+  if (!PyLong_CheckExact(root_mode_object)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "workspace root mode must be an exact integer");
+    goto error;
+  }
+  root_mode = PyLong_AsLong(root_mode_object);
+  if (root_mode == -1 && PyErr_Occurred()) {
+    goto error;
+  }
+  if (root_mode < 0 || root_mode > 0777) {
+    PyErr_SetString(PyExc_ValueError, "workspace root mode is invalid");
+    goto error;
+  }
+  if (split_destination(destination, &parent_path, &destination_name) < 0 ||
+      parse_directories(self, directories_object, deadline_ns) < 0 ||
+      validate_directory_plan(self, deadline_ns) < 0 ||
+      preflight_descriptor_budget(self, allowed_root, parent_path) < 0) {
+    goto error;
+  }
+  destination_path = join_destination_path(allowed_root, destination);
+  if (destination_path == NULL) {
+    goto error;
+  }
+  self->destination_name = destination_name;
+  destination_name = NULL;
+  self->destination_path = destination_path;
+  destination_path = NULL;
+  self->stage_name = stage_name;
+  stage_name = NULL;
+  self->initial_stage_name = strdup(self->stage_name);
+  if (self->initial_stage_name == NULL) {
+    PyErr_NoMemory();
+    goto error;
+  }
+  self->plan_digest = plan_digest;
+  plan_digest = NULL;
+  if (strcmp(self->destination_name, self->stage_name) == 0) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace stage and destination must differ");
+    goto error;
+  }
+  if (check_deadline(deadline_ns) < 0) {
+    goto error;
+  }
+
+  acquisition_started = 1;
+  self->provision_started = 1;
+  self->anchor_fd = open_absolute_directory(self, allowed_root);
+  self->absolute_chain_count = self->scratch_count;
+  if (self->anchor_fd >= 0) {
+    self->anchor_fd = transfer_scratch_descriptor(
+        self, self->anchor_fd, &self->anchor_guard_fd, &self->anchor_device,
+        &self->anchor_inode);
+    if (self->anchor_fd >= 0) {
+      self->anchor_identity_known = 1;
+    }
+  }
+  if (self->anchor_fd < 0 ||
+      record_identity(self->anchor_fd, &self->anchor_device,
+                      &self->anchor_inode, S_IFDIR) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->allowed_root_euid = geteuid();
+  self->allowed_root_policy_known = 1;
+  if (verify_allowed_root_policy(self) < 0) {
+    if (errno == EPERM) {
+      PyErr_SetString(PyExc_PermissionError,
+                      "workspace allowed root must be owned by the current "
+                      "effective user with exact mode 0700");
+    } else {
+      PyErr_SetFromErrno(PyExc_OSError);
+    }
+    goto error;
+  }
+  self->relative_chain_start = self->scratch_count;
+  self->parent_fd = walk_relative_directory(self, self->anchor_fd, parent_path);
+  self->relative_chain_count = self->scratch_count - self->relative_chain_start;
+  if (self->parent_fd >= 0) {
+    self->parent_fd = transfer_scratch_descriptor(
+        self, self->parent_fd, &self->parent_guard_fd, &self->parent_device,
+        &self->parent_inode);
+    if (self->parent_fd >= 0) {
+      self->parent_identity_known = 1;
+    }
+  }
+  if (self->parent_fd < 0 ||
+      record_identity(self->parent_fd, &self->parent_device,
+                      &self->parent_inode, S_IFDIR) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (self->parent_device != self->anchor_device) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace destination crosses the allowed-root device");
+    goto error;
+  }
+  if (verify_parent_binding(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "workspace allowed-root binding changed before provision");
+    goto error;
+  }
+  if (native_fstatat_retry(self->parent_guard_fd, self->destination_name,
+                           &metadata, AT_SYMLINK_NOFOLLOW) == 0) {
+    PyErr_SetString(PyExc_FileExistsError,
+                    "workspace destination already exists");
+    goto error;
+  }
+  if (errno != ENOENT) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (native_fstatat_retry(self->parent_guard_fd, self->stage_name, &metadata,
+                           AT_SYMLINK_NOFOLLOW) == 0) {
+    PyErr_SetString(PyExc_FileExistsError, "workspace stage already exists");
+    goto error;
+  }
+  if (errno != ENOENT || check_deadline(deadline_ns) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetFromErrno(PyExc_OSError);
+    }
+    goto error;
+  }
+  if (verify_parent_binding(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "workspace allowed-root binding changed before mutation");
+    goto error;
+  }
+  /* This is the last instruction boundary before the first namespace
+     mutation.  Reattest the pinned allowed-root guard here, after all path
+     probes and immediately before mkdirat. */
+  if (verify_allowed_root_policy(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "workspace allowed-root policy changed before mutation");
+    goto error;
+  }
+  self->namespace_state = WORKSPACE_PROVISIONING;
+  if (mkdirat(self->parent_guard_fd, self->stage_name, 0700) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->namespace_created = 1;
+  if (identify_created_root(self) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->root_identity_known = 1;
+  self->root_fd = open_directory_at(self->parent_guard_fd, self->stage_name);
+  if (self->root_fd < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->root_guard_fd = duplicate_cloexec(self->root_fd);
+  if (self->root_guard_fd < 0) {
+    int error = errno;
+    discard_uncommitted_pair(&self->root_fd, &self->root_guard_fd, error);
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (record_identity(self->root_fd, &metadata.st_dev, &metadata.st_ino,
+                      S_IFDIR) < 0) {
+    int error = errno;
+    discard_uncommitted_pair(&self->root_fd, &self->root_guard_fd, error);
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (metadata.st_dev != self->root_device ||
+      metadata.st_ino != self->root_inode) {
+    errno = ESTALE;
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (fchmod(self->root_fd, (mode_t)root_mode) < 0 ||
+      same_identity_at(self->parent_guard_fd, self->stage_name,
+                       self->root_device, self->root_inode) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (self->root_device != self->parent_device) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace root crosses the destination-parent device");
+    goto error;
+  }
+  for (index = 0; index < self->directory_count; ++index) {
+    if (check_deadline(deadline_ns) < 0 || verify_parent_binding(self) < 0) {
+      if (!PyErr_Occurred()) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "workspace allowed-root binding changed during provision");
+      }
+      goto error;
+    }
+    parent = find_parent_descriptor(self, self->directories[index].path);
+    if (parent < 0) {
+      PyErr_SetString(PyExc_ValueError,
+                      "workspace directory parent is absent from its plan");
+      goto error;
+    }
+    name = path_basename(self->directories[index].path);
+    if (verify_allowed_root_policy(self) < 0) {
+      PyErr_SetString(
+          PyExc_RuntimeError,
+          "workspace allowed-root policy changed before directory mutation");
+      goto error;
+    }
+    if (mkdirat(parent, name, 0700) < 0) {
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (native_fstatat_retry(parent, name, &metadata, AT_SYMLINK_NOFOLLOW) <
+        0) {
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (!S_ISDIR(metadata.st_mode) || metadata.st_dev == 0 ||
+        metadata.st_ino == 0) {
+      errno = EINVAL;
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    self->directories[index].device = metadata.st_dev;
+    self->directories[index].inode = metadata.st_ino;
+    self->directories[index].identity_known = 1;
+    self->directories[index].fd = open_directory_at(parent, name);
+    if (self->directories[index].fd < 0) {
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    self->directories[index].guard_fd =
+        duplicate_cloexec(self->directories[index].fd);
+    if (self->directories[index].guard_fd < 0) {
+      int error = errno;
+      discard_uncommitted_pair(&self->directories[index].fd,
+                               &self->directories[index].guard_fd, error);
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (record_identity(self->directories[index].fd, &opened_device,
+                        &opened_inode, S_IFDIR) < 0) {
+      int error = errno;
+      discard_uncommitted_pair(&self->directories[index].fd,
+                               &self->directories[index].guard_fd, error);
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (opened_device != self->directories[index].device ||
+        opened_inode != self->directories[index].inode) {
+      errno = ESTALE;
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (fchmod(self->directories[index].fd, self->directories[index].mode) <
+            0 ||
+        same_identity_at(parent, name, self->directories[index].device,
+                         self->directories[index].inode) < 0) {
+      PyErr_SetFromErrno(PyExc_OSError);
+      goto error;
+    }
+    if (self->directories[index].device != self->root_device) {
+      PyErr_SetString(PyExc_ValueError,
+                      "workspace directory crosses the root device");
+      goto error;
+    }
+  }
+  if (native_fsync_retry(self->root_guard_fd) < 0 ||
+      native_fsync_retry(self->parent_guard_fd) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  if (verify_owner_authority(self) < 0) {
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        "workspace allowed-root binding changed before provision commit");
+    goto error;
+  }
+  if (verify_allowed_root_policy(self) < 0) {
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        "workspace allowed-root policy changed before provision commit");
+    goto error;
+  }
+  self->namespace_state = WORKSPACE_PROVISIONED;
+  free(allowed_root);
+  free(destination);
+  free(parent_path);
+  Py_RETURN_NONE;
+
+error:
+  if (!acquisition_started) {
+    free_configuration(self);
+  }
+  free(allowed_root);
+  free(destination);
+  free(parent_path);
+  free(destination_name);
+  free(destination_path);
+  free(stage_name);
+  free(plan_digest);
+  return NULL;
+}
+
+static int verify_descriptor(int descriptor, int guard, dev_t device,
+                             ino_t inode) {
+  struct stat metadata;
+  int flags;
+  if (descriptor < 0 || guard < 0 ||
+      compare_open_file_description(descriptor, guard) != OFD_SAME ||
+      native_fstat_retry(descriptor, &metadata) < 0) {
+    return -1;
+  }
+  flags = native_fcntl_getfd_retry(descriptor);
+  if (!S_ISDIR(metadata.st_mode) || metadata.st_dev != device ||
+      metadata.st_ino != inode || flags < 0 || (flags & FD_CLOEXEC) == 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
+static int verify_hidden_directory(int descriptor, dev_t device, ino_t inode) {
+  struct stat metadata;
+  int flags;
+
+  if (descriptor < 0 || native_fstat_retry(descriptor, &metadata) < 0) {
+    return -1;
+  }
+  flags = native_fcntl_getfd_retry(descriptor);
+  if (!S_ISDIR(metadata.st_mode) || metadata.st_dev != device ||
+      metadata.st_ino != inode || flags < 0 || (flags & FD_CLOEXEC) == 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
+static int verify_absolute_chain(WorkspaceOwner *self) {
+  Py_ssize_t index;
+  int descriptor;
+  int guard;
+  int parent;
+  struct stat metadata;
+
+  if (self->absolute_chain_count <= 0 ||
+      self->absolute_chain_count > self->scratch_count) {
+    errno = ESTALE;
+    return -1;
+  }
+  for (index = 0; index < self->absolute_chain_count; ++index) {
+    WorkspaceDirectoryRecord *record = &self->scratch[index];
+    if (index + 1 == self->absolute_chain_count) {
+      descriptor = self->anchor_fd;
+      guard = self->anchor_guard_fd;
+    } else {
+      descriptor = record->fd;
+      guard = record->guard_fd;
+    }
+    if (!record->identity_known ||
+        verify_descriptor(descriptor, guard, record->device, record->inode) <
+            0) {
+      return -1;
+    }
+    if (index == 0) {
+      if (record->path == NULL || strcmp(record->path, "/") != 0 ||
+          native_fstatat_retry(AT_FDCWD, "/", &metadata, AT_SYMLINK_NOFOLLOW) <
+              0 ||
+          !S_ISDIR(metadata.st_mode) || metadata.st_dev != record->device ||
+          metadata.st_ino != record->inode) {
+        errno = ESTALE;
+        return -1;
+      }
+      continue;
+    }
+    parent = self->scratch[index - 1].guard_fd;
+    if (parent < 0 || record->path == NULL ||
+        same_identity_at(parent, record->path, record->device, record->inode) <
+            0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+static int verify_relative_chain(WorkspaceOwner *self) {
+  Py_ssize_t offset;
+  int descriptor;
+  int guard;
+  int parent;
+
+  if (self->relative_chain_count <= 0 || self->relative_chain_start < 0 ||
+      self->relative_chain_start + self->relative_chain_count >
+          self->scratch_count) {
+    errno = ESTALE;
+    return -1;
+  }
+  for (offset = 0; offset < self->relative_chain_count; ++offset) {
+    Py_ssize_t index = self->relative_chain_start + offset;
+    WorkspaceDirectoryRecord *record = &self->scratch[index];
+    if (offset + 1 == self->relative_chain_count) {
+      descriptor = self->parent_fd;
+      guard = self->parent_guard_fd;
+    } else {
+      descriptor = record->fd;
+      guard = record->guard_fd;
+    }
+    if (!record->identity_known ||
+        verify_descriptor(descriptor, guard, record->device, record->inode) <
+            0) {
+      return -1;
+    }
+    if (offset == 0) {
+      if (record->path != NULL ||
+          compare_open_file_description(guard, self->anchor_guard_fd) !=
+              OFD_SAME ||
+          record->device != self->anchor_device ||
+          record->inode != self->anchor_inode) {
+        errno = ESTALE;
+        return -1;
+      }
+      continue;
+    }
+    parent = self->scratch[index - 1].guard_fd;
+    if (parent < 0 || record->path == NULL ||
+        same_identity_at(parent, record->path, record->device, record->inode) <
+            0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+static int verify_parent_binding(WorkspaceOwner *self) {
+  if (verify_allowed_root_policy(self) < 0 || !self->anchor_identity_known ||
+      !self->parent_identity_known ||
+      verify_descriptor(self->anchor_fd, self->anchor_guard_fd,
+                        self->anchor_device, self->anchor_inode) < 0 ||
+      verify_descriptor(self->parent_fd, self->parent_guard_fd,
+                        self->parent_device, self->parent_inode) < 0 ||
+      verify_absolute_chain(self) < 0 || verify_relative_chain(self) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
+static int verify_owner_authority(WorkspaceOwner *self) {
+  Py_ssize_t index;
+  if (verify_parent_binding(self) < 0 || !self->root_identity_known ||
+      verify_descriptor(self->root_fd, self->root_guard_fd, self->root_device,
+                        self->root_inode) < 0 ||
+      !self->namespace_created || self->stage_name == NULL ||
+      same_identity_at(self->parent_guard_fd, self->stage_name,
+                       self->root_device, self->root_inode) < 0) {
+    return -1;
+  }
+  for (index = 0; index < self->directory_count; ++index) {
+    int parent;
+    const char *name;
+    if (!self->directories[index].identity_known ||
+        verify_descriptor(self->directories[index].fd,
+                          self->directories[index].guard_fd,
+                          self->directories[index].device,
+                          self->directories[index].inode) < 0) {
+      return -1;
+    }
+    parent = find_parent_descriptor(self, self->directories[index].path);
+    name = path_basename(self->directories[index].path);
+    if (parent < 0 ||
+        same_identity_at(parent, name, self->directories[index].device,
+                         self->directories[index].inode) < 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+static PyObject *WorkspaceOwner_verify(WorkspaceOwner *self,
+                                       PyObject *Py_UNUSED(ignored)) {
+  Py_ssize_t index;
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (self->closed || verify_owner_authority(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace descriptor authority changed");
+    return NULL;
+  }
+  for (index = 0; index < self->directory_count; ++index) {
+    if (!self->directories[index].identity_known ||
+        verify_descriptor(self->directories[index].fd,
+                          self->directories[index].guard_fd,
+                          self->directories[index].device,
+                          self->directories[index].inode) < 0) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace directory authority changed");
+      return NULL;
+    }
+  }
+  for (index = 0; index < self->scratch_count; ++index) {
+    if (self->scratch[index].fd >= 0 &&
+        (!self->scratch[index].identity_known ||
+         verify_descriptor(
+             self->scratch[index].fd, self->scratch[index].guard_fd,
+             self->scratch[index].device, self->scratch[index].inode) < 0)) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace anchor-chain authority changed");
+      return NULL;
+    }
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject *WorkspaceOwner_mark_adopted(WorkspaceOwner *self,
+                                             PyObject *Py_UNUSED(ignored)) {
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (self->closed || self->namespace_state != WORKSPACE_PROVISIONED ||
+      verify_owner_authority(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner is not provisioned");
+    return NULL;
+  }
+  self->namespace_state = WORKSPACE_ADOPTED;
+  Py_RETURN_NONE;
+}
+
+static int exact_bytes_equal(PyObject *value, const char *expected,
+                             const char *label) {
+  char *observed;
+  Py_ssize_t observed_size;
+  size_t expected_size;
+
+  if (!PyBytes_CheckExact(value)) {
+    PyErr_Format(PyExc_TypeError, "%s must be exact bytes", label);
+    return -1;
+  }
+  if (PyBytes_AsStringAndSize(value, &observed, &observed_size) < 0) {
+    return -1;
+  }
+  expected_size = strlen(expected);
+  if (observed_size < 0 || (size_t)observed_size != expected_size ||
+      memchr(observed, '\0', (size_t)observed_size) != NULL ||
+      memcmp(observed, expected, expected_size) != 0) {
+    PyErr_SetString(PyExc_ValueError,
+                    "native workspace adoption binding differs");
+    return -1;
+  }
+  return 0;
+}
+
+static PyObject *WorkspaceOwner_verify_adoption_binding(WorkspaceOwner *self,
+                                                        PyObject *args) {
+  PyObject *destination;
+  PyObject *stage;
+  PyObject *plan_digest;
+
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (!PyArg_UnpackTuple(args, "verify_adoption_binding", 3, 3, &destination,
+                         &stage, &plan_digest)) {
+    return NULL;
+  }
+  if (self->closed || self->namespace_state != WORKSPACE_PROVISIONED ||
+      self->destination_path == NULL || self->stage_name == NULL ||
+      self->plan_digest == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner is not provisioned");
+    return NULL;
+  }
+  if (exact_bytes_equal(destination, self->destination_path,
+                        "workspace adoption destination") < 0 ||
+      exact_bytes_equal(stage, self->stage_name, "workspace adoption stage") <
+          0 ||
+      exact_bytes_equal(plan_digest, self->plan_digest,
+                        "workspace adoption plan digest") < 0) {
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
+static int exact_file_mode(PyObject *value, const char *label, mode_t *mode) {
+  long observed;
+
+  if (!PyLong_CheckExact(value)) {
+    PyErr_Format(PyExc_TypeError, "%s must be an exact integer", label);
+    return -1;
+  }
+  observed = PyLong_AsLong(value);
+  if (observed == -1 && PyErr_Occurred()) {
+    return -1;
+  }
+  if (observed < 0 || observed > 0777) {
+    PyErr_Format(PyExc_ValueError, "%s is outside 0000..0777", label);
+    return -1;
+  }
+  *mode = (mode_t)observed;
+  return 0;
+}
+
+static int resolve_file_parent(WorkspaceOwner *self, PyObject *value,
+                               Py_ssize_t *parent_index, int *parent_descriptor,
+                               int *parent_guard_descriptor) {
+  char *path;
+  Py_ssize_t size;
+  Py_ssize_t index;
+
+  if (!PyBytes_CheckExact(value) ||
+      PyBytes_AsStringAndSize(value, &path, &size) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_TypeError,
+                      "workspace file parent must be exact bytes");
+    }
+    return -1;
+  }
+  if (size < 0 || size > CODENIB_MAX_PATH_BYTES ||
+      memchr(path, '\0', (size_t)size) != NULL) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace file parent is unbounded or contains NUL");
+    return -1;
+  }
+  if (size == 0) {
+    *parent_index = -1;
+    *parent_descriptor = self->root_fd;
+    *parent_guard_descriptor = self->root_guard_fd;
+    return 0;
+  }
+  if (!valid_relative_path(path)) {
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace file parent must be normalized relative POSIX");
+    return -1;
+  }
+  index = find_directory_index(self, path, (size_t)size, self->directory_count);
+  if (index < 0) {
+    PyErr_SetString(PyExc_KeyError,
+                    "workspace file parent is absent from its plan");
+    return -1;
+  }
+  *parent_index = index;
+  *parent_descriptor = self->directories[index].fd;
+  *parent_guard_descriptor = self->directories[index].guard_fd;
+  return 0;
+}
+
+static int inflight_parent_descriptors(WorkspaceOwner *self,
+                                       int *parent_descriptor,
+                                       int *parent_guard_descriptor) {
+  if (self->file_parent_index == -1) {
+    *parent_descriptor = self->root_fd;
+    *parent_guard_descriptor = self->root_guard_fd;
+    return 0;
+  }
+  if (self->file_parent_index < 0 ||
+      self->file_parent_index >= self->directory_count) {
+    errno = ESTALE;
+    return -1;
+  }
+  *parent_descriptor = self->directories[self->file_parent_index].fd;
+  *parent_guard_descriptor =
+      self->directories[self->file_parent_index].guard_fd;
+  return 0;
+}
+
+static int verify_inflight_parent(WorkspaceOwner *self, int parent_descriptor,
+                                  int parent_guard_descriptor) {
+  if (self->file_parent_index == -1) {
+    return verify_descriptor(parent_descriptor, parent_guard_descriptor,
+                             self->root_device, self->root_inode);
+  }
+  if (self->file_parent_index < 0 ||
+      self->file_parent_index >= self->directory_count) {
+    errno = ESTALE;
+    return -1;
+  }
+  return verify_descriptor(parent_descriptor, parent_guard_descriptor,
+                           self->directories[self->file_parent_index].device,
+                           self->directories[self->file_parent_index].inode);
+}
+
+static int same_file_identity_at(int parent, const char *name, dev_t device,
+                                 ino_t inode, struct stat *metadata) {
+  if (native_fstatat_retry(parent, name, metadata, AT_SYMLINK_NOFOLLOW) < 0) {
+    return -1;
+  }
+  if (!S_ISREG(metadata->st_mode) || metadata->st_dev != device ||
+      metadata->st_ino != inode || metadata->st_nlink != 1) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
+static int verify_inflight_file(WorkspaceOwner *self, struct stat *metadata) {
+  int parent_descriptor;
+  int parent_guard_descriptor;
+  int flags;
+  struct stat linked_metadata;
+
+  if (!self->file_active || self->file_failed || self->file_fd < 0 ||
+      self->file_guard_fd < 0 || !self->file_identity_known ||
+      self->file_name == NULL ||
+      inflight_parent_descriptors(self, &parent_descriptor,
+                                  &parent_guard_descriptor) < 0 ||
+      parent_guard_descriptor < 0 ||
+      verify_inflight_parent(self, parent_descriptor, parent_guard_descriptor) <
+          0 ||
+      native_fstat_retry(self->file_guard_fd, metadata) < 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  (void)parent_descriptor;
+  flags = native_fcntl_getfd_retry(self->file_guard_fd);
+  if (compare_open_file_description(self->file_fd, self->file_guard_fd) !=
+          OFD_SAME ||
+      flags < 0 || (flags & FD_CLOEXEC) == 0 || !S_ISREG(metadata->st_mode) ||
+      metadata->st_dev != self->file_device ||
+      metadata->st_ino != self->file_inode || metadata->st_nlink != 1 ||
+      metadata->st_size != self->file_offset ||
+      same_file_identity_at(parent_guard_descriptor, self->file_name,
+                            self->file_device, self->file_inode,
+                            &linked_metadata) < 0 ||
+      linked_metadata.st_size != metadata->st_size) {
+    errno = ESTALE;
+    return -1;
+  }
+  return 0;
+}
+
+static PyObject *WorkspaceOwner_begin_file(WorkspaceOwner *self,
+                                           PyObject *args) {
+  PyObject *parent_object;
+  PyObject *name_object;
+  PyObject *mode_object;
+  char *name = NULL;
+  mode_t create_mode;
+  Py_ssize_t parent_index;
+  int parent_descriptor;
+  int parent_guard_descriptor;
+  struct stat metadata;
+
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (!PyArg_UnpackTuple(args, "begin_file", 3, 3, &parent_object, &name_object,
+                         &mode_object)) {
+    return NULL;
+  }
+  if (self->closed || self->namespace_state != WORKSPACE_ADOPTED ||
+      self->file_active || self->file_failed ||
+      verify_owner_authority(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner cannot begin a file");
+    return NULL;
+  }
+  name = copy_exact_bytes(name_object, "workspace file name",
+                          CODENIB_MAX_COMPONENT_BYTES);
+  if (name == NULL || !valid_component(name) ||
+      exact_file_mode(mode_object, "workspace file create mode", &create_mode) <
+          0 ||
+      resolve_file_parent(self, parent_object, &parent_index,
+                          &parent_descriptor, &parent_guard_descriptor) < 0) {
+    if (name != NULL && !valid_component(name) && !PyErr_Occurred()) {
+      PyErr_SetString(PyExc_ValueError,
+                      "workspace file name must be one safe component");
+    }
+    free(name);
+    return NULL;
+  }
+  (void)parent_descriptor;
+  self->file_name = name;
+  self->file_parent_index = parent_index;
+  self->file_active = 1;
+  self->file_offset = 0;
+  self->file_fd = native_open_file_retry(parent_guard_descriptor,
+                                         self->file_name, create_mode);
+  if (self->file_fd < 0) {
+    self->file_failed = 1;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  self->file_guard_fd = duplicate_cloexec(self->file_fd);
+  if (self->file_guard_fd < 0) {
+    int error = errno;
+    discard_uncommitted_pair(&self->file_fd, &self->file_guard_fd, error);
+    self->file_failed = 1;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  if (native_fstat_retry(self->file_guard_fd, &metadata) < 0) {
+    int error = errno;
+    discard_uncommitted_pair(&self->file_fd, &self->file_guard_fd, error);
+    self->file_failed = 1;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  if (!S_ISREG(metadata.st_mode) || metadata.st_dev == 0 ||
+      metadata.st_ino == 0 || metadata.st_nlink != 1 ||
+      metadata.st_dev != self->root_device) {
+    self->file_failed = 1;
+    errno = ESTALE;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  self->file_device = metadata.st_dev;
+  self->file_inode = metadata.st_ino;
+  self->file_identity_known = 1;
+  if (verify_inflight_file(self, &metadata) < 0) {
+    self->file_failed = 1;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject *WorkspaceOwner_write_file(WorkspaceOwner *self,
+                                           PyObject *payload) {
+  char *data;
+  Py_ssize_t size;
+  Py_ssize_t offset = 0;
+  struct stat metadata;
+
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (!PyBytes_CheckExact(payload) ||
+      PyBytes_AsStringAndSize(payload, &data, &size) < 0) {
+    if (self->file_active) {
+      self->file_failed = 1;
+    }
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_TypeError,
+                      "workspace file payload must be exact bytes");
+    }
+    return NULL;
+  }
+  if (size < 0 || size > CODENIB_MAX_FILE_WRITE_BYTES) {
+    if (self->file_active) {
+      self->file_failed = 1;
+    }
+    PyErr_SetString(PyExc_ValueError,
+                    "workspace file payload exceeds the native chunk budget");
+    return NULL;
+  }
+  if (self->closed || self->namespace_state != WORKSPACE_ADOPTED ||
+      verify_inflight_file(self, &metadata) < 0) {
+    self->file_failed = 1;
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace file authority changed");
+    return NULL;
+  }
+  if (size > 0 && self->file_offset > (off_t)(LLONG_MAX - size)) {
+    self->file_failed = 1;
+    PyErr_SetString(PyExc_OverflowError,
+                    "native workspace file offset overflowed");
+    return NULL;
+  }
+  while (offset < size) {
+    ssize_t written = -1;
+    int attempts;
+    for (attempts = 0; attempts < 64; ++attempts) {
+      written =
+          pwrite(self->file_guard_fd, data + offset, (size_t)(size - offset),
+                 self->file_offset + (off_t)offset);
+      if (written >= 0 || errno != EINTR) {
+        break;
+      }
+    }
+    if (written <= 0) {
+      if (written == 0) {
+        errno = EIO;
+      }
+      self->file_failed = 1;
+      return PyErr_SetFromErrno(PyExc_OSError);
+    }
+    offset += (Py_ssize_t)written;
+  }
+  self->file_offset += (off_t)size;
+  Py_RETURN_NONE;
+}
+
+static PyObject *WorkspaceOwner_finish_file(WorkspaceOwner *self,
+                                            PyObject *mode_object) {
+  mode_t final_mode;
+  struct stat metadata;
+  struct stat linked_metadata;
+  int parent_descriptor;
+  int parent_guard_descriptor;
+  int close_error;
+  long long modified_ns;
+  long long changed_ns;
+  PyObject *result;
+
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (exact_file_mode(mode_object, "workspace file final mode", &final_mode) <
+      0) {
+    if (self->file_active) {
+      self->file_failed = 1;
+    }
+    return NULL;
+  }
+  if (self->closed || self->namespace_state != WORKSPACE_ADOPTED) {
+    self->file_failed = 1;
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace file is not finishable");
+    return NULL;
+  }
+  if (verify_inflight_file(self, &metadata) < 0 ||
+      inflight_parent_descriptors(self, &parent_descriptor,
+                                  &parent_guard_descriptor) < 0) {
+    self->file_failed = 1;
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace file binding changed");
+    return NULL;
+  }
+  (void)parent_descriptor;
+  if (native_fchmod_retry(self->file_guard_fd, final_mode) < 0 ||
+      native_fsync_retry(self->file_guard_fd) < 0 ||
+      native_fstat_retry(self->file_guard_fd, &metadata) < 0) {
+    self->file_failed = 1;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  if (!S_ISREG(metadata.st_mode) || metadata.st_dev != self->file_device ||
+      metadata.st_ino != self->file_inode || metadata.st_nlink != 1 ||
+      metadata.st_size != self->file_offset ||
+      (metadata.st_mode & 0777) != final_mode) {
+    self->file_failed = 1;
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace file metadata changed");
+    return NULL;
+  }
+  if (same_file_identity_at(parent_guard_descriptor, self->file_name,
+                            self->file_device, self->file_inode,
+                            &linked_metadata) < 0 ||
+      linked_metadata.st_size != metadata.st_size) {
+    self->file_failed = 1;
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace file binding changed");
+    return NULL;
+  }
+  if (native_fsync_retry(parent_guard_descriptor) < 0) {
+    self->file_failed = 1;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+#if defined(__linux__)
+  modified_ns = ((long long)metadata.st_mtim.tv_sec * 1000000000LL) +
+                metadata.st_mtim.tv_nsec;
+  changed_ns = ((long long)metadata.st_ctim.tv_sec * 1000000000LL) +
+               metadata.st_ctim.tv_nsec;
+#else
+  modified_ns = (long long)metadata.st_mtime * 1000000000LL;
+  changed_ns = (long long)metadata.st_ctime * 1000000000LL;
+#endif
+  close_error = close_inflight_file(self);
+  if (close_error != 0) {
+    self->file_failed = 1;
+    errno = close_error;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  result = Py_BuildValue(
+      "(KKKLLLKK)", (unsigned long long)metadata.st_dev,
+      (unsigned long long)metadata.st_ino, (unsigned long long)metadata.st_mode,
+      (long long)metadata.st_size, modified_ns, changed_ns,
+      (unsigned long long)metadata.st_nlink, (unsigned long long)0);
+  if (result == NULL) {
+    self->file_failed = 1;
+  }
+  return result;
+}
+
+static PyObject *WorkspaceOwner_abort_file(WorkspaceOwner *self,
+                                           PyObject *Py_UNUSED(ignored)) {
+  int close_error;
+
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (!self->file_active && self->file_fd < 0 && self->file_guard_fd < 0) {
+    Py_RETURN_NONE;
+  }
+  self->file_failed = 1;
+  close_error = close_inflight_file(self);
+  if (close_error != 0) {
+    errno = close_error;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject *WorkspaceOwner_seal_directories(WorkspaceOwner *self,
+                                                 PyObject *Py_UNUSED(ignored)) {
+  Py_ssize_t index;
+
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (self->closed || self->namespace_state != WORKSPACE_ADOPTED ||
+      self->file_active || self->file_failed ||
+      verify_owner_authority(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace directories are not seal-ready");
+    return NULL;
+  }
+  for (index = self->directory_count; index > 0; --index) {
+    if (native_fsync_retry(self->directories[index - 1].guard_fd) < 0) {
+      return PyErr_SetFromErrno(PyExc_OSError);
+    }
+  }
+  if (native_fsync_retry(self->root_guard_fd) < 0 ||
+      verify_owner_authority(self) < 0) {
+    if (errno == ESTALE) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace directory binding changed");
+    } else {
+      PyErr_SetFromErrno(PyExc_OSError);
+    }
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject *
+WorkspaceOwner_sync_parent_method(WorkspaceOwner *self,
+                                  PyObject *Py_UNUSED(ignored)) {
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (self->closed || verify_parent_binding(self) < 0 ||
+      sync_parent(self) < 0) {
+    if (errno == ESTALE) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace parent binding changed");
+    } else {
+      PyErr_SetFromErrno(PyExc_OSError);
+    }
+    return NULL;
+  }
+  self->namespace_sync_pending = 0;
+  Py_RETURN_NONE;
+}
+
+static int rename_noreplace(int parent, const char *source,
+                            const char *destination) {
+#if defined(__linux__) && defined(SYS_renameat2)
+  return (int)syscall(SYS_renameat2, parent, source, parent, destination,
+                      RENAME_NOREPLACE);
+#else
+  (void)parent;
+  (void)source;
+  (void)destination;
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+
+static int rename_owned_root(WorkspaceOwner *self, const char *source,
+                             const char *destination,
+                             int require_lexical_binding) {
+  char *next_name = NULL;
+  char *next_orphan = NULL;
+  enum workspace_namespace_state next_state;
+
+  if (self->closed ||
+      (require_lexical_binding
+           ? verify_parent_binding(self)
+           : verify_hidden_directory(self->parent_guard_fd, self->parent_device,
+                                     self->parent_inode)) < 0 ||
+      !valid_component(source) || !valid_component(destination) ||
+      strcmp(source, destination) == 0 || self->stage_name == NULL ||
+      strcmp(source, self->stage_name) != 0 ||
+      self->namespace_state == WORKSPACE_EMPTY ||
+      same_identity_at(self->parent_guard_fd, source, self->root_device,
+                       self->root_inode) < 0) {
+    errno = ESTALE;
+    return -1;
+  }
+  next_name = strdup(destination);
+  if (next_name == NULL) {
+    errno = ENOMEM;
+    return -1;
+  }
+  if (!require_lexical_binding) {
+    next_state = WORKSPACE_QUARANTINED;
+    next_orphan = strdup(destination);
+    if (next_orphan == NULL) {
+      free(next_name);
+      errno = ENOMEM;
+      return -1;
+    }
+  } else if (strcmp(destination, self->destination_name) == 0) {
+    if (self->namespace_state != WORKSPACE_ADOPTED || self->file_active ||
+        self->file_failed || strcmp(source, self->initial_stage_name) != 0) {
+      free(next_name);
+      errno = EINVAL;
+      return -1;
+    }
+    next_state = WORKSPACE_PUBLISHED_UNRECEIPTED;
+  } else {
+    free(next_name);
+    errno = EINVAL;
+    return -1;
+  }
+  if (rename_noreplace(self->parent_guard_fd, source, destination) < 0) {
+    int error = errno;
+    free(next_name);
+    free(next_orphan);
+    errno = error;
+    return -1;
+  }
+  free(self->stage_name);
+  self->stage_name = next_name;
+  free(self->orphan_name);
+  self->orphan_name = next_orphan;
+  self->namespace_state = next_state;
+  self->namespace_sync_pending = 1;
+  return 0;
+}
+
+static PyObject *
+WorkspacePublishPermit_rename_child_noreplace(WorkspacePublishPermit *permit,
+                                              PyObject *args) {
+  WorkspaceOwner *self = permit->owner;
+  PyObject *source_object;
+  PyObject *destination_object;
+  char *source = NULL;
+  char *destination = NULL;
+  int publishes_receipt;
+  PyObject *receipt_token = NULL;
+
+  if (self == NULL || getpid() != permit->owner_pid || permit->consumed ||
+      !self->publish_permit_claimed || !self->publish_permit_active) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace publish permit is unavailable");
+    return NULL;
+  }
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (!PyArg_UnpackTuple(args, "rename_child_noreplace", 2, 2, &source_object,
+                         &destination_object)) {
+    return NULL;
+  }
+  source = copy_exact_bytes(source_object, "workspace rename source",
+                            CODENIB_MAX_COMPONENT_BYTES);
+  destination =
+      copy_exact_bytes(destination_object, "workspace rename destination",
+                       CODENIB_MAX_COMPONENT_BYTES);
+  if (source == NULL || destination == NULL) {
+    goto error;
+  }
+  publishes_receipt = self->initial_stage_name != NULL &&
+                      self->destination_name != NULL &&
+                      strcmp(source, self->initial_stage_name) == 0 &&
+                      strcmp(destination, self->destination_name) == 0;
+  if (publishes_receipt && self->receipt_generation == UINT64_MAX) {
+    PyErr_SetString(PyExc_OverflowError,
+                    "native workspace receipt generation exhausted");
+    goto error;
+  }
+  if (rename_owned_root(self, source, destination, 1) < 0) {
+    if (errno == ENOMEM) {
+      PyErr_NoMemory();
+    } else if (errno == ESTALE || errno == EINVAL) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace rename binding changed");
+    } else {
+      PyErr_SetFromErrno(PyExc_OSError);
+    }
+    goto error;
+  }
+  permit->consumed = 1;
+  self->publish_permit_active = 0;
+  if (sync_parent(self) < 0) {
+    PyErr_SetFromErrno(PyExc_OSError);
+    goto error;
+  }
+  self->namespace_sync_pending = 0;
+  if (publishes_receipt) {
+    ++self->receipt_generation;
+    receipt_token = new_workspace_receipt_token(self);
+    if (receipt_token == NULL) {
+      goto error;
+    }
+  }
+  free(source);
+  free(destination);
+  if (receipt_token != NULL) {
+    return receipt_token;
+  }
+  Py_RETURN_NONE;
+
+error:
+  free(source);
+  free(destination);
+  return NULL;
+}
+
+static PyObject *WorkspaceReceiptToken_commit(WorkspaceReceiptToken *token) {
+  WorkspaceOwner *self = token->owner;
+
+  if (self == NULL || getpid() != token->owner_pid ||
+      require_owner_pid(self) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace receipt token is unavailable");
+    }
+    return NULL;
+  }
+  if (self->closed) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "closed native workspace owner cannot commit a receipt");
+    return NULL;
+  }
+  if (token->consumed && self->namespace_state == WORKSPACE_RECEIPTED &&
+      token->generation == self->receipt_generation) {
+    Py_RETURN_NONE;
+  }
+  if (token->consumed || token->generation != self->receipt_generation ||
+      self->namespace_state != WORKSPACE_PUBLISHED_UNRECEIPTED ||
+      self->file_active || self->file_failed) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace publication is not receipt-ready");
+    return NULL;
+  }
+  if ((self->namespace_sync_pending && sync_parent(self) < 0) ||
+      verify_owner_authority(self) < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace publication binding changed");
+    return NULL;
+  }
+  self->namespace_sync_pending = 0;
+  self->namespace_state = WORKSPACE_RECEIPTED;
+  token->consumed = 1;
+  Py_RETURN_NONE;
+}
+
+static int random_bytes(unsigned char *buffer, size_t size) {
+#ifdef __linux__
+  size_t offset = 0;
+  ssize_t result;
+  int interruptions = 0;
+  while (offset < size) {
+    result = getrandom(buffer + offset, size - offset, 0);
+    if (result < 0 && errno == EINTR) {
+      if (++interruptions >= 64) {
+        errno = EINTR;
+        return -1;
+      }
+      continue;
+    }
+    if (result == 0) {
+      errno = EIO;
+      return -1;
+    }
+    if (result < 0) {
+      return -1;
+    }
+    offset += (size_t)result;
+  }
+  return 0;
+#else
+  (void)buffer;
+  (void)size;
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+
+static int quarantine_namespace_internal(WorkspaceOwner *self) {
+  static const char hex[] = "0123456789abcdef";
+  static const char prefix[] = ".codenib-workspace-orphan-";
+  unsigned char entropy[16];
+  char candidate[sizeof(prefix) - 1 + 32 + 1];
+  size_t index;
+  int attempt;
+  int close_error;
+
+  if (self->namespace_state == WORKSPACE_QUARANTINED) {
+    if (self->namespace_sync_pending && sync_parent(self) < 0) {
+      return -1;
+    }
+    self->namespace_sync_pending = 0;
+    return 0;
+  }
+  if (!self->namespace_created || self->namespace_state == WORKSPACE_EMPTY) {
+    return 0;
+  }
+  if (self->namespace_state == WORKSPACE_RECEIPTED) {
+    errno = EPERM;
+    return -1;
+  }
+  if (self->closed) {
+    errno = EBADF;
+    return -1;
+  }
+  close_error = close_inflight_file(self);
+  if (close_error != 0) {
+    errno = close_error;
+    return -1;
+  }
+  if (!self->parent_identity_known ||
+      verify_hidden_directory(self->parent_guard_fd, self->parent_device,
+                              self->parent_inode) < 0) {
+    return -1;
+  }
+  if ((self->root_device == 0 || self->root_inode == 0) &&
+      identify_created_root(self) < 0) {
+    return -1;
+  }
+  memcpy(candidate, prefix, sizeof(prefix) - 1);
+  for (attempt = 0; attempt < CODENIB_ORPHAN_ATTEMPTS; ++attempt) {
+    if (random_bytes(entropy, sizeof(entropy)) < 0) {
+      return -1;
+    }
+    for (index = 0; index < sizeof(entropy); ++index) {
+      candidate[sizeof(prefix) - 1 + (index * 2)] = hex[entropy[index] >> 4];
+      candidate[sizeof(prefix) - 1 + (index * 2) + 1] =
+          hex[entropy[index] & 0x0f];
+    }
+    candidate[sizeof(candidate) - 1] = '\0';
+    if (rename_owned_root(self, self->stage_name, candidate, 0) == 0) {
+      if (sync_parent(self) < 0) {
+        return -1;
+      }
+      self->namespace_sync_pending = 0;
+      return 0;
+    }
+    if (errno != EEXIST) {
+      return -1;
+    }
+  }
+  errno = EEXIST;
+  return -1;
+}
+
+static PyObject *WorkspaceOwner_quarantine(WorkspaceOwner *self,
+                                           PyObject *Py_UNUSED(ignored)) {
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (quarantine_namespace_internal(self) < 0) {
+    if (errno == ENOMEM) {
+      PyErr_NoMemory();
+    } else if (errno == EPERM) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "receipted workspace cannot be quarantined");
+    } else if (errno == EEXIST) {
+      PyErr_SetString(PyExc_FileExistsError,
+                      "native workspace quarantine names were exhausted");
+    } else {
+      PyErr_SetFromErrno(PyExc_OSError);
+    }
+    return NULL;
+  }
+  if (self->orphan_name == NULL) {
+    Py_RETURN_NONE;
+  }
+  return PyUnicode_FromString(self->orphan_name);
+}
+
+static PyObject *WorkspaceOwner_close(WorkspaceOwner *self,
+                                      PyObject *Py_UNUSED(ignored)) {
+  int owner_changed = getpid() != self->owner_pid;
+  int close_error;
+
+  if (self->closed) {
+    if (owner_changed) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace owner cannot cross a PID boundary");
+      return NULL;
+    }
+    Py_RETURN_NONE;
+  }
+  if (!owner_changed && self->namespace_created &&
+      self->namespace_state != WORKSPACE_RECEIPTED) {
+    if (quarantine_namespace_internal(self) < 0) {
+      if (errno == ENOMEM) {
+        PyErr_NoMemory();
+      } else {
+        PyErr_SetFromErrno(PyExc_OSError);
+      }
+      return NULL;
+    }
+  }
+  close_error = close_all(self);
+  if (owner_changed) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner cannot cross a PID boundary");
+    return NULL;
+  }
+  if (close_error != 0) {
+    errno = close_error;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject *WorkspaceOwner_abort(WorkspaceOwner *self,
+                                      PyObject *Py_UNUSED(ignored)) {
+  int close_error;
+
+  if (require_owner_pid(self) < 0) {
+    return NULL;
+  }
+  if (self->closed) {
+    Py_RETURN_NONE;
+  }
+  if (self->namespace_created && self->namespace_state != WORKSPACE_RECEIPTED) {
+    if (quarantine_namespace_internal(self) < 0) {
+      if (errno == ENOMEM) {
+        PyErr_NoMemory();
+      } else {
+        PyErr_SetFromErrno(PyExc_OSError);
+      }
+      return NULL;
+    }
+  }
+  close_error = close_all(self);
+  if (close_error != 0) {
+    errno = close_error;
+    return PyErr_SetFromErrno(PyExc_OSError);
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject *WorkspaceOwner_directory_descriptor(WorkspaceOwner *self,
+                                                     PyObject *argument) {
+  char *path = NULL;
+  Py_ssize_t size;
+  Py_ssize_t index;
+
+  if (require_owner_pid(self) < 0 || self->closed ||
+      verify_owner_authority(self) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_RuntimeError, "native workspace owner is closed");
+    }
+    return NULL;
+  }
+  if (!PyBytes_CheckExact(argument) ||
+      PyBytes_AsStringAndSize(argument, &path, &size) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_TypeError,
+                      "workspace directory path must be exact bytes");
+    }
+    return NULL;
+  }
+  if (size <= 0 || size > CODENIB_MAX_PATH_BYTES ||
+      memchr(path, '\0', (size_t)size) != NULL) {
+    PyErr_SetString(PyExc_ValueError, "workspace directory path is invalid");
+    return NULL;
+  }
+  index = find_directory_index(self, path, (size_t)size, self->directory_count);
+  if (index >= 0) {
+    self->directories[index].exposed = 1;
+    return PyLong_FromLong(self->directories[index].fd);
+  }
+  PyErr_SetString(PyExc_KeyError,
+                  "workspace directory descriptor is not owned");
+  return NULL;
+}
+
+static PyObject *WorkspaceOwner_get_parent_descriptor(WorkspaceOwner *self,
+                                                      void *closure) {
+  (void)closure;
+  if (require_owner_pid(self) < 0 || self->closed || self->parent_fd < 0 ||
+      verify_parent_binding(self) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace parent descriptor is unavailable");
+    }
+    return NULL;
+  }
+  self->parent_exposed = 1;
+  return PyLong_FromLong(self->parent_fd);
+}
+
+static PyObject *WorkspaceOwner_get_root_descriptor(WorkspaceOwner *self,
+                                                    void *closure) {
+  (void)closure;
+  if (require_owner_pid(self) < 0 || self->closed || self->root_fd < 0 ||
+      verify_owner_authority(self) < 0) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "native workspace root descriptor is unavailable");
+    }
+    return NULL;
+  }
+  self->root_exposed = 1;
+  return PyLong_FromLong(self->root_fd);
+}
+
+static PyObject *WorkspaceOwner_get_closed(WorkspaceOwner *self,
+                                           void *closure) {
+  (void)closure;
+  return PyBool_FromLong(self->closed);
+}
+
+static PyObject *WorkspaceOwner_get_state(WorkspaceOwner *self, void *closure) {
+  const char *state;
+  (void)closure;
+  if (self->closed) {
+    state = "closed";
+  } else {
+    switch (self->namespace_state) {
+    case WORKSPACE_EMPTY:
+      state = "empty";
+      break;
+    case WORKSPACE_PROVISIONING:
+      state = "provisioning";
+      break;
+    case WORKSPACE_PROVISIONED:
+      state = "provisioned";
+      break;
+    case WORKSPACE_ADOPTED:
+      state = "adopted";
+      break;
+    case WORKSPACE_PUBLISHED_UNRECEIPTED:
+      state = "published-unreceipted";
+      break;
+    case WORKSPACE_RECEIPTED:
+      state = "receipted";
+      break;
+    case WORKSPACE_QUARANTINED:
+      state = "quarantined";
+      break;
+    default:
+      state = "invalid";
+      break;
+    }
+  }
+  return PyUnicode_FromString(state);
+}
+
+static PyType_Slot WorkspaceOwner_slots[] = {
+    {Py_tp_new, WorkspaceOwner_new},
+    {Py_tp_dealloc, WorkspaceOwner_dealloc},
+    {Py_tp_doc, "Opaque native owner for one strict workspace skeleton."},
+    {0, NULL},
+};
+
+static PyType_Spec WorkspaceOwner_spec = {
+    "codenib._workspace_owner_impl.WorkspaceOwner", sizeof(WorkspaceOwner), 0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,  WorkspaceOwner_slots,
+};
+
+static PyObject *WorkspaceOwnerTypeObject = NULL;
+
+static PyObject *WorkspacePublishPermit_new(PyTypeObject *type, PyObject *args,
+                                            PyObject *keywords) {
+  (void)type;
+  (void)args;
+  (void)keywords;
+  PyErr_SetString(PyExc_TypeError,
+                  "native workspace publish permits cannot be constructed");
+  return NULL;
+}
+
+static void WorkspacePublishPermit_dealloc(WorkspacePublishPermit *self) {
+  freefunc release;
+  WorkspaceOwner *owner = self->owner;
+
+  self->owner = NULL;
+  if (owner != NULL) {
+    if (!self->consumed && getpid() == self->owner_pid) {
+      owner->publish_permit_active = 0;
+    }
+    Py_DECREF((PyObject *)owner);
+  }
+  release = (freefunc)PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+  if (release != NULL) {
+    release((PyObject *)self);
+  }
+}
+
+static PyType_Slot WorkspacePublishPermit_slots[] = {
+    {Py_tp_new, WorkspacePublishPermit_new},
+    {Py_tp_dealloc, WorkspacePublishPermit_dealloc},
+    {Py_tp_doc,
+     "Private one-shot capability for one native workspace publication."},
+    {0, NULL},
+};
+
+static PyType_Spec WorkspacePublishPermit_spec = {
+    "codenib._workspace_owner_impl._WorkspacePublishPermit",
+    sizeof(WorkspacePublishPermit),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
+    WorkspacePublishPermit_slots,
+};
+
+static PyObject *new_workspace_publish_permit(WorkspaceOwner *owner) {
+  allocfunc allocate;
+  WorkspacePublishPermit *permit;
+
+  if (WorkspacePublishPermitTypeObject == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace publish permit type is unavailable");
+    return NULL;
+  }
+  allocate = (allocfunc)PyType_GetSlot(
+      (PyTypeObject *)WorkspacePublishPermitTypeObject, Py_tp_alloc);
+  if (allocate == NULL) {
+    return NULL;
+  }
+  permit = (WorkspacePublishPermit *)allocate(
+      (PyTypeObject *)WorkspacePublishPermitTypeObject, 0);
+  if (permit == NULL) {
+    return NULL;
+  }
+  Py_INCREF((PyObject *)owner);
+  permit->owner = owner;
+  permit->owner_pid = owner->owner_pid;
+  permit->consumed = 0;
+  return (PyObject *)permit;
+}
+
+static WorkspacePublishPermit *
+require_workspace_publish_permit_exact(PyObject *candidate) {
+  if (WorkspacePublishPermitTypeObject == NULL ||
+      Py_TYPE(candidate) != (PyTypeObject *)WorkspacePublishPermitTypeObject) {
+    PyErr_SetString(PyExc_TypeError,
+                    "workspace publish capability has an invalid native type");
+    return NULL;
+  }
+  return (WorkspacePublishPermit *)candidate;
+}
+
+static PyObject *WorkspaceReceiptToken_new(PyTypeObject *type, PyObject *args,
+                                           PyObject *keywords) {
+  (void)type;
+  (void)args;
+  (void)keywords;
+  PyErr_SetString(PyExc_TypeError,
+                  "native workspace receipt tokens cannot be constructed");
+  return NULL;
+}
+
+static void WorkspaceReceiptToken_dealloc(WorkspaceReceiptToken *self) {
+  freefunc release;
+  WorkspaceOwner *owner = self->owner;
+
+  self->owner = NULL;
+  if (owner != NULL) {
+    Py_DECREF((PyObject *)owner);
+  }
+  release = (freefunc)PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+  if (release != NULL) {
+    release((PyObject *)self);
+  }
+}
+
+static PyType_Slot WorkspaceReceiptToken_slots[] = {
+    {Py_tp_new, WorkspaceReceiptToken_new},
+    {Py_tp_dealloc, WorkspaceReceiptToken_dealloc},
+    {Py_tp_doc,
+     "Private single-owner capability for one native publication receipt."},
+    {0, NULL},
+};
+
+static PyType_Spec WorkspaceReceiptToken_spec = {
+    "codenib._workspace_owner_impl._WorkspaceReceiptToken",
+    sizeof(WorkspaceReceiptToken),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
+    WorkspaceReceiptToken_slots,
+};
+
+static PyObject *new_workspace_receipt_token(WorkspaceOwner *owner) {
+  allocfunc allocate;
+  WorkspaceReceiptToken *token;
+
+  if (WorkspaceReceiptTokenTypeObject == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace receipt token type is unavailable");
+    return NULL;
+  }
+  allocate = (allocfunc)PyType_GetSlot(
+      (PyTypeObject *)WorkspaceReceiptTokenTypeObject, Py_tp_alloc);
+  if (allocate == NULL) {
+    return NULL;
+  }
+  token = (WorkspaceReceiptToken *)allocate(
+      (PyTypeObject *)WorkspaceReceiptTokenTypeObject, 0);
+  if (token == NULL) {
+    return NULL;
+  }
+  Py_INCREF((PyObject *)owner);
+  token->owner = owner;
+  token->owner_pid = owner->owner_pid;
+  token->generation = owner->receipt_generation;
+  token->consumed = 0;
+  return (PyObject *)token;
+}
+
+static WorkspaceReceiptToken *
+require_workspace_receipt_token_exact(PyObject *candidate) {
+  if (WorkspaceReceiptTokenTypeObject == NULL ||
+      Py_TYPE(candidate) != (PyTypeObject *)WorkspaceReceiptTokenTypeObject) {
+    PyErr_SetString(PyExc_TypeError,
+                    "workspace receipt capability has an invalid native type");
+    return NULL;
+  }
+  return (WorkspaceReceiptToken *)candidate;
+}
+
+static WorkspaceOwner *require_workspace_owner_exact(PyObject *candidate) {
+  if (WorkspaceOwnerTypeObject == NULL ||
+      Py_TYPE(candidate) != (PyTypeObject *)WorkspaceOwnerTypeObject) {
+    PyErr_SetString(PyExc_TypeError,
+                    "provisioned workspace owner has an invalid native type");
+    return NULL;
+  }
+  return (WorkspaceOwner *)candidate;
+}
+
+typedef PyObject *(*owner_varargs_function)(WorkspaceOwner *, PyObject *);
+typedef PyObject *(*owner_argument_function)(WorkspaceOwner *, PyObject *);
+typedef PyObject *(*owner_noargs_function)(WorkspaceOwner *, PyObject *);
+
+static PyObject *dispatch_owner_varargs_exact(PyObject *args,
+                                              Py_ssize_t expected_size,
+                                              const char *label,
+                                              owner_varargs_function function) {
+  WorkspaceOwner *owner;
+  PyObject *tail;
+  PyObject *result;
+
+  if (!PyTuple_CheckExact(args) || PyTuple_Size(args) != expected_size) {
+    PyErr_Format(PyExc_TypeError, "%s requires exactly %zd arguments", label,
+                 expected_size);
+    return NULL;
+  }
+  owner = require_workspace_owner_exact(PyTuple_GetItem(args, 0));
+  if (owner == NULL) {
+    return NULL;
+  }
+  tail = PyTuple_GetSlice(args, 1, expected_size);
+  if (tail == NULL) {
+    return NULL;
+  }
+  result = function(owner, tail);
+  Py_DECREF(tail);
+  return result;
+}
+
+static PyObject *
+dispatch_owner_argument_exact(PyObject *args, const char *label,
+                              owner_argument_function function) {
+  WorkspaceOwner *owner;
+  PyObject *argument;
+
+  if (!PyTuple_CheckExact(args) || PyTuple_Size(args) != 2) {
+    PyErr_Format(PyExc_TypeError, "%s requires exactly 2 arguments", label);
+    return NULL;
+  }
+  owner = require_workspace_owner_exact(PyTuple_GetItem(args, 0));
+  argument = PyTuple_GetItem(args, 1);
+  if (owner == NULL || argument == NULL) {
+    return NULL;
+  }
+  return function(owner, argument);
+}
+
+static PyObject *dispatch_owner_noargs_exact(PyObject *candidate,
+                                             owner_noargs_function function) {
+  WorkspaceOwner *owner = require_workspace_owner_exact(candidate);
+  if (owner == NULL) {
+    return NULL;
+  }
+  return function(owner, NULL);
+}
+
+static PyObject *module_provision_owner_exact(PyObject *module,
+                                              PyObject *args) {
+  (void)module;
+  return dispatch_owner_varargs_exact(args, 8, "provision_owner_exact",
+                                      WorkspaceOwner_provision);
+}
+
+static PyObject *module_claim_owner_publish_permit_exact(PyObject *module,
+                                                         PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner,
+                                     WorkspaceOwner_claim_publish_permit);
+}
+
+static PyObject *module_verify_owner_authority_exact(PyObject *module,
+                                                     PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner, WorkspaceOwner_verify);
+}
+
+static PyObject *module_verify_owner_adoption_binding_exact(PyObject *module,
+                                                            PyObject *args) {
+  (void)module;
+  return dispatch_owner_varargs_exact(args, 4,
+                                      "verify_owner_adoption_binding_exact",
+                                      WorkspaceOwner_verify_adoption_binding);
+}
+
+static PyObject *module_borrow_owner_parent_descriptor_exact(PyObject *module,
+                                                             PyObject *owner) {
+  WorkspaceOwner *exact_owner;
+  (void)module;
+  exact_owner = require_workspace_owner_exact(owner);
+  if (exact_owner == NULL) {
+    return NULL;
+  }
+  return WorkspaceOwner_get_parent_descriptor(exact_owner, NULL);
+}
+
+static PyObject *module_borrow_owner_root_descriptor_exact(PyObject *module,
+                                                           PyObject *owner) {
+  WorkspaceOwner *exact_owner;
+  (void)module;
+  exact_owner = require_workspace_owner_exact(owner);
+  if (exact_owner == NULL) {
+    return NULL;
+  }
+  return WorkspaceOwner_get_root_descriptor(exact_owner, NULL);
+}
+
+static PyObject *
+module_borrow_owner_directory_descriptor_exact(PyObject *module,
+                                               PyObject *args) {
+  (void)module;
+  return dispatch_owner_argument_exact(
+      args, "borrow_owner_directory_descriptor_exact",
+      WorkspaceOwner_directory_descriptor);
+}
+
+static PyObject *module_begin_owner_file_exact(PyObject *module,
+                                               PyObject *args) {
+  (void)module;
+  return dispatch_owner_varargs_exact(args, 4, "begin_owner_file_exact",
+                                      WorkspaceOwner_begin_file);
+}
+
+static PyObject *module_write_owner_file_exact(PyObject *module,
+                                               PyObject *args) {
+  (void)module;
+  return dispatch_owner_argument_exact(args, "write_owner_file_exact",
+                                       WorkspaceOwner_write_file);
+}
+
+static PyObject *module_finish_owner_file_exact(PyObject *module,
+                                                PyObject *args) {
+  (void)module;
+  return dispatch_owner_argument_exact(args, "finish_owner_file_exact",
+                                       WorkspaceOwner_finish_file);
+}
+
+static PyObject *module_abort_owner_file_exact(PyObject *module,
+                                               PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner, WorkspaceOwner_abort_file);
+}
+
+static PyObject *module_seal_owner_directories_exact(PyObject *module,
+                                                     PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner, WorkspaceOwner_seal_directories);
+}
+
+static PyObject *module_sync_owner_parent_exact(PyObject *module,
+                                                PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner, WorkspaceOwner_sync_parent_method);
+}
+
+static PyObject *module_mark_owner_adopted_exact(PyObject *module,
+                                                 PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner, WorkspaceOwner_mark_adopted);
+}
+
+static PyObject *module_rename_owner_child_noreplace_exact(PyObject *module,
+                                                           PyObject *args) {
+  WorkspacePublishPermit *permit;
+  PyObject *tail;
+  PyObject *result;
+  (void)module;
+  if (!PyTuple_CheckExact(args) || PyTuple_Size(args) != 3) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "rename_owner_child_noreplace_exact requires exactly 3 arguments");
+    return NULL;
+  }
+  permit = require_workspace_publish_permit_exact(PyTuple_GetItem(args, 0));
+  if (permit == NULL) {
+    return NULL;
+  }
+  tail = PyTuple_GetSlice(args, 1, 3);
+  if (tail == NULL) {
+    return NULL;
+  }
+  result = WorkspacePublishPermit_rename_child_noreplace(permit, tail);
+  Py_DECREF(tail);
+  return result;
+}
+
+static PyObject *module_commit_owner_receipt_exact(PyObject *module,
+                                                   PyObject *candidate) {
+  WorkspaceReceiptToken *token;
+  (void)module;
+  token = require_workspace_receipt_token_exact(candidate);
+  if (token == NULL) {
+    return NULL;
+  }
+  return WorkspaceReceiptToken_commit(token);
+}
+
+static PyObject *module_abort_owner_exact(PyObject *module, PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner, WorkspaceOwner_abort);
+}
+
+static PyObject *module_quarantine_owner_exact(PyObject *module,
+                                               PyObject *owner) {
+  (void)module;
+  return dispatch_owner_noargs_exact(owner, WorkspaceOwner_quarantine);
+}
+
+static PyObject *module_owner_state_exact(PyObject *module, PyObject *owner) {
+  WorkspaceOwner *exact_owner;
+  (void)module;
+  exact_owner = require_workspace_owner_exact(owner);
+  if (exact_owner == NULL) {
+    return NULL;
+  }
+  return WorkspaceOwner_get_state(exact_owner, NULL);
+}
+
+static PyObject *module_owner_closed_exact(PyObject *module, PyObject *owner) {
+  WorkspaceOwner *exact_owner;
+  (void)module;
+  exact_owner = require_workspace_owner_exact(owner);
+  if (exact_owner == NULL) {
+    return NULL;
+  }
+  return WorkspaceOwner_get_closed(exact_owner, NULL);
+}
+
+static PyObject *module_close_owner_exact(PyObject *module, PyObject *owner) {
+  WorkspaceOwner *exact_owner;
+  (void)module;
+  exact_owner = require_workspace_owner_exact(owner);
+  if (exact_owner == NULL) {
+    return NULL;
+  }
+  return WorkspaceOwner_close(exact_owner, NULL);
+}
+
+static PyObject *module_create_owner_exact(PyObject *module,
+                                           PyObject *Py_UNUSED(ignored)) {
+  (void)module;
+  if (WorkspaceOwnerTypeObject == NULL ||
+      WorkspacePublishPermitTypeObject == NULL ||
+      WorkspaceReceiptTokenTypeObject == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner type is unavailable");
+    return NULL;
+  }
+  return PyObject_CallObject(WorkspaceOwnerTypeObject, NULL);
+}
+
+static PyObject *module_require_owner_exact(PyObject *module, PyObject *owner) {
+  (void)module;
+  if (require_workspace_owner_exact(owner) == NULL) {
+    return NULL;
+  }
+  Py_INCREF(owner);
+  return owner;
+}
+
+#define CODENIB_WORKSPACE_OWNER_PROTOCOL_VERSION 2
+
+static PyObject *module_require_support(PyObject *module,
+                                        PyObject *Py_UNUSED(ignored)) {
+  (void)module;
+  if (WorkspaceOwnerTypeObject == NULL ||
+      WorkspacePublishPermitTypeObject == NULL ||
+      WorkspaceReceiptTokenTypeObject == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native workspace owner ABI is incomplete");
+    return NULL;
+  }
+  if (require_linux() < 0) {
+    return NULL;
+  }
+#if !defined(SYS_renameat2) || !defined(SYS_fstat) ||                          \
+    !defined(SYS_newfstatat) || !defined(SYS_kcmp) || !defined(SYS_close)
+  PyErr_SetString(PyExc_RuntimeError,
+                  "native strict workspace provisioning requires Linux "
+                  "descriptor and OFD-comparison syscalls");
+  return NULL;
+#endif
+  if (probe_kcmp_support() < 0) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "native strict workspace provisioning requires permitted "
+                    "same-process kcmp OFD comparison");
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
+static PyMethodDef workspace_module_methods[] = {
+    {"require_support", (PyCFunction)module_require_support, METH_NOARGS,
+     "Require native Linux workspace ownership support."},
+    {"close_owner_exact", (PyCFunction)module_close_owner_exact, METH_O,
+     "Close an exact native owner without instance method dispatch."},
+    {"create_owner_exact", (PyCFunction)module_create_owner_exact, METH_NOARGS,
+     "Create the internally pinned exact native owner type."},
+    {"require_owner_exact", (PyCFunction)module_require_owner_exact, METH_O,
+     "Authenticate against the internally pinned native owner type."},
+    {"provision_owner_exact", (PyCFunction)module_provision_owner_exact,
+     METH_VARARGS, "Provision through exact native-owner dispatch."},
+    {"claim_owner_publish_permit_exact",
+     (PyCFunction)module_claim_owner_publish_permit_exact, METH_O,
+     "Claim the exact owner's private one-shot publication capability."},
+    {"verify_owner_authority_exact",
+     (PyCFunction)module_verify_owner_authority_exact, METH_O,
+     "Verify authority through exact native-owner dispatch."},
+    {"verify_owner_adoption_binding_exact",
+     (PyCFunction)module_verify_owner_adoption_binding_exact, METH_VARARGS,
+     "Verify adoption binding through exact native-owner dispatch."},
+    {"borrow_owner_parent_descriptor_exact",
+     (PyCFunction)module_borrow_owner_parent_descriptor_exact, METH_O,
+     "Borrow the exact owner's destination-parent descriptor."},
+    {"borrow_owner_root_descriptor_exact",
+     (PyCFunction)module_borrow_owner_root_descriptor_exact, METH_O,
+     "Borrow the exact owner's workspace-root descriptor."},
+    {"borrow_owner_directory_descriptor_exact",
+     (PyCFunction)module_borrow_owner_directory_descriptor_exact, METH_VARARGS,
+     "Borrow one planned directory through exact native-owner dispatch."},
+    {"begin_owner_file_exact", (PyCFunction)module_begin_owner_file_exact,
+     METH_VARARGS, "Begin a file through exact native-owner dispatch."},
+    {"write_owner_file_exact", (PyCFunction)module_write_owner_file_exact,
+     METH_VARARGS, "Write a file through exact native-owner dispatch."},
+    {"finish_owner_file_exact", (PyCFunction)module_finish_owner_file_exact,
+     METH_VARARGS, "Finish a file through exact native-owner dispatch."},
+    {"abort_owner_file_exact", (PyCFunction)module_abort_owner_file_exact,
+     METH_O, "Abort a file through exact native-owner dispatch."},
+    {"seal_owner_directories_exact",
+     (PyCFunction)module_seal_owner_directories_exact, METH_O,
+     "Seal directories through exact native-owner dispatch."},
+    {"sync_owner_parent_exact", (PyCFunction)module_sync_owner_parent_exact,
+     METH_O, "Sync the parent through exact native-owner dispatch."},
+    {"mark_owner_adopted_exact", (PyCFunction)module_mark_owner_adopted_exact,
+     METH_O, "Mark adoption through exact native-owner dispatch."},
+    {"rename_owner_child_noreplace_exact",
+     (PyCFunction)module_rename_owner_child_noreplace_exact, METH_VARARGS,
+     "Publish through one exact native publication capability."},
+    {"commit_owner_receipt_exact",
+     (PyCFunction)module_commit_owner_receipt_exact, METH_O,
+     "Commit one exact native receipt capability."},
+    {"abort_owner_exact", (PyCFunction)module_abort_owner_exact, METH_O,
+     "Abort through exact native-owner dispatch."},
+    {"quarantine_owner_exact", (PyCFunction)module_quarantine_owner_exact,
+     METH_O, "Quarantine through exact native-owner dispatch."},
+    {"owner_state_exact", (PyCFunction)module_owner_state_exact, METH_O,
+     "Return state through exact native-owner dispatch."},
+    {"owner_closed_exact", (PyCFunction)module_owner_closed_exact, METH_O,
+     "Return closed state through exact native-owner dispatch."},
+    {NULL, NULL, 0, NULL},
+};
+
+static struct PyModuleDef workspace_owner_module = {
+    PyModuleDef_HEAD_INIT,
+    "_workspace_owner_impl",
+    "Native ownership for strict local workspaces.",
+    -1,
+    workspace_module_methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+PyMODINIT_FUNC PyInit__workspace_owner_impl(void);
+
+PyMODINIT_FUNC PyInit__workspace_owner_impl(void) {
+  PyObject *module;
+  PyObject *owner_type;
+  PyObject *publish_permit_type;
+  PyObject *receipt_token_type;
+
+  module = PyModule_Create(&workspace_owner_module);
+  if (module == NULL) {
+    return NULL;
+  }
+  if (PyModule_AddIntConstant(module, "workspace_owner_protocol_version",
+                              CODENIB_WORKSPACE_OWNER_PROTOCOL_VERSION) < 0) {
+    Py_DECREF(module);
+    return NULL;
+  }
+  owner_type = PyType_FromSpec(&WorkspaceOwner_spec);
+  if (owner_type == NULL) {
+    Py_DECREF(module);
+    return NULL;
+  }
+  publish_permit_type = PyType_FromSpec(&WorkspacePublishPermit_spec);
+  if (publish_permit_type == NULL) {
+    Py_DECREF(owner_type);
+    Py_DECREF(module);
+    return NULL;
+  }
+  receipt_token_type = PyType_FromSpec(&WorkspaceReceiptToken_spec);
+  if (receipt_token_type == NULL) {
+    Py_DECREF(publish_permit_type);
+    Py_DECREF(owner_type);
+    Py_DECREF(module);
+    return NULL;
+  }
+  /* Keep the exact type private: every operation enters through a pinned
+     module-level wrapper, never through mutable attribute dispatch. */
+  WorkspaceOwnerTypeObject = owner_type;
+  WorkspacePublishPermitTypeObject = publish_permit_type;
+  WorkspaceReceiptTokenTypeObject = receipt_token_type;
+  return module;
+}

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -9,16 +9,12 @@ from __future__ import annotations
 
 import argparse
 import email
+import platform
 import sys
 import tarfile
 import zipfile
 from pathlib import Path
 from typing import Sequence
-
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
-    import tomli as tomllib
 
 
 class ReleaseValidationError(RuntimeError):
@@ -31,6 +27,28 @@ README_CITATION_MARKERS = (
     "@misc{yu2026codenibmultiviewdataserving,",
 )
 MCP_OWNERSHIP_MARKER = "mcp-name: ai.codenib/codenib"
+WORKSPACE_OWNER_EXTENSION = "codenib/_workspace_owner_impl.abi3.so"
+PRODUCTION_WHEEL_TAGS = (
+    "cp310-abi3-manylinux_2_28_x86_64",
+    "cp310-abi3-manylinux_2_28_aarch64",
+)
+_MACHINE_ARCHITECTURES = {
+    "amd64": "x86_64",
+    "arm64": "aarch64",
+    "aarch64": "aarch64",
+    "x86_64": "x86_64",
+}
+_COMPILED_BINARY_SUFFIXES = (
+    ".a",
+    ".dll",
+    ".dylib",
+    ".exe",
+    ".lib",
+    ".o",
+    ".obj",
+    ".pyd",
+    ".so",
+)
 
 
 def validate_readme_citation(readme: str) -> None:
@@ -51,6 +69,11 @@ def validate_readme_mcp_ownership(readme: str) -> None:
 
 
 def project_identity(project_file: Path) -> tuple[str, str]:
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+        import tomli as tomllib
+
     with project_file.open("rb") as handle:
         project = tomllib.load(handle)["project"]
     return str(project["name"]), str(project["version"])
@@ -107,6 +130,41 @@ def _single(paths: list[Path], kind: str) -> Path:
     return paths[0]
 
 
+def _wheel_name(name: str, version: str, tag: str) -> str:
+    normalized = name.replace("-", "_")
+    return f"{normalized}-{version}-{tag}.whl"
+
+
+def _is_compiled_binary(member: str) -> bool:
+    filename = Path(member).name.lower()
+    return filename.endswith(_COMPILED_BINARY_SUFFIXES) or ".so." in filename
+
+
+def select_compatible_wheel(
+    dist_dir: Path,
+    *,
+    system: str | None = None,
+    machine: str | None = None,
+) -> Path:
+    """Select the one production wheel compatible with this Linux machine."""
+    current_system = sys.platform if system is None else system
+    current_machine = platform.machine() if machine is None else machine
+    if not current_system.startswith("linux"):
+        raise ReleaseValidationError(
+            f"production wheels require Linux, found {current_system!r}"
+        )
+    architecture = _MACHINE_ARCHITECTURES.get(current_machine.lower())
+    if architecture is None:
+        raise ReleaseValidationError(
+            f"no production wheel supports machine {current_machine!r}"
+        )
+    suffix = f"-cp310-abi3-manylinux_2_28_{architecture}.whl"
+    return _single(
+        sorted(path for path in dist_dir.glob("*.whl") if path.name.endswith(suffix)),
+        f"compatible {architecture} wheel",
+    )
+
+
 def _validate_wheel(wheel: Path, name: str, version: str) -> None:
     required = {
         "codenib/__init__.py",
@@ -123,7 +181,8 @@ def _validate_wheel(wheel: Path, name: str, version: str) -> None:
         "codenib/web/frontend/runtime-config.js",
     }
     with zipfile.ZipFile(wheel) as archive:
-        members = set(archive.namelist())
+        member_names = archive.namelist()
+        members = set(member_names)
         missing = sorted(required - members)
         if missing:
             raise ReleaseValidationError(
@@ -135,6 +194,18 @@ def _validate_wheel(wheel: Path, name: str, version: str) -> None:
         ):
             raise ReleaseValidationError(
                 f"{wheel.name} has no compiled Wiki JavaScript assets"
+            )
+
+        workspace_owner_members = [
+            member
+            for member in member_names
+            if member.startswith("codenib/_workspace_owner_impl")
+        ]
+        if workspace_owner_members != [WORKSPACE_OWNER_EXTENSION]:
+            found = ", ".join(workspace_owner_members) or "none"
+            raise ReleaseValidationError(
+                f"{wheel.name} must contain exactly one "
+                f"{WORKSPACE_OWNER_EXTENSION}, found: {found}"
             )
 
         metadata_members = sorted(
@@ -179,16 +250,27 @@ def _validate_sdist(sdist: Path, name: str, version: str) -> None:
         f"{root}/CHANGELOG.md",
         f"{root}/LICENSE",
         f"{root}/README.md",
+        f"{root}/native/workspace_owner.c",
         f"{root}/server.json",
         f"{root}/pyproject.toml",
         f"{root}/web/package-lock.json",
     }
     with tarfile.open(sdist, mode="r:gz") as archive:
-        members = {member.name for member in archive.getmembers()}
+        archive_members = archive.getmembers()
+        members = {member.name for member in archive_members}
         missing = sorted(required - members)
         if missing:
             raise ReleaseValidationError(
                 f"{sdist.name} is missing source-release files: {', '.join(missing)}"
+            )
+        binary_members = sorted(
+            member.name
+            for member in archive_members
+            if member.isfile() and _is_compiled_binary(member.name)
+        )
+        if binary_members:
+            raise ReleaseValidationError(
+                f"{sdist.name} contains compiled binaries: " + ", ".join(binary_members)
             )
         readme_file = archive.extractfile(f"{root}/README.md")
         if readme_file is None:  # guarded by the required-members check
@@ -203,28 +285,39 @@ def validate_release(
     *,
     project_file: Path,
     tag: str | None = None,
-) -> tuple[Path, Path]:
+) -> tuple[tuple[Path, ...], Path]:
     name, version = project_identity(project_file)
     validate_tag(tag, version)
     validate_release_notes(project_file)
 
-    wheel = _single(sorted(dist_dir.glob("*.whl")), "wheel")
+    wheels = tuple(sorted(dist_dir.glob("*.whl")))
     sdist = _single(sorted(dist_dir.glob("*.tar.gz")), "sdist")
-    normalized = name.replace("-", "_")
-    wheel_prefix = f"{normalized}-{version}-"
+    expected_wheel_names = {
+        _wheel_name(name, version, tag) for tag in PRODUCTION_WHEEL_TAGS
+    }
+    actual_wheel_names = {wheel.name for wheel in wheels}
     sdist_name = f"{name}-{version}.tar.gz"
-    if not wheel.name.startswith(wheel_prefix):
+    if actual_wheel_names != expected_wheel_names:
+        missing = sorted(expected_wheel_names - actual_wheel_names)
+        unexpected = sorted(actual_wheel_names - expected_wheel_names)
+        details = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if unexpected:
+            details.append("unexpected " + ", ".join(unexpected))
         raise ReleaseValidationError(
-            f"wheel filename {wheel.name!r} must start with {wheel_prefix!r}"
+            "production wheels must be exactly the cp310-abi3 manylinux_2_28 "
+            "x86_64 and aarch64 artifacts: " + "; ".join(details)
         )
     if sdist.name != sdist_name:
         raise ReleaseValidationError(
             f"sdist filename {sdist.name!r} must equal {sdist_name!r}"
         )
 
-    _validate_wheel(wheel, name, version)
+    for wheel in wheels:
+        _validate_wheel(wheel, name, version)
     _validate_sdist(sdist, name, version)
-    return wheel, sdist
+    return wheels, sdist
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -236,16 +329,22 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=Path("pyproject.toml"),
     )
     parser.add_argument("--tag")
+    parser.add_argument(
+        "--print-compatible-wheel",
+        action="store_true",
+        help="print the current Linux architecture's production wheel",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     try:
-        wheel, sdist = validate_release(
-            args.dist_dir,
-            project_file=args.project_file,
-            tag=args.tag,
+        if args.print_compatible_wheel:
+            print(select_compatible_wheel(args.dist_dir))
+            return 0
+        wheels, sdist = validate_release(
+            args.dist_dir, project_file=args.project_file, tag=args.tag
         )
     except (
         OSError,
@@ -255,7 +354,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     ) as exc:
         print(f"release validation failed: {exc}", file=sys.stderr)
         return 1
-    print(f"Release artifacts verified: {wheel.name}, {sdist.name}")
+    artifacts = ", ".join([*(wheel.name for wheel in wheels), sdist.name])
+    print(f"Release artifacts verified: {artifacts}")
     return 0
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Setuptools hooks for release-only non-Python assets."""
+"""Setuptools hooks for optional native and prebuilt release assets."""
 
 from __future__ import annotations
 
 import shutil
 from pathlib import Path
 
-from setuptools import setup
+from setuptools import Extension, setup
 from setuptools.command.build_py import build_py as _build_py
 
 
@@ -30,4 +30,17 @@ class BuildPy(_build_py):
         shutil.copytree(source, target)
 
 
-setup(cmdclass={"build_py": BuildPy})
+workspace_owner = Extension(
+    "codenib._workspace_owner_impl",
+    sources=["native/workspace_owner.c"],
+    define_macros=[("Py_LIMITED_API", "0x030A0000")],
+    py_limited_api=True,
+    optional=True,
+)
+
+
+setup(
+    cmdclass={"build_py": BuildPy},
+    ext_modules=[workspace_owner],
+    options={"bdist_wheel": {"py_limited_api": "cp310"}},
+)

--- a/test/artifacts/test_strict_bm25_publication.py
+++ b/test/artifacts/test_strict_bm25_publication.py
@@ -16,11 +16,13 @@ from typing import Any, TypeVar
 import pytest
 
 import codenib.artifacts.strict_bm25 as strict_bm25_module
+from codenib import LocalWorkspaceProvider
 from codenib._atomic_directory import TreeFileRecord
 from codenib._bounded_json import canonical_json_value_chunks
 from codenib._captured_directory import (
     OwnedWorkspaceAuthority,
     PublishedWorkspaceReceiptOwner,
+    UnsupportedWorkspaceCreation,
     WorkspaceFile,
     WorkspacePlan,
 )
@@ -322,6 +324,47 @@ def test_strict_bm25_plans_replays_and_serves_same_query_semantics(
         ]
     finally:
         output_owner.close()
+
+
+def test_strict_bm25_rejects_missing_only_local_provider_before_mutation(
+    strict_generation,
+    tmp_path: Path,
+) -> None:
+    fixture = strict_generation
+    view_config = {"builder_schema": 2, "tokenizer": "code-aware-v1"}
+    planned = plan_bm25_view_strict(
+        fixture.source_owner,
+        repository_source=fixture.repository_source,
+        view_config=view_config,
+        environ={},
+    )
+    os.chmod(tmp_path, 0o700)
+    provider = LocalWorkspaceProvider(tmp_path)
+    try:
+        provider.require_support()
+    except UnsupportedWorkspaceCreation as error:
+        pytest.skip(f"native local workspace provider is unavailable: {error}")
+    output_owner = PublishedWorkspaceReceiptOwner()
+
+    with pytest.raises(
+        UnsupportedWorkspaceCreation,
+        match="requires a missing destination",
+    ):
+        publish_planned_bm25_view_strict(
+            fixture.destination,
+            planned=planned,
+            source_generation=fixture.source_owner,
+            repository_source=fixture.repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_config=view_config,
+            environ={},
+        )
+
+    assert output_owner.state == "empty"
+    assert fixture.source_owner.active
+    assert not tuple(tmp_path.glob(".codenib-workspace-stage-*"))
+    assert not tuple(tmp_path.glob(".codenib-workspace-orphan-*"))
 
 
 def test_strict_bm25_high_level_freezes_caller_mappings_once(

--- a/test/artifacts/test_strict_context_publication.py
+++ b/test/artifacts/test_strict_context_publication.py
@@ -18,9 +18,11 @@ import pytest
 import codenib.artifacts as artifacts_module
 import codenib.artifacts.portable_views as portable_views_module
 import codenib.artifacts.strict_context as strict_context_module
+from codenib import LocalWorkspaceProvider
 from codenib._captured_directory import (
     OwnedWorkspaceAuthority,
     PublishedWorkspaceReceiptOwner,
+    UnsupportedWorkspaceCreation,
     WorkspaceDirectory,
     WorkspaceFile,
     WorkspacePlan,
@@ -390,6 +392,16 @@ def _fixture(tmp_path: Path, views: tuple[str, ...]) -> _Fixture:
         raise
 
 
+def _native_local_provider(root: Path) -> LocalWorkspaceProvider:
+    root.mkdir(mode=0o700)
+    provider = LocalWorkspaceProvider(root)
+    try:
+        provider.require_support()
+    except UnsupportedWorkspaceCreation as error:
+        pytest.skip(f"native local workspace provider is unavailable: {error}")
+    return provider
+
+
 @pytest.mark.parametrize(
     "views",
     [("bm25",), ("vector",), ("bm25", "vector")],
@@ -433,6 +445,41 @@ def test_strict_context_publishes_portable_view_combinations(
             expected_commit=_COMMIT,
         )
         assert verified.views == tuple(sorted(views))
+        assert verified.file_count == result.file_count
+        assert verified.byte_count == result.byte_count
+    finally:
+        output_owner.close()
+        fixture.close()
+
+
+def test_strict_context_publishes_with_native_local_provider(tmp_path: Path) -> None:
+    input_root = tmp_path / "inputs"
+    input_root.mkdir()
+    fixture = _fixture(input_root, ("bm25", "vector"))
+    provider = _native_local_provider(tmp_path / "authority")
+    output_owner = PublishedWorkspaceReceiptOwner()
+    destination = provider.allowed_root / "context"
+    try:
+        result = stage_context_artifact_strict(
+            destination,
+            manifest=fixture.manifest,
+            repository="owner/repo",
+            repository_source=fixture.repository_source,
+            view_generations=fixture.owners,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            environ={},
+        )
+
+        assert result.output_dir == destination
+        assert result.views == ("bm25", "vector")
+        assert output_owner.active
+        verified = verify_context_artifact(
+            destination,
+            expected_repository="owner/repo",
+            expected_commit=_COMMIT,
+        )
+        assert verified.views == result.views
         assert verified.file_count == result.file_count
         assert verified.byte_count == result.byte_count
     finally:

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -625,7 +625,9 @@ def test_authority_publish_helper_borrows_authority_and_commits_exact_once(
         sealed: object,
         published: object,
         previous: DirectoryOrphan | None,
+        publication_token: object | None,
     ) -> None:
+        assert publication_token is None
         assert events == ["verified", "synced"]
         events.append("committed")
         observed.append((sealed, published, previous))
@@ -694,8 +696,8 @@ def test_authority_publish_helper_does_not_commit_before_validation_finishes(
                 stage,
                 destination,
                 validate_published_destination=fail_validation,
-                commit_callback=lambda sealed, _published, _previous: commits.append(
-                    sealed
+                commit_callback=lambda sealed, _published, _previous, _token: (
+                    commits.append(sealed)
                 ),
             )
         assert not authority._closed
@@ -745,8 +747,8 @@ def test_authority_publish_helper_rechecks_exact_tree_after_orphan_receipt(
                 authority,
                 stage,
                 destination,
-                commit_callback=lambda sealed, _published, _previous: commits.append(
-                    sealed
+                commit_callback=lambda sealed, _published, _previous, _token: (
+                    commits.append(sealed)
                 ),
             )
         assert not authority._closed
@@ -789,8 +791,8 @@ def test_authority_publish_helper_fsync_failure_prevents_commit(
                 authority,
                 stage,
                 destination,
-                commit_callback=lambda sealed, _published, _previous: commits.append(
-                    sealed
+                commit_callback=lambda sealed, _published, _previous, _token: (
+                    commits.append(sealed)
                 ),
             )
         assert caught.value is error
@@ -828,8 +830,8 @@ def test_authority_publish_helper_rejects_unsupported_durable_commit(
                 authority,
                 stage,
                 destination,
-                commit_callback=lambda sealed, _published, _previous: commits.append(
-                    sealed
+                commit_callback=lambda sealed, _published, _previous, _token: (
+                    commits.append(sealed)
                 ),
             )
         assert not authority._closed
@@ -876,7 +878,9 @@ def test_authority_publish_helper_never_rolls_back_commit_interruptions(
         sealed: object,
         published: object,
         previous: DirectoryOrphan | None,
+        publication_token: object | None,
     ) -> None:
+        assert publication_token is None
         assert synced
         observed.append((sealed, published, previous))
         raise error_type("injected commit interruption")

--- a/test/test_local_workspace_provider.py
+++ b/test/test_local_workspace_provider.py
@@ -1,0 +1,673 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+import codenib
+import codenib._local_workspace_provider as local_provider_module
+import codenib._workspace_owner as workspace_owner
+from codenib._captured_directory import (
+    PublishedWorkspaceReceiptOwner,
+    UnsupportedWorkspaceCreation,
+    WorkspaceDirectory,
+    WorkspaceFile,
+    WorkspacePlan,
+)
+from codenib._local_workspace_provider import LocalWorkspaceProvider
+from codenib._workspace_provider import (
+    DestinationExpectation,
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_strict_workspace,
+)
+
+
+def _require_native_provider(root: Path) -> LocalWorkspaceProvider:
+    root.mkdir(mode=0o700)
+    root.chmod(0o700)
+    provider = LocalWorkspaceProvider(root)
+    try:
+        provider.require_support()
+    except UnsupportedWorkspaceCreation as error:
+        pytest.skip(f"native local workspace provider is unavailable: {error}")
+    return provider
+
+
+def _plan() -> WorkspacePlan:
+    return WorkspacePlan(
+        subject_digest=hashlib.sha256(b"local-workspace-provider").hexdigest(),
+        directories=(WorkspaceDirectory(Path("data")),),
+        files=(
+            WorkspaceFile(
+                Path("data/result.json"),
+                mode=0o600,
+                max_bytes=1 << 20,
+            ),
+        ),
+    )
+
+
+def _request(
+    root: Path,
+    *,
+    expectation: DestinationExpectation = "missing",
+) -> StrictWorkspaceRequest:
+    return StrictWorkspaceRequest(
+        purpose="test-local-workspace-provider",
+        destination=root / "published",
+        plan=_plan(),
+        destination_expectation=expectation,
+    )
+
+
+def _write_and_publish(session: StrictWorkspaceSession, payload: bytes) -> object:
+    record = session.write_file("data/result.json", (payload,))
+    return session.publish_validated(
+        lambda reader: (record, reader.capture_ownership(allow_empty_root=True))
+    )
+
+
+def test_local_provider_and_receipt_owner_are_public_lazy_exports() -> None:
+    assert codenib.LocalWorkspaceProvider is LocalWorkspaceProvider
+    assert codenib.PublishedWorkspaceReceiptOwner is PublishedWorkspaceReceiptOwner
+
+
+def test_local_provider_publishes_and_transfers_one_receipt(tmp_path: Path) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    payload = b'{"result":"ok"}'
+
+    record, ownership = run_strict_workspace(
+        provider,
+        request,
+        receipt_owner=receipt_owner,
+        operation=lambda session: _write_and_publish(session, payload),
+    )
+
+    assert record.sha256 == hashlib.sha256(payload).hexdigest()
+    assert ownership.file_records == (record,)
+    assert receipt_owner.active
+    assert (request.destination / "data/result.json").read_bytes() == payload
+
+    receipt_owner.close()
+
+    assert receipt_owner.closed
+    assert (request.destination / "data/result.json").read_bytes() == payload
+
+
+def test_local_provider_aborts_an_exact_prepublish_error(tmp_path: Path) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    error = RuntimeError("injected prepublish failure")
+
+    def fail(session: StrictWorkspaceSession) -> None:
+        session.write_file("data/result.json", (b"partial",))
+        raise error
+
+    with pytest.raises(RuntimeError) as caught:
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=fail,
+        )
+
+    assert caught.value is error
+    assert receipt_owner.state == "empty"
+    assert not request.destination.exists()
+    assert not tuple(root.glob(".codenib-workspace-stage-*"))
+    assert tuple(root.glob(".codenib-workspace-orphan-*"))
+
+
+def test_local_provider_retains_owner_when_native_cleanup_cannot_authenticate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    primary_error = RuntimeError("injected operation failure")
+    cleanup_error = PermissionError(errno.EPERM, "injected OFD comparison denial")
+    real_abort = workspace_owner.abort_owner
+
+    def reject_abort(_owner: object) -> None:
+        raise cleanup_error
+
+    monkeypatch.setattr(
+        local_provider_module._workspace_owner,
+        "abort_owner",
+        reject_abort,
+    )
+
+    def fail(_session: StrictWorkspaceSession) -> None:
+        raise primary_error
+
+    with pytest.raises(RuntimeError) as caught:
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=fail,
+        )
+
+    assert caught.value is primary_error
+    cleanup_owners = getattr(primary_error, "publication_cleanup_owners", ())
+    assert len(cleanup_owners) == 1
+    cleanup_owner = cleanup_owners[0]
+    assert type(cleanup_owner).__name__ == "_ProviderWorkspaceCleanupOwner"
+    assert not cleanup_owner.closed
+    monkeypatch.setattr(
+        local_provider_module._workspace_owner,
+        "abort_owner",
+        real_abort,
+    )
+    cleanup_owner.close()
+    assert cleanup_owner.closed
+    assert receipt_owner.state == "empty"
+    assert not request.destination.exists()
+    assert not tuple(root.glob(".codenib-workspace-stage-*"))
+    assert tuple(root.glob(".codenib-workspace-orphan-*"))
+
+
+def test_local_provider_keeps_a_postpublish_receipt_active(tmp_path: Path) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    error = KeyboardInterrupt("injected postpublish cancellation")
+
+    def publish_then_fail(session: StrictWorkspaceSession) -> None:
+        _write_and_publish(session, b"committed")
+        raise error
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=publish_then_fail,
+        )
+
+    assert caught.value is error
+    assert receipt_owner.active
+    assert (request.destination / "data/result.json").read_bytes() == b"committed"
+    receipt_owner.close()
+    assert receipt_owner.closed
+
+
+def test_local_provider_rejects_outside_root_before_mutation(tmp_path: Path) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = StrictWorkspaceRequest(
+        purpose="test-local-workspace-provider",
+        destination=tmp_path / "outside",
+        plan=_plan(),
+    )
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+
+    with pytest.raises(ValueError, match="outside the provider root"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=lambda session: _write_and_publish(session, b"forbidden"),
+        )
+
+    assert tuple(root.iterdir()) == ()
+    assert not request.destination.exists()
+    assert receipt_owner.state == "empty"
+
+
+def test_local_provider_native_policy_recheck_rejects_late_root_widening(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    real_provision = workspace_owner.provision_owner
+
+    def widen_root_then_provision(*args: object, **kwargs: object) -> None:
+        root.chmod(0o755)
+        real_provision(*args, **kwargs)
+
+    monkeypatch.setattr(
+        local_provider_module._workspace_owner,
+        "provision_owner",
+        widen_root_then_provision,
+    )
+    try:
+        with pytest.raises(PermissionError):
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=receipt_owner,
+                operation=lambda session: _write_and_publish(session, b"forbidden"),
+            )
+    finally:
+        root.chmod(0o700)
+
+    assert receipt_owner.state == "empty"
+    assert tuple(root.iterdir()) == ()
+    assert not request.destination.exists()
+
+
+def test_local_provider_preserves_an_existing_destination(tmp_path: Path) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    request.destination.mkdir()
+    marker = request.destination / "old.txt"
+    marker.write_text("old", encoding="utf-8")
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+
+    with pytest.raises(FileExistsError):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=lambda session: _write_and_publish(session, b"new"),
+        )
+
+    assert marker.read_text(encoding="utf-8") == "old"
+    assert not tuple(root.glob(".codenib-workspace-stage-*"))
+    assert receipt_owner.state == "empty"
+
+
+def test_local_provider_rejects_bound_exact_expectation_before_mutation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root, expectation="provider-bound-exact")
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+
+    with pytest.raises(UnsupportedWorkspaceCreation, match="missing destination"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=lambda session: _write_and_publish(session, b"forbidden"),
+        )
+
+    assert tuple(root.iterdir()) == ()
+    assert receipt_owner.state == "empty"
+
+
+def test_local_provider_fails_closed_without_the_complete_native_abi(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    root.mkdir(mode=0o700)
+    root.chmod(0o700)
+    provider = LocalWorkspaceProvider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    monkeypatch.setattr(
+        workspace_owner,
+        "_workspace_owner_protocol_available",
+        False,
+    )
+
+    with pytest.raises(UnsupportedWorkspaceCreation, match="ownership is unavailable"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=lambda session: _write_and_publish(session, b"forbidden"),
+        )
+
+    assert tuple(root.iterdir()) == ()
+    assert receipt_owner.state == "empty"
+
+
+@pytest.mark.parametrize("invalid_plan", ("subclass", "digest"))
+def test_local_provider_rejects_nonexact_plan_before_native_mutation(
+    tmp_path: Path,
+    invalid_plan: str,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    plan = _plan()
+    if invalid_plan == "subclass":
+
+        class DerivedWorkspacePlan(WorkspacePlan):
+            pass
+
+        plan = DerivedWorkspacePlan(
+            subject_digest=plan.subject_digest,
+            directories=plan.directories,
+            files=plan.files,
+            root_mode=plan.root_mode,
+        )
+        expected_error = TypeError
+    else:
+        object.__setattr__(plan, "digest", "0" * 64)
+        expected_error = ValueError
+    request = _request(root)
+    object.__setattr__(request, "plan", plan)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+
+    with pytest.raises(expected_error):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=lambda session: _write_and_publish(session, b"forbidden"),
+        )
+
+    assert tuple(root.iterdir()) == ()
+    assert receipt_owner.state == "empty"
+
+
+def test_local_provider_requires_a_private_owner_only_root(tmp_path: Path) -> None:
+    root = tmp_path / "authority"
+    root.mkdir(mode=0o755)
+    root.chmod(0o755)
+    provider = LocalWorkspaceProvider(root)
+
+    with pytest.raises(UnsupportedWorkspaceCreation, match="private owner-only"):
+        provider.require_support()
+
+    assert tuple(root.iterdir()) == ()
+    assert os.stat(root).st_mode & 0o777 == 0o755
+
+
+def test_local_provider_timeout_precedes_namespace_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    monkeypatch.setattr(local_provider_module.time, "monotonic_ns", lambda: 0)
+
+    with pytest.raises(TimeoutError, match="deadline expired"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=lambda session: _write_and_publish(session, b"too late"),
+        )
+
+    assert tuple(root.iterdir()) == ()
+    assert receipt_owner.state == "empty"
+
+
+def test_local_provider_aborts_when_operation_returns_without_publish(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+
+    with pytest.raises(RuntimeError, match="without publishing"):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=lambda _session: "unpublished",
+        )
+
+    assert receipt_owner.state == "empty"
+    assert not request.destination.exists()
+    assert not tuple(root.glob(".codenib-workspace-stage-*"))
+    assert tuple(root.glob(".codenib-workspace-orphan-*"))
+
+
+def test_local_provider_same_destination_has_one_noreplace_winner(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    barrier = threading.Barrier(2)
+    owners = (PublishedWorkspaceReceiptOwner(), PublishedWorkspaceReceiptOwner())
+    payloads = (b"first", b"second")
+
+    def publish(index: int) -> tuple[str, object]:
+        request = _request(root)
+
+        def operation(session: StrictWorkspaceSession) -> object:
+            barrier.wait(timeout=10)
+            return _write_and_publish(session, payloads[index])
+
+        try:
+            return (
+                "published",
+                run_strict_workspace(
+                    provider,
+                    request,
+                    receipt_owner=owners[index],
+                    operation=operation,
+                ),
+            )
+        except BaseException as error:  # noqa: B036 - assert the exact loser
+            return "failed", error
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(executor.map(publish, range(2)))
+
+    winner_indexes = tuple(
+        index for index, outcome in enumerate(outcomes) if outcome[0] == "published"
+    )
+    loser_indexes = tuple(
+        index for index, outcome in enumerate(outcomes) if outcome[0] == "failed"
+    )
+    assert len(winner_indexes) == 1
+    assert len(loser_indexes) == 1
+    winner_index = winner_indexes[0]
+    loser_index = loser_indexes[0]
+    assert isinstance(outcomes[loser_index][1], FileExistsError)
+    assert owners[winner_index].active
+    assert owners[loser_index].state == "cleanup"
+    assert (root / "published/data/result.json").read_bytes() == payloads[winner_index]
+    assert not tuple(root.glob(".codenib-workspace-stage-*"))
+    assert len(tuple(root.glob(".codenib-workspace-orphan-*"))) == 1
+
+    owners[winner_index].close()
+    owners[loser_index].close()
+    assert all(owner.closed for owner in owners)
+
+
+def test_local_provider_runs_distinct_destinations_concurrently(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    barrier = threading.Barrier(2)
+    owners = (PublishedWorkspaceReceiptOwner(), PublishedWorkspaceReceiptOwner())
+    destinations = (root / "first", root / "second")
+    payloads = (b"one", b"two")
+
+    def publish(index: int) -> object:
+        request = StrictWorkspaceRequest(
+            purpose="test-local-workspace-provider",
+            destination=destinations[index],
+            plan=_plan(),
+        )
+
+        def operation(session: StrictWorkspaceSession) -> object:
+            barrier.wait(timeout=10)
+            return _write_and_publish(session, payloads[index])
+
+        return run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=owners[index],
+            operation=operation,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        tuple(executor.map(publish, range(2)))
+
+    assert all(owner.active for owner in owners)
+    for destination, payload in zip(destinations, payloads, strict=True):
+        assert (destination / "data/result.json").read_bytes() == payload
+    assert not tuple(root.glob(".codenib-workspace-stage-*"))
+    assert not tuple(root.glob(".codenib-workspace-orphan-*"))
+    for owner in owners:
+        owner.close()
+
+
+@pytest.mark.parametrize("incumbent_kind", ("directory", "file", "symlink"))
+def test_local_provider_never_overwrites_a_late_destination(
+    tmp_path: Path,
+    incumbent_kind: str,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    incumbent_target = root / "incumbent-target"
+
+    def install_incumbent(session: StrictWorkspaceSession) -> object:
+        if incumbent_kind == "directory":
+            request.destination.mkdir()
+            (request.destination / "marker").write_bytes(b"incumbent-directory")
+        elif incumbent_kind == "file":
+            request.destination.write_bytes(b"incumbent-file")
+        else:
+            incumbent_target.mkdir()
+            request.destination.symlink_to(incumbent_target, target_is_directory=True)
+        return _write_and_publish(session, b"must not replace")
+
+    with pytest.raises((FileExistsError, RuntimeError, ValueError)):
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=install_incumbent,
+        )
+
+    if incumbent_kind == "directory":
+        assert (request.destination / "marker").read_bytes() == b"incumbent-directory"
+    elif incumbent_kind == "file":
+        assert request.destination.read_bytes() == b"incumbent-file"
+    else:
+        assert request.destination.is_symlink()
+        assert request.destination.readlink() == incumbent_target
+    assert receipt_owner.state == "cleanup"
+    assert not tuple(root.glob(".codenib-workspace-stage-*"))
+    assert len(tuple(root.glob(".codenib-workspace-orphan-*"))) == 1
+    receipt_owner.close()
+    assert receipt_owner.closed
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_inherited_local_provider_rejects_child_before_mutation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    read_descriptor, write_descriptor = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(read_descriptor)
+        child_owner = PublishedWorkspaceReceiptOwner()
+        try:
+            run_strict_workspace(
+                provider,
+                request,
+                receipt_owner=child_owner,
+                operation=lambda session: _write_and_publish(session, b"child"),
+            )
+        except RuntimeError as error:
+            report = repr((str(error), child_owner.state, tuple(root.iterdir())))
+            os.write(write_descriptor, report.encode("utf-8"))
+        finally:
+            os.close(write_descriptor)
+            os._exit(0)
+
+    os.close(write_descriptor)
+    report = os.read(read_descriptor, 1 << 20).decode("utf-8")
+    os.close(read_descriptor)
+    waited_pid, status = os.waitpid(child_pid, 0)
+
+    assert waited_pid == child_pid
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert (
+        report
+        == "('local workspace provider cannot cross a PID boundary', 'empty', ())"
+    )
+    assert tuple(root.iterdir()) == ()
+    provider.require_support()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_local_provider_child_escape_closes_only_inherited_native_descriptors(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    read_descriptor, write_descriptor = os.pipe()
+    original_pid = os.getpid()
+    child_pids: list[int] = []
+
+    def operation(session: StrictWorkspaceSession) -> object:
+        child_pid = os.fork()
+        if child_pid == 0:
+            os.close(read_descriptor)
+            raise RuntimeError("child escaped the provider callback")
+        child_pids.append(child_pid)
+        os.close(write_descriptor)
+        return _write_and_publish(session, b"parent")
+
+    try:
+        run_strict_workspace(
+            provider,
+            request,
+            receipt_owner=receipt_owner,
+            operation=operation,
+        )
+    except RuntimeError as error:
+        if os.getpid() != original_pid:
+            try:
+                descriptor_targets = []
+                for name in os.listdir("/proc/self/fd"):
+                    try:
+                        target = os.readlink(f"/proc/self/fd/{name}")
+                    except OSError:
+                        continue
+                    if str(root) in target:
+                        descriptor_targets.append(target)
+                cleanup_owners = getattr(error, "publication_cleanup_owners", ())
+                report = repr((str(error), descriptor_targets, cleanup_owners))
+                os.write(write_descriptor, report.encode("utf-8"))
+            finally:
+                os.close(write_descriptor)
+                os._exit(0)
+        raise
+
+    child_pid = child_pids[0]
+    report = os.read(read_descriptor, 1 << 20).decode("utf-8")
+    os.close(read_descriptor)
+    waited_pid, status = os.waitpid(child_pid, 0)
+
+    assert waited_pid == child_pid
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert report == "('child escaped the provider callback', [], ())"
+    assert receipt_owner.active
+    assert (request.destination / "data/result.json").read_bytes() == b"parent"
+    receipt_owner.close()

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -4,7 +4,10 @@
 
 from __future__ import annotations
 
+import io
 import subprocess
+import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -15,11 +18,127 @@ from scripts.verify_release_artifacts import (
     ReleaseValidationError,
     expected_tag,
     project_identity,
+    select_compatible_wheel,
     validate_readme_citation,
     validate_readme_mcp_ownership,
+    validate_release,
     validate_release_notes,
     validate_tag,
 )
+
+_PACKAGED_README = """# CodeNib
+
+<!-- mcp-name: ai.codenib/codenib -->
+
+## Citation
+
+https://arxiv.org/abs/2607.25431
+
+@misc{yu2026codenibmultiviewdataserving,
+"""
+
+
+def _write_project_release_contract(root: Path) -> Path:
+    project = root / "pyproject.toml"
+    project.write_text(
+        '[project]\nname = "codenib"\nversion = "0.2.1"\n',
+        encoding="utf-8",
+    )
+    notes = root / "docs" / "releases"
+    notes.mkdir(parents=True)
+    (notes / "0.2.1.md").write_text(
+        "# CodeNib 0.2.1\n\nInstall with `codenib==0.2.1`.\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def _write_test_wheel(path: Path, *, native_member: str) -> None:
+    metadata = f"""Metadata-Version: 2.4
+Name: codenib
+Version: 0.2.1
+License-Expression: Apache-2.0
+Description-Content-Type: text/markdown
+
+{_PACKAGED_README}
+"""
+    members = {
+        "codenib/__init__.py": "",
+        "codenib/__main__.py": "",
+        "codenib/agent/tools/sandbox.py": "",
+        "codenib/cli.py": "",
+        "codenib/sandbox/__init__.py": "",
+        "codenib/sandbox/docker.py": "",
+        "codenib/sandbox/protocol.py": "",
+        "codenib/sandbox/types.py": "",
+        "codenib/toolchains.py": "",
+        "codenib/web/frontend/index.html": "",
+        "codenib/web/frontend/codenib-icon.svg": "",
+        "codenib/web/frontend/runtime-config.js": "",
+        "codenib/web/frontend/assets/index.js": "",
+        native_member: "native",
+        "codenib-0.2.1.dist-info/METADATA": metadata,
+        "codenib-0.2.1.dist-info/entry_points.txt": (
+            "[console_scripts]\ncodenib = codenib.cli:main\n"
+        ),
+    }
+    with zipfile.ZipFile(path, mode="w") as archive:
+        for member, contents in members.items():
+            archive.writestr(member, contents)
+
+
+def _write_test_sdist(
+    path: Path,
+    *,
+    include_native_source: bool = True,
+    binary_member: str | None = None,
+) -> None:
+    root = "codenib-0.2.1"
+    members = {
+        f"{root}/CHANGELOG.md": "",
+        f"{root}/LICENSE": "",
+        f"{root}/README.md": _PACKAGED_README,
+        f"{root}/server.json": "{}",
+        f"{root}/pyproject.toml": "[project]\n",
+        f"{root}/web/package-lock.json": "{}",
+    }
+    if include_native_source:
+        members[f"{root}/native/workspace_owner.c"] = "/* source */\n"
+    if binary_member is not None:
+        members[f"{root}/{binary_member}"] = "native"
+    with tarfile.open(path, mode="w:gz") as archive:
+        for member, contents in members.items():
+            payload = contents.encode("utf-8")
+            info = tarfile.TarInfo(member)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+
+
+def _write_test_release(
+    root: Path,
+    *,
+    x86_native: str = "codenib/_workspace_owner_impl.abi3.so",
+    arm_native: str = "codenib/_workspace_owner_impl.abi3.so",
+    include_native_source: bool = True,
+    sdist_binary: str | None = None,
+) -> tuple[Path, Path]:
+    project = _write_project_release_contract(root)
+    dist = root / "dist"
+    dist.mkdir()
+    _write_test_wheel(
+        dist / "codenib-0.2.1-cp310-abi3-manylinux_2_28_x86_64.whl",
+        native_member=x86_native,
+    )
+    _write_test_wheel(
+        dist / "codenib-0.2.1-cp310-abi3-manylinux_2_28_aarch64.whl",
+        native_member=arm_native,
+    )
+    _write_test_sdist(
+        dist / "codenib-0.2.1.tar.gz",
+        include_native_source=include_native_source,
+        binary_member=sdist_binary,
+    )
+    return project, dist
 
 
 def test_release_service_smoke_accepts_authenticated_source_mismatch(
@@ -140,6 +259,98 @@ def test_packaged_readme_requires_mcp_registry_ownership() -> None:
         validate_readme_mcp_ownership("# CodeNib\n")
 
 
+def test_release_requires_both_native_abi3_manylinux_wheels(tmp_path: Path) -> None:
+    project, dist = _write_test_release(tmp_path)
+
+    wheels, sdist = validate_release(dist, project_file=project)
+
+    assert {wheel.name for wheel in wheels} == {
+        "codenib-0.2.1-cp310-abi3-manylinux_2_28_x86_64.whl",
+        "codenib-0.2.1-cp310-abi3-manylinux_2_28_aarch64.whl",
+    }
+    assert sdist.name == "codenib-0.2.1.tar.gz"
+
+    wheels[0].unlink()
+    with pytest.raises(
+        ReleaseValidationError, match="production wheels must be exactly"
+    ):
+        validate_release(dist, project_file=project)
+
+    _write_test_wheel(wheels[0], native_member="codenib/_workspace_owner_impl.abi3.so")
+    (dist / "codenib-0.2.1-py3-none-any.whl").touch()
+    with pytest.raises(ReleaseValidationError, match="unexpected .*py3-none-any"):
+        validate_release(dist, project_file=project)
+
+
+def test_release_wheel_requires_exact_native_extension_name(tmp_path: Path) -> None:
+    project, dist = _write_test_release(
+        tmp_path,
+        x86_native="codenib/_workspace_owner_impl.cpython-310-x86_64-linux-gnu.so",
+    )
+
+    with pytest.raises(
+        ReleaseValidationError,
+        match="must contain exactly one codenib/_workspace_owner_impl.abi3.so",
+    ):
+        validate_release(dist, project_file=project)
+
+    x86_wheel = dist / "codenib-0.2.1-cp310-abi3-manylinux_2_28_x86_64.whl"
+    _write_test_wheel(x86_wheel, native_member="codenib/_workspace_owner_impl.abi3.so")
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        with zipfile.ZipFile(x86_wheel, mode="a") as archive:
+            archive.writestr("codenib/_workspace_owner_impl.abi3.so", "duplicate")
+    with pytest.raises(ReleaseValidationError, match="must contain exactly one"):
+        validate_release(dist, project_file=project)
+
+
+@pytest.mark.parametrize(
+    ("include_native_source", "sdist_binary", "message"),
+    (
+        (False, None, "native/workspace_owner.c"),
+        (True, "codenib/_workspace_owner_impl.abi3.so", "compiled binaries"),
+    ),
+)
+def test_release_sdist_is_source_only(
+    tmp_path: Path,
+    include_native_source: bool,
+    sdist_binary: str | None,
+    message: str,
+) -> None:
+    project, dist = _write_test_release(
+        tmp_path,
+        include_native_source=include_native_source,
+        sdist_binary=sdist_binary,
+    )
+
+    with pytest.raises(ReleaseValidationError, match=message):
+        validate_release(dist, project_file=project)
+
+
+@pytest.mark.parametrize(
+    ("machine", "architecture"),
+    (("x86_64", "x86_64"), ("AMD64", "x86_64"), ("aarch64", "aarch64")),
+)
+def test_select_compatible_wheel_uses_current_architecture(
+    tmp_path: Path,
+    machine: str,
+    architecture: str,
+) -> None:
+    _, dist = _write_test_release(tmp_path)
+
+    selected = select_compatible_wheel(dist, system="linux", machine=machine)
+
+    assert selected.name.endswith(f"manylinux_2_28_{architecture}.whl")
+
+
+def test_select_compatible_wheel_rejects_unsupported_platform(tmp_path: Path) -> None:
+    _, dist = _write_test_release(tmp_path)
+
+    with pytest.raises(ReleaseValidationError, match="require Linux"):
+        select_compatible_wheel(dist, system="darwin", machine="arm64")
+    with pytest.raises(ReleaseValidationError, match="no production wheel"):
+        select_compatible_wheel(dist, system="linux", machine="ppc64le")
+
+
 def test_stable_release_notes_describe_the_codegraph_product_path() -> None:
     root = Path(__file__).resolve().parents[1]
     notes = (root / "docs" / "releases" / "0.2.1.md").read_text(encoding="utf-8")
@@ -232,6 +443,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "${{ github.ref_type != 'tag' }}"
     )
     assert "docs/releases/**" in production["on"]["pull_request"]["paths"]
+    assert "native/**" in production["on"]["pull_request"]["paths"]
 
     release_tag_push = (
         "github.event_name == 'push' && github.ref_type == 'tag' && "
@@ -275,6 +487,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
     ]
     assert '"codenib==$VERSION"' in public_download
     assert "sha256sum" in public_download
+    assert public_download.count("--print-compatible-wheel") == 2
     assert (
         "scripts/smoke_release_services.py"
         in pypi_install_steps["Exercise public Wiki and MCP services"]["run"]
@@ -348,6 +561,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert "--index-url https://test.pypi.org/simple/" in download
     assert "--no-deps" in download
     assert "hashlib.sha256" in download
+    assert "select_compatible_wheel" in download
     exercise = install_steps["Exercise the installed CLI"]["run"]
     assert "doctor --require core --require wiki" in exercise
     assert "scripts/smoke_release_install.py" in exercise
@@ -358,13 +572,143 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "type": "boolean",
         "default": "true",
     }
-    verification_steps = {
-        step["name"]: step for step in verification["jobs"]["build"]["steps"]
+    assert set(verification["jobs"]) == {
+        "build-sdist",
+        "build-wheel",
+        "limited-abi-compile",
+        "build",
+        "source-smoke",
+        "abi3-smoke",
+        "install-smoke",
+        "upgrade-smoke",
+        "service-smoke",
+        "agent-smoke",
+        "graph-smoke",
     }
+    sdist_job = verification["jobs"]["build-sdist"]
+    sdist_steps = {step["name"]: step for step in sdist_job["steps"]}
+    assert "--sdist" in sdist_steps["Build source distribution"]["run"]
+    assert sdist_steps["Upload source distribution"]["with"]["path"] == (
+        "dist/*.tar.gz"
+    )
+
+    wheel_job = verification["jobs"]["build-wheel"]
+    assert wheel_job["needs"] == "build-sdist"
+    assert wheel_job["strategy"]["matrix"]["arch"] == ["x86_64", "aarch64"]
+    wheel_steps = {step["name"]: step for step in wheel_job["steps"]}
+    qemu = wheel_steps["Set up QEMU for aarch64"]
+    assert qemu["if"] == "matrix.arch == 'aarch64'"
+    assert qemu["uses"] == (
+        "docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8"
+    )
+    wheel_build = wheel_steps["Build and smoke-test wheel"]
+    assert wheel_build["uses"] == (
+        "pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c"
+    )
+    wheel_env = wheel_build["env"]
+    assert wheel_env["CIBW_BUILD"] == "cp310-manylinux_${{ matrix.arch }}"
+    assert wheel_env["CIBW_ARCHS_LINUX"] == "${{ matrix.arch }}"
+    assert "--cap-add SYS_PTRACE" in wheel_env["CIBW_CONTAINER_ENGINE"]
+    assert wheel_env["CIBW_MANYLINUX_X86_64_IMAGE"] == "manylinux_2_28"
+    assert wheel_env["CIBW_MANYLINUX_AARCH64_IMAGE"] == "manylinux_2_28"
+    assert (
+        "manylinux_2_28_${{ matrix.arch }}"
+        in wheel_env["CIBW_REPAIR_WHEEL_COMMAND_LINUX"]
+    )
+    wheel_smoke = wheel_env["CIBW_TEST_COMMAND"]
+    assert "workspace_owner_protocol_version == 2" in wheel_smoke
+    assert "implementation.require_support() is None" in wheel_smoke
+    assert "_workspace_owner.require_support()" in wheel_smoke
+
+    limited_abi_job = verification["jobs"]["limited-abi-compile"]
+    assert "if" not in limited_abi_job
+    limited_abi_steps = {step["name"]: step for step in limited_abi_job["steps"]}
+    limited_abi_compile = limited_abi_steps[
+        "Compile the native extension against the limited API"
+    ]["run"]
+    assert "-DPy_LIMITED_API=0x030A0000" in limited_abi_compile
+    assert "-Wall" in limited_abi_compile
+    assert "-Wextra" in limited_abi_compile
+    assert "-Werror" in limited_abi_compile
+    assert "-c native/workspace_owner.c" in limited_abi_compile
+
+    build_job = verification["jobs"]["build"]
+    assert build_job["needs"] == [
+        "build-sdist",
+        "build-wheel",
+        "limited-abi-compile",
+    ]
+    verification_steps = {step["name"]: step for step in build_job["steps"]}
+    inspect_distributions = verification_steps["Inspect Python distributions"]["run"]
+    assert "scripts/verify_release_artifacts.py dist" in inspect_distributions
+    assert '"jsonschema>=4,<5"' in inspect_distributions
+    assert verification_steps["Upload distributions"]["with"]["path"] == (
+        "dist/*.whl\ndist/*.tar.gz\n"
+    )
     assert (
         "--connect-timeout 10 --max-time 90"
         in verification_steps["Validate MCP Registry metadata"]["run"]
     )
+
+    source_job = verification["jobs"]["source-smoke"]
+    assert "if" not in source_job
+    source_steps = {step["name"]: step for step in source_job["steps"]}
+    source_install = source_steps["Install source distribution without a compiler"]
+    assert source_install["env"] == {"CC": "/bin/false"}
+    assert "--no-cache-dir" in source_install["run"]
+    assert "dist/*.tar.gz" in source_install["run"]
+    source_exercise = source_steps["Exercise core and fail-closed workspace support"][
+        "run"
+    ]
+    assert "doctor --require core" in source_exercise
+    assert "scripts/smoke_release_install.py" in source_exercise
+    assert 'find_spec("codenib._workspace_owner_impl")' in source_exercise
+    assert "_workspace_owner.require_support()" in source_exercise
+    assert "LocalWorkspaceProvider(Path(root))" in source_exercise
+    assert "provider.require_support()" in source_exercise
+    assert "UnsupportedWorkspaceCreation" in source_exercise
+
+    abi3_job = verification["jobs"]["abi3-smoke"]
+    assert "if" not in abi3_job
+    assert abi3_job["strategy"]["matrix"]["python-version"] == [
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    ]
+    abi3_steps = {step["name"]: step for step in abi3_job["steps"]}
+    abi3_install = abi3_steps["Install the compatible ABI3 wheel"]["run"]
+    assert "--print-compatible-wheel" in abi3_install
+    assert "--no-deps" in abi3_install
+    abi3_exercise = abi3_steps["Exercise native ABI and local workspace lifecycle"][
+        "run"
+    ]
+    assert 'name == "_workspace_owner_impl.abi3.so"' in abi3_exercise
+    assert "workspace_owner_protocol_version == 2" in abi3_exercise
+    assert "implementation.require_support() is None" in abi3_exercise
+    assert "_workspace_owner.require_support() is None" in abi3_exercise
+    assert "LocalWorkspaceProvider(root)" in abi3_exercise
+    assert "run_strict_workspace(" in abi3_exercise
+    assert "root.mkdir(mode=0o700)" in abi3_exercise
+    assert "session.write_file" in abi3_exercise
+    assert "session.publish_validated" in abi3_exercise
+    assert "receipt_owner.active" in abi3_exercise
+    assert "receipt_owner.close()" in abi3_exercise
+    assert "receipt_owner.closed" in abi3_exercise
+    assert abi3_exercise.count("assert output.read_bytes() == payload") == 2
+
+    compatible_install_steps = {
+        "abi3-smoke": "Install the compatible ABI3 wheel",
+        "install-smoke": "Install wheel",
+        "upgrade-smoke": "Exercise the supported upgrade boundary",
+        "service-smoke": "Install wheel with MCP support",
+        "agent-smoke": "Install wheel with agent support",
+        "graph-smoke": "Install wheel, Python graph runtime, and MCP",
+    }
+    for job_name, step_name in compatible_install_steps.items():
+        steps = {step["name"]: step for step in verification["jobs"][job_name]["steps"]}
+        assert "--print-compatible-wheel" in steps[step_name]["run"]
     for job_name in (
         "install-smoke",
         "upgrade-smoke",
@@ -374,3 +718,13 @@ def test_registry_publishers_use_separate_workflows() -> None:
     ):
         assert verification["jobs"][job_name]["if"] == "inputs.full"
     assert not any(name.startswith("publish-") for name in verification["jobs"])
+
+    for workflow in (production, test, verification):
+        for job in workflow["jobs"].values():
+            for step in job.get("steps", []):
+                action = step.get("uses")
+                if action is None or action.startswith("./"):
+                    continue
+                revision = action.rpartition("@")[2]
+                assert len(revision) == 40
+                assert all(character in "0123456789abcdef" for character in revision)

--- a/test/test_workspace_owner.py
+++ b/test/test_workspace_owner.py
@@ -1,0 +1,1098 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ctypes.util
+import gc
+import hashlib
+import os
+import stat
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+import codenib._atomic_directory as atomic_module
+import codenib._captured_directory as captured_module
+import codenib._workspace_owner as workspace_owner
+from codenib._captured_directory import (
+    OwnedWorkspaceAuthority,
+    PublishedWorkspaceReceiptOwner,
+    WorkspaceDirectory,
+    WorkspaceFile,
+    WorkspacePlan,
+)
+
+
+def _plan() -> WorkspacePlan:
+    return WorkspacePlan(
+        subject_digest=hashlib.sha256(b"workspace-owner-native").hexdigest(),
+        directories=(
+            WorkspaceDirectory(Path("views")),
+            WorkspaceDirectory(Path("views/bm25")),
+        ),
+    )
+
+
+def _file_plan() -> WorkspacePlan:
+    return WorkspacePlan(
+        subject_digest=hashlib.sha256(b"workspace-owner-native-file").hexdigest(),
+        directories=(
+            WorkspaceDirectory(Path("views")),
+            WorkspaceDirectory(Path("views/bm25")),
+        ),
+        files=(
+            WorkspaceFile(
+                Path("views/bm25/documents.json"),
+                mode=0o600,
+                max_bytes=1 << 20,
+            ),
+        ),
+    )
+
+
+def _require_native_owner() -> object:
+    if not workspace_owner._workspace_owner_protocol_available:
+        pytest.skip("optional workspace-owner extension is not built")
+    try:
+        workspace_owner.require_support()
+    except RuntimeError as error:
+        pytest.skip(f"native workspace ownership is unavailable: {error}")
+    return workspace_owner.create_owner()
+
+
+def _provision(
+    root: Path,
+    *,
+    stage: bytes = b".stage",
+    plan: WorkspacePlan | None = None,
+) -> tuple[object, WorkspacePlan, object]:
+    selected_plan = _plan() if plan is None else plan
+    owner = _require_native_owner()
+    publication_permit = workspace_owner.claim_owner_publish_permit(owner)
+    assert (
+        workspace_owner.provision_owner(
+            owner,
+            os.fsencode(root),
+            b"published",
+            stage,
+            selected_plan.digest.encode("ascii"),
+            selected_plan.root_mode,
+            tuple(
+                (os.fsencode(item.path.as_posix()), item.mode)
+                for item in selected_plan.directories
+            ),
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        is None
+    )
+    return owner, selected_plan, publication_permit
+
+
+def test_workspace_owner_facade_rejects_an_incomplete_abi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workspace_owner,
+        "_workspace_owner_protocol_available",
+        False,
+    )
+    monkeypatch.setattr(workspace_owner, "_require_support_exact", None)
+
+    with pytest.raises(RuntimeError, match="workspace-owner extension"):
+        workspace_owner.require_support()
+
+
+def test_workspace_owner_facade_rejects_symbol_complete_protocol_v1() -> None:
+    required_symbols = (
+        "require_support",
+        "create_owner_exact",
+        "claim_owner_publish_permit_exact",
+        "require_owner_exact",
+        "close_owner_exact",
+        "provision_owner_exact",
+        "verify_owner_authority_exact",
+        "verify_owner_adoption_binding_exact",
+        "borrow_owner_parent_descriptor_exact",
+        "borrow_owner_root_descriptor_exact",
+        "borrow_owner_directory_descriptor_exact",
+        "begin_owner_file_exact",
+        "write_owner_file_exact",
+        "finish_owner_file_exact",
+        "abort_owner_file_exact",
+        "seal_owner_directories_exact",
+        "sync_owner_parent_exact",
+        "mark_owner_adopted_exact",
+        "rename_owner_child_noreplace_exact",
+        "commit_owner_receipt_exact",
+        "abort_owner_exact",
+        "quarantine_owner_exact",
+        "owner_state_exact",
+        "owner_closed_exact",
+    )
+    script = textwrap.dedent(
+        f"""
+        import sys
+        import types
+
+        implementation = types.ModuleType("codenib._workspace_owner_impl")
+        implementation.workspace_owner_protocol_version = 1
+        for name in {required_symbols!r}:
+            setattr(implementation, name, lambda *args, **kwargs: None)
+        sys.modules[implementation.__name__] = implementation
+
+        import codenib._workspace_owner as facade
+
+        assert not facade._workspace_owner_protocol_available
+        try:
+            facade.require_support()
+        except RuntimeError as error:
+            assert "workspace-owner extension" in str(error)
+        else:
+            raise AssertionError("protocol-v1 implementation was accepted")
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repository_root,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_workspace_owner_cleanup_does_not_repeat_the_support_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = object()
+    closed: list[object] = []
+
+    def reject_support() -> None:
+        raise PermissionError("support probe was blocked after acquisition")
+
+    def require_owner(value: object) -> object:
+        return value
+
+    def close_owner(value: object) -> None:
+        closed.append(value)
+
+    monkeypatch.setattr(
+        workspace_owner,
+        "_workspace_owner_protocol_available",
+        True,
+    )
+    monkeypatch.setattr(workspace_owner, "_require_support_exact", reject_support)
+    monkeypatch.setattr(workspace_owner, "_require_owner_exact", require_owner)
+    monkeypatch.setattr(workspace_owner, "_close_owner_exact", close_owner)
+
+    assert workspace_owner.require_exact_owner(candidate) is candidate
+    assert workspace_owner.close_owner_exact(candidate) is None
+    assert closed == [candidate]
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or ctypes.util.find_library("seccomp") is None,
+    reason="requires Linux libseccomp",
+)
+@pytest.mark.parametrize("deny_f_setfl", (False, True))
+def test_native_cleanup_remains_safe_after_seccomp_tightening(
+    tmp_path: Path,
+    deny_f_setfl: bool,
+) -> None:
+    probe_owner = _require_native_owner()
+    workspace_owner.close_owner_exact(probe_owner)
+    root = tmp_path / ("deny-both" if deny_f_setfl else "deny-kcmp")
+    root.mkdir(mode=0o700)
+    root.chmod(0o700)
+    script = textwrap.dedent(
+        f"""
+        import ctypes
+        import ctypes.util
+        import errno
+        import fcntl
+        import os
+        import sys
+        import time
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = os.fsencode(sys.argv[1])
+        owner = workspace_owner.create_owner()
+        publication_permit = workspace_owner.claim_owner_publish_permit(owner)
+        workspace_owner.provision_owner(
+            owner,
+            root,
+            b"published",
+            b".stage",
+            b"0" * 64,
+            0o700,
+            (),
+            time.monotonic_ns() + 10_000_000_000,
+        )
+        workspace_owner.borrow_owner_root_descriptor(owner)
+
+        library_name = ctypes.util.find_library("seccomp") or "libseccomp.so.2"
+        library = ctypes.CDLL(library_name, use_errno=True)
+        library.seccomp_init.argtypes = [ctypes.c_uint32]
+        library.seccomp_init.restype = ctypes.c_void_p
+        library.seccomp_syscall_resolve_name.argtypes = [ctypes.c_char_p]
+        library.seccomp_syscall_resolve_name.restype = ctypes.c_int
+        library.seccomp_rule_add.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.c_int,
+            ctypes.c_uint,
+        ]
+        library.seccomp_rule_add.restype = ctypes.c_int
+        library.seccomp_load.argtypes = [ctypes.c_void_p]
+        library.seccomp_load.restype = ctypes.c_int
+        library.seccomp_release.argtypes = [ctypes.c_void_p]
+
+        allow = 0x7FFF0000
+        deny = 0x00050000 | errno.EPERM
+        context = library.seccomp_init(allow)
+        if not context:
+            raise SystemExit(77)
+
+        def deny_syscall(name):
+            number = library.seccomp_syscall_resolve_name(name.encode("ascii"))
+            if number < 0:
+                raise SystemExit(77)
+            if library.seccomp_rule_add(context, deny, number, 0) != 0:
+                raise SystemExit(77)
+
+        deny_syscall("kcmp")
+        if {deny_f_setfl!r}:
+            class ArgCmp(ctypes.Structure):
+                _fields_ = [
+                    ("arg", ctypes.c_uint),
+                    ("op", ctypes.c_int),
+                    ("datum_a", ctypes.c_uint64),
+                    ("datum_b", ctypes.c_uint64),
+                ]
+
+            library.seccomp_rule_add_array.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_uint32,
+                ctypes.c_int,
+                ctypes.c_uint,
+                ctypes.POINTER(ArgCmp),
+            ]
+            library.seccomp_rule_add_array.restype = ctypes.c_int
+            fcntl_number = library.seccomp_syscall_resolve_name(b"fcntl")
+            comparison = ArgCmp(1, 4, fcntl.F_SETFL, 0)
+            if fcntl_number < 0 or library.seccomp_rule_add_array(
+                context,
+                deny,
+                fcntl_number,
+                1,
+                ctypes.byref(comparison),
+            ) != 0:
+                raise SystemExit(77)
+
+        if library.seccomp_load(context) != 0:
+            raise SystemExit(77)
+        library.seccomp_release(context)
+
+        def owned_targets():
+            observed = []
+            for name in os.listdir("/proc/self/fd"):
+                try:
+                    target = os.readlink(f"/proc/self/fd/{{name}}")
+                except OSError:
+                    continue
+                if os.fsdecode(root) in target:
+                    observed.append(target)
+            return tuple(sorted(observed))
+
+        if {deny_f_setfl!r}:
+            before = owned_targets()
+            assert before
+            after_first = None
+            for attempt in range(2):
+                try:
+                    workspace_owner.abort_owner(owner)
+                except PermissionError as error:
+                    assert error.errno == errno.EPERM
+                else:
+                    raise AssertionError("cleanup unexpectedly bypassed denied OFD checks")
+                observed = owned_targets()
+                assert len(observed) >= 2
+                if attempt == 0:
+                    after_first = observed
+                else:
+                    assert observed == after_first
+            assert workspace_owner.owner_state(owner) == "quarantined"
+            assert not workspace_owner.owner_closed(owner)
+        else:
+            workspace_owner.abort_owner(owner)
+            assert workspace_owner.owner_closed(owner)
+
+        del publication_permit
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(root)],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode == 77:
+        pytest.skip("libseccomp filter could not be installed")
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="requires Linux")
+def test_native_low_available_fd_failure_is_cleanup_atomic(tmp_path: Path) -> None:
+    probe_owner = _require_native_owner()
+    workspace_owner.close_owner_exact(probe_owner)
+    root = tmp_path / "low-fd"
+    root.mkdir(mode=0o700)
+    root.chmod(0o700)
+    script = textwrap.dedent(
+        """
+        import errno
+        import gc
+        import os
+        import resource
+        import sys
+        import time
+
+        import codenib._workspace_owner as workspace_owner
+
+        root = os.fsencode(sys.argv[1])
+        owner = workspace_owner.create_owner()
+        publication_permit = workspace_owner.claim_owner_publish_permit(owner)
+        soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+        selected_limit = (
+            128 if hard_limit == resource.RLIM_INFINITY else min(hard_limit, 128)
+        )
+        if selected_limit < 64:
+            raise SystemExit(77)
+        resource.setrlimit(resource.RLIMIT_NOFILE, (selected_limit, hard_limit))
+        pressure = []
+        try:
+            while True:
+                pressure.append(
+                    os.open("/dev/null", os.O_RDONLY | getattr(os, "O_CLOEXEC", 0))
+                )
+        except OSError as error:
+            assert error.errno == errno.EMFILE
+        for descriptor in pressure[-11:]:
+            os.close(descriptor)
+        del pressure[-11:]
+
+        try:
+            workspace_owner.provision_owner(
+                owner,
+                root,
+                b"published",
+                b".stage",
+                b"0" * 64,
+                0o700,
+                (),
+                time.monotonic_ns() + 10_000_000_000,
+            )
+        except OSError as error:
+            assert error.errno == errno.EMFILE
+        else:
+            raise AssertionError("low-descriptor provision unexpectedly succeeded")
+
+        workspace_owner.abort_owner(owner)
+        assert workspace_owner.owner_closed(owner)
+        assert os.listdir(os.fsdecode(root)) == []
+        del publication_permit
+        del owner
+        gc.collect()
+        targets = []
+        for name in os.listdir("/proc/self/fd"):
+            try:
+                target = os.readlink(f"/proc/self/fd/{name}")
+            except OSError:
+                continue
+            if os.fsdecode(root) in target:
+                targets.append(target)
+        assert targets == []
+        for descriptor in pressure:
+            os.close(descriptor)
+        """
+    )
+    repository_root = Path(__file__).resolve().parents[1]
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(repository_root), environment.get("PYTHONPATH", ""))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(root)],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode == 77:
+        pytest.skip("RLIMIT_NOFILE is too low for the probe")
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_native_owner_provisions_exact_skeleton_and_quarantines(
+    tmp_path: Path,
+) -> None:
+    owner, plan, _publication_permit = _provision(tmp_path)
+    stage = tmp_path / ".stage"
+
+    assert workspace_owner.owner_state(owner) == "provisioned"
+    assert stat.S_IMODE(stage.stat().st_mode) == plan.root_mode
+    assert tuple(
+        path.relative_to(stage).as_posix() for path in sorted(stage.rglob("*"))
+    ) == ("views", "views/bm25")
+    assert workspace_owner.require_exact_owner(owner) is owner
+
+    orphan_name = workspace_owner.quarantine_owner(owner)
+    assert workspace_owner.quarantine_owner(owner) == orphan_name
+    assert orphan_name is not None
+    assert not stage.exists()
+    assert (tmp_path / orphan_name).is_dir()
+    workspace_owner.close_owner_exact(owner)
+    workspace_owner.close_owner_exact(owner)
+    assert workspace_owner.owner_closed(owner)
+
+
+def test_native_owner_writes_without_exposing_the_file_descriptor(
+    tmp_path: Path,
+) -> None:
+    owner, _plan_value, _publication_permit = _provision(tmp_path)
+    workspace_owner.mark_owner_adopted(owner)
+
+    assert (
+        workspace_owner.begin_owner_file(
+            owner,
+            b"views/bm25",
+            b"documents.json",
+            0o600,
+        )
+        is None
+    )
+    assert workspace_owner.write_owner_file(owner, b'{"documents":') is None
+    assert workspace_owner.write_owner_file(owner, b"[]}") is None
+    metadata = workspace_owner.finish_owner_file(owner, 0o600)
+
+    assert type(metadata) is tuple
+    assert len(metadata) == 8
+    assert metadata[2] & 0o170000 == stat.S_IFREG
+    assert metadata[3] == len(b'{"documents":[]}')
+    assert (tmp_path / ".stage/views/bm25/documents.json").read_bytes() == (
+        b'{"documents":[]}'
+    )
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+
+
+def test_native_publication_facade_borrows_without_closing_the_owner(
+    tmp_path: Path,
+) -> None:
+    owner, _plan_value, publication_permit = _provision(tmp_path)
+    authority_owner = atomic_module._PublicationAuthorityOwner()
+    authority = atomic_module._adopt_native_posix_publication_authority(
+        tmp_path,
+        native_owner=owner,
+        publication_permit=publication_permit,
+        authority_owner=authority_owner,
+    )
+
+    ownership = authority.capture_child(
+        ".stage",
+        path=tmp_path / ".stage",
+        label="native workspace stage",
+        allow_empty_root=True,
+    )
+    assert ownership.inventory == (("views", "directory"), ("views/bm25", "directory"))
+    authority.sync_parent()
+    authority_owner.close()
+
+    assert authority._closed
+    assert not workspace_owner.owner_closed(owner)
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)
+
+
+def test_native_owner_publishes_through_the_caller_receipt(
+    tmp_path: Path,
+) -> None:
+    plan = _file_plan()
+    owner, _plan_value, publication_permit = _provision(tmp_path, plan=plan)
+    workspace = OwnedWorkspaceAuthority()
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    payload = b'{"documents":[]}'
+
+    workspace.adopt_provisioned(
+        destination=tmp_path / "published",
+        stage_name=".stage",
+        provisioned_owner=owner,
+        publication_permit=publication_permit,
+        plan=plan,
+        expected_destination=None,
+    )
+    record = workspace.write_file(
+        "views/bm25/documents.json",
+        (payload[:5], payload[5:]),
+    )
+    assert record.sha256 == hashlib.sha256(payload).hexdigest()
+    workspace.seal()
+    workspace.publish_into(receipt_owner)
+
+    assert receipt_owner.active
+    assert workspace_owner.owner_state(owner) == "receipted"
+    assert (tmp_path / "published/views/bm25/documents.json").read_bytes() == payload
+
+    receipt_owner.close()
+
+    assert receipt_owner.closed
+    assert workspace_owner.owner_closed(owner)
+    assert (tmp_path / "published/views/bm25/documents.json").read_bytes() == payload
+
+
+def test_native_publication_binds_exact_rename_before_validators(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _file_plan()
+    owner, _plan_value, publication_permit = _provision(tmp_path, plan=plan)
+    workspace = OwnedWorkspaceAuthority()
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    workspace.adopt_provisioned(
+        destination=tmp_path / "published",
+        stage_name=".stage",
+        provisioned_owner=owner,
+        publication_permit=publication_permit,
+        plan=plan,
+        expected_destination=None,
+    )
+    workspace.write_file("views/bm25/documents.json", (b"{}",))
+    workspace.seal()
+    intercepted_tokens: list[object] = []
+    original_rename = workspace_owner.rename_owner_child_noreplace
+
+    def intercept_rename(
+        permit: object,
+        source: bytes,
+        destination: bytes,
+    ) -> object | None:
+        token = original_rename(permit, source, destination)
+        if token is not None:
+            intercepted_tokens.append(token)
+        return token
+
+    monkeypatch.setattr(
+        workspace_owner,
+        "rename_owner_child_noreplace",
+        intercept_rename,
+    )
+
+    workspace.publish_into(
+        receipt_owner,
+        validate_staged_directory=lambda _reader: None,
+        validate_published_destination=lambda _reader: None,
+    )
+
+    assert intercepted_tokens == []
+    assert receipt_owner.active
+    assert workspace_owner.owner_state(owner) == "receipted"
+    receipt_owner.close()
+    assert receipt_owner.closed
+
+
+def test_native_publication_binds_receipt_installation_before_validators(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _file_plan()
+    owner, _plan_value, publication_permit = _provision(tmp_path, plan=plan)
+    workspace = OwnedWorkspaceAuthority()
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    workspace.adopt_provisioned(
+        destination=tmp_path / "published",
+        stage_name=".stage",
+        provisioned_owner=owner,
+        publication_permit=publication_permit,
+        plan=plan,
+        expected_destination=None,
+    )
+    workspace.write_file("views/bm25/documents.json", (b"{}",))
+    workspace.seal()
+    receipt_type = captured_module.PublishedWorkspaceReceipt
+    intercepted: list[str] = []
+
+    def intercept_receipt(*_args: object, **_kwargs: object) -> object:
+        intercepted.append("receipt")
+        raise AssertionError("validator intercepted the native receipt token")
+
+    def intercept_install(
+        _candidate: PublishedWorkspaceReceiptOwner,
+        _reservation: object,
+        _receipt: object,
+    ) -> None:
+        intercepted.append("install")
+        raise AssertionError("validator intercepted receipt installation")
+
+    def mutate_public_receipt_names(_reader: object) -> None:
+        monkeypatch.setattr(
+            captured_module,
+            "PublishedWorkspaceReceipt",
+            intercept_receipt,
+        )
+        monkeypatch.setattr(
+            PublishedWorkspaceReceiptOwner,
+            "_install",
+            intercept_install,
+        )
+
+    workspace.publish_into(
+        receipt_owner,
+        validate_published_destination=mutate_public_receipt_names,
+    )
+
+    assert intercepted == []
+    assert receipt_owner.active
+    assert type(receipt_owner.receipt) is receipt_type
+    assert workspace_owner.owner_state(owner) == "receipted"
+    receipt_owner.close()
+    assert receipt_owner.closed
+
+
+def test_native_workspace_close_aborts_before_receipt_publication(
+    tmp_path: Path,
+) -> None:
+    plan = _file_plan()
+    owner, _plan_value, publication_permit = _provision(tmp_path, plan=plan)
+    workspace = OwnedWorkspaceAuthority()
+    workspace.adopt_provisioned(
+        destination=tmp_path / "published",
+        stage_name=".stage",
+        provisioned_owner=owner,
+        publication_permit=publication_permit,
+        plan=plan,
+        expected_destination=None,
+    )
+
+    workspace.close()
+
+    assert workspace.state == "closed"
+    assert workspace_owner.owner_closed(owner)
+    assert not (tmp_path / ".stage").exists()
+    assert not (tmp_path / "published").exists()
+    assert tuple(tmp_path.glob(".codenib-workspace-orphan-*"))
+
+
+def test_native_post_rename_validation_failure_aborts_the_candidate(
+    tmp_path: Path,
+) -> None:
+    plan = _file_plan()
+    owner, _plan_value, publication_permit = _provision(tmp_path, plan=plan)
+    workspace = OwnedWorkspaceAuthority()
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    workspace.adopt_provisioned(
+        destination=tmp_path / "published",
+        stage_name=".stage",
+        provisioned_owner=owner,
+        publication_permit=publication_permit,
+        plan=plan,
+        expected_destination=None,
+    )
+    workspace.write_file("views/bm25/documents.json", (b"{}",))
+    workspace.seal()
+
+    def reject(_reader: object) -> None:
+        raise RuntimeError("injected post-rename validation failure")
+
+    with pytest.raises(RuntimeError):
+        workspace.publish_into(
+            receipt_owner,
+            validate_published_destination=reject,
+        )
+
+    assert receipt_owner.state == "cleanup"
+    receipt_owner.close()
+    assert receipt_owner.closed
+    assert workspace_owner.owner_closed(owner)
+    assert not (tmp_path / "published").exists()
+    assert tuple(tmp_path.glob(".codenib-workspace-orphan-*"))
+
+
+def test_staged_validator_cannot_mint_native_publication_authority(
+    tmp_path: Path,
+) -> None:
+    plan = _file_plan()
+    owner, _plan_value, publication_permit = _provision(tmp_path, plan=plan)
+    workspace = OwnedWorkspaceAuthority()
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    workspace.adopt_provisioned(
+        destination=tmp_path / "published",
+        stage_name=".stage",
+        provisioned_owner=owner,
+        publication_permit=publication_permit,
+        plan=plan,
+        expected_destination=None,
+    )
+    workspace.write_file("views/bm25/documents.json", (b"{}",))
+    workspace.seal()
+    error = RuntimeError("injected hostile staged validator")
+
+    def reject(_reader: object) -> None:
+        with pytest.raises(RuntimeError):
+            workspace_owner.claim_owner_publish_permit(owner)
+        with pytest.raises(TypeError):
+            workspace_owner.rename_owner_child_noreplace(
+                owner,
+                b".stage",
+                b"published",
+            )
+        with pytest.raises(TypeError):
+            workspace_owner.commit_owner_receipt(owner)
+        assert workspace_owner.owner_state(owner) == "adopted"
+        raise error
+
+    with pytest.raises(RuntimeError) as caught:
+        workspace.publish_into(
+            receipt_owner,
+            validate_staged_directory=reject,
+        )
+
+    assert caught.value is error
+    assert receipt_owner.state == "cleanup"
+    receipt_owner.close()
+    assert receipt_owner.closed
+    assert workspace_owner.owner_closed(owner)
+    assert not (tmp_path / "published").exists()
+    assert tuple(tmp_path.glob(".codenib-workspace-orphan-*"))
+
+
+def test_published_validator_cannot_forge_native_receipt_commit(
+    tmp_path: Path,
+) -> None:
+    plan = _file_plan()
+    owner, _plan_value, publication_permit = _provision(tmp_path, plan=plan)
+    workspace = OwnedWorkspaceAuthority()
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    workspace.adopt_provisioned(
+        destination=tmp_path / "published",
+        stage_name=".stage",
+        provisioned_owner=owner,
+        publication_permit=publication_permit,
+        plan=plan,
+        expected_destination=None,
+    )
+    workspace.write_file("views/bm25/documents.json", (b"{}",))
+    workspace.seal()
+    error = RuntimeError("injected hostile published validator")
+
+    def reject(_reader: object) -> None:
+        with pytest.raises(RuntimeError):
+            workspace_owner.claim_owner_publish_permit(owner)
+        with pytest.raises(TypeError):
+            workspace_owner.rename_owner_child_noreplace(
+                owner,
+                b".stage",
+                b"published",
+            )
+        with pytest.raises(TypeError):
+            workspace_owner.commit_owner_receipt(owner)
+        assert workspace_owner.owner_state(owner) == "published-unreceipted"
+        raise error
+
+    with pytest.raises(RuntimeError) as caught:
+        workspace.publish_into(
+            receipt_owner,
+            validate_published_destination=reject,
+        )
+
+    assert caught.value is error
+    assert receipt_owner.state == "cleanup"
+    receipt_owner.close()
+    assert receipt_owner.closed
+    assert workspace_owner.owner_closed(owner)
+    assert not (tmp_path / "published").exists()
+    assert tuple(tmp_path.glob(".codenib-workspace-orphan-*"))
+
+
+def test_native_owner_aborts_an_unreceipted_publication(
+    tmp_path: Path,
+) -> None:
+    owner, _plan_value, publication_permit = _provision(tmp_path)
+    workspace_owner.mark_owner_adopted(owner)
+    receipt_token = workspace_owner.rename_owner_child_noreplace(
+        publication_permit,
+        b".stage",
+        b"published",
+    )
+    assert receipt_token is not None
+
+    assert workspace_owner.owner_state(owner) == "published-unreceipted"
+    workspace_owner.abort_owner(owner)
+
+    assert workspace_owner.owner_closed(owner)
+    assert not (tmp_path / "published").exists()
+    assert tuple(tmp_path.glob(".codenib-workspace-orphan-*"))
+
+
+def test_native_owner_preserves_only_an_explicitly_receipted_publication(
+    tmp_path: Path,
+) -> None:
+    owner, _plan_value, publication_permit = _provision(tmp_path)
+    workspace_owner.mark_owner_adopted(owner)
+    receipt_token = workspace_owner.rename_owner_child_noreplace(
+        publication_permit,
+        b".stage",
+        b"published",
+    )
+    assert receipt_token is not None
+    assert workspace_owner.commit_owner_receipt(receipt_token) is None
+    assert workspace_owner.commit_owner_receipt(receipt_token) is None
+    assert workspace_owner.owner_state(owner) == "receipted"
+
+    workspace_owner.close_owner_exact(owner)
+
+    assert workspace_owner.owner_closed(owner)
+    assert (tmp_path / "published").is_dir()
+    assert not tuple(tmp_path.glob(".codenib-workspace-orphan-*"))
+
+
+def test_native_owner_deallocation_aborts_a_candidate_publication(
+    tmp_path: Path,
+) -> None:
+    owner, _plan_value, publication_permit = _provision(tmp_path)
+    workspace_owner.mark_owner_adopted(owner)
+    workspace_owner.rename_owner_child_noreplace(
+        publication_permit,
+        b".stage",
+        b"published",
+    )
+    del publication_permit
+    del owner
+    gc.collect()
+
+    assert not (tmp_path / "published").exists()
+    assert tuple(tmp_path.glob(".codenib-workspace-orphan-*"))
+
+
+@pytest.mark.parametrize("interrupt_after_store", (False, True))
+def test_native_receipt_slot_store_is_the_publication_authority_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interrupt_after_store: bool,
+) -> None:
+    plan = _file_plan()
+    owner, _plan_value, publication_permit = _provision(tmp_path, plan=plan)
+    workspace = OwnedWorkspaceAuthority()
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    workspace.adopt_provisioned(
+        destination=tmp_path / "published",
+        stage_name=".stage",
+        provisioned_owner=owner,
+        publication_permit=publication_permit,
+        plan=plan,
+        expected_destination=None,
+    )
+    workspace.write_file("views/bm25/documents.json", (b"{}",))
+    workspace.seal()
+    error = KeyboardInterrupt("injected receipt installation interruption")
+    original_install = PublishedWorkspaceReceiptOwner._install
+
+    def interrupt_install(
+        candidate: PublishedWorkspaceReceiptOwner,
+        reservation: object,
+        receipt: object,
+    ) -> None:
+        if interrupt_after_store:
+            original_install(candidate, reservation, receipt)  # type: ignore[arg-type]
+        raise error
+
+    monkeypatch.setattr(PublishedWorkspaceReceiptOwner, "_install", interrupt_install)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        workspace.publish_into(receipt_owner)
+
+    assert caught.value is error
+    if interrupt_after_store:
+        assert receipt_owner.active
+        assert workspace_owner.owner_state(owner) == "receipted"
+        assert (tmp_path / "published/views/bm25/documents.json").is_file()
+    else:
+        assert receipt_owner.state == "cleanup"
+        assert workspace_owner.owner_closed(owner)
+        assert not (tmp_path / "published").exists()
+        assert tuple(tmp_path.glob(".codenib-workspace-orphan-*"))
+    receipt_owner.close()
+    assert receipt_owner.closed
+
+
+def test_native_receipt_commit_return_interruption_keeps_active_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _file_plan()
+    owner, _plan_value, publication_permit = _provision(tmp_path, plan=plan)
+    workspace = OwnedWorkspaceAuthority()
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    workspace.adopt_provisioned(
+        destination=tmp_path / "published",
+        stage_name=".stage",
+        provisioned_owner=owner,
+        publication_permit=publication_permit,
+        plan=plan,
+        expected_destination=None,
+    )
+    workspace.write_file("views/bm25/documents.json", (b"{}",))
+    workspace.seal()
+    error = KeyboardInterrupt("injected native receipt commit return interruption")
+    original_commit = workspace_owner.commit_owner_receipt
+
+    def commit_then_interrupt(candidate: object) -> None:
+        original_commit(candidate)
+        raise error
+
+    monkeypatch.setattr(workspace_owner, "commit_owner_receipt", commit_then_interrupt)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        workspace.publish_into(receipt_owner)
+
+    assert caught.value is error
+    assert receipt_owner.active
+    assert workspace_owner.owner_state(owner) == "receipted"
+    assert (tmp_path / "published/views/bm25/documents.json").is_file()
+    receipt_owner.close()
+    assert receipt_owner.closed
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+@pytest.mark.parametrize("receipted", (False, True))
+def test_native_owner_child_close_does_not_change_parent_namespace(
+    tmp_path: Path,
+    receipted: bool,
+) -> None:
+    owner, _plan_value, publication_permit = _provision(tmp_path)
+    expected_state = "provisioned"
+    expected_path = tmp_path / ".stage"
+    if receipted:
+        workspace_owner.mark_owner_adopted(owner)
+        receipt_token = workspace_owner.rename_owner_child_noreplace(
+            publication_permit,
+            b".stage",
+            b"published",
+        )
+        assert receipt_token is not None
+        workspace_owner.commit_owner_receipt(receipt_token)
+        expected_state = "receipted"
+        expected_path = tmp_path / "published"
+    read_descriptor, write_descriptor = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(read_descriptor)
+        try:
+            try:
+                workspace_owner.close_owner_exact(owner)
+            except RuntimeError as error:
+                descriptor_targets = []
+                for name in os.listdir("/proc/self/fd"):
+                    try:
+                        target = os.readlink(f"/proc/self/fd/{name}")
+                    except OSError:
+                        continue
+                    if str(tmp_path) in target:
+                        descriptor_targets.append(target)
+                report = repr((str(error), descriptor_targets))
+                os.write(write_descriptor, report.encode("utf-8"))
+        finally:
+            os.close(write_descriptor)
+            os._exit(0)
+
+    os.close(write_descriptor)
+    report = os.read(read_descriptor, 1 << 20).decode("utf-8")
+    os.close(read_descriptor)
+    waited_pid, status = os.waitpid(child_pid, 0)
+
+    assert waited_pid == child_pid
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert report == "('native workspace owner cannot cross a PID boundary', [])"
+    assert workspace_owner.owner_state(owner) == expected_state
+    assert expected_path.is_dir()
+    if receipted:
+        workspace_owner.close_owner_exact(owner)
+        assert expected_path.is_dir()
+    else:
+        workspace_owner.abort_owner(owner)
+        assert not expected_path.exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_native_owner_child_cleanup_does_not_close_reused_foreign_fds(
+    tmp_path: Path,
+) -> None:
+    owner, _plan_value, _publication_permit = _provision(tmp_path)
+    borrowed = (
+        workspace_owner.borrow_owner_parent_descriptor(owner),
+        workspace_owner.borrow_owner_root_descriptor(owner),
+        workspace_owner.borrow_owner_directory_descriptor(owner, b"views"),
+    )
+    read_descriptor, write_descriptor = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(read_descriptor)
+        try:
+            foreign_source = os.open(
+                "/dev/null", os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+            )
+            for descriptor in borrowed:
+                os.close(descriptor)
+                os.dup2(foreign_source, descriptor, inheritable=False)
+            sentinels = borrowed
+            with pytest.raises(RuntimeError, match="PID boundary"):
+                workspace_owner.close_owner_exact(owner)
+            for descriptor in sentinels:
+                os.fstat(descriptor)
+            owned_targets = []
+            for name in os.listdir("/proc/self/fd"):
+                try:
+                    target = os.readlink(f"/proc/self/fd/{name}")
+                except OSError:
+                    continue
+                if str(tmp_path) in target:
+                    owned_targets.append(target)
+            assert owned_targets == []
+            os.write(write_descriptor, b"ok")
+        except BaseException as error:  # noqa: B036 - report child failure
+            os.write(write_descriptor, repr(error).encode("utf-8"))
+        finally:
+            os.close(write_descriptor)
+            os._exit(0)
+
+    os.close(write_descriptor)
+    report = os.read(read_descriptor, 4096)
+    os.close(read_descriptor)
+    waited_pid, status = os.waitpid(child_pid, 0)
+    assert waited_pid == child_pid
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert report == b"ok"
+    assert workspace_owner.owner_state(owner) == "provisioned"
+    assert (tmp_path / ".stage").is_dir()
+    workspace_owner.abort_owner(owner)
+    assert workspace_owner.owner_closed(owner)

--- a/test/test_workspace_provider.py
+++ b/test/test_workspace_provider.py
@@ -221,6 +221,25 @@ def test_request_is_lexical_and_rejects_invalid_contract(tmp_path: Path) -> None
     with pytest.raises(ValueError, match="name one directory"):
         StrictWorkspaceRequest("test", tmp_path / "parent" / "..", _plan())
 
+    class DerivedWorkspacePlan(WorkspacePlan):
+        pass
+
+    original = _plan()
+    with pytest.raises(TypeError, match="exact WorkspacePlan"):
+        StrictWorkspaceRequest(
+            "test",
+            destination,
+            DerivedWorkspacePlan(
+                subject_digest=original.subject_digest,
+                directories=original.directories,
+                files=original.files,
+                root_mode=original.root_mode,
+            ),
+        )
+    object.__setattr__(original, "digest", "0" * 64)
+    with pytest.raises(ValueError, match="digest is inconsistent"):
+        StrictWorkspaceRequest("test", destination, original)
+
 
 def test_provider_runs_one_callback_scoped_validated_publication(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Add the production Linux missing-destination `LocalWorkspaceProvider` boundary
for strict workspace publication. Native protocol v2 retains namespace and
descriptor ownership through a caller-owned receipt, while installations
without a compatible native extension continue to fail closed before mutation.

This advances storage M1 but does not complete compiler/runtime wiring. Strict
BM25 still requires the unsupported `provider-bound-exact` replacement mode.

## Changes

- Add the ABI3 native workspace owner, one-shot publish permit, and receipt-token
  lifecycle.
- Integrate native ownership with strict atomic publication, recovery,
  quarantine, cancellation, and fork cleanup.
- Expose `LocalWorkspaceProvider` and `PublishedWorkspaceReceiptOwner` for
  private current-euid Linux roots and missing destinations.
- Cover concurrency, late destinations, RLIMIT/EMFILE, seccomp, fork/PID,
  callback replacement, cleanup retry, and whole-context publication.
- Build exact `cp310-abi3-manylinux_2_28` x86-64 and AArch64 wheels plus one
  source-only sdist, with compiler-less fallback.
- Document the support and authority boundaries and update the storage roadmap.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Final provider, publication, artifact, and release surface: 547 passed,
  10 skipped.
- Unit tier excluding three nodes that require an absolute `/usr/bin/docker`:
  6204 passed, 70 skipped, 193 deselected.
- Complete Docker sandbox test file in an isolated mount namespace with a
  non-executing `/usr/bin/docker` stand-in: 36 passed.
- Strict CPython 3.10 limited-API compile with `-Wall -Wextra -Werror`, plus GCC
  analyzer and clang-format checks.
- Installed AArch64 ABI3 wheel lifecycle on Python 3.10, 3.12, and 3.14.
- Black 24.8.0, isort 5.13.2, flake8+bugbear, actionlint, compileall, and
  `git diff --check`.
- Namespace/capability checks, `mkdocs build --strict`, and the public-docs
  boundary check.

The cross-architecture x86-64/AArch64 cibuildwheel lifecycle is intentionally
left to the PR Release workflow, including QEMU for the non-native architecture.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
