### PR TITLE
fix(storage): close retained materialization gaps

### DIFF
--- a/codenib/_local_workspace_provider.py
+++ b/codenib/_local_workspace_provider.py
@@ -25,7 +25,11 @@ from pathlib import Path
 from typing import Callable, TypeVar
 
 from . import _workspace_owner
-from ._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
+from ._atomic_directory import (
+    _OrderedAction,
+    _run_context_with_cleanup_actions,
+    publication_parent_identity,
+)
 from ._captured_directory import (
     OwnedWorkspaceAuthority,
     PublishedWorkspaceReceiptOwner,
@@ -132,6 +136,7 @@ class LocalWorkspaceProvider:
         *,
         receipt_owner: PublishedWorkspaceReceiptOwner,
         operation: Callable[[StrictWorkspaceSession], _OperationResult],
+        _expected_parent_identity: tuple[int, ...] | None = None,
     ) -> _OperationResult:
         self._require_owner_pid()
         if type(request) is not StrictWorkspaceRequest:
@@ -142,6 +147,12 @@ class LocalWorkspaceProvider:
             raise UnsupportedWorkspaceCreation(
                 "local workspace provider currently requires a missing destination"
             )
+        if _expected_parent_identity is not None and (
+            type(_expected_parent_identity) is not tuple
+            or len(_expected_parent_identity) < 2
+            or any(type(value) is not int for value in _expected_parent_identity)
+        ):
+            raise TypeError("expected workspace parent identity is invalid")
         detached_plan = _snapshot_workspace_plan(request.plan)
         relative_destination = self._relative_destination(request.destination)
         self.require_support()
@@ -177,6 +188,17 @@ class LocalWorkspaceProvider:
                 ),
                 deadline_ns,
             )
+            if _expected_parent_identity is not None:
+                parent_descriptor = _workspace_owner.borrow_owner_parent_descriptor(
+                    native_owner
+                )
+                if (
+                    publication_parent_identity(parent_descriptor)
+                    != _expected_parent_identity
+                ):
+                    raise RuntimeError(
+                        "native workspace parent differs from retained authority"
+                    )
             workspace.adopt_provisioned(
                 destination=request.destination,
                 stage_name=stage_name,

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -10,6 +10,7 @@ import argparse
 import importlib.util
 import json
 import os
+import posixpath
 import re
 import shlex
 import shutil
@@ -19,7 +20,7 @@ import subprocess
 import sys
 from collections import Counter
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterable, Sequence
 
 from ._version import package_version
@@ -47,7 +48,10 @@ _RETAINED_REPOSITORY_RE = re.compile(
     re.ASCII,
 )
 _SIGNED_INT64_MAX = 9_223_372_036_854_775_807
-_MAX_PROC_MOUNTINFO_BYTES = 16 * 1024 * 1024
+_MAX_RETAINED_MOUNTINFO_ENTRIES = 65_536
+_MAX_RETAINED_MOUNTINFO_LINE_BYTES = 64 * 1024
+_MAX_RETAINED_ALIAS_COMPONENTS = 256
+_MAX_RETAINED_ALIAS_PATH_BYTES = 4_096
 
 
 class CLIError(RuntimeError):
@@ -1001,11 +1005,408 @@ def _retained_materialization_paths(args: argparse.Namespace) -> tuple[Path, ...
     return catalog_path, cas_root, workspace_root, output
 
 
+def _retained_open_directory_identity(authority: object) -> tuple[int, ...]:
+    """Read one stable directory object identity from its opened authority."""
+
+    from ._atomic_directory import publication_parent_identity
+
+    try:
+        resource = authority.resource  # type: ignore[attr-defined]
+        observed = publication_parent_identity(resource)
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        raise CLIError("directory authority identity could not be verified") from exc
+    if (
+        type(observed) is not tuple
+        or len(observed) < 2
+        or any(type(value) is not int for value in observed)
+        or observed[0] < 1
+        or observed[1] < 1
+    ):
+        raise CLIError("directory authority has no reliable filesystem identity")
+    return observed
+
+
 @dataclass(frozen=True, slots=True)
+class _RetainedDirectoryBinding:
+    label: str
+    path: Path
+    identity: tuple[int, ...]
+    owner: object = field(repr=False, compare=False)
+
+    @property
+    def authority(self) -> object:
+        authority = self.owner.authority  # type: ignore[attr-defined]
+        if authority is None:
+            raise CLIError(f"{self.label} directory authority is closed")
+        return authority
+
+    def verify(self) -> tuple[int, ...]:
+        authority = self.authority
+        try:
+            authority.verify_path_binding()  # type: ignore[attr-defined]
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise CLIError(f"{self.label} directory binding changed") from exc
+        observed = _retained_open_directory_identity(authority)
+        if observed != self.identity:
+            raise CLIError(f"{self.label} directory authority identity changed")
+        return observed
+
+
+def _retained_descendant_paths(ancestor: Path, descendant: Path) -> tuple[Path, ...]:
+    try:
+        relative = descendant.relative_to(ancestor)
+    except ValueError as exc:
+        raise CLIError("physical storage ancestry changed") from exc
+    current = ancestor
+    paths: list[Path] = []
+    for component in relative.parts:
+        current = current / component
+        paths.append(current)
+    return tuple(paths)
+
+
+@dataclass(frozen=True, slots=True)
+class _RetainedLinuxMountMapping:
+    mount_id: int
+    device: str
+    root: PurePosixPath
+    mount_point: Path
+
+
+@dataclass(frozen=True, slots=True)
+class _RetainedLinuxPhysicalPath:
+    device: str
+    path: PurePosixPath
+
+
+def _retained_physical_paths_overlap(
+    first: _RetainedLinuxPhysicalPath,
+    second: _RetainedLinuxPhysicalPath,
+) -> bool:
+    if first.device != second.device:
+        return False
+    return (
+        first.path == second.path
+        or first.path in second.path.parents
+        or second.path in first.path.parents
+    )
+
+
+def _retained_linux_mount_mappings() -> tuple[_RetainedLinuxMountMapping, ...]:
+    """Snapshot bounded Linux mount roots needed for physical path mapping."""
+
+    if not sys.platform.startswith("linux"):
+        return ()
+    from ._atomic_directory import _mountinfo_path
+
+    mappings: list[_RetainedLinuxMountMapping] = []
+    try:
+        with open("/proc/self/mountinfo", "rb") as mountinfo:
+            for index, line in enumerate(mountinfo):
+                if index >= _MAX_RETAINED_MOUNTINFO_ENTRIES:
+                    raise CLIError("Linux mount table exceeds its safe entry limit")
+                if len(line) > _MAX_RETAINED_MOUNTINFO_LINE_BYTES:
+                    raise CLIError("Linux mount table contains an oversized entry")
+                fields = line.split()
+                try:
+                    separator = fields.index(b"-")
+                except ValueError as exc:
+                    raise CLIError(
+                        "Linux mount table contains a malformed entry"
+                    ) from exc
+                if separator < 6 or len(fields) < separator + 4:
+                    raise CLIError("Linux mount table contains a malformed entry")
+                try:
+                    mount_id = int(fields[0])
+                except ValueError as exc:
+                    raise CLIError(
+                        "Linux mount table contains an invalid mount ID"
+                    ) from exc
+                device = os.fsdecode(fields[2])
+                device_parts = device.split(":", 1)
+                if (
+                    mount_id < 1
+                    or len(device_parts) != 2
+                    or any(not part.isdigit() for part in device_parts)
+                ):
+                    raise CLIError("Linux mount table contains an invalid identity")
+                root_text = posixpath.normpath(_mountinfo_path(os.fsdecode(fields[3])))
+                mount_text = os.path.normpath(_mountinfo_path(os.fsdecode(fields[4])))
+                root = PurePosixPath(root_text)
+                mount_point = Path(mount_text)
+                # nsfs and similar pseudo mounts expose opaque roots such as
+                # ``net:[id]``. They cannot contain a regular SQLite catalog
+                # and have no filesystem-relative suffix to map.
+                if not root.is_absolute():
+                    continue
+                if not mount_point.is_absolute():
+                    raise CLIError("Linux mount table contains a relative path")
+                mappings.append(
+                    _RetainedLinuxMountMapping(
+                        mount_id=mount_id,
+                        device=device,
+                        root=root,
+                        mount_point=mount_point,
+                    )
+                )
+    except CLIError:
+        raise
+    except (OSError, UnicodeError) as exc:
+        raise CLIError("Linux mount table could not be inspected safely") from exc
+    if not mappings:
+        raise CLIError("Linux mount table is empty")
+    return tuple(mappings)
+
+
+def _retained_linux_physical_path(
+    path: Path,
+    mappings: tuple[_RetainedLinuxMountMapping, ...],
+) -> _RetainedLinuxPhysicalPath | None:
+    candidates = tuple(
+        mapping
+        for mapping in mappings
+        if path == mapping.mount_point or mapping.mount_point in path.parents
+    )
+    if not candidates:
+        return None
+    deepest = max(len(mapping.mount_point.parts) for mapping in candidates)
+    selected_candidates = tuple(
+        mapping for mapping in candidates if len(mapping.mount_point.parts) == deepest
+    )
+    if len(selected_candidates) != 1:
+        raise CLIError("Linux mount table contains an ambiguous stacked mapping")
+    selected = selected_candidates[0]
+    try:
+        relative = path.relative_to(selected.mount_point)
+    except ValueError as exc:  # pragma: no cover - candidates prove containment
+        raise CLIError("Linux mount mapping changed") from exc
+    internal = PurePosixPath(
+        posixpath.normpath(
+            posixpath.join(selected.root.as_posix(), relative.as_posix())
+        )
+    )
+    if not internal.is_absolute():  # pragma: no cover - normalized absolute root
+        raise CLIError("Linux mount mapping produced a relative physical path")
+    return _RetainedLinuxPhysicalPath(selected.device, internal)
+
+
+def _retained_alias_file_identity(path: Path) -> tuple[int, int] | None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError("mapped catalog alias could not be inspected safely") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or not metadata.st_dev
+        or not metadata.st_ino
+    ):
+        raise CLIError("mapped catalog alias is not one real regular file")
+    return int(metadata.st_dev), int(metadata.st_ino)
+
+
+def _require_catalog_outside_retained_roots(
+    catalog_path: Path,
+    catalog_identity: tuple[int, int, int],
+    bindings: tuple[_RetainedDirectoryBinding, ...],
+    mappings: tuple[_RetainedLinuxMountMapping, ...],
+) -> None:
+    """Deny one exact catalog suffix reachable through a protected mount."""
+
+    catalog_physical = _retained_linux_physical_path(catalog_path, mappings)
+    if catalog_physical is None:
+        return
+    expected_device = f"{os.major(catalog_identity[0])}:{os.minor(catalog_identity[0])}"
+    if catalog_physical.device != expected_device:
+        raise CLIError("catalog mount mapping differs from its file authority")
+    for binding in bindings:
+        root_physical = _retained_linux_physical_path(binding.path, mappings)
+        if root_physical is None or root_physical.device != catalog_physical.device:
+            continue
+        try:
+            suffix = catalog_physical.path.relative_to(root_physical.path)
+        except ValueError:
+            continue
+        if (
+            not suffix.parts
+            or len(suffix.parts) > _MAX_RETAINED_ALIAS_COMPONENTS
+            or len(os.fsencode(suffix.as_posix())) > _MAX_RETAINED_ALIAS_PATH_BYTES
+            or any(component in {"", ".", ".."} for component in suffix.parts)
+        ):
+            raise CLIError("catalog mount alias has an unsafe relative path")
+        candidate = binding.path.joinpath(*suffix.parts)
+        candidate_physical = _retained_linux_physical_path(candidate, mappings)
+        if candidate_physical != catalog_physical:
+            continue
+        candidate_identity = _retained_alias_file_identity(candidate)
+        if candidate_identity is None:
+            raise CLIError("mapped catalog alias disappeared during validation")
+        if candidate_identity != catalog_identity[:2]:
+            raise CLIError("mapped catalog alias identity changed during validation")
+        raise CLIError(f"catalog is physically reachable below the {binding.label}")
+
+
+def _require_retained_mount_topology(
+    catalog_path: Path,
+    catalog_identity: tuple[int, int, int],
+    cas: _RetainedDirectoryBinding,
+    workspace: _RetainedDirectoryBinding,
+    output_parent: _RetainedDirectoryBinding,
+) -> None:
+    """Reject mount crossings that can re-enter another protected tree."""
+
+    from ._atomic_directory import _path_is_mount_point
+
+    mappings = _retained_linux_mount_mappings()
+    mount_points = frozenset(
+        os.path.normpath(os.fspath(mapping.mount_point)) for mapping in mappings
+    )
+    if os.path.normpath(os.path.realpath(catalog_path)) in mount_points:
+        raise CLIError("catalog must not be a file mount point")
+    _require_catalog_outside_retained_roots(
+        catalog_path,
+        catalog_identity,
+        (cas, workspace, output_parent),
+        mappings,
+    )
+    for candidate in _retained_descendant_paths(
+        workspace.path,
+        output_parent.path,
+    ):
+        if _path_is_mount_point(candidate, mount_points=mount_points):
+            raise CLIError("output parent must not cross a mount point")
+
+    cas_physical = _retained_linux_physical_path(cas.path, mappings)
+    workspace_physical = _retained_linux_physical_path(workspace.path, mappings)
+    if (
+        cas_physical is not None
+        and workspace_physical is not None
+        and _retained_physical_paths_overlap(cas_physical, workspace_physical)
+    ):
+        raise CLIError("retained roots must not traverse a same-device mount alias")
+
+
+@dataclass(slots=True)
 class _RetainedMaterializationTopology:
     catalog_path: Path
     catalog_identity: tuple[int, int, int]
     cas_root: Path
+    workspace_root: Path
+    output: Path
+    cas_binding: _RetainedDirectoryBinding
+    workspace_binding: _RetainedDirectoryBinding
+    output_parent_binding: _RetainedDirectoryBinding
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    @property
+    def closed(self) -> bool:
+        if not self._closed and all(
+            binding.owner.closed  # type: ignore[attr-defined]
+            for binding in self._bindings
+        ):
+            self._closed = True
+        return self._closed
+
+    @property
+    def _bindings(self) -> tuple[_RetainedDirectoryBinding, ...]:
+        return (
+            self.cas_binding,
+            self.workspace_binding,
+            self.output_parent_binding,
+        )
+
+    def verify_bindings(self) -> None:
+        if self.closed:
+            raise CLIError("retained materialization topology authority is closed")
+        cas_identity = self.cas_binding.verify()
+        workspace_identity = self.workspace_binding.verify()
+        output_parent_identity = self.output_parent_binding.verify()
+        if cas_identity == workspace_identity:
+            raise CLIError("CAS root and workspace root are the same physical object")
+        if cas_identity == output_parent_identity:
+            raise CLIError("output parent physically aliases the CAS root")
+        if (
+            self.output_parent_binding.path != self.workspace_binding.path
+            and workspace_identity == output_parent_identity
+        ):
+            raise CLIError("output parent physically aliases the workspace root")
+        _require_retained_mount_topology(
+            self.catalog_path,
+            self.catalog_identity,
+            self.cas_binding,
+            self.workspace_binding,
+            self.output_parent_binding,
+        )
+
+    def verify(self) -> None:
+        self.verify_bindings()
+        try:
+            output_metadata = self.output_parent_binding.authority.child_metadata(  # type: ignore[attr-defined]
+                self.output.name,
+                path=self.output,
+                label="output",
+            )
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise CLIError("output cannot be inspected through its authority") from exc
+        if output_metadata is not None:
+            raise CLIError("output must be missing")
+
+    def close(self) -> None:
+        from ._atomic_directory import _annotate_secondary_error
+
+        if self.closed:
+            return
+        primary_error: BaseException | None = None
+        for binding in reversed(self._bindings):
+            try:
+                binding.owner.close()  # type: ignore[attr-defined]
+            except BaseException as close_error:  # noqa: B036 - visit every owner
+                if primary_error is None:
+                    primary_error = close_error
+                else:
+                    _annotate_secondary_error(
+                        primary_error,
+                        "retained directory authority cleanup also failed",
+                        close_error,
+                    )
+        self._closed = all(
+            binding.owner.closed  # type: ignore[attr-defined]
+            for binding in self._bindings
+        )
+        if primary_error is not None:
+            raise primary_error
+
+
+@dataclass(frozen=True, slots=True)
+class _RetainedTopologyWorkspaceProvider:
+    """Recheck retained path authorities before provider provisioning."""
+
+    delegate: object
+    topology: _RetainedMaterializationTopology
+
+    def require_support(self) -> None:
+        self.topology.verify()
+        self.delegate.require_support()  # type: ignore[attr-defined]
+        self.topology.verify()
+
+    def run_workspace(
+        self,
+        request: object,
+        *,
+        receipt_owner: object,
+        operation: object,
+    ) -> object:
+        self.topology.verify()
+        result = self.delegate.run_workspace(  # type: ignore[attr-defined]
+            request,
+            receipt_owner=receipt_owner,
+            operation=operation,
+            _expected_parent_identity=self.topology.output_parent_binding.identity,
+        )
+        self.topology.verify_bindings()
+        return result
 
 
 def _resolved_retained_materialization_path(
@@ -1073,45 +1474,6 @@ def _require_distinct_directory_ancestry(
                 )
 
 
-def _decode_mountinfo_path(value: bytes) -> Path:
-    decoded = value
-    for escaped, replacement in (
-        (b"\\040", b" "),
-        (b"\\011", b"\t"),
-        (b"\\012", b"\n"),
-        (b"\\134", b"\\"),
-    ):
-        decoded = decoded.replace(escaped, replacement)
-    path = Path(os.fsdecode(decoded))
-    if not path.is_absolute():
-        raise CLIError("Linux mount information contains a relative mount point")
-    return path
-
-
-def _retained_linux_mount_points() -> frozenset[Path]:
-    mountinfo = Path("/proc/self/mountinfo")
-    try:
-        with mountinfo.open("rb") as stream:
-            payload = stream.read(_MAX_PROC_MOUNTINFO_BYTES + 1)
-    except (OSError, RuntimeError, ValueError) as exc:
-        raise CLIError("Linux mount information could not be inspected safely") from exc
-    if len(payload) > _MAX_PROC_MOUNTINFO_BYTES:
-        raise CLIError("Linux mount information exceeds the safe size limit")
-    mount_points: set[Path] = set()
-    for line in payload.splitlines():
-        fields = line.split(b" ")
-        try:
-            separator = fields.index(b"-")
-        except ValueError as exc:
-            raise CLIError("Linux mount information is malformed") from exc
-        if separator < 6 or len(fields) < separator + 4:
-            raise CLIError("Linux mount information is malformed")
-        mount_points.add(_decode_mountinfo_path(fields[4]))
-    if not mount_points:
-        raise CLIError("Linux mount information is empty")
-    return frozenset(mount_points)
-
-
 def _retained_catalog_file_identity(path: Path) -> tuple[int, int, int]:
     try:
         metadata = path.lstat()
@@ -1146,7 +1508,14 @@ def _require_retained_materialization_topology(
     workspace_root: Path,
     output: Path,
 ) -> _RetainedMaterializationTopology:
-    """Deny stable physical aliases before opening the retained authorities."""
+    """Open and retain physical authorities for every mutable storage root."""
+
+    from ._atomic_directory import (
+        _annotate_secondary_error,
+        _attach_publication_cleanup_owner,
+        _open_publication_authority,
+        _PublicationAuthorityOwner,
+    )
 
     try:
         output.lstat()
@@ -1173,33 +1542,24 @@ def _require_retained_materialization_topology(
         strict=True,
     )
     catalog_identity = _retained_catalog_file_identity(resolved_catalog)
-    mount_points = _retained_linux_mount_points()
-    if resolved_catalog in mount_points:
-        raise CLIError("catalog must not be a mounted file")
-    catalog_ancestry = _retained_directory_ancestry(
-        resolved_catalog.parent,
-        label="catalog parent",
-    )
-    cas_ancestry = _retained_directory_ancestry(
-        resolved_cas,
-        label="CAS root",
-    )
-    workspace_ancestry = _retained_directory_ancestry(
-        resolved_workspace,
-        label="workspace root",
-    )
-    workspace_identity = workspace_ancestry[0][1]
-    workspace_device = workspace_identity[0]
+    try:
+        workspace_metadata = resolved_workspace.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError("workspace root cannot be inspected safely") from exc
+    if (
+        not stat.S_ISDIR(workspace_metadata.st_mode)
+        or stat.S_ISLNK(workspace_metadata.st_mode)
+        or not workspace_metadata.st_dev
+    ):
+        raise CLIError("workspace root must resolve to one real directory")
+    workspace_device = int(workspace_metadata.st_dev)
     try:
         relative_parent = output.parent.relative_to(workspace_root)
     except ValueError as exc:  # pragma: no cover - lexical preflight already binds it
         raise CLIError("output parent escaped the workspace root") from exc
     current_parent = workspace_root
-    output_ancestry: list[tuple[Path, tuple[int, int]]] = []
-    resolved_current_parent = resolved_workspace
     for component in relative_parent.parts:
         current_parent = current_parent / component
-        resolved_current_parent = resolved_current_parent / component
         try:
             metadata = current_parent.lstat()
         except FileNotFoundError as exc:
@@ -1210,16 +1570,6 @@ def _require_retained_materialization_topology(
             raise CLIError("output parent must contain only existing real directories")
         if metadata.st_dev != workspace_device:
             raise CLIError("output parent must remain on the workspace filesystem")
-        if not metadata.st_ino:
-            raise CLIError("output parent directory identity is invalid")
-        if resolved_current_parent in mount_points:
-            raise CLIError("output parent must not cross a nested mount point")
-        output_ancestry.append(
-            (
-                resolved_current_parent,
-                (int(metadata.st_dev), int(metadata.st_ino)),
-            )
-        )
     resolved_output_parent = _resolved_retained_materialization_path(
         current_parent,
         label="output parent",
@@ -1236,29 +1586,70 @@ def _require_retained_materialization_topology(
         (resolved_catalog, "catalog", resolved_cas, "CAS root"),
         (resolved_catalog, "catalog", resolved_workspace, "workspace root"),
         (resolved_cas, "CAS root", resolved_workspace, "workspace root"),
+        (resolved_cas, "CAS root", resolved_output_parent, "output parent"),
     ):
         if _paths_overlap(first, second):
             raise CLIError(
                 f"{first_label} must not physically overlap the {second_label}"
             )
-    for first, first_label, second, second_label in (
-        (catalog_ancestry, "catalog", cas_ancestry, "CAS root"),
-        (catalog_ancestry, "catalog", workspace_ancestry, "workspace root"),
-        (cas_ancestry, "CAS root", workspace_ancestry, "workspace root"),
-        (tuple(output_ancestry), "output parent", catalog_ancestry, "catalog"),
-        (tuple(output_ancestry), "output parent", cas_ancestry, "CAS root"),
-    ):
-        _require_distinct_directory_ancestry(
-            first,
-            first_label,
-            second,
-            second_label,
+
+    owners = tuple(_PublicationAuthorityOwner() for _index in range(3))
+
+    def open_binding(
+        path: Path,
+        label: str,
+        owner: object,
+    ) -> _RetainedDirectoryBinding:
+        authority = _open_publication_authority(
+            path,
+            parent_resource=None,
+            expected_parent_identity=None,
+            authority_owner=owner,  # type: ignore[arg-type]
         )
-    return _RetainedMaterializationTopology(
-        catalog_path=resolved_catalog,
-        catalog_identity=catalog_identity,
-        cas_root=resolved_cas,
-    )
+        return _RetainedDirectoryBinding(
+            label=label,
+            path=path,
+            identity=_retained_open_directory_identity(authority),
+            owner=owner,
+        )
+
+    try:
+        cas_binding = open_binding(resolved_cas, "CAS root", owners[0])
+        workspace_binding = open_binding(
+            resolved_workspace,
+            "workspace root",
+            owners[1],
+        )
+        output_parent_binding = open_binding(
+            resolved_output_parent,
+            "output parent",
+            owners[2],
+        )
+        topology = _RetainedMaterializationTopology(
+            catalog_path=resolved_catalog,
+            catalog_identity=catalog_identity,
+            cas_root=resolved_cas,
+            workspace_root=resolved_workspace,
+            output=resolved_output,
+            cas_binding=cas_binding,
+            workspace_binding=workspace_binding,
+            output_parent_binding=output_parent_binding,
+        )
+        topology.verify()
+        return topology
+    except BaseException as primary_error:  # noqa: B036 - close every authority
+        for owner in reversed(owners):
+            try:
+                owner.close()
+            except BaseException as close_error:  # noqa: B036 - preserve primary
+                _annotate_secondary_error(
+                    primary_error,
+                    "retained directory authority cleanup also failed",
+                    close_error,
+                )
+            finally:
+                _attach_publication_cleanup_owner(primary_error, owner)
+        raise
 
 
 def _warn_possible_retained_publication(output: Path) -> None:
@@ -1309,6 +1700,27 @@ class _RetainedMaterializationResourceOwner:
             return
         resource.close()  # type: ignore[attr-defined]
         self._resource = _RETAINED_RESOURCE_MISSING
+
+
+def _inherit_publication_cleanup_owners(
+    target: BaseException,
+    source: BaseException,
+) -> None:
+    """Preserve incomplete internal cleanup owners across a public wrapper."""
+
+    from ._atomic_directory import _attach_publication_cleanup_owner
+
+    try:
+        owners = BaseException.__getattribute__(
+            source,
+            "publication_cleanup_owners",
+        )
+    except AttributeError:
+        return
+    if type(owners) is not tuple:
+        return
+    for owner in owners:
+        _attach_publication_cleanup_owner(target, owner)
 
 
 def _compiler_cache_import_selection(
@@ -1413,22 +1825,72 @@ def _require_compiler_cache_import_topology(
 ) -> _CompilerCacheImportTopology:
     """Freeze existing inputs and deny physical storage/source aliases."""
 
-    materialization_topologies = tuple(
-        _require_retained_materialization_topology(
-            paths.catalog_path,
-            paths.cas_root,
-            paths.workspace_root,
-            destination,
+    from ._atomic_directory import _OrderedAction, _run_context_with_cleanup_actions
+
+    materialization_snapshots: list[
+        tuple[
+            Path,
+            tuple[int, int, int],
+            Path,
+            Path,
+            Path,
+            tuple[int, ...],
+            tuple[int, ...],
+            tuple[int, ...],
+        ]
+    ] = []
+    for destination in (
+        paths.bm25_destination,
+        paths.context_destination,
+        paths.suggested_materialization,
+    ):
+        topology_owner = _RetainedMaterializationResourceOwner()
+        cleanup_action = _OrderedAction(
+            label="cache import path authority cleanup also failed",
+            action=topology_owner.close,
+            complete=lambda owner=topology_owner: owner.closed,
+            retry_incomplete="cancellation",
+            incomplete_owner=topology_owner,
         )
-        for destination in (
-            paths.bm25_destination,
-            paths.context_destination,
-            paths.suggested_materialization,
-        )
-    )
-    first = materialization_topologies[0]
-    if any(candidate != first for candidate in materialization_topologies[1:]):
+
+        def acquire_topology(
+            selected_destination: Path = destination,
+        ) -> _RetainedMaterializationTopology:
+            return _require_retained_materialization_topology(
+                paths.catalog_path,
+                paths.cas_root,
+                paths.workspace_root,
+                selected_destination,
+            )
+
+        with _run_context_with_cleanup_actions((cleanup_action,)):
+            materialization_topology = topology_owner.acquire(acquire_topology)
+            materialization_topology.verify()
+            materialization_snapshots.append(
+                (
+                    materialization_topology.catalog_path,
+                    materialization_topology.catalog_identity,
+                    materialization_topology.cas_root,
+                    materialization_topology.workspace_root,
+                    materialization_topology.output.parent,
+                    materialization_topology.cas_binding.identity,
+                    materialization_topology.workspace_binding.identity,
+                    materialization_topology.output_parent_binding.identity,
+                )
+            )
+    first = materialization_snapshots[0]
+    if any(candidate != first for candidate in materialization_snapshots[1:]):
         raise CLIError("storage topology changed while allocating import outputs")
+    (
+        frozen_catalog_path,
+        frozen_catalog_identity,
+        frozen_cas_root,
+        _frozen_workspace_root,
+        _frozen_output_parent,
+        _frozen_cas_identity,
+        _frozen_workspace_identity,
+        _frozen_output_parent_identity,
+    ) = first
 
     resolved_repo = _resolved_retained_materialization_path(
         paths.repo_path,
@@ -1457,11 +1919,11 @@ def _require_compiler_cache_import_topology(
         strict=True,
     )
     catalog_ancestry = _retained_directory_ancestry(
-        first.catalog_path.parent,
+        frozen_catalog_path.parent,
         label="catalog parent",
     )
     cas_ancestry = _retained_directory_ancestry(
-        first.cas_root,
+        frozen_cas_root,
         label="CAS root",
     )
     workspace_ancestry = _retained_directory_ancestry(
@@ -1473,8 +1935,8 @@ def _require_compiler_cache_import_topology(
         (resolved_cache, "cache directory"),
     ):
         for storage, storage_label in (
-            (first.catalog_path, "catalog"),
-            (first.cas_root, "CAS root"),
+            (frozen_catalog_path, "catalog"),
+            (frozen_cas_root, "CAS root"),
             (resolved_workspace, "workspace root"),
         ):
             if _paths_overlap(source, storage):
@@ -1511,9 +1973,9 @@ def _require_compiler_cache_import_topology(
         )
     return _CompilerCacheImportTopology(
         cache_dir=resolved_cache,
-        catalog_path=first.catalog_path,
-        catalog_identity=first.catalog_identity,
-        cas_root=first.cas_root,
+        catalog_path=frozen_catalog_path,
+        catalog_identity=frozen_catalog_identity,
+        cas_root=frozen_cas_root,
     )
 
 
@@ -1558,25 +2020,10 @@ def _run_artifact_materialize(args: argparse.Namespace) -> int:
     catalog_path, cas_root, workspace_root, output = _retained_materialization_paths(
         args
     )
-    try:
-        provider = LocalWorkspaceProvider(workspace_root)
-        # Fail before opening the catalog or CAS.  The strict publication frame
-        # repeats this non-mutating probe immediately before provisioning.
-        provider.require_support()
-        topology = _require_retained_materialization_topology(
-            catalog_path,
-            cas_root,
-            workspace_root,
-            output,
-        )
-    except CLIError:
-        raise
-    except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
-        raise CLIError(str(exc)) from exc
-
     summary: tuple[str, str, str, str, tuple[str, ...], Path] | None = None
     try:
         owner = _new_retained_output_receipt_owner()
+        topology_owner = _RetainedMaterializationResourceOwner()
         object_store_owner = _RetainedMaterializationResourceOwner()
         catalog_owner = _RetainedMaterializationResourceOwner()
         cleanup_actions = (
@@ -1601,8 +2048,30 @@ def _run_artifact_materialize(args: argparse.Namespace) -> int:
                 retry_incomplete="cancellation",
                 incomplete_owner=owner,
             ),
+            _OrderedAction(
+                label="retained path authority cleanup also failed",
+                action=topology_owner.close,
+                complete=lambda: topology_owner.closed,
+                retry_incomplete="cancellation",
+                incomplete_owner=topology_owner,
+            ),
         )
         with _run_context_with_cleanup_actions(cleanup_actions):
+            base_provider = LocalWorkspaceProvider(workspace_root)
+            # Preserve provider/platform failure precedence before any storage
+            # authority is opened.  The retained wrapper then repeats the
+            # physical checks at the strict provisioning boundary.
+            base_provider.require_support()
+            topology = topology_owner.acquire(
+                lambda: _require_retained_materialization_topology(
+                    catalog_path,
+                    cas_root,
+                    workspace_root,
+                    output,
+                )
+            )
+            provider = _RetainedTopologyWorkspaceProvider(base_provider, topology)
+            topology.verify()
             object_store = object_store_owner.acquire(
                 lambda: LocalCAS(topology.cas_root, require_preprovisioned=True)
             )
@@ -1709,7 +2178,9 @@ def _run_artifact_materialize(args: argparse.Namespace) -> int:
         if isinstance(
             primary_error, (OSError, RuntimeError, ValueError, sqlite3.Error)
         ):
-            raise CLIError(str(primary_error)) from primary_error
+            wrapped = CLIError(str(primary_error))
+            _inherit_publication_cleanup_owners(wrapped, primary_error)
+            raise wrapped from primary_error
         raise
 
 
@@ -1741,7 +2212,9 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
     except CLIError:
         raise
     except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
-        raise CLIError(str(exc)) from exc
+        wrapped = CLIError(str(exc))
+        _inherit_publication_cleanup_owners(wrapped, exc)
+        raise wrapped from exc
 
     source_exclusions = tuple(
         dict.fromkeys(
@@ -1917,7 +2390,9 @@ def _run_artifact_import_cache(args: argparse.Namespace) -> int:
         if isinstance(
             primary_error, (OSError, RuntimeError, ValueError, sqlite3.Error)
         ):
-            raise CLIError(str(primary_error)) from primary_error
+            wrapped = CLIError(str(primary_error))
+            _inherit_publication_cleanup_owners(wrapped, primary_error)
+            raise wrapped from primary_error
         raise
 
 

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -16,11 +16,13 @@ can adapt it without coupling the SQLite implementation to application models.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import stat
+import sys
+import tempfile
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterator, Mapping, Sequence
 
@@ -63,20 +65,18 @@ CatalogValidationError = StorageValidationError
 
 _DB_NOW_MS_SQL = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)"
 _SQLITE_INT64_MAX = 9_223_372_036_854_775_807
-_V1_CATALOG_TABLES = frozenset(
-    {
-        "namespaces",
-        "objects",
-        "refs",
-        "repositories",
-        "schema_migrations",
-        "snapshot_views",
-        "snapshots",
-        "source_revisions",
-        "view_generations",
-        "view_profiles",
-    }
+_MAX_VALIDATION_NAMESPACE_BYTES = 1_073_741_824
+_MAX_VALIDATION_SHM_BYTES = 16_777_216
+_VALIDATION_COPY_CHUNK_BYTES = 1_048_576
+_MAX_VALIDATION_MOUNTINFO_ENTRIES = 100_000
+_MAX_VALIDATION_MOUNTINFO_LINE_BYTES = 65_536
+_WINDOWS_REPARSE_POINT_ATTRIBUTE = 0x400
+_SCHEMA_MIGRATIONS_SQL = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
 )
+"""
 
 
 def _now() -> str:
@@ -1041,50 +1041,495 @@ _MIGRATIONS: dict[int, tuple[str, ...]] = {
     4: _SCHEMA_V4,
 }
 
-_SCHEMA_MIGRATIONS_SQL = """
-CREATE TABLE IF NOT EXISTS schema_migrations (
-    version INTEGER PRIMARY KEY,
-    applied_at TEXT NOT NULL
+_CatalogSchemaObject = tuple[str, str, str, str | None]
+_CatalogSchemaSignature = tuple[_CatalogSchemaObject, ...]
+
+_SQLITE_ANALYZE_SCHEMA_OBJECTS = frozenset(
+    {
+        (
+            "table",
+            "sqlite_stat1",
+            "sqlite_stat1",
+            "CREATE TABLE sqlite_stat1(tbl,idx,stat)",
+        ),
+        (
+            "table",
+            "sqlite_stat2",
+            "sqlite_stat2",
+            "CREATE TABLE sqlite_stat2(tbl,idx,sampleno,sample)",
+        ),
+        (
+            "table",
+            "sqlite_stat3",
+            "sqlite_stat3",
+            "CREATE TABLE sqlite_stat3(tbl,idx,neq,nlt,ndlt,sample)",
+        ),
+        (
+            "table",
+            "sqlite_stat4",
+            "sqlite_stat4",
+            "CREATE TABLE sqlite_stat4(tbl,idx,neq,nlt,ndlt,sample)",
+        ),
+    }
 )
-"""
+
+
+def _normalized_schema_sql(sql: str | None) -> str | None:
+    if sql is None:
+        return None
+    return "\n".join(line.strip() for line in sql.strip().splitlines() if line.strip())
 
 
 def _catalog_schema_signature(
     connection: sqlite3.Connection,
-) -> tuple[tuple[object, ...], ...]:
-    """Return every caller-defined schema object in a stable order."""
+) -> _CatalogSchemaSignature:
+    """Return every application schema object in a formatting-stable form."""
 
-    return tuple(
-        tuple(row)
-        for row in connection.execute(
-            """
-            SELECT type, name, tbl_name, sql
-            FROM sqlite_master
-            WHERE substr(name, 1, 7) != 'sqlite_'
-            ORDER BY type, name, tbl_name
-            """
+    signature: list[_CatalogSchemaObject] = []
+    for row in connection.execute(
+        """
+        SELECT type, name, tbl_name, sql
+        FROM sqlite_schema
+        ORDER BY type, name, tbl_name
+        """
+    ):
+        schema_object = (
+            row[0],
+            row[1],
+            row[2],
+            _normalized_schema_sql(row[3]),
         )
+        # ANALYZE can add one of SQLite's exact internal statistics-table
+        # schemas after routine maintenance.  Ignore only those known exact
+        # objects; a forged or malformed ``sqlite_*`` entry remains part of
+        # the authenticated signature and is rejected.
+        if schema_object in _SQLITE_ANALYZE_SCHEMA_OBJECTS:
+            continue
+        signature.append(schema_object)
+    return tuple(signature)
+
+
+def _canonical_catalog_schemas() -> dict[int, _CatalogSchemaSignature]:
+    """Materialize the exact schema produced after each supported migration."""
+
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    try:
+        connection.execute(_SCHEMA_MIGRATIONS_SQL)
+        schemas: dict[int, _CatalogSchemaSignature] = {}
+        for version in range(1, LATEST_SCHEMA_VERSION + 1):
+            for statement in _MIGRATIONS[version]:
+                connection.execute(statement)
+            schemas[version] = _catalog_schema_signature(connection)
+        return schemas
+    finally:
+        connection.close()
+
+
+_CANONICAL_CATALOG_SCHEMAS = _canonical_catalog_schemas()
+
+
+def _validation_source_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        int(metadata.st_dev),
+        int(metadata.st_ino),
+        int(metadata.st_mode),
+        int(metadata.st_nlink),
+        int(metadata.st_size),
+        int(metadata.st_mtime_ns),
+        int(metadata.st_ctime_ns),
+        int(getattr(metadata, "st_file_attributes", 0)),
     )
 
 
-@lru_cache(maxsize=LATEST_SCHEMA_VERSION)
-def _expected_catalog_schema_signature(
-    version: int,
-) -> tuple[tuple[object, ...], ...]:
-    """Build the exact schema authorized by the immutable migration sequence."""
+def _validation_linux_mount_points() -> frozenset[str]:
+    """Read a bounded Linux mount table without a fail-open fallback."""
 
-    reference = sqlite3.connect(":memory:", isolation_level=None)
+    if not sys.platform.startswith("linux"):
+        return frozenset()
+    from .._atomic_directory import _mountinfo_path
+
+    points: set[str] = set()
     try:
-        reference.execute(_SCHEMA_MIGRATIONS_SQL)
-        for migration_version in range(1, version + 1):
-            statements = _MIGRATIONS.get(migration_version)
-            if statements is None:  # pragma: no cover - module invariant
-                raise CatalogError(f"missing catalog migration {migration_version}")
-            for statement in statements:
-                reference.execute(statement)
-        return _catalog_schema_signature(reference)
+        with open("/proc/self/mountinfo", "rb") as mountinfo:
+            for index, line in enumerate(mountinfo):
+                if index >= _MAX_VALIDATION_MOUNTINFO_ENTRIES:
+                    raise CatalogError("Linux mount table exceeds its safe entry limit")
+                if len(line) > _MAX_VALIDATION_MOUNTINFO_LINE_BYTES:
+                    raise CatalogError("Linux mount table contains an oversized entry")
+                fields = line.split()
+                try:
+                    separator = fields.index(b"-")
+                except ValueError as exc:
+                    raise CatalogError(
+                        "Linux mount table contains a malformed entry"
+                    ) from exc
+                if separator < 6 or len(fields) < separator + 4:
+                    raise CatalogError("Linux mount table contains a malformed entry")
+                point = os.path.normpath(_mountinfo_path(os.fsdecode(fields[4])))
+                if not os.path.isabs(point):
+                    raise CatalogError("Linux mount table contains a relative path")
+                points.add(point)
+    except CatalogError:
+        raise
+    except (OSError, UnicodeError) as exc:
+        raise CatalogError("Linux mount table could not be inspected safely") from exc
+    if not points:
+        raise CatalogError("Linux mount table is empty")
+    return frozenset(points)
+
+
+def _require_validation_source_not_mount(path: Path, *, label: str) -> None:
+    """Reject a catalog leaf whose bytes are supplied by a mount alias."""
+
+    try:
+        normalized = os.path.normpath(os.path.realpath(path))
+        is_mount = os.path.ismount(path) or os.path.ismount(normalized)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CatalogError(
+            f"existing SQLite catalog {label} mount identity could not be inspected"
+        ) from exc
+    if sys.platform.startswith("linux"):
+        is_mount = is_mount or normalized in _validation_linux_mount_points()
+    if is_mount:
+        raise CatalogError(
+            f"existing SQLite catalog {label} must not be a file mount point"
+        )
+
+
+def _open_validation_source(
+    path: Path,
+    *,
+    label: str,
+    required: bool,
+) -> tuple[int, os.stat_result] | None:
+    try:
+        before = path.lstat()
+    except FileNotFoundError as exc:
+        if not required:
+            return None
+        raise CatalogError(f"existing SQLite catalog {label} is missing") from exc
+    except OSError as exc:
+        raise CatalogError(
+            f"existing SQLite catalog {label} could not be inspected"
+        ) from exc
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or stat.S_ISLNK(before.st_mode)
+        or before.st_dev < 1
+        or before.st_ino < 1
+        or before.st_nlink != 1
+        or before.st_size < 0
+        or getattr(before, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT_ATTRIBUTE
+    ):
+        raise CatalogError(
+            f"existing SQLite catalog {label} must be a single-linked regular file"
+        )
+    _require_validation_source_not_mount(path, label=label)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise CatalogError(
+            f"existing SQLite catalog {label} could not be opened safely"
+        ) from exc
+    after = before
+    try:
+        after = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(after.st_mode)
+            or after.st_nlink != 1
+            or getattr(after, "st_file_attributes", 0)
+            & _WINDOWS_REPARSE_POINT_ATTRIBUTE
+            or _validation_source_identity(before) != _validation_source_identity(after)
+        ):
+            raise CatalogError(f"existing SQLite catalog {label} changed before copy")
+        _require_validation_source_not_mount(path, label=label)
+    except BaseException as primary_error:  # noqa: B036 - retain failed cleanup
+        _close_validation_descriptor(
+            descriptor,
+            after,
+            primary_error=primary_error,
+            label=label,
+        )
+        raise
+    return descriptor, after
+
+
+def _close_validation_descriptor(
+    descriptor: int,
+    expected: os.stat_result,
+    *,
+    primary_error: BaseException | None,
+    label: str,
+) -> None:
+    """Close one file descriptor while retaining any provably open owner."""
+
+    from .._contained_source import _PosixDescriptorCleanup
+
+    cleanup = _PosixDescriptorCleanup()
+    cleanup.retain(descriptor, expected)
+    _finish_validation_cleanup(
+        cleanup,
+        primary_error=primary_error,
+        label=label,
+    )
+
+
+def _finish_validation_cleanup(
+    cleanup: object,
+    *,
+    primary_error: BaseException | None,
+    label: str,
+) -> None:
+    """Finish one retryable descriptor owner without replacing a primary."""
+
+    from .._atomic_directory import (
+        _annotate_secondary_error,
+        _attach_publication_cleanup_owner,
+    )
+
+    try:
+        cleanup.close()  # type: ignore[attr-defined]
+    except BaseException as close_error:  # noqa: B036 - preserve primary
+        target = close_error if primary_error is None else primary_error
+        if primary_error is not None:
+            _annotate_secondary_error(
+                primary_error,
+                f"SQLite validation {label} cleanup also failed",
+                close_error,
+            )
+        _attach_publication_cleanup_owner(target, cleanup)
+        if primary_error is None:
+            raise
+    else:
+        if primary_error is not None:
+            _attach_publication_cleanup_owner(primary_error, cleanup)
+
+
+def _copy_validation_source(
+    descriptor: int,
+    expected: os.stat_result,
+    destination: Path,
+    *,
+    label: str,
+) -> None:
+    from .._contained_source import _PosixDescriptorCleanup
+
+    destination_cleanup = _PosixDescriptorCleanup()
+    destination_descriptor = -1
+    try:
+        destination_descriptor = os.open(
+            destination,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_BINARY", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+        )
+        destination_metadata = os.fstat(destination_descriptor)
+        destination_cleanup.retain(
+            destination_descriptor,
+            destination_metadata,
+        )
+    except OSError as exc:
+        primary_error = CatalogError(
+            f"private SQLite validation {label} could not be created"
+        )
+        if destination_descriptor >= 0:
+            if destination_cleanup.closed:
+                try:
+                    destination_cleanup.retain(destination_descriptor)
+                except BaseException as retention_error:  # noqa: B036
+                    from .._atomic_directory import _annotate_secondary_error
+
+                    _annotate_secondary_error(
+                        primary_error,
+                        "private SQLite validation cleanup ownership also failed",
+                        retention_error,
+                    )
+            _finish_validation_cleanup(
+                destination_cleanup,
+                primary_error=primary_error,
+                label=f"private {label}",
+            )
+        raise primary_error from exc
+    except BaseException as primary_error:  # noqa: B036 - retain acquisition
+        if destination_descriptor >= 0:
+            if destination_cleanup.closed:
+                try:
+                    destination_cleanup.retain(destination_descriptor)
+                except BaseException as retention_error:  # noqa: B036
+                    from .._atomic_directory import _annotate_secondary_error
+
+                    _annotate_secondary_error(
+                        primary_error,
+                        "private SQLite validation cleanup ownership also failed",
+                        retention_error,
+                    )
+            _finish_validation_cleanup(
+                destination_cleanup,
+                primary_error=primary_error,
+                label=f"private {label}",
+            )
+        raise
+    primary_error: BaseException | None = None
+    try:
+        remaining = int(expected.st_size)
+        while remaining:
+            chunk = os.read(
+                descriptor,
+                min(remaining, _VALIDATION_COPY_CHUNK_BYTES),
+            )
+            if not chunk:
+                raise CatalogError(
+                    f"existing SQLite catalog {label} changed during copy"
+                )
+            view = memoryview(chunk)
+            while view:
+                written = os.write(destination_descriptor, view)
+                if written < 1:
+                    raise CatalogError(
+                        f"private SQLite validation {label} copy stalled"
+                    )
+                view = view[written:]
+            remaining -= len(chunk)
+        if os.read(descriptor, 1):
+            raise CatalogError(f"existing SQLite catalog {label} changed during copy")
+    except OSError as exc:
+        primary_error = CatalogError(
+            f"existing SQLite catalog {label} could not be copied safely"
+        )
+        raise primary_error from exc
+    except BaseException as exc:  # noqa: B036 - preserve primary across cleanup
+        primary_error = exc
+        raise
     finally:
-        reference.close()
+        _finish_validation_cleanup(
+            destination_cleanup,
+            primary_error=primary_error,
+            label=f"private {label}",
+        )
+    try:
+        observed = os.fstat(descriptor)
+    except OSError as exc:
+        raise CatalogError(
+            f"existing SQLite catalog {label} could not be rechecked after copy"
+        ) from exc
+    if _validation_source_identity(observed) != _validation_source_identity(expected):
+        raise CatalogError(f"existing SQLite catalog {label} changed during copy")
+
+
+def _require_no_rollback_journal(path: Path) -> None:
+    journal = Path(f"{path}-journal")
+    try:
+        journal.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise CatalogError(
+            "existing SQLite catalog rollback journal could not be inspected"
+        ) from exc
+    raise CatalogError("existing SQLite catalog rollback journal is not allowed")
+
+
+def _require_safe_shared_memory(path: Path) -> None:
+    source = _open_validation_source(
+        Path(f"{path}-shm"),
+        label="SHM sidecar",
+        required=False,
+    )
+    if source is None:
+        return
+    descriptor, expected = source
+    primary_error: BaseException | None = None
+    try:
+        if expected.st_size > _MAX_VALIDATION_SHM_BYTES:
+            raise CatalogError(
+                "existing SQLite catalog SHM sidecar exceeds "
+                f"{_MAX_VALIDATION_SHM_BYTES} bytes"
+            )
+        try:
+            observed = os.fstat(descriptor)
+        except OSError as exc:
+            raise CatalogError(
+                "existing SQLite catalog SHM sidecar could not be rechecked"
+            ) from exc
+        if _validation_source_identity(observed) != _validation_source_identity(
+            expected
+        ):
+            raise CatalogError("existing SQLite catalog SHM sidecar changed")
+    except BaseException as exc:  # noqa: B036 - preserve primary across cleanup
+        primary_error = exc
+        raise
+    finally:
+        _close_validation_descriptor(
+            descriptor,
+            expected,
+            primary_error=primary_error,
+            label="SHM sidecar",
+        )
+
+
+@contextmanager
+def _catalog_validation_snapshot(path: Path) -> Iterator[Path]:
+    """Copy the SQLite recovery namespace without mutating the source files."""
+
+    from .._contained_source import _PosixDescriptorCleanup
+
+    with tempfile.TemporaryDirectory(prefix="codenib-sqlite-validation-") as root:
+        snapshot = Path(root) / "catalog.sqlite3"
+        _require_no_rollback_journal(path)
+        sources: list[tuple[int, os.stat_result, Path, str]] = []
+        source_cleanup = _PosixDescriptorCleanup()
+        primary_error: BaseException | None = None
+        try:
+            main_source = _open_validation_source(
+                path,
+                label="main file",
+                required=True,
+            )
+            assert main_source is not None
+            source_cleanup.retain(*main_source)
+            sources.append((*main_source, snapshot, "main file"))
+            wal_source = _open_validation_source(
+                Path(f"{path}-wal"),
+                label="WAL sidecar",
+                required=False,
+            )
+            if wal_source is not None:
+                source_cleanup.retain(*wal_source)
+                sources.append((*wal_source, Path(f"{snapshot}-wal"), "WAL sidecar"))
+            total_bytes = sum(source[1].st_size for source in sources)
+            if total_bytes > _MAX_VALIDATION_NAMESPACE_BYTES:
+                raise CatalogError(
+                    "existing SQLite catalog validation namespace exceeds "
+                    f"{_MAX_VALIDATION_NAMESPACE_BYTES} bytes"
+                )
+            for descriptor, metadata, destination, label in sources:
+                _copy_validation_source(
+                    descriptor,
+                    metadata,
+                    destination,
+                    label=label,
+                )
+            _require_no_rollback_journal(path)
+        except BaseException as exc:  # noqa: B036 - preserve primary across cleanup
+            primary_error = exc
+            raise
+        finally:
+            _finish_validation_cleanup(
+                source_cleanup,
+                primary_error=primary_error,
+                label="source namespace",
+            )
+        yield snapshot
 
 
 class SQLiteCatalog:
@@ -1141,6 +1586,7 @@ class SQLiteCatalog:
         raw_path = str(path)
         connection_target = raw_path
         use_uri = False
+        resolved: Path | None = None
         if raw_path != ":memory:":
             resolved = Path(path).expanduser().resolve()
             raw_path = str(resolved)
@@ -1156,7 +1602,52 @@ class SQLiteCatalog:
             )
         self.path = raw_path
         if expected_file_identity is not None:
+            assert resolved is not None
             self._require_expected_file_identity(resolved, expected_file_identity)
+        if not create:
+            assert resolved is not None
+            with _catalog_validation_snapshot(resolved) as validation_path:
+                validation_target = f"{validation_path.as_uri()}?mode=rw"
+                try:
+                    validation_connection = sqlite3.connect(
+                        validation_target,
+                        timeout=busy_timeout_ms / 1_000,
+                        isolation_level=None,
+                        uri=True,
+                    )
+                except sqlite3.Error as exc:
+                    raise CatalogError(
+                        f"existing SQLite catalog could not be opened: {raw_path}"
+                    ) from exc
+                try:
+                    if expected_file_identity is not None:
+                        self._require_expected_file_identity(
+                            resolved,
+                            expected_file_identity,
+                        )
+                    validation_connection.row_factory = sqlite3.Row
+                    self._connection = validation_connection
+                    self._require_existing_catalog_identity()
+                    if expected_file_identity is not None:
+                        self._require_expected_file_identity(
+                            resolved,
+                            expected_file_identity,
+                        )
+                except sqlite3.Error as exc:
+                    raise CatalogError(
+                        f"existing SQLite catalog could not be initialized: {raw_path}"
+                    ) from exc
+                finally:
+                    validation_connection.close()
+            _require_no_rollback_journal(resolved)
+            # The SHM file is a derived WAL index, so the private copy rebuilds
+            # it.  Authenticate the original before SQLite may map or update it.
+            _require_safe_shared_memory(resolved)
+            if expected_file_identity is not None:
+                self._require_expected_file_identity(
+                    resolved,
+                    expected_file_identity,
+                )
         try:
             connection = sqlite3.connect(
                 connection_target,
@@ -1172,6 +1663,7 @@ class SQLiteCatalog:
             raise
         try:
             if expected_file_identity is not None:
+                assert resolved is not None
                 self._require_expected_file_identity(
                     resolved,
                     expected_file_identity,
@@ -1242,26 +1734,20 @@ class SQLiteCatalog:
         self._connection.close()
 
     def _require_existing_catalog_identity(self) -> None:
-        observed_tables = frozenset(
-            row["name"]
-            for row in self._connection.execute(
-                "SELECT name FROM sqlite_master WHERE type = 'table'"
-            )
-        )
-        if not _V1_CATALOG_TABLES.issubset(observed_tables):
-            raise CatalogError("existing file is not an initialized CodeNib catalog")
-        migration_columns = tuple(
-            (row["name"], row["type"], row["notnull"], row["pk"])
-            for row in self._connection.execute("PRAGMA table_info(schema_migrations)")
-        )
-        if migration_columns != (
-            ("version", "INTEGER", 0, 1),
-            ("applied_at", "TEXT", 1, 0),
+        observed_schema = _catalog_schema_signature(self._connection)
+        if not any(
+            object_type == "table" and name == "schema_migrations"
+            for object_type, name, _table_name, _sql in observed_schema
         ):
             raise CatalogError("existing file is not an initialized CodeNib catalog")
-        migration_rows = self._connection.execute(
-            "SELECT version, applied_at FROM schema_migrations ORDER BY version"
-        ).fetchall()
+        try:
+            migration_rows = self._connection.execute(
+                "SELECT version, applied_at FROM schema_migrations ORDER BY version"
+            ).fetchall()
+        except sqlite3.Error as exc:
+            raise CatalogError(
+                "existing file is not an initialized CodeNib catalog"
+            ) from exc
         versions: list[int] = []
         for row in migration_rows:
             version = row["version"]
@@ -1287,10 +1773,12 @@ class SQLiteCatalog:
                 "catalog schema is newer than this CodeNib version: "
                 f"{user_version} > {LATEST_SCHEMA_VERSION}"
             )
-        if _catalog_schema_signature(
-            self._connection
-        ) != _expected_catalog_schema_signature(user_version):
-            raise CatalogError("existing file is not an initialized CodeNib catalog")
+        expected_schema = _CANONICAL_CATALOG_SCHEMAS.get(user_version)
+        if expected_schema is None or observed_schema != expected_schema:
+            raise CatalogError(
+                "existing file is not an initialized CodeNib catalog: "
+                f"schema is not canonical for version {user_version}"
+            )
 
     def __enter__(self) -> SQLiteCatalog:
         return self
@@ -2360,12 +2848,13 @@ class SQLiteCatalog:
         normalized_schema_version = _required_text(
             schema_version, "view schema version"
         )
-        normalized_metadata, normalized_member_tuple = (
-            normalize_view_generation_metadata(
-                digest,
-                metadata,
-                member_object_digests=member_object_digests,
-            )
+        (
+            normalized_metadata,
+            normalized_member_tuple,
+        ) = normalize_view_generation_metadata(
+            digest,
+            metadata,
+            member_object_digests=member_object_digests,
         )
         normalized_members = list(normalized_member_tuple)
         metadata_json = canonical_json(normalized_metadata)

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -557,19 +557,26 @@ The first explicit local bridge over this API is now
 SQLite catalog, a fully preprovisioned strict `LocalCAS`, an existing private
 Linux workspace root owned by the current effective UID with exact mode `0700`,
 and a missing output below that root. The three storage/authority locations
-must not overlap. Existing-only catalog open is read-write rather than
-read-only: it enables WAL and may apply forward migrations, while rejecting a
-missing, empty, foreign, or corrupt database. The database must be a
-single-linked regular file. Existing-only open binds its captured `(st_dev,
-st_ino, st_nlink=1)` identity across `sqlite3.connect` and rechecks it before
-authenticating the complete schema declared by its migration version, WAL
-activation, or migration. Its resolved ancestor chain and WAL/SHM sidecar
-namespace are an explicit trusted, quiescent deployment boundary for the whole
-invocation; the identity checks do not claim a path-based sandbox against
-arbitrary concurrent renames. Physical preflight rejects distinct storage
-paths whose ancestor directory identities alias, plus mounted catalog files and
-nested mount points below the workspace root. Every existing output-parent
-component must be a real directory on the workspace root filesystem.
+must not overlap or resolve through physical mount aliases. Existing-only
+catalog open is read-write rather than read-only: before opening the original
+namespace, it descriptor-copies a bounded, no-follow main/WAL snapshot and
+requires the complete canonical SQLite schema for the recorded v1-v4 migration
+level. It rejects rollback journals, unsafe or oversized WAL/SHM sidecars, and
+missing, empty, foreign, or corrupt databases without enabling WAL or migrating
+the original. The database must be a single-linked regular file. Existing-only
+open binds its captured `(st_dev, st_ino, st_nlink=1)` identity across
+`sqlite3.connect` and repeats the canonical schema check before WAL activation
+or migration. Its resolved ancestor chain and WAL/SHM sidecar namespace remain
+an explicit trusted, quiescent deployment boundary for the whole invocation;
+the identity checks do not claim a path-based sandbox against arbitrary
+concurrent renames. The CLI retains opened filesystem authorities for the CAS,
+workspace, and output parent through publication, revalidates them immediately
+before provisioning, and passes the retained output-parent identity into the
+native workspace owner so its pinned publication parent must match before any
+callback can publish. It rejects same-object, bind-mount, workspace re-entry,
+ambiguous stacked-mount, and catalog file-mount aliases before opening storage.
+Every existing output-parent component must be a real directory on the
+workspace root filesystem.
 The command resolves either one ref (optionally guarded by its expected
 generation) or one explicit immutable snapshot, materializes the retained
 portable generation, then closes the CLI-owned caller receipt, strict CAS

--- a/test/compiler/test_manifest_materialization.py
+++ b/test/compiler/test_manifest_materialization.py
@@ -200,7 +200,9 @@ class _PostCommitFailureProvider(_TestWorkspaceProvider):
         *,
         receipt_owner: PublishedWorkspaceReceiptOwner,
         operation: Callable[[StrictWorkspaceSession], _Result],
+        _expected_parent_identity: tuple[int, ...] | None = None,
     ) -> _Result:
+        del _expected_parent_identity
         super().run_workspace(
             request,
             receipt_owner=receipt_owner,

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -6,7 +6,12 @@
 
 from __future__ import annotations
 
+import io
+import os
+import shutil
 import sqlite3
+import subprocess
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Barrier
@@ -110,20 +115,133 @@ def _prepare_delete_journal_catalog(path: Path) -> bytes:
     return path.read_bytes()
 
 
-def _schema_snapshot(path: Path) -> tuple[tuple[object, ...], ...]:
+def _prepare_supported_schema_version(path: Path, version: int) -> None:
     connection = sqlite3.connect(path)
     try:
-        return tuple(
-            tuple(row)
-            for row in connection.execute(
+        connection.execute(sqlite_catalog_module._SCHEMA_MIGRATIONS_SQL)
+        for migration_version in range(1, version + 1):
+            for statement in sqlite_catalog_module._MIGRATIONS[migration_version]:
+                connection.execute(statement)
+            if migration_version == 1:
+                connection.execute(
+                    """
+                    INSERT INTO namespaces(namespace_id, name, created_at)
+                    VALUES (?, ?, '2026-08-20T00:00:00+00:00')
+                    """,
+                    (
+                        sqlite_catalog_module.DEFAULT_NAMESPACE_ID,
+                        sqlite_catalog_module.DEFAULT_NAMESPACE_NAME,
+                    ),
+                )
+            connection.execute(
                 """
-                SELECT type, name, tbl_name, sql
-                FROM sqlite_master
-                WHERE substr(name, 1, 7) != 'sqlite_'
-                ORDER BY type, name, tbl_name
+                INSERT INTO schema_migrations(version, applied_at)
+                VALUES (?, '2026-08-20T00:00:00+00:00')
+                """,
+                (migration_version,),
+            )
+            connection.execute(f"PRAGMA user_version = {migration_version}")
+        connection.commit()
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+    finally:
+        connection.close()
+
+
+def _catalog_namespace_bytes(path: Path) -> dict[str, bytes | None]:
+    return {
+        suffix: (
+            sidecar.read_bytes()
+            if (sidecar := Path(f"{path}{suffix}")).exists()
+            else None
+        )
+        for suffix in ("", "-wal", "-shm", "-journal")
+    }
+
+
+def _rewrite_schema_sql(
+    connection: sqlite3.Connection,
+    *,
+    object_type: str,
+    name: str,
+    old: str,
+    new: str,
+) -> None:
+    row = connection.execute(
+        "SELECT sql FROM sqlite_schema WHERE type = ? AND name = ?",
+        (object_type, name),
+    ).fetchone()
+    assert row is not None
+    sql = row[0]
+    assert old in sql
+    schema_version = connection.execute("PRAGMA schema_version").fetchone()[0]
+    connection.execute("PRAGMA writable_schema = ON")
+    try:
+        connection.execute(
+            "UPDATE sqlite_schema SET sql = ? WHERE type = ? AND name = ?",
+            (sql.replace(old, new, 1), object_type, name),
+        )
+        connection.execute(f"PRAGMA schema_version = {schema_version + 1}")
+    finally:
+        connection.execute("PRAGMA writable_schema = OFF")
+
+
+def _corrupt_catalog_schema(path: Path, corruption: str) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        if corruption == "table":
+            connection.execute("DROP TABLE namespaces")
+        elif corruption == "column":
+            _rewrite_schema_sql(
+                connection,
+                object_type="table",
+                name="objects",
+                old="created_at TEXT NOT NULL",
+                new="created_at BLOB NOT NULL",
+            )
+        elif corruption == "constraint":
+            _rewrite_schema_sql(
+                connection,
+                object_type="table",
+                name="objects",
+                old="byte_size INTEGER NOT NULL CHECK (byte_size >= 0)",
+                new="byte_size INTEGER NOT NULL",
+            )
+        elif corruption == "index":
+            connection.execute("DROP INDEX source_revisions_repository_idx")
+            connection.execute(
+                """
+                CREATE INDEX source_revisions_repository_idx
+                    ON source_revisions(source_revision_id)
                 """
             )
-        )
+        elif corruption == "foreign-key":
+            _rewrite_schema_sql(
+                connection,
+                object_type="table",
+                name="repositories",
+                old=(
+                    "FOREIGN KEY (namespace_id) "
+                    "REFERENCES namespaces(namespace_id)\n"
+                    "            ON DELETE RESTRICT"
+                ),
+                new="CHECK (namespace_id IS NOT NULL)",
+            )
+        elif corruption == "trigger":
+            connection.execute("DROP TRIGGER objects_are_immutable")
+            connection.execute(
+                """
+                CREATE TRIGGER objects_are_immutable
+                BEFORE UPDATE ON objects
+                BEGIN
+                    SELECT 1;
+                END
+                """
+            )
+        elif corruption == "extra-object":
+            connection.execute("CREATE TABLE counterfeit(value TEXT)")
+        else:  # pragma: no cover - the parametrization is closed
+            raise AssertionError(f"unexpected corruption: {corruption}")
+        connection.commit()
     finally:
         connection.close()
 
@@ -179,6 +297,732 @@ def test_existing_only_mode_never_creates_a_missing_catalog(tmp_path):
         pass
     with SQLiteCatalog(escaped, create=False) as reopened:
         assert reopened.schema_version == LATEST_SCHEMA_VERSION
+
+
+@pytest.mark.parametrize("version", range(1, LATEST_SCHEMA_VERSION + 1))
+def test_existing_only_accepts_every_canonical_supported_schema(tmp_path, version):
+    path = tmp_path / f"catalog-v{version}.sqlite3"
+    _prepare_supported_schema_version(path, version)
+
+    with SQLiteCatalog(path, create=False) as catalog:
+        assert catalog.schema_version == LATEST_SCHEMA_VERSION
+        assert (
+            catalog._connection.execute(
+                "SELECT COUNT(*) FROM schema_migrations"
+            ).fetchone()[0]
+            == LATEST_SCHEMA_VERSION
+        )
+
+
+def test_existing_only_accepts_sqlite_analyze_statistics(tmp_path):
+    path = tmp_path / "analyzed-catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("ANALYZE")
+        connection.commit()
+        assert connection.execute(
+            "SELECT 1 FROM sqlite_schema WHERE name = 'sqlite_stat1'"
+        ).fetchone() == (1,)
+    finally:
+        connection.close()
+
+    with SQLiteCatalog(path, create=False) as catalog:
+        assert catalog.schema_version == LATEST_SCHEMA_VERSION
+
+
+def test_existing_only_rejects_malformed_sqlite_statistics_schema(tmp_path):
+    path = tmp_path / "malformed-statistics.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("ANALYZE")
+        _rewrite_schema_sql(
+            connection,
+            object_type="table",
+            name="sqlite_stat1",
+            old="CREATE TABLE sqlite_stat1(tbl,idx,stat)",
+            new="CREATE TABLE sqlite_stat1(tbl,idx,stat,extra)",
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(CatalogError, match="schema is not canonical"):
+        SQLiteCatalog(path, create=False)
+
+
+def test_existing_only_accepts_schema_and_data_from_uncheckpointed_wal(tmp_path):
+    path = tmp_path / "live-wal.sqlite3"
+
+    with SQLiteCatalog(path) as writer:
+        writer._connection.execute("PRAGMA wal_autocheckpoint = 0")
+        repository_id = writer.create_repository("owner/live-wal")
+        assert Path(f"{path}-wal").stat().st_size > 0
+        assert Path(f"{path}-shm").exists()
+
+        main_only = sqlite3.connect(
+            f"{path.resolve().as_uri()}?mode=ro&immutable=1",
+            uri=True,
+        )
+        try:
+            assert main_only.execute("PRAGMA user_version").fetchone()[0] == 0
+            assert (
+                main_only.execute(
+                    "SELECT name FROM sqlite_schema WHERE name = 'schema_migrations'"
+                ).fetchone()
+                is None
+            )
+        finally:
+            main_only.close()
+
+        with SQLiteCatalog(
+            path,
+            create=False,
+            expected_file_identity=_catalog_file_identity(path),
+        ) as reader:
+            assert reader.schema_version == LATEST_SCHEMA_VERSION
+            assert (
+                reader._connection.execute(
+                    "SELECT repository_id FROM repositories WHERE repository_key = ?",
+                    ("owner/live-wal",),
+                ).fetchone()[0]
+                == repository_id
+            )
+
+
+def test_existing_only_revalidates_original_before_wal_or_migration(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    real_require = SQLiteCatalog._require_existing_catalog_identity
+    schema_checks = 0
+    migration_calls = 0
+
+    def corrupt_after_snapshot_check(catalog):
+        nonlocal schema_checks
+        schema_checks += 1
+        real_require(catalog)
+        if schema_checks == 1:
+            _corrupt_catalog_schema(path, "index")
+
+    def forbidden_migration(_catalog):
+        nonlocal migration_calls
+        migration_calls += 1
+        pytest.fail("noncanonical original must be rejected before migration")
+
+    monkeypatch.setattr(
+        SQLiteCatalog,
+        "_require_existing_catalog_identity",
+        corrupt_after_snapshot_check,
+    )
+    monkeypatch.setattr(SQLiteCatalog, "_migrate", forbidden_migration)
+
+    with pytest.raises(CatalogError, match="schema is not canonical"):
+        SQLiteCatalog(path, create=False)
+
+    assert schema_checks == 2
+    assert migration_calls == 0
+    assert not Path(f"{path}-wal").exists()
+    assert not Path(f"{path}-shm").exists()
+    connection = sqlite3.connect(path)
+    try:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize("version", range(1, LATEST_SCHEMA_VERSION + 1))
+@pytest.mark.parametrize(
+    "corruption",
+    (
+        "table",
+        "column",
+        "constraint",
+        "index",
+        "foreign-key",
+        "trigger",
+        "extra-object",
+    ),
+)
+def test_existing_only_rejects_noncanonical_schema_without_mutating_namespace(
+    tmp_path,
+    version,
+    corruption,
+):
+    path = tmp_path / f"catalog-v{version}-{corruption}.sqlite3"
+    _prepare_supported_schema_version(path, version)
+    _corrupt_catalog_schema(path, corruption)
+    before = _catalog_namespace_bytes(path)
+    assert before["-wal"] is None
+    assert before["-shm"] is None
+
+    with pytest.raises(CatalogError, match="schema is not canonical"):
+        SQLiteCatalog(path, create=False)
+
+    assert _catalog_namespace_bytes(path) == before
+
+
+@pytest.mark.parametrize("version", range(1, LATEST_SCHEMA_VERSION + 1))
+def test_existing_only_preserves_existing_sidecars_for_noncanonical_schema(
+    tmp_path,
+    version,
+):
+    path = tmp_path / f"catalog-v{version}.sqlite3"
+    _prepare_supported_schema_version(path, version)
+    _corrupt_catalog_schema(path, "index")
+    Path(f"{path}-wal").write_bytes(b"untrusted WAL must remain byte-exact")
+    Path(f"{path}-shm").write_bytes(b"untrusted SHM must remain byte-exact")
+    before = _catalog_namespace_bytes(path)
+
+    with pytest.raises(CatalogError, match="schema is not canonical"):
+        SQLiteCatalog(path, create=False)
+
+    assert _catalog_namespace_bytes(path) == before
+
+
+def test_existing_only_rejects_symlink_wal_without_reading_its_target(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    protected = tmp_path / "protected"
+    protected.write_bytes(b"must not be copied")
+    wal = Path(f"{path}-wal")
+    wal.symlink_to(protected)
+    before_main = path.read_bytes()
+    before_target = protected.read_bytes()
+
+    with pytest.raises(CatalogError, match="single-linked regular file"):
+        SQLiteCatalog(path, create=False)
+
+    assert path.read_bytes() == before_main
+    assert wal.is_symlink()
+    assert wal.readlink() == protected
+    assert protected.read_bytes() == before_target
+    assert not Path(f"{path}-shm").exists()
+
+
+def test_existing_only_rejects_special_wal_without_blocking_or_mutation(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    wal = Path(f"{path}-wal")
+    os.mkfifo(wal, 0o600)
+    before_main = path.read_bytes()
+
+    with pytest.raises(CatalogError, match="single-linked regular file"):
+        SQLiteCatalog(path, create=False)
+
+    assert path.read_bytes() == before_main
+    assert wal.is_fifo()
+    assert not Path(f"{path}-shm").exists()
+
+
+def test_existing_only_rejects_symlink_shm_without_writing_its_target(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    protected = tmp_path / "protected"
+    protected.write_bytes(b"must not be mapped or changed")
+    shm = Path(f"{path}-shm")
+    shm.symlink_to(protected)
+    before_main = path.read_bytes()
+    before_target = protected.read_bytes()
+
+    with pytest.raises(CatalogError, match="single-linked regular file"):
+        SQLiteCatalog(path, create=False)
+
+    assert path.read_bytes() == before_main
+    assert shm.is_symlink()
+    assert shm.readlink() == protected
+    assert protected.read_bytes() == before_target
+    assert not Path(f"{path}-wal").exists()
+
+
+def test_existing_only_rejects_special_shm_without_blocking_or_mutation(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    shm = Path(f"{path}-shm")
+    os.mkfifo(shm, 0o600)
+    before_main = path.read_bytes()
+
+    with pytest.raises(CatalogError, match="single-linked regular file"):
+        SQLiteCatalog(path, create=False)
+
+    assert path.read_bytes() == before_main
+    assert shm.is_fifo()
+    assert not Path(f"{path}-wal").exists()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="exact file-mount authentication uses Linux mountinfo",
+)
+@pytest.mark.parametrize(
+    ("leaf", "label"),
+    (
+        ("main", "main file"),
+        ("wal", "WAL sidecar"),
+        ("shm", "SHM sidecar"),
+    ),
+)
+def test_existing_only_rejects_mounted_namespace_leaf_before_opening_original(
+    tmp_path,
+    monkeypatch,
+    leaf,
+    label,
+):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    mounted = {
+        "main": path,
+        "wal": Path(f"{path}-wal"),
+        "shm": Path(f"{path}-shm"),
+    }[leaf]
+    if mounted != path:
+        mounted.write_bytes(f"protected {label}".encode())
+    before = _catalog_namespace_bytes(path)
+    monkeypatch.setattr(
+        sqlite_catalog_module,
+        "_validation_linux_mount_points",
+        lambda: frozenset({os.path.normpath(os.path.realpath(mounted))}),
+    )
+
+    with pytest.raises(CatalogError, match=f"{label} must not be a file mount"):
+        SQLiteCatalog(path, create=False)
+
+    assert _catalog_namespace_bytes(path) == before
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict mount-table authentication is Linux-specific",
+)
+def test_existing_only_fails_closed_when_mount_table_cannot_be_read(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    before = _catalog_namespace_bytes(path)
+
+    def unavailable():
+        raise CatalogError("Linux mount table could not be inspected safely")
+
+    monkeypatch.setattr(
+        sqlite_catalog_module,
+        "_validation_linux_mount_points",
+        unavailable,
+    )
+
+    with pytest.raises(CatalogError, match="mount table could not be inspected"):
+        SQLiteCatalog(path, create=False)
+
+    assert _catalog_namespace_bytes(path) == before
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict mount-table authentication is Linux-specific",
+)
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    (
+        ("", "mount table is empty"),
+        (
+            "1 0 0:1 / / rw shared:1 ext4 /dev/root rw\n",
+            "malformed entry",
+        ),
+    ),
+)
+def test_existing_only_fails_closed_on_untrusted_mount_table(
+    tmp_path,
+    monkeypatch,
+    payload,
+    message,
+):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    before = _catalog_namespace_bytes(path)
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *_args, **_kwargs: io.BytesIO(payload.encode()),
+    )
+
+    with pytest.raises(CatalogError, match=message):
+        SQLiteCatalog(path, create=False)
+
+    assert _catalog_namespace_bytes(path) == before
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict mount-table authentication is Linux-specific",
+)
+def test_validation_mount_table_accepts_non_utf8_filesystem_paths(
+    monkeypatch,
+):
+    mount_point = b"/mnt/non-utf8-\xff"
+    payload = b"1 0 8:1 / " + mount_point + b" rw - ext4 /dev/root rw\n"
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *_args, **_kwargs: io.BytesIO(payload),
+    )
+
+    points = sqlite_catalog_module._validation_linux_mount_points()
+
+    assert {os.fsencode(point) for point in points} == {mount_point}
+
+
+def test_validation_snapshot_closes_all_sources_after_first_close_failure(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "catalog.sqlite3"
+    snapshot = tmp_path / "snapshot.sqlite3"
+    path.touch()
+    wal = tmp_path / "catalog.sqlite3-wal"
+    wal.touch()
+    descriptors = (os.open(path, os.O_RDONLY), os.open(wal, os.O_RDONLY))
+    metadata = tuple(os.fstat(descriptor) for descriptor in descriptors)
+    sources = iter(
+        (
+            (descriptors[0], metadata[0], snapshot, "main file"),
+            (
+                descriptors[1],
+                metadata[1],
+                Path(f"{snapshot}-wal"),
+                "WAL sidecar",
+            ),
+        )
+    )
+    close_calls: list[int] = []
+    original_close = os.close
+    fail_close = True
+
+    def open_source(*_args, **_kwargs):
+        return next(sources)[:2]
+
+    def close_source(descriptor):
+        if descriptor not in descriptors:
+            return original_close(descriptor)
+        close_calls.append(descriptor)
+        if descriptor == descriptors[1] and fail_close:
+            raise OSError("first close failed")
+        return original_close(descriptor)
+
+    monkeypatch.setattr(sqlite_catalog_module, "_open_validation_source", open_source)
+    monkeypatch.setattr(
+        sqlite_catalog_module,
+        "_copy_validation_source",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        sqlite_catalog_module,
+        "_require_no_rollback_journal",
+        lambda _path: None,
+    )
+    monkeypatch.setattr(os, "close", close_source)
+
+    try:
+        with pytest.raises(OSError, match="first close failed") as caught:
+            with sqlite_catalog_module._catalog_validation_snapshot(path):
+                pass
+
+        assert close_calls[:2] == [descriptors[1], descriptors[0]]
+        retained = caught.value.publication_cleanup_owners  # type: ignore[attr-defined]
+        assert len(retained) == 1
+        assert not retained[0].closed
+        fail_close = False
+        retained[0].close()
+        assert retained[0].closed
+    finally:
+        for descriptor in descriptors:
+            try:
+                original_close(descriptor)
+            except OSError:
+                pass
+
+
+def test_validation_source_retains_failed_post_open_cleanup(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "catalog.sqlite3"
+    path.write_bytes(b"catalog")
+    opened: list[int] = []
+    mount_checks = 0
+    fail_close = True
+    original_open = os.open
+    original_close = os.close
+
+    def capture_open(*args, **kwargs):
+        descriptor = original_open(*args, **kwargs)
+        opened.append(descriptor)
+        return descriptor
+
+    def reject_post_open(_path, *, label):
+        nonlocal mount_checks
+        mount_checks += 1
+        if mount_checks == 2:
+            raise CatalogError(f"{label} post-open validation failed")
+
+    def interrupt_close(descriptor):
+        if opened and descriptor == opened[0] and fail_close:
+            raise OSError("injected descriptor close failure")
+        return original_close(descriptor)
+
+    monkeypatch.setattr(os, "open", capture_open)
+    monkeypatch.setattr(os, "close", interrupt_close)
+    monkeypatch.setattr(
+        sqlite_catalog_module,
+        "_require_validation_source_not_mount",
+        reject_post_open,
+    )
+
+    with pytest.raises(CatalogError, match="post-open validation failed") as caught:
+        sqlite_catalog_module._open_validation_source(
+            path,
+            label="main file",
+            required=True,
+        )
+
+    retained = caught.value.publication_cleanup_owners  # type: ignore[attr-defined]
+    assert len(retained) == 1
+    assert not retained[0].closed
+    fail_close = False
+    retained[0].close()
+    assert retained[0].closed
+
+
+def test_shared_memory_retains_cleanup_after_validation_failure(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "catalog.sqlite3"
+    shm = Path(f"{path}-shm")
+    with shm.open("wb") as stream:
+        stream.truncate(sqlite_catalog_module._MAX_VALIDATION_SHM_BYTES + 1)
+    opened: list[int] = []
+    fail_close = True
+    original_open = os.open
+    original_close = os.close
+
+    def capture_open(*args, **kwargs):
+        descriptor = original_open(*args, **kwargs)
+        opened.append(descriptor)
+        return descriptor
+
+    def interrupt_close(descriptor):
+        if opened and descriptor == opened[0] and fail_close:
+            raise OSError("injected SHM close failure")
+        return original_close(descriptor)
+
+    monkeypatch.setattr(os, "open", capture_open)
+    monkeypatch.setattr(os, "close", interrupt_close)
+    monkeypatch.setattr(
+        sqlite_catalog_module,
+        "_require_validation_source_not_mount",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(CatalogError, match="SHM sidecar exceeds") as caught:
+        sqlite_catalog_module._require_safe_shared_memory(path)
+
+    retained = caught.value.publication_cleanup_owners  # type: ignore[attr-defined]
+    assert len(retained) == 1
+    assert not retained[0].closed
+    fail_close = False
+    retained[0].close()
+    assert retained[0].closed
+
+
+def test_validation_copy_preserves_primary_and_retains_destination_cleanup(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    source.write_bytes(b"source")
+    destination = tmp_path / "destination"
+    source_descriptor = os.open(source, os.O_RDONLY)
+    observed = os.fstat(source_descriptor)
+    fields = list(observed)
+    fields[6] = observed.st_size + 1
+    expected = os.stat_result(fields)
+    opened: list[int] = []
+    fail_close = True
+    original_open = os.open
+    original_close = os.close
+
+    def capture_open(*args, **kwargs):
+        descriptor = original_open(*args, **kwargs)
+        opened.append(descriptor)
+        return descriptor
+
+    def interrupt_close(descriptor):
+        if opened and descriptor == opened[0] and fail_close:
+            raise OSError("injected destination close failure")
+        return original_close(descriptor)
+
+    monkeypatch.setattr(os, "open", capture_open)
+    monkeypatch.setattr(os, "close", interrupt_close)
+    try:
+        with pytest.raises(CatalogError, match="changed during copy") as caught:
+            sqlite_catalog_module._copy_validation_source(
+                source_descriptor,
+                expected,
+                destination,
+                label="main file",
+            )
+
+        retained = caught.value.publication_cleanup_owners  # type: ignore[attr-defined]
+        assert len(retained) == 1
+        assert not retained[0].closed
+        fail_close = False
+        retained[0].close()
+        assert retained[0].closed
+    finally:
+        original_close(source_descriptor)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="bind-mount regression requires Linux mount namespaces",
+)
+def test_existing_only_rejects_real_shm_file_bind_without_mutating_source(
+    tmp_path,
+):
+    unshare = shutil.which("unshare")
+    mount = shutil.which("mount")
+    if unshare is None or mount is None:
+        pytest.skip("Linux unshare/mount tools are unavailable")
+    probe = subprocess.run(
+        [
+            unshare,
+            "--user",
+            "--map-root-user",
+            "--mount",
+            "--fork",
+            "true",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if probe.returncode != 0:
+        detail = (probe.stderr or probe.stdout).strip() or "permission denied"
+        pytest.skip(f"Linux user/mount namespace is unavailable: {detail}")
+
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    shm = Path(f"{path}-shm")
+    shm.write_bytes(b"destination".ljust(32_768, b"!"))
+    protected = tmp_path / "protected-shm"
+    protected.write_bytes(b"protected".ljust(32_768, b"?"))
+    script = r"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from codenib.storage.sqlite_catalog import CatalogError, SQLiteCatalog
+
+mount, catalog, shm, protected = sys.argv[1:]
+subprocess.run([mount, "--bind", protected, shm], check=True)
+catalog_path = Path(catalog)
+shm_path = Path(shm)
+protected_path = Path(protected)
+before = protected_path.read_bytes()
+if (shm_path.stat().st_dev, shm_path.stat().st_ino) != (
+    protected_path.stat().st_dev,
+    protected_path.stat().st_ino,
+):
+    raise SystemExit("bind mount did not alias the protected file")
+try:
+    SQLiteCatalog(catalog_path, create=False)
+except CatalogError as exc:
+    if "SHM sidecar must not be a file mount point" not in str(exc):
+        raise
+else:
+    raise SystemExit("mounted SHM sidecar was accepted")
+if protected_path.read_bytes() != before:
+    raise SystemExit("mounted SHM source bytes changed")
+"""
+    result = subprocess.run(
+        [
+            unshare,
+            "--user",
+            "--map-root-user",
+            "--mount",
+            "--fork",
+            sys.executable,
+            "-c",
+            script,
+            mount,
+            os.fspath(path),
+            os.fspath(shm),
+            os.fspath(protected),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=Path.cwd(),
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_existing_only_rejects_oversized_shm_without_mutation(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    Path(f"{path}-shm").write_bytes(b"oversized SHM")
+    monkeypatch.setattr(sqlite_catalog_module, "_MAX_VALIDATION_SHM_BYTES", 3)
+    before = _catalog_namespace_bytes(path)
+
+    with pytest.raises(CatalogError, match="SHM sidecar exceeds"):
+        SQLiteCatalog(path, create=False)
+
+    assert _catalog_namespace_bytes(path) == before
+
+
+@pytest.mark.parametrize("oversized", ("main", "wal"))
+def test_existing_only_rejects_oversized_validation_namespace_without_mutation(
+    tmp_path,
+    monkeypatch,
+    oversized,
+):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    if oversized == "wal":
+        Path(f"{path}-wal").write_bytes(b"oversized WAL")
+        limit = path.stat().st_size + len(b"oversized WAL") - 1
+    else:
+        limit = path.stat().st_size - 1
+    monkeypatch.setattr(
+        sqlite_catalog_module,
+        "_MAX_VALIDATION_NAMESPACE_BYTES",
+        limit,
+    )
+    before = _catalog_namespace_bytes(path)
+
+    with pytest.raises(CatalogError, match="validation namespace exceeds"):
+        SQLiteCatalog(path, create=False)
+
+    assert _catalog_namespace_bytes(path) == before
+
+
+def test_existing_only_rejects_rollback_journal_without_mutation(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    _prepare_supported_schema_version(path, LATEST_SCHEMA_VERSION)
+    Path(f"{path}-journal").write_bytes(b"untrusted hot rollback journal")
+    before = _catalog_namespace_bytes(path)
+
+    with pytest.raises(CatalogError, match="rollback journal is not allowed"):
+        SQLiteCatalog(path, create=False)
+
+    assert _catalog_namespace_bytes(path) == before
 
 
 @pytest.mark.parametrize(
@@ -397,69 +1241,6 @@ def test_existing_only_mode_rejects_empty_or_foreign_databases(tmp_path):
         connection.close()
     assert not Path(f"{migration_db}-wal").exists()
     assert not Path(f"{migration_db}-shm").exists()
-
-
-def test_existing_only_rejects_a_foreign_claimed_complete_version_before_wal(
-    tmp_path,
-):
-    path = tmp_path / "foreign-version-claim.sqlite3"
-    connection = sqlite3.connect(path)
-    connection.execute(sqlite_catalog_module._SCHEMA_MIGRATIONS_SQL)
-    for table in sorted(
-        sqlite_catalog_module._V1_CATALOG_TABLES - {"schema_migrations"}
-    ):
-        connection.execute(f"CREATE TABLE {table} (foreign_value TEXT)")
-    connection.executemany(
-        "INSERT INTO schema_migrations(version, applied_at) VALUES (?, 'foreign')",
-        ((version,) for version in range(1, LATEST_SCHEMA_VERSION + 1)),
-    )
-    connection.execute(f"PRAGMA user_version = {LATEST_SCHEMA_VERSION:d}")
-    connection.commit()
-    connection.close()
-    schema_before = _schema_snapshot(path)
-
-    with pytest.raises(CatalogError, match="initialized CodeNib catalog"):
-        SQLiteCatalog(path, create=False)
-
-    assert _schema_snapshot(path) == schema_before
-    connection = sqlite3.connect(path)
-    try:
-        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == (
-            LATEST_SCHEMA_VERSION
-        )
-    finally:
-        connection.close()
-    assert not Path(f"{path}-wal").exists()
-    assert not Path(f"{path}-shm").exists()
-
-
-def test_existing_only_forward_migrates_an_exact_older_catalog_schema(tmp_path):
-    path = tmp_path / "version-one.sqlite3"
-    connection = sqlite3.connect(path)
-    connection.execute(sqlite_catalog_module._SCHEMA_MIGRATIONS_SQL)
-    for statement in sqlite_catalog_module._MIGRATIONS[1]:
-        connection.execute(statement)
-    connection.execute(
-        """
-        INSERT INTO namespaces(namespace_id, name, created_at)
-        VALUES (?, 'default', '2026-01-01T00:00:00+00:00')
-        """,
-        (DEFAULT_NAMESPACE_ID,),
-    )
-    connection.execute(
-        "INSERT INTO schema_migrations(version, applied_at) VALUES (1, 'legacy')"
-    )
-    connection.execute("PRAGMA user_version = 1")
-    connection.commit()
-    connection.close()
-
-    with SQLiteCatalog(path, create=False) as catalog:
-        assert catalog.schema_version == LATEST_SCHEMA_VERSION
-        assert catalog.create_namespace("default") == DEFAULT_NAMESPACE_ID
-
-    with SQLiteCatalog(path, create=False) as reopened:
-        assert reopened.schema_version == LATEST_SCHEMA_VERSION
 
 
 def test_existing_only_mode_maps_corrupt_database_errors(tmp_path):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,9 +6,13 @@ from __future__ import annotations
 
 import dis
 import errno
+import io
 import json
+import os
+import shutil
+import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from subprocess import CompletedProcess
 from types import SimpleNamespace
 
@@ -320,6 +324,76 @@ def _cache_import_cli_test_args(tmp_path: Path) -> SimpleNamespace:
         ref="main",
         expected_generation=0,
     )
+
+
+def test_artifact_import_cache_retains_failed_topology_cleanup_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _cache_import_cli_test_args(tmp_path)
+    monkeypatch.setattr(cli, "_new_compiler_cache_import_nonce", lambda: "f" * 32)
+    created: list[object] = []
+
+    class Provider:
+        def __init__(self, _root: Path) -> None:
+            pass
+
+        def require_support(self) -> None:
+            pass
+
+    class RetryableTopology:
+        def __init__(self, output: Path) -> None:
+            self.catalog_path = Path(args.catalog).resolve(strict=True)
+            self.catalog_identity = cli._retained_catalog_file_identity(
+                self.catalog_path
+            )
+            self.cas_root = Path(args.cas_root).resolve(strict=True)
+            self.workspace_root = Path(args.workspace_root).resolve(strict=True)
+            self.output = output
+            self.cas_binding = SimpleNamespace(identity=(1, 11))
+            self.workspace_binding = SimpleNamespace(identity=(1, 12))
+            self.output_parent_binding = SimpleNamespace(identity=(1, 12))
+            self.allow_close = False
+            self.closed = False
+
+        def verify(self) -> None:
+            pass
+
+        def close(self) -> None:
+            if not self.allow_close:
+                raise OSError("injected topology close failure")
+            self.closed = True
+
+    def topology_factory(
+        _catalog: Path,
+        _cas: Path,
+        _workspace: Path,
+        output: Path,
+    ) -> RetryableTopology:
+        topology = RetryableTopology(output)
+        created.append(topology)
+        return topology
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_require_retained_materialization_topology",
+        topology_factory,
+    )
+
+    with pytest.raises(cli.CLIError, match="topology close failure") as caught:
+        cli._run_artifact_import_cache(args)
+
+    assert len(created) == 1
+    topology = created[0]
+    retained = caught.value.publication_cleanup_owners  # type: ignore[attr-defined]
+    assert type(retained) is tuple
+    assert len(retained) == 1
+    assert not retained[0].closed
+    topology.allow_close = True  # type: ignore[attr-defined]
+    retained[0].close()
+    assert retained[0].closed
+    assert topology.closed  # type: ignore[attr-defined]
 
 
 def test_artifact_import_cache_uses_frozen_authorities_and_closes_before_output(
@@ -1077,23 +1151,365 @@ def test_artifact_materialize_rejects_cross_device_output_parent_before_storage(
         cli._run_artifact_materialize(args)
 
 
-def test_artifact_materialize_rejects_directory_identity_alias_before_storage(
+def test_retained_materialization_topology_keeps_independent_authorities(
+    tmp_path: Path,
+) -> None:
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    output_parent = workspace_root / "nested"
+    output_parent.mkdir()
+
+    topology = cli._require_retained_materialization_topology(
+        catalog,
+        cas_root,
+        workspace_root,
+        output_parent / "context",
+    )
+    try:
+        topology.verify()
+        assert topology.cas_binding.identity != topology.workspace_binding.identity
+        assert len(topology.cas_binding.identity) > 2
+        assert not topology.closed
+    finally:
+        topology.close()
+
+    assert topology.closed
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict mount-table authentication is Linux-specific",
+)
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    (
+        ("", "mount table is empty"),
+        (
+            "1 0 0:1 / / rw shared:1 ext4 /dev/root rw\n",
+            "malformed entry",
+        ),
+    ),
+)
+def test_retained_linux_mount_mappings_fail_closed_on_untrusted_table(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: str,
+    message: str,
+) -> None:
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *_args, **_kwargs: io.BytesIO(payload.encode()),
+    )
+
+    with pytest.raises(cli.CLIError, match=message):
+        cli._retained_linux_mount_mappings()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="strict mount-table authentication is Linux-specific",
+)
+def test_retained_linux_mount_mappings_accept_non_utf8_filesystem_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mount_point = b"/mnt/non-utf8-\xff"
+    payload = b"1 0 8:1 / " + mount_point + b" rw - ext4 /dev/root rw\n"
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *_args, **_kwargs: io.BytesIO(payload),
+    )
+
+    mappings = cli._retained_linux_mount_mappings()
+
+    assert len(mappings) == 1
+    assert os.fsencode(mappings[0].mount_point) == mount_point
+
+
+def test_retained_linux_physical_path_rejects_stacked_mount_mapping() -> None:
+    mount_point = Path("/workspace")
+    mappings = (
+        cli._RetainedLinuxMountMapping(
+            mount_id=20,
+            device="8:1",
+            root=PurePosixPath("/first"),
+            mount_point=mount_point,
+        ),
+        cli._RetainedLinuxMountMapping(
+            mount_id=10,
+            device="8:1",
+            root=PurePosixPath("/second"),
+            mount_point=mount_point,
+        ),
+    )
+
+    with pytest.raises(cli.CLIError, match="ambiguous stacked mapping"):
+        cli._retained_linux_physical_path(mount_point / "child", mappings)
+
+
+def test_retained_materialization_topology_partial_open_closes_all_authorities(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    workspace_root = tmp_path / "workspaces"
-    workspace_root.mkdir()
-    catalog_path = tmp_path / "catalog.sqlite3"
-    catalog_path.touch()
+    import codenib._atomic_directory as atomic_directory
+
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
     cas_root = tmp_path / "cas"
     cas_root.mkdir()
-    resolved_workspace = workspace_root.resolve(strict=True)
-    resolved_cas = cas_root.resolve(strict=True)
-    workspace_identity = cli._retained_real_directory_identity(
-        resolved_workspace,
-        label="workspace root",
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    owners: list[object] = []
+    open_calls = 0
+    original_owner = atomic_directory._PublicationAuthorityOwner
+    original_open = atomic_directory._open_publication_authority
+
+    class CapturingOwner(original_owner):
+        def __init__(self) -> None:
+            super().__init__()
+            owners.append(self)
+
+    def fail_second_open(*args: object, **kwargs: object):
+        nonlocal open_calls
+        open_calls += 1
+        if open_calls == 2:
+            raise OSError("second authority open failed")
+        return original_open(*args, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_directory,
+        "_PublicationAuthorityOwner",
+        CapturingOwner,
     )
-    real_identity = cli._retained_real_directory_identity
+    monkeypatch.setattr(
+        atomic_directory,
+        "_open_publication_authority",
+        fail_second_open,
+    )
+
+    with pytest.raises(OSError, match="second authority open failed"):
+        cli._require_retained_materialization_topology(
+            catalog,
+            cas_root,
+            workspace_root,
+            workspace_root / "context",
+        )
+
+    assert open_calls == 2
+    assert len(owners) == 3
+    assert all(owner.closed for owner in owners)  # type: ignore[attr-defined]
+
+
+def test_retained_materialization_topology_retains_partial_open_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codenib._atomic_directory as atomic_directory
+
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    owners: list[object] = []
+    open_calls = 0
+    original_owner = atomic_directory._PublicationAuthorityOwner
+    original_open = atomic_directory._open_publication_authority
+
+    class RetryableOwner(original_owner):
+        allow_close = False
+
+        def __init__(self) -> None:
+            super().__init__()
+            owners.append(self)
+
+        def close(self, *args: object, **kwargs: object) -> None:
+            if self.authority is not None and not self.allow_close:
+                raise OSError("injected authority close failure")
+            super().close(*args, **kwargs)
+
+    def fail_second_open(*args: object, **kwargs: object):
+        nonlocal open_calls
+        open_calls += 1
+        if open_calls == 2:
+            raise OSError("second authority open failed")
+        return original_open(*args, **kwargs)
+
+    monkeypatch.setattr(atomic_directory, "_PublicationAuthorityOwner", RetryableOwner)
+    monkeypatch.setattr(
+        atomic_directory, "_open_publication_authority", fail_second_open
+    )
+
+    with pytest.raises(OSError, match="second authority open failed") as caught:
+        cli._require_retained_materialization_topology(
+            catalog,
+            cas_root,
+            workspace_root,
+            workspace_root / "context",
+        )
+
+    retained = caught.value.publication_cleanup_owners  # type: ignore[attr-defined]
+    assert retained == (owners[0],)
+    owners[0].allow_close = True  # type: ignore[attr-defined]
+    retained[0].close()
+    assert retained[0].closed
+
+
+def test_retained_materialization_topology_close_retries_every_authority(
+    tmp_path: Path,
+) -> None:
+    class RetryableOwner:
+        def __init__(self, label: str) -> None:
+            self.label = label
+            self.closed = False
+            self.allow_close = False
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+            if not self.allow_close:
+                raise OSError(f"{self.label} authority close failed")
+            self.closed = True
+
+    owners = tuple(RetryableOwner(label) for label in ("CAS", "workspace", "output"))
+    bindings = tuple(
+        cli._RetainedDirectoryBinding(
+            label=owner.label,
+            path=tmp_path / owner.label,
+            identity=(1, index + 1),
+            owner=owner,
+        )
+        for index, owner in enumerate(owners)
+    )
+    topology = cli._RetainedMaterializationTopology(
+        catalog_path=tmp_path / "catalog.sqlite3",
+        catalog_identity=(1, 10, 1),
+        cas_root=tmp_path / "CAS",
+        workspace_root=tmp_path / "workspace",
+        output=tmp_path / "workspace" / "context",
+        cas_binding=bindings[0],
+        workspace_binding=bindings[1],
+        output_parent_binding=bindings[2],
+    )
+
+    with pytest.raises(OSError, match="output authority close failed"):
+        topology.close()
+
+    assert not topology.closed
+    assert tuple(owner.close_calls for owner in owners) == (1, 1, 1)
+    for owner in owners:
+        owner.allow_close = True
+    topology.close()
+
+    assert topology.closed
+    assert tuple(owner.close_calls for owner in owners) == (2, 2, 2)
+
+
+def test_retained_materialization_topology_rechecks_open_identity_before_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    topology = cli._require_retained_materialization_topology(
+        catalog,
+        cas_root,
+        workspace_root,
+        workspace_root / "context",
+    )
+    delegate_called = False
+    original_identity = cli._retained_open_directory_identity
+
+    class Delegate:
+        def run_workspace(self, *_args: object, **_kwargs: object) -> None:
+            nonlocal delegate_called
+            delegate_called = True
+
+    def regressed_identity(authority: object) -> tuple[int, ...]:
+        observed = original_identity(authority)
+        if authority.display_parent == topology.cas_root:  # type: ignore[attr-defined]
+            return observed[:1] + (observed[1] + 1,) + observed[2:]
+        return observed
+
+    monkeypatch.setattr(cli, "_retained_open_directory_identity", regressed_identity)
+    provider = cli._RetainedTopologyWorkspaceProvider(Delegate(), topology)
+    try:
+        with pytest.raises(cli.CLIError, match="authority identity changed"):
+            provider.run_workspace(
+                object(),
+                receipt_owner=object(),
+                operation=object(),
+            )
+    finally:
+        topology.close()
+
+    assert not delegate_called
+
+
+def test_retained_provider_passes_output_parent_identity_to_delegate(
+    tmp_path: Path,
+) -> None:
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    topology = cli._require_retained_materialization_topology(
+        catalog,
+        cas_root,
+        workspace_root,
+        workspace_root / "context",
+    )
+    observed: list[tuple[int, ...] | None] = []
+
+    class Delegate:
+        def run_workspace(
+            self,
+            _request: object,
+            *,
+            receipt_owner: object,
+            operation: object,
+            _expected_parent_identity: tuple[int, ...] | None = None,
+        ) -> str:
+            assert receipt_owner is not None
+            assert operation is not None
+            observed.append(_expected_parent_identity)
+            return "bound"
+
+    provider = cli._RetainedTopologyWorkspaceProvider(Delegate(), topology)
+    try:
+        assert (
+            provider.run_workspace(
+                object(),
+                receipt_owner=object(),
+                operation=object(),
+            )
+            == "bound"
+        )
+    finally:
+        topology.close()
+
+    assert observed == [topology.output_parent_binding.identity]
+
+
+def test_artifact_materialize_rejects_catalog_file_mount_before_storage_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
 
     class Provider:
         def __init__(self, root: Path) -> None:
@@ -1102,16 +1518,20 @@ def test_artifact_materialize_rejects_directory_identity_alias_before_storage(
         def require_support(self) -> None:
             pass
 
-    def aliased_identity(path: Path, *, label: str) -> tuple[int, int]:
-        if path == resolved_cas:
-            return workspace_identity
-        return real_identity(path, label=label)
-
+    catalog_mount = os.path.normpath(os.path.realpath(catalog))
+    catalog_device = catalog.stat().st_dev
     monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
     monkeypatch.setattr(
         cli,
-        "_retained_real_directory_identity",
-        aliased_identity,
+        "_retained_linux_mount_mappings",
+        lambda: (
+            cli._RetainedLinuxMountMapping(
+                mount_id=1,
+                device=f"{os.major(catalog_device)}:{os.minor(catalog_device)}",
+                root=PurePosixPath("/catalog-source.sqlite3"),
+                mount_point=Path(catalog_mount),
+            ),
+        ),
     )
     monkeypatch.setattr(
         storage_module,
@@ -1129,28 +1549,43 @@ def test_artifact_materialize_rejects_directory_identity_alias_before_storage(
         ref="main",
         snapshot=None,
         expected_generation=None,
-        catalog=str(catalog_path),
+        catalog=str(catalog),
         cas_root=str(cas_root),
         workspace_root=str(workspace_root),
         output=str(workspace_root / "context"),
     )
 
-    with pytest.raises(cli.CLIError, match="physically alias the workspace root"):
+    with pytest.raises(cli.CLIError, match="catalog must not be a file mount point"):
         cli._run_artifact_materialize(args)
 
 
-def test_artifact_materialize_rejects_nested_mount_before_storage(
+def test_artifact_materialize_rejects_simulated_catalog_identity_below_cas(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    workspace_root = tmp_path / "workspaces"
-    workspace_root.mkdir()
-    mounted_parent = workspace_root / "mounted"
-    mounted_parent.mkdir()
-    catalog_path = tmp_path / "catalog.sqlite3"
-    catalog_path.touch()
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    catalog_identity = cli._retained_catalog_file_identity(catalog)
     cas_root = tmp_path / "cas"
     cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    device = f"{os.major(catalog_identity[0])}:{os.minor(catalog_identity[0])}"
+    mappings = (
+        cli._RetainedLinuxMountMapping(
+            mount_id=1,
+            device=device,
+            root=PurePosixPath("/"),
+            mount_point=Path("/"),
+        ),
+        cli._RetainedLinuxMountMapping(
+            mount_id=2,
+            device=device,
+            root=PurePosixPath(catalog.parent.as_posix()),
+            mount_point=cas_root,
+        ),
+    )
+    inspected_aliases: list[Path] = []
 
     class Provider:
         def __init__(self, root: Path) -> None:
@@ -1159,12 +1594,13 @@ def test_artifact_materialize_rejects_nested_mount_before_storage(
         def require_support(self) -> None:
             pass
 
+    def alias_identity(path: Path) -> tuple[int, int]:
+        inspected_aliases.append(path)
+        return catalog_identity[:2]
+
     monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
-    monkeypatch.setattr(
-        cli,
-        "_retained_linux_mount_points",
-        lambda: frozenset({mounted_parent.resolve(strict=True)}),
-    )
+    monkeypatch.setattr(cli, "_retained_linux_mount_mappings", lambda: mappings)
+    monkeypatch.setattr(cli, "_retained_alias_file_identity", alias_identity)
     monkeypatch.setattr(
         storage_module,
         "LocalCAS",
@@ -1181,14 +1617,228 @@ def test_artifact_materialize_rejects_nested_mount_before_storage(
         ref="main",
         snapshot=None,
         expected_generation=None,
-        catalog=str(catalog_path),
+        catalog=str(catalog),
         cas_root=str(cas_root),
         workspace_root=str(workspace_root),
-        output=str(mounted_parent / "context"),
+        output=str(workspace_root / "context"),
     )
 
-    with pytest.raises(cli.CLIError, match="nested mount point"):
+    with pytest.raises(cli.CLIError, match="physically reachable below the CAS"):
         cli._run_artifact_materialize(args)
+
+    assert inspected_aliases == [cas_root / catalog.name]
+
+
+def test_retained_materialization_accepts_disjoint_same_device_bind_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    catalog_identity = cli._retained_catalog_file_identity(catalog)
+    device = f"{os.major(catalog_identity[0])}:{os.minor(catalog_identity[0])}"
+    mappings = (
+        cli._RetainedLinuxMountMapping(
+            mount_id=1,
+            device=device,
+            root=PurePosixPath("/"),
+            mount_point=Path("/"),
+        ),
+        cli._RetainedLinuxMountMapping(
+            mount_id=2,
+            device=device,
+            root=PurePosixPath("/backing/cas"),
+            mount_point=cas_root,
+        ),
+        cli._RetainedLinuxMountMapping(
+            mount_id=3,
+            device=device,
+            root=PurePosixPath("/backing/workspaces"),
+            mount_point=workspace_root,
+        ),
+    )
+    monkeypatch.setattr(cli, "_retained_linux_mount_mappings", lambda: mappings)
+
+    def binding(path: Path, label: str) -> cli._RetainedDirectoryBinding:
+        metadata = path.lstat()
+        return cli._RetainedDirectoryBinding(
+            label=label,
+            path=path,
+            identity=(int(metadata.st_dev), int(metadata.st_ino)),
+            owner=object(),
+        )
+
+    cli._require_retained_mount_topology(
+        catalog,
+        catalog_identity,
+        binding(cas_root, "CAS root"),
+        binding(workspace_root, "workspace root"),
+        binding(workspace_root, "output parent"),
+    )
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="bind-mount topology requires Linux mount namespaces",
+)
+@pytest.mark.parametrize(
+    "scenario",
+    (
+        "root-alias",
+        "root-reentry",
+        "output-parent",
+        "catalog-file",
+        "catalog-dir-cas",
+        "catalog-dir-workspace",
+    ),
+)
+def test_retained_materialization_rejects_linux_bind_mount_aliases(
+    tmp_path: Path,
+    scenario: str,
+) -> None:
+    unshare = shutil.which("unshare")
+    mount = shutil.which("mount")
+    if unshare is None or mount is None:
+        pytest.skip("Linux unshare/mount tools are unavailable")
+    probe = subprocess.run(
+        [
+            unshare,
+            "--user",
+            "--map-root-user",
+            "--mount",
+            "--fork",
+            "true",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if probe.returncode != 0:
+        detail = (probe.stderr or probe.stdout).strip() or "permission denied"
+        pytest.skip(f"Linux user/mount namespace is unavailable: {detail}")
+
+    catalog = tmp_path / "catalog.sqlite3"
+    catalog.touch()
+    catalog_source = tmp_path / "catalog-source.sqlite3"
+    catalog_source.touch()
+    cas_root = tmp_path / "cas"
+    cas_root.mkdir()
+    workspace_root = tmp_path / "workspaces"
+    workspace_root.mkdir()
+    source = tmp_path / "bind-source"
+    source.mkdir()
+    (source / "nested").mkdir()
+    source_catalog = source / "catalog.sqlite3"
+    source_catalog.touch()
+    mounted_parent = workspace_root / "mounted"
+    mounted_parent.mkdir()
+    script = r"""
+import subprocess
+import sys
+from pathlib import Path
+
+from codenib import cli
+
+(
+    scenario,
+    mount,
+    catalog,
+    catalog_source,
+    cas_root,
+    workspace_root,
+    source,
+    source_catalog,
+    mounted_parent,
+) = sys.argv[1:]
+try:
+    if scenario == "root-alias":
+        subprocess.run([mount, "--bind", source, cas_root], check=True)
+        subprocess.run([mount, "--bind", source, workspace_root], check=True)
+        output = Path(workspace_root) / "context"
+    elif scenario == "root-reentry":
+        subprocess.run([mount, "--bind", source, workspace_root], check=True)
+        subprocess.run(
+            [mount, "--bind", str(Path(source) / "nested"), cas_root],
+            check=True,
+        )
+        output = Path(workspace_root) / "context"
+    elif scenario == "output-parent":
+        subprocess.run([mount, "--bind", source, mounted_parent], check=True)
+        output = Path(mounted_parent) / "context"
+    elif scenario == "catalog-file":
+        subprocess.run([mount, "--bind", catalog_source, catalog], check=True)
+        output = Path(workspace_root) / "context"
+    elif scenario == "catalog-dir-cas":
+        subprocess.run([mount, "--bind", source, cas_root], check=True)
+        catalog = source_catalog
+        output = Path(workspace_root) / "context"
+    else:
+        subprocess.run([mount, "--bind", source, workspace_root], check=True)
+        catalog = source_catalog
+        output = Path(workspace_root) / "context"
+except (OSError, subprocess.CalledProcessError) as error:
+    print(f"BIND_UNAVAILABLE: {error}", file=sys.stderr)
+    raise SystemExit(77)
+
+try:
+    cli._require_retained_materialization_topology(
+        Path(catalog),
+        Path(cas_root),
+        Path(workspace_root),
+        output,
+    )
+except cli.CLIError as error:
+    message = str(error)
+    if scenario == "root-alias" and not (
+        "same physical object" in message or "same-device mount alias" in message
+    ):
+        raise
+    if scenario == "root-reentry" and "same-device mount alias" not in message:
+        raise
+    if scenario == "output-parent" and "cross a mount point" not in message:
+        raise
+    if scenario == "catalog-file" and "file mount point" not in message:
+        raise
+    if scenario in {"catalog-dir-cas", "catalog-dir-workspace"} and not (
+        "catalog is physically reachable" in message
+    ):
+        raise
+else:
+    raise AssertionError("bind-mounted storage alias was accepted")
+"""
+    result = subprocess.run(
+        [
+            unshare,
+            "--user",
+            "--map-root-user",
+            "--mount",
+            "--fork",
+            sys.executable,
+            "-c",
+            script,
+            scenario,
+            mount,
+            str(catalog),
+            str(catalog_source),
+            str(cas_root),
+            str(workspace_root),
+            str(source),
+            str(source_catalog),
+            str(mounted_parent),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=Path(__file__).parents[1],
+        text=True,
+    )
+    if result.returncode == 77:
+        detail = (result.stderr or result.stdout).strip()
+        pytest.skip(f"Linux bind mount is unavailable: {detail}")
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 def test_artifact_materialize_provider_failure_precedes_storage_open(
@@ -1255,6 +1905,120 @@ def _materialize_cli_test_args(tmp_path: Path) -> SimpleNamespace:
         workspace_root=str(workspace_root),
         output=str(workspace_root / "context"),
     )
+
+
+def test_artifact_materialize_storage_failure_closes_topology_authorities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[cli._RetainedMaterializationTopology] = []
+    original_topology = cli._require_retained_materialization_topology
+
+    class Provider:
+        def __init__(self, _root: Path) -> None:
+            pass
+
+        def require_support(self) -> None:
+            pass
+
+    class ReceiptOwner:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    receipt_owner = ReceiptOwner()
+
+    def capture_topology(*args: object, **kwargs: object):
+        topology = original_topology(*args, **kwargs)
+        captured.append(topology)
+        return topology
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli,
+        "_new_retained_output_receipt_owner",
+        lambda: receipt_owner,
+    )
+    monkeypatch.setattr(
+        cli,
+        "_require_retained_materialization_topology",
+        capture_topology,
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("stop after topology acquisition")
+        ),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: pytest.fail("catalog must not be opened"),
+    )
+
+    with pytest.raises(cli.CLIError, match="stop after topology acquisition"):
+        cli._run_artifact_materialize(_materialize_cli_test_args(tmp_path))
+
+    assert len(captured) == 1
+    topology = captured[0]
+    assert topology.closed
+    assert all(
+        binding.owner.closed  # type: ignore[attr-defined]
+        for binding in topology._bindings
+    )
+    assert receipt_owner.closed
+
+
+def test_artifact_materialize_inherits_failed_topology_cleanup_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_close = cli._RetainedMaterializationTopology.close
+    allow_close = False
+
+    class Provider:
+        def __init__(self, _root: Path) -> None:
+            pass
+
+        def require_support(self) -> None:
+            pass
+
+    def interrupt_topology_close(self) -> None:
+        if not allow_close:
+            raise OSError("injected topology close failure")
+        original_close(self)
+
+    monkeypatch.setattr(codenib, "LocalWorkspaceProvider", Provider)
+    monkeypatch.setattr(
+        cli._RetainedMaterializationTopology,
+        "close",
+        interrupt_topology_close,
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "LocalCAS",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("stop after topology acquisition")
+        ),
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "SQLiteCatalog",
+        lambda *_args, **_kwargs: pytest.fail("catalog must not be opened"),
+    )
+
+    with pytest.raises(cli.CLIError, match="stop after topology acquisition") as caught:
+        cli._run_artifact_materialize(_materialize_cli_test_args(tmp_path))
+
+    retained = caught.value.publication_cleanup_owners  # type: ignore[attr-defined]
+    assert len(retained) == 1
+    assert not retained[0].closed
+    allow_close = True
+    retained[0].close()
+    assert retained[0].closed
 
 
 def test_artifact_materialize_resource_store_interruption_closes_authorities(

--- a/test/test_local_workspace_provider.py
+++ b/test/test_local_workspace_provider.py
@@ -16,6 +16,7 @@ import pytest
 import codenib
 import codenib._local_workspace_provider as local_provider_module
 import codenib._workspace_owner as workspace_owner
+from codenib._atomic_directory import publication_parent_identity
 from codenib._captured_directory import (
     PublishedWorkspaceReceiptOwner,
     UnsupportedWorkspaceCreation,
@@ -266,6 +267,103 @@ def test_local_provider_native_policy_recheck_rejects_late_root_widening(
     assert receipt_owner.state == "empty"
     assert tuple(root.iterdir()) == ()
     assert not request.destination.exists()
+
+
+def test_local_provider_binds_native_parent_to_expected_identity(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    operation_called = False
+    descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        expected = publication_parent_identity(descriptor)
+    finally:
+        os.close(descriptor)
+    wrong = expected[:1] + (expected[1] + 1,) + expected[2:]
+
+    def operation(session: StrictWorkspaceSession) -> object:
+        nonlocal operation_called
+        operation_called = True
+        return _write_and_publish(session, b"forbidden")
+
+    class BoundProvider:
+        def require_support(self) -> None:
+            provider.require_support()
+
+        def run_workspace(
+            self,
+            bound_request: StrictWorkspaceRequest,
+            *,
+            receipt_owner: PublishedWorkspaceReceiptOwner,
+            operation,
+        ) -> object:
+            return provider.run_workspace(
+                bound_request,
+                receipt_owner=receipt_owner,
+                operation=operation,
+                _expected_parent_identity=wrong,
+            )
+
+    with pytest.raises(
+        RuntimeError,
+        match="native workspace parent differs from retained authority",
+    ):
+        run_strict_workspace(
+            BoundProvider(),
+            request,
+            receipt_owner=receipt_owner,
+            operation=operation,
+        )
+
+    assert not operation_called
+    assert receipt_owner.state == "empty"
+    assert not request.destination.exists()
+    assert not tuple(root.glob(".codenib-workspace-stage-*"))
+
+
+def test_local_provider_accepts_matching_expected_parent_identity(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "authority"
+    provider = _require_native_provider(root)
+    request = _request(root)
+    receipt_owner = PublishedWorkspaceReceiptOwner()
+    descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        expected = publication_parent_identity(descriptor)
+    finally:
+        os.close(descriptor)
+
+    class BoundProvider:
+        def require_support(self) -> None:
+            provider.require_support()
+
+        def run_workspace(
+            self,
+            bound_request: StrictWorkspaceRequest,
+            *,
+            receipt_owner: PublishedWorkspaceReceiptOwner,
+            operation,
+        ) -> object:
+            return provider.run_workspace(
+                bound_request,
+                receipt_owner=receipt_owner,
+                operation=operation,
+                _expected_parent_identity=expected,
+            )
+
+    run_strict_workspace(
+        BoundProvider(),
+        request,
+        receipt_owner=receipt_owner,
+        operation=lambda session: _write_and_publish(session, b"bound"),
+    )
+
+    assert (request.destination / "data/result.json").read_bytes() == b"bound"
+    receipt_owner.close()
 
 
 def test_local_provider_preserves_an_existing_destination(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Follow up on #642 to close the remaining retained-materialization topology and SQLite existing-only validation gaps before the 0.2.2 release. This preserves the compiler BM25 cache-import surface added by #643 while applying the stronger authority lifecycle to its shared preflight.

## Changes
- Authenticate canonical SQLite v1-v4 schemas from bounded descriptor snapshots before opening the original database for WAL or migration work.
- Accept exact SQLite-maintained ANALYZE statistics schemas while rejecting malformed or forged internal schema objects.
- Reject unsafe main/WAL/SHM file mounts, aliases, rollback journals, malformed mount tables, and ambiguous stacked Linux mount mappings.
- Parse Linux mount paths as filesystem bytes so valid non-UTF-8 filenames retain surrogateescape semantics.
- Retain CAS, workspace, and output-parent authorities through strict workspace provisioning; bind the native publication parent to the retained output-parent identity before callbacks can publish.
- Keep failed materialization, cache-import, partial-acquisition, and descriptor cleanup complete or retryable from the public failure.
- Detect physical directory-bind aliases between the catalog and retained storage roots without rejecting disjoint same-filesystem bind roots.
- Preserve #643 cache-import topology checks and close every temporary authority after preflight.
- Record the hardened publication and compatibility boundary in the storage roadmap.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Focused storage/materialization/CLI/provider surface — 328 passed.
- Full unit tier in an isolated 0.2.1 editable environment — 6382 passed, 71 skipped, 191 deselected; the sole explicit deselection is the known Web caplog baseline.
- Integration tier — 36 passed, 18 skipped.
- Changed-file pre-commit hooks, py_compile, and git diff checks — all passed.
- Fresh GitHub checks are running for 84a701f1.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published