### PR TITLE
feat(storage): add retained artifact materialization CLI

### DIFF
--- a/codenib/_workspace_provider.py
+++ b/codenib/_workspace_provider.py
@@ -175,7 +175,9 @@ class StrictWorkspaceProvider(Protocol):
     expectation or share the revocation gate.
     """
 
-    def require_support(self) -> None: ...
+    def require_support(self) -> None:
+        """Repeatably probe support without provisioning or consuming authority."""
+        ...
 
     def run_workspace(
         self,

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -47,6 +47,7 @@ _RETAINED_REPOSITORY_RE = re.compile(
     re.ASCII,
 )
 _SIGNED_INT64_MAX = 9_223_372_036_854_775_807
+_MAX_PROC_MOUNTINFO_BYTES = 16 * 1024 * 1024
 
 
 class CLIError(RuntimeError):
@@ -1009,6 +1010,98 @@ def _resolved_retained_materialization_path(
         raise CLIError(f"{label} path could not be resolved safely") from exc
 
 
+def _retained_real_directory_identity(
+    path: Path,
+    *,
+    label: str,
+) -> tuple[int, int]:
+    try:
+        metadata = path.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError(f"{label} cannot be inspected safely") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or not metadata.st_dev
+        or not metadata.st_ino
+    ):
+        raise CLIError(f"{label} must resolve to one real directory")
+    return int(metadata.st_dev), int(metadata.st_ino)
+
+
+def _retained_directory_ancestry(
+    path: Path,
+    *,
+    label: str,
+) -> tuple[tuple[Path, tuple[int, int]], ...]:
+    ancestry: list[tuple[Path, tuple[int, int]]] = []
+    current = path
+    while True:
+        ancestry.append(
+            (
+                current,
+                _retained_real_directory_identity(current, label=label),
+            )
+        )
+        parent = current.parent
+        if parent == current:
+            return tuple(ancestry)
+        current = parent
+
+
+def _require_distinct_directory_ancestry(
+    first: tuple[tuple[Path, tuple[int, int]], ...],
+    first_label: str,
+    second: tuple[tuple[Path, tuple[int, int]], ...],
+    second_label: str,
+) -> None:
+    for first_path, first_identity in first:
+        for second_path, second_identity in second:
+            if first_identity == second_identity and first_path != second_path:
+                raise CLIError(
+                    f"{first_label} must not physically alias the {second_label}"
+                )
+
+
+def _decode_mountinfo_path(value: bytes) -> Path:
+    decoded = value
+    for escaped, replacement in (
+        (b"\\040", b" "),
+        (b"\\011", b"\t"),
+        (b"\\012", b"\n"),
+        (b"\\134", b"\\"),
+    ):
+        decoded = decoded.replace(escaped, replacement)
+    path = Path(os.fsdecode(decoded))
+    if not path.is_absolute():
+        raise CLIError("Linux mount information contains a relative mount point")
+    return path
+
+
+def _retained_linux_mount_points() -> frozenset[Path]:
+    mountinfo = Path("/proc/self/mountinfo")
+    try:
+        with mountinfo.open("rb") as stream:
+            payload = stream.read(_MAX_PROC_MOUNTINFO_BYTES + 1)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError("Linux mount information could not be inspected safely") from exc
+    if len(payload) > _MAX_PROC_MOUNTINFO_BYTES:
+        raise CLIError("Linux mount information exceeds the safe size limit")
+    mount_points: set[Path] = set()
+    for line in payload.splitlines():
+        fields = line.split(b" ")
+        try:
+            separator = fields.index(b"-")
+        except ValueError as exc:
+            raise CLIError("Linux mount information is malformed") from exc
+        if separator < 6 or len(fields) < separator + 4:
+            raise CLIError("Linux mount information is malformed")
+        mount_points.add(_decode_mountinfo_path(fields[4]))
+    if not mount_points:
+        raise CLIError("Linux mount information is empty")
+    return frozenset(mount_points)
+
+
 def _retained_catalog_file_identity(path: Path) -> tuple[int, int, int]:
     try:
         metadata = path.lstat()
@@ -1070,24 +1163,33 @@ def _require_retained_materialization_topology(
         strict=True,
     )
     catalog_identity = _retained_catalog_file_identity(resolved_catalog)
-    try:
-        workspace_metadata = resolved_workspace.lstat()
-    except (OSError, RuntimeError, ValueError) as exc:
-        raise CLIError("workspace root cannot be inspected safely") from exc
-    if (
-        not stat.S_ISDIR(workspace_metadata.st_mode)
-        or stat.S_ISLNK(workspace_metadata.st_mode)
-        or not workspace_metadata.st_dev
-    ):
-        raise CLIError("workspace root must resolve to one real directory")
-    workspace_device = int(workspace_metadata.st_dev)
+    mount_points = _retained_linux_mount_points()
+    if resolved_catalog in mount_points:
+        raise CLIError("catalog must not be a mounted file")
+    catalog_ancestry = _retained_directory_ancestry(
+        resolved_catalog.parent,
+        label="catalog parent",
+    )
+    cas_ancestry = _retained_directory_ancestry(
+        resolved_cas,
+        label="CAS root",
+    )
+    workspace_ancestry = _retained_directory_ancestry(
+        resolved_workspace,
+        label="workspace root",
+    )
+    workspace_identity = workspace_ancestry[0][1]
+    workspace_device = workspace_identity[0]
     try:
         relative_parent = output.parent.relative_to(workspace_root)
     except ValueError as exc:  # pragma: no cover - lexical preflight already binds it
         raise CLIError("output parent escaped the workspace root") from exc
     current_parent = workspace_root
+    output_ancestry: list[tuple[Path, tuple[int, int]]] = []
+    resolved_current_parent = resolved_workspace
     for component in relative_parent.parts:
         current_parent = current_parent / component
+        resolved_current_parent = resolved_current_parent / component
         try:
             metadata = current_parent.lstat()
         except FileNotFoundError as exc:
@@ -1098,6 +1200,16 @@ def _require_retained_materialization_topology(
             raise CLIError("output parent must contain only existing real directories")
         if metadata.st_dev != workspace_device:
             raise CLIError("output parent must remain on the workspace filesystem")
+        if not metadata.st_ino:
+            raise CLIError("output parent directory identity is invalid")
+        if resolved_current_parent in mount_points:
+            raise CLIError("output parent must not cross a nested mount point")
+        output_ancestry.append(
+            (
+                resolved_current_parent,
+                (int(metadata.st_dev), int(metadata.st_ino)),
+            )
+        )
     resolved_output_parent = _resolved_retained_materialization_path(
         current_parent,
         label="output parent",
@@ -1119,6 +1231,19 @@ def _require_retained_materialization_topology(
             raise CLIError(
                 f"{first_label} must not physically overlap the {second_label}"
             )
+    for first, first_label, second, second_label in (
+        (catalog_ancestry, "catalog", cas_ancestry, "CAS root"),
+        (catalog_ancestry, "catalog", workspace_ancestry, "workspace root"),
+        (cas_ancestry, "CAS root", workspace_ancestry, "workspace root"),
+        (tuple(output_ancestry), "output parent", catalog_ancestry, "catalog"),
+        (tuple(output_ancestry), "output parent", cas_ancestry, "CAS root"),
+    ):
+        _require_distinct_directory_ancestry(
+            first,
+            first_label,
+            second,
+            second_label,
+        )
     return _RetainedMaterializationTopology(
         catalog_path=resolved_catalog,
         catalog_identity=catalog_identity,

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -13,6 +13,7 @@ import os
 import re
 import shlex
 import shutil
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -41,6 +42,11 @@ _PRESET_CHOICES = ("auto", *_PRESET_VIEWS)
 _REMOTE_EMBEDDING_DEFAULTS = {
     "openai": ("text-embedding-3-small", 1536),
 }
+_RETAINED_REPOSITORY_RE = re.compile(
+    r"[a-z0-9_.-]+(?:/[a-z0-9_.-]+)*\Z",
+    re.ASCII,
+)
+_SIGNED_INT64_MAX = 9_223_372_036_854_775_807
 
 
 class CLIError(RuntimeError):
@@ -66,6 +72,16 @@ def _optional_int(value: object, *, source: str) -> int | None:
         raise CLIError(f"{source} must be a positive integer") from exc
     if parsed <= 0:
         raise CLIError(f"{source} must be a positive integer")
+    return parsed
+
+
+def _argparse_positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed < 1 or parsed > _SIGNED_INT64_MAX:
+        raise argparse.ArgumentTypeError("must be a positive signed 64-bit integer")
     return parsed
 
 
@@ -860,6 +876,484 @@ def _run_artifact_fetch(args: argparse.Namespace) -> int:
     if result.record is not None:
         print(f"GitHub artifact:  {result.record.artifact_id}")
     return 0
+
+
+def _retained_materialization_identity(
+    repository: object,
+    namespace: object,
+) -> tuple[str, str]:
+    from .compiler.snapshot_store import normalize_repo
+    from .storage.models import NamespaceIdentity, RepositoryIdentity
+
+    if type(repository) is not str:
+        raise CLIError("retained repository must be exact text")
+    if (
+        not repository
+        or len(repository) > 32_768
+        or "\x00" in repository
+        or repository != repository.strip()
+    ):
+        raise CLIError("retained repository must be a canonical owner/repository slug")
+    try:
+        normalized_repository = normalize_repo(repository)
+    except ValueError as exc:
+        raise CLIError(
+            "retained repository must be a canonical owner/repository slug"
+        ) from exc
+    if (
+        normalized_repository != repository
+        or _RETAINED_REPOSITORY_RE.fullmatch(repository) is None
+    ):
+        raise CLIError("retained repository must be a canonical owner/repository slug")
+    if type(namespace) is not str:
+        raise CLIError("retained namespace must be exact text")
+    try:
+        namespace_identity = NamespaceIdentity(namespace)
+        RepositoryIdentity(
+            namespace_id=namespace_identity.namespace_id,
+            repository_key=repository,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise CLIError(str(exc)) from exc
+    if namespace_identity.name != namespace:
+        raise CLIError("retained namespace must be canonical")
+    return repository, namespace
+
+
+def _retained_materialization_selector(
+    *,
+    ref_name: object,
+    snapshot_id: object,
+    expected_generation: object,
+) -> tuple[str | None, str | None, int | None]:
+    generation = _optional_int(
+        expected_generation,
+        source="expected ref generation",
+    )
+    if generation is not None and generation > _SIGNED_INT64_MAX:
+        raise CLIError("expected ref generation exceeds signed 64-bit range")
+    if snapshot_id is not None:
+        if generation is not None:
+            raise CLIError("--expected-generation requires ref selection")
+        if (
+            type(snapshot_id) is not str
+            or not snapshot_id
+            or snapshot_id != snapshot_id.strip()
+            or "\x00" in snapshot_id
+            or len(snapshot_id) > 32_768
+        ):
+            raise CLIError("retained snapshot ID is not canonical")
+        return None, snapshot_id, None
+    selected_ref = "main" if ref_name is None else ref_name
+    if (
+        type(selected_ref) is not str
+        or not selected_ref
+        or selected_ref != selected_ref.strip()
+        or "\x00" in selected_ref
+        or len(selected_ref) > 32_768
+    ):
+        raise CLIError("retained ref name is not canonical")
+    return selected_ref, None, generation
+
+
+def _lexical_cli_path(value: object, *, label: str) -> Path:
+    if type(value) is not str or not value:
+        raise CLIError(f"{label} path is required")
+    if "\x00" in value:
+        raise CLIError(f"{label} path is invalid")
+    try:
+        return Path(os.path.abspath(os.fspath(Path(value).expanduser())))
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError(f"{label} path is invalid") from exc
+
+
+def _retained_materialization_paths(args: argparse.Namespace) -> tuple[Path, ...]:
+    """Freeze lexical paths without touching the destination namespace."""
+
+    catalog_path = _lexical_cli_path(args.catalog, label="catalog")
+    cas_root = _lexical_cli_path(args.cas_root, label="CAS root")
+    workspace_root = _lexical_cli_path(args.workspace_root, label="workspace root")
+    output = _lexical_cli_path(args.output, label="output")
+    try:
+        output_relative = output.relative_to(workspace_root)
+    except ValueError as exc:
+        raise CLIError("output must be below the workspace root") from exc
+    if not output_relative.parts:
+        raise CLIError("output must be a child of the workspace root")
+    for first, first_label, second, second_label in (
+        (catalog_path, "catalog", cas_root, "CAS root"),
+        (catalog_path, "catalog", workspace_root, "workspace root"),
+        (cas_root, "CAS root", workspace_root, "workspace root"),
+    ):
+        if _paths_overlap(first, second):
+            raise CLIError(f"{first_label} must not overlap the {second_label}")
+    return catalog_path, cas_root, workspace_root, output
+
+
+@dataclass(frozen=True, slots=True)
+class _RetainedMaterializationTopology:
+    catalog_path: Path
+    catalog_identity: tuple[int, int, int]
+    cas_root: Path
+
+
+def _resolved_retained_materialization_path(
+    path: Path,
+    *,
+    label: str,
+    strict: bool,
+) -> Path:
+    try:
+        return path.resolve(strict=strict)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError(f"{label} path could not be resolved safely") from exc
+
+
+def _retained_catalog_file_identity(path: Path) -> tuple[int, int, int]:
+    try:
+        metadata = path.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError("catalog file cannot be inspected safely") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or not metadata.st_dev
+        or not metadata.st_ino
+        or metadata.st_nlink != 1
+    ):
+        raise CLIError("catalog must resolve to one single-linked regular file")
+    return int(metadata.st_dev), int(metadata.st_ino), int(metadata.st_nlink)
+
+
+def _require_retained_catalog_binding(
+    path: Path,
+    expected_identity: tuple[int, int, int],
+) -> None:
+    try:
+        observed_identity = _retained_catalog_file_identity(path)
+    except CLIError as exc:
+        raise CLIError("catalog changed after physical topology validation") from exc
+    if observed_identity != expected_identity:
+        raise CLIError("catalog changed after physical topology validation")
+
+
+def _require_retained_materialization_topology(
+    catalog_path: Path,
+    cas_root: Path,
+    workspace_root: Path,
+    output: Path,
+) -> _RetainedMaterializationTopology:
+    """Deny stable physical aliases before opening the retained authorities."""
+
+    try:
+        output.lstat()
+    except FileNotFoundError:
+        pass
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError("output cannot be inspected safely") from exc
+    else:
+        raise CLIError("output must be missing")
+
+    resolved_catalog = _resolved_retained_materialization_path(
+        catalog_path,
+        label="catalog",
+        strict=True,
+    )
+    resolved_cas = _resolved_retained_materialization_path(
+        cas_root,
+        label="CAS root",
+        strict=True,
+    )
+    resolved_workspace = _resolved_retained_materialization_path(
+        workspace_root,
+        label="workspace root",
+        strict=True,
+    )
+    catalog_identity = _retained_catalog_file_identity(resolved_catalog)
+    try:
+        workspace_metadata = resolved_workspace.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError("workspace root cannot be inspected safely") from exc
+    if (
+        not stat.S_ISDIR(workspace_metadata.st_mode)
+        or stat.S_ISLNK(workspace_metadata.st_mode)
+        or not workspace_metadata.st_dev
+    ):
+        raise CLIError("workspace root must resolve to one real directory")
+    workspace_device = int(workspace_metadata.st_dev)
+    try:
+        relative_parent = output.parent.relative_to(workspace_root)
+    except ValueError as exc:  # pragma: no cover - lexical preflight already binds it
+        raise CLIError("output parent escaped the workspace root") from exc
+    current_parent = workspace_root
+    for component in relative_parent.parts:
+        current_parent = current_parent / component
+        try:
+            metadata = current_parent.lstat()
+        except FileNotFoundError as exc:
+            raise CLIError("output parent must already exist") from exc
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise CLIError("output parent cannot be inspected safely") from exc
+        if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+            raise CLIError("output parent must contain only existing real directories")
+        if metadata.st_dev != workspace_device:
+            raise CLIError("output parent must remain on the workspace filesystem")
+    resolved_output_parent = _resolved_retained_materialization_path(
+        current_parent,
+        label="output parent",
+        strict=True,
+    )
+    resolved_output = resolved_output_parent / output.name
+    try:
+        resolved_output_relative = resolved_output.relative_to(resolved_workspace)
+    except ValueError as exc:
+        raise CLIError("output must remain below the physical workspace root") from exc
+    if not resolved_output_relative.parts:
+        raise CLIError("output must be a child of the physical workspace root")
+    for first, first_label, second, second_label in (
+        (resolved_catalog, "catalog", resolved_cas, "CAS root"),
+        (resolved_catalog, "catalog", resolved_workspace, "workspace root"),
+        (resolved_cas, "CAS root", resolved_workspace, "workspace root"),
+    ):
+        if _paths_overlap(first, second):
+            raise CLIError(
+                f"{first_label} must not physically overlap the {second_label}"
+            )
+    return _RetainedMaterializationTopology(
+        catalog_path=resolved_catalog,
+        catalog_identity=catalog_identity,
+        cas_root=resolved_cas,
+    )
+
+
+def _warn_possible_retained_publication(output: Path) -> None:
+    try:
+        output.lstat()
+    except (OSError, RuntimeError, ValueError):
+        return
+    print(
+        "warning: retained context output now exists and may have been published; "
+        f"verify it before reuse: {output}",
+        file=sys.stderr,
+    )
+
+
+def _new_retained_output_receipt_owner():
+    from ._captured_directory import PublishedWorkspaceReceiptOwner
+
+    return PublishedWorkspaceReceiptOwner()
+
+
+_RETAINED_RESOURCE_MISSING = object()
+
+
+class _RetainedMaterializationResourceOwner:
+    """Keep one CLI-opened resource retryable across ordered cleanup."""
+
+    __slots__ = ("_resource",)
+
+    def __init__(self) -> None:
+        self._resource: object = _RETAINED_RESOURCE_MISSING
+
+    @property
+    def closed(self) -> bool:
+        return self._resource is _RETAINED_RESOURCE_MISSING
+
+    def acquire(self, factory):
+        if self._resource is not _RETAINED_RESOURCE_MISSING:
+            raise RuntimeError("retained materialization resource is already acquired")
+        # The cleanup owner is reachable before the factory runs.  A direct
+        # attribute store leaves only the native-return-to-STORE_ATTR edge that
+        # Python cannot protect without a constructor-owned handoff protocol.
+        self._resource = factory()
+        return self._resource
+
+    def close(self) -> None:
+        resource = self._resource
+        if resource is _RETAINED_RESOURCE_MISSING:
+            return
+        resource.close()  # type: ignore[attr-defined]
+        self._resource = _RETAINED_RESOURCE_MISSING
+
+
+def _run_artifact_materialize(args: argparse.Namespace) -> int:
+    from . import LocalWorkspaceProvider
+    from ._atomic_directory import (
+        _annotate_secondary_error,
+        _OrderedAction,
+        _run_context_with_cleanup_actions,
+    )
+    from .compiler.manifest_materialization import (
+        materialize_retained_repo_manifest_ref,
+        materialize_retained_repo_manifest_snapshot,
+    )
+    from .storage import LocalCAS, SQLiteCatalog
+
+    repository, namespace = _retained_materialization_identity(
+        args.repository,
+        args.namespace,
+    )
+    ref_name, snapshot_id, expected_generation = _retained_materialization_selector(
+        ref_name=args.ref,
+        snapshot_id=args.snapshot,
+        expected_generation=args.expected_generation,
+    )
+    catalog_path, cas_root, workspace_root, output = _retained_materialization_paths(
+        args
+    )
+    try:
+        provider = LocalWorkspaceProvider(workspace_root)
+        # Fail before opening the catalog or CAS.  The strict publication frame
+        # repeats this non-mutating probe immediately before provisioning.
+        provider.require_support()
+        topology = _require_retained_materialization_topology(
+            catalog_path,
+            cas_root,
+            workspace_root,
+            output,
+        )
+    except CLIError:
+        raise
+    except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
+        raise CLIError(str(exc)) from exc
+
+    summary: tuple[str, str, str, str, tuple[str, ...], Path] | None = None
+    try:
+        owner = _new_retained_output_receipt_owner()
+        object_store_owner = _RetainedMaterializationResourceOwner()
+        catalog_owner = _RetainedMaterializationResourceOwner()
+        cleanup_actions = (
+            _OrderedAction(
+                label="retained SQLite catalog cleanup also failed",
+                action=catalog_owner.close,
+                complete=lambda: catalog_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=catalog_owner,
+            ),
+            _OrderedAction(
+                label="retained local CAS cleanup also failed",
+                action=object_store_owner.close,
+                complete=lambda: object_store_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=object_store_owner,
+            ),
+            _OrderedAction(
+                label="retained output receipt cleanup also failed",
+                action=owner.close,
+                complete=lambda: owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=owner,
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            object_store = object_store_owner.acquire(
+                lambda: LocalCAS(topology.cas_root, require_preprovisioned=True)
+            )
+            # Python's sqlite3 API reopens a pathname and its WAL/SHM sidecars;
+            # it cannot consume a caller-owned descriptor.  The documented
+            # deployment boundary therefore keeps that resolved namespace
+            # quiescent and excludes an A-B-A rename during connect, while the
+            # identity handoff and surrounding checks reject persistent
+            # rebinding around authority acquisition and SQLite construction.
+            _require_retained_catalog_binding(
+                topology.catalog_path,
+                topology.catalog_identity,
+            )
+            catalog = catalog_owner.acquire(
+                lambda: SQLiteCatalog(
+                    topology.catalog_path,
+                    create=False,
+                    expected_file_identity=topology.catalog_identity,
+                )
+            )
+            _require_retained_catalog_binding(
+                topology.catalog_path,
+                topology.catalog_identity,
+            )
+            if snapshot_id is None:
+                result = materialize_retained_repo_manifest_ref(
+                    repository,
+                    output,
+                    namespace_name=namespace,
+                    ref_name=ref_name or "main",
+                    expected_generation=expected_generation,
+                    catalog=catalog,
+                    object_store=object_store,
+                    workspace_provider=provider,
+                    output_receipt_owner=owner,
+                )
+            else:
+                result = materialize_retained_repo_manifest_snapshot(
+                    repository,
+                    snapshot_id,
+                    output,
+                    namespace_name=namespace,
+                    catalog=catalog,
+                    object_store=object_store,
+                    workspace_provider=provider,
+                    output_receipt_owner=owner,
+                )
+            receipt = result.export_receipt
+            selector = (
+                f"{receipt.ref_name}@{receipt.ref_generation}"
+                if receipt.ref_name is not None
+                else "immutable snapshot"
+            )
+            summary = (
+                result.artifact.repository,
+                receipt.snapshot_id,
+                selector,
+                result.artifact.commit,
+                result.artifact.views,
+                result.artifact.output_dir,
+            )
+        if summary is None:  # pragma: no cover - successful producer always sets it
+            raise RuntimeError("retained materialization returned no summary")
+
+        (
+            materialized_repository,
+            materialized_snapshot,
+            selector,
+            commit,
+            views,
+            root,
+        ) = summary
+        print(f"Context artifact: {root}")
+        print(f"Repository:       {materialized_repository}")
+        print(f"Snapshot:         {materialized_snapshot}")
+        print(f"Selection:        {selector}")
+        print(f"Commit:           {commit}")
+        print(f"Views:            {', '.join(views)}")
+        print(
+            "Next:             "
+            + shlex.join(
+                [
+                    "codenib",
+                    "mcp",
+                    "--artifact",
+                    os.fspath(root),
+                    "--repository",
+                    materialized_repository,
+                ]
+            )
+        )
+        return 0
+    except BaseException as primary_error:  # noqa: B036 - preserve cancellation
+        try:
+            _warn_possible_retained_publication(output)
+        except BaseException as warning_error:  # noqa: B036 - diagnostic only
+            _annotate_secondary_error(
+                primary_error,
+                "retained publication warning also failed",
+                warning_error,
+            )
+        if isinstance(primary_error, CLIError):
+            raise
+        if isinstance(
+            primary_error, (OSError, RuntimeError, ValueError, sqlite3.Error)
+        ):
+            raise CLIError(str(primary_error)) from primary_error
+        raise
 
 
 def _run_artifact_mcp_config(args: argparse.Namespace) -> int:
@@ -2685,6 +3179,57 @@ def build_parser() -> argparse.ArgumentParser:
         help="current view to include; repeat or use a comma-separated list",
     )
     artifact_pack_parser.set_defaults(handler=_run_artifact_pack)
+
+    artifact_materialize_parser = artifact_subparsers.add_parser(
+        "materialize",
+        help="materialize one retained catalog ref or snapshot as a context artifact",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    artifact_materialize_parser.add_argument(
+        "--catalog",
+        required=True,
+        help="existing initialized SQLite catalog path",
+    )
+    artifact_materialize_parser.add_argument(
+        "--cas-root",
+        required=True,
+        help="existing fully preprovisioned local CAS root",
+    )
+    artifact_materialize_parser.add_argument(
+        "--workspace-root",
+        required=True,
+        help="existing private owner-only LocalWorkspaceProvider root",
+    )
+    artifact_materialize_parser.add_argument(
+        "--repository",
+        required=True,
+        help="canonical owner/repository key",
+    )
+    artifact_materialize_parser.add_argument(
+        "--namespace",
+        default="default",
+        help="logical catalog namespace",
+    )
+    materialize_selector = artifact_materialize_parser.add_mutually_exclusive_group()
+    materialize_selector.add_argument(
+        "--ref",
+        help="repository ref to resolve; defaults to main",
+    )
+    materialize_selector.add_argument(
+        "--snapshot",
+        help="immutable snapshot ID to materialize instead of a ref",
+    )
+    artifact_materialize_parser.add_argument(
+        "--expected-generation",
+        type=_argparse_positive_int,
+        help="required current generation for optimistic ref resolution",
+    )
+    artifact_materialize_parser.add_argument(
+        "--output",
+        required=True,
+        help="missing output directory below the workspace root",
+    )
+    artifact_materialize_parser.set_defaults(handler=_run_artifact_materialize)
 
     artifact_verify_parser = artifact_subparsers.add_parser(
         "verify",

--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -41,7 +41,10 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
         import_retained_repo_manifest,
     )
     from codenib.compiler.manifest_materialization import (
+        RepoManifestMaterializationResult,
         materialize_retained_context_artifact,
+        materialize_retained_repo_manifest_ref,
+        materialize_retained_repo_manifest_snapshot,
     )
     from codenib.compiler.manifest_storage import (
         RepoManifestImportPlan,
@@ -121,6 +124,18 @@ _EXPORTS = {
         "codenib.compiler.manifest_materialization",
         "materialize_retained_context_artifact",
     ),
+    "RepoManifestMaterializationResult": (
+        "codenib.compiler.manifest_materialization",
+        "RepoManifestMaterializationResult",
+    ),
+    "materialize_retained_repo_manifest_ref": (
+        "codenib.compiler.manifest_materialization",
+        "materialize_retained_repo_manifest_ref",
+    ),
+    "materialize_retained_repo_manifest_snapshot": (
+        "codenib.compiler.manifest_materialization",
+        "materialize_retained_repo_manifest_snapshot",
+    ),
     "export_retained_repo_manifest_ref": (
         "codenib.compiler.manifest_export",
         "export_retained_repo_manifest_ref",
@@ -169,7 +184,10 @@ __all__ = [
     "plan_repo_manifest_import",
     "plan_repo_manifest_import_bytes",
     "import_retained_repo_manifest",
+    "RepoManifestMaterializationResult",
     "materialize_retained_context_artifact",
+    "materialize_retained_repo_manifest_ref",
+    "materialize_retained_repo_manifest_snapshot",
     "export_retained_repo_manifest_ref",
     "export_retained_repo_manifest_snapshot",
     # Resources

--- a/codenib/compiler/manifest_materialization.py
+++ b/codenib/compiler/manifest_materialization.py
@@ -60,8 +60,10 @@ from ..source_fingerprint import is_secure_source_fingerprint_v2
 from ..storage.cas import BlobInfo
 from ..storage.models import (
     ArtifactMember,
+    NamespaceIdentity,
     ObjectRecord,
     PublishedSnapshot,
+    RepositoryIdentity,
     SnapshotView,
     SourceRevision,
     StorageIntegrityError,
@@ -70,7 +72,7 @@ from ..storage.models import (
     ViewProfile,
     canonical_json,
 )
-from ..storage.protocols import ReceiptRetainingObjectStore
+from ..storage.protocols import ReceiptRetainingObjectStore, RetainedSnapshotCatalog
 from ..storage.view_bundle import (
     DEFAULT_MAX_BUNDLE_BYTES,
     DEFAULT_MAX_BUNDLE_FILES,
@@ -92,11 +94,15 @@ from .manifest_export import (
     _require_bundle_semantics,
     _run_with_owned_close,
     _strict_json_bytes,
+    export_retained_repo_manifest_ref,
+    export_retained_repo_manifest_snapshot,
 )
 from .manifest_import import (
     DEFAULT_MAX_CONTEXT_BYTES,
     DEFAULT_MAX_CONTEXT_FILES,
     DEFAULT_MAX_PROJECTION_BYTES,
+    DEFAULT_NAMESPACE_NAME,
+    DEFAULT_REF_NAME,
 )
 from .manifest_storage import (
     DEFAULT_MAX_MANIFEST_BYTES,
@@ -132,6 +138,48 @@ _REPOSITORY_RE = re.compile(
 _MISSING = object()
 _UNSET_RESULT = object()
 _CALLBACK_RECOVERY_LIMIT = 64
+
+
+@dataclass(frozen=True, slots=True)
+class RepoManifestMaterializationResult:
+    """Data result for one retained export plus filesystem materialization."""
+
+    artifact: ContextArtifactResult
+    export_receipt: RepoManifestExportReceipt
+
+    def __post_init__(self) -> None:
+        if type(self) is not RepoManifestMaterializationResult:
+            raise StorageValidationError(
+                "retained materialization result must use the exact model type"
+            )
+        if type(self.artifact) is not ContextArtifactResult:
+            raise StorageValidationError(
+                "retained materialization result artifact is invalid"
+            )
+        if type(self.export_receipt) is not RepoManifestExportReceipt:
+            raise StorageValidationError(
+                "retained materialization result export receipt is invalid"
+            )
+        if (
+            self.artifact.repository != self.export_receipt.repository_key
+            or self.artifact.views != self.export_receipt.views
+        ):
+            raise StorageIntegrityError(
+                "retained materialization result identity is inconsistent"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class _MaterializationPreflight:
+    destination: Path
+    environment: Mapping[str, str]
+    max_manifest_bytes: int
+    max_projection_bytes: int
+    max_context_files: int
+    max_context_bytes: int
+    max_bundle_files: int
+    max_bundle_bytes: int
+    max_bundle_metadata_bytes: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -1653,31 +1701,22 @@ def _preflight_authorities(
     )
 
 
-def materialize_retained_context_artifact(
-    exported: RepoManifestExportResult,
+def _preflight_materialization_request(
     destination: Path,
     *,
-    object_store: ReceiptRetainingObjectStore,
-    workspace_provider: StrictWorkspaceProvider,
-    output_receipt_owner: PublishedWorkspaceReceiptOwner,
-    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
-    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
-    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
-    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
-    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
-    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
-    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
-    environ: Mapping[str, str] | None = None,
-) -> ContextArtifactResult:
-    """Publish one retained export as an exact, query-compatible artifact.
-
-    ``output_receipt_owner`` is caller-owned and must be empty.  On success it
-    remains active and is the only authority for the published generation;
-    this function never closes it, including after a post-publication failure.
-    """
-
-    if type(exported) is not RepoManifestExportResult:
-        raise TypeError("retained context materialization requires an exact export")
+    object_store: object,
+    workspace_provider: object,
+    output_receipt_owner: object,
+    max_manifest_bytes: object,
+    max_projection_bytes: object,
+    max_context_files: object,
+    max_context_bytes: object,
+    max_bundle_files: object,
+    max_bundle_bytes: object,
+    max_bundle_metadata_bytes: object,
+    environ: Mapping[str, str] | None,
+    probe_provider_support: bool = False,
+) -> _MaterializationPreflight:
     if not isinstance(destination, Path):
         raise TypeError("retained context destination must be a Path")
     _preflight_authorities(
@@ -1685,22 +1724,64 @@ def materialize_retained_context_artifact(
         workspace_provider=workspace_provider,
         output_receipt_owner=output_receipt_owner,
     )
-    max_manifest_bytes = _positive_limit(max_manifest_bytes, "manifest byte limit")
-    max_projection_bytes = _positive_limit(
-        max_projection_bytes,
-        "projection byte limit",
-    )
-    max_context_files = _positive_limit(max_context_files, "context file limit")
-    max_context_bytes = _positive_limit(max_context_bytes, "context byte limit")
-    max_bundle_files = _positive_limit(max_bundle_files, "bundle file limit")
-    max_bundle_bytes = _positive_limit(max_bundle_bytes, "bundle byte limit")
-    max_bundle_metadata_bytes = _positive_limit(
+    if probe_provider_support:
+        workspace_provider.require_support()  # type: ignore[union-attr]
+    manifest_limit = _positive_limit(max_manifest_bytes, "manifest byte limit")
+    projection_limit = _positive_limit(max_projection_bytes, "projection byte limit")
+    context_files = _positive_limit(max_context_files, "context file limit")
+    context_bytes = _positive_limit(max_context_bytes, "context byte limit")
+    bundle_files = _positive_limit(max_bundle_files, "bundle file limit")
+    bundle_bytes = _positive_limit(max_bundle_bytes, "bundle byte limit")
+    bundle_metadata = _positive_limit(
         max_bundle_metadata_bytes,
         "bundle metadata byte limit",
     )
     environment = _snapshot_environment(environ)
     lexical_destination = lexical_directory_path(destination)
     _require_missing_destination(lexical_destination)
+    return _MaterializationPreflight(
+        destination=lexical_destination,
+        environment=environment,
+        max_manifest_bytes=manifest_limit,
+        max_projection_bytes=projection_limit,
+        max_context_files=context_files,
+        max_context_bytes=context_bytes,
+        max_bundle_files=bundle_files,
+        max_bundle_bytes=bundle_bytes,
+        max_bundle_metadata_bytes=bundle_metadata,
+    )
+
+
+def _recheck_materialization_target(
+    preflight: _MaterializationPreflight,
+    *,
+    object_store: object,
+    workspace_provider: object,
+    output_receipt_owner: object,
+) -> None:
+    _preflight_authorities(
+        object_store=object_store,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    _require_missing_destination(preflight.destination)
+
+
+def _materialize_retained_context_artifact_preflighted(
+    exported: RepoManifestExportResult,
+    preflight: _MaterializationPreflight,
+    *,
+    object_store: ReceiptRetainingObjectStore,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+) -> ContextArtifactResult:
+    max_manifest_bytes = preflight.max_manifest_bytes
+    max_projection_bytes = preflight.max_projection_bytes
+    max_context_files = preflight.max_context_files
+    max_context_bytes = preflight.max_context_bytes
+    max_bundle_files = preflight.max_bundle_files
+    max_bundle_bytes = preflight.max_bundle_bytes
+    max_bundle_metadata_bytes = preflight.max_bundle_metadata_bytes
     frozen = _snapshot_exported(
         exported,
         max_manifest_bytes=max_manifest_bytes,
@@ -1780,13 +1861,13 @@ def materialize_retained_context_artifact(
             max_context_bytes=max_context_bytes,
         )
         return _publish_plan(
-            lexical_destination,
+            preflight.destination,
             planned=planned,
             retained_receipts=retained_receipts,
             object_store=object_store,
             workspace_provider=workspace_provider,
             output_receipt_owner=output_receipt_owner,
-            environment=environment,
+            environment=preflight.environment,
             max_context_files=max_context_files,
             max_context_bytes=max_context_bytes,
         )
@@ -1794,4 +1875,278 @@ def materialize_retained_context_artifact(
     return _run_retention_callback(object_store, retained_receipts, retained)
 
 
-__all__ = ["materialize_retained_context_artifact"]
+def materialize_retained_context_artifact(
+    exported: RepoManifestExportResult,
+    destination: Path,
+    *,
+    object_store: ReceiptRetainingObjectStore,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    environ: Mapping[str, str] | None = None,
+) -> ContextArtifactResult:
+    """Publish one retained export as an exact, query-compatible artifact.
+
+    ``output_receipt_owner`` is caller-owned and must be empty.  On success it
+    remains active and is the only authority for the published generation;
+    this function never closes it, including after a post-publication failure.
+    """
+
+    if type(exported) is not RepoManifestExportResult:
+        raise TypeError("retained context materialization requires an exact export")
+    preflight = _preflight_materialization_request(
+        destination,
+        object_store=object_store,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        max_manifest_bytes=max_manifest_bytes,
+        max_projection_bytes=max_projection_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        environ=environ,
+    )
+    return _materialize_retained_context_artifact_preflighted(
+        exported,
+        preflight,
+        object_store=object_store,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+
+
+def _retained_repository_id(repository_key: str, namespace_name: str) -> str:
+    if type(repository_key) is not str:
+        raise TypeError("retained materialization repository key must be exact text")
+    if type(namespace_name) is not str:
+        raise TypeError("retained materialization namespace name must be exact text")
+    if (
+        not repository_key
+        or len(repository_key) > _MAX_TEXT
+        or "\x00" in repository_key
+        or repository_key != repository_key.strip()
+    ):
+        raise StorageValidationError(
+            "retained materialization repository key must be a canonical slug"
+        )
+    namespace = NamespaceIdentity(namespace_name)
+    if namespace.name != namespace_name:
+        raise StorageValidationError(
+            "retained materialization namespace name must be canonical"
+        )
+    try:
+        normalized_repository = normalize_repo(repository_key)
+    except ValueError as exc:
+        raise StorageValidationError(
+            "retained materialization repository key is invalid"
+        ) from exc
+    if (
+        normalized_repository != repository_key
+        or _REPOSITORY_RE.fullmatch(repository_key) is None
+    ):
+        raise StorageValidationError(
+            "retained materialization repository key must be a canonical slug"
+        )
+    return RepositoryIdentity(
+        namespace_id=namespace.namespace_id,
+        repository_key=repository_key,
+    ).repository_id
+
+
+def _retained_selector_text(value: object, label: str) -> str:
+    if type(value) is not str:
+        raise StorageValidationError(f"{label} must be exact text")
+    if not value or value != value.strip() or "\x00" in value or len(value) > _MAX_TEXT:
+        raise StorageValidationError(f"{label} is not canonical")
+    return value
+
+
+def _retained_expected_generation(value: object) -> int | None:
+    if value is None:
+        return None
+    if type(value) is not int or not 0 < value <= _INT64_MAX:
+        raise StorageValidationError(
+            "expected ref generation must be a positive signed 64-bit integer"
+        )
+    return value
+
+
+def _materialize_retained_export(
+    exported: RepoManifestExportResult,
+    preflight: _MaterializationPreflight,
+    *,
+    object_store: ReceiptRetainingObjectStore,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+) -> RepoManifestMaterializationResult:
+    artifact = _materialize_retained_context_artifact_preflighted(
+        exported,
+        preflight,
+        object_store=object_store,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    return RepoManifestMaterializationResult(
+        artifact=artifact,
+        export_receipt=exported.receipt,
+    )
+
+
+def materialize_retained_repo_manifest_ref(
+    repository_key: str,
+    destination: Path,
+    *,
+    catalog: RetainedSnapshotCatalog,
+    object_store: ReceiptRetainingObjectStore,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    ref_name: str = DEFAULT_REF_NAME,
+    expected_generation: int | None = None,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    environ: Mapping[str, str] | None = None,
+) -> RepoManifestMaterializationResult:
+    """Resolve one retained ref and publish its exact context generation.
+
+    ``output_receipt_owner`` is caller-owned and must be empty.  This function
+    never closes it.  Success leaves it active, and a failure after publication
+    may also leave it active so the caller can settle the published authority.
+    """
+
+    repository_id = _retained_repository_id(repository_key, namespace_name)
+    ref_name = _retained_selector_text(ref_name, "retained materialization ref name")
+    expected_generation = _retained_expected_generation(expected_generation)
+    preflight = _preflight_materialization_request(
+        destination,
+        object_store=object_store,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        max_manifest_bytes=max_manifest_bytes,
+        max_projection_bytes=max_projection_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        environ=environ,
+        probe_provider_support=True,
+    )
+    exported = export_retained_repo_manifest_ref(
+        repository_id,
+        catalog=catalog,
+        object_store=object_store,
+        ref_name=ref_name,
+        expected_generation=expected_generation,
+        max_manifest_bytes=preflight.max_manifest_bytes,
+        max_projection_bytes=preflight.max_projection_bytes,
+        max_bundle_files=preflight.max_bundle_files,
+        max_bundle_bytes=preflight.max_bundle_bytes,
+        max_bundle_metadata_bytes=preflight.max_bundle_metadata_bytes,
+    )
+    _recheck_materialization_target(
+        preflight,
+        object_store=object_store,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    return _materialize_retained_export(
+        exported,
+        preflight,
+        object_store=object_store,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+
+
+def materialize_retained_repo_manifest_snapshot(
+    repository_key: str,
+    snapshot_id: str,
+    destination: Path,
+    *,
+    catalog: RetainedSnapshotCatalog,
+    object_store: ReceiptRetainingObjectStore,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    environ: Mapping[str, str] | None = None,
+) -> RepoManifestMaterializationResult:
+    """Read one retained immutable snapshot and publish its exact context.
+
+    ``output_receipt_owner`` is caller-owned and must be empty.  This function
+    never closes it.  Success leaves it active, and a failure after publication
+    may also leave it active so the caller can settle the published authority.
+    """
+
+    repository_id = _retained_repository_id(repository_key, namespace_name)
+    snapshot_id = _retained_selector_text(
+        snapshot_id,
+        "retained materialization snapshot ID",
+    )
+    preflight = _preflight_materialization_request(
+        destination,
+        object_store=object_store,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        max_manifest_bytes=max_manifest_bytes,
+        max_projection_bytes=max_projection_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        environ=environ,
+        probe_provider_support=True,
+    )
+    exported = export_retained_repo_manifest_snapshot(
+        repository_id,
+        snapshot_id,
+        catalog=catalog,
+        object_store=object_store,
+        max_manifest_bytes=preflight.max_manifest_bytes,
+        max_projection_bytes=preflight.max_projection_bytes,
+        max_bundle_files=preflight.max_bundle_files,
+        max_bundle_bytes=preflight.max_bundle_bytes,
+        max_bundle_metadata_bytes=preflight.max_bundle_metadata_bytes,
+    )
+    _recheck_materialization_target(
+        preflight,
+        object_store=object_store,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    return _materialize_retained_export(
+        exported,
+        preflight,
+        object_store=object_store,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+
+
+__all__ = [
+    "RepoManifestMaterializationResult",
+    "materialize_retained_context_artifact",
+    "materialize_retained_repo_manifest_ref",
+    "materialize_retained_repo_manifest_snapshot",
+]

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -20,6 +20,7 @@ import sqlite3
 import stat
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterator, Mapping, Sequence
 
@@ -1040,6 +1041,51 @@ _MIGRATIONS: dict[int, tuple[str, ...]] = {
     4: _SCHEMA_V4,
 }
 
+_SCHEMA_MIGRATIONS_SQL = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+)
+"""
+
+
+def _catalog_schema_signature(
+    connection: sqlite3.Connection,
+) -> tuple[tuple[object, ...], ...]:
+    """Return every caller-defined schema object in a stable order."""
+
+    return tuple(
+        tuple(row)
+        for row in connection.execute(
+            """
+            SELECT type, name, tbl_name, sql
+            FROM sqlite_master
+            WHERE substr(name, 1, 7) != 'sqlite_'
+            ORDER BY type, name, tbl_name
+            """
+        )
+    )
+
+
+@lru_cache(maxsize=LATEST_SCHEMA_VERSION)
+def _expected_catalog_schema_signature(
+    version: int,
+) -> tuple[tuple[object, ...], ...]:
+    """Build the exact schema authorized by the immutable migration sequence."""
+
+    reference = sqlite3.connect(":memory:", isolation_level=None)
+    try:
+        reference.execute(_SCHEMA_MIGRATIONS_SQL)
+        for migration_version in range(1, version + 1):
+            statements = _MIGRATIONS.get(migration_version)
+            if statements is None:  # pragma: no cover - module invariant
+                raise CatalogError(f"missing catalog migration {migration_version}")
+            for statement in statements:
+                reference.execute(statement)
+        return _catalog_schema_signature(reference)
+    finally:
+        reference.close()
+
 
 class SQLiteCatalog:
     """Transactional SQLite catalog for immutable index snapshots."""
@@ -1241,6 +1287,10 @@ class SQLiteCatalog:
                 "catalog schema is newer than this CodeNib version: "
                 f"{user_version} > {LATEST_SCHEMA_VERSION}"
             )
+        if _catalog_schema_signature(
+            self._connection
+        ) != _expected_catalog_schema_signature(user_version):
+            raise CatalogError("existing file is not an initialized CodeNib catalog")
 
     def __enter__(self) -> SQLiteCatalog:
         return self
@@ -1271,14 +1321,7 @@ class SQLiteCatalog:
 
     def _migrate(self) -> None:
         with self._transaction():
-            self._connection.execute(
-                """
-                CREATE TABLE IF NOT EXISTS schema_migrations (
-                    version INTEGER PRIMARY KEY,
-                    applied_at TEXT NOT NULL
-                )
-                """
-            )
+            self._connection.execute(_SCHEMA_MIGRATIONS_SQL)
             rows = self._connection.execute(
                 "SELECT version FROM schema_migrations ORDER BY version"
             ).fetchall()

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import stat
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -61,6 +62,20 @@ CatalogValidationError = StorageValidationError
 
 _DB_NOW_MS_SQL = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)"
 _SQLITE_INT64_MAX = 9_223_372_036_854_775_807
+_V1_CATALOG_TABLES = frozenset(
+    {
+        "namespaces",
+        "objects",
+        "refs",
+        "repositories",
+        "schema_migrations",
+        "snapshot_views",
+        "snapshots",
+        "source_revisions",
+        "view_generations",
+        "view_profiles",
+    }
+)
 
 
 def _now() -> str:
@@ -1039,27 +1054,90 @@ class SQLiteCatalog:
         path: str | Path,
         *,
         busy_timeout_ms: int = 5_000,
+        create: bool = True,
+        expected_file_identity: tuple[int, int, int] | None = None,
     ) -> None:
+        """Open a catalog, optionally requiring an initialized existing file.
+
+        ``create=False`` prevents path creation and rejects empty, foreign, or
+        corrupt databases.  A recognized older CodeNib catalog is still opened
+        read-write, switched to WAL, and forward-migrated transactionally.  An
+        expected file identity binds that existing-only open to one resolved
+        single-linked regular inode across ``sqlite3.connect``.
+        """
+
         if (
             isinstance(busy_timeout_ms, bool)
             or not isinstance(busy_timeout_ms, int)
             or busy_timeout_ms < 0
         ):
             raise ValueError("busy_timeout_ms must be a non-negative integer")
+        if type(create) is not bool:
+            raise TypeError("create must be a boolean")
+        if expected_file_identity is not None:
+            if create:
+                raise ValueError("expected_file_identity requires create=False")
+            if (
+                type(expected_file_identity) is not tuple
+                or len(expected_file_identity) != 3
+                or any(type(value) is not int for value in expected_file_identity)
+            ):
+                raise TypeError(
+                    "expected_file_identity must be an exact 3-tuple of integers"
+                )
+            if any(value < 1 for value in expected_file_identity):
+                raise ValueError(
+                    "expected_file_identity must contain positive integers"
+                )
+            if expected_file_identity[2] != 1:
+                raise ValueError("expected_file_identity link count must be 1")
 
         raw_path = str(path)
+        connection_target = raw_path
+        use_uri = False
         if raw_path != ":memory:":
             resolved = Path(path).expanduser().resolve()
-            resolved.parent.mkdir(parents=True, exist_ok=True)
             raw_path = str(resolved)
+            if create:
+                resolved.parent.mkdir(parents=True, exist_ok=True)
+                connection_target = raw_path
+            else:
+                connection_target = f"{resolved.as_uri()}?mode=rw"
+                use_uri = True
+        elif not create:
+            raise ValueError(
+                "an in-memory SQLite catalog cannot be opened existing-only"
+            )
         self.path = raw_path
-        self._connection = sqlite3.connect(
-            raw_path,
-            timeout=busy_timeout_ms / 1_000,
-            isolation_level=None,
-        )
+        if expected_file_identity is not None:
+            self._require_expected_file_identity(resolved, expected_file_identity)
+        try:
+            connection = sqlite3.connect(
+                connection_target,
+                timeout=busy_timeout_ms / 1_000,
+                isolation_level=None,
+                uri=use_uri,
+            )
+        except sqlite3.Error as exc:
+            if not create:
+                raise CatalogError(
+                    f"existing SQLite catalog could not be opened: {raw_path}"
+                ) from exc
+            raise
+        try:
+            if expected_file_identity is not None:
+                self._require_expected_file_identity(
+                    resolved,
+                    expected_file_identity,
+                )
+        except BaseException:
+            connection.close()
+            raise
+        self._connection = connection
         self._connection.row_factory = sqlite3.Row
         try:
+            if not create:
+                self._require_existing_catalog_identity()
             self._connection.execute("PRAGMA foreign_keys = ON")
             self._connection.execute("PRAGMA recursive_triggers = ON")
             if self._connection.execute("PRAGMA recursive_triggers").fetchone()[0] != 1:
@@ -1076,13 +1154,93 @@ class SQLiteCatalog:
             self._connection.execute("PRAGMA journal_mode = WAL")
             self._connection.execute("PRAGMA synchronous = FULL")
             self._migrate()
+        except sqlite3.Error as exc:
+            self._connection.close()
+            if not create:
+                raise CatalogError(
+                    f"existing SQLite catalog could not be initialized: {raw_path}"
+                ) from exc
+            raise
         except BaseException:
             self._connection.close()
             raise
 
+    @staticmethod
+    def _require_expected_file_identity(
+        path: Path,
+        expected: tuple[int, int, int],
+    ) -> None:
+        try:
+            metadata = path.lstat()
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise CatalogError(
+                "existing SQLite catalog file identity could not be verified"
+            ) from exc
+        observed = (
+            int(metadata.st_dev),
+            int(metadata.st_ino),
+            int(metadata.st_nlink),
+        )
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_dev < 1
+            or metadata.st_ino < 1
+            or metadata.st_nlink != 1
+            or observed != expected
+        ):
+            raise CatalogError("existing SQLite catalog file identity changed")
+
     def close(self) -> None:
         """Close the underlying database connection."""
         self._connection.close()
+
+    def _require_existing_catalog_identity(self) -> None:
+        observed_tables = frozenset(
+            row["name"]
+            for row in self._connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        )
+        if not _V1_CATALOG_TABLES.issubset(observed_tables):
+            raise CatalogError("existing file is not an initialized CodeNib catalog")
+        migration_columns = tuple(
+            (row["name"], row["type"], row["notnull"], row["pk"])
+            for row in self._connection.execute("PRAGMA table_info(schema_migrations)")
+        )
+        if migration_columns != (
+            ("version", "INTEGER", 0, 1),
+            ("applied_at", "TEXT", 1, 0),
+        ):
+            raise CatalogError("existing file is not an initialized CodeNib catalog")
+        migration_rows = self._connection.execute(
+            "SELECT version, applied_at FROM schema_migrations ORDER BY version"
+        ).fetchall()
+        versions: list[int] = []
+        for row in migration_rows:
+            version = row["version"]
+            applied_at = row["applied_at"]
+            if (
+                type(version) is not int
+                or version < 1
+                or version > _SQLITE_INT64_MAX
+                or type(applied_at) is not str
+                or not applied_at
+            ):
+                raise CatalogError(
+                    "existing file is not an initialized CodeNib catalog"
+                )
+            versions.append(version)
+        if not versions or versions != list(range(1, len(versions) + 1)):
+            raise CatalogError("existing file is not an initialized CodeNib catalog")
+        user_version = self._connection.execute("PRAGMA user_version").fetchone()[0]
+        if type(user_version) is not int or user_version != versions[-1]:
+            raise CatalogError("existing file is not an initialized CodeNib catalog")
+        if user_version > LATEST_SCHEMA_VERSION:
+            raise CatalogError(
+                "catalog schema is newer than this CodeNib version: "
+                f"{user_version} > {LATEST_SCHEMA_VERSION}"
+            )
 
     def __enter__(self) -> SQLiteCatalog:
         return self

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -15,10 +15,81 @@ strict workspace contract. It publishes one fully validated directory into a
 missing destination and transfers the generation to a caller-owned
 `PublishedWorkspaceReceiptOwner`.
 
-The provider is currently a library boundary. CodeNib's compiler and runtime do
-not construct one automatically, and the strict BM25 replacement path still
-requires the unsupported `provider-bound-exact` destination mode. The portable
-whole-context producer can use the provider when its destination is missing.
+The provider is not part of CodeNib's default compiler, import, or runtime
+path. The first explicit operator bridge is `codenib artifact materialize`,
+which can publish a retained catalog ref or immutable snapshot to a missing
+portable-artifact directory. The strict BM25 replacement path still requires
+the unsupported `provider-bound-exact` destination mode.
+
+## Materialize a retained artifact
+
+This command is for a control plane that has already been populated. It does
+not initialize a catalog, provision a CAS, import an existing cache, build a
+view, or advance a ref. Prepare all three authorities before running it:
+
+- `--catalog` names an existing, initialized CodeNib SQLite catalog. Existing-
+  only means that a missing, empty, foreign, or corrupt database is rejected;
+  it does **not** mean read-only. CodeNib opens a recognized catalog read-write,
+  enables WAL, and may apply forward migrations before reading the selection.
+  The database file must be a single-linked regular file. The CLI binds its
+  captured `(st_dev, st_ino, st_nlink=1)` identity into the existing-only open;
+  SQLite rechecks it immediately before and after `sqlite3.connect`, before
+  schema inspection, WAL activation, or migration. Its resolved ancestor chain
+  and WAL/SHM sidecar namespace must remain trusted and quiescent for the entire
+  invocation. These identity checks are not a filesystem sandbox against an
+  actor racing arbitrary renames.
+- `--cas-root` names a fully preprovisioned strict `LocalCAS` layout. The
+  command will not create the root, `sha256` directory, or 256 digest shards.
+  Provision the layout once, while its namespace is trusted and quiescent, with
+  `LocalCAS.provision(...)`, then close the returned store before invoking the
+  CLI.
+- `--workspace-root` names an existing Linux directory owned by the current
+  effective UID with exact mode `0700`. The catalog path, CAS root, and
+  workspace root must not overlap. `--output` must be a missing child below the
+  workspace root, and every existing output-parent component must be a real
+  directory on the workspace root filesystem. An existing file, directory, or
+  symlink is never replaced.
+
+For example, materialize the current generation of the `main` ref:
+
+```bash
+install -d -m 0700 /var/lib/codenib/workspaces
+
+codenib artifact materialize \
+  --catalog /var/lib/codenib/catalog.sqlite3 \
+  --cas-root /var/lib/codenib/cas \
+  --workspace-root /var/lib/codenib/workspaces \
+  --repository owner/repository \
+  --ref main \
+  --expected-generation 7 \
+  --output /var/lib/codenib/workspaces/repository-context-v1
+```
+
+Omit `--ref` to use `main`, or replace it with `--snapshot <snapshot-id>` to
+select one immutable snapshot. `--expected-generation` is valid only for ref
+selection. `--namespace` defaults to `default`.
+
+The CLI creates the caller-owned publication receipt for this invocation. It
+closes that receipt, the strict CAS anchors, and the catalog connection before
+printing success and returning. Closing the receipt releases its native
+handles; it does not delete the published artifact. The success output includes
+the separate query-only handoff:
+
+```bash
+codenib mcp \
+  --artifact /var/lib/codenib/workspaces/repository-context-v1 \
+  --repository owner/repository
+```
+
+A failure can occur after the no-replace publication has committed. If the CLI
+warns that the output now exists, do not assume that the path is disposable or
+retry over it; verify the retained artifact before reuse or reclaim it through
+an ownership-aware workflow.
+
+This is the first explicit local bridge, not completion of the hybrid-storage
+M1 milestone. Default compiler/import/runtime wiring is still missing, as is a
+production provider for the strict BM25 producer's `provider-bound-exact`
+destination contract.
 
 ## Lifecycle
 

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -34,10 +34,10 @@ view, or advance a ref. Prepare all three authorities before running it:
   The database file must be a single-linked regular file. The CLI binds its
   captured `(st_dev, st_ino, st_nlink=1)` identity into the existing-only open;
   SQLite rechecks it immediately before and after `sqlite3.connect`, before
-  schema inspection, WAL activation, or migration. Its resolved ancestor chain
-  and WAL/SHM sidecar namespace must remain trusted and quiescent for the entire
-  invocation. These identity checks are not a filesystem sandbox against an
-  actor racing arbitrary renames.
+  complete claimed-version schema authentication, WAL activation, or
+  migration. Its resolved ancestor chain and WAL/SHM sidecar namespace must
+  remain trusted and quiescent for the entire invocation. These identity checks
+  are not a filesystem sandbox against an actor racing arbitrary renames.
 - `--cas-root` names a fully preprovisioned strict `LocalCAS` layout. The
   command will not create the root, `sha256` directory, or 256 digest shards.
   Provision the layout once, while its namespace is trusted and quiescent, with
@@ -45,10 +45,11 @@ view, or advance a ref. Prepare all three authorities before running it:
   CLI.
 - `--workspace-root` names an existing Linux directory owned by the current
   effective UID with exact mode `0700`. The catalog path, CAS root, and
-  workspace root must not overlap. `--output` must be a missing child below the
+  workspace root must not overlap or resolve through distinct directory names
+  to the same filesystem identity. `--output` must be a missing child below the
   workspace root, and every existing output-parent component must be a real
-  directory on the workspace root filesystem. An existing file, directory, or
-  symlink is never replaced.
+  directory on the workspace root filesystem without a nested mount point. An
+  existing file, directory, or symlink is never replaced.
 
 For example, materialize the current generation of the `main` ref:
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -238,8 +238,9 @@ closed in staging, binding, BM25 reads, and MCP reads.  The shared credential
 classifier lives outside both artifacts and storage so the artifact layer does
 not depend on the catalog implementation.  These gates close the current
 portable context publication surface, and the injectable retained materializer
-described below now closes the retained filesystem boundary. Production
-compiler/runtime wiring and a future streaming payload revision remain.
+described below now closes the retained filesystem boundary. The explicit local
+CLI bridge described below can invoke it, but default compiler/import/runtime
+wiring and a future streaming payload revision remain.
 
 Local filesystem publication now has an explicit strict-authority gate. Regular
 files are written through caller-owned staged descriptors, installed with
@@ -271,8 +272,9 @@ publish permit. The caller-owned receipt slot is the publication-authority
 linearization point: unreceipted same-process failures quarantine the exact
 candidate, while a fork child authenticates and closes only its inherited
 descriptor pairs. The provider is an authority boundary for trusted callbacks,
-not an in-process Python sandbox. No compiler or runtime route constructs it by
-default yet.
+not an in-process Python sandbox. The explicit retained-artifact CLI constructs
+it for one operator-requested publication; no compiler, import, or runtime
+route constructs it by default yet.
 
 Callback-scoped directory results are likewise provisional until ordered
 reader-validity, exact-ownership, child-namespace, and parent-authority
@@ -358,8 +360,10 @@ materialization APIs are now available as injectable library producers. The
 Linux local provider deliberately accepts only missing destinations, so
 whole-context retained materialization can use it explicitly, while strict BM25
 requests `provider-bound-exact` and still lacks a concrete production provider.
-No compiler or runtime route constructs these producers yet. M1 remains in
-progress and the M2 BM25 profile adapter is still outstanding.
+The explicit retained-artifact CLI can now construct the whole-context producer
+for one existing catalog selection, but no default compiler/import/runtime route
+constructs these producers. M1 remains in progress and the M2 BM25 profile
+adapter is still outstanding.
 
 Strict whole-context publication can now aggregate already-normalized BM25 and
 vector generations retained by active workspace receipt owners. The plan binds
@@ -373,11 +377,12 @@ output receipt. Large canonical documents remain element-streamed, and vector
 indexes stay authenticated but native-inert throughout context assembly.
 Planning and publication never consult mutable public source projections after
 that identity is captured. The producer can now use a caller-supplied
-`LocalWorkspaceProvider` for a missing destination, but no compiler/runtime
-route constructs the provider or manages the output receipt lifetime by
-default. This slice does not normalize native vector state or route compiler
-output. Its retained receipt is now accepted by the direct M1 importer below,
-but it is not yet an M2 fenced job output.
+`LocalWorkspaceProvider` for a missing destination. The explicit CLI bridge now
+constructs that provider and closes its output receipt for one invocation, but
+no default compiler/import/runtime route manages either lifecycle. This slice
+does not normalize native vector state or route compiler output. Its retained
+receipt is now accepted by the direct M1 importer below, but it is not yet an M2
+fenced job output.
 
 Retained manifest import now has additional backend-neutral prerequisite
 gates. `BlobInfo` is an exact point-in-time CAS receipt, and
@@ -416,8 +421,11 @@ operation, receipt minting, or ref publication. Execution is a separate
 authority-bearing API, so inspecting or serializing a plan cannot publish it.
 The retained exporter described below now supplies equivalent canonical v1.1
 bytes, and the injectable retained materializer closes their filesystem
-publication boundary. Production provider/compiler/runtime wiring and GC policy
-remain outstanding, so M1 and M2 remain in progress.
+publication boundary. The explicit local CLI bridge uses the concrete local
+provider only for an operator-selected retained ref or snapshot. Default
+compiler/import/runtime wiring remains outstanding, so M1 remains in progress.
+Profile adapters and fenced publication remain M2 work;
+production retention and garbage collection remain M5 work.
 
 The retained-import foundation now also exposes schema-v4 compound-generation
 identity as one backend-neutral model rule, including the canonical member
@@ -475,8 +483,8 @@ publication cannot move the old ref. If cancellation lands after SQLite commits
 but before the caller observes the result, the direct M1 call is at-least-once:
 an exact retry idempotently resolves to the already-published snapshot without
 advancing the ref again. This is the direct M1 bootstrap path, not the M2 fenced
-job-success transaction. Production compiler/runtime wiring and a production GC
-implementation and policy remain outstanding, so M1 remains in progress.
+job-success transaction. Default compiler/import/runtime wiring remains the M1
+gap; production retention and garbage collection remain M5 work.
 
 The first read-only retained `RepoManifest` exporter now closes the data-only
 round trip without introducing path authority. It accepts the additive
@@ -512,8 +520,39 @@ both staged and published semantic verification. Static metadata is `0600`,
 directories are `0700`, and the caller-precreated output receipt owner remains
 the sole authority for the published generation. The API is backend-neutral
 and injectable, and it can use `LocalWorkspaceProvider` for a missing
-destination. No default compiler/runtime route constructs that provider or
-manages the output receipt lifetime yet.
+destination.
+
+The first explicit local bridge over this API is now
+`codenib artifact materialize`. It requires an existing initialized CodeNib
+SQLite catalog, a fully preprovisioned strict `LocalCAS`, an existing private
+Linux workspace root owned by the current effective UID with exact mode `0700`,
+and a missing output below that root. The three storage/authority locations
+must not overlap. Existing-only catalog open is read-write rather than
+read-only: it enables WAL and may apply forward migrations, while rejecting a
+missing, empty, foreign, or corrupt database. The database must be a
+single-linked regular file. Existing-only open binds its captured `(st_dev,
+st_ino, st_nlink=1)` identity across `sqlite3.connect` and rechecks it before
+schema inspection, WAL activation, or migration. Its resolved ancestor chain
+and WAL/SHM sidecar namespace are an explicit trusted, quiescent deployment
+boundary for the whole invocation; the identity checks do not claim a
+path-based sandbox against arbitrary concurrent renames. Every existing output-
+parent component must be a real directory on the workspace root filesystem.
+The command resolves either one ref (optionally guarded by its expected
+generation) or one explicit immutable snapshot, materializes the retained
+portable generation, then closes the CLI-owned caller receipt, strict CAS
+anchors, and catalog connection before it prints success. Receipt closure
+releases native authority without deleting the published output. The printed
+handoff starts a separate query-only process with `codenib mcp --artifact
+<output> --repository <owner/repository>`. A post-publication failure may
+therefore leave a valid missing-only output; the CLI warns when the path exists
+rather than deleting it.
+
+This command does not initialize or populate the control plane, import a legacy
+cache, build views, advance refs, or make retained storage the default. It is
+the first explicit local bridge only. Default compiler/import/runtime wiring
+remains the outstanding M1 deliverable, and strict BM25 still lacks the
+`provider-bound-exact` production provider; fenced job publication remains M2
+work.
 
 Schema v2 now adds
 canonical idempotent job requests, immutable
@@ -522,8 +561,9 @@ per-ref leases.  Catalog reads revalidate the normalized view rows against the
 canonical request; the M2 publication transaction must repeat that gate before
 associating outputs.  An explicit acquire may atomically retire an expired
 holder while taking over its slot; this slice adds no background reaper and is
-not wired to the compiler or Web workers. Production compiler/runtime wiring
-remains the outstanding M1 deliverable; fenced job publication remains M2 work.
+not wired to the compiler or Web workers. Default compiler/import/runtime
+wiring remains the outstanding M1 deliverable; fenced job publication remains
+M2 work.
 
 The shared compiler-cache lock is a cooperative serialization boundary for
 compiler and importer processes using a cache namespace private to one OS

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -532,11 +532,14 @@ read-only: it enables WAL and may apply forward migrations, while rejecting a
 missing, empty, foreign, or corrupt database. The database must be a
 single-linked regular file. Existing-only open binds its captured `(st_dev,
 st_ino, st_nlink=1)` identity across `sqlite3.connect` and rechecks it before
-schema inspection, WAL activation, or migration. Its resolved ancestor chain
-and WAL/SHM sidecar namespace are an explicit trusted, quiescent deployment
-boundary for the whole invocation; the identity checks do not claim a
-path-based sandbox against arbitrary concurrent renames. Every existing output-
-parent component must be a real directory on the workspace root filesystem.
+authenticating the complete schema declared by its migration version, WAL
+activation, or migration. Its resolved ancestor chain and WAL/SHM sidecar
+namespace are an explicit trusted, quiescent deployment boundary for the whole
+invocation; the identity checks do not claim a path-based sandbox against
+arbitrary concurrent renames. Physical preflight rejects distinct storage
+paths whose ancestor directory identities alias, plus mounted catalog files and
+nested mount points below the workspace root. Every existing output-parent
+component must be a real directory on the workspace root filesystem.
 The command resolves either one ref (optionally guarded by its expected
 generation) or one explicit immutable snapshot, materializes the retained
 portable generation, then closes the CLI-owned caller receipt, strict CAS

--- a/test/compiler/test_manifest_materialization.py
+++ b/test/compiler/test_manifest_materialization.py
@@ -8,6 +8,7 @@ import asyncio
 import inspect
 import io
 import json
+import sqlite3
 import stat
 import sys
 from collections.abc import Callable
@@ -19,9 +20,12 @@ from unittest.mock import patch
 import pytest
 from mcp import Client
 
+import codenib as codenib_module
 import codenib.compiler as compiler_module
 import codenib.compiler.manifest_materialization as materialization_module
+import codenib.storage as storage_module
 from codenib import LocalWorkspaceProvider
+from codenib import cli as cli_module
 from codenib._captured_directory import (
     PublishedWorkspaceReceiptOwner,
     UnsupportedWorkspaceCreation,
@@ -894,6 +898,297 @@ def test_local_provider_materializes_real_retained_snapshot_for_mcp_bm25(
         assert owner.closed
         assert destination.is_dir()
         assert fixture.repository.is_dir()
+
+
+def test_cli_materializes_existing_ref_and_snapshot_for_mcp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (fixture, imported, object_store, catalog):
+        catalog_path = Path(catalog.path)
+        cas_root = object_store.root
+        catalog.close()
+        object_store.close()
+        catalog_identity = cli_module._retained_catalog_file_identity(catalog_path)
+        with LocalCAS.provision(cas_root):
+            pass
+
+        workspace_root = tmp_path / "local-workspaces"
+        provider = _local_workspace_provider(workspace_root)
+        ref_output = workspace_root / "ref-context"
+        snapshot_output = workspace_root / "snapshot-context"
+        owners: list[PublishedWorkspaceReceiptOwner] = []
+        stores: list[LocalCAS] = []
+        catalogs: list[Any] = []
+        real_owner = PublishedWorkspaceReceiptOwner
+        real_store = LocalCAS
+        real_catalog = storage_module.SQLiteCatalog
+
+        def owner_factory() -> PublishedWorkspaceReceiptOwner:
+            owner = real_owner()
+            owners.append(owner)
+            return owner
+
+        def store_factory(
+            root: str | Path,
+            *,
+            require_preprovisioned: bool = False,
+        ) -> LocalCAS:
+            assert require_preprovisioned is True
+            store = real_store(root, require_preprovisioned=True)
+            stores.append(store)
+            return store
+
+        def catalog_factory(
+            path: str | Path,
+            *,
+            create: bool = True,
+            expected_file_identity: tuple[int, int, int] | None = None,
+        ) -> Any:
+            assert create is False
+            assert type(expected_file_identity) is tuple
+            assert expected_file_identity == catalog_identity
+            opened = real_catalog(
+                path,
+                create=False,
+                expected_file_identity=expected_file_identity,
+            )
+            catalogs.append(opened)
+            return opened
+
+        monkeypatch.setattr(
+            cli_module,
+            "_new_retained_output_receipt_owner",
+            owner_factory,
+        )
+        monkeypatch.setattr(storage_module, "LocalCAS", store_factory)
+        monkeypatch.setattr(storage_module, "SQLiteCatalog", catalog_factory)
+        monkeypatch.setattr(
+            codenib_module,
+            "LocalWorkspaceProvider",
+            lambda _root: provider,
+        )
+
+        common = [
+            "artifact",
+            "materialize",
+            "--catalog",
+            str(catalog_path),
+            "--cas-root",
+            str(cas_root),
+            "--workspace-root",
+            str(workspace_root),
+            "--repository",
+            "owner/repo",
+        ]
+        ref_args = cli_module.build_parser().parse_args(
+            [
+                *common,
+                "--ref",
+                imported.ref_name,
+                "--expected-generation",
+                str(imported.generation),
+                "--output",
+                str(ref_output),
+            ]
+        )
+        snapshot_args = cli_module.build_parser().parse_args(
+            [
+                *common,
+                "--snapshot",
+                imported.snapshot_id,
+                "--output",
+                str(snapshot_output),
+            ]
+        )
+        assert ref_args.handler(ref_args) == 0
+        assert snapshot_args.handler(snapshot_args) == 0
+
+        assert len(owners) == 2
+        assert all(owner.closed for owner in owners)
+        assert len(stores) == 2
+        for store in stores:
+            with pytest.raises(StorageIntegrityError, match="closed"):
+                store.has("0" * 64)
+        assert len(catalogs) == 2
+        for opened_catalog in catalogs:
+            with pytest.raises(sqlite3.ProgrammingError):
+                opened_catalog._connection.execute("SELECT 1")
+        for output in (ref_output, snapshot_output):
+            verified = verify_context_artifact(
+                output,
+                expected_repository="owner/repo",
+                expected_commit="a" * 40,
+            )
+            assert verified.views == ("bm25",)
+            assert output.is_dir()
+
+        binding = query_context_artifact(
+            snapshot_output,
+            expected_repository="owner/repo",
+            expected_commit="a" * 40,
+        )
+        context: ServerContext | None = None
+        original_context = mcp_server._ctx
+        original_surface = mcp_server.mcp.tool_surface
+        try:
+            assert not binding.source_bound
+            context = ServerContext.load(
+                binding.manifest,
+                views=("bm25",),
+                artifact_binding=binding,
+            )
+            mcp_server._ctx = context
+            mcp_server.configure_tool_surface("full")
+
+            async def search() -> Any:
+                async with Client(mcp_server.mcp, mode="auto", cache=None) as client:
+                    return await client.call_tool(
+                        "search_bm25",
+                        {"query": "VALUE", "top_k": 5},
+                    )
+
+            response = asyncio.run(search())
+            assert response.is_error is False
+            assert response.structured_content is not None
+            hits = response.structured_content["result"]
+            assert len(hits) == 1
+            assert hits[0]["node_name"] == "sample.VALUE"
+            assert hits[0]["file"] == "sample.py"
+            assert "content" not in hits[0]
+        finally:
+            mcp_server._ctx = original_context
+            mcp_server.configure_tool_surface(original_surface)
+            if context is not None:
+                context.close()
+            binding.close()
+
+        assert fixture.repository.is_dir()
+        cli_output = capsys.readouterr().out
+        assert cli_output.count(f"Snapshot:         {imported.snapshot_id}") == 2
+        assert (
+            f"Selection:        {imported.ref_name}@{imported.generation}" in cli_output
+        )
+        assert "Selection:        immutable snapshot" in cli_output
+        assert cli_output.count("codenib mcp --artifact") == 2
+
+
+def test_cli_post_commit_cancellation_closes_authorities_and_warns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        catalog_path = Path(catalog.path)
+        cas_root = object_store.root
+        catalog.close()
+        object_store.close()
+        catalog_identity = cli_module._retained_catalog_file_identity(catalog_path)
+        with LocalCAS.provision(cas_root):
+            pass
+
+        workspace_root = tmp_path / "local-workspaces"
+        workspace_root.mkdir(mode=0o700)
+        output = workspace_root / "context"
+        cancellation = KeyboardInterrupt("after CLI commit")
+        provider = _PostCommitFailureProvider(cancellation)
+        owners: list[PublishedWorkspaceReceiptOwner] = []
+        stores: list[LocalCAS] = []
+        catalogs: list[Any] = []
+        real_store = LocalCAS
+        real_catalog = storage_module.SQLiteCatalog
+
+        def owner_factory() -> PublishedWorkspaceReceiptOwner:
+            owner = PublishedWorkspaceReceiptOwner()
+            owners.append(owner)
+            return owner
+
+        def store_factory(
+            root: str | Path,
+            *,
+            require_preprovisioned: bool = False,
+        ) -> LocalCAS:
+            assert require_preprovisioned is True
+            opened = real_store(root, require_preprovisioned=True)
+            stores.append(opened)
+            return opened
+
+        def catalog_factory(
+            path: str | Path,
+            *,
+            create: bool = True,
+            expected_file_identity: tuple[int, int, int] | None = None,
+        ) -> Any:
+            assert create is False
+            assert type(expected_file_identity) is tuple
+            assert expected_file_identity == catalog_identity
+            opened = real_catalog(
+                path,
+                create=False,
+                expected_file_identity=expected_file_identity,
+            )
+            catalogs.append(opened)
+            return opened
+
+        monkeypatch.setattr(
+            cli_module,
+            "_new_retained_output_receipt_owner",
+            owner_factory,
+        )
+        monkeypatch.setattr(storage_module, "LocalCAS", store_factory)
+        monkeypatch.setattr(storage_module, "SQLiteCatalog", catalog_factory)
+        monkeypatch.setattr(
+            codenib_module,
+            "LocalWorkspaceProvider",
+            lambda _root: provider,
+        )
+        args = cli_module.build_parser().parse_args(
+            [
+                "artifact",
+                "materialize",
+                "--catalog",
+                str(catalog_path),
+                "--cas-root",
+                str(cas_root),
+                "--workspace-root",
+                str(workspace_root),
+                "--repository",
+                "owner/repo",
+                "--ref",
+                imported.ref_name,
+                "--expected-generation",
+                str(imported.generation),
+                "--output",
+                str(output),
+            ]
+        )
+
+        with pytest.raises(KeyboardInterrupt) as raised:
+            args.handler(args)
+
+        assert raised.value is cancellation
+        assert len(owners) == 1
+        assert owners[0].closed
+        assert len(stores) == 1
+        with pytest.raises(StorageIntegrityError, match="closed"):
+            stores[0].has("0" * 64)
+        assert len(catalogs) == 1
+        with pytest.raises(sqlite3.ProgrammingError):
+            catalogs[0]._connection.execute("SELECT 1")
+        assert verify_context_artifact(
+            output,
+            expected_repository="owner/repo",
+            expected_commit="a" * 40,
+        ).views == ("bm25",)
+        assert output.is_dir()
+        assert "may have been published" in capsys.readouterr().err
 
 
 def test_materializer_requires_retention_without_requiring_ingestion(

--- a/test/compiler/test_manifest_materialization.py
+++ b/test/compiler/test_manifest_materialization.py
@@ -37,7 +37,10 @@ from codenib.compiler.manifest_export import (
     export_retained_repo_manifest_snapshot,
 )
 from codenib.compiler.manifest_materialization import (
+    RepoManifestMaterializationResult,
     materialize_retained_context_artifact,
+    materialize_retained_repo_manifest_ref,
+    materialize_retained_repo_manifest_snapshot,
 )
 from codenib.mcp import server as mcp_server
 from codenib.mcp.context import ServerContext
@@ -203,6 +206,24 @@ class _PostCommitFailureProvider(_TestWorkspaceProvider):
         raise self.error
 
 
+class _SupportProbeProvider(_TestWorkspaceProvider):
+    def __init__(
+        self,
+        error: BaseException | None = None,
+        *,
+        fail_on_call: int = 1,
+    ) -> None:
+        super().__init__()
+        self.error = error
+        self.fail_on_call = fail_on_call
+        self.support_calls = 0
+
+    def require_support(self) -> None:
+        self.support_calls += 1
+        if self.error is not None and self.support_calls >= self.fail_on_call:
+            raise self.error
+
+
 class _TrackedBytesIO(io.BytesIO):
     close_calls = 0
 
@@ -354,6 +375,287 @@ def test_materializer_is_available_through_the_lazy_compiler_api() -> None:
         compiler_module.materialize_retained_context_artifact
         is materialize_retained_context_artifact
     )
+    assert (
+        compiler_module.RepoManifestMaterializationResult
+        is RepoManifestMaterializationResult
+    )
+    assert (
+        compiler_module.materialize_retained_repo_manifest_ref
+        is materialize_retained_repo_manifest_ref
+    )
+    assert (
+        compiler_module.materialize_retained_repo_manifest_snapshot
+        is materialize_retained_repo_manifest_snapshot
+    )
+
+
+def test_materializes_retained_ref_and_snapshot_through_public_orchestration(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        provider = _SupportProbeProvider()
+        ref_owner = PublishedWorkspaceReceiptOwner()
+        snapshot_owner = PublishedWorkspaceReceiptOwner()
+        try:
+            ref_result = materialize_retained_repo_manifest_ref(
+                "owner/repo",
+                tmp_path / "ref-artifact",
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=provider,
+                output_receipt_owner=ref_owner,
+                ref_name=imported.ref_name,
+                expected_generation=imported.generation,
+            )
+            snapshot_result = materialize_retained_repo_manifest_snapshot(
+                "owner/repo",
+                imported.snapshot_id,
+                tmp_path / "snapshot-artifact",
+                catalog=catalog,
+                object_store=object_store,
+                workspace_provider=provider,
+                output_receipt_owner=snapshot_owner,
+            )
+
+            assert type(ref_result) is RepoManifestMaterializationResult
+            assert ref_result.artifact.repository == "owner/repo"
+            assert ref_result.artifact.views == ("bm25",)
+            assert ref_result.export_receipt.repository_id == imported.repository_id
+            assert ref_result.export_receipt.snapshot_id == imported.snapshot_id
+            assert ref_result.export_receipt.ref_name == imported.ref_name
+            assert ref_result.export_receipt.ref_generation == imported.generation
+            assert snapshot_result.artifact.repository == "owner/repo"
+            assert snapshot_result.artifact.views == ("bm25",)
+            assert snapshot_result.export_receipt.snapshot_id == imported.snapshot_id
+            assert snapshot_result.export_receipt.ref_name is None
+            assert snapshot_result.export_receipt.ref_generation is None
+            assert ref_owner.active
+            assert snapshot_owner.active
+            assert provider.support_calls == 4
+
+            with patch.object(
+                materialization_module,
+                "export_retained_repo_manifest_ref",
+            ) as export_ref:
+                with pytest.raises(RuntimeError, match="owner must be empty"):
+                    materialize_retained_repo_manifest_ref(
+                        "owner/repo",
+                        tmp_path / "second-ref-artifact",
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=provider,
+                        output_receipt_owner=ref_owner,
+                    )
+                export_ref.assert_not_called()
+        finally:
+            snapshot_owner.close()
+            ref_owner.close()
+
+
+def test_orchestration_rejects_invalid_output_before_retained_export(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, _imported, object_store, catalog):
+        provider = _TestWorkspaceProvider()
+        owner = PublishedWorkspaceReceiptOwner()
+        existing = tmp_path / "existing"
+        existing.mkdir()
+        try:
+            with patch.object(
+                materialization_module,
+                "export_retained_repo_manifest_ref",
+            ) as export_ref:
+                with pytest.raises(StorageValidationError, match="context byte limit"):
+                    materialize_retained_repo_manifest_ref(
+                        "owner/repo",
+                        tmp_path / "invalid-limit",
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=provider,
+                        output_receipt_owner=owner,
+                        max_context_bytes=0,
+                    )
+                with pytest.raises(ValueError, match="destination|missing|exist"):
+                    materialize_retained_repo_manifest_ref(
+                        "owner/repo",
+                        existing,
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=provider,
+                        output_receipt_owner=owner,
+                    )
+                export_ref.assert_not_called()
+        finally:
+            owner.close()
+
+
+def test_orchestration_rejects_invalid_identity_or_support_before_export(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, _imported, object_store, catalog):
+        support_error = UnsupportedWorkspaceCreation("unsupported provider")
+        unsupported = _SupportProbeProvider(support_error)
+        unused = _SupportProbeProvider()
+        owner = PublishedWorkspaceReceiptOwner()
+        try:
+            with (
+                patch.object(
+                    materialization_module,
+                    "export_retained_repo_manifest_ref",
+                ) as export_ref,
+                patch.object(
+                    materialization_module,
+                    "export_retained_repo_manifest_snapshot",
+                ) as export_snapshot,
+            ):
+                with pytest.raises(StorageValidationError, match="canonical slug"):
+                    materialize_retained_repo_manifest_ref(
+                        " Owner/Repo ",
+                        tmp_path / "invalid-repository",
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=unused,
+                        output_receipt_owner=owner,
+                    )
+                with pytest.raises(StorageValidationError, match="ref name"):
+                    materialize_retained_repo_manifest_ref(
+                        "owner/repo",
+                        tmp_path / "invalid-ref",
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=unused,
+                        output_receipt_owner=owner,
+                        ref_name=" main ",
+                    )
+                with pytest.raises(StorageValidationError, match="namespace"):
+                    materialize_retained_repo_manifest_ref(
+                        "owner/repo",
+                        tmp_path / "invalid-namespace",
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=unused,
+                        output_receipt_owner=owner,
+                        namespace_name=" default ",
+                    )
+                with pytest.raises(StorageValidationError, match="generation"):
+                    materialize_retained_repo_manifest_ref(
+                        "owner/repo",
+                        tmp_path / "invalid-generation",
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=unused,
+                        output_receipt_owner=owner,
+                        expected_generation=0,
+                    )
+                with pytest.raises(StorageValidationError, match="snapshot ID"):
+                    materialize_retained_repo_manifest_snapshot(
+                        "owner/repo",
+                        " snapshot ",
+                        tmp_path / "invalid-snapshot",
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=unused,
+                        output_receipt_owner=owner,
+                    )
+                with pytest.raises(StorageValidationError, match="canonical slug"):
+                    materialize_retained_repo_manifest_ref(
+                        "a" * 32_769,
+                        tmp_path / "oversized-repository",
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=unused,
+                        output_receipt_owner=owner,
+                    )
+                with pytest.raises(UnsupportedWorkspaceCreation) as raised:
+                    materialize_retained_repo_manifest_ref(
+                        "owner/repo",
+                        tmp_path / "unsupported",
+                        catalog=catalog,
+                        object_store=object_store,
+                        workspace_provider=unsupported,
+                        output_receipt_owner=owner,
+                    )
+                assert raised.value is support_error
+                export_ref.assert_not_called()
+                export_snapshot.assert_not_called()
+            assert unused.support_calls == 0
+            assert unsupported.support_calls == 1
+        finally:
+            owner.close()
+
+
+def test_orchestration_preserves_post_commit_output_authority(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        cancellation = KeyboardInterrupt("after orchestrated commit")
+        provider = _PostCommitFailureProvider(cancellation)
+        owner = PublishedWorkspaceReceiptOwner()
+        destination = tmp_path / "artifact"
+        try:
+            with pytest.raises(KeyboardInterrupt) as raised:
+                materialize_retained_repo_manifest_ref(
+                    "owner/repo",
+                    destination,
+                    catalog=catalog,
+                    object_store=object_store,
+                    workspace_provider=provider,
+                    output_receipt_owner=owner,
+                    ref_name=imported.ref_name,
+                    expected_generation=imported.generation,
+                )
+            assert raised.value is cancellation
+            assert owner.active
+            assert owner.receipt.path == destination
+            assert verify_context_artifact(destination).views == ("bm25",)
+        finally:
+            owner.close()
+        assert owner.closed
+        assert destination.is_dir()
+
+
+def test_orchestration_rechecks_provider_support_before_publication(
+    tmp_path: Path,
+) -> None:
+    with _retained_fixture(
+        tmp_path / "retained",
+        views=("bm25",),
+    ) as (_fixture, imported, object_store, catalog):
+        support_error = UnsupportedWorkspaceCreation("support changed")
+        provider = _SupportProbeProvider(support_error, fail_on_call=2)
+        owner = PublishedWorkspaceReceiptOwner()
+        destination = tmp_path / "artifact"
+        try:
+            with pytest.raises(UnsupportedWorkspaceCreation) as raised:
+                materialize_retained_repo_manifest_ref(
+                    "owner/repo",
+                    destination,
+                    catalog=catalog,
+                    object_store=object_store,
+                    workspace_provider=provider,
+                    output_receipt_owner=owner,
+                    ref_name=imported.ref_name,
+                    expected_generation=imported.generation,
+                )
+            assert raised.value is support_error
+            assert provider.support_calls == 2
+            assert provider.run_count == 0
+            assert owner.state == "empty"
+            assert not destination.exists()
+        finally:
+            owner.close()
 
 
 def test_materializes_retained_export_as_exact_query_compatible_artifact(

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from threading import Barrier
 
 import pytest
 
 import codenib.storage.protocols as storage_protocols
+import codenib.storage.sqlite_catalog as sqlite_catalog_module
 from codenib.storage.cas import LocalCAS
 from codenib.storage.models import (
     ObjectRecord,
@@ -90,6 +92,24 @@ def _setup_staged_view(catalog: SQLiteCatalog, suffix: str = "a"):
     return repository_id, source_revision_id, profile_id, object_digest, view_id
 
 
+def _catalog_file_identity(path: Path) -> tuple[int, int, int]:
+    metadata = path.lstat()
+    return int(metadata.st_dev), int(metadata.st_ino), int(metadata.st_nlink)
+
+
+def _prepare_delete_journal_catalog(path: Path) -> bytes:
+    with SQLiteCatalog(path):
+        pass
+    connection = sqlite3.connect(path)
+    try:
+        assert connection.execute("PRAGMA journal_mode = DELETE").fetchone()[0] == (
+            "delete"
+        )
+    finally:
+        connection.close()
+    return path.read_bytes()
+
+
 def test_initializes_pragmas_default_namespace_and_idempotent_reopen(tmp_path):
     path = tmp_path / "catalog.sqlite3"
 
@@ -116,6 +136,269 @@ def test_initializes_pragmas_default_namespace_and_idempotent_reopen(tmp_path):
             "SELECT COUNT(*) FROM schema_migrations"
         ).fetchone()[0]
         assert migration_count == LATEST_SCHEMA_VERSION
+
+
+def test_existing_only_mode_never_creates_a_missing_catalog(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+
+    with pytest.raises(CatalogError, match="existing SQLite catalog"):
+        SQLiteCatalog(path, create=False)
+
+    assert not path.exists()
+
+    nested = tmp_path / "missing" / "catalog.sqlite3"
+    with pytest.raises(CatalogError, match="existing SQLite catalog"):
+        SQLiteCatalog(nested, create=False)
+    assert not nested.parent.exists()
+
+    with SQLiteCatalog(path) as created:
+        assert created.schema_version == LATEST_SCHEMA_VERSION
+    with SQLiteCatalog(path, create=False) as reopened:
+        assert reopened.schema_version == LATEST_SCHEMA_VERSION
+
+    escaped = tmp_path / "catalog #%25.sqlite3"
+    with SQLiteCatalog(escaped):
+        pass
+    with SQLiteCatalog(escaped, create=False) as reopened:
+        assert reopened.schema_version == LATEST_SCHEMA_VERSION
+
+
+@pytest.mark.parametrize(
+    ("identity", "error", "message"),
+    (
+        ([1, 2, 1], TypeError, "exact 3-tuple"),
+        ((1, 2), TypeError, "exact 3-tuple"),
+        ((True, 2, 1), TypeError, "exact 3-tuple"),
+        ((0, 2, 1), ValueError, "positive integers"),
+        ((1, 0, 1), ValueError, "positive integers"),
+        ((1, 2, 2), ValueError, "link count must be 1"),
+    ),
+)
+def test_existing_only_expected_file_identity_is_an_exact_single_link_token(
+    tmp_path,
+    identity,
+    error,
+    message,
+):
+    path = tmp_path / "catalog.sqlite3"
+
+    with pytest.raises(error, match=message):
+        SQLiteCatalog(
+            path,
+            create=False,
+            expected_file_identity=identity,
+        )
+
+    assert not path.exists()
+
+
+def test_expected_file_identity_is_existing_only(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+
+    with pytest.raises(ValueError, match="requires create=False"):
+        SQLiteCatalog(path, expected_file_identity=(1, 2, 1))
+
+    assert not path.exists()
+
+
+def test_existing_only_rejects_stable_replacement_before_connect(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_delete_journal_catalog(path)
+    expected_identity = _catalog_file_identity(path)
+    replacement = tmp_path / "replacement.sqlite3"
+    expected_bytes = _prepare_delete_journal_catalog(replacement)
+    replacement.replace(path)
+    real_connect = sqlite3.connect
+    connect_calls = 0
+
+    def forbidden_connect(*_args, **_kwargs):
+        nonlocal connect_calls
+        connect_calls += 1
+        pytest.fail("a persistently replaced catalog must be rejected before connect")
+
+    monkeypatch.setattr(sqlite_catalog_module.sqlite3, "connect", forbidden_connect)
+
+    with pytest.raises(CatalogError, match="file identity changed"):
+        SQLiteCatalog(
+            path,
+            create=False,
+            expected_file_identity=expected_identity,
+        )
+
+    assert connect_calls == 0
+    assert path.read_bytes() == expected_bytes
+    assert not Path(f"{path}-wal").exists()
+    assert not Path(f"{path}-shm").exists()
+    connection = real_connect(path)
+    try:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == (
+            LATEST_SCHEMA_VERSION
+        )
+    finally:
+        connection.close()
+
+
+def test_existing_only_rejects_persistent_replacement_during_connect(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_delete_journal_catalog(path)
+    expected_identity = _catalog_file_identity(path)
+    replacement = tmp_path / "replacement.sqlite3"
+    expected_bytes = _prepare_delete_journal_catalog(replacement)
+    real_connect = sqlite3.connect
+    opened_connections: list[sqlite3.Connection] = []
+    schema_checks = 0
+    migration_calls = 0
+
+    def replacing_connect(database, *args, **kwargs):
+        replacement.replace(path)
+        connection = real_connect(database, *args, **kwargs)
+        opened_connections.append(connection)
+        return connection
+
+    def forbidden_schema_check(_catalog):
+        nonlocal schema_checks
+        schema_checks += 1
+        pytest.fail("replacement must be rejected before catalog schema inspection")
+
+    def forbidden_migration(_catalog):
+        nonlocal migration_calls
+        migration_calls += 1
+        pytest.fail("replacement must be rejected before migration")
+
+    monkeypatch.setattr(sqlite_catalog_module.sqlite3, "connect", replacing_connect)
+    monkeypatch.setattr(
+        SQLiteCatalog,
+        "_require_existing_catalog_identity",
+        forbidden_schema_check,
+    )
+    monkeypatch.setattr(SQLiteCatalog, "_migrate", forbidden_migration)
+
+    with pytest.raises(CatalogError, match="file identity changed"):
+        SQLiteCatalog(
+            path,
+            create=False,
+            expected_file_identity=expected_identity,
+        )
+
+    assert len(opened_connections) == 1
+    with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+        opened_connections[0].execute("SELECT 1")
+    assert schema_checks == 0
+    assert migration_calls == 0
+    assert path.read_bytes() == expected_bytes
+    assert not Path(f"{path}-wal").exists()
+    assert not Path(f"{path}-shm").exists()
+    connection = real_connect(path)
+    try:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == (
+            LATEST_SCHEMA_VERSION
+        )
+    finally:
+        connection.close()
+
+
+def test_existing_only_mode_rejects_empty_or_foreign_databases(tmp_path):
+    empty = tmp_path / "empty.sqlite3"
+    empty.touch()
+
+    with pytest.raises(CatalogError, match="initialized CodeNib catalog"):
+        SQLiteCatalog(empty, create=False)
+
+    assert empty.stat().st_size == 0
+    assert not Path(f"{empty}-wal").exists()
+    assert not Path(f"{empty}-shm").exists()
+
+    foreign = tmp_path / "foreign.sqlite3"
+    connection = sqlite3.connect(foreign)
+    connection.execute("CREATE TABLE sentinel(value TEXT NOT NULL)")
+    connection.execute("INSERT INTO sentinel(value) VALUES ('preserved')")
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(CatalogError, match="initialized CodeNib catalog"):
+        SQLiteCatalog(foreign, create=False)
+
+    connection = sqlite3.connect(foreign)
+    try:
+        tables = tuple(
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+            )
+        )
+        assert tables == ("sentinel",)
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 0
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert connection.execute("SELECT value FROM sentinel").fetchone()[0] == (
+            "preserved"
+        )
+    finally:
+        connection.close()
+    assert not Path(f"{foreign}-wal").exists()
+    assert not Path(f"{foreign}-shm").exists()
+
+    migration_db = tmp_path / "foreign-migrations.sqlite3"
+    connection = sqlite3.connect(migration_db)
+    connection.execute(
+        """
+        CREATE TABLE schema_migrations (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        "INSERT INTO schema_migrations(version, applied_at) VALUES (1, 'foreign')"
+    )
+    connection.execute("PRAGMA user_version = 1")
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(CatalogError, match="initialized CodeNib catalog"):
+        SQLiteCatalog(migration_db, create=False)
+
+    connection = sqlite3.connect(migration_db)
+    try:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert tuple(
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+            )
+        ) == ("schema_migrations",)
+    finally:
+        connection.close()
+    assert not Path(f"{migration_db}-wal").exists()
+    assert not Path(f"{migration_db}-shm").exists()
+
+
+def test_existing_only_mode_maps_corrupt_database_errors(tmp_path):
+    path = tmp_path / "corrupt.sqlite3"
+    path.write_bytes(b"not a sqlite database")
+
+    with pytest.raises(CatalogError, match="could not be initialized") as raised:
+        SQLiteCatalog(path, create=False)
+
+    assert isinstance(raised.value.__cause__, sqlite3.DatabaseError)
+    assert path.read_bytes() == b"not a sqlite database"
+
+
+def test_existing_only_mode_requires_an_exact_boolean(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+
+    with pytest.raises(TypeError, match="create must be a boolean"):
+        SQLiteCatalog(path, create=1)  # type: ignore[arg-type]
+
+    assert not path.exists()
 
 
 def test_reopen_rejects_mismatched_schema_version_records(tmp_path):

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -110,6 +110,24 @@ def _prepare_delete_journal_catalog(path: Path) -> bytes:
     return path.read_bytes()
 
 
+def _schema_snapshot(path: Path) -> tuple[tuple[object, ...], ...]:
+    connection = sqlite3.connect(path)
+    try:
+        return tuple(
+            tuple(row)
+            for row in connection.execute(
+                """
+                SELECT type, name, tbl_name, sql
+                FROM sqlite_master
+                WHERE substr(name, 1, 7) != 'sqlite_'
+                ORDER BY type, name, tbl_name
+                """
+            )
+        )
+    finally:
+        connection.close()
+
+
 def test_initializes_pragmas_default_namespace_and_idempotent_reopen(tmp_path):
     path = tmp_path / "catalog.sqlite3"
 
@@ -379,6 +397,69 @@ def test_existing_only_mode_rejects_empty_or_foreign_databases(tmp_path):
         connection.close()
     assert not Path(f"{migration_db}-wal").exists()
     assert not Path(f"{migration_db}-shm").exists()
+
+
+def test_existing_only_rejects_a_foreign_claimed_complete_version_before_wal(
+    tmp_path,
+):
+    path = tmp_path / "foreign-version-claim.sqlite3"
+    connection = sqlite3.connect(path)
+    connection.execute(sqlite_catalog_module._SCHEMA_MIGRATIONS_SQL)
+    for table in sorted(
+        sqlite_catalog_module._V1_CATALOG_TABLES - {"schema_migrations"}
+    ):
+        connection.execute(f"CREATE TABLE {table} (foreign_value TEXT)")
+    connection.executemany(
+        "INSERT INTO schema_migrations(version, applied_at) VALUES (?, 'foreign')",
+        ((version,) for version in range(1, LATEST_SCHEMA_VERSION + 1)),
+    )
+    connection.execute(f"PRAGMA user_version = {LATEST_SCHEMA_VERSION:d}")
+    connection.commit()
+    connection.close()
+    schema_before = _schema_snapshot(path)
+
+    with pytest.raises(CatalogError, match="initialized CodeNib catalog"):
+        SQLiteCatalog(path, create=False)
+
+    assert _schema_snapshot(path) == schema_before
+    connection = sqlite3.connect(path)
+    try:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == (
+            LATEST_SCHEMA_VERSION
+        )
+    finally:
+        connection.close()
+    assert not Path(f"{path}-wal").exists()
+    assert not Path(f"{path}-shm").exists()
+
+
+def test_existing_only_forward_migrates_an_exact_older_catalog_schema(tmp_path):
+    path = tmp_path / "version-one.sqlite3"
+    connection = sqlite3.connect(path)
+    connection.execute(sqlite_catalog_module._SCHEMA_MIGRATIONS_SQL)
+    for statement in sqlite_catalog_module._MIGRATIONS[1]:
+        connection.execute(statement)
+    connection.execute(
+        """
+        INSERT INTO namespaces(namespace_id, name, created_at)
+        VALUES (?, 'default', '2026-01-01T00:00:00+00:00')
+        """,
+        (DEFAULT_NAMESPACE_ID,),
+    )
+    connection.execute(
+        "INSERT INTO schema_migrations(version, applied_at) VALUES (1, 'legacy')"
+    )
+    connection.execute("PRAGMA user_version = 1")
+    connection.commit()
+    connection.close()
+
+    with SQLiteCatalog(path, create=False) as catalog:
+        assert catalog.schema_version == LATEST_SCHEMA_VERSION
+        assert catalog.create_namespace("default") == DEFAULT_NAMESPACE_ID
+
+    with SQLiteCatalog(path, create=False) as reopened:
+        assert reopened.schema_version == LATEST_SCHEMA_VERSION
 
 
 def test_existing_only_mode_maps_corrupt_database_errors(tmp_path):

--- a/test/storage/test_sqlite_jobs.py
+++ b/test/storage/test_sqlite_jobs.py
@@ -259,7 +259,7 @@ def test_forward_migrates_v1_catalog_without_losing_existing_rows(
     monkeypatch.setattr(
         sqlite_catalog_module, "LATEST_SCHEMA_VERSION", LATEST_SCHEMA_VERSION
     )
-    with SQLiteCatalog(path) as catalog:
+    with SQLiteCatalog(path, create=False) as catalog:
         assert catalog.schema_version == LATEST_SCHEMA_VERSION
         assert catalog.create_repository("owner/repo") == repository_id
         assert (

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import dis
 import errno
 import json
 import sys
@@ -14,11 +15,21 @@ from types import SimpleNamespace
 import pytest
 import yaml
 
+import codenib
+import codenib.compiler.manifest_materialization as materialization_module
+import codenib.storage as storage_module
 import codenib.web.local as local_module
 from codenib import cli
 from codenib.source_fingerprint import RepositorySourceBinding
 from codenib.web import launcher
 from codenib.web.local import prepare_local_wiki
+
+
+def _cleanup_notes(error: BaseException) -> tuple[str, ...]:
+    return (
+        *tuple(getattr(error, "__notes__", ())),
+        *tuple(getattr(error, "_codenib_cleanup_notes", ())),
+    )
 
 
 def test_parser_exposes_release_commands() -> None:
@@ -142,6 +153,794 @@ def test_publish_and_artifact_parsers_expose_distribution_options() -> None:
     assert publish.embedding_provider == "openai"
     assert artifact.artifact_command == "pack"
     assert artifact.view == ["bm25,vector"]
+
+
+def test_artifact_materialize_parser_exposes_strict_storage_inputs() -> None:
+    base = [
+        "artifact",
+        "materialize",
+        "--catalog",
+        "/state/catalog.sqlite3",
+        "--cas-root",
+        "/state/cas",
+        "--workspace-root",
+        "/state/workspaces",
+        "--repository",
+        "owner/repo",
+        "--output",
+        "/state/workspaces/context",
+    ]
+    ref = cli.build_parser().parse_args(
+        [*base, "--ref", "release", "--expected-generation", "7"]
+    )
+    snapshot = cli.build_parser().parse_args([*base, "--snapshot", "snap_123"])
+
+    assert ref.handler is cli._run_artifact_materialize
+    assert ref.ref == "release"
+    assert ref.snapshot is None
+    assert ref.expected_generation == 7
+    assert snapshot.ref is None
+    assert snapshot.snapshot == "snap_123"
+    assert snapshot.expected_generation is None
+
+    with pytest.raises(SystemExit) as both:
+        cli.build_parser().parse_args(
+            [*base, "--ref", "main", "--snapshot", "snap_123"]
+        )
+    assert both.value.code == 2
+    with pytest.raises(SystemExit) as nonpositive:
+        cli.build_parser().parse_args([*base, "--expected-generation", "0"])
+    assert nonpositive.value.code == 2
+
+
+def test_artifact_materialize_preflight_rejects_unsafe_selection_and_paths(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(cli.CLIError, match="requires ref"):
+        cli._retained_materialization_selector(
+            ref_name=None,
+            snapshot_id="snap_123",
+            expected_generation=1,
+        )
+
+    args = cli.build_parser().parse_args(
+        [
+            "artifact",
+            "materialize",
+            "--catalog",
+            str(tmp_path / "catalog.sqlite3"),
+            "--cas-root",
+            str(tmp_path / "cas"),
+            "--workspace-root",
+            str(tmp_path / "workspaces"),
+            "--repository",
+            "owner/repo",
+            "--output",
+            str(tmp_path / "outside"),
+        ]
+    )
+    with pytest.raises(cli.CLIError, match="below the workspace root"):
+        cli._retained_materialization_paths(args)
+
+    with pytest.raises(cli.CLIError, match="path is invalid"):
+        cli._lexical_cli_path("bad\x00path", label="catalog")
+    with pytest.raises(cli.CLIError, match="path is invalid"):
+        cli._lexical_cli_path("~__codenib_missing_user__/catalog", label="catalog")
+
+
+def test_artifact_materialize_rejects_physical_storage_aliases(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    catalog_target = workspace_root / "catalog.sqlite3"
+    catalog_target.touch()
+    catalog_link = tmp_path / "catalog-link.sqlite3"
+    catalog_link.symlink_to(catalog_target)
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    output = workspace_root / "context"
+
+    with pytest.raises(cli.CLIError, match="physically overlap the workspace"):
+        cli._require_retained_materialization_topology(
+            catalog_link,
+            cas_root,
+            workspace_root,
+            output,
+        )
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    redirected_parent = workspace_root / "redirected"
+    redirected_parent.symlink_to(outside, target_is_directory=True)
+    outside_catalog = tmp_path / "catalog.sqlite3"
+    outside_catalog.touch()
+    with pytest.raises(cli.CLIError, match="existing real directories"):
+        cli._require_retained_materialization_topology(
+            outside_catalog,
+            cas_root,
+            workspace_root,
+            redirected_parent / "context",
+        )
+
+    real_parent = workspace_root / "real-parent"
+    real_parent.mkdir()
+    aliased_parent = workspace_root / "aliased-parent"
+    aliased_parent.symlink_to(real_parent, target_is_directory=True)
+    with pytest.raises(cli.CLIError, match="existing real directories"):
+        cli._require_retained_materialization_topology(
+            outside_catalog,
+            cas_root,
+            workspace_root,
+            aliased_parent / "context",
+        )
+    with pytest.raises(cli.CLIError, match="parent must already exist"):
+        cli._require_retained_materialization_topology(
+            outside_catalog,
+            cas_root,
+            workspace_root,
+            workspace_root / "missing-parent" / "context",
+        )
+
+    hardlink = tmp_path / "catalog-hardlink.sqlite3"
+    hardlink.hardlink_to(outside_catalog)
+    with pytest.raises(cli.CLIError, match="single-linked regular file"):
+        cli._require_retained_materialization_topology(
+            outside_catalog,
+            cas_root,
+            workspace_root,
+            output,
+        )
+    hardlink.unlink()
+
+    support_calls = 0
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            nonlocal support_calls
+            support_calls += 1
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: pytest.fail("CAS must not be opened"),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: pytest.fail("catalog must not be opened"),
+    )
+    args = SimpleNamespace(
+        repository="owner/repo",
+        namespace="default",
+        ref="main",
+        snapshot=None,
+        expected_generation=None,
+        catalog=str(catalog_link),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        output=str(output),
+    )
+    with pytest.raises(cli.CLIError, match="physically overlap the workspace"):
+        cli._run_artifact_materialize(args)
+    assert support_calls == 1
+
+
+def test_artifact_materialize_opens_frozen_physical_storage_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    outside_catalog = tmp_path / "catalog.sqlite3"
+    outside_catalog.touch()
+    inside_catalog = workspace_root / "catalog.sqlite3"
+    inside_catalog.touch()
+    catalog_link = tmp_path / "catalog-link.sqlite3"
+    catalog_link.symlink_to(outside_catalog)
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    catalog_identity = cli._retained_catalog_file_identity(outside_catalog)
+    opened_catalogs: list[tuple[Path, dict[str, object]]] = []
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            pass
+
+    class Closeable:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    owner = Closeable()
+    store = Closeable()
+
+    def store_factory(root: Path, **_kwargs: object) -> Closeable:
+        assert root == cas_root.resolve(strict=True)
+        catalog_link.unlink()
+        catalog_link.symlink_to(inside_catalog)
+        return store
+
+    def catalog_factory(path: Path, **_kwargs: object) -> None:
+        opened_catalogs.append((path, _kwargs))
+        raise RuntimeError("stop after catalog path capture")
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(cli, "_new_retained_output_receipt_owner", lambda: owner)
+    monkeypatch.setattr(storage_module, "LocalCAS", store_factory)
+    monkeypatch.setattr(storage_module, "SQLiteCatalog", catalog_factory)
+    args = SimpleNamespace(
+        repository="owner/repo",
+        namespace="default",
+        ref="main",
+        snapshot=None,
+        expected_generation=None,
+        catalog=str(catalog_link),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        output=str(workspace_root / "context"),
+    )
+
+    with pytest.raises(cli.CLIError, match="stop after catalog path capture"):
+        cli._run_artifact_materialize(args)
+
+    assert catalog_link.resolve(strict=True) == inside_catalog
+    assert opened_catalogs == [
+        (
+            outside_catalog.resolve(strict=True),
+            {
+                "create": False,
+                "expected_file_identity": catalog_identity,
+            },
+        )
+    ]
+    assert store.closed
+    assert owner.closed
+
+
+def test_artifact_materialize_rejects_catalog_leaf_rebinding_before_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    catalog_path = tmp_path / "catalog.sqlite3"
+    catalog_path.touch()
+    replacement = workspace_root / "replacement.sqlite3"
+    replacement.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    catalog_opened = False
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            pass
+
+    class Closeable:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    owner = Closeable()
+    store = Closeable()
+
+    def store_factory(root: Path, **_kwargs: object) -> Closeable:
+        assert root == cas_root.resolve(strict=True)
+        catalog_path.unlink()
+        catalog_path.symlink_to(replacement)
+        return store
+
+    def catalog_factory(*_args: object, **_kwargs: object) -> None:
+        nonlocal catalog_opened
+        catalog_opened = True
+        pytest.fail("rebound catalog must not be opened")
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(cli, "_new_retained_output_receipt_owner", lambda: owner)
+    monkeypatch.setattr(storage_module, "LocalCAS", store_factory)
+    monkeypatch.setattr(storage_module, "SQLiteCatalog", catalog_factory)
+    args = SimpleNamespace(
+        repository="owner/repo",
+        namespace="default",
+        ref="main",
+        snapshot=None,
+        expected_generation=None,
+        catalog=str(catalog_path),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        output=str(workspace_root / "context"),
+    )
+
+    with pytest.raises(cli.CLIError, match="changed after physical topology"):
+        cli._run_artifact_materialize(args)
+
+    assert catalog_path.resolve(strict=True) == replacement
+    assert not catalog_opened
+    assert store.closed
+    assert owner.closed
+
+
+def test_artifact_materialize_rejects_catalog_rebinding_during_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    catalog_path = tmp_path / "catalog.sqlite3"
+    catalog_path.touch()
+    replacement = workspace_root / "replacement.sqlite3"
+    replacement.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    catalog_identity = cli._retained_catalog_file_identity(catalog_path)
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            pass
+
+    class Closeable:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    owner = Closeable()
+    store = Closeable()
+    catalog = Closeable()
+
+    def catalog_factory(path: Path, **kwargs: object) -> Closeable:
+        assert path == catalog_path
+        assert kwargs == {
+            "create": False,
+            "expected_file_identity": catalog_identity,
+        }
+        catalog_path.unlink()
+        catalog_path.symlink_to(replacement)
+        return catalog
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(cli, "_new_retained_output_receipt_owner", lambda: owner)
+    monkeypatch.setattr(storage_module, "LocalCAS", lambda *_args, **_kwargs: store)
+    monkeypatch.setattr(storage_module, "SQLiteCatalog", catalog_factory)
+    args = SimpleNamespace(
+        repository="owner/repo",
+        namespace="default",
+        ref="main",
+        snapshot=None,
+        expected_generation=None,
+        catalog=str(catalog_path),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        output=str(workspace_root / "context"),
+    )
+
+    with pytest.raises(cli.CLIError, match="changed after physical topology"):
+        cli._run_artifact_materialize(args)
+
+    assert catalog_path.resolve(strict=True) == replacement
+    assert catalog.closed
+    assert store.closed
+    assert owner.closed
+
+
+def test_artifact_materialize_rejects_cross_device_output_parent_before_storage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    mounted_parent = workspace_root / "mounted"
+    mounted_parent.mkdir()
+    catalog_path = tmp_path / "catalog.sqlite3"
+    catalog_path.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    mounted_metadata = mounted_parent.lstat()
+    original_lstat = Path.lstat
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            pass
+
+    def lstat_with_mount(path: Path):
+        metadata = original_lstat(path)
+        if path == mounted_parent:
+            return SimpleNamespace(
+                st_mode=metadata.st_mode,
+                st_dev=mounted_metadata.st_dev + 1,
+            )
+        return metadata
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(Path, "lstat", lstat_with_mount)
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: pytest.fail("CAS must not be opened"),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: pytest.fail("catalog must not be opened"),
+    )
+    args = SimpleNamespace(
+        repository="owner/repo",
+        namespace="default",
+        ref="main",
+        snapshot=None,
+        expected_generation=None,
+        catalog=str(catalog_path),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        output=str(mounted_parent / "context"),
+    )
+
+    with pytest.raises(cli.CLIError, match="workspace filesystem"):
+        cli._run_artifact_materialize(args)
+
+
+def test_artifact_materialize_provider_failure_precedes_storage_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_output = tmp_path / "workspaces" / "context"
+    existing_output.mkdir(parents=True)
+
+    class UnsupportedProvider:
+        def __init__(self, root: Path) -> None:
+            assert root == tmp_path / "workspaces"
+
+        def require_support(self) -> None:
+            raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", UnsupportedProvider)
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: pytest.fail("CAS must not be opened"),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: pytest.fail("catalog must not be opened"),
+    )
+    args = cli.build_parser().parse_args(
+        [
+            "artifact",
+            "materialize",
+            "--catalog",
+            str(tmp_path / "catalog.sqlite3"),
+            "--cas-root",
+            str(tmp_path / "cas"),
+            "--workspace-root",
+            str(tmp_path / "workspaces"),
+            "--repository",
+            "owner/repo",
+            "--output",
+            str(existing_output),
+        ]
+    )
+
+    with pytest.raises(cli.CLIError, match="provider unavailable"):
+        args.handler(args)
+
+
+def _materialize_cli_test_args(tmp_path: Path) -> SimpleNamespace:
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    return SimpleNamespace(
+        repository="owner/repo",
+        namespace="default",
+        ref="main",
+        snapshot=None,
+        expected_generation=None,
+        catalog=str(catalog),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        output=str(workspace_root / "context"),
+    )
+
+
+def test_artifact_materialize_resource_store_interruption_closes_authorities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    interruption = KeyboardInterrupt("resource result stored")
+
+    class Provider:
+        def __init__(self, _root: Path) -> None:
+            pass
+
+        def require_support(self) -> None:
+            pass
+
+    class Closeable:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    owner = Closeable()
+    store = Closeable()
+    acquire = cli._RetainedMaterializationResourceOwner.acquire
+    instructions = tuple(dis.get_instructions(acquire))
+    store_indexes = {
+        index
+        for index, instruction in enumerate(instructions[:-1])
+        if instruction.opname == "STORE_ATTR" and instruction.argval == "_resource"
+    }
+    assert len(store_indexes) == 1
+    injection_offsets = {instructions[index + 1].offset for index in store_indexes}
+    injected = False
+    previous_trace = sys.gettrace()
+
+    def trace(frame, event: str, _arg: object):
+        nonlocal injected
+        if event == "call" and frame.f_code is acquire.__code__:
+            frame.f_trace_opcodes = True
+            return trace
+        if (
+            not injected
+            and event == "opcode"
+            and frame.f_code is acquire.__code__
+            and frame.f_lasti in injection_offsets
+            and frame.f_locals["self"]._resource is store
+        ):
+            injected = True
+            sys.settrace(None)
+            raise interruption
+        return trace
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(cli, "_new_retained_output_receipt_owner", lambda: owner)
+    monkeypatch.setattr(storage_module, "LocalCAS", lambda *_args, **_kwargs: store)
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: pytest.fail("catalog must not be opened"),
+    )
+    sys.settrace(trace)
+    try:
+        with pytest.raises(KeyboardInterrupt) as raised:
+            cli._run_artifact_materialize(_materialize_cli_test_args(tmp_path))
+    finally:
+        sys.settrace(previous_trace)
+
+    assert injected
+    assert raised.value is interruption
+    assert store.closed
+    assert owner.closed
+
+
+def test_artifact_materialize_cleanup_failures_preserve_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = KeyboardInterrupt("materialization primary")
+
+    class Provider:
+        def __init__(self, _root: Path) -> None:
+            pass
+
+        def require_support(self) -> None:
+            pass
+
+    class ReceiptOwner:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class RetryableResource:
+        def __init__(self, label: str) -> None:
+            self.label = label
+            self.allow_close = False
+            self.closed = False
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+            if not self.allow_close:
+                raise OSError(f"{self.label} close failed")
+            self.closed = True
+
+    owner = ReceiptOwner()
+    store = RetryableResource("CAS")
+    catalog = RetryableResource("catalog")
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(cli, "_new_retained_output_receipt_owner", lambda: owner)
+    monkeypatch.setattr(storage_module, "LocalCAS", lambda *_args, **_kwargs: store)
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: catalog,
+    )
+
+    def fail_materialization(*_args: object, **_kwargs: object) -> None:
+        raise primary
+
+    monkeypatch.setattr(
+        materialization_module,
+        "materialize_retained_repo_manifest_ref",
+        fail_materialization,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        cli._run_artifact_materialize(_materialize_cli_test_args(tmp_path))
+
+    assert raised.value is primary
+    assert owner.closed
+    assert store.close_calls == 1
+    assert catalog.close_calls == 1
+    notes = _cleanup_notes(primary)
+    assert any("SQLite catalog cleanup" in note for note in notes)
+    assert any("local CAS cleanup" in note for note in notes)
+    retained = primary.publication_cleanup_owners  # type: ignore[attr-defined]
+    assert type(retained) is tuple
+    assert len(retained) == 2
+    store.allow_close = True
+    catalog.allow_close = True
+    for cleanup_owner in retained:
+        cleanup_owner.close()
+        assert cleanup_owner.closed
+    assert store.closed
+    assert catalog.closed
+
+
+def test_artifact_materialize_warning_failure_is_secondary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = KeyboardInterrupt("materialization primary")
+    warning_error = OSError("warning failed")
+
+    class Provider:
+        def __init__(self, _root: Path) -> None:
+            pass
+
+        def require_support(self) -> None:
+            pass
+
+    class Closeable:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    owner = Closeable()
+    store = Closeable()
+    catalog = Closeable()
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(cli, "_new_retained_output_receipt_owner", lambda: owner)
+    monkeypatch.setattr(storage_module, "LocalCAS", lambda *_args, **_kwargs: store)
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: catalog,
+    )
+    monkeypatch.setattr(
+        materialization_module,
+        "materialize_retained_repo_manifest_ref",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(primary),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_warn_possible_retained_publication",
+        lambda _output: (_ for _ in ()).throw(warning_error),
+    )
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        cli._run_artifact_materialize(_materialize_cli_test_args(tmp_path))
+
+    assert raised.value is primary
+    assert owner.closed
+    assert store.closed
+    assert catalog.closed
+    assert any(
+        "retained publication warning also failed" in note
+        for note in _cleanup_notes(primary)
+    )
+
+
+def test_artifact_materialize_print_interruption_warns_after_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = KeyboardInterrupt("success output interrupted")
+
+    class Provider:
+        def __init__(self, _root: Path) -> None:
+            pass
+
+        def require_support(self) -> None:
+            pass
+
+    class Closeable:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    owner = Closeable()
+    store = Closeable()
+    catalog = Closeable()
+    args = _materialize_cli_test_args(tmp_path)
+    output = Path(args.output)
+
+    def materialize(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        output.mkdir()
+        return SimpleNamespace(
+            export_receipt=SimpleNamespace(
+                ref_name="main",
+                ref_generation=1,
+                snapshot_id="snapshot-id",
+            ),
+            artifact=SimpleNamespace(
+                repository="owner/repo",
+                commit="a" * 40,
+                views=("bm25",),
+                output_dir=output,
+            ),
+        )
+
+    warning_outputs: list[Path] = []
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(cli, "_new_retained_output_receipt_owner", lambda: owner)
+    monkeypatch.setattr(storage_module, "LocalCAS", lambda *_args, **_kwargs: store)
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: catalog,
+    )
+    monkeypatch.setattr(
+        materialization_module,
+        "materialize_retained_repo_manifest_ref",
+        materialize,
+    )
+    monkeypatch.setattr(
+        cli,
+        "_warn_possible_retained_publication",
+        warning_outputs.append,
+    )
+
+    def interrupt_print(*_args: object, **_kwargs: object) -> None:
+        raise primary
+
+    monkeypatch.setattr("builtins.print", interrupt_print)
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        cli._run_artifact_materialize(args)
+
+    assert raised.value is primary
+    assert owner.closed
+    assert store.closed
+    assert catalog.closed
+    assert output.is_dir()
+    assert warning_outputs == [output]
 
 
 def test_wiki_parser_accepts_headless_quality_audit() -> None:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -598,6 +598,120 @@ def test_artifact_materialize_rejects_cross_device_output_parent_before_storage(
         cli._run_artifact_materialize(args)
 
 
+def test_artifact_materialize_rejects_directory_identity_alias_before_storage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    catalog_path = tmp_path / "catalog.sqlite3"
+    catalog_path.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    resolved_workspace = workspace_root.resolve(strict=True)
+    resolved_cas = cas_root.resolve(strict=True)
+    workspace_identity = cli._retained_real_directory_identity(
+        resolved_workspace,
+        label="workspace root",
+    )
+    real_identity = cli._retained_real_directory_identity
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            pass
+
+    def aliased_identity(path: Path, *, label: str) -> tuple[int, int]:
+        if path == resolved_cas:
+            return workspace_identity
+        return real_identity(path, label=label)
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_retained_real_directory_identity",
+        aliased_identity,
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: pytest.fail("CAS must not be opened"),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: pytest.fail("catalog must not be opened"),
+    )
+    args = SimpleNamespace(
+        repository="owner/repo",
+        namespace="default",
+        ref="main",
+        snapshot=None,
+        expected_generation=None,
+        catalog=str(catalog_path),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        output=str(workspace_root / "context"),
+    )
+
+    with pytest.raises(cli.CLIError, match="physically alias the workspace root"):
+        cli._run_artifact_materialize(args)
+
+
+def test_artifact_materialize_rejects_nested_mount_before_storage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    mounted_parent = workspace_root / "mounted"
+    mounted_parent.mkdir()
+    catalog_path = tmp_path / "catalog.sqlite3"
+    catalog_path.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+
+        def require_support(self) -> None:
+            pass
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_retained_linux_mount_points",
+        lambda: frozenset({mounted_parent.resolve(strict=True)}),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: pytest.fail("CAS must not be opened"),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: pytest.fail("catalog must not be opened"),
+    )
+    args = SimpleNamespace(
+        repository="owner/repo",
+        namespace="default",
+        ref="main",
+        snapshot=None,
+        expected_generation=None,
+        catalog=str(catalog_path),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        output=str(mounted_parent / "context"),
+    )
+
+    with pytest.raises(cli.CLIError, match="nested mount point"):
+        cli._run_artifact_materialize(args)
+
+
 def test_artifact_materialize_provider_failure_precedes_storage_open(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Add the first explicit production bridge from an existing retained SQLite/CAS selection to a portable context artifact. The bridge preserves the catalog/CAS/workspace authority boundaries, closes all caller-owned resources before success, and keeps M1 open for default compiler/import/runtime wiring.

Related to #199; this PR does not close it.

## Changes

- add a non-creating SQLite catalog mode that authenticates initialized CodeNib schemas before WAL or migration and optionally binds a single-link file identity across `sqlite3.connect`
- add backend-neutral ref and snapshot orchestration over retained export and strict missing-only context materialization
- add `codenib artifact materialize` with existing-catalog, strict-preprovisioned-CAS, private-workspace, no-overwrite, and topology gates
- preserve exact primary failures across catalog, CAS, receipt, warning, and post-publication cleanup
- verify the emitted artifact through real query-only MCP/BM25 consumption
- document the SQLite pathname/WAL trust boundary, receipt lifetime, MCP handoff, and remaining M1/M2/M5 work

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short --ignore=test/sandbox/test_docker.py`: 6226 passed, 71 skipped, 190 deselected
- `test/sandbox/test_docker.py`: 36 passed in a disposable mount namespace with `/usr/bin/docker` mapped to `true` before the final SQLite-only identity hardening; the host has no Docker executable
- CLI suite: 80 passed
- retained materialization/export/contracts: 74 passed
- SQLite catalog/jobs: 105 passed
- local workspace provider/owner/session: 90 passed
- Black 24.8.0, isort 5.13.2, flake8+bugbear, py_compile, and `git diff --check`
- strict MkDocs build and public-docs boundary checker

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published