### PR TITLE
feat(storage): import compiler BM25 caches

### DIFF
--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -37,6 +37,7 @@ from .strict_bm25 import (
     normalize_owned_query_view_strict,
     plan_bm25_view_strict,
     publish_planned_bm25_view_strict,
+    recapture_bm25_view_strict,
 )
 from .strict_context import (
     PlannedContextArtifact,
@@ -70,6 +71,7 @@ __all__ = [
     "publish_planned_bm25_view_strict",
     "publish_planned_context_artifact_strict",
     "query_context_artifact",
+    "recapture_bm25_view_strict",
     "validate_portable_query_view",
     "resolve_github_context_artifact",
     "render_artifact_mcp_config",

--- a/codenib/artifacts/strict_bm25.py
+++ b/codenib/artifacts/strict_bm25.py
@@ -21,10 +21,12 @@ from .._atomic_directory import (
     PublicationDirectoryReader,
     TreeFileRecord,
     _annotate_secondary_error,
+    capture_directory_ownership,
     directory_ownership_digest,
     directory_ownership_file_records,
     directory_ownership_inventory,
     lexical_directory_path,
+    reopen_authenticated_directory,
 )
 from .._bounded_json import (
     canonical_json_array_chunks,
@@ -174,6 +176,37 @@ def _preflight_publication_authorities(
             raise TypeError("strict workspace provider has an invalid contract")
 
 
+def _preflight_recapture_publication_authorities(
+    *,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+) -> None:
+    """Reject unusable recapture authority before source or provider mutation."""
+
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("strict BM25 repository source has an invalid type")
+    if type(output_receipt_owner) is not PublishedWorkspaceReceiptOwner:
+        raise TypeError("strict BM25 output receipt owner has an invalid type")
+    if not repository_source.usable:
+        raise RuntimeError("strict BM25 repository source is not usable")
+    if output_receipt_owner.state != "empty":
+        raise RuntimeError("strict BM25 output receipt owner must be empty")
+
+    require_owned_workspace_publication_support()
+    for member in ("require_support", "run_workspace"):
+        try:
+            raw = inspect.getattr_static(workspace_provider, member)
+        except AttributeError as exc:
+            raise TypeError(
+                "strict workspace provider has an invalid contract"
+            ) from exc
+        if isinstance(raw, (classmethod, staticmethod)):
+            raw = raw.__func__
+        if not callable(raw):
+            raise TypeError("strict workspace provider has an invalid contract")
+
+
 def _authenticated_repository_identity(
     repository_source: RepositorySourceBinding,
 ) -> RepositorySourceIdentitySnapshot:
@@ -233,6 +266,104 @@ def _preflight_view_location(
             "strict BM25 normalization must replace its exact source generation"
         )
     return source_receipt, lexical_destination
+
+
+def _path_relation(path: Path, boundary: Path) -> str:
+    if path == boundary:
+        return "same"
+    if boundary in path.parents:
+        return "descendant"
+    if path in boundary.parents:
+        return "ancestor"
+    return "disjoint"
+
+
+def _resolved_recapture_path(path: Path, *, strict: bool, label: str) -> Path:
+    try:
+        return path.resolve(strict=strict)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"strict BM25 {label} cannot be authenticated") from exc
+
+
+def _require_missing_recapture_destination(destination: Path) -> None:
+    try:
+        destination.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise ValueError(
+            "strict BM25 recapture destination cannot be authenticated"
+        ) from exc
+    raise FileExistsError("strict BM25 recapture destination must be missing")
+
+
+def _recapture_locations(
+    source: Path,
+    destination: Path,
+    *,
+    repository_identity: RepositorySourceIdentitySnapshot,
+) -> tuple[Path, Path]:
+    """Authenticate denial-only topology for an ordinary cache recapture."""
+
+    lexical_source = lexical_directory_path(source)
+    lexical_destination = lexical_directory_path(destination)
+    repository = lexical_directory_path(repository_identity.root)
+    source_relation = _path_relation(lexical_source, repository)
+    physical_source = _resolved_recapture_path(
+        lexical_source,
+        strict=True,
+        label="recapture source location",
+    )
+    physical_repository = _resolved_recapture_path(
+        repository,
+        strict=True,
+        label="repository location",
+    )
+    physical_source_relation = _path_relation(
+        physical_source,
+        physical_repository,
+    )
+    if source_relation != physical_source_relation:
+        raise ValueError(
+            "strict BM25 recapture source has inconsistent lexical and physical "
+            "repository topology"
+        )
+    if source_relation in {"same", "ancestor"}:
+        raise ValueError(
+            "strict BM25 recapture source must not contain the source repository"
+        )
+    if source_relation == "descendant":
+        relative = lexical_source.relative_to(repository).as_posix()
+        prefix = relative + "/"
+        if any(
+            record.path == relative or record.path.startswith(prefix)
+            for record in repository_identity.file_records
+        ):
+            raise ValueError(
+                "strict BM25 recapture source inside the repository must be "
+                "excluded from its authenticated source identity"
+            )
+
+    physical_destination = _resolved_recapture_path(
+        lexical_destination,
+        strict=False,
+        label="recapture destination location",
+    )
+    if any(
+        _path_relation(candidate, boundary) != "disjoint"
+        for candidate, boundary in (
+            (lexical_destination, lexical_source),
+            (lexical_destination, repository),
+            (physical_destination, physical_source),
+            (physical_destination, physical_repository),
+        )
+    ):
+        raise ValueError(
+            "strict BM25 recapture destination must be disjoint from source and "
+            "repository"
+        )
+    _require_missing_recapture_destination(lexical_destination)
+    return lexical_source, lexical_destination
 
 
 def _entry_policy(relative: str, kind: str, mode: int, size: int) -> None:
@@ -718,17 +849,30 @@ class PlannedBm25View:
         }
 
 
+def _captured_source_view(
+    expected_ownership: object,
+    publication: PublicationDirectoryReader,
+    *,
+    label: str,
+) -> tuple[object, tuple[TreeFileRecord, ...], _PublicationBm25Reader]:
+    ownership = publication.capture_ownership(entry_policy=_entry_policy)
+    if ownership != expected_ownership:
+        raise RuntimeError(f"{label} changed")
+    records = tuple(directory_ownership_file_records(ownership))  # type: ignore[arg-type]
+    if {record.path for record in records} != _STRICT_BM25_FILES:
+        raise ValueError(f"{label} is incomplete")
+    return ownership, records, _PublicationBm25Reader(publication, ownership)
+
+
 def _source_view(
     receipt: PublishedWorkspaceReceipt,
     publication: PublicationDirectoryReader,
 ) -> tuple[object, tuple[TreeFileRecord, ...], _PublicationBm25Reader]:
-    ownership = publication.capture_ownership(entry_policy=_entry_policy)
-    if ownership != receipt.ownership:
-        raise RuntimeError("strict BM25 source generation changed")
-    records = tuple(directory_ownership_file_records(ownership))  # type: ignore[arg-type]
-    if {record.path for record in records} != _STRICT_BM25_FILES:
-        raise ValueError("strict BM25 source generation is incomplete")
-    return ownership, records, _PublicationBm25Reader(publication, ownership)
+    return _captured_source_view(
+        receipt.ownership,
+        publication,
+        label="strict BM25 source generation",
+    )
 
 
 def _repository_files(
@@ -768,6 +912,63 @@ def _policy(
     )
 
 
+def _planned_view_from_publication(
+    publication: PublicationDirectoryReader,
+    expected_ownership: object,
+    *,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    config_digest: str,
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+    authenticated_source_files: frozenset[str],
+    source_label: str,
+) -> PlannedBm25View:
+    ownership, source_records, reader = _captured_source_view(
+        expected_ownership,
+        publication,
+        label=source_label,
+    )
+    metadata_bytes, document_chunks = _payloads(
+        reader,
+        repository_identity.root,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+        authenticated_source_files=authenticated_source_files,
+    )
+    documents_record = _record_chunks(
+        "documents.json",
+        document_chunks,
+        max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
+    )
+    metadata_record = TreeFileRecord(
+        path="bm25_metadata.json",
+        mode=0o600,
+        size=len(metadata_bytes),
+        sha256=hashlib.sha256(metadata_bytes).hexdigest(),
+    )
+    reader.verify_root()
+    output_records = tuple(
+        sorted((documents_record, metadata_record), key=lambda item: item.path)
+    )
+    source_digest = directory_ownership_digest(ownership)  # type: ignore[arg-type]
+    plan = _workspace_plan(
+        source_digest=source_digest,
+        source_records=source_records,
+        output_records=output_records,
+        view_config_digest=config_digest,
+        repository_fingerprint=repository_identity.fingerprint,
+    )
+    return PlannedBm25View(
+        plan=plan,
+        source_ownership=ownership,
+        source_digest=source_digest,
+        source_records=source_records,
+        output_records=output_records,
+        view_config_digest=config_digest,
+        repository_fingerprint=repository_identity.fingerprint,
+    )
+
+
 def _plan_bm25_view_with_identity(
     source_generation: PublishedWorkspaceReceiptOwner,
     *,
@@ -788,45 +989,15 @@ def _plan_bm25_view_with_identity(
         receipt: PublishedWorkspaceReceipt,
         publication: PublicationDirectoryReader,
     ) -> PlannedBm25View:
-        ownership, source_records, reader = _source_view(receipt, publication)
-        metadata_bytes, document_chunks = _payloads(
-            reader,
-            repository_identity.root,
+        return _planned_view_from_publication(
+            publication,
+            receipt.ownership,
+            repository_identity=repository_identity,
+            config_digest=config_digest,
             forbidden_paths=forbidden,
             environ=environ,
             authenticated_source_files=authenticated_files,
-        )
-        documents_record = _record_chunks(
-            "documents.json",
-            document_chunks,
-            max_bytes=_MAX_DOCUMENTS_JSON_BYTES,
-        )
-        metadata_record = TreeFileRecord(
-            path="bm25_metadata.json",
-            mode=0o600,
-            size=len(metadata_bytes),
-            sha256=hashlib.sha256(metadata_bytes).hexdigest(),
-        )
-        reader.verify_root()
-        output_records = tuple(
-            sorted((documents_record, metadata_record), key=lambda item: item.path)
-        )
-        source_digest = directory_ownership_digest(ownership)  # type: ignore[arg-type]
-        plan = _workspace_plan(
-            source_digest=source_digest,
-            source_records=source_records,
-            output_records=output_records,
-            view_config_digest=config_digest,
-            repository_fingerprint=repository_identity.fingerprint,
-        )
-        return PlannedBm25View(
-            plan=plan,
-            source_ownership=ownership,
-            source_digest=source_digest,
-            source_records=source_records,
-            output_records=output_records,
-            view_config_digest=config_digest,
-            repository_fingerprint=repository_identity.fingerprint,
+            source_label="strict BM25 source generation",
         )
 
     with repository_source.read_session():
@@ -872,21 +1043,21 @@ def plan_bm25_view_strict(
     )
 
 
-def _require_plan(
+def _require_plan_for_ownership(
     planned: PlannedBm25View,
     *,
-    source_receipt: PublishedWorkspaceReceipt,
+    source_ownership: object,
     repository_identity: RepositorySourceIdentitySnapshot,
     view_config_digest: str,
 ) -> None:
     if type(planned) is not PlannedBm25View:
         raise TypeError("strict BM25 execution requires a PlannedBm25View")
     if (
-        planned.source_ownership != source_receipt.ownership
+        planned.source_ownership != source_ownership
         or planned.source_records
-        != tuple(directory_ownership_file_records(source_receipt.ownership))  # type: ignore[arg-type]
+        != tuple(directory_ownership_file_records(source_ownership))  # type: ignore[arg-type]
         or planned.source_digest
-        != directory_ownership_digest(source_receipt.ownership)  # type: ignore[arg-type]
+        != directory_ownership_digest(source_ownership)  # type: ignore[arg-type]
     ):
         raise ValueError("strict BM25 plan belongs to another source generation")
     if planned.repository_fingerprint != repository_identity.fingerprint:
@@ -902,6 +1073,21 @@ def _require_plan(
     )
     if planned.plan != expected:
         raise ValueError("strict BM25 workspace plan is not canonical")
+
+
+def _require_plan(
+    planned: PlannedBm25View,
+    *,
+    source_receipt: PublishedWorkspaceReceipt,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    view_config_digest: str,
+) -> None:
+    _require_plan_for_ownership(
+        planned,
+        source_ownership=source_receipt.ownership,
+        repository_identity=repository_identity,
+        view_config_digest=view_config_digest,
+    )
 
 
 def _candidate_records(
@@ -1098,6 +1284,314 @@ def publish_planned_bm25_view_strict(
     )
 
 
+def _plan_recaptured_bm25_view_with_identity(
+    lexical_source: Path,
+    *,
+    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    view_config: Mapping[str, Any],
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+) -> PlannedBm25View:
+    config_digest, forbidden, authenticated_files = _policy(
+        repository_identity,
+        view_config,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+    source_ownership = capture_directory_ownership(
+        lexical_source,
+        entry_policy=_entry_policy,
+    )
+
+    def consume_source(publication: PublicationDirectoryReader) -> PlannedBm25View:
+        return _planned_view_from_publication(
+            publication,
+            source_ownership,
+            repository_identity=repository_identity,
+            config_digest=config_digest,
+            forbidden_paths=forbidden,
+            environ=environ,
+            authenticated_source_files=authenticated_files,
+            source_label="strict BM25 recapture source",
+        )
+
+    with repository_source.read_session():
+        return reopen_authenticated_directory(
+            lexical_source,
+            source_ownership,  # type: ignore[arg-type]
+            consume_source,
+        )
+
+
+def _plan_recaptured_bm25_view(
+    source: Path,
+    destination: Path,
+    *,
+    repository_source: RepositorySourceBinding,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> PlannedBm25View:
+    """Privately pre-plan an ordinary BM25 tree without workspace mutation."""
+
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("strict BM25 repository source has an invalid type")
+    if not repository_source.usable:
+        raise RuntimeError("strict BM25 repository source is not usable")
+    repository_identity = _authenticated_repository_identity(repository_source)
+    lexical_source, _lexical_destination = _recapture_locations(
+        source,
+        destination,
+        repository_identity=repository_identity,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="portable BM25 view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden_tail = tuple(forbidden_paths)
+    return _plan_recaptured_bm25_view_with_identity(
+        lexical_source,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+
+
+def _publish_recaptured_bm25_view_with_identity(
+    lexical_source: Path,
+    lexical_destination: Path,
+    *,
+    planned: PlannedBm25View,
+    repository_source: RepositorySourceBinding,
+    repository_identity: RepositorySourceIdentitySnapshot,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_config: Mapping[str, Any],
+    forbidden_paths: tuple[Path, ...],
+    environ: Mapping[str, str],
+) -> dict[str, Any]:
+    config_digest, forbidden, authenticated_files = _policy(
+        repository_identity,
+        view_config,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+    if type(planned) is not PlannedBm25View:
+        raise TypeError("strict BM25 execution requires a PlannedBm25View")
+    _require_plan_for_ownership(
+        planned,
+        source_ownership=planned.source_ownership,
+        repository_identity=repository_identity,
+        view_config_digest=config_digest,
+    )
+    observed_source_ownership = capture_directory_ownership(
+        lexical_source,
+        entry_policy=_entry_policy,
+    )
+    _require_plan_for_ownership(
+        planned,
+        source_ownership=observed_source_ownership,
+        repository_identity=repository_identity,
+        view_config_digest=config_digest,
+    )
+    request = StrictWorkspaceRequest(
+        purpose="portable-bm25-recapture",
+        destination=lexical_destination,
+        plan=planned.plan,
+        destination_expectation="missing",
+    )
+
+    def operation(session: StrictWorkspaceSession) -> None:
+        if session.request != request:
+            raise RuntimeError("strict BM25 provider changed its request")
+
+        def replay_source(publication: PublicationDirectoryReader) -> None:
+            ownership, source_records, reader = _captured_source_view(
+                planned.source_ownership,
+                publication,
+                label="strict BM25 recapture source",
+            )
+            if (
+                ownership != planned.source_ownership
+                or source_records != planned.source_records
+            ):
+                raise ValueError("strict BM25 recapture source changed after planning")
+            metadata_bytes, document_chunks = _payloads(
+                reader,
+                repository_identity.root,
+                forbidden_paths=forbidden,
+                environ=environ,
+                authenticated_source_files=authenticated_files,
+            )
+            written = tuple(
+                sorted(
+                    (
+                        session.write_file("documents.json", document_chunks),
+                        session.write_file("bm25_metadata.json", (metadata_bytes,)),
+                    ),
+                    key=lambda item: item.path,
+                )
+            )
+            reader.verify_root()
+            if written != planned.output_records:
+                raise RuntimeError("strict BM25 replay differs from its exact plan")
+
+        def validate_candidate(candidate: PublicationDirectoryReader) -> None:
+            with repository_source.read_session():
+                if (
+                    _candidate_records(
+                        candidate,
+                        planned=planned,
+                        repository_identity=repository_identity,
+                        forbidden_paths=forbidden,
+                        environ=environ,
+                        authenticated_source_files=authenticated_files,
+                    )
+                    != planned.output_records
+                ):
+                    raise RuntimeError("strict BM25 candidate is not canonical")
+
+        with repository_source.read_session():
+            reopen_authenticated_directory(
+                lexical_source,
+                planned.source_ownership,  # type: ignore[arg-type]
+                replay_source,
+            )
+        session.publish_validated(validate_candidate)
+
+    # Recheck mutable authority state after the potentially long source scan
+    # and immediately before the provider can provision its first workspace.
+    _preflight_recapture_publication_authorities(
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    _require_missing_recapture_destination(lexical_destination)
+    run_strict_workspace(
+        workspace_provider,
+        request,
+        receipt_owner=output_receipt_owner,
+        operation=operation,
+    )
+    if not output_receipt_owner.active:
+        raise RuntimeError("strict BM25 publication returned without a receipt")
+    receipt = output_receipt_owner.receipt
+    if receipt.path != lexical_destination or receipt.plan != planned.plan:
+        raise RuntimeError("strict BM25 publication returned the wrong receipt")
+    return planned.adjustments
+
+
+def _publish_recaptured_bm25_view(
+    source: Path,
+    destination: Path,
+    *,
+    planned: PlannedBm25View,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Privately publish one exact pre-planned ordinary BM25 tree."""
+
+    _preflight_recapture_publication_authorities(
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    repository_identity = _authenticated_repository_identity(repository_source)
+    lexical_source, lexical_destination = _recapture_locations(
+        source,
+        destination,
+        repository_identity=repository_identity,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="portable BM25 view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden_tail = tuple(forbidden_paths)
+    return _publish_recaptured_bm25_view_with_identity(
+        lexical_source,
+        lexical_destination,
+        planned=planned,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+
+
+def recapture_bm25_view_strict(
+    source: Path,
+    destination: Path,
+    *,
+    repository_source: RepositorySourceBinding,
+    workspace_provider: StrictWorkspaceProvider,
+    output_receipt_owner: PublishedWorkspaceReceiptOwner,
+    view_config: Mapping[str, Any],
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Recapture one ordinary BM25 tree into a missing strict workspace."""
+
+    _preflight_recapture_publication_authorities(
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    repository_identity = _authenticated_repository_identity(repository_source)
+    lexical_source, lexical_destination = _recapture_locations(
+        source,
+        destination,
+        repository_identity=repository_identity,
+    )
+    config_snapshot = _json_object_snapshot(
+        view_config,
+        label="portable BM25 view config",
+    )
+    environment = _environment_snapshot(environ)
+    forbidden_tail = tuple(forbidden_paths)
+    planned = _plan_recaptured_bm25_view_with_identity(
+        lexical_source,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+    _preflight_recapture_publication_authorities(
+        repository_source=repository_source,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+    )
+    lexical_source, lexical_destination = _recapture_locations(
+        lexical_source,
+        lexical_destination,
+        repository_identity=repository_identity,
+    )
+    return _publish_recaptured_bm25_view_with_identity(
+        lexical_source,
+        lexical_destination,
+        planned=planned,
+        repository_source=repository_source,
+        repository_identity=repository_identity,
+        workspace_provider=workspace_provider,
+        output_receipt_owner=output_receipt_owner,
+        view_config=config_snapshot,
+        forbidden_paths=forbidden_tail,
+        environ=environment,
+    )
+
+
 def normalize_owned_query_view_strict(
     destination: Path,
     *,
@@ -1166,4 +1660,5 @@ __all__ = [
     "normalize_owned_query_view_strict",
     "plan_bm25_view_strict",
     "publish_planned_bm25_view_strict",
+    "recapture_bm25_view_strict",
 ]

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -86,6 +86,16 @@ def _argparse_positive_int(value: str) -> int:
     return parsed
 
 
+def _argparse_nonnegative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from exc
+    if parsed < 0 or parsed > _SIGNED_INT64_MAX:
+        raise argparse.ArgumentTypeError("must be a non-negative signed 64-bit integer")
+    return parsed
+
+
 def _embedding_route_for_args(args: argparse.Namespace) -> InferenceRoute:
     """Resolve the secret-free embedding identity selected by CLI and env."""
 
@@ -1301,6 +1311,228 @@ class _RetainedMaterializationResourceOwner:
         self._resource = _RETAINED_RESOURCE_MISSING
 
 
+def _compiler_cache_import_selection(
+    *,
+    ref_name: object,
+    expected_generation: object,
+) -> tuple[str, int]:
+    selected_ref = "main" if ref_name is None else ref_name
+    if (
+        type(selected_ref) is not str
+        or not selected_ref
+        or selected_ref != selected_ref.strip()
+        or "\x00" in selected_ref
+        or len(selected_ref) > 32_768
+    ):
+        raise CLIError("retained ref name is not canonical")
+    raw_generation = 0 if expected_generation is None else expected_generation
+    if isinstance(raw_generation, bool):
+        raise CLIError("expected ref generation must be a non-negative integer")
+    try:
+        generation = int(raw_generation)
+    except (TypeError, ValueError) as exc:
+        raise CLIError(
+            "expected ref generation must be a non-negative integer"
+        ) from exc
+    if generation < 0 or generation > _SIGNED_INT64_MAX:
+        raise CLIError(
+            "expected ref generation must be a non-negative signed 64-bit integer"
+        )
+    return selected_ref, generation
+
+
+def _new_compiler_cache_import_nonce() -> str:
+    import secrets
+
+    nonce = secrets.token_hex(16)
+    if re.fullmatch(r"[0-9a-f]{32}", nonce, flags=re.ASCII) is None:
+        raise RuntimeError("cache import destination nonce is invalid")
+    return nonce
+
+
+@dataclass(frozen=True, slots=True)
+class _CompilerCacheImportPaths:
+    repo_path: Path
+    cache_dir: Path
+    catalog_path: Path
+    cas_root: Path
+    workspace_root: Path
+    bm25_destination: Path
+    context_destination: Path
+    suggested_materialization: Path
+
+
+def _compiler_cache_import_paths(args: argparse.Namespace) -> _CompilerCacheImportPaths:
+    """Freeze all user paths and allocate missing-only generation names."""
+
+    repo_path = resolve_repo_path(args.repo)
+    cache_dir = _lexical_cli_path(args.cache_dir, label="cache directory")
+    catalog_path = _lexical_cli_path(args.catalog, label="catalog")
+    cas_root = _lexical_cli_path(args.cas_root, label="CAS root")
+    workspace_root = _lexical_cli_path(args.workspace_root, label="workspace root")
+    for first, first_label, second, second_label in (
+        (catalog_path, "catalog", cas_root, "CAS root"),
+        (catalog_path, "catalog", workspace_root, "workspace root"),
+        (cas_root, "CAS root", workspace_root, "workspace root"),
+        (repo_path, "repository", catalog_path, "catalog"),
+        (repo_path, "repository", cas_root, "CAS root"),
+        (repo_path, "repository", workspace_root, "workspace root"),
+        (cache_dir, "cache directory", catalog_path, "catalog"),
+        (cache_dir, "cache directory", cas_root, "CAS root"),
+        (cache_dir, "cache directory", workspace_root, "workspace root"),
+    ):
+        if _paths_overlap(first, second):
+            raise CLIError(f"{first_label} must not overlap the {second_label}")
+    if cache_dir == repo_path or cache_dir in repo_path.parents:
+        raise CLIError("cache directory must not contain the repository")
+
+    nonce = _new_compiler_cache_import_nonce()
+    prefix = f".codenib-cache-import-{nonce}"
+    return _CompilerCacheImportPaths(
+        repo_path=repo_path,
+        cache_dir=cache_dir,
+        catalog_path=catalog_path,
+        cas_root=cas_root,
+        workspace_root=workspace_root,
+        bm25_destination=workspace_root / f"{prefix}-bm25",
+        context_destination=workspace_root / f"{prefix}-context",
+        suggested_materialization=workspace_root / f"{prefix}-materialized",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _CompilerCacheImportTopology:
+    cache_dir: Path
+    catalog_path: Path
+    catalog_identity: tuple[int, int, int]
+    cas_root: Path
+
+
+def _require_compiler_cache_import_topology(
+    paths: _CompilerCacheImportPaths,
+) -> _CompilerCacheImportTopology:
+    """Freeze existing inputs and deny physical storage/source aliases."""
+
+    materialization_topologies = tuple(
+        _require_retained_materialization_topology(
+            paths.catalog_path,
+            paths.cas_root,
+            paths.workspace_root,
+            destination,
+        )
+        for destination in (
+            paths.bm25_destination,
+            paths.context_destination,
+            paths.suggested_materialization,
+        )
+    )
+    first = materialization_topologies[0]
+    if any(candidate != first for candidate in materialization_topologies[1:]):
+        raise CLIError("storage topology changed while allocating import outputs")
+
+    resolved_repo = _resolved_retained_materialization_path(
+        paths.repo_path,
+        label="repository",
+        strict=True,
+    )
+    resolved_cache = _resolved_retained_materialization_path(
+        paths.cache_dir,
+        label="cache directory",
+        strict=True,
+    )
+    repository_ancestry = _retained_directory_ancestry(
+        resolved_repo,
+        label="repository",
+    )
+    cache_ancestry = _retained_directory_ancestry(
+        resolved_cache,
+        label="cache directory",
+    )
+    if resolved_cache == resolved_repo or resolved_cache in resolved_repo.parents:
+        raise CLIError("cache directory must not physically contain the repository")
+
+    resolved_workspace = _resolved_retained_materialization_path(
+        paths.workspace_root,
+        label="workspace root",
+        strict=True,
+    )
+    catalog_ancestry = _retained_directory_ancestry(
+        first.catalog_path.parent,
+        label="catalog parent",
+    )
+    cas_ancestry = _retained_directory_ancestry(
+        first.cas_root,
+        label="CAS root",
+    )
+    workspace_ancestry = _retained_directory_ancestry(
+        resolved_workspace,
+        label="workspace root",
+    )
+    for source, source_label in (
+        (resolved_repo, "repository"),
+        (resolved_cache, "cache directory"),
+    ):
+        for storage, storage_label in (
+            (first.catalog_path, "catalog"),
+            (first.cas_root, "CAS root"),
+            (resolved_workspace, "workspace root"),
+        ):
+            if _paths_overlap(source, storage):
+                raise CLIError(
+                    f"{source_label} must not physically overlap the {storage_label}"
+                )
+    for first_ancestry, first_label, second_ancestry, second_label in (
+        (repository_ancestry, "repository", cache_ancestry, "cache directory"),
+        (repository_ancestry, "repository", catalog_ancestry, "catalog"),
+        (repository_ancestry, "repository", cas_ancestry, "CAS root"),
+        (
+            repository_ancestry,
+            "repository",
+            workspace_ancestry,
+            "workspace root",
+        ),
+        (cache_ancestry, "cache directory", catalog_ancestry, "catalog"),
+        (cache_ancestry, "cache directory", cas_ancestry, "CAS root"),
+        (
+            cache_ancestry,
+            "cache directory",
+            workspace_ancestry,
+            "workspace root",
+        ),
+        (catalog_ancestry, "catalog", cas_ancestry, "CAS root"),
+        (catalog_ancestry, "catalog", workspace_ancestry, "workspace root"),
+        (cas_ancestry, "CAS root", workspace_ancestry, "workspace root"),
+    ):
+        _require_distinct_directory_ancestry(
+            first_ancestry,
+            first_label,
+            second_ancestry,
+            second_label,
+        )
+    return _CompilerCacheImportTopology(
+        cache_dir=resolved_cache,
+        catalog_path=first.catalog_path,
+        catalog_identity=first.catalog_identity,
+        cas_root=first.cas_root,
+    )
+
+
+def _warn_possible_compiler_cache_import_publication(
+    destination: Path,
+    *,
+    label: str,
+) -> None:
+    try:
+        destination.lstat()
+    except (OSError, RuntimeError, ValueError):
+        return
+    print(
+        f"warning: cache import {label} now exists and may have been published; "
+        f"verify it before reuse: {destination}",
+        file=sys.stderr,
+    )
+
+
 def _run_artifact_materialize(args: argparse.Namespace) -> int:
     from . import LocalWorkspaceProvider
     from ._atomic_directory import (
@@ -1472,6 +1704,214 @@ def _run_artifact_materialize(args: argparse.Namespace) -> int:
                 "retained publication warning also failed",
                 warning_error,
             )
+        if isinstance(primary_error, CLIError):
+            raise
+        if isinstance(
+            primary_error, (OSError, RuntimeError, ValueError, sqlite3.Error)
+        ):
+            raise CLIError(str(primary_error)) from primary_error
+        raise
+
+
+def _run_artifact_import_cache(args: argparse.Namespace) -> int:
+    from . import LocalWorkspaceProvider
+    from ._atomic_directory import (
+        _annotate_secondary_error,
+        _OrderedAction,
+        _run_context_with_cleanup_actions,
+    )
+    from .artifacts.runtime import SourceBindingCleanupOwner
+    from .compiler.cache_import import import_compiler_cache_bm25
+    from .source_fingerprint import capture_repository_source
+    from .storage import LocalCAS, SQLiteCatalog
+
+    repository, namespace = _retained_materialization_identity(
+        args.repository,
+        args.namespace,
+    )
+    ref_name, expected_generation = _compiler_cache_import_selection(
+        ref_name=args.ref,
+        expected_generation=args.expected_generation,
+    )
+    paths = _compiler_cache_import_paths(args)
+    try:
+        provider = LocalWorkspaceProvider(paths.workspace_root)
+        provider.require_support()
+        topology = _require_compiler_cache_import_topology(paths)
+    except CLIError:
+        raise
+    except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
+        raise CLIError(str(exc)) from exc
+
+    source_exclusions = tuple(
+        dict.fromkeys(
+            (
+                paths.cache_dir,
+                topology.cache_dir,
+                paths.bm25_destination,
+                paths.context_destination,
+                paths.suggested_materialization,
+            )
+        )
+    )
+    publication_forbidden_paths = tuple(
+        dict.fromkeys(
+            (
+                paths.cache_dir,
+                topology.cache_dir,
+                topology.catalog_path,
+                topology.cas_root,
+                paths.workspace_root,
+                paths.bm25_destination,
+                paths.context_destination,
+                paths.suggested_materialization,
+            )
+        )
+    )
+    summary: tuple[str, str, int] | None = None
+    try:
+        bm25_owner = _new_retained_output_receipt_owner()
+        context_owner = _new_retained_output_receipt_owner()
+        source_owner = SourceBindingCleanupOwner()
+        object_store_owner = _RetainedMaterializationResourceOwner()
+        catalog_owner = _RetainedMaterializationResourceOwner()
+        cleanup_actions = (
+            _OrderedAction(
+                label="cache import SQLite catalog cleanup also failed",
+                action=catalog_owner.close,
+                complete=lambda: catalog_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=catalog_owner,
+            ),
+            _OrderedAction(
+                label="cache import local CAS cleanup also failed",
+                action=object_store_owner.close,
+                complete=lambda: object_store_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=object_store_owner,
+            ),
+            _OrderedAction(
+                label="cache import context receipt cleanup also failed",
+                action=context_owner.close,
+                complete=lambda: context_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=context_owner,
+            ),
+            _OrderedAction(
+                label="cache import BM25 receipt cleanup also failed",
+                action=bm25_owner.close,
+                complete=lambda: bm25_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=bm25_owner,
+            ),
+            _OrderedAction(
+                label="cache import repository source cleanup also failed",
+                action=source_owner.close,
+                complete=lambda: source_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=source_owner,
+            ),
+        )
+        with _run_context_with_cleanup_actions(cleanup_actions):
+            repository_source = capture_repository_source(
+                paths.repo_path,
+                exclude_roots=source_exclusions,
+                _source_owner=source_owner.retain,
+            )
+            object_store = object_store_owner.acquire(
+                lambda: LocalCAS(topology.cas_root, require_preprovisioned=True)
+            )
+            _require_retained_catalog_binding(
+                topology.catalog_path,
+                topology.catalog_identity,
+            )
+            catalog = catalog_owner.acquire(
+                lambda: SQLiteCatalog(
+                    topology.catalog_path,
+                    create=False,
+                    expected_file_identity=topology.catalog_identity,
+                )
+            )
+            _require_retained_catalog_binding(
+                topology.catalog_path,
+                topology.catalog_identity,
+            )
+            result = import_compiler_cache_bm25(
+                topology.cache_dir,
+                repository_source=repository_source,
+                bm25_output_owner=bm25_owner,
+                context_output_owner=context_owner,
+                bm25_destination=paths.bm25_destination,
+                context_destination=paths.context_destination,
+                workspace_provider=provider,
+                repository_key=repository,
+                catalog=catalog,
+                object_store=object_store,
+                namespace_name=namespace,
+                ref_name=ref_name,
+                expected_generation=expected_generation,
+                forbidden_paths=publication_forbidden_paths,
+                environ=_publication_environment(),
+            )
+            imported = result.import_result
+            summary = (
+                imported.snapshot_id,
+                imported.ref_name,
+                imported.generation,
+            )
+        if summary is None:  # pragma: no cover - successful producer always sets it
+            raise RuntimeError("compiler cache import returned no summary")
+
+        snapshot_id, published_ref, generation = summary
+        print(f"Snapshot:           {snapshot_id}")
+        print(f"Ref:                {published_ref}")
+        print(f"Generation:         {generation}")
+        print(f"BM25 generation:    {paths.bm25_destination}")
+        print(f"Context generation: {paths.context_destination}")
+        print(
+            "Suggested output:   " f"{paths.suggested_materialization} (not reserved)"
+        )
+        print(
+            "Next:               "
+            + shlex.join(
+                [
+                    "codenib",
+                    "artifact",
+                    "materialize",
+                    "--catalog",
+                    os.fspath(topology.catalog_path),
+                    "--cas-root",
+                    os.fspath(topology.cas_root),
+                    "--workspace-root",
+                    os.fspath(paths.workspace_root),
+                    "--repository",
+                    repository,
+                    "--namespace",
+                    namespace,
+                    "--snapshot",
+                    snapshot_id,
+                    "--output",
+                    os.fspath(paths.suggested_materialization),
+                ]
+            )
+        )
+        return 0
+    except BaseException as primary_error:  # noqa: B036 - preserve cancellation
+        for destination, label in (
+            (paths.bm25_destination, "BM25 generation"),
+            (paths.context_destination, "context generation"),
+        ):
+            try:
+                _warn_possible_compiler_cache_import_publication(
+                    destination,
+                    label=label,
+                )
+            except BaseException as warning_error:  # noqa: B036 - diagnostic only
+                _annotate_secondary_error(
+                    primary_error,
+                    f"cache import {label} warning also failed",
+                    warning_error,
+                )
         if isinstance(primary_error, CLIError):
             raise
         if isinstance(
@@ -3304,6 +3744,58 @@ def build_parser() -> argparse.ArgumentParser:
         help="current view to include; repeat or use a comma-separated list",
     )
     artifact_pack_parser.set_defaults(handler=_run_artifact_pack)
+
+    artifact_import_cache_parser = artifact_subparsers.add_parser(
+        "import-cache",
+        help="import an existing compiler BM25 cache into retained storage",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    artifact_import_cache_parser.add_argument(
+        "repo",
+        help="existing repository source captured for the imported cache",
+    )
+    artifact_import_cache_parser.add_argument(
+        "--cache-dir",
+        required=True,
+        help="existing compiler cache containing repo_manifest.json and BM25",
+    )
+    artifact_import_cache_parser.add_argument(
+        "--catalog",
+        required=True,
+        help="existing initialized SQLite catalog path",
+    )
+    artifact_import_cache_parser.add_argument(
+        "--cas-root",
+        required=True,
+        help="existing fully preprovisioned local CAS root",
+    )
+    artifact_import_cache_parser.add_argument(
+        "--workspace-root",
+        required=True,
+        help="existing private owner-only LocalWorkspaceProvider root",
+    )
+    artifact_import_cache_parser.add_argument(
+        "--repository",
+        required=True,
+        help="canonical owner/repository key",
+    )
+    artifact_import_cache_parser.add_argument(
+        "--namespace",
+        default="default",
+        help="logical catalog namespace",
+    )
+    artifact_import_cache_parser.add_argument(
+        "--ref",
+        default="main",
+        help="repository ref advanced by the import",
+    )
+    artifact_import_cache_parser.add_argument(
+        "--expected-generation",
+        type=_argparse_nonnegative_int,
+        default=0,
+        help="required current generation for optimistic ref publication",
+    )
+    artifact_import_cache_parser.set_defaults(handler=_run_artifact_import_cache)
 
     artifact_materialize_parser = artifact_subparsers.add_parser(
         "materialize",

--- a/codenib/compiler/__init__.py
+++ b/codenib/compiler/__init__.py
@@ -26,6 +26,11 @@ from typing import TYPE_CHECKING, Any
 from .._lazy import exported_dir, load_export
 
 if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
+    from codenib.compiler.cache_import import (
+        CompilerCacheBm25RecaptureResult,
+        CompilerCacheImportResult,
+        import_compiler_cache_bm25,
+    )
     from codenib.compiler.index_builders import IndexBuilderRegistry
     from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
     from codenib.compiler.manifest import ManifestIndexStateStore, RepoManifest
@@ -68,6 +73,18 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     )
 
 _EXPORTS = {
+    "CompilerCacheBm25RecaptureResult": (
+        "codenib.compiler.cache_import",
+        "CompilerCacheBm25RecaptureResult",
+    ),
+    "CompilerCacheImportResult": (
+        "codenib.compiler.cache_import",
+        "CompilerCacheImportResult",
+    ),
+    "import_compiler_cache_bm25": (
+        "codenib.compiler.cache_import",
+        "import_compiler_cache_bm25",
+    ),
     "IndexCompiler": ("codenib.compiler.index_compiler", "IndexCompiler"),
     "IndexCompilerConfig": (
         "codenib.compiler.index_compiler",
@@ -167,6 +184,9 @@ _EXPORTS = {
 
 __all__ = [
     # Index compilation
+    "CompilerCacheBm25RecaptureResult",
+    "CompilerCacheImportResult",
+    "import_compiler_cache_bm25",
     "IndexCompiler",
     "IndexCompilerConfig",
     "IndexBuilderRegistry",

--- a/codenib/compiler/cache_import.py
+++ b/codenib/compiler/cache_import.py
@@ -1,0 +1,808 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Import one compiler-cache BM25 generation through retained authority.
+
+The compiler cache is mutable local state, so it is never handed directly to
+the retained importer.  This coordinator holds the compiler cache lock while
+it authenticates the fixed manifest and BM25 tree, plans the exact portable
+manifest, and publishes immutable BM25 and context generations.  Only the
+immutable context receipt crosses the lock boundary into storage import.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import inspect
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .._atomic_directory import (
+    PublicationDirectoryReader,
+    TreeFileRecord,
+    lexical_directory_path,
+)
+from .._captured_directory import (
+    PublishedWorkspaceReceipt,
+    PublishedWorkspaceReceiptOwner,
+)
+from .._workspace_provider import StrictWorkspaceProvider
+from ..artifacts.context import ContextArtifactResult
+from ..artifacts.portable_views import _read_bounded_json
+from ..artifacts.strict_bm25 import (
+    PlannedBm25View,
+    _plan_recaptured_bm25_view,
+    _publish_recaptured_bm25_view,
+)
+from ..artifacts.strict_context import (
+    _canonical_json_bytes,
+    _portable_capabilities,
+    stage_context_artifact_strict,
+)
+from ..source_fingerprint import (
+    RepositorySourceBinding,
+    RepositorySourceIdentitySnapshot,
+    is_secure_source_fingerprint_v2,
+)
+from ..storage.models import (
+    DEFAULT_NAMESPACE_NAME,
+    RepositoryIdentity,
+    StorageIntegrityError,
+    StorageValidationError,
+)
+from ..storage.protocols import (
+    RETAINED_IMPORT_CATALOG_CONTRACT,
+    RetainedImportCatalog,
+    RetainedImportObjectStore,
+)
+from ..storage.view_bundle import (
+    DEFAULT_MAX_BUNDLE_BYTES,
+    DEFAULT_MAX_BUNDLE_FILES,
+    DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+)
+from .cache_lock import compiler_cache_lock
+from .manifest import MANIFEST_FILENAME, MANIFEST_VERSION, IndexEntry, RepoManifest
+from .manifest_import import (
+    _CATALOG_METHODS,
+    _OBJECT_STORE_METHODS,
+    DEFAULT_MAX_CONTEXT_BYTES,
+    DEFAULT_MAX_CONTEXT_FILES,
+    DEFAULT_MAX_PROJECTION_BYTES,
+    DEFAULT_REF_NAME,
+    RepoManifestImportResult,
+    _exact_text,
+    _expected_generation,
+    _expected_namespace_id,
+    _positive_limit,
+    _require_static_methods,
+    _snapshot_environment,
+    _snapshot_forbidden_paths,
+    import_retained_repo_manifest,
+)
+from .manifest_storage import (
+    DEFAULT_MAX_MANIFEST_BYTES,
+    RepoManifestImportPlan,
+    _manifest_limit,
+    _preflight_json_bytes,
+    _strict_json_loads,
+    plan_repo_manifest_import_bytes,
+)
+from .snapshot_store import normalize_repo
+
+_COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z", re.ASCII)
+
+
+@dataclass(frozen=True, slots=True)
+class CompilerCacheBm25RecaptureResult:
+    """Detached evidence for the mutable-to-immutable BM25 recapture."""
+
+    source_view: Path
+    output_view: Path
+    source_records: tuple[TreeFileRecord, ...]
+    output_records: tuple[TreeFileRecord, ...]
+    canonical_manifest_bytes: bytes
+
+    def __post_init__(self) -> None:
+        if type(self) is not CompilerCacheBm25RecaptureResult:
+            raise TypeError("compiler cache recapture must use the exact result type")
+        if type(self.source_view) is not type(Path()) or type(
+            self.output_view
+        ) is not type(Path()):
+            raise TypeError("compiler cache recapture paths must be exact paths")
+        source_records = tuple(self.source_records)
+        output_records = tuple(self.output_records)
+        for records, label in (
+            (source_records, "source"),
+            (output_records, "output"),
+        ):
+            if any(type(record) is not TreeFileRecord for record in records):
+                raise TypeError(f"compiler cache recapture {label} records are invalid")
+            if records != tuple(sorted(records, key=lambda item: item.path)):
+                raise ValueError(
+                    f"compiler cache recapture {label} records are not canonical"
+                )
+            if {record.path for record in records} != {
+                "bm25_metadata.json",
+                "documents.json",
+            }:
+                raise ValueError(
+                    f"compiler cache recapture {label} records are incomplete"
+                )
+        if type(self.canonical_manifest_bytes) is not bytes:
+            raise TypeError("compiler cache portable manifest must be exact bytes")
+        object.__setattr__(self, "source_records", source_records)
+        object.__setattr__(self, "output_records", output_records)
+
+    @property
+    def manifest_digest(self) -> str:
+        return hashlib.sha256(self.canonical_manifest_bytes).hexdigest()
+
+    @property
+    def artifact_file_fingerprints(self) -> dict[str, dict[str, Any]]:
+        return _fingerprints_for_records(self.output_records)
+
+
+@dataclass(frozen=True, slots=True)
+class CompilerCacheImportResult:
+    """Pure-data result of one compiler-cache BM25 retained import."""
+
+    recapture: CompilerCacheBm25RecaptureResult
+    import_plan: RepoManifestImportPlan
+    context_artifact: ContextArtifactResult
+    import_result: RepoManifestImportResult
+
+    def __post_init__(self) -> None:
+        if type(self) is not CompilerCacheImportResult:
+            raise TypeError("compiler cache import must use the exact result type")
+        if type(self.recapture) is not CompilerCacheBm25RecaptureResult:
+            raise TypeError("compiler cache import recapture result is invalid")
+        if type(self.import_plan) is not RepoManifestImportPlan:
+            raise TypeError("compiler cache import plan is invalid")
+        if type(self.context_artifact) is not ContextArtifactResult:
+            raise TypeError("compiler cache context artifact result is invalid")
+        if type(self.import_result) is not RepoManifestImportResult:
+            raise TypeError("compiler cache retained import result is invalid")
+        if (
+            self.import_plan.selection.selected_views != ("bm25",)
+            or self.context_artifact.views != ("bm25",)
+            or self.import_result.views != ("bm25",)
+            or self.recapture.canonical_manifest_bytes
+            != _pretty_manifest_bytes(self.import_plan.manifest)
+        ):
+            raise StorageIntegrityError(
+                "compiler cache import result identities are inconsistent"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class _ImportPreflight:
+    repository_key: str
+    namespace_name: str
+    ref_name: str
+    expected_generation: int
+    max_manifest_bytes: int
+    max_context_files: int
+    max_context_bytes: int
+    max_bundle_files: int
+    max_bundle_bytes: int
+    max_bundle_metadata_bytes: int
+    max_projection_bytes: int
+    forbidden_paths: tuple[Path, ...]
+    environment: Mapping[str, str]
+
+
+def _path_relation(path: Path, boundary: Path) -> str:
+    if path == boundary:
+        return "same"
+    if boundary in path.parents:
+        return "descendant"
+    if path in boundary.parents:
+        return "ancestor"
+    return "disjoint"
+
+
+def _resolved_path(path: Path, *, strict: bool, label: str) -> Path:
+    try:
+        return path.resolve(strict=strict)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"{label} cannot be authenticated") from exc
+
+
+def _require_missing(path: Path, *, label: str) -> None:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise ValueError(f"{label} cannot be inspected safely") from exc
+    raise FileExistsError(f"{label} must be missing")
+
+
+def _preflight_authorities(
+    *,
+    repository_source: RepositorySourceBinding,
+    bm25_output_owner: PublishedWorkspaceReceiptOwner,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+) -> None:
+    if type(repository_source) is not RepositorySourceBinding:
+        raise TypeError("compiler cache source must be an exact source binding")
+    if (
+        type(bm25_output_owner) is not PublishedWorkspaceReceiptOwner
+        or type(context_output_owner) is not PublishedWorkspaceReceiptOwner
+    ):
+        raise TypeError("compiler cache outputs must be exact receipt owners")
+    if bm25_output_owner is context_output_owner:
+        raise ValueError("compiler cache outputs must use distinct receipt owners")
+    if not repository_source.usable:
+        raise RuntimeError("compiler cache repository source is not usable")
+    if bm25_output_owner.state != "empty" or context_output_owner.state != "empty":
+        raise RuntimeError("compiler cache output receipt owners must be empty")
+
+
+def _preflight_workspace_provider(
+    workspace_provider: StrictWorkspaceProvider,
+) -> None:
+    for member in ("require_support", "run_workspace"):
+        try:
+            candidate = inspect.getattr_static(workspace_provider, member)
+        except AttributeError as exc:
+            raise TypeError(
+                "compiler cache workspace provider has an invalid contract"
+            ) from exc
+        if isinstance(candidate, (classmethod, staticmethod)):
+            candidate = candidate.__func__
+        if not callable(candidate):
+            raise TypeError("compiler cache workspace provider has an invalid contract")
+    workspace_provider.require_support()
+
+
+def _preflight_import_inputs(
+    *,
+    repository_key: str,
+    catalog: RetainedImportCatalog,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str,
+    ref_name: str,
+    expected_generation: int,
+    max_manifest_bytes: int,
+    max_context_files: int,
+    max_context_bytes: int,
+    max_bundle_files: int,
+    max_bundle_bytes: int,
+    max_bundle_metadata_bytes: int,
+    max_projection_bytes: int,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str] | None,
+) -> _ImportPreflight:
+    repository = _exact_text(repository_key, "repository key")
+    try:
+        normalized_repository = normalize_repo(repository)
+    except ValueError as exc:
+        raise StorageValidationError("repository key is not canonical") from exc
+    if normalized_repository != repository:
+        raise StorageValidationError("repository key is not canonical")
+    namespace = _exact_text(namespace_name, "namespace name")
+    ref = _exact_text(ref_name, "ref name")
+    expected = _expected_generation(expected_generation)
+    manifest_limit = _manifest_limit(max_manifest_bytes)
+    context_files = _positive_limit(max_context_files, "context file limit")
+    context_bytes = _positive_limit(max_context_bytes, "context byte limit")
+    bundle_files = _positive_limit(max_bundle_files, "bundle file limit")
+    bundle_bytes = _positive_limit(max_bundle_bytes, "bundle byte limit")
+    bundle_metadata_bytes = _positive_limit(
+        max_bundle_metadata_bytes,
+        "bundle metadata byte limit",
+    )
+    projection_bytes = _positive_limit(max_projection_bytes, "projection byte limit")
+    environment = _snapshot_environment(environ)
+    forbidden = _snapshot_forbidden_paths(forbidden_paths)
+
+    if not isinstance(catalog, RetainedImportCatalog):
+        raise TypeError("compiler cache import catalog lacks required capabilities")
+    if not isinstance(object_store, RetainedImportObjectStore):
+        raise TypeError(
+            "compiler cache import object store lacks required capabilities"
+        )
+    _require_static_methods(
+        object_store,
+        label="retained import object store",
+        names=_OBJECT_STORE_METHODS,
+    )
+    _require_static_methods(
+        catalog,
+        label="retained import catalog",
+        names=_CATALOG_METHODS,
+    )
+    namespace_id = _expected_namespace_id(namespace)
+    RepositoryIdentity(namespace_id=namespace_id, repository_key=repository)
+    return _ImportPreflight(
+        repository_key=repository,
+        namespace_name=namespace,
+        ref_name=ref,
+        expected_generation=expected,
+        max_manifest_bytes=manifest_limit,
+        max_context_files=context_files,
+        max_context_bytes=context_bytes,
+        max_bundle_files=bundle_files,
+        max_bundle_bytes=bundle_bytes,
+        max_bundle_metadata_bytes=bundle_metadata_bytes,
+        max_projection_bytes=projection_bytes,
+        forbidden_paths=forbidden,
+        environment=environment,
+    )
+
+
+def _preflight_catalog_contract(catalog: RetainedImportCatalog) -> None:
+    contract = catalog.retained_import_contract()
+    if type(contract) is not str or contract != RETAINED_IMPORT_CATALOG_CONTRACT:
+        raise TypeError("compiler cache import catalog contract is incompatible")
+
+
+def _cache_topology(
+    cache: Path,
+    identity: RepositorySourceIdentitySnapshot,
+) -> None:
+    repository = lexical_directory_path(identity.root)
+    lexical_relation = _path_relation(cache, repository)
+    physical_cache = _resolved_path(cache, strict=True, label="compiler cache")
+    physical_repository = _resolved_path(
+        repository,
+        strict=True,
+        label="compiler cache repository",
+    )
+    physical_relation = _path_relation(physical_cache, physical_repository)
+    if lexical_relation != physical_relation:
+        raise ValueError(
+            "compiler cache has inconsistent lexical and physical repository topology"
+        )
+    if lexical_relation in {"same", "ancestor"}:
+        raise ValueError("compiler cache must not contain the repository source")
+    if lexical_relation != "descendant":
+        return
+    relative = cache.relative_to(repository).as_posix()
+    prefix = relative + "/"
+    if any(
+        record.path == relative or record.path.startswith(prefix)
+        for record in identity.file_records
+    ):
+        raise StorageIntegrityError(
+            "compiler cache is present in the authenticated repository source records"
+        )
+
+
+def _destination_topology(
+    bm25_destination: Path,
+    context_destination: Path,
+    *,
+    cache: Path,
+    repository: Path,
+    source_view: Path,
+) -> None:
+    lexical_boundaries = (cache, repository, source_view)
+    physical_boundaries = tuple(
+        _resolved_path(path, strict=True, label="compiler cache input")
+        for path in lexical_boundaries
+    )
+    physical_destinations = tuple(
+        _resolved_path(path, strict=False, label="compiler cache destination")
+        for path in (bm25_destination, context_destination)
+    )
+    for destination, physical_destination in zip(
+        (bm25_destination, context_destination),
+        physical_destinations,
+        strict=True,
+    ):
+        if any(
+            _path_relation(destination, boundary) != "disjoint"
+            for boundary in lexical_boundaries
+        ) or any(
+            _path_relation(physical_destination, boundary) != "disjoint"
+            for boundary in physical_boundaries
+        ):
+            raise ValueError("compiler cache destination overlaps an input authority")
+        _require_missing(destination, label="compiler cache destination")
+    if _path_relation(bm25_destination, context_destination) != "disjoint" or (
+        _path_relation(physical_destinations[0], physical_destinations[1]) != "disjoint"
+    ):
+        raise ValueError("compiler cache output destinations overlap")
+
+
+def _read_manifest(cache: Path, *, max_manifest_bytes: int) -> bytes:
+    return bytes(
+        _read_bounded_json(
+            cache / MANIFEST_FILENAME,
+            label="compiler cache repository manifest",
+            max_bytes=max_manifest_bytes,
+        )
+    )
+
+
+def _parse_exact_manifest(payload: bytes, *, max_manifest_bytes: int) -> RepoManifest:
+    if payload.startswith(b"\xef\xbb\xbf"):
+        raise ValueError("compiler cache repository manifest must not contain a BOM")
+    _preflight_json_bytes(
+        payload,
+        label="compiler cache repository manifest",
+        max_bytes=max_manifest_bytes,
+    )
+    try:
+        text = payload.decode("utf-8", errors="strict")
+    except UnicodeError as exc:
+        raise ValueError(
+            "compiler cache repository manifest is not valid UTF-8"
+        ) from exc
+    data = _strict_json_loads(text, label="compiler cache repository manifest")
+    try:
+        manifest = RepoManifest.from_dict(data)
+        exact = manifest.to_dict()
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("compiler cache repository manifest is invalid") from exc
+    if exact != data:
+        raise ValueError("compiler cache repository manifest is not exact v1.1 data")
+    return manifest
+
+
+def _require_manifest_source(
+    manifest: RepoManifest,
+    identity: RepositorySourceIdentitySnapshot,
+) -> None:
+    if manifest.version != MANIFEST_VERSION:
+        raise ValueError("compiler cache repository manifest version is incompatible")
+    declared_path = Path(manifest.repo_path)
+    if not manifest.repo_path or not declared_path.is_absolute():
+        raise ValueError("compiler cache repository path must be absolute")
+    declared_repository = lexical_directory_path(declared_path)
+    if declared_repository != lexical_directory_path(identity.root):
+        raise StorageIntegrityError(
+            "compiler cache repository manifest belongs to another repository"
+        )
+    if (
+        not is_secure_source_fingerprint_v2(manifest.source_fingerprint)
+        or manifest.source_fingerprint != identity.fingerprint
+        or manifest.file_count != identity.file_count
+    ):
+        raise StorageIntegrityError(
+            "compiler cache repository manifest differs from the retained source"
+        )
+
+
+def _bm25_source(cache: Path, entry: IndexEntry) -> Path:
+    declared = Path(entry.path).expanduser()
+    if not declared.is_absolute():
+        declared = cache / declared
+    source = lexical_directory_path(declared)
+    expected = lexical_directory_path(cache / "bm25")
+    if source != expected:
+        raise ValueError("compiler cache BM25 entry does not name its fixed view")
+    return source
+
+
+def _require_current_bm25(manifest: RepoManifest) -> IndexEntry:
+    entry = manifest.indexes.get("bm25")
+    if (
+        type(entry) is not IndexEntry
+        or entry.index_type != "bm25"
+        or entry.status != "fresh"
+        or entry.commit != manifest.commit
+        or entry.source_fingerprint != manifest.source_fingerprint
+        or not manifest.index_is_current("bm25")
+    ):
+        raise ValueError("compiler cache repository manifest has no exact current BM25")
+    return entry
+
+
+def _fingerprints_for_records(
+    records: tuple[TreeFileRecord, ...],
+) -> dict[str, dict[str, Any]]:
+    return {
+        record.path: {"size": record.size, "sha256": record.sha256}
+        for record in records
+    }
+
+
+def _require_source_fingerprints(
+    entry: IndexEntry,
+    planned: PlannedBm25View,
+) -> None:
+    expected = _fingerprints_for_records(planned.source_records)
+    if (
+        entry.config.get("artifact_file_fingerprints") != expected
+        or entry.metadata.get("artifact_file_fingerprints") != expected
+    ):
+        raise StorageIntegrityError(
+            "compiler cache BM25 files differ from their manifest fingerprints"
+        )
+
+
+def _pretty_manifest_bytes(manifest: RepoManifest) -> bytes:
+    return _canonical_json_bytes(
+        manifest.to_dict(),
+        label="compiler cache portable repository manifest",
+    )
+
+
+def _portable_manifest(
+    manifest: RepoManifest,
+    planned: PlannedBm25View,
+) -> tuple[RepoManifest, bytes]:
+    portable = copy.deepcopy(manifest.to_dict())
+    portable["repo"]["path"] = "source"
+    entry = copy.deepcopy(portable["indexes"]["bm25"])
+    entry["path"] = "views/bm25"
+    fingerprints = _fingerprints_for_records(planned.output_records)
+    for section_name in ("config", "metadata"):
+        section = entry.get(section_name)
+        if not isinstance(section, dict):
+            raise ValueError(
+                f"compiler cache BM25 {section_name} must be an exact object"
+            )
+        section["artifact_file_fingerprints"] = copy.deepcopy(fingerprints)
+    portable["indexes"] = {"bm25": entry}
+    portable["capabilities"] = _portable_capabilities(
+        portable["capabilities"],
+        ("bm25",),
+    )
+    try:
+        portable_manifest = RepoManifest.from_dict(portable)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("compiler cache portable manifest is invalid") from exc
+    if portable_manifest.to_dict() != portable:
+        raise ValueError("compiler cache portable manifest is not canonical")
+    return portable_manifest, _pretty_manifest_bytes(portable_manifest)
+
+
+def _read_context_manifest(
+    owner: PublishedWorkspaceReceiptOwner,
+    *,
+    max_manifest_bytes: int,
+) -> bytes:
+    def read(
+        receipt: PublishedWorkspaceReceipt,
+        publication: PublicationDirectoryReader,
+    ) -> bytes:
+        del receipt
+        before = publication.capture_ownership()
+        with publication.open_authenticated_file(
+            MANIFEST_FILENAME,
+            max_bytes=max_manifest_bytes,
+        ) as source:
+            payload = b"".join(source.iter_bytes())
+        if publication.capture_ownership() != before:
+            raise StorageIntegrityError(
+                "compiler cache context artifact changed while reading its manifest"
+            )
+        return payload
+
+    return owner.consume(read)
+
+
+def import_compiler_cache_bm25(
+    cache_dir: str | Path,
+    *,
+    repository_source: RepositorySourceBinding,
+    bm25_output_owner: PublishedWorkspaceReceiptOwner,
+    context_output_owner: PublishedWorkspaceReceiptOwner,
+    bm25_destination: Path,
+    context_destination: Path,
+    workspace_provider: StrictWorkspaceProvider,
+    repository_key: str,
+    catalog: RetainedImportCatalog,
+    object_store: RetainedImportObjectStore,
+    namespace_name: str = DEFAULT_NAMESPACE_NAME,
+    ref_name: str = DEFAULT_REF_NAME,
+    expected_generation: int = 0,
+    max_manifest_bytes: int = DEFAULT_MAX_MANIFEST_BYTES,
+    max_context_files: int = DEFAULT_MAX_CONTEXT_FILES,
+    max_context_bytes: int = DEFAULT_MAX_CONTEXT_BYTES,
+    max_bundle_files: int = DEFAULT_MAX_BUNDLE_FILES,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+    max_bundle_metadata_bytes: int = DEFAULT_MAX_BUNDLE_METADATA_BYTES,
+    max_projection_bytes: int = DEFAULT_MAX_PROJECTION_BYTES,
+    forbidden_paths: Iterable[Path] = (),
+    environ: Mapping[str, str] | None = None,
+) -> CompilerCacheImportResult:
+    """Recapture and import the exact current BM25 compiler-cache generation.
+
+    Both receipt owners and the retained repository binding are borrowed.  The
+    caller remains responsible for closing them, on both success and failure.
+    Published directories are immutable evidence and are never recursively
+    removed by this coordinator when a later stage fails.
+    """
+
+    _preflight_authorities(
+        repository_source=repository_source,
+        bm25_output_owner=bm25_output_owner,
+        context_output_owner=context_output_owner,
+    )
+    cache = lexical_directory_path(Path(cache_dir))
+    bm25_output = lexical_directory_path(bm25_destination)
+    context_output = lexical_directory_path(context_destination)
+    inputs = _preflight_import_inputs(
+        repository_key=repository_key,
+        catalog=catalog,
+        object_store=object_store,
+        namespace_name=namespace_name,
+        ref_name=ref_name,
+        expected_generation=expected_generation,
+        max_manifest_bytes=max_manifest_bytes,
+        max_context_files=max_context_files,
+        max_context_bytes=max_context_bytes,
+        max_bundle_files=max_bundle_files,
+        max_bundle_bytes=max_bundle_bytes,
+        max_bundle_metadata_bytes=max_bundle_metadata_bytes,
+        max_projection_bytes=max_projection_bytes,
+        forbidden_paths=forbidden_paths,
+        environ=environ,
+    )
+    fixed_source_view = lexical_directory_path(cache / "bm25")
+    policy_forbidden = _snapshot_forbidden_paths(
+        (
+            *inputs.forbidden_paths,
+            cache,
+            fixed_source_view,
+            bm25_output,
+            context_output,
+        )
+    )
+    _preflight_workspace_provider(workspace_provider)
+    _preflight_catalog_contract(catalog)
+
+    with compiler_cache_lock(cache, create=False):
+        source_manifest_bytes = _read_manifest(
+            cache,
+            max_manifest_bytes=inputs.max_manifest_bytes,
+        )
+        manifest = _parse_exact_manifest(
+            source_manifest_bytes,
+            max_manifest_bytes=inputs.max_manifest_bytes,
+        )
+        if _COMMIT_RE.fullmatch(manifest.commit) is None:
+            raise ValueError(
+                "compiler cache repository manifest commit must be a full "
+                "lowercase Git SHA"
+            )
+        identity = repository_source.authenticated_identity_snapshot()
+        if type(identity) is not RepositorySourceIdentitySnapshot:
+            raise TypeError("compiler cache repository identity has an invalid type")
+        _cache_topology(cache, identity)
+        _require_manifest_source(manifest, identity)
+        bm25_entry = _require_current_bm25(manifest)
+        source_view = _bm25_source(cache, bm25_entry)
+        _destination_topology(
+            bm25_output,
+            context_output,
+            cache=cache,
+            repository=lexical_directory_path(identity.root),
+            source_view=source_view,
+        )
+        if source_view != fixed_source_view:  # pragma: no cover - helper invariant
+            raise AssertionError("compiler cache fixed BM25 source changed")
+
+        # This exact plan, portable manifest, and import plan all exist before
+        # the first provider call can mutate either destination.
+        planned_bm25 = _plan_recaptured_bm25_view(
+            source_view,
+            bm25_output,
+            repository_source=repository_source,
+            view_config=bm25_entry.config,
+            forbidden_paths=policy_forbidden,
+            environ=inputs.environment,
+        )
+        _require_source_fingerprints(bm25_entry, planned_bm25)
+        portable_manifest, canonical_manifest_bytes = _portable_manifest(
+            manifest,
+            planned_bm25,
+        )
+        import_plan = plan_repo_manifest_import_bytes(
+            canonical_manifest_bytes,
+            views=("bm25",),
+            max_manifest_bytes=inputs.max_manifest_bytes,
+        )
+        if (
+            import_plan.selection.selected_views != ("bm25",)
+            or import_plan.manifest.to_dict() != portable_manifest.to_dict()
+        ):
+            raise StorageIntegrityError(
+                "compiler cache portable manifest changed during import planning"
+            )
+
+        adjustments = _publish_recaptured_bm25_view(
+            source_view,
+            bm25_output,
+            planned=planned_bm25,
+            repository_source=repository_source,
+            workspace_provider=workspace_provider,
+            output_receipt_owner=bm25_output_owner,
+            view_config=bm25_entry.config,
+            forbidden_paths=policy_forbidden,
+            environ=inputs.environment,
+        )
+        if adjustments != _fingerprints_adjustment(planned_bm25.output_records):
+            raise StorageIntegrityError(
+                "compiler cache BM25 publication differs from its exact plan"
+            )
+
+        context_artifact = stage_context_artifact_strict(
+            context_output,
+            manifest=portable_manifest,
+            repository=inputs.repository_key,
+            repository_source=repository_source,
+            view_generations={"bm25": bm25_output_owner},
+            workspace_provider=workspace_provider,
+            output_receipt_owner=context_output_owner,
+            environ=inputs.environment,
+        )
+        observed_manifest_bytes = _read_context_manifest(
+            context_output_owner,
+            max_manifest_bytes=inputs.max_manifest_bytes,
+        )
+        if observed_manifest_bytes != canonical_manifest_bytes:
+            raise StorageIntegrityError(
+                "compiler cache context manifest differs from its preplanned bytes"
+            )
+        if repository_source.authenticated_identity_snapshot() != identity:
+            raise StorageIntegrityError(
+                "compiler cache repository source changed during recapture"
+            )
+        if (
+            _read_manifest(cache, max_manifest_bytes=inputs.max_manifest_bytes)
+            != source_manifest_bytes
+        ):
+            raise StorageIntegrityError(
+                "compiler cache repository manifest changed during recapture"
+            )
+
+        recapture = CompilerCacheBm25RecaptureResult(
+            source_view=source_view,
+            output_view=bm25_output,
+            source_records=planned_bm25.source_records,
+            output_records=planned_bm25.output_records,
+            canonical_manifest_bytes=canonical_manifest_bytes,
+        )
+
+    # Catalog/CAS publication deliberately occurs after releasing the mutable
+    # compiler cache lock.  The context receipt remains the exact authority
+    # authenticated above, so the mutable cache is no longer consulted.
+    import_result = import_retained_repo_manifest(
+        import_plan,
+        artifact_owner=context_output_owner,
+        repository_source=repository_source,
+        repository_key=inputs.repository_key,
+        catalog=catalog,
+        object_store=object_store,
+        namespace_name=inputs.namespace_name,
+        ref_name=inputs.ref_name,
+        expected_generation=inputs.expected_generation,
+        max_context_files=inputs.max_context_files,
+        max_context_bytes=inputs.max_context_bytes,
+        max_bundle_files=inputs.max_bundle_files,
+        max_bundle_bytes=inputs.max_bundle_bytes,
+        max_bundle_metadata_bytes=inputs.max_bundle_metadata_bytes,
+        max_projection_bytes=inputs.max_projection_bytes,
+        forbidden_paths=policy_forbidden,
+        environ=inputs.environment,
+    )
+    return CompilerCacheImportResult(
+        recapture=recapture,
+        import_plan=import_plan,
+        context_artifact=context_artifact,
+        import_result=import_result,
+    )
+
+
+def _fingerprints_adjustment(
+    records: tuple[TreeFileRecord, ...],
+) -> dict[str, Any]:
+    return {"artifact_file_fingerprints": _fingerprints_for_records(records)}
+
+
+__all__ = [
+    "CompilerCacheBm25RecaptureResult",
+    "CompilerCacheImportResult",
+    "import_compiler_cache_bm25",
+]

--- a/codenib/compiler/cache_lock.py
+++ b/codenib/compiler/cache_lock.py
@@ -33,6 +33,9 @@ _WINDOWS_LOCK_RETRY_SECONDS = 0.05
 _ACTIVE_POSIX_LOCK_DESCRIPTORS: set[int] = set()
 _POSIX_FORK_GENERATION = 0
 _POSIX_LOCK_LIFECYCLE_DEPTH = threading.local()
+_CACHE_LOCK_THREAD_CLAIMS = threading.local()
+
+_ThreadCacheLockClaim = tuple[int, tuple[int, ...], object]
 
 
 def _posix_lifecycle_guard_depth() -> int:
@@ -462,6 +465,98 @@ def _inode_identity(metadata: os.stat_result) -> tuple[int, ...]:
     )
 
 
+def _release_thread_cache_lock_claim(claim: _ThreadCacheLockClaim) -> None:
+    owner_generation, identity, token = claim
+    deferred: BaseException | None = None
+    while True:
+        try:
+            state = getattr(_CACHE_LOCK_THREAD_CLAIMS, "state", None)
+            if state is None:
+                break
+            state_generation, tokens = state
+            if (
+                owner_generation != _POSIX_FORK_GENERATION
+                or state_generation != _POSIX_FORK_GENERATION
+            ):
+                break
+            if type(tokens) is not dict:
+                raise RuntimeError("compiler cache thread claim state is invalid")
+            # ``pop(..., None)`` is deliberately idempotent: if cancellation
+            # arrives after the C operation mutated the dict, retrying remains
+            # safe.  Token identity prevents a failed duplicate claim from
+            # releasing the outer lock's ownership entry.
+            if tokens.get(identity) is token:
+                tokens.pop(identity, None)
+        except BaseException as exc:  # noqa: B036 - finish release first
+            if isinstance(exc, Exception):
+                raise
+            deferred = _remember_cleanup_interruption(deferred, exc)
+            continue
+        break
+    if deferred is not None:
+        raise deferred
+
+
+def _new_thread_cache_lock_claim(
+    identity: tuple[int, ...],
+) -> _ThreadCacheLockClaim:
+    return (_POSIX_FORK_GENERATION, identity, object())
+
+
+def _claim_thread_cache_lock(
+    cache: Path,
+    claim: _ThreadCacheLockClaim,
+) -> None:
+    owner_generation, identity, token = claim
+    if owner_generation != _POSIX_FORK_GENERATION:
+        raise RuntimeError("compiler cache thread claim generation changed")
+    state = getattr(_CACHE_LOCK_THREAD_CLAIMS, "state", None)
+    if state is None or state[0] != owner_generation:
+        tokens: dict[tuple[int, ...], object] = {}
+        _CACHE_LOCK_THREAD_CLAIMS.state = (owner_generation, tokens)
+    else:
+        tokens = state[1]
+        if type(tokens) is not dict:
+            raise RuntimeError("compiler cache thread claim state is invalid")
+    if identity in tokens:
+        raise RuntimeError(
+            f"compiler cache lock is already held by this thread: {cache}"
+        )
+    try:
+        tokens[identity] = token
+    except BaseException as exc:  # noqa: B036 - reconcile ambiguous mutation
+        _finish_cleanup_preserving_primary(
+            exc,
+            "compiler cache thread claim rollback also failed",
+            lambda: _release_thread_cache_lock_claim(claim),
+        )
+        raise
+
+
+def _finish_claimed_lock_cleanup(
+    primary_error: BaseException | None,
+    *,
+    close_label: str,
+    close: Callable[[], None],
+    claim: _ThreadCacheLockClaim,
+) -> None:
+    close_error: BaseException | None = None
+    try:
+        _finish_cleanup_preserving_primary(primary_error, close_label, close)
+    except BaseException as exc:  # noqa: B036 - release claim before propagation
+        close_error = exc
+    cleanup_primary = primary_error if primary_error is not None else close_error
+    try:
+        _finish_cleanup_preserving_primary(
+            cleanup_primary,
+            "compiler cache thread claim release also failed",
+            lambda: _release_thread_cache_lock_claim(claim),
+        )
+    finally:
+        if primary_error is None and close_error is not None:
+            raise close_error
+
+
 def _validate_lock_metadata(metadata: os.stat_result, lock_path: Path) -> None:
     if stat.S_ISLNK(metadata.st_mode) or _is_reparse_point(metadata):
         raise RuntimeError(f"compiler cache lock is a link: {lock_path}")
@@ -534,11 +629,16 @@ def _make_bounded_cache_directories(cache: Path) -> None:
 
 
 @contextmanager
-def _open_posix_cache_directory(cache_dir: str | Path) -> Iterator[tuple[Path, int]]:
+def _open_posix_cache_directory(
+    cache_dir: str | Path,
+    *,
+    create: bool = True,
+) -> Iterator[tuple[Path, int]]:
     _require_posix_primitives()
     cache = _cache_path(cache_dir)
     try:
-        _make_bounded_cache_directories(cache)
+        if create:
+            _make_bounded_cache_directories(cache)
         descriptor = os.open(cache, _directory_open_flags())
     except OSError as exc:
         raise RuntimeError(f"could not open compiler cache directory: {cache}") from exc
@@ -611,6 +711,8 @@ def _open_posix_lock_file(
     cache: Path,
     directory_descriptor: int,
     descriptor_owner: list[int],
+    *,
+    create: bool = True,
 ) -> tuple[int, tuple[int, ...]]:
     lock_path = cache / COMPILER_CACHE_LOCK_FILENAME
     with _PosixLifecycleGuardLease() as acquire_interruption:
@@ -625,8 +727,12 @@ def _open_posix_lock_file(
                     follow_symlinks=False,
                 )
             except FileNotFoundError:
+                if not create:
+                    raise RuntimeError(
+                        f"compiler cache lock does not exist: {lock_path}"
+                    ) from None
                 expected_identity = None
-                create = True
+                create_entry = True
             except OSError as exc:
                 raise RuntimeError(
                     f"could not inspect compiler cache lock: {lock_path}"
@@ -634,13 +740,13 @@ def _open_posix_lock_file(
             else:
                 _validate_lock_metadata(before, lock_path)
                 expected_identity = _inode_identity(before)
-                create = False
+                create_entry = False
 
             descriptor: int | None = None
             try:
                 descriptor = os.open(
                     COMPILER_CACHE_LOCK_FILENAME,
-                    _posix_lock_flags(create=create),
+                    _posix_lock_flags(create=create_entry),
                     0o600,
                     dir_fd=directory_descriptor,
                 )
@@ -727,20 +833,63 @@ def _close_posix_lock_file(
         raise deferred
 
 
+def _validate_posix_cache_entry(cache: Path, descriptor: int) -> None:
+    try:
+        opened = os.fstat(descriptor)
+        visible = cache.lstat()
+    except OSError as exc:
+        raise RuntimeError(f"compiler cache path changed: {cache}") from exc
+    if (
+        not stat.S_ISDIR(opened.st_mode)
+        or not stat.S_ISDIR(visible.st_mode)
+        or stat.S_ISLNK(visible.st_mode)
+        or _is_reparse_point(opened)
+        or _is_reparse_point(visible)
+        or _inode_identity(opened) != _inode_identity(visible)
+    ):
+        raise RuntimeError(f"compiler cache path changed: {cache}")
+
+
 @contextmanager
-def _posix_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
-    with _open_posix_cache_directory(cache_dir) as (cache, directory_descriptor):
+def _posix_compiler_cache_lock(
+    cache_dir: str | Path,
+    *,
+    create: bool = True,
+) -> Iterator[None]:
+    cache_directory = (
+        _open_posix_cache_directory(cache_dir)
+        if create
+        else _open_posix_cache_directory(cache_dir, create=False)
+    )
+    with cache_directory as (
+        cache,
+        directory_descriptor,
+    ):
         owner_generation = _POSIX_FORK_GENERATION
         lock_path = cache / COMPILER_CACHE_LOCK_FILENAME
         descriptor_owner: list[int] = []
+        thread_claim: _ThreadCacheLockClaim | None = None
         locked = False
         primary_error: BaseException | None = None
         try:
-            descriptor, identity = _open_posix_lock_file(
-                cache,
-                directory_descriptor,
-                descriptor_owner,
+            _validate_posix_cache_entry(cache, directory_descriptor)
+            thread_claim = _new_thread_cache_lock_claim(
+                _inode_identity(os.fstat(directory_descriptor)),
             )
+            _claim_thread_cache_lock(cache, thread_claim)
+            if create:
+                descriptor, identity = _open_posix_lock_file(
+                    cache,
+                    directory_descriptor,
+                    descriptor_owner,
+                )
+            else:
+                descriptor, identity = _open_posix_lock_file(
+                    cache,
+                    directory_descriptor,
+                    descriptor_owner,
+                    create=False,
+                )
             assert fcntl is not None  # narrowed by _require_posix_primitives
             fcntl.flock(descriptor, fcntl.LOCK_EX)
             locked = True
@@ -750,6 +899,7 @@ def _posix_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
                 lock_path,
                 expected_identity=identity,
             )
+            _validate_posix_cache_entry(cache, directory_descriptor)
             yield
         except BaseException as exc:  # noqa: B036 - cleanup preserves first fault
             primary_error = exc
@@ -757,7 +907,26 @@ def _posix_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
         finally:
             # The child-side at-fork callback already closed its inherited
             # descriptor.  The generation guard prevents closing a reused fd.
-            if descriptor_owner and _POSIX_FORK_GENERATION == owner_generation:
+            owns_descriptor = bool(
+                descriptor_owner and _POSIX_FORK_GENERATION == owner_generation
+            )
+            if thread_claim is not None:
+                _finish_claimed_lock_cleanup(
+                    primary_error,
+                    close_label="compiler cache lock cleanup also failed",
+                    close=(
+                        (
+                            lambda: _close_posix_lock_file(
+                                descriptor_owner,
+                                locked=locked,
+                            )
+                        )
+                        if owns_descriptor
+                        else (lambda: None)
+                    ),
+                    claim=thread_claim,
+                )
+            elif owns_descriptor:  # pragma: no cover - claim precedes lock open
                 _finish_cleanup_preserving_primary(
                     primary_error,
                     "compiler cache lock cleanup also failed",
@@ -818,6 +987,8 @@ def _validate_windows_lock_entry(
 def _open_windows_lock_file(
     cache: Path,
     descriptor_owner: list[int] | None = None,
+    *,
+    create: bool = True,
 ) -> tuple[int, tuple[int, ...]]:
     lock_path = cache / COMPILER_CACHE_LOCK_FILENAME
     owner = descriptor_owner if descriptor_owner is not None else []
@@ -831,6 +1002,10 @@ def _open_windows_lock_file(
         try:
             before = lock_path.lstat()
         except FileNotFoundError:
+            if not create:
+                raise RuntimeError(
+                    f"compiler cache lock does not exist: {lock_path}"
+                ) from None
             expected_identity = None
             flags = common_flags | os.O_EXCL
         except OSError as exc:
@@ -840,7 +1015,7 @@ def _open_windows_lock_file(
         else:
             _validate_lock_metadata(before, lock_path)
             expected_identity = _windows_identity(before, lock_path)
-            flags = common_flags
+            flags = common_flags if create else common_flags & ~os.O_CREAT
         descriptor: int | None = None
         try:
             descriptor = os.open(lock_path, flags, 0o600)
@@ -941,25 +1116,40 @@ def _close_windows_lock_file(
 
 
 @contextmanager
-def _windows_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
+def _windows_compiler_cache_lock(
+    cache_dir: str | Path,
+    *,
+    create: bool = True,
+) -> Iterator[None]:
     if msvcrt is None:
         raise RuntimeError("compiler cache locking requires Windows msvcrt support")
     cache = _cache_path(cache_dir)
-    try:
-        os.makedirs(cache, mode=0o700, exist_ok=True)
-    except OSError as exc:
-        raise RuntimeError(
-            f"could not create compiler cache directory: {cache}"
-        ) from exc
+    if create:
+        try:
+            os.makedirs(cache, mode=0o700, exist_ok=True)
+        except OSError as exc:
+            raise RuntimeError(
+                f"could not create compiler cache directory: {cache}"
+            ) from exc
     cache_identity = _validate_windows_cache(cache)
     descriptor_owner: list[int] = []
+    thread_claim: _ThreadCacheLockClaim | None = None
     locked = False
     primary_error: BaseException | None = None
     try:
-        descriptor, lock_identity = _open_windows_lock_file(
-            cache,
-            descriptor_owner,
-        )
+        thread_claim = _new_thread_cache_lock_claim(cache_identity)
+        _claim_thread_cache_lock(cache, thread_claim)
+        if create:
+            descriptor, lock_identity = _open_windows_lock_file(
+                cache,
+                descriptor_owner,
+            )
+        else:
+            descriptor, lock_identity = _open_windows_lock_file(
+                cache,
+                descriptor_owner,
+                create=False,
+            )
         _acquire_windows_lock(descriptor)
         locked = True
         if _validate_windows_cache(cache) != cache_identity:
@@ -974,7 +1164,23 @@ def _windows_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
         primary_error = exc
         raise
     finally:
-        if descriptor_owner:
+        if thread_claim is not None:
+            _finish_claimed_lock_cleanup(
+                primary_error,
+                close_label="compiler cache lock cleanup also failed",
+                close=(
+                    (
+                        lambda: _close_windows_lock_file(
+                            descriptor_owner,
+                            locked=locked,
+                        )
+                    )
+                    if descriptor_owner
+                    else (lambda: None)
+                ),
+                claim=thread_claim,
+            )
+        elif descriptor_owner:  # pragma: no cover - claim precedes lock open
             _finish_cleanup_preserving_primary(
                 primary_error,
                 "compiler cache lock cleanup also failed",
@@ -986,7 +1192,11 @@ def _windows_compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
 
 
 @contextmanager
-def compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
+def compiler_cache_lock(
+    cache_dir: str | Path,
+    *,
+    create: bool = True,
+) -> Iterator[None]:
     """Serialize cooperating users of one private compiler cache.
 
     The fixed lock entry is opened read/write without following links or
@@ -995,16 +1205,32 @@ def compiler_cache_lock(cache_dir: str | Path) -> Iterator[None]:
     uses the equivalent cooperative ``msvcrt`` byte lock after rejecting an
     existing reparse-point cache or lock entry.
 
+    Set ``create=False`` for an existing-only lease: both the cache directory
+    and its fixed lock file must already exist, and neither is created while
+    acquiring the lease.
+
     This helper protects participating compiler/importer operations from each
     other.  It does not validate or defend the manifest and view tree against
     a user who actively replaces paths while the lock is held.
     """
 
+    if type(create) is not bool:
+        raise TypeError("compiler cache lock create policy must be an exact bool")
     if os.name == "nt":
-        with _windows_compiler_cache_lock(cache_dir):
+        lock = (
+            _windows_compiler_cache_lock(cache_dir)
+            if create
+            else _windows_compiler_cache_lock(cache_dir, create=False)
+        )
+        with lock:
             yield
         return
-    with _posix_compiler_cache_lock(cache_dir):
+    lock = (
+        _posix_compiler_cache_lock(cache_dir)
+        if create
+        else _posix_compiler_cache_lock(cache_dir, create=False)
+    )
+    with lock:
         yield
 
 

--- a/docs/development/local-workspace-provider.md
+++ b/docs/development/local-workspace-provider.md
@@ -16,10 +16,78 @@ missing destination and transfers the generation to a caller-owned
 `PublishedWorkspaceReceiptOwner`.
 
 The provider is not part of CodeNib's default compiler, import, or runtime
-path. The first explicit operator bridge is `codenib artifact materialize`,
-which can publish a retained catalog ref or immutable snapshot to a missing
-portable-artifact directory. The strict BM25 replacement path still requires
-the unsupported `provider-bound-exact` destination mode.
+path. Two explicit operator bridges use it: `codenib artifact import-cache`
+recaptures one current compiler-cache BM25 view into retained storage, and
+`codenib artifact materialize` publishes a retained catalog ref or immutable
+snapshot to a missing portable-artifact directory. The strict BM25 replacement
+path still requires the unsupported `provider-bound-exact` destination mode.
+
+## Import a compiler BM25 cache
+
+`codenib artifact import-cache` imports one exact current BM25 view from an
+existing `IndexCompiler` cache as a ready retained snapshot. This is a
+BM25-only bootstrap: it does not change the default `codenib index` route,
+import vector or graph views, run an M2 fenced job, or hot-switch a runtime.
+
+Prepare these authorities before running it:
+
+- The positional repository must be the source used to build the cache. The
+  retained source-fingerprint-v2 identity must match the manifest, whose commit
+  must be a full lowercase 40-character Git SHA. The manifest must contain one
+  exact current BM25 entry and exact fingerprints for
+  `bm25/documents.json` and `bm25/bm25_metadata.json`.
+- `--cache-dir` must be an existing cache produced by the current compiler. It
+  must already contain `repo_manifest.json`, the fixed BM25 tree, and the
+  single-link regular `.index-compiler.lock`. Run or update the cache with the
+  current `IndexCompiler`; do not add a lock file by hand. Import opens the
+  lease existing-only and never creates the cache or lock. The importer owns
+  that lease, so a library caller must not wrap it in another lock for the same
+  cache; same-thread re-entry fails fast. The lock serializes cooperating
+  CodeNib compiler and importer processes in a private cache namespace. It is
+  not a sandbox against an actor actively replacing cache paths while the lock
+  is held.
+- `--catalog`, `--cas-root`, and `--workspace-root` have the same strict
+  requirements documented for materialization below: an existing initialized
+  SQLite catalog, a fully preprovisioned strict `LocalCAS`, and an existing
+  private Linux workspace root owned by the current effective UID with exact
+  mode `0700`. Repository and cache paths must neither overlap nor physically
+  alias those storage authorities; the cache must not contain the repository.
+
+`codenib index` prints its `repo_manifest.json` location; use that file's
+parent as `--cache-dir`. For example, import the first generation of `main`:
+
+```bash
+codenib artifact import-cache /srv/src/repository \
+  --cache-dir /var/lib/codenib/compiler-cache/repository \
+  --catalog /var/lib/codenib/catalog.sqlite3 \
+  --cas-root /var/lib/codenib/cas \
+  --workspace-root /var/lib/codenib/workspaces \
+  --repository owner/repository \
+  --ref main \
+  --expected-generation 0
+```
+
+Under the cooperative cache lease, the command authenticates the source,
+manifest, and ordinary BM25 files; completes the canonical BM25-only portable
+manifest and import plan; and publishes fresh missing-only BM25 and context
+generations. It then revalidates those exact bytes and releases the lease
+before retained CAS ingestion or catalog/ref publication begins.
+
+Every invocation allocates random
+`.codenib-cache-import-<nonce>-bm25` and
+`.codenib-cache-import-<nonce>-context` directories below the workspace root.
+They remain immutable generation evidence after their receipt owners close,
+including when a later stage fails; the command warns instead of deleting
+them. Their future ownership-aware reclamation belongs to M5. On success, the
+CLI prints the snapshot, ref generation, both evidence paths, and a copyable
+`codenib artifact materialize --snapshot ...` command. Its suggested
+`.codenib-cache-import-<nonce>-materialized` output is not created or reserved.
+
+Use the current ref generation for a changed cache. If a call might have
+committed before its result was observed, retry the exact same source, cache,
+repository, namespace, and ref with the original `--expected-generation`.
+The retry gets fresh missing evidence destinations but resolves the same
+snapshot and generation without advancing the ref again.
 
 ## Materialize a retained artifact
 
@@ -87,10 +155,10 @@ warns that the output now exists, do not assume that the path is disposable or
 retry over it; verify the retained artifact before reuse or reclaim it through
 an ownership-aware workflow.
 
-This is the first explicit local bridge, not completion of the hybrid-storage
-M1 milestone. Default compiler/import/runtime wiring is still missing, as is a
-production provider for the strict BM25 producer's `provider-bound-exact`
-destination contract.
+This retained-read bridge and the BM25 ingress above do not complete the
+hybrid-storage M1 milestone. Default compiler/runtime routing and non-BM25
+cache ingress are still missing, as is a production provider for the strict
+BM25 replacement producer's `provider-bound-exact` destination contract.
 
 ## Lifecycle
 

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -359,11 +359,11 @@ profile or durable job payload. Strict whole-context and retained
 materialization APIs are now available as injectable library producers. The
 Linux local provider deliberately accepts only missing destinations, so
 whole-context retained materialization can use it explicitly, while strict BM25
-requests `provider-bound-exact` and still lacks a concrete production provider.
-The explicit retained-artifact CLI can now construct the whole-context producer
-for one existing catalog selection, but no default compiler/import/runtime route
-constructs these producers. M1 remains in progress and the M2 BM25 profile
-adapter is still outstanding.
+replacement requests `provider-bound-exact` and still lacks a concrete
+production provider. The explicit retained-artifact CLI can now construct the
+whole-context producer for one existing catalog selection, but no default
+compiler/import/runtime route constructs these producers. M1 remains in
+progress and the M2 BM25 profile adapter is still outstanding.
 
 Strict whole-context publication can now aggregate already-normalized BM25 and
 vector generations retained by active workspace receipt owners. The plan binds
@@ -380,9 +380,9 @@ that identity is captured. The producer can now use a caller-supplied
 `LocalWorkspaceProvider` for a missing destination. The explicit CLI bridge now
 constructs that provider and closes its output receipt for one invocation, but
 no default compiler/import/runtime route manages either lifecycle. This slice
-does not normalize native vector state or route compiler output. Its retained
-receipt is now accepted by the direct M1 importer below, but it is not yet an M2
-fenced job output.
+does not normalize native vector state or route compiler output by default. Its
+retained receipt is now accepted by the direct M1 importer below, but it is not
+yet an M2 fenced job output.
 
 Retained manifest import now has additional backend-neutral prerequisite
 gates. `BlobInfo` is an exact point-in-time CAS receipt, and
@@ -486,6 +486,36 @@ advancing the ref again. This is the direct M1 bootstrap path, not the M2 fenced
 job-success transaction. Default compiler/import/runtime wiring remains the M1
 gap; production retention and garbage collection remain M5 work.
 
+The first BM25-only compiler-cache ingress now connects current
+`IndexCompiler` output to this executor without treating mutable cache paths as
+retained authority. `recapture_bm25_view_strict` converts the ordinary fixed
+two-file BM25 tree into a missing-only strict workspace generation. The
+`import_compiler_cache_bm25` coordinator takes the existing-only cooperative
+cache lease; validates the retained source-fingerprint-v2 identity, exact
+manifest data, full lowercase 40-character Git commit, current BM25 metadata,
+and both file fingerprints; and completes the canonical portable BM25-only
+manifest and retained import plan before the first workspace mutation. While
+the lock is held, it publishes separate immutable BM25 and whole-context
+evidence generations and repeats the source, manifest, byte, and receipt
+checks. It releases the cache lock before any retained CAS or catalog data
+operation, so only the authenticated context receipt crosses the mutable-cache
+boundary.
+
+`codenib artifact import-cache` exposes that coordinator as an explicit local
+bootstrap. It requires an existing initialized SQLite catalog, a fully
+preprovisioned strict `LocalCAS`, an existing private Linux workspace root with
+exact mode `0700`, and a real producer cache with its existing lock. Each call
+chooses fresh missing-only BM25 and context destinations and never recursively
+removes a published directory after a later failure. A changed import
+atomically advances the selected ref and prints an immutable-snapshot
+`artifact materialize` handoff without reserving the suggested output. An
+exact retry uses fresh destinations but the original expected ref generation
+and idempotently returns the already-published snapshot without another ref
+advance. This advances BM25 ingress only. M1 remains in progress: default
+compiler/runtime routing and non-BM25 cache ingress remain. Generic builder
+profiles and fenced job publication remain M2 work, runtime hot switching
+remains M3 work, and evidence retention and reclamation remain M5 work.
+
 The first read-only retained `RepoManifest` exporter now closes the data-only
 round trip without introducing path authority. It accepts the additive
 `RetainedSnapshotCatalog` capability plus a receipt-verifying object store,
@@ -552,10 +582,10 @@ rather than deleting it.
 
 This command does not initialize or populate the control plane, import a legacy
 cache, build views, advance refs, or make retained storage the default. It is
-the first explicit local bridge only. Default compiler/import/runtime wiring
-remains the outstanding M1 deliverable, and strict BM25 still lacks the
-`provider-bound-exact` production provider; fenced job publication remains M2
-work.
+the retained-read bridge only. Default compiler/runtime routing and non-BM25
+cache ingress remain outstanding M1 work, and strict BM25 replacement still
+lacks the `provider-bound-exact` production provider; fenced job publication
+remains M2 work.
 
 Schema v2 now adds
 canonical idempotent job requests, immutable
@@ -580,6 +610,12 @@ exposes it, and an explicit read-only directory fallback otherwise.  Windows
 retains a cooperative `msvcrt` byte lock with pre-entry reparse/link and
 identity checks; a future handle-based implementation is required before
 adversarial junction or path-replacement races can enter its contract.
+The compiler-cache importer borrows this lease existing-only: both the cache
+directory and `.index-compiler.lock` must already have been created by a real
+producer run, and import never creates either one. Manually adding a lock file
+cannot establish prior cooperative discipline. The importer acquires the lease
+itself; same-thread re-entry for the same cache inode fails fast, while nested
+leases for different caches remain valid.
 
 Schema v2 deliberately retains complete job aggregates.  Duplicate-insert
 guards reject `REPLACE` of jobs, requested views, and persistent lease slots

--- a/test/artifacts/test_strict_bm25_publication.py
+++ b/test/artifacts/test_strict_bm25_publication.py
@@ -37,6 +37,7 @@ from codenib.artifacts import (
     normalize_owned_query_view_strict,
     plan_bm25_view_strict,
     publish_planned_bm25_view_strict,
+    recapture_bm25_view_strict,
     validate_portable_query_view,
 )
 from codenib.artifacts.strict_bm25 import _record_chunks
@@ -226,6 +227,38 @@ def _publish_source(
     return destination, owner
 
 
+def _write_raw_bm25_source(
+    source: Path,
+    repository: Path,
+) -> tuple[bytes, bytes]:
+    documents = _canonical_bytes(
+        [
+            {
+                "page_content": "alpha VALUE omega",
+                "metadata": {
+                    "file": str(repository / "sample.py"),
+                    "node_id": "sample.VALUE",
+                },
+            },
+            {
+                "page_content": "beta helper",
+                "metadata": {"file": "sample.py", "node_id": "sample.helper"},
+            },
+        ]
+    )
+    metadata = _canonical_bytes(
+        {
+            "project_root": str(repository),
+            "max_k": 17,
+            "language": "english",
+        }
+    )
+    source.mkdir(parents=True)
+    (source / "documents.json").write_bytes(documents)
+    (source / "bm25_metadata.json").write_bytes(metadata)
+    return documents, metadata
+
+
 @pytest.fixture
 def strict_generation(tmp_path: Path):
     repository = _repository(tmp_path)
@@ -324,6 +357,445 @@ def test_strict_bm25_plans_replays_and_serves_same_query_semantics(
         ]
     finally:
         output_owner.close()
+
+
+def test_strict_bm25_recaptures_raw_directory_with_missing_test_provider(
+    tmp_path: Path,
+) -> None:
+    repository = _repository(tmp_path)
+    source = tmp_path / "legacy-bm25"
+    destination = tmp_path / "strict-output" / "bm25"
+    source_documents, source_metadata = _write_raw_bm25_source(source, repository)
+    repository_source = capture_repository_source(repository)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(expected_destination=None)
+    view_config = {"builder_schema": 2, "tokenizer": "code-aware-v1"}
+    try:
+        planned = strict_bm25_module._plan_recaptured_bm25_view(
+            source,
+            destination,
+            repository_source=repository_source,
+            view_config=view_config,
+            environ={},
+        )
+        assert isinstance(planned, PlannedBm25View)
+        assert not destination.exists()
+        assert planned.output_records == (
+            TreeFileRecord(
+                path="bm25_metadata.json",
+                mode=0o600,
+                size=71,
+                sha256=(
+                    "579b6c52fa161af428ca5fc99969fbe4eb7f68c28ff00aadfda3c1522be3bcad"
+                ),
+            ),
+            TreeFileRecord(
+                path="documents.json",
+                mode=0o600,
+                size=264,
+                sha256=(
+                    "31da28af246dec6b8069d7128da2f2f108c514dcba9718c1faa3bb165eb81a41"
+                ),
+            ),
+        )
+
+        adjustments = strict_bm25_module._publish_recaptured_bm25_view(
+            source,
+            destination,
+            planned=planned,
+            repository_source=repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_config=view_config,
+            environ={},
+        )
+
+        assert provider.support_count == 1
+        assert provider.run_count == 1
+        assert provider.requests[0].destination_expectation == "missing"
+        assert provider.requests[0].plan == planned.plan
+        assert output_owner.active
+        assert output_owner.receipt.path == destination
+        assert output_owner.receipt.plan == planned.plan
+        assert adjustments == planned.adjustments
+        assert (source / "documents.json").read_bytes() == source_documents
+        assert (source / "bm25_metadata.json").read_bytes() == source_metadata
+        assert json.loads(
+            (destination / "bm25_metadata.json").read_text(encoding="utf-8")
+        ) == {
+            "project_root": "source",
+            "max_k": 17,
+            "language": "english",
+        }
+        output_documents = json.loads(
+            (destination / "documents.json").read_text(encoding="utf-8")
+        )
+        assert [item["metadata"]["file"] for item in output_documents] == [
+            "sample.py",
+            "sample.py",
+        ]
+        validate_portable_query_view(
+            destination,
+            repo_path=repository,
+            view_type="bm25",
+            view_config={**view_config, **adjustments},
+            environ={},
+        )
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_recapture_has_public_package_export() -> None:
+    assert recapture_bm25_view_strict is strict_bm25_module.recapture_bm25_view_strict
+
+
+def test_strict_bm25_public_recapture_uses_local_missing_provider(
+    tmp_path: Path,
+) -> None:
+    repository = _repository(tmp_path)
+    source = tmp_path / "legacy-bm25"
+    _write_raw_bm25_source(source, repository)
+    workspace_root = tmp_path / "private-workspaces"
+    workspace_root.mkdir(mode=0o700)
+    os.chmod(workspace_root, 0o700)
+    destination = workspace_root / "published-bm25"
+    provider = LocalWorkspaceProvider(workspace_root)
+    try:
+        provider.require_support()
+    except UnsupportedWorkspaceCreation as error:
+        pytest.skip(f"native local workspace provider is unavailable: {error}")
+    repository_source = capture_repository_source(repository)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    try:
+        adjustments = strict_bm25_module.recapture_bm25_view_strict(
+            source,
+            destination,
+            repository_source=repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_config={"builder_schema": 2},
+            environ={},
+        )
+        assert output_owner.active
+        assert output_owner.receipt.path == destination
+        assert set(adjustments["artifact_file_fingerprints"]) == {
+            "bm25_metadata.json",
+            "documents.json",
+        }
+        assert destination.is_dir()
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_recapture_accepts_excluded_source_inside_repository(
+    tmp_path: Path,
+) -> None:
+    repository = _repository(tmp_path)
+    source = repository / "compiler-cache" / "bm25"
+    _write_raw_bm25_source(source, repository)
+    repository_source = capture_repository_source(
+        repository,
+        exclude_roots=(source,),
+    )
+    destination = tmp_path / "strict-output" / "bm25"
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(expected_destination=None)
+    try:
+        identity = repository_source.authenticated_identity_snapshot()
+        assert not any(
+            record.path.startswith("compiler-cache/bm25/")
+            for record in identity.file_records
+        )
+        strict_bm25_module.recapture_bm25_view_strict(
+            source,
+            destination,
+            repository_source=repository_source,
+            workspace_provider=provider,
+            output_receipt_owner=output_owner,
+            view_config={},
+            environ={},
+        )
+        assert output_owner.active
+        assert provider.run_count == 1
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_recapture_rejects_included_repository_source_before_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(tmp_path)
+    source = repository / "compiler-cache" / "bm25"
+    _write_raw_bm25_source(source, repository)
+    repository_source = capture_repository_source(repository)
+    destination = tmp_path / "strict-output" / "bm25"
+
+    def forbidden_capture(*_args, **_kwargs):
+        raise AssertionError("source capture ran before repository exclusion proof")
+
+    monkeypatch.setattr(
+        strict_bm25_module,
+        "capture_directory_ownership",
+        forbidden_capture,
+    )
+    try:
+        with pytest.raises(ValueError, match="must be excluded"):
+            strict_bm25_module._plan_recaptured_bm25_view(
+                source,
+                destination,
+                repository_source=repository_source,
+                view_config={},
+                environ={},
+            )
+        assert not destination.exists()
+    finally:
+        repository_source.close()
+
+
+@pytest.mark.parametrize("destination_kind", ["existing", "repository"])
+def test_strict_bm25_recapture_rejects_destination_preflight_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    destination_kind: str,
+) -> None:
+    repository = _repository(tmp_path)
+    source = tmp_path / "legacy-bm25"
+    source_documents, source_metadata = _write_raw_bm25_source(source, repository)
+    repository_source = capture_repository_source(repository)
+    if destination_kind == "existing":
+        destination = tmp_path / "occupied"
+        destination.mkdir()
+        marker = destination / "marker"
+        marker.write_text("retained\n", encoding="utf-8")
+    else:
+        destination = repository / "strict-output"
+        marker = None
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(expected_destination=None)
+
+    def forbidden_capture(*_args, **_kwargs):
+        raise AssertionError("source capture ran after invalid destination preflight")
+
+    monkeypatch.setattr(
+        strict_bm25_module,
+        "capture_directory_ownership",
+        forbidden_capture,
+    )
+    try:
+        with pytest.raises((FileExistsError, ValueError), match="destination"):
+            strict_bm25_module.recapture_bm25_view_strict(
+                source,
+                destination,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert provider.run_count == 0
+        assert provider.support_count == 0
+        assert output_owner.state == "empty"
+        assert (source / "documents.json").read_bytes() == source_documents
+        assert (source / "bm25_metadata.json").read_bytes() == source_metadata
+        if marker is not None:
+            assert marker.read_text(encoding="utf-8") == "retained\n"
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_recapture_rejects_source_drift_before_provider(
+    tmp_path: Path,
+) -> None:
+    repository = _repository(tmp_path)
+    source = tmp_path / "legacy-bm25"
+    _write_raw_bm25_source(source, repository)
+    destination = tmp_path / "strict-output" / "bm25"
+    repository_source = capture_repository_source(repository)
+    planned = strict_bm25_module._plan_recaptured_bm25_view(
+        source,
+        destination,
+        repository_source=repository_source,
+        view_config={},
+        environ={},
+    )
+    (source / "documents.json").write_bytes(_canonical_bytes([]))
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(expected_destination=None)
+    try:
+        with pytest.raises(ValueError, match="another source generation"):
+            strict_bm25_module._publish_recaptured_bm25_view(
+                source,
+                destination,
+                planned=planned,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert provider.run_count == 0
+        assert provider.support_count == 0
+        assert output_owner.state == "empty"
+        assert not destination.exists()
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_recapture_rejects_plan_tamper_before_source_reopen(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(tmp_path)
+    source = tmp_path / "legacy-bm25"
+    _write_raw_bm25_source(source, repository)
+    destination = tmp_path / "strict-output" / "bm25"
+    repository_source = capture_repository_source(repository)
+    planned = strict_bm25_module._plan_recaptured_bm25_view(
+        source,
+        destination,
+        repository_source=repository_source,
+        view_config={},
+        environ={},
+    )
+    tampered = replace(
+        planned,
+        plan=WorkspacePlan(
+            subject_digest=hashlib.sha256(b"tampered-recapture-plan").hexdigest(),
+            files=planned.plan.files,
+        ),
+    )
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(expected_destination=None)
+
+    def forbidden_capture(*_args, **_kwargs):
+        raise AssertionError("source was recaptured before plan validation")
+
+    monkeypatch.setattr(
+        strict_bm25_module,
+        "capture_directory_ownership",
+        forbidden_capture,
+    )
+    try:
+        with pytest.raises(ValueError, match="not canonical"):
+            strict_bm25_module._publish_recaptured_bm25_view(
+                source,
+                destination,
+                planned=tampered,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert provider.run_count == 0
+        assert output_owner.state == "empty"
+        assert not destination.exists()
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_recapture_detects_tamper_at_reopen_and_rolls_back(
+    tmp_path: Path,
+) -> None:
+    repository = _repository(tmp_path)
+    source = tmp_path / "legacy-bm25"
+    _write_raw_bm25_source(source, repository)
+    destination = tmp_path / "strict-output" / "bm25"
+    repository_source = capture_repository_source(repository)
+    planned = strict_bm25_module._plan_recaptured_bm25_view(
+        source,
+        destination,
+        repository_source=repository_source,
+        view_config={},
+        environ={},
+    )
+
+    def tamper_before_workspace() -> None:
+        (source / "documents.json").write_bytes(_canonical_bytes([]))
+
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(
+        expected_destination=None,
+        support_hook=tamper_before_workspace,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="differs|changed"):
+            strict_bm25_module._publish_recaptured_bm25_view(
+                source,
+                destination,
+                planned=planned,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                environ={},
+            )
+        assert provider.support_count == 1
+        assert provider.run_count == 1
+        assert output_owner.state == "empty"
+        assert not destination.exists()
+    finally:
+        output_owner.close()
+        repository_source.close()
+
+
+def test_strict_bm25_recapture_rejects_forbidden_policy_postflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(tmp_path)
+    source = tmp_path / "legacy-bm25"
+    _write_raw_bm25_source(source, repository)
+    destination = tmp_path / "strict-output" / "bm25"
+    forbidden = tmp_path / "private-build-root"
+    repository_source = capture_repository_source(repository)
+    output_owner = PublishedWorkspaceReceiptOwner()
+    provider = _TestWorkspaceProvider(expected_destination=None)
+    candidate_calls = 0
+    real_candidate_records = strict_bm25_module._candidate_records
+
+    def reject_published_candidate(*args, **kwargs):
+        nonlocal candidate_calls
+        assert kwargs["forbidden_paths"] == (repository, forbidden)
+        records = real_candidate_records(*args, **kwargs)
+        candidate_calls += 1
+        if candidate_calls == 2:
+            raise ValueError("strict BM25 forbidden path postflight failed")
+        return records
+
+    monkeypatch.setattr(
+        strict_bm25_module,
+        "_candidate_records",
+        reject_published_candidate,
+    )
+    try:
+        with pytest.raises(
+            (RuntimeError, ValueError),
+            match="forbidden path postflight|identity failed validation",
+        ):
+            strict_bm25_module.recapture_bm25_view_strict(
+                source,
+                destination,
+                repository_source=repository_source,
+                workspace_provider=provider,
+                output_receipt_owner=output_owner,
+                view_config={},
+                forbidden_paths=(forbidden,),
+                environ={},
+            )
+        assert candidate_calls == 2
+        assert provider.run_count == 1
+        assert not output_owner.active
+    finally:
+        output_owner.close()
+        repository_source.close()
 
 
 def test_strict_bm25_rejects_missing_only_local_provider_before_mutation(

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -1,0 +1,1084 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import inspect
+import json
+import os
+import subprocess
+from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeVar
+
+import pytest
+
+import codenib.compiler as compiler_module
+import codenib.compiler.cache_import as cache_import_module
+from codenib._captured_directory import (
+    OwnedWorkspaceAuthority,
+    PublishedWorkspaceReceiptOwner,
+)
+from codenib._workspace_provider import (
+    StrictWorkspaceRequest,
+    StrictWorkspaceSession,
+    run_adopted_workspace_operation,
+)
+from codenib.artifacts import query_context_artifact
+from codenib.compiler.cache_import import (
+    CompilerCacheBm25RecaptureResult,
+    CompilerCacheImportResult,
+    import_compiler_cache_bm25,
+)
+from codenib.compiler.index_builders import BM25IndexBuilder, IndexBuilderRegistry
+from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.compiler.manifest_import import RepoManifestImportResult
+from codenib.compiler.manifest_materialization import (
+    materialize_retained_repo_manifest_ref,
+)
+from codenib.mcp.context import ServerContext
+from codenib.source_fingerprint import (
+    RepositorySourceBinding,
+    capture_repository_source,
+)
+from codenib.storage import (
+    RETAINED_IMPORT_CATALOG_CONTRACT,
+    LocalCAS,
+    SQLiteCatalog,
+    StorageIntegrityError,
+    StorageValidationError,
+)
+
+_Result = TypeVar("_Result")
+_COMMIT = "a" * 40
+_REPOSITORY_KEY = "owner/repo"
+
+
+class _BackendTripwire:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def retained_import_contract(self) -> str:
+        self.calls.append("contract")
+        return RETAINED_IMPORT_CATALOG_CONTRACT
+
+    def _unexpected(self, name: str):
+        self.calls.append(name)
+        raise AssertionError(f"unexpected backend data operation: {name}")
+
+    def put_bytes(self, *args, **kwargs):
+        return self._unexpected("put_bytes")
+
+    def put_file(self, *args, **kwargs):
+        return self._unexpected("put_file")
+
+    def has(self, *args, **kwargs):
+        return self._unexpected("has")
+
+    def open(self, *args, **kwargs):
+        return self._unexpected("open")
+
+    def read_bytes(self, *args, **kwargs):
+        return self._unexpected("read_bytes")
+
+    def verify(self, *args, **kwargs):
+        return self._unexpected("verify")
+
+    def materialize(self, *args, **kwargs):
+        return self._unexpected("materialize")
+
+    def put_chunks(self, *args, **kwargs):
+        return self._unexpected("put_chunks")
+
+    def verify_receipt(self, *args, **kwargs):
+        return self._unexpected("verify_receipt")
+
+    def retain_receipts(self, *args, **kwargs):
+        return self._unexpected("retain_receipts")
+
+    def create_namespace(self, *args, **kwargs):
+        return self._unexpected("create_namespace")
+
+    def create_repository(self, *args, **kwargs):
+        return self._unexpected("create_repository")
+
+    def create_source_revision(self, *args, **kwargs):
+        return self._unexpected("create_source_revision")
+
+    def create_view_profile(self, *args, **kwargs):
+        return self._unexpected("create_view_profile")
+
+    def register_object(self, *args, **kwargs):
+        return self._unexpected("register_object")
+
+    def stage_view_generation(self, *args, **kwargs):
+        return self._unexpected("stage_view_generation")
+
+    def publish_snapshot(self, *args, **kwargs):
+        return self._unexpected("publish_snapshot")
+
+    def resolve_ref(self, *args, **kwargs):
+        return self._unexpected("resolve_ref")
+
+    def get_manifest_summary(self, *args, **kwargs):
+        return self._unexpected("get_manifest_summary")
+
+
+class _TestWorkspaceProvider:
+    """Quiescent test provider exercising the real workspace authority."""
+
+    def __init__(self) -> None:
+        self.support_count = 0
+        self.run_count = 0
+
+    def require_support(self) -> None:
+        self.support_count += 1
+
+    def run_workspace(
+        self,
+        request: StrictWorkspaceRequest,
+        *,
+        receipt_owner: PublishedWorkspaceReceiptOwner,
+        operation: Callable[[StrictWorkspaceSession], _Result],
+    ) -> _Result:
+        self.run_count += 1
+        plan = request.plan
+        parent = request.destination.parent
+        parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        stage = parent / (
+            f".{request.destination.name}.cache-import-{id(self):x}-"
+            f"{self.run_count}"
+        )
+        stage.mkdir(mode=plan.root_mode)
+        for directory in plan.directories:
+            (stage / directory.path.as_posix()).mkdir(mode=directory.mode)
+
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        parent_descriptor = os.open(parent, flags)
+        root_descriptor = os.open(stage, flags)
+        directory_descriptors = {
+            directory.path.as_posix(): os.open(stage / directory.path.as_posix(), flags)
+            for directory in plan.directories
+        }
+        workspace = OwnedWorkspaceAuthority()
+        try:
+            workspace.adopt(
+                destination=request.destination,
+                stage_name=stage.name,
+                parent_descriptor=parent_descriptor,
+                root_descriptor=root_descriptor,
+                directory_descriptors=directory_descriptors,
+                plan=plan,
+                expected_destination=None,
+            )
+            try:
+                return run_adopted_workspace_operation(
+                    request,
+                    workspace=workspace,
+                    receipt_owner=receipt_owner,
+                    operation=operation,
+                )
+            except BaseException:
+                if receipt_owner.state == "empty":
+                    workspace.close()
+                raise
+        finally:
+            for descriptor in directory_descriptors.values():
+                os.close(descriptor)
+            os.close(root_descriptor)
+            os.close(parent_descriptor)
+
+
+class _LockAwareCAS(LocalCAS):
+    def __init__(self, root: Path, state: dict[str, object]) -> None:
+        self._test_state = state
+        super().__init__(root)
+
+    def put_chunks(
+        self,
+        chunks,
+        expected_digest: str,
+        expected_size: int,
+    ):
+        assert self._test_state["phase"] == "released"
+        self._test_state["events"].append(  # type: ignore[union-attr]
+            ("cas.put_chunks", self._test_state["phase"])
+        )
+        return super().put_chunks(chunks, expected_digest, expected_size)
+
+
+class _LockAwareCatalog(SQLiteCatalog):
+    def __init__(self, path: Path, state: dict[str, object]) -> None:
+        self._test_state = state
+        super().__init__(path)
+
+    def retained_import_contract(self) -> str:
+        assert self._test_state["phase"] != "locked"
+        self._test_state["events"].append(  # type: ignore[union-attr]
+            ("catalog.retained_import_contract", self._test_state["phase"])
+        )
+        return super().retained_import_contract()
+
+    def create_namespace(self, name: str) -> str:
+        assert self._test_state["phase"] == "released"
+        self._test_state["events"].append(  # type: ignore[union-attr]
+            ("catalog.create_namespace", self._test_state["phase"])
+        )
+        return super().create_namespace(name)
+
+
+class _PostCommitInterruptCatalog(SQLiteCatalog):
+    def __init__(self, path: Path) -> None:
+        self._interrupt_after_first_publish = True
+        super().__init__(path)
+
+    def publish_snapshot(self, *args, **kwargs):
+        publication = super().publish_snapshot(*args, **kwargs)
+        if self._interrupt_after_first_publish:
+            self._interrupt_after_first_publish = False
+            raise RuntimeError("postcommit interruption")
+        return publication
+
+
+def _json_bytes(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _file_fingerprint(path: Path) -> dict[str, object]:
+    payload = path.read_bytes()
+    return {
+        "size": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def _fake_import_result() -> RepoManifestImportResult:
+    return RepoManifestImportResult(
+        repository_id="repository-test",
+        source_revision_id="source-test",
+        snapshot_id="snapshot-test",
+        ref_name="main",
+        generation=1,
+        changed=True,
+        views=("bm25",),
+        skipped_items=(),
+        view_generation_items=(("bm25", "generation-test"),),
+    )
+
+
+@dataclass
+class _CacheFixture:
+    repository: Path
+    cache: Path
+    source: RepositorySourceBinding
+    workspace: Path
+    provider: _TestWorkspaceProvider
+    bm25_owner: PublishedWorkspaceReceiptOwner
+    context_owner: PublishedWorkspaceReceiptOwner
+
+    @property
+    def bm25_destination(self) -> Path:
+        return self.workspace / "published-bm25"
+
+    @property
+    def context_destination(self) -> Path:
+        return self.workspace / "published-context"
+
+    def close(self) -> None:
+        self.context_owner.close()
+        self.bm25_owner.close()
+        self.source.close()
+
+
+def _cache_fixture(tmp_path: Path) -> _CacheFixture:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    source_file = repository / "sample.py"
+    source_text = "VALUE = 1\n"
+    source_file.write_text(source_text, encoding="utf-8")
+
+    cache = repository / ".codenib_cache"
+    bm25 = cache / "bm25"
+    bm25.mkdir(mode=0o700, parents=True)
+    # Mirror a real IndexCompiler cache: its fixed coordination inode already
+    # exists before the existing-only import bridge borrows it.
+    with cache_import_module.compiler_cache_lock(cache):
+        pass
+    documents = [
+        {
+            "page_content": source_text,
+            "metadata": {
+                "file": str(source_file),
+                "node_id": "sample.py",
+                "start_line": 0,
+                "end_line": 0,
+                "type": "file",
+            },
+        }
+    ]
+    (bm25 / "documents.json").write_bytes(_json_bytes(documents))
+    (bm25 / "bm25_metadata.json").write_bytes(
+        _json_bytes(
+            {
+                "project_root": str(repository),
+                "max_k": 17,
+                "language": "python",
+            }
+        )
+    )
+    for path in bm25.iterdir():
+        path.chmod(0o600)
+
+    source = capture_repository_source(repository, exclude_roots=(cache,))
+    fingerprints = {
+        name: _file_fingerprint(bm25 / name)
+        for name in ("bm25_metadata.json", "documents.json")
+    }
+    config = BM25IndexBuilder(
+        languages=["python"],
+        max_k=17,
+        max_lines_per_chunk=300,
+    ).artifact_identity()
+    config.update(
+        {
+            "artifact_file_fingerprints": fingerprints,
+            "chunk_count": 1,
+            "source_file_count": 1,
+            "file_count": 1,
+        }
+    )
+    entry = IndexEntry(
+        index_type="bm25",
+        path=str(bm25),
+        built_at="2026-01-01T00:00:00+00:00",
+        built_at_epoch=1.0,
+        status="fresh",
+        config=copy.deepcopy(config),
+        metadata={**copy.deepcopy(config), "build_duration_seconds": 0.1},
+        commit=_COMMIT,
+        source_fingerprint=source.fingerprint,
+    )
+    manifest = RepoManifest(
+        repo_path=str(repository),
+        commit=_COMMIT,
+        last_indexed_commit=_COMMIT,
+        source_fingerprint=source.fingerprint,
+        last_indexed_source_fingerprint=source.fingerprint,
+        languages=["python"],
+        file_count=source.file_count,
+        indexes={"bm25": entry},
+        compiled_at="2026-01-01T00:00:00+00:00",
+        compiled_at_epoch=1.0,
+    )
+    manifest.derive_capabilities()
+    manifest.save(cache / "repo_manifest.json")
+    (cache / "repo_manifest.json").chmod(0o600)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    return _CacheFixture(
+        repository=repository,
+        cache=cache,
+        source=source,
+        workspace=workspace,
+        provider=_TestWorkspaceProvider(),
+        bm25_owner=PublishedWorkspaceReceiptOwner(),
+        context_owner=PublishedWorkspaceReceiptOwner(),
+    )
+
+
+def _call(
+    fixture: _CacheFixture,
+    *,
+    catalog: object | None = None,
+    object_store: object | None = None,
+    **overrides,
+) -> CompilerCacheImportResult:
+    if catalog is None:
+        catalog = _BackendTripwire()
+    if object_store is None:
+        object_store = catalog
+    arguments = {
+        "repository_source": fixture.source,
+        "bm25_output_owner": fixture.bm25_owner,
+        "context_output_owner": fixture.context_owner,
+        "bm25_destination": fixture.bm25_destination,
+        "context_destination": fixture.context_destination,
+        "workspace_provider": fixture.provider,
+        "repository_key": _REPOSITORY_KEY,
+        "catalog": catalog,
+        "object_store": object_store,
+        "environ": {},
+    }
+    arguments.update(overrides)
+    return import_compiler_cache_bm25(fixture.cache, **arguments)  # type: ignore[arg-type]
+
+
+def test_compiler_cache_import_is_a_lazy_public_export() -> None:
+    assert compiler_module.CompilerCacheImportResult is CompilerCacheImportResult
+    assert (
+        compiler_module.CompilerCacheBm25RecaptureResult
+        is CompilerCacheBm25RecaptureResult
+    )
+    assert compiler_module.import_compiler_cache_bm25 is import_compiler_cache_bm25
+    assert list(inspect.signature(import_compiler_cache_bm25).parameters)[:10] == [
+        "cache_dir",
+        "repository_source",
+        "bm25_output_owner",
+        "context_output_owner",
+        "bm25_destination",
+        "context_destination",
+        "workspace_provider",
+        "repository_key",
+        "catalog",
+        "object_store",
+    ]
+
+
+def test_import_recaptures_inside_cache_lock_and_imports_after_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    lock_state = {"held": False}
+    real_lock = cache_import_module.compiler_cache_lock
+    real_plan = cache_import_module.plan_repo_manifest_import_bytes
+    planned_before_publish = {"value": False}
+
+    @contextmanager
+    def tracked_lock(cache: Path, *, create: bool = True):
+        assert create is False
+        with real_lock(cache, create=create):
+            lock_state["held"] = True
+            try:
+                yield
+            finally:
+                lock_state["held"] = False
+
+    def tracked_plan(*args, **kwargs):
+        assert lock_state["held"]
+        planned_before_publish["value"] = True
+        return real_plan(*args, **kwargs)
+
+    real_publish = cache_import_module._publish_recaptured_bm25_view
+
+    def tracked_publish(*args, **kwargs):
+        assert planned_before_publish["value"]
+        return real_publish(*args, **kwargs)
+
+    def imported(plan, **kwargs):
+        assert not lock_state["held"]
+        assert plan.selection.selected_views == ("bm25",)
+        assert kwargs["artifact_owner"] is fixture.context_owner
+        assert kwargs["repository_source"] is fixture.source
+        return _fake_import_result()
+
+    monkeypatch.setattr(cache_import_module, "compiler_cache_lock", tracked_lock)
+    monkeypatch.setattr(
+        cache_import_module,
+        "plan_repo_manifest_import_bytes",
+        tracked_plan,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "_publish_recaptured_bm25_view",
+        tracked_publish,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_retained_repo_manifest",
+        imported,
+    )
+
+    try:
+        result = _call(fixture)
+
+        assert result.import_result == _fake_import_result()
+        assert result.import_plan.selection.selected_views == ("bm25",)
+        assert result.context_artifact.manifest_path.read_bytes() == (
+            result.recapture.canonical_manifest_bytes
+        )
+        assert result.recapture.output_view == fixture.bm25_destination
+        assert fixture.provider.support_count == 3
+        assert fixture.provider.run_count == 2
+        assert fixture.bm25_owner.active
+        assert fixture.context_owner.active
+        assert fixture.source.usable
+    finally:
+        fixture.close()
+
+
+def test_manifest_fingerprint_mismatch_fails_before_workspace_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    manifest = RepoManifest.load(fixture.cache / "repo_manifest.json")
+    manifest.indexes["bm25"].config["artifact_file_fingerprints"]["documents.json"][
+        "sha256"
+    ] = ("0" * 64)
+    manifest.save(fixture.cache / "repo_manifest.json")
+    (fixture.cache / "repo_manifest.json").chmod(0o600)
+    imported = False
+
+    def unexpected_import(*args, **kwargs):
+        nonlocal imported
+        imported = True
+        raise AssertionError("storage import must not run")
+
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_retained_repo_manifest",
+        unexpected_import,
+    )
+    try:
+        with pytest.raises(StorageIntegrityError, match="manifest fingerprints"):
+            _call(fixture)
+        assert fixture.provider.run_count == 0
+        assert fixture.bm25_owner.state == "empty"
+        assert fixture.context_owner.state == "empty"
+        assert not imported
+    finally:
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    ("tamper", "error"),
+    [
+        ("source", "repository source"),
+        ("documents", "manifest fingerprints"),
+        ("manifest", "manifest fingerprints"),
+    ],
+)
+def test_source_and_cache_tamper_fail_before_storage_or_workspace_io(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tamper: str,
+    error: str,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    if tamper == "source":
+        (fixture.repository / "sample.py").write_text(
+            "SOURCE_CHANGED = True\n",
+            encoding="utf-8",
+        )
+    elif tamper == "documents":
+        with (fixture.cache / "bm25/documents.json").open("ab") as handle:
+            handle.write(b"\n")
+    else:
+        manifest = RepoManifest.load(fixture.cache / "repo_manifest.json")
+        manifest.indexes["bm25"].metadata["artifact_file_fingerprints"][
+            "documents.json"
+        ]["sha256"] = ("f" * 64)
+        manifest.save(fixture.cache / "repo_manifest.json")
+        (fixture.cache / "repo_manifest.json").chmod(0o600)
+
+    storage_calls: list[str] = []
+
+    def unexpected_import(*args, **kwargs):
+        storage_calls.append("import")
+        raise AssertionError("storage import must not run")
+
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_retained_repo_manifest",
+        unexpected_import,
+    )
+    backend = _BackendTripwire()
+    try:
+        with pytest.raises((RuntimeError, ValueError), match=error):
+            _call(fixture, catalog=backend, object_store=backend)
+        assert storage_calls == []
+        assert backend.calls == ["contract"]
+        assert fixture.provider.support_count == 1
+        assert fixture.provider.run_count == 0
+        assert fixture.bm25_owner.state == "empty"
+        assert fixture.context_owner.state == "empty"
+        fixture.bm25_owner.close()
+        fixture.context_owner.close()
+        assert fixture.bm25_owner.closed
+        assert fixture.context_owner.closed
+    finally:
+        fixture.close()
+
+
+def test_existing_context_destination_denies_before_bm25_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    fixture.context_destination.mkdir()
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_retained_repo_manifest",
+        lambda *args, **kwargs: pytest.fail("storage import must not run"),
+    )
+    try:
+        with pytest.raises(FileExistsError, match="must be missing"):
+            _call(fixture)
+        assert fixture.provider.run_count == 0
+        assert fixture.bm25_owner.state == "empty"
+        assert fixture.context_owner.state == "empty"
+    finally:
+        fixture.close()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error", "contract_probes"),
+    [
+        ({"repository_key": "Owner/Repo"}, "repository key", 0),
+        ({"max_context_files": 0}, "context file limit", 0),
+        ({"expected_generation": -1}, "expected ref generation", 0),
+    ],
+)
+def test_invalid_import_inputs_fail_before_support_contract_or_workspace(
+    tmp_path: Path,
+    overrides: dict[str, object],
+    error: str,
+    contract_probes: int,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    backend = _BackendTripwire()
+    try:
+        with pytest.raises(StorageValidationError, match=error):
+            _call(
+                fixture,
+                catalog=backend,
+                object_store=backend,
+                **overrides,
+            )
+        assert backend.calls == ["contract"] * contract_probes
+        assert fixture.provider.support_count == 0
+        assert fixture.provider.run_count == 0
+        assert fixture.bm25_owner.state == "empty"
+        assert fixture.context_owner.state == "empty"
+    finally:
+        fixture.close()
+
+
+def test_short_manifest_commit_fails_after_contract_probe_without_data_io(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    manifest = RepoManifest.load(fixture.cache / "repo_manifest.json")
+    manifest.commit = "abc123"
+    manifest.last_indexed_commit = "abc123"
+    manifest.indexes["bm25"].commit = "abc123"
+    manifest.save(fixture.cache / "repo_manifest.json")
+    (fixture.cache / "repo_manifest.json").chmod(0o600)
+    backend = _BackendTripwire()
+    try:
+        with pytest.raises(ValueError, match="full lowercase Git SHA"):
+            _call(fixture, catalog=backend, object_store=backend)
+        assert backend.calls == ["contract"]
+        assert fixture.provider.support_count == 1
+        assert fixture.provider.run_count == 0
+        assert fixture.bm25_owner.state == "empty"
+        assert fixture.context_owner.state == "empty"
+    finally:
+        fixture.close()
+
+
+def test_nested_cache_must_be_absent_from_retained_source_records(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    fixture.source.close()
+    included_cache = fixture.repository / "compiler-state"
+    fixture.cache.rename(included_cache)
+    fixture.cache = included_cache
+    # Stabilize the lock file, then deliberately capture the cache as source.
+    with cache_import_module.compiler_cache_lock(fixture.cache):
+        pass
+    fixture.source = capture_repository_source(fixture.repository)
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_retained_repo_manifest",
+        lambda *args, **kwargs: pytest.fail("storage import must not run"),
+    )
+    try:
+        with pytest.raises(StorageIntegrityError, match="source records"):
+            _call(fixture)
+        assert fixture.provider.run_count == 0
+    finally:
+        fixture.close()
+
+
+def test_manifest_is_read_bounded_without_following_links(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    manifest = fixture.cache / "repo_manifest.json"
+    target = fixture.cache / "manifest-target.json"
+    manifest.rename(target)
+    manifest.symlink_to(target.name)
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_retained_repo_manifest",
+        lambda *args, **kwargs: pytest.fail("storage import must not run"),
+    )
+    try:
+        with pytest.raises(ValueError, match="not a private regular file"):
+            _call(fixture)
+        assert fixture.provider.run_count == 0
+    finally:
+        fixture.close()
+
+
+def test_missing_cache_fails_without_creating_directory_or_lock(tmp_path: Path) -> None:
+    fixture = _cache_fixture(tmp_path)
+    missing_cache = tmp_path / "missing-cache"
+    fixture.cache = missing_cache
+    backend = _BackendTripwire()
+    try:
+        with pytest.raises(RuntimeError, match="open compiler cache directory"):
+            _call(fixture, catalog=backend, object_store=backend)
+        assert not missing_cache.exists()
+        assert backend.calls == ["contract"]
+        assert fixture.provider.support_count == 1
+        assert fixture.provider.run_count == 0
+        assert fixture.bm25_owner.state == "empty"
+        assert fixture.context_owner.state == "empty"
+    finally:
+        fixture.close()
+
+
+def test_missing_fixed_lock_fails_without_mutating_existing_cache(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    lock_path = fixture.cache / ".index-compiler.lock"
+    lock_path.unlink()
+    before = tuple(
+        sorted(
+            path.relative_to(fixture.cache).as_posix()
+            for path in fixture.cache.rglob("*")
+        )
+    )
+    backend = _BackendTripwire()
+    try:
+        with pytest.raises(RuntimeError, match="lock does not exist"):
+            _call(fixture, catalog=backend, object_store=backend)
+        after = tuple(
+            sorted(
+                path.relative_to(fixture.cache).as_posix()
+                for path in fixture.cache.rglob("*")
+            )
+        )
+        assert after == before
+        assert not lock_path.exists()
+        assert backend.calls == ["contract"]
+        assert fixture.provider.support_count == 1
+        assert fixture.provider.run_count == 0
+        assert fixture.bm25_owner.state == "empty"
+        assert fixture.context_owner.state == "empty"
+    finally:
+        fixture.close()
+
+
+def test_import_failure_preserves_published_evidence_and_caller_owners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+
+    def fail_import(*args, **kwargs):
+        raise RuntimeError("catalog unavailable")
+
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_retained_repo_manifest",
+        fail_import,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="catalog unavailable"):
+            _call(fixture)
+        assert fixture.bm25_destination.is_dir()
+        assert fixture.context_destination.is_dir()
+        assert fixture.bm25_owner.active
+        assert fixture.context_owner.active
+        assert fixture.source.usable
+    finally:
+        fixture.close()
+
+
+def test_postcommit_interruption_retries_as_exact_unchanged_import(
+    tmp_path: Path,
+) -> None:
+    fixture = _cache_fixture(tmp_path)
+    first_bm25_owner = fixture.bm25_owner
+    first_context_owner = fixture.context_owner
+    first_bm25_destination = fixture.bm25_destination
+    first_context_destination = fixture.context_destination
+    try:
+        with (
+            LocalCAS(tmp_path / "cas") as cas,
+            _PostCommitInterruptCatalog(tmp_path / "catalog.sqlite") as catalog,
+        ):
+            with pytest.raises(RuntimeError, match="postcommit interruption"):
+                _call(fixture, catalog=catalog, object_store=cas)
+
+            assert first_bm25_destination.is_dir()
+            assert first_context_destination.is_dir()
+            assert first_bm25_owner.active
+            assert first_context_owner.active
+            assert fixture.source.usable
+
+            fixture.workspace = tmp_path / "retry-workspace"
+            fixture.workspace.mkdir(mode=0o700)
+            fixture.bm25_owner = PublishedWorkspaceReceiptOwner()
+            fixture.context_owner = PublishedWorkspaceReceiptOwner()
+            retry = _call(fixture, catalog=catalog, object_store=cas)
+
+            assert retry.import_result.generation == 1
+            assert retry.import_result.changed is False
+            assert retry.import_result.snapshot_id
+            assert fixture.provider.support_count == 6
+            assert fixture.provider.run_count == 4
+            assert first_bm25_owner.active
+            assert first_context_owner.active
+    finally:
+        fixture.close()
+        first_context_owner.close()
+        first_bm25_owner.close()
+
+
+def _git_commit(repository: Path, message: str) -> str:
+    subprocess.run(["git", "-C", str(repository), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "commit", "-qm", message],
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_real_compiler_cache_import_retry_update_and_latest_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.email", "test@example.test"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.name", "CodeNib Test"],
+        check=True,
+    )
+    source_file = repository / "sample.py"
+    source_file.write_text(
+        'GENERATION_MARKER = "GENERATION_A_ONLY"\n',
+        encoding="utf-8",
+    )
+    commit_a = _git_commit(repository, "generation-a")
+
+    registry = IndexBuilderRegistry()
+    registry.register(
+        "bm25",
+        BM25IndexBuilder(languages=["python"], max_k=17),
+    )
+    compiler = IndexCompiler(
+        registry,
+        IndexCompilerConfig(index_types=["bm25"], languages=["python"]),
+    )
+    cache = repository / ".codenib_cache"
+    manifest_a = compiler.compile_repo(
+        str(repository),
+        index_types=["bm25"],
+        cache_dir=str(cache),
+    )
+    assert manifest_a.commit == commit_a
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    provider = _TestWorkspaceProvider()
+    state: dict[str, object] = {"phase": "before", "events": []}
+    real_lock = cache_import_module.compiler_cache_lock
+
+    @contextmanager
+    def tracked_lock(cache_path: Path, *, create: bool = True):
+        assert create is False
+        with real_lock(cache_path, create=create):
+            state["phase"] = "locked"
+            state["events"].append(  # type: ignore[union-attr]
+                ("cache.lock.acquired", state["phase"])
+            )
+            try:
+                yield
+            finally:
+                state["phase"] = "released"
+                state["events"].append(  # type: ignore[union-attr]
+                    ("cache.lock.released", state["phase"])
+                )
+
+    monkeypatch.setattr(cache_import_module, "compiler_cache_lock", tracked_lock)
+
+    owners: list[PublishedWorkspaceReceiptOwner] = []
+    source_a = capture_repository_source(repository, exclude_roots=(cache,))
+    source_b: RepositorySourceBinding | None = None
+    materialized_owner = PublishedWorkspaceReceiptOwner()
+    binding = None
+    context: ServerContext | None = None
+
+    def import_generation(
+        name: str,
+        source: RepositorySourceBinding,
+        *,
+        expected_generation: int,
+        catalog: SQLiteCatalog,
+        cas: LocalCAS,
+    ) -> CompilerCacheImportResult:
+        bm25_owner = PublishedWorkspaceReceiptOwner()
+        context_owner = PublishedWorkspaceReceiptOwner()
+        owners.extend((bm25_owner, context_owner))
+        return import_compiler_cache_bm25(
+            cache,
+            repository_source=source,
+            bm25_output_owner=bm25_owner,
+            context_output_owner=context_owner,
+            bm25_destination=workspace / f"{name}-bm25",
+            context_destination=workspace / f"{name}-context",
+            workspace_provider=provider,
+            repository_key=_REPOSITORY_KEY,
+            catalog=catalog,
+            object_store=cas,
+            expected_generation=expected_generation,
+            environ={},
+        )
+
+    try:
+        with (
+            _LockAwareCAS(tmp_path / "cas", state) as cas,
+            _LockAwareCatalog(tmp_path / "catalog.sqlite", state) as catalog,
+        ):
+            first = import_generation(
+                "a-first",
+                source_a,
+                expected_generation=0,
+                catalog=catalog,
+                cas=cas,
+            )
+            assert first.import_result.generation == 1
+            assert first.import_result.changed is True
+            assert state["events"][:4] == [  # type: ignore[index]
+                ("catalog.retained_import_contract", "before"),
+                ("cache.lock.acquired", "locked"),
+                ("cache.lock.released", "released"),
+                ("catalog.retained_import_contract", "released"),
+            ]
+            assert all(
+                phase == "released"
+                for event, phase in state["events"]  # type: ignore[union-attr]
+                if event in {"cas.put_chunks", "catalog.create_namespace"}
+            )
+
+            retry = import_generation(
+                "a-retry",
+                source_a,
+                expected_generation=0,
+                catalog=catalog,
+                cas=cas,
+            )
+            assert retry.import_plan.plan_digest == first.import_plan.plan_digest
+            assert retry.import_result.snapshot_id == first.import_result.snapshot_id
+            assert retry.import_result.generation == 1
+            assert retry.import_result.changed is False
+
+            source_a.close()
+            source_file.write_text(
+                'GENERATION_MARKER = "GENERATION_B_ONLY"\n',
+                encoding="utf-8",
+            )
+            commit_b = _git_commit(repository, "generation-b")
+            manifest_b = compiler.update_repo(
+                str(repository),
+                index_types=["bm25"],
+                cache_dir=str(cache),
+            )
+            assert commit_b != commit_a
+            assert manifest_b.commit == commit_b
+            source_b = capture_repository_source(repository, exclude_roots=(cache,))
+
+            updated = import_generation(
+                "b-updated",
+                source_b,
+                expected_generation=1,
+                catalog=catalog,
+                cas=cas,
+            )
+            assert updated.import_result.generation == 2
+            assert updated.import_result.changed is True
+            assert updated.import_result.snapshot_id != first.import_result.snapshot_id
+
+            materialized = materialize_retained_repo_manifest_ref(
+                _REPOSITORY_KEY,
+                workspace / "latest-materialized",
+                catalog=catalog,
+                object_store=cas,
+                workspace_provider=provider,
+                output_receipt_owner=materialized_owner,
+                expected_generation=2,
+                environ={},
+            )
+            assert materialized.export_receipt.ref_generation == 2
+            assert materialized.artifact.commit == commit_b
+
+            binding = query_context_artifact(
+                materialized.artifact.output_dir,
+                expected_repository=_REPOSITORY_KEY,
+                expected_commit=commit_b,
+            )
+            context = ServerContext.load(
+                binding.manifest,
+                views=("bm25",),
+                artifact_binding=binding,
+            )
+            assert context.loaded_views == frozenset({"bm25"})
+            assert context.errors == {}
+            assert context.bm25 is not None
+            assert any(
+                "generation b only" in document.page_content
+                for document in context.bm25.documents
+            )
+            assert all(
+                "generation a only" not in document.page_content
+                for document in context.bm25.documents
+            )
+            assert context.bm25.search("GENERATION_B_ONLY", top_k=5)
+    finally:
+        if context is not None:
+            context.close()
+        if binding is not None:
+            binding.close()
+        materialized_owner.close()
+        for owner in reversed(owners):
+            owner.close()
+        if source_b is not None:
+            source_b.close()
+        source_a.close()

--- a/test/compiler/test_cache_import.py
+++ b/test/compiler/test_cache_import.py
@@ -20,9 +20,12 @@ import pytest
 
 import codenib.compiler as compiler_module
 import codenib.compiler.cache_import as cache_import_module
+from codenib import LocalWorkspaceProvider
+from codenib import cli as cli_module
 from codenib._captured_directory import (
     OwnedWorkspaceAuthority,
     PublishedWorkspaceReceiptOwner,
+    UnsupportedWorkspaceCreation,
 )
 from codenib._workspace_provider import (
     StrictWorkspaceRequest,
@@ -1082,3 +1085,160 @@ def test_real_compiler_cache_import_retry_update_and_latest_query(
         if source_b is not None:
             source_b.close()
         source_a.close()
+
+
+def test_real_cli_import_cache_materialize_snapshot_and_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(mode=0o700)
+    workspace.chmod(0o700)
+    provider = LocalWorkspaceProvider(workspace)
+    try:
+        provider.require_support()
+    except UnsupportedWorkspaceCreation as error:
+        pytest.skip(f"native local workspace provider is unavailable: {error}")
+
+    repository = tmp_path / "repository"
+    repository.mkdir(mode=0o700)
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.email", "test@example.test"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.name", "CodeNib Test"],
+        check=True,
+    )
+    source_file = repository / "sample.py"
+    source_file.write_text(
+        'CLI_E2E_MARKER = "PRODUCTION_SHAPED_CACHE_IMPORT"\n',
+        encoding="utf-8",
+    )
+    commit = _git_commit(repository, "cli-cache-import")
+
+    registry = IndexBuilderRegistry()
+    registry.register(
+        "bm25",
+        BM25IndexBuilder(languages=["python"], max_k=17),
+    )
+    compiler = IndexCompiler(
+        registry,
+        IndexCompilerConfig(index_types=["bm25"], languages=["python"]),
+    )
+    cache = repository / ".codenib_cache"
+    manifest = compiler.compile_repo(
+        str(repository),
+        index_types=["bm25"],
+        cache_dir=str(cache),
+    )
+    assert manifest.commit == commit
+
+    catalog_path = tmp_path / "catalog.sqlite"
+    with SQLiteCatalog(catalog_path):
+        pass
+    cas_root = tmp_path / "cas"
+    with LocalCAS.provision(cas_root):
+        pass
+
+    nonce = "0123456789abcdef0123456789abcdef"
+    monkeypatch.setattr(cli_module, "_new_compiler_cache_import_nonce", lambda: nonce)
+    parser = cli_module.build_parser()
+    import_args = parser.parse_args(
+        [
+            "artifact",
+            "import-cache",
+            os.fspath(repository),
+            "--cache-dir",
+            os.fspath(cache),
+            "--catalog",
+            os.fspath(catalog_path),
+            "--cas-root",
+            os.fspath(cas_root),
+            "--workspace-root",
+            os.fspath(workspace),
+            "--repository",
+            _REPOSITORY_KEY,
+        ]
+    )
+    assert import_args.handler is cli_module._run_artifact_import_cache
+    assert import_args.handler(import_args) == 0
+
+    import_output = capsys.readouterr().out
+    snapshot_id = next(
+        line.partition(":")[2].strip()
+        for line in import_output.splitlines()
+        if line.startswith("Snapshot:")
+    )
+    assert snapshot_id
+    assert "Generation:         1" in import_output
+
+    prefix = f".codenib-cache-import-{nonce}"
+    bm25_generation = workspace / f"{prefix}-bm25"
+    context_generation = workspace / f"{prefix}-context"
+    suggested_output = workspace / f"{prefix}-materialized"
+    materialized_output = workspace / "materialized"
+    assert bm25_generation.is_dir()
+    assert context_generation.is_dir()
+    assert not suggested_output.exists()
+    assert not materialized_output.exists()
+
+    materialize_args = parser.parse_args(
+        [
+            "artifact",
+            "materialize",
+            "--catalog",
+            os.fspath(catalog_path),
+            "--cas-root",
+            os.fspath(cas_root),
+            "--workspace-root",
+            os.fspath(workspace),
+            "--repository",
+            _REPOSITORY_KEY,
+            "--snapshot",
+            snapshot_id,
+            "--output",
+            os.fspath(materialized_output),
+        ]
+    )
+    assert materialize_args.handler is cli_module._run_artifact_materialize
+    assert materialize_args.handler(materialize_args) == 0
+
+    materialize_output = capsys.readouterr().out
+    assert f"Snapshot:         {snapshot_id}" in materialize_output
+    assert materialized_output.is_dir()
+    assert bm25_generation.is_dir()
+    assert context_generation.is_dir()
+
+    binding = query_context_artifact(
+        materialized_output,
+        expected_repository=_REPOSITORY_KEY,
+        expected_commit=commit,
+    )
+    context: ServerContext | None = None
+    try:
+        context = ServerContext.load(
+            binding.manifest,
+            views=("bm25",),
+            artifact_binding=binding,
+        )
+        assert context.errors == {}
+        assert context.loaded_views == frozenset({"bm25"})
+        assert context.bm25 is not None
+        hits = context.bm25.search(
+            "PRODUCTION_SHAPED_CACHE_IMPORT",
+            top_k=5,
+            return_code_content=True,
+        )
+        assert hits
+        assert hits[0].file == "sample.py"
+        assert any(
+            "production shaped cache import" in document.page_content
+            for document in context.bm25.documents
+        )
+    finally:
+        if context is not None:
+            context.close()
+        binding.close()

--- a/test/compiler/test_cache_lock.py
+++ b/test/compiler/test_cache_lock.py
@@ -303,6 +303,155 @@ def test_creates_bounded_entries_without_chmodding_existing_parent(
     assert lock_mode & 0o177 == 0
 
 
+def test_existing_only_lock_rejects_missing_cache_without_creation(
+    tmp_path: Path,
+) -> None:
+    cache = tmp_path / "missing-cache"
+
+    with pytest.raises(RuntimeError, match="open compiler cache directory"):
+        with compiler_cache_lock(cache, create=False):
+            raise AssertionError("unreachable")
+
+    assert not cache.exists()
+
+
+def test_existing_only_lock_rejects_missing_lock_without_creation(
+    tmp_path: Path,
+) -> None:
+    cache = tmp_path / "cache"
+    cache.mkdir()
+
+    with pytest.raises(RuntimeError, match="lock does not exist"):
+        with compiler_cache_lock(cache, create=False):
+            raise AssertionError("unreachable")
+
+    assert list(cache.iterdir()) == []
+
+
+def test_existing_only_lock_borrows_existing_cache_and_lock(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    with compiler_cache_lock(cache):
+        pass
+    lock_path = cache / COMPILER_CACHE_LOCK_FILENAME
+    before = _metadata_identity(lock_path)
+    entered = False
+
+    with compiler_cache_lock(cache, create=False):
+        entered = True
+
+    assert entered is True
+    assert _metadata_identity(lock_path) == before
+
+
+def test_lock_create_policy_rejects_non_bool_before_directory_io(
+    tmp_path: Path,
+) -> None:
+    cache = tmp_path / "missing-cache"
+
+    with pytest.raises(TypeError, match="exact bool"):
+        with compiler_cache_lock(cache, create=1):  # type: ignore[arg-type]
+            raise AssertionError("unreachable")
+
+    assert not cache.exists()
+
+
+@pytest.mark.timeout(5)
+def test_same_thread_same_cache_reentry_fails_fast_and_outer_stays_locked(
+    tmp_path: Path,
+) -> None:
+    cache = tmp_path / "cache"
+    contender_acquired = threading.Event()
+
+    def contend() -> None:
+        with compiler_cache_lock(cache):
+            contender_acquired.set()
+
+    with compiler_cache_lock(cache):
+        with pytest.raises(RuntimeError, match="already held by this thread"):
+            with compiler_cache_lock(cache):
+                raise AssertionError("unreachable")
+
+        contender = threading.Thread(target=contend)
+        contender.start()
+        assert not contender_acquired.wait(timeout=0.25)
+
+    assert contender_acquired.wait(timeout=5)
+    contender.join(timeout=5)
+    assert not contender.is_alive()
+    with compiler_cache_lock(cache, create=False):
+        pass
+
+
+def test_same_thread_can_nest_distinct_cache_locks(tmp_path: Path) -> None:
+    first = tmp_path / "first-cache"
+    second = tmp_path / "second-cache"
+
+    with compiler_cache_lock(first):
+        with compiler_cache_lock(second):
+            assert (first / COMPILER_CACHE_LOCK_FILENAME).is_file()
+            assert (second / COMPILER_CACHE_LOCK_FILENAME).is_file()
+
+
+def test_interruption_after_thread_claim_does_not_leave_ghost_ownership(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = tmp_path / "cache"
+    with compiler_cache_lock(cache):
+        pass
+    real_claim = lock_module._claim_thread_cache_lock
+    interrupted = False
+
+    def interrupt_after_claim(cache_path: Path, claim: object) -> None:
+        nonlocal interrupted
+        real_claim(cache_path, claim)  # type: ignore[arg-type]
+        if not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        lock_module,
+        "_claim_thread_cache_lock",
+        interrupt_after_claim,
+    )
+    with pytest.raises(KeyboardInterrupt):
+        with compiler_cache_lock(cache, create=False):
+            raise AssertionError("unreachable")
+
+    with compiler_cache_lock(cache, create=False):
+        pass
+
+
+def test_interruption_after_thread_claim_release_does_not_leave_ghost_ownership(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = tmp_path / "cache"
+    with compiler_cache_lock(cache):
+        pass
+    real_release = lock_module._release_thread_cache_lock_claim
+    interrupted = False
+
+    def interrupt_after_release(claim: object) -> None:
+        nonlocal interrupted
+        real_release(claim)  # type: ignore[arg-type]
+        if not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        lock_module,
+        "_release_thread_cache_lock_claim",
+        interrupt_after_release,
+    )
+    with pytest.raises(KeyboardInterrupt):
+        with compiler_cache_lock(cache, create=False):
+            pass
+
+    with compiler_cache_lock(cache, create=False):
+        pass
+
+
 def test_serializes_threads(tmp_path: Path) -> None:
     cache = tmp_path / "cache"
     started = threading.Event()
@@ -1424,6 +1573,43 @@ def test_rejects_lock_entry_swap_before_entering_body(
     assert entered is False
     assert stolen.read_bytes() == b"original"
     assert lock_path.read_bytes() == b"replacement"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="exercises POSIX identity binding")
+def test_existing_only_lock_rejects_cache_path_swap_without_creating_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = tmp_path / "cache"
+    with compiler_cache_lock(cache):
+        pass
+    moved_cache = tmp_path / "moved-cache"
+    real_validate = lock_module._validate_posix_lock_entry
+    calls = 0
+
+    def replace_cache_after_lock_validation(*args, **kwargs):
+        nonlocal calls
+        identity = real_validate(*args, **kwargs)
+        calls += 1
+        if calls == 2:
+            cache.rename(moved_cache)
+            cache.mkdir()
+        return identity
+
+    monkeypatch.setattr(
+        lock_module,
+        "_validate_posix_lock_entry",
+        replace_cache_after_lock_validation,
+    )
+    entered = False
+
+    with pytest.raises(RuntimeError, match="compiler cache path changed"):
+        with compiler_cache_lock(cache, create=False):
+            entered = True
+
+    assert entered is False
+    assert list(cache.iterdir()) == []
+    assert (moved_cache / COMPILER_CACHE_LOCK_FILENAME).is_file()
 
 
 @pytest.mark.skipif(os.name != "posix", reason="exercises POSIX identity binding")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -16,7 +16,9 @@ import pytest
 import yaml
 
 import codenib
+import codenib.compiler.cache_import as cache_import_module
 import codenib.compiler.manifest_materialization as materialization_module
+import codenib.source_fingerprint as source_fingerprint_module
 import codenib.storage as storage_module
 import codenib.web.local as local_module
 from codenib import cli
@@ -153,6 +155,483 @@ def test_publish_and_artifact_parsers_expose_distribution_options() -> None:
     assert publish.embedding_provider == "openai"
     assert artifact.artifact_command == "pack"
     assert artifact.view == ["bm25,vector"]
+
+
+def test_artifact_import_cache_parser_exposes_existing_storage_inputs() -> None:
+    base = [
+        "artifact",
+        "import-cache",
+        "/src/repo",
+        "--cache-dir",
+        "/src/repo/.codenib_index",
+        "--catalog",
+        "/state/catalog.sqlite3",
+        "--cas-root",
+        "/state/cas",
+        "--workspace-root",
+        "/state/workspaces",
+        "--repository",
+        "owner/repo",
+    ]
+    args = cli.build_parser().parse_args(
+        [
+            *base,
+            "--namespace",
+            "production",
+            "--ref",
+            "release",
+            "--expected-generation",
+            "0",
+        ]
+    )
+    defaults = cli.build_parser().parse_args(base)
+
+    assert args.handler is cli._run_artifact_import_cache
+    assert args.artifact_command == "import-cache"
+    assert args.repo == "/src/repo"
+    assert args.cache_dir == "/src/repo/.codenib_index"
+    assert args.namespace == "production"
+    assert args.ref == "release"
+    assert args.expected_generation == 0
+    assert defaults.namespace == "default"
+    assert defaults.ref == "main"
+    assert defaults.expected_generation == 0
+    assert cli._compiler_cache_import_selection(
+        ref_name=None,
+        expected_generation=None,
+    ) == ("main", 0)
+
+    with pytest.raises(SystemExit) as negative:
+        cli.build_parser().parse_args([*base, "--expected-generation", "-1"])
+    assert negative.value.code == 2
+    with pytest.raises(SystemExit) as overflow:
+        cli.build_parser().parse_args([*base, "--expected-generation", str(2**63)])
+    assert overflow.value.code == 2
+
+
+def test_artifact_import_cache_freezes_missing_disjoint_topology(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cache = repo / ".codenib_index"
+    cache.mkdir()
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    monkeypatch.setattr(cli, "_new_compiler_cache_import_nonce", lambda: "a" * 32)
+    args = SimpleNamespace(
+        repo=str(repo),
+        cache_dir=str(cache),
+        catalog=str(catalog),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+    )
+
+    paths = cli._compiler_cache_import_paths(args)
+    topology = cli._require_compiler_cache_import_topology(paths)
+
+    prefix = ".codenib-cache-import-" + "a" * 32
+    assert topology.cache_dir == cache.resolve(strict=True)
+    assert topology.catalog_path == catalog.resolve(strict=True)
+    assert topology.cas_root == cas_root.resolve(strict=True)
+    assert paths.bm25_destination == workspace_root / f"{prefix}-bm25"
+    assert paths.context_destination == workspace_root / f"{prefix}-context"
+    assert paths.suggested_materialization == (
+        workspace_root / f"{prefix}-materialized"
+    )
+
+    paths.context_destination.mkdir()
+    with pytest.raises(cli.CLIError, match="output must be missing"):
+        cli._require_compiler_cache_import_topology(paths)
+    paths.context_destination.rmdir()
+
+    cache_alias = tmp_path / "cache-alias"
+    cache_alias.symlink_to(workspace_root, target_is_directory=True)
+    alias_paths = cli._compiler_cache_import_paths(
+        SimpleNamespace(
+            repo=str(repo),
+            cache_dir=str(cache_alias),
+            catalog=str(catalog),
+            cas_root=str(cas_root),
+            workspace_root=str(workspace_root),
+        )
+    )
+    with pytest.raises(cli.CLIError, match="physically overlap the workspace"):
+        cli._require_compiler_cache_import_topology(alias_paths)
+
+
+def test_artifact_import_cache_rejects_directory_identity_aliases(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _cache_import_cli_test_args(tmp_path)
+    monkeypatch.setattr(cli, "_new_compiler_cache_import_nonce", lambda: "e" * 32)
+    paths = cli._compiler_cache_import_paths(args)
+    workspace = Path(args.workspace_root).resolve(strict=True)
+    workspace_identity = cli._retained_real_directory_identity(
+        workspace,
+        label="workspace root",
+    )
+    real_ancestry = cli._retained_directory_ancestry
+
+    def aliased_ancestry(
+        path: Path,
+        *,
+        label: str,
+    ) -> tuple[tuple[Path, tuple[int, int]], ...]:
+        ancestry = real_ancestry(path, label=label)
+        if label == "cache directory":
+            return ((ancestry[0][0], workspace_identity), *ancestry[1:])
+        return ancestry
+
+    monkeypatch.setattr(cli, "_retained_directory_ancestry", aliased_ancestry)
+
+    with pytest.raises(
+        cli.CLIError,
+        match="cache directory must not physically alias the workspace root",
+    ):
+        cli._require_compiler_cache_import_topology(paths)
+
+
+def _cache_import_cli_test_args(tmp_path: Path) -> SimpleNamespace:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cache = repo / ".codenib_index"
+    cache.mkdir()
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir(mode=0o700)
+    return SimpleNamespace(
+        repo=str(repo),
+        cache_dir=str(cache),
+        catalog=str(catalog),
+        cas_root=str(cas_root),
+        workspace_root=str(workspace_root),
+        repository="owner/repo",
+        namespace="default",
+        ref="main",
+        expected_generation=0,
+    )
+
+
+def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = _cache_import_cli_test_args(tmp_path)
+    nonce = "b" * 32
+    monkeypatch.setattr(cli, "_new_compiler_cache_import_nonce", lambda: nonce)
+    workspace_root = Path(args.workspace_root)
+    cache = Path(args.cache_dir)
+    catalog_path = Path(args.catalog)
+    cas_root = Path(args.cas_root)
+    bm25_destination = workspace_root / f".codenib-cache-import-{nonce}-bm25"
+    context_destination = workspace_root / f".codenib-cache-import-{nonce}-context"
+    suggested = workspace_root / f".codenib-cache-import-{nonce}-materialized"
+    events: list[str] = []
+    bridge_calls: list[tuple[Path, dict[str, object]]] = []
+    capture_calls: list[tuple[Path, tuple[Path, ...]]] = []
+
+    class Provider:
+        def __init__(self, root: Path) -> None:
+            assert root == workspace_root
+            events.append("provider")
+
+        def require_support(self) -> None:
+            events.append("provider-support")
+
+    class Closeable:
+        def __init__(self, label: str) -> None:
+            self.label = label
+            self.closed = False
+
+        def close(self) -> None:
+            events.append(f"{self.label}-close")
+            self.closed = True
+
+    bm25_owner = Closeable("bm25")
+    context_owner = Closeable("context")
+    source = Closeable("source")
+    store = Closeable("cas")
+    catalog = Closeable("catalog")
+    receipt_owners = iter((bm25_owner, context_owner))
+    catalog_identity = cli._retained_catalog_file_identity(catalog_path)
+
+    def capture(
+        root: Path,
+        *,
+        exclude_roots: tuple[Path, ...],
+        _source_owner,
+    ) -> Closeable:
+        events.append("capture")
+        capture_calls.append((root, exclude_roots))
+        _source_owner(source)
+        return source
+
+    def open_store(root: Path, **kwargs: object) -> Closeable:
+        events.append("cas-open")
+        assert root == cas_root.resolve(strict=True)
+        assert kwargs == {"require_preprovisioned": True}
+        return store
+
+    def open_catalog(path: Path, **kwargs: object) -> Closeable:
+        events.append("catalog-open")
+        assert path == catalog_path.resolve(strict=True)
+        assert kwargs == {
+            "create": False,
+            "expected_file_identity": catalog_identity,
+        }
+        return catalog
+
+    def import_cache(cache_dir: Path, **kwargs: object) -> SimpleNamespace:
+        events.append("bridge")
+        bridge_calls.append((cache_dir, kwargs))
+        bm25_destination.mkdir()
+        context_destination.mkdir()
+        return SimpleNamespace(
+            import_result=SimpleNamespace(
+                snapshot_id="snapshot-id",
+                ref_name="main",
+                generation=1,
+            )
+        )
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_new_retained_output_receipt_owner",
+        lambda: next(receipt_owners),
+    )
+    monkeypatch.setattr(source_fingerprint_module, "capture_repository_source", capture)
+    monkeypatch.setattr(storage_module, "LocalCAS", open_store)
+    monkeypatch.setattr(storage_module, "SQLiteCatalog", open_catalog)
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_compiler_cache_bm25",
+        import_cache,
+    )
+    real_print = print
+
+    def print_after_cleanup(*values: object, **kwargs: object) -> None:
+        assert bm25_owner.closed
+        assert context_owner.closed
+        assert source.closed
+        assert store.closed
+        assert catalog.closed
+        real_print(*values, **kwargs)
+
+    monkeypatch.setattr("builtins.print", print_after_cleanup)
+
+    assert cli._run_artifact_import_cache(args) == 0
+
+    assert capture_calls == [
+        (
+            Path(args.repo),
+            (cache, bm25_destination, context_destination, suggested),
+        )
+    ]
+    assert len(bridge_calls) == 1
+    passed_cache, passed = bridge_calls[0]
+    assert passed_cache == cache.resolve(strict=True)
+    assert passed["repository_source"] is source
+    assert passed["bm25_output_owner"] is bm25_owner
+    assert passed["context_output_owner"] is context_owner
+    assert passed["bm25_destination"] == bm25_destination
+    assert passed["context_destination"] == context_destination
+    assert passed["repository_key"] == "owner/repo"
+    assert passed["namespace_name"] == "default"
+    assert passed["ref_name"] == "main"
+    assert passed["expected_generation"] == 0
+    forbidden = passed["forbidden_paths"]
+    assert bm25_destination in forbidden
+    assert context_destination in forbidden
+    assert events.index("provider-support") < events.index("capture")
+    assert events.index("capture") < events.index("cas-open")
+    assert events.index("cas-open") < events.index("catalog-open")
+    assert events.index("catalog-open") < events.index("bridge")
+    assert events[-5:] == [
+        "catalog-close",
+        "cas-close",
+        "context-close",
+        "bm25-close",
+        "source-close",
+    ]
+    assert bm25_destination.is_dir()
+    assert context_destination.is_dir()
+    assert not suggested.exists()
+    output = capsys.readouterr().out
+    assert "Snapshot:           snapshot-id" in output
+    assert "Ref:                main" in output
+    assert "Generation:         1" in output
+    assert f"BM25 generation:    {bm25_destination}" in output
+    assert f"Context generation: {context_destination}" in output
+    assert f"Suggested output:   {suggested} (not reserved)" in output
+    assert "codenib artifact materialize" in output
+    assert "--snapshot snapshot-id" in output
+
+
+def test_artifact_import_cache_failure_preserves_primary_and_published_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = _cache_import_cli_test_args(tmp_path)
+    nonce = "c" * 32
+    monkeypatch.setattr(cli, "_new_compiler_cache_import_nonce", lambda: nonce)
+    workspace_root = Path(args.workspace_root)
+    bm25_destination = workspace_root / f".codenib-cache-import-{nonce}-bm25"
+    context_destination = workspace_root / f".codenib-cache-import-{nonce}-context"
+    primary = KeyboardInterrupt("import interrupted after publication")
+
+    class Provider:
+        def __init__(self, _root: Path) -> None:
+            pass
+
+        def require_support(self) -> None:
+            pass
+
+    class RetryableCloseable:
+        def __init__(self) -> None:
+            self.allow_close = False
+            self.closed = False
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+            if not self.allow_close:
+                raise OSError("injected cache import cleanup failure")
+            self.closed = True
+
+    bm25_owner = RetryableCloseable()
+    context_owner = RetryableCloseable()
+    source = RetryableCloseable()
+    store = RetryableCloseable()
+    catalog = RetryableCloseable()
+    receipt_owners = iter((bm25_owner, context_owner))
+
+    def capture(
+        *_args: object,
+        _source_owner,
+        **_kwargs: object,
+    ) -> RetryableCloseable:
+        _source_owner(source)
+        return source
+
+    def fail_after_publication(*_args: object, **_kwargs: object) -> None:
+        bm25_destination.mkdir()
+        context_destination.mkdir()
+        raise primary
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_new_retained_output_receipt_owner",
+        lambda: next(receipt_owners),
+    )
+    monkeypatch.setattr(source_fingerprint_module, "capture_repository_source", capture)
+    monkeypatch.setattr(storage_module, "LocalCAS", lambda *_args, **_kwargs: store)
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: catalog,
+    )
+    monkeypatch.setattr(
+        cache_import_module,
+        "import_compiler_cache_bm25",
+        fail_after_publication,
+    )
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        cli._run_artifact_import_cache(args)
+
+    assert raised.value is primary
+    assert not bm25_owner.closed
+    assert not context_owner.closed
+    assert not source.closed
+    assert not store.closed
+    assert not catalog.closed
+    assert bm25_owner.close_calls == 1
+    assert context_owner.close_calls == 1
+    assert source.close_calls == 1
+    assert store.close_calls == 1
+    assert catalog.close_calls == 1
+    notes = _cleanup_notes(primary)
+    assert any("SQLite catalog cleanup" in note for note in notes)
+    assert any("local CAS cleanup" in note for note in notes)
+    assert any("context receipt cleanup" in note for note in notes)
+    assert any("BM25 receipt cleanup" in note for note in notes)
+    assert any("repository source cleanup" in note for note in notes)
+    assert bm25_destination.is_dir()
+    assert context_destination.is_dir()
+    warnings = capsys.readouterr().err
+    assert "cache import BM25 generation now exists" in warnings
+    assert "cache import context generation now exists" in warnings
+
+    retained = primary.publication_cleanup_owners  # type: ignore[attr-defined]
+    assert type(retained) is tuple
+    assert len(retained) == 5
+    for resource in (bm25_owner, context_owner, source, store, catalog):
+        resource.allow_close = True
+    for cleanup_owner in retained:
+        cleanup_owner.close()
+        assert cleanup_owner.closed
+    assert bm25_owner.closed
+    assert context_owner.closed
+    assert source.closed
+    assert store.closed
+    assert catalog.closed
+
+
+def test_artifact_import_cache_rejects_existing_destination_before_authorities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _cache_import_cli_test_args(tmp_path)
+    nonce = "d" * 32
+    monkeypatch.setattr(cli, "_new_compiler_cache_import_nonce", lambda: nonce)
+    destination = Path(args.workspace_root) / f".codenib-cache-import-{nonce}-bm25"
+    destination.mkdir()
+
+    class Provider:
+        def __init__(self, _root: Path) -> None:
+            pass
+
+        def require_support(self) -> None:
+            pass
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_new_retained_output_receipt_owner",
+        lambda: pytest.fail("receipt owners must not be created"),
+    )
+    monkeypatch.setattr(
+        source_fingerprint_module,
+        "capture_repository_source",
+        lambda *_args, **_kwargs: pytest.fail("source must not be captured"),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: pytest.fail("CAS must not be opened"),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: pytest.fail("catalog must not be opened"),
+    )
+
+    with pytest.raises(cli.CLIError, match="output must be missing"):
+        cli._run_artifact_import_cache(args)
 
 
 def test_artifact_materialize_parser_exposes_strict_storage_inputs() -> None:


### PR DESCRIPTION
## Summary

Add the first explicit BM25-only bridge from a current `IndexCompiler`
cache into retained SQLite/CAS storage. The bridge authenticates one cache
generation under its existing cooperative lock, publishes immutable strict
BM25/context evidence, imports a ready snapshot, and hands it to retained
materialization.

This advances storage M1 but does not close #199. Default compiler/runtime
routing and non-BM25 cache ingress remain outstanding; generic fenced
publication, runtime hot switching, and evidence reclamation remain M2, M3,
and M5 work.

## Changes

- Add strict missing-only recapture for ordinary compiler BM25 generations.
- Harden compiler-cache locking with existing-only acquisition and safe
  same-thread reentry detection.
- Add the retained BM25 cache-import coordinator with exact post-commit retry.
- Add `codenib artifact import-cache` with strict local authority checks,
  ordered cleanup, immutable evidence paths, and a snapshot materialization
  handoff.
- Add production-shaped CLI-to-materialization-to-BM25-query coverage and
  document the operator workflow and milestone boundaries.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Core cache-import, lock, and strict-publication suites — 424 passed.
- Manifest materialization/export, SQLite catalog/jobs, and CLI suites —
  258 passed.
- Workspace and provider suites — 476 passed, 10 skipped.
- Unit marker tier — 6311 passed, 71 skipped, 190 deselected. The host lacks
  `/usr/bin/docker`, so the run used an isolated one-shot bwrap mapping for
  that fixed executable; the targeted mocked-Docker case passed separately.
- Production-shaped Linux E2E: real Git repository and `IndexCompiler` BM25
  cache → `artifact import-cache` → SQLite/LocalCAS → `artifact materialize
  --snapshot` → authenticated `ServerContext` BM25 hit.
- Black 24.8.0, isort 5.13.2, flake8 7.1.1 with bugbear, compileall,
  pre-commit, namespace checks, `mkdocs build --strict`, public-docs check,
  and `git diff --check` passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Refs #199