### PR TITLE
test(cli): stabilize resource-store interruption probe

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1286,20 +1286,27 @@ def test_artifact_materialize_resource_store_interruption_closes_authorities(
         if instruction.opname == "STORE_ATTR" and instruction.argval == "_resource"
     }
     assert len(store_indexes) == 1
-    injection_offsets = {instructions[index + 1].offset for index in store_indexes}
+    store_index = next(iter(store_indexes))
+    # A line event at the next source line is the portable trace boundary after
+    # STORE_ATTR and before acquire() returns.  Some supported CPython builds do
+    # not emit the optional per-opcode trace events.
+    post_store_line = next(
+        instruction.starts_line
+        for instruction in instructions[store_index + 1 :]
+        if instruction.starts_line is not None
+    )
     injected = False
     previous_trace = sys.gettrace()
 
     def trace(frame, event: str, _arg: object):
         nonlocal injected
         if event == "call" and frame.f_code is acquire.__code__:
-            frame.f_trace_opcodes = True
             return trace
         if (
             not injected
-            and event == "opcode"
+            and event == "line"
             and frame.f_code is acquire.__code__
-            and frame.f_lasti in injection_offsets
+            and frame.f_lineno == post_store_line
             and frame.f_locals["self"]._resource is store
         ):
             injected = True


### PR DESCRIPTION
## Summary

Make the retained-materialization cleanup interruption regression deterministic on every supported CPython version. The previous opcode-trace probe never fired on the Python 3.12 build used by full CI, so the test continued into an intentionally forbidden catalog open.

## Changes

- derive the first source line after the resource `STORE_ATTR`
- inject cancellation at that line event, after ownership is stored and before `acquire()` returns
- document why optional opcode events are not a portable test boundary

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- Python 3.10 targeted regression: 1 passed
- Python 3.12 targeted regression: 1 passed
- Python 3.12 pytest-xdist regression: 1 passed
- Python 3.10 full `test/test_cli.py`: 88 passed
- Black 24.8.0, isort 5.13.2, flake8 7.1.1 + bugbear, and `git diff --check`

This directly fixes the failure in full CI run https://github.com/sysevol-ai/CodeNib/actions/runs/32437581901.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published