### PR TITLE
docs(agents): require literal commit-body newlines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,10 @@ clang-format for C/C++.
   `fix`, `docs`, `refactor`, `perf`, `test`, `chore`, or `ci`.
 - Keep commit subjects imperative and at most 72 characters. Use the body for
   why the change was made and how it was verified.
+- When passing multiline commit, squash-merge, PR, or review bodies through a
+  CLI, supply real newline bytes rather than literal `\n` escapes. After a
+  squash or rebase merge, inspect the resulting commit message before treating
+  reconciliation as complete.
 - PR bodies must follow `.github/PULL_REQUEST_TEMPLATE.md` with the existing
   headings in order: `Summary`, `Changes`, `Type of Change`, `Testing`,
   `Checklist`.


### PR DESCRIPTION
## Summary

Require CLI-authored commit and squash-merge bodies to contain real newline
bytes, then require inspection of the resulting commit message before merge
reconciliation is considered complete.

## Changes

- Add a repository agent rule against literal `\n` escape text in multiline
  commit, PR, review, and squash-merge bodies.
- Require post-squash/rebase inspection of the actual commit message.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes

- `git diff --check`
- Inspected the exact commit object with `git cat-file commit HEAD`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published